### PR TITLE
coinsecure: fetchTicker: base volume fix

### DIFF
--- a/js/coinsecure.js
+++ b/js/coinsecure.js
@@ -195,6 +195,11 @@ module.exports = class coinsecure extends Exchange {
         let response = await this.publicGetExchangeTicker (params);
         let ticker = response['message'];
         let timestamp = ticker['timestamp'];
+        let baseVolume = parseFloat (ticker['coinvolume']);
+        if (symbol == 'BTC/INR') {
+            let satoshi = 0.00000001;
+            baseVolume = baseVolume * satoshi;
+        }
         return {
             'symbol': symbol,
             'timestamp': timestamp,
@@ -211,7 +216,7 @@ module.exports = class coinsecure extends Exchange {
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': parseFloat (ticker['coinvolume']),
+            'baseVolume': baseVolume,
             'quoteVolume': parseFloat (ticker['fiatvolume']),
             'info': ticker,
         };


### PR DESCRIPTION
Apparently, they report base volume in satoshis:

```
  info: 
   { lastPrice: 49850000,
     timestamp: 1510222808264,
     bid: 49750000,
     ask: 49850000,
     fiatvolume: 6259007411,
     coinvolume: 12563400000,
     open: 49920000,
     high: 51052500,
     low: 48900000 }
```

I've made an explicit check for the symbol just in case they introduce another currency and report it differently.