### PR TITLE
fetchBalance: used funds undefined: define when cached orders match exchange orders

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -934,8 +934,12 @@ const Exchange = function (config) {
         currencies.forEach (currency => {
 
             if (typeof balance[currency].used == 'undefined') {
-                balance[currency].used = this.getCurrencyUsedOnOpenOrders (currency)
-                balance[currency].total = balance[currency].used + balance[currency].free
+                const exchangeOrdersCount = balance['info']['open_orders'];
+                const cachedOrdersCount = Object.values (this.orders).filter (order => (order['status'] == 'open')).length;
+                if (cachedOrdersCount == exchangeOrdersCount) {
+                    balance[currency].used = this.getCurrencyUsedOnOpenOrders (currency)
+                    balance[currency].total = balance[currency].used + balance[currency].free
+                }
             }
 
             [ 'free', 'used', 'total' ].forEach (account => {


### PR DESCRIPTION
If you place/cancel an order manually then cached orders get out of sync.

If after you `fetchBalance()` then current version of this function "defines" used funds (although they essentially become `undefined`).

This little fix checks if cached and exchange orders are in sync and if they are not then it keeps used funds undefined. The client code then can detect inconsistency and trigger an update.

On the one hand, I'm not sure if it really should be merged because:
- this case is quite exotic
- `parseBalance` is generic while reference to `balance['info']['open_orders']` is exchange-specific

On the other hand:
- it won't hurt
- if you know other exchanges that have `used` funds undefined this could be generalized

Anyway feel free to discard it if it doesn't fit your vision, I'll keep it in my rep.