### PR TITLE
binance: BCC -> BCH

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -181,8 +181,8 @@ module.exports = class binance extends Exchange {
         for (let i = 0; i < markets.length; i++) {
             let market = markets[i];
             let id = market['symbol'];
-            let base = market['baseAsset'];
-            let quote = market['quoteAsset'];
+            let base = this.commonCurrencyCode (market['baseAsset']);
+            let quote = this.commonCurrencyCode (market['quoteAsset']);
             let symbol = base + '/' + quote;
             let lot = parseFloat (market['minTrade']);
             let tickSize = parseFloat (market['tickSize']);
@@ -351,7 +351,7 @@ module.exports = class binance extends Exchange {
         if ('commission' in trade) {
             fee = {
                 'cost': parseFloat (trade['commission']),
-                'currency': trade['commissionAsset'],
+                'currency': this.commonCurrencyCode (trade['commissionAsset']),
             };
         }
         return {
@@ -533,7 +533,7 @@ module.exports = class binance extends Exchange {
 
     async withdraw (currency, amount, address, params = {}) {
         let response = await this.wapiPostWithdraw (this.extend ({
-            'asset': currency,
+            'asset': this.commonCurrencyCode (currency),
             'address': address,
             'amount': parseFloat (amount),
             'recvWindow': 10000000,


### PR DESCRIPTION
Seems like Binance uses BCC instead of BCH.