### PR TITLE
liqui: cancelOrder: account for safeString returning undefined

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -349,7 +349,7 @@ module.exports = class liqui extends Exchange {
         } catch (e) {
             if (this.last_json_response) {
                 let message = this.safeString (this.last_json_response, 'error');
-                if (message.indexOf ('not found') >= 0)
+                if (message && message.indexOf ('not found') >= 0)
                     throw new OrderNotFound (this.id + ' cancelOrder() error: ' + this.last_http_response);
             }
             throw e;


### PR DESCRIPTION
Apparently, an exception happened during order cancellation but I was not able to figure what was it as it's been eaten:

```
[TypeError] Cannot read property 'indexOf' of undefined

    at cancelOrder  ccxt/ccxt.js:8561  if (message.indexOf ('not found') >= 0)
```

(Line 8561 corresponds to btc-e as of version 1.9.289 but I've forward ported it to the latest commit).