### PR TITLE
bitflyer: fetchTicker: quoteVolume fix

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -154,7 +154,7 @@ module.exports = class bitflyer extends Exchange {
             'percentage': undefined,
             'average': undefined,
             'baseVolume': parseFloat (ticker['volume_by_product']),
-            'quoteVolume': parseFloat (ticker['volume']),
+            'quoteVolume': undefined,
             'info': ticker,
         };
     }


### PR DESCRIPTION
I don't really understand what's their 'volume' about, but definitely it's not 'quoteVolume'.

```
Symbol          | bid     | ask     | base volume | quote volume
----------------|---------|---------|-------------|----------------
BCH/BTC         | 0.08517 | 0.0869  | 722.5542892 | 722.5542892
BTC/JPY         | 838200  | 838499  | 17763.91097 | 213454.0109
BTCJPY10NOV2017 | 834501  | 843180  | 25.344666   | 213456.0109
BTCJPY17NOV2017 | 824300  | 840500  | 278.52201   | 213456.5438
ETH/BTC         | 0.04036 | 0.04049 | 4423.6201   | 4423.6201
FX_BTC_JPY      | 834958  | 835000  | 195389.5567 | 213457.3452
```