### PR TITLE
Reference previous commit message

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-LAST_COMMIT_MESSAGE="$(git log --no-merges -1 --pretty=%B)"
+LAST_COMMIT_MESSAGE="$(git log --no-merges -2 --pretty=%B)"
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis CI"
 git add --force build/ccxt.browser.js


### PR DESCRIPTION
#428 

@kroitor @xpl  Your changes did something but now it's showing the version number twice, not the previous commit message. I think this should do the trick.