### PR TITLE
wex: fetchOpenOrders: work around exchange bug if we have no open orders

### DIFF
--- a/js/wex.js
+++ b/js/wex.js
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 const liqui = require ('./liqui.js')
+const { ExchangeError, InsufficientFunds, OrderNotFound, DDoSProtection } = require ('./base/errors')
 
 // ---------------------------------------------------------------------------
 

--- a/js/wex.js
+++ b/js/wex.js
@@ -88,7 +88,7 @@ module.exports = class wex extends liqui {
         let response = await this.fetch2 (path, api, method, params, headers, body);
         if ('success' in response) {
             if (response['success'] == 0 && response['error'] == 'no orders')
-              return response; // if no active orders then ActiveOrders method returns `{"success":0,"error":"no orders"}`
+                return response; // if no active orders then ActiveOrders method returns `{"success":0,"error":"no orders"}`
 
             if (!response['success']) {
                 if (response['error'].indexOf ('Not enougth') >= 0) { // not enougTh is a typo inside Liqui's own API...

--- a/js/wex.js
+++ b/js/wex.js
@@ -54,6 +54,12 @@ module.exports = class wex extends liqui {
                     ],
                 },
             },
+            'fees': {
+                'trading': {
+                    'maker': 0.2 / 100,
+                    'taker': 0.2 / 100,
+                },
+            },
         });
     }
 

--- a/js/wex.js
+++ b/js/wex.js
@@ -82,4 +82,26 @@ module.exports = class wex extends liqui {
             'info': ticker,
         };
     }
+
+    async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+        let response = await this.fetch2 (path, api, method, params, headers, body);
+        if ('success' in response) {
+            if (response['success'] == 0 && response['error'] == 'no orders')
+              return response; // if no active orders then ActiveOrders method returns `{"success":0,"error":"no orders"}`
+
+            if (!response['success']) {
+                if (response['error'].indexOf ('Not enougth') >= 0) { // not enougTh is a typo inside Liqui's own API...
+                    throw new InsufficientFunds (this.id + ' ' + this.json (response));
+                } else if (response['error'] == 'Requests too often') {
+                    throw new DDoSProtection (this.id + ' ' + this.json (response));
+                } else if ((response['error'] == 'not available') || (response['error'] == 'external service unavailable')) {
+                    throw new DDoSProtection (this.id + ' ' + this.json (response));
+                } else {
+                    throw new ExchangeError (this.id + ' ' + this.json (response));
+                }
+            }
+        }
+        return response;
+    }
+
 }


### PR DESCRIPTION
If we have no open orders then `wex` returns error:
```
wex POST https://wex.nz/tapi 
Request:
 { 'Content-Type': 'application/x-www-form-urlencoded',
  Key: 'XX-YY-ZZ',
  Sign: '0123asdf' } nonce=1510062887&method=ActiveOrders&pair=btc_usd
wex POST https://wex.nz/tapi 
Response:
{"success":0,"error":"no orders"}
```

Have no idea on how to integrate this workaround in a more organic way.
