### PR TITLE
bitfinex: now throws InsufficientFunds exception

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -363,7 +363,7 @@ module.exports = class Exchange {
 
     defaultErrorHandler (code, reason, url, method, headers, body) {
         if (this.verbose)
-            console.log (this.id, method, url, body ? ("\nResponse:\n" + body) : '')
+            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '')
         if ((code >= 200) && (code <= 300))
             return body
         let error = undefined

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -578,12 +578,16 @@ module.exports = class bitfinex extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body) {
+        if (this.verbose)
+            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '')
         if (code == 400) {
             if (body[0] == "{") {
                 let response = JSON.parse (body);
                 let message = response['message'];
                 if (message.indexOf ('Key price should be a decimal number') >= 0) {
                     throw new InvalidOrder (this.id + ' ' + message);
+                } else if (message.indexOf ('Invalid order: not enough exchange balance') >= 0) {
+                    throw new InsufficientFunds (this.id + ' ' + message);
                 } else if (message.indexOf ('Invalid order') >= 0) {
                     throw new InvalidOrder (this.id + ' ' + message);
                 }
@@ -595,8 +599,6 @@ module.exports = class bitfinex extends Exchange {
     async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let response = await this.fetch2 (path, api, method, params, headers, body);
         if ('message' in response) {
-            if (response['message'].indexOf ('not enough exchange balance') >= 0)
-                throw new InsufficientFunds (this.id + ' ' + this.json (response));
             throw new ExchangeError (this.id + ' ' + this.json (response));
         }
         return response;

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -578,8 +578,9 @@ module.exports = class bitfinex extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body) {
-        if (this.verbose)
+        if (this.verbose) {
             console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '');
+        }
         if (code == 400) {
             if (body[0] == "{") {
                 let response = JSON.parse (body);

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -579,7 +579,7 @@ module.exports = class bitfinex extends Exchange {
 
     handleErrors (code, reason, url, method, headers, body) {
         if (this.verbose)
-            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '')
+            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '');
         if (code == 400) {
             if (body[0] == "{") {
                 let response = JSON.parse (body);

--- a/js/test/testbfx.js
+++ b/js/test/testbfx.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const ccxt = require('../../ccxt');
+const keys = require('../../zero-balance-keys.json');
+const ex = 'bitfinex';
+const bfx = new ccxt[ex](keys[ex]);
+
+
+async function main() {
+  await bfx.loadMarkets();
+  try {
+    await bfx.createLimitBuyOrder('BTC/USD', 1000, 1000);
+  } catch (e) {
+    if (e instanceof ccxt.InsufficientFunds) {
+      // swallow
+    } else {
+      throw e;
+    }
+  }
+}
+
+main();
+


### PR DESCRIPTION
bug:
- the exception was never thrown (it was checked in a bit wrong place)
- there still remains a `throw new ExchangeError` one line down - not sure if it ever gets called. but as I'm not sure I left it as is

a side note:
- while chasing this bug I've got lost for a moment in `Exchange`s request/response promise chains... is it done on purpose? wouldn't async/await be more obvious?

- as a side effect, I extended verbose output for `Exchange` default handler. hope it won't hurt but might be handy

tests:
- order management testcases are commented out in your tests... and they do not check for `InsufficientFunds` anyway
- and as such I added a testcase for that in a separate file - it won't be a part of the suite but just in case you want to test the fix it'll save you a minute
