### PR TITLE
bitmex: fetchMarkets(): remove unlisted symbols from loading

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -128,6 +128,10 @@ module.exports = class bitmex extends Exchange {
         let result = [];
         for (let p = 0; p < markets.length; p++) {
             let market = markets[p];
+
+            if (market['state'] == 'Unlisted')
+              continue;
+
             let id = market['symbol'];
             let base = market['underlying'];
             let quote = market['quoteCurrency'];
@@ -208,6 +212,10 @@ module.exports = class bitmex extends Exchange {
         let tickers = await this.publicGetTradeBucketed (request);
         let ticker = tickers[0];
         let timestamp = this.milliseconds ();
+
+        if (ticker['state'] == 'Unlisted')
+          throw new ExchangeError (this.id + ': symbol ' + symbol + ' is unlisted');
+
         return {
             'symbol': symbol,
             'timestamp': timestamp,


### PR DESCRIPTION
If unlisted symbols are not removed then later interrogations with them lead to errors, like:

```
TypeError: Cannot read property 'high' of undefined
    at bitmex.fetchTicker (/root/mm/node_modules/ccxt/js/bitmex.js:215:39)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```