### PR TITLE
Fix BTCTurk fees

### DIFF
--- a/js/btcturk.js
+++ b/js/btcturk.js
@@ -50,9 +50,9 @@ module.exports = class btcturk extends Exchange {
                 },
             },
             'markets': {
-                'BTC/TRY': { 'id': 'BTCTRY', 'symbol': 'BTC/TRY', 'base': 'BTC', 'quote': 'TRY', 'maker': 0.002, 'taker': 0.0035 },
-                'ETH/TRY': { 'id': 'ETHTRY', 'symbol': 'ETH/TRY', 'base': 'ETH', 'quote': 'TRY', 'maker': 0.002, 'taker': 0.0035 },
-                'ETH/BTC': { 'id': 'ETHBTC', 'symbol': 'ETH/BTC', 'base': 'ETH', 'quote': 'BTC', 'maker': 0.002, 'taker': 0.0035 },
+                'BTC/TRY': { 'id': 'BTCTRY', 'symbol': 'BTC/TRY', 'base': 'BTC', 'quote': 'TRY', 'maker': 0.002 * 1.18, 'taker': 0.0035 * 1.18 },
+                'ETH/TRY': { 'id': 'ETHTRY', 'symbol': 'ETH/TRY', 'base': 'ETH', 'quote': 'TRY', 'maker': 0.002 * 1.18, 'taker': 0.0035 * 1.18 },
+                'ETH/BTC': { 'id': 'ETHBTC', 'symbol': 'ETH/BTC', 'base': 'ETH', 'quote': 'BTC', 'maker': 0.002 * 1.18, 'taker': 0.0035 * 1.18 },
             },
         });
     }


### PR DESCRIPTION
BTCTurk adds VAT (KDV in Turkish) to order fees. This PR adds VAT to fees and fixes inaccurate calculation.

Sources:
BTCTurk fees: https://www.btcturk.com/yardim/komisyonlar 
Turkish VAT rate: https://www.vatlive.com/country-guides/asia/turkey/turkey-vat-compliance-and-rates/

Edit: VAT rate is 18%