### PR TITLE
bitbay: taker/maker fees added

### DIFF
--- a/js/bitbay.js
+++ b/js/bitbay.js
@@ -71,6 +71,12 @@ module.exports = class bitbay extends Exchange {
                 'LSK/PLN': { 'id': 'LSKPLN', 'symbol': 'LSK/PLN', 'base': 'LSK', 'quote': 'PLN' },
                 'LSK/BTC': { 'id': 'LSKBTC', 'symbol': 'LSK/BTC', 'base': 'LSK', 'quote': 'BTC' },
             },
+            'fees': {
+                'trading': {
+                    'maker': 0.3 / 100,
+                    'taker': 0.0043,
+                },
+            },
         });
     }
 


### PR DESCRIPTION
Some exchanges have a complex fee structure, usually volume dependent. Still, setting a higher limit seems to be ok for market discovery.