### PR TITLE
ohlcv trades-based emulation

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -16,7 +16,8 @@ const { deepExtend
       , sortBy
       , aggregate
       , uuid
-      , precisionFromString } = functions
+      , precisionFromString
+      , buildOHLCV } = functions
 
 const { ExchangeError
       , NotSupported
@@ -96,7 +97,7 @@ module.exports = class Exchange {
         this.hasFetchClosedOrders = false
         this.hasFetchCurrencies   = false
         this.hasFetchMyTrades     = false
-        this.hasFetchOHLCV        = false
+        this.hasFetchOHLCV        = true
         this.hasFetchOpenOrders   = false
         this.hasFetchOrder        = false
         this.hasFetchOrderBook    = true
@@ -188,7 +189,7 @@ module.exports = class Exchange {
             'fetchCurrencies': false,
             'fetchMarkets': true,
             'fetchMyTrades': false,
-            'fetchOHLCV': false,
+            'fetchOHLCV': true,
             'fetchOpenOrders': false,
             'fetchOrder': false,
             'fetchOrderBook': true,
@@ -218,6 +219,7 @@ module.exports = class Exchange {
             journal (() => this.journal, this, Object.keys (this.has))
         }
     }
+
 
     defaults () {
         return { /* override me */ }
@@ -488,6 +490,12 @@ module.exports = class Exchange {
             currencies = await this.fetchCurrencies ()
         }
         return this.setMarkets (markets, currencies)
+    }
+
+    async fetchOHLCV (symbol, timeframe) {
+        await this.loadMarkets();
+        let trades = await this.fetchTrades (symbol, undefined, undefined, {limit: 1000});
+        return buildOHLCV (trades, timeframe);
     }
 
     fetchTickers (symbols = undefined, params = {}) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -492,10 +492,10 @@ module.exports = class Exchange {
         return this.setMarkets (markets, currencies)
     }
 
-    async fetchOHLCV (symbol, timeframe) {
+    async fetchOHLCV (symbol, since = undefined, limits = undefined, timeframe = '1m', params = {}) {
         await this.loadMarkets();
-        let trades = await this.fetchTrades (symbol, undefined, undefined, {limit: 1000});
-        return buildOHLCV (trades, timeframe);
+        let trades = await this.fetchTrades (symbol, since, limits, params);
+        return buildOHLCV (trades, since, limits, timeframe);
     }
 
     fetchTickers (symbols = undefined, params = {}) {

--- a/js/base/functions.js
+++ b/js/base/functions.js
@@ -10,6 +10,56 @@ const CryptoJS = require ('crypto-js')
 const { RequestTimeout } = require ('./errors')
 
 //-----------------------------------------------------------------------------
+
+// converts timeframe to ms
+const parseTimeframe = (timeframe) => {
+    let amount = timeframe.slice(0, -1);
+    let unit = timeframe.slice(-1);
+    let scale;
+    switch (unit) {
+        case 'm':
+            scale = 60;
+            break;
+        case 'h':
+            scale = 60 * 60;
+            break;
+        case 'd':
+            scale = 60 * 60 * 24;
+            break;
+        case 'M':
+            scale = 60 * 60 * 24 * 30;
+            break;
+        default:
+            throw Error(`unknown timeframe unit: '${unit}'`);
+    }
+    return amount * scale;
+}
+
+// given a sorted arrays of trades (recent first) and a timeframe builds an array of OHLCV candles
+const buildOHLCV = (trades, timeframe) => {
+    let ms = parseTimeframe (timeframe) * 1000;
+    let ohlcvs = [];
+    const [/* timestamp */, /* open */, high, low, close, volume] = [0, 1, 2, 3, 4, 5];
+
+    for (let i = trades.length - 1; i >= 0; i--) {
+        let trade = trades[i];
+        let openingTime = Math.floor (trade.timestamp / ms) * ms; // shift to the edge of m/h/d (but not M)
+        let j = ohlcvs.length;
+        
+        if (j == 0 || openingTime >= ohlcvs[j-1][0] + ms) {
+            // moved to a new timeframe -> create a new candle from opening trade
+            ohlcvs.push([openingTime, trade.price, trade.price, trade.price, trade.price, trade.amount]);
+        } else {
+            // still processing the same timeframe -> update opening trade
+            ohlcvs[j-1][high] = Math.max (ohlcvs[j-1][high], trade.price);
+            ohlcvs[j-1][low] = Math.min (ohlcvs[j-1][low], trade.price);
+            ohlcvs[j-1][close] = trade.price;
+            ohlcvs[j-1][volume] += trade.amount;
+        } // if
+    } // for
+    return ohlcvs;
+}
+
 // utility helpers
 
 const setTimeout_safe = (done, ms, targetTime = Date.now () + ms) => { // setTimeout can fire earlier than specified, so we need to ensure it does not happen...
@@ -283,6 +333,9 @@ const jwt = (request, secret, alg = 'HS256', hash = 'sha256') => {
 //-----------------------------------------------------------------------------
 
 module.exports = {
+
+    buildOHLCV,
+
 
     // common utility functions
 

--- a/js/base/functions.js
+++ b/js/base/functions.js
@@ -36,16 +36,17 @@ const parseTimeframe = (timeframe) => {
 }
 
 // given a sorted arrays of trades (recent first) and a timeframe builds an array of OHLCV candles
-const buildOHLCV = (trades, timeframe) => {
+const buildOHLCV = (trades, since = -Infinity, limits = Infinity, timeframe = '1m') => {
     let ms = parseTimeframe (timeframe) * 1000;
     let ohlcvs = [];
     const [/* timestamp */, /* open */, high, low, close, volume] = [0, 1, 2, 3, 4, 5];
 
-    for (let i = trades.length - 1; i >= 0; i--) {
+    for (let i = Math.min(trades.length - 1, limits); i >= 0; i--) {
         let trade = trades[i];
+        if (trade.timestamp < since) continue;
         let openingTime = Math.floor (trade.timestamp / ms) * ms; // shift to the edge of m/h/d (but not M)
         let j = ohlcvs.length;
-        
+
         if (j == 0 || openingTime >= ohlcvs[j-1][0] + ms) {
             // moved to a new timeframe -> create a new candle from opening trade
             ohlcvs.push([openingTime, trade.price, trade.price, trade.price, trade.price, trade.amount]);


### PR DESCRIPTION
Now one can go with any exchange with smth like:

```
:air:~/src/ccxt max$ node examples/js/cli.js wex fetchOHLCV BTC/USD 30m
[ [ 1511843400000, 9587.999, 9637.848, 9567.64, 9637.848, 10.517885140000026 ],
  [ 1511845200000, 9638.758, 9665.57, 9638.758, 9665.57, 11.138057089999998 ] ]
```

Things to note:
- it works on sorted (recent first) trades. instead of sorting them unconditionally I'd prefer to sort that outlier specifically. what do you think?
- i don't know where it'd be better to position these functions in the code, therefore placed them near the top of the modules. move them as you please
- if/when fetchTrades provides a unified api for `since`/`limits` we may integrate with it more gracefully