### PR TITLE
tidex: increase rateLimit

### DIFF
--- a/js/tidex.js
+++ b/js/tidex.js
@@ -13,7 +13,7 @@ module.exports = class tidex extends liqui {
             'id': 'tidex',
             'name': 'Tidex',
             'countries': 'UK',
-            'rateLimit': 1000,
+            'rateLimit': 2000,
             'version': '3',
             // 'hasCORS': false,
             // 'hasFetchTickers': true,


### PR DESCRIPTION
With 1s I got too many DDoSProtection error.

Also the [tidex API](https://tidex.com/public-api) says:

> All information is cached every 2 seconds, so there's no point in making more frequent requests.