### PR TITLE
yobit: hasFetchTickers: switched to 'false'

### DIFF
--- a/js/yobit.js
+++ b/js/yobit.js
@@ -17,6 +17,7 @@ module.exports = class yobit extends liqui {
             'version': '3',
             'hasCORS': false,
             'hasWithdraw': true,
+            'hasFetchTickers': false,
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/27766910-cdcbfdae-5eea-11e7-9859-03fea873272d.jpg',
                 'api': {


### PR DESCRIPTION
 List of all symbols is too large to go through so this method just throws an error. Switching it off entirely.