### PR TITLE
Fix hasFetchTickers for btcturk, cex

### DIFF
--- a/js/btcturk.js
+++ b/js/btcturk.js
@@ -16,6 +16,7 @@ module.exports = class btcturk extends Exchange {
             'countries': 'TR', // Turkey
             'rateLimit': 1000,
             'hasCORS': true,
+            'hasFetchTickers': true,
             'hasFetchOHLCV': true,
             'timeframes': {
                 '1d': '1d',

--- a/js/cex.js
+++ b/js/cex.js
@@ -16,8 +16,8 @@ module.exports = class cex extends Exchange {
             'countries': [ 'GB', 'EU', 'CY', 'RU' ],
             'rateLimit': 1500,
             'hasCORS': true,
+            'hasFetchTickers': true,
             'hasFetchOHLCV': true,
-            'hasFetchTickers': false,
             'hasFetchOpenOrders': true,
             'timeframes': {
                 '1m': '1m',
@@ -357,7 +357,7 @@ module.exports = class cex extends Exchange {
     }
 
     async fetchOpenOrders (symbol = undefined, params = {}) {
-        await this.loadMarkets();
+        await this.loadMarkets ();
         let request = {};
         let method = 'privatePostOpenOrders';
         let market = undefined;


### PR DESCRIPTION
fetchTickers seems to be working on both of those exchanges, however feature-detection reported otherwise.

Similar cases are btcbox and jubi too, but there seem to be other issues with these, like inconsistencies between their APIs (since one is extended on the other), and not being able to get the full list of currencies.