### PR TITLE
Fixed bug with liqui fetch order

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -452,10 +452,7 @@ module.exports = class liqui extends Exchange {
         let response = await this.privatePostOrderInfo (this.extend ({
             'order_id': parseInt (id),
         }, params));
-        id = id.toString ();
-        let order = this.parseOrder (this.extend ({ 'id': id }, response['return'][id]));
-        this.orders[id] = this.extend (this.orders[id], order);
-        return order;
+        return this.parseOrders (response['return'])[0];
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
It doesn't work, and this pull requests fixes the issue

```
    return await self.exchange.fetch_order(id=id)
  File ".venv/lib/python3.6/site-packages/ccxt/async/liqui.py", line 425, in fetch_order
    self.orders[id] = self.extend(self.orders[id], order)
KeyError: '125<redacted>'
```