### PR TITLE
binance: fetchTrades: 'buy' <=> 'sell'

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -341,11 +341,9 @@ module.exports = class binance extends Exchange {
         if ('orderId' in trade)
             order = trade['orderId'].toString ();
         if ('m' in trade) {
-            side = 'sell';
-            if (trade['m'])
-                side = 'buy';
+            side = trade['m'] ? 'sell' : 'buy';
         } else {
-            side = (trade['isBuyer']) ? 'buy' : 'sell';
+            side = (trade['isBuyer']) ? 'buy' : 'sell'; // probably should be swapped as well
         }
         let fee = undefined;
         if ('commission' in trade) {


### PR DESCRIPTION
I was pretty much unsure why no-one stumbled on it before so had to double-check it.

With this fix the trade side is consistent with what I see on their web-site as well as with what's written in their doc:

> "m": true,          // Was the buyer the maker?

(If the buyer is maker than this transaction was triggered by market sell order and vice-versa).


Side note. I also see a reference to `isBuyer` but see it neither in their doc nor in live trades. I'm reluctant to touch the code that I don't understand so just left a comment there.