### PR TITLE
examples: fs.readFileSync -> require

### DIFF
--- a/examples/js/bcc-vs-bch.js
+++ b/examples/js/bcc-vs-bch.js
@@ -3,7 +3,7 @@
 const ccxt      = require ('../../ccxt.js')
 const asTable   = require ('as-table')
 const log       = require ('ololog').configure ({ locate: false })
-const fs        = require ('fs')
+const config    = require ('../../keys')
 
 
 require ('ansicolor').nice;
@@ -29,9 +29,6 @@ let proxies = [
                 substituteCommonCurrencyCodes: true,
             })
     })
-
-    // load api keys from config
-    let config = JSON.parse (fs.readFileSync ('./keys.json', 'utf8'))
 
     // set up api keys appropriately
     for (let id in config) {

--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -8,7 +8,7 @@ const verbose = process.argv.includes ('--verbose')
 //-----------------------------------------------------------------------------
 
 const ccxt      = require ('../../ccxt.js')
-const fs        = require ('fs')
+const config    = require ('../../keys')
 const asTable   = require ('as-table')
 const util      = require ('util')
 const log       = require ('ololog').configure ({ locate: false })
@@ -28,7 +28,7 @@ const exchange = new (ccxt)[exchangeId] ({ verbose })
 
 //-----------------------------------------------------------------------------
 
-let apiKeys = JSON.parse (fs.readFileSync ('./keys.json', 'utf8'))[exchangeId]
+let apiKeys = config[exchangeId];
 
 Object.assign (exchange, apiKeys)
 


### PR DESCRIPTION
We (users) usually take examples as references and copypaste a code from them from time to time.

Not everybody knows that node's `require` could be used instead of `readFileSync` so we may spread the knowledge!