### PR TITLE
markets as first class citizens

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -23,8 +23,40 @@ const { ExchangeError
       , ExchangeNotAvailable } = require ('./errors')
 
 //-----------------------------------------------------------------------------
+class Market {
+    constructor (exchange, symbol) {
+        this.exchange = exchange;
+        this.symbol = symbol;
+        this.market = exchange.markets[symbol];
+    }
+
+    amountToPrecision(amount) {
+      return this.exchange.amountToPrecision(this.symbol, amount);
+    }
+    createLimitBuyOrder(amount, price) {
+      return this.exchange.createLimitBuyOrder(this.symbol, amount, price);
+    }
+    createLimitSellOrder(amount, price) {
+      return this.exchange.createLimitSellOrder(this.symbol, amount, price);
+    }
+}
+
 
 module.exports = class Exchange {
+
+    getMarket (symbol) {
+        if (!this.marketClasses)
+          this.marketClasses = {};
+
+        let marketClass = this.marketClasses[symbol];
+
+        if (marketClass)
+          return marketClass;
+
+        marketClass = new Market(this, symbol);
+        this.marketClasses[symbol] = marketClass; // only one Market instance per market
+        return marketClass;
+    }
 
     describe () { return {} }
 

--- a/testmarkets.js
+++ b/testmarkets.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const ccxt = require('./ccxt');
+const liqui = new ccxt['liqui'];
+
+async function main() {
+  await liqui.loadMarkets();
+
+  const market = liqui.getMarket('BTC/USDT');
+
+  const amount = market.amountToPrecision(1.123456789);
+  console.log(amount); // should truncate to 1.12345678
+  console.log(market.market);
+}
+
+main();


### PR DESCRIPTION
Right now we handle markets implicitly, by providing `symbol` as the first argument to market-level functions.

What if we factor out Markets as a separate class?

The client code would be much more descriptive, consider:
```
/* old way with the symbol */
let amount = exchange.amountToPrecision(symbol, amount);
exchange.createLimitSellOrder(symbol, amount, price);


/* new way */
const market = exchange.getMarket(symbol);

// move on without passing the symbol around!
let amount = market.amountToPrecision(amount);
market.createLimitSellOrder(amount, price);
```

But not only client code would benefit. `ccxt` core handle markets in two different ways: sometimes accepting `symbol` and sometimes `market` property while applying conversion in between. Consider:
```
    async fetchOrderBook (symbol, params = {}) {
        let market = this.market (symbol);
```
I see these snippets all throughout the code and if we switch to Market class all these conversions will no longer be necessary leading to more concise and cleaner implementation.

How do you feel about that?