### PR TITLE
add constructor definition to Exchange

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -58,6 +58,8 @@ declare module 'ccxt' {
 
     export class Exchange {
 
+        constructor(userConfig?: {});
+
         readonly rateLimit: number;
         readonly hasFetchOHLCV: boolean;
 


### PR DESCRIPTION
#693 
as discussed quick fix to allow typescript to compile with the current typings.
