### PR TITLE
Support futures trading api in Zaif 

### DIFF
--- a/js/zaif.js
+++ b/js/zaif.js
@@ -78,6 +78,15 @@ module.exports = class zaif extends Exchange {
                         'cancel_position',
                     ],
                 },
+                'fapi': {
+                    'get': [
+                        'groups/{group_id}',
+                        'last_price/{group_id}/{pair}',
+                        'ticker/{group_id}/{pair}',
+                        'trades/{group_id}/{pair}',
+                        'depth/{group_id}/{pair}',
+                    ],
+                },
             },
         });
     }
@@ -312,6 +321,8 @@ module.exports = class zaif extends Exchange {
         let url = this.urls['api'] + '/';
         if (api == 'public') {
             url += 'api/' + this.version + '/' + this.implodeParams (path, params);
+        } else if (api == 'fapi') {
+            url += 'fapi/' + this.version + '/' + this.implodeParams (path, params);
         } else {
             let nonce = this.nonce ();
             let query = {

--- a/js/zaif.js
+++ b/js/zaif.js
@@ -324,21 +324,18 @@ module.exports = class zaif extends Exchange {
         } else if (api == 'fapi') {
             url += 'fapi/' + this.version + '/' + this.implodeParams (path, params);
         } else {
-            let nonce = this.nonce ();
-            let query = {
-                'method': path,
-                'type': 'margin',
-                'nonce': nonce,
-            };
             if (api == 'ecapi') {
                 url += 'ecapi';
             } else if (api == 'tlapi') {
                 url += 'tlapi';
-                query['type'] = 'margin';
             } else {
                 url += 'tapi';
             }
-            body = this.urlencode (this.extend (query, params));
+            let nonce = this.nonce ();
+            body = this.urlencode (this.extend ({
+                'method': path,
+                'nonce': nonce,
+            }, params));
             headers = {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Key': this.apiKey,


### PR DESCRIPTION
- Add public futures api 

> http://techbureau-api-document.readthedocs.io/ja/latest/public_futures/index.html

- change private margin trade api in order to call futures trade api

> http://techbureau-api-document.readthedocs.io/ja/latest/trade_leverage/index.html