### PR TITLE
wex: error handling: false positive on public endpoints

### DIFF
--- a/js/wex.js
+++ b/js/wex.js
@@ -98,6 +98,10 @@ module.exports = class wex extends liqui {
             }
             let response = JSON.parse (body);
             let success = this.safeValue (response, 'success');
+            if (success == undefined) {
+                // response from public endpoints does not contain 'success'
+                return;
+            }
             if (!success) {
                 let error = this.safeValue (response, 'error');
                 if (!error) {


### PR DESCRIPTION
It didn't pass newly created testcases.

You don't have testing keys for wex, that's why you probably didn't run them.