### PR TITLE
Fix Error/Warning: A non-numeric value encountered

### DIFF
--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -396,7 +396,7 @@ class Exchange {
         } else {
             $t = mktime ($h, $m, $s, $mm, $dd, $yyyy, 0);
         }
-        $t += $hours * 3600 + $minutes * 60;
+        $t += (int)$hours * 3600 + (int)$minutes * 60;
         $t *= 1000;
         return $t;
     }


### PR DESCRIPTION
We Need to cast the vars as int else i got this error in a laravel command : 

`Error: A non-numeric value encountered`

And it's very anoying to debug because no line number is shown

Thanks