### PR TITLE
 okcoinusd: now handling response error codes

### DIFF
--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -183,8 +183,6 @@ module.exports = class okcoinusd extends Exchange {
             request['contract_type'] = 'this_week'; // next_week, quarter
         }
         method += 'Ticker';
-        console.log(method);
-        console.log(request);
         let response = await this[method] (this.extend (request, params));
         let timestamp = parseInt (response['date']) * 1000;
         let ticker = this.extend (response['ticker'], { 'timestamp': timestamp });

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -183,6 +183,8 @@ module.exports = class okcoinusd extends Exchange {
             request['contract_type'] = 'this_week'; // next_week, quarter
         }
         method += 'Ticker';
+        console.log(method);
+        console.log(request);
         let response = await this[method] (this.extend (request, params));
         let timestamp = parseInt (response['date']) * 1000;
         let ticker = this.extend (response['ticker'], { 'timestamp': timestamp });
@@ -498,6 +500,8 @@ module.exports = class okcoinusd extends Exchange {
         if ('result' in response)
             if (!response['result'])
                 throw new ExchangeError (this.id + ' ' + this.json (response));
+        if ('error_code' in response)
+            throw new ExchangeError (this.id + ' ' + this.json (response));
         return response;
     }
 }


### PR DESCRIPTION
```
> node examples/js/cli okex fetchTicker ETC/USD --verbose
```

The response was:
```
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at okex.Exchange.iso8601.timestamp [as iso8601] (/root/mm/node_modules/ccxt/js/base/Exchange.js:50:66)
    at okex.parseTicker (/root/mm/node_modules/ccxt/js/okcoinusd.js:154:30)
    at okex.fetchTicker (/root/mm/node_modules/ccxt/js/okcoinusd.js:188:21)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

With this fix the response is:
```
okex GET https://www.okex.com/api/v1/ticker.do?symbol=etc_usd 
Request:
 undefined undefined
okex GET https://www.okex.com/api/v1/ticker.do?symbol=etc_usd 
Response:
{"error_code":1007}
[EXCEPTION] okex {"error_code":1007}

    at request        js/okcoinusd.js:504                throw new ExchangeError (this.id + ' ' + this.json (response));
    at _tickCallback  internal/process/next_tick.js:188                                                                 

```