### PR TITLE
bitmarket: removed outdated symbol

### DIFF
--- a/js/bitmarket.js
+++ b/js/bitmarket.js
@@ -102,7 +102,6 @@ module.exports = class bitmarket extends Exchange {
                 'LTC/PLN': { 'id': 'LTCPLN', 'symbol': 'LTC/PLN', 'base': 'LTC', 'quote': 'PLN' },
                 'LTC/BTC': { 'id': 'LTCBTC', 'symbol': 'LTC/BTC', 'base': 'LTC', 'quote': 'BTC' },
                 'LiteMineX/BTC': { 'id': 'LiteMineXBTC', 'symbol': 'LiteMineX/BTC', 'base': 'LiteMineX', 'quote': 'BTC' },
-                'PlnX/BTC': { 'id': 'PlnxBTC', 'symbol': 'PlnX/BTC', 'base': 'PlnX', 'quote': 'BTC' },
             },
         });
     }


### PR DESCRIPTION
I don't see it through the web and fetching it leads to:
```
{ Error: bitmarket GET https://www.bitmarket.net/json/PlnxBTC/ticker.json 404 Not Found...
```