### PR TITLE
Improved typings

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -1,61 +1,82 @@
 declare module 'ccxt' {
 
-    export interface Market {
-        id: string;
-        symbol: string;
+    // error.js -----------------------------------------
+    export class BaseError extends Error {
+        constructor(message: string);
+    }
+
+    export class ExchangeError extends BaseError {
+        constructor(message: string);
+    }
+
+    export class NotSupported extends ExchangeError {
+        constructor(message: string);
+    }
+
+    export class AuthenticationError extends ExchangeError {
+        constructor(message: string);
+    }
+
+    export class InvalidNonce extends ExchangeError {
+        constructor(message: string);
+    }
+
+    export class InsufficientFunds extends ExchangeError {
+        constructor(message: string);
+    }
+
+    export class InvalidOrder extends ExchangeError {
+        constructor(message: string);
+    }
+
+    export class OrderNotFound extends InvalidOrder {
+        constructor(message: string);
+    }
+
+    export class OrderNotCached extends InvalidOrder {
+        constructor(message: string);
+    }
+
+    export class CancelPending extends InvalidOrder {
+        constructor(message: string);
+    }
+
+    export class NetworkError extends BaseError {
+        constructor(message: string);
+    }
+
+    export class DDoSProtection extends NetworkError {
+        constructor(message: string);
+    }
+
+    export class RequestTimeout extends NetworkError {
+        constructor(message: string);
+    }
+
+    export class ExchangeNotAvailable extends NetworkError {
+        constructor(message: string);
+    }
+
+    // -----------------------------------------------
+
+    export interface IMinMax {
+        max: number;
+        min: number;
+    }
+
+    export interface IMarket {
+        [key: string]: any
         base: string;
-        quote: string;
+        id: string;
         info: any;
+        limits: { amount: IMinMax, price: IMinMax, cost?: IMinMax };
         lot: number;
+        precision: { amount: number, price: number };
+        quote: string;
+        symbol: string;
     }
 
-    export interface OrderBook {
-        bids: number[][];
-        asks: number[][];
-        timestamp: number;
-        datetime: string;
-    }
-
-    export interface Trade {
-        info: {};                  // the original decoded JSON as is
-        id: string;                // string trade id
-        timestamp: number;         // Unix timestamp in milliseconds
-        datetime: string;          // ISO8601 datetime with milliseconds;
-        symbol: string;            // symbol in CCXT format
-        order?: string;            // string order id or undefined/None/null
-        type?: 'market' | 'limit'; // order type, 'market', 'limit' or undefined/None/null
-        side: 'buy' | 'sell';
-        price: number;             // float price in quote currency
-        amount: number;            // amount of base currency
-    }
-
-    export interface Ticker {
-        symbol: string,
-        timestamp: number,
-        datetime: string,
-        high: number,
-        low: number,
-        bid: number,
-        ask: number,
-        vwap?: number,
-        open?: number,
-        close?: number,
-        first?: number,
-        last?: number,
-        change?: number,
-        percentage?: number,
-        average?: number,
-        baseVolume?: number,
-        quoteVolume?: number,
-        info: {}
-    }
-
-    export class Tickers {
-        info: any;
-        [symbol: string]: Ticker;
-    }
-    
-    export interface Order {
+    export interface IOrder {
         id: string,
         info: {},
         timestamp: number,
@@ -72,150 +93,296 @@ declare module 'ccxt' {
         fee: number
     }
 
-    export interface Balance {
+    export interface IMarketInfo {
+        exchange: Exchange;
+        symbol: string;
+        market: IMarket;
+    }
+
+    export interface IOrderBook {
+        asks: [number, number][];
+        bids: [number, number][];
+        datetime: string;
+        timestamp: number;
+    }
+
+    export interface Trade {
+        amount: number;            // amount of base currency
+        datetime: string;          // ISO8601 datetime with milliseconds;
+        id: string;                // string trade id
+        info: {};                  // the original decoded JSON as is
+        order?: string;            // string order id or undefined/None/null
+        price: number;             // float price in quote currency
+        timestamp: number;         // Unix timestamp in milliseconds
+        type?: 'market' | 'limit'; // order type, 'market', 'limit' or undefined/None/null
+        side: 'buy' | 'sell';
+        symbol: string;            // symbol in CCXT format
+    }
+
+    export interface ITicker {
+        ask: number;
+        average?: number;
+        baseVolume?: number;
+        bid: number;
+        change?: number;
+        close?: number;
+        datetime: string;
+        first?: number;
+        high: number;
+        info: object;
+        last?: number;
+        low: number;
+        open?: number;
+        percentage?: number;
+        quoteVolume?: number;
+        symbol: string,
+        timestamp: number;
+        vwap?: number;
+    }
+
+    export interface ITickers {
+        info: any;
+        [symbol: string]: ITicker;
+    }
+
+    export interface ICurrency {
+        id: string;
+        code: string;
+    }
+
+    export interface IBalance {
         free: number,
         used: number,
         total: number
     }
 
-    export class Balances {
+    export interface IBalances {
         info: any;
-        [key: string]: Balance;
+        [key: string]: IBalance;
     }
 
-    // timestamp, open, high, low, close, volume
     export type OHLCV = [number, number, number, number, number, number];
 
     export class Exchange {
+        constructor(config?: {[key in keyof Exchange]?: Exchange[key]});
+        // allow dynamic keys
+        [key: string]: any;
 
-        constructor(userConfig?: {});
+        // properties
+        hash: any;
+        hmac: any;
+        jwt: any;
+        binaryConcat: any;
+        stringToBinary: any;
+        stringToBase64: any;
+        base64ToBinary: any;
+        base64ToString: any;
+        binaryToString: any;
+        utf16ToBase64: any;
+        urlencode: any;
+        pluck: any;
+        unique: any;
+        extend: any;
+        deepExtend: any;
+        flatten: any;
+        groupBy: any;
+        indexBy: any;
+        sortBy: any;
+        keysort: any;
+        decimal: any;
+        safeFloat: any;
+        safeString: any;
+        safeInteger: any;
+        safeValue: any;
+        capitalize: any;
+        json: JSON["stringify"]
+        sum: any;
+        ordered: any;
+        aggregate: any;
+        truncate: any;
+        name: string;
+        nodeVersion: string;
+        fees: object;
+        enableRateLimit: boolean;
+        countries: string;
+        // set by loadMarkets
+        markets: { [symbol: string]: IMarket };
+        marketsById: { [id: string]: IMarket };
+        currencies: { [symbol: string]: ICurrency };
+        ids: string[];
+        symbols: string[];
+        id: string;
+        proxy: string;
+        parse8601: typeof Date.parse
+        milliseconds: typeof Date.now;
+        rateLimit: number;  // milliseconds = seconds * 1000
+        timeout: number; // milliseconds
+        verbose: boolean;
+        twofa: boolean;// two-factor authentication
+        substituteCommonCurrencyCodes: boolean;
+        timeframes: any;
+        hasPublicAPI: boolean;
+        hasPrivateAPI: boolean;
+        hasCORS: boolean;
+        hasFetchTicker: boolean;
+        hasFetchOrderBook: boolean;
+        hasFetchTrades: boolean;
+        hasFetchTickers: boolean;
+        hasFetchOHLCV: boolean;
+        hasFetchOrder: boolean;
+        hasFetchOrders: boolean;
+        hasFetchOpenOrders: boolean;
+        hasFetchClosedOrders: boolean;
+        hasFetchMyTrades: boolean;
+        hasDeposit: boolean;
+        hasWithdraw: boolean;
+        hasCreateOrder: boolean;
+        hasCancelOrder: boolean;
+        balance: object;
+        orderbooks: object;
+        orders: object;
+        trades: object;
+        userAgent: { 'User-Agent': string } | false;
 
-        readonly rateLimit: number;
-        readonly hasFetchOHLCV: boolean;
-
-        public verbose: boolean;
-        public substituteCommonCurrencyCodes: boolean;
-        public hasFetchTickers: boolean;
-        
-        fetch (url: string, method: string, headers?: any, body?: any): Promise<any>;
-        handleResponse (url: string, method: string, headers?: any, body?: any): any;
-        loadMarkets (reload?: boolean): Promise<Market[]>;
-        fetchOrderStatus (id: string, market: string): Promise<string>;
-        account (): any;
-        commonCurrencyCode (currency: string): string;
-        market (symbol: string): Market;
-        marketId (symbol: string): string;
-        marketIds (symbols: string): string[];
-        symbol (symbol: string): string;
-        createOrder (market: string, type: string, side: string, amount: string, price?: string, params?: any): Promise<any>;
-        fetchBalance (params?: any): Promise<Balances>;
-        fetchOrderBook (market: string, params?: any): Promise<OrderBook>;
-        fetchTicker (market: string): Promise<Ticker>;
-        fetchTickers (): Promise<Tickers>;
-        fetchTrades (symbol: string, params?: {}): Promise<Trade[]>;
-        fetchOHLCV? (symbol: string, params?: {}): Promise<OHLCV[]>;
-        fetchOrders (symbol?: string, params?: {}): Promise<Order[]>;
-        fetchOpenOrders (symbol?: string, params?: {}): Promise<Order[]>;
-        cancelOrder (id: string): Promise<any>;
-        deposit (currency: string, amount: string, address: string, params?: any): Promise<any>;
-        withdraw (currency: string, amount: string, address: string, params?: any): Promise<any>;
-        request (path: string, api?: string, method?: string, params?: any, headers?: any, body?: any): Promise<any>;
+        // methods
+        getMarket(symbol: string): IMarket;
+        describe(): any;
+        defaults(): any;
+        nonce(): number;
+        encodeURIComponent(...args: any[]): string;
+        checkRequiredCredentials(): void;
+        initRestRateLimiter(): void;
+        handleResponse(url: string, method: string, headers?: any, body?: any): any;
+        defineRestApi(api: any, methodName: any, options?: { [x: string]: any }): void;
+        fetch(url: string, method?: string, headers?: any, body?: any): Promise<any>;
+        fetch2(path: any, api?: string, method?: string, params?: { [x: string]: any }, headers?: any, body?: any): Promise<any>;
+        setMarkets(markets: IMarket[], currencies?: ICurrency[]): { [symbol: string]: IMarket };
+        loadMarkets(reload?: boolean): Promise<{ [symbol: string]: IMarket }>;
+        fetchTicker(symbol: string, params?: { [x: string]: any }): Promise<ITicker>;
+        fetchTickers(symbols?: string[], params?: { [x: string]: any }): Promise<{ [x: string]: ITicker }>;
+        fetchMarkets(): Promise<IMarket[]>;
+        fetchOrderBook(symbol: string): Promise<IOrderBook>;
+        fetchOrderStatus(id: string, market: string): Promise<string>;
+        encode(str: string): string;
+        decode(str: string): string;
+        account(): IBalance;
+        commonCurrencyCode(currency: string): string;
+        market(symbol: string): IMarket;
+        marketId(symbol: string): string;
+        marketIds(symbols: string[]): string[];
+        symbol(symbol: string): string;
+        extractParams(str: string): string[];
+        createOrder(market: string, type: string, side: string, amount: string, price?: string, params?: string): Promise<any>;
+        fetchBalance(params?: any): Promise<IBalances>;
+        fetchOrderBook(market: string, params?: any): Promise<IOrderBook>;
+        fetchTicker(market: string): Promise<ITicker>;
+        fetchTickers(): Promise<ITickers>;
+        fetchTrades(symbol: string, params?: {}): Promise<Trade[]>;
+        fetchOHLCV?(symbol: string, params?: {}): Promise<OHLCV[]>;
+        fetchOrders(symbol?: string, params?: {}): Promise<IOrder[]>;
+        fetchOpenOrders(symbol?: string, params?: {}): Promise<IOrder[]>;
+        cancelOrder(id: string): Promise<any>;
+        deposit(currency: string, amount: string, address: string, params?: any): Promise<any>;
+        withdraw(currency: string, amount: string, address: string, params?: any): Promise<any>;
+        request(path: string, api?: string, method?: string, params?: any, headers?: any, body?: any): Promise<any>;
+        YmdHMS(timestamp: string, infix: string) : string;
+        iso8601(timestamp: string): string;
+        seconds(): number;
+        microseconds(): number;
     }
 
-    /* tslint:disable */
-
-    export class _1broker extends Exchange {}
-    export class _1btcxe extends Exchange {}
-    export class acx extends Exchange {}
-    export class allcoin extends okcoinusd {}
-    export class anxpro extends Exchange {}
-    export class binance extends Exchange {}
-    export class bit2c extends Exchange {}
-    export class bitbay extends Exchange {}
-    export class bitcoincoid extends Exchange {}
-    export class bitfinex extends Exchange {}
-    export class bitfinex2 extends bitfinex {}
-    export class bitflyer extends Exchange {}
-    export class bithumb extends Exchange {}
-    export class bitlish extends Exchange {}
-    export class bitmarket extends Exchange {}
-    export class bitmex extends Exchange {}
-    export class bitso extends Exchange {}
-    export class bitstamp extends Exchange {}
-    export class bitstamp1 extends Exchange {}
-    export class bittrex extends Exchange {}
-    export class bl3p extends Exchange {}
-    export class bleutrade extends bittrex {}
-    export class btcbox extends Exchange {}
-    export class btcchina extends Exchange {}
-    export class btcexchange extends btcturk {}
-    export class btcmarkets extends Exchange {}
-    export class btctradeua extends Exchange {}
-    export class btcturk extends Exchange {}
-    export class btcx extends Exchange {}
-    export class bter extends Exchange {}
-    export class bxinth extends Exchange {}
-    export class ccex extends Exchange {}
-    export class cex extends Exchange {}
-    export class chbtc extends zb {}
-    export class chilebit extends foxbit {}
-    export class coincheck extends Exchange {}
-    export class coinfloor extends Exchange {}
-    export class coingi extends Exchange {}
-    export class coinmarketcap extends Exchange {}
-    export class coinmate extends Exchange {}
-    export class coinsecure extends Exchange {}
-    export class coinspot extends Exchange {}
-    export class cryptopia extends Exchange {}
-    export class dsx extends liqui {}
-    export class exmo extends Exchange {}
-    export class flowbtc extends Exchange {}
-    export class foxbit extends Exchange {}
-    export class fybse extends Exchange {}
-    export class fybsg extends fybse {}
-    export class gatecoin extends Exchange {}
-    export class gateio extends bter {}
-    export class gdax extends Exchange {}
-    export class gemini extends Exchange {}
-    export class hitbtc extends Exchange {}
-    export class hitbtc2 extends hitbtc {}
-    export class huobi extends Exchange {}
-    export class huobicny extends huobipro {}
-    export class huobipro extends Exchange {}
-    export class independentreserve extends Exchange {}
-    export class itbit extends Exchange {}
-    export class jubi extends btcbox {}
-    export class kraken extends Exchange {}
-    export class kuna extends acx {}
-    export class lakebtc extends Exchange {}
-    export class liqui extends Exchange {}
-    export class livecoin extends Exchange {}
-    export class luno extends Exchange {}
-    export class mercado extends Exchange {}
-    export class mixcoins extends Exchange {}
-    export class nova extends Exchange {}
-    export class okcoincny extends okcoinusd {}
-    export class okcoinusd extends Exchange {}
-    export class okex extends okcoinusd {}
-    export class paymium extends Exchange {}
-    export class poloniex extends Exchange {}
-    export class qryptos extends Exchange {}
-    export class quadrigacx extends Exchange {}
-    export class quoine extends qryptos {}
-    export class southxchange extends Exchange {}
-    export class surbitcoin extends foxbit {}
-    export class therock extends Exchange {}
-    export class tidex extends liqui {}
-    export class urdubit extends foxbit {}
-    export class vaultoro extends Exchange {}
-    export class vbtc extends foxbit {}
-    export class virwox extends Exchange {}
-    export class wex extends liqui {}
-    export class xbtce extends Exchange {}
-    export class yobit extends liqui {}
-    export class yunbi extends acx {}
-    export class zaif extends Exchange {}
-    export class zb extends Exchange {}
-
-    /* tslint:enable */
+    export const exchanges: string[];
+    export const version: string;
+    export class _1broker extends Exchange { }
+    export class _1btcxe extends Exchange { }
+    export class acx extends Exchange { }
+    export class allcoin extends okcoinusd { }
+    export class anxpro extends Exchange { }
+    export class binance extends Exchange { }
+    export class bit2c extends Exchange { }
+    export class bitbay extends Exchange { }
+    export class bitcoincoid extends Exchange { }
+    export class bitfinex extends Exchange { }
+    export class bitfinex2 extends bitfinex { }
+    export class bitflyer extends Exchange { }
+    export class bithumb extends Exchange { }
+    export class bitlish extends Exchange { }
+    export class bitmarket extends Exchange { }
+    export class bitmex extends Exchange { }
+    export class bitso extends Exchange { }
+    export class bitstamp extends Exchange { }
+    export class bitstamp1 extends Exchange { }
+    export class bittrex extends Exchange { }
+    export class bl3p extends Exchange { }
+    export class bleutrade extends bittrex { }
+    export class btcbox extends Exchange { }
+    export class btcchina extends Exchange { }
+    export class btcexchange extends btcturk { }
+    export class btcmarkets extends Exchange { }
+    export class btctradeua extends Exchange { }
+    export class btcturk extends Exchange { }
+    export class btcx extends Exchange { }
+    export class bter extends Exchange { }
+    export class bxinth extends Exchange { }
+    export class ccex extends Exchange { }
+    export class cex extends Exchange { }
+    export class chbtc extends zb { }
+    export class chilebit extends foxbit { }
+    export class coincheck extends Exchange { }
+    export class coinfloor extends Exchange { }
+    export class coingi extends Exchange { }
+    export class coinmarketcap extends Exchange { }
+    export class coinmate extends Exchange { }
+    export class coinsecure extends Exchange { }
+    export class coinspot extends Exchange { }
+    export class cryptopia extends Exchange { }
+    export class dsx extends liqui { }
+    export class exmo extends Exchange { }
+    export class flowbtc extends Exchange { }
+    export class foxbit extends Exchange { }
+    export class fybse extends Exchange { }
+    export class fybsg extends fybse { }
+    export class gatecoin extends Exchange { }
+    export class gateio extends bter { }
+    export class gdax extends Exchange { }
+    export class gemini extends Exchange { }
+    export class hitbtc extends Exchange { }
+    export class hitbtc2 extends hitbtc { }
+    export class huobi extends Exchange { }
+    export class huobicny extends huobipro { }
+    export class huobipro extends Exchange { }
+    export class independentreserve extends Exchange { }
+    export class itbit extends Exchange { }
+    export class jubi extends btcbox { }
+    export class kraken extends Exchange { }
+    export class kuna extends acx { }
+    export class lakebtc extends Exchange { }
+    export class liqui extends Exchange { }
+    export class livecoin extends Exchange { }
+    export class luno extends Exchange { }
+    export class mercado extends Exchange { }
+    export class mixcoins extends Exchange { }
+    export class nova extends Exchange { }
+    export class okcoincny extends okcoinusd { }
+    export class okcoinusd extends Exchange { }
+    export class okex extends okcoinusd { }
+    export class paymium extends Exchange { }
+    export class poloniex extends Exchange { }
+    export class qryptos extends Exchange { }
+    export class quadrigacx extends Exchange { }
+    export class quoine extends qryptos { }
+    export class southxchange extends Exchange { }
+    export class surbitcoin extends foxbit { }
+    export class therock extends Exchange { }
+    export class tidex extends liqui { }
+    export class urdubit extends foxbit { }
+    export class vaultoro extends Exchange { }
+    export class vbtc extends foxbit { }
+    export class virwox extends Exchange { }
+    export class wex extends liqui { }
+    export class xbtce extends Exchange { }
+    export class yobit extends liqui { }
+    export class yunbi extends acx { }
+    export class zaif extends Exchange { }
+    export class zb extends Exchange { }
 }

--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -1,5 +1,5 @@
 declare module 'ccxt' {
-
+    
     // error.js -----------------------------------------
     export class BaseError extends Error {
         constructor(message: string);
@@ -64,7 +64,7 @@ declare module 'ccxt' {
         min: number;
     }
 
-    export interface IMarket {
+    export interface IMarketInfo {
         [key: string]: any
         base: string;
         id: string;
@@ -74,6 +74,15 @@ declare module 'ccxt' {
         precision: { amount: number, price: number };
         quote: string;
         symbol: string;
+    }
+
+    export interface IMarket {
+        exchange: Exchange;
+        symbol: string;
+        market: IMarketInfo;
+        amountToPrecision(amount: number): number;
+        createLimitBuyOrder(amount: number, price: number): any;
+        createLimitSellOrder(amount: number, price: number): any;
     }
 
     export interface IOrder {
@@ -91,12 +100,6 @@ declare module 'ccxt' {
         filled: number,
         remaining: number,
         fee: number
-    }
-
-    export interface IMarketInfo {
-        exchange: Exchange;
-        symbol: string;
-        market: IMarket;
     }
 
     export interface IOrderBook {
@@ -167,7 +170,6 @@ declare module 'ccxt' {
         constructor(config?: {[key in keyof Exchange]?: Exchange[key]});
         // allow dynamic keys
         [key: string]: any;
-
         // properties
         hash: any;
         hmac: any;
@@ -206,8 +208,8 @@ declare module 'ccxt' {
         enableRateLimit: boolean;
         countries: string;
         // set by loadMarkets
-        markets: { [symbol: string]: IMarket };
-        marketsById: { [id: string]: IMarket };
+        markets: { [symbol: string]: IMarketInfo };
+        marketsById: { [id: string]: IMarketInfo };
         currencies: { [symbol: string]: ICurrency };
         ids: string[];
         symbols: string[];
@@ -256,18 +258,18 @@ declare module 'ccxt' {
         defineRestApi(api: any, methodName: any, options?: { [x: string]: any }): void;
         fetch(url: string, method?: string, headers?: any, body?: any): Promise<any>;
         fetch2(path: any, api?: string, method?: string, params?: { [x: string]: any }, headers?: any, body?: any): Promise<any>;
-        setMarkets(markets: IMarket[], currencies?: ICurrency[]): { [symbol: string]: IMarket };
-        loadMarkets(reload?: boolean): Promise<{ [symbol: string]: IMarket }>;
+        setMarkets(markets: IMarketInfo[], currencies?: ICurrency[]): { [symbol: string]: IMarketInfo };
+        loadMarkets(reload?: boolean): Promise<{ [symbol: string]: IMarketInfo }>;
         fetchTicker(symbol: string, params?: { [x: string]: any }): Promise<ITicker>;
         fetchTickers(symbols?: string[], params?: { [x: string]: any }): Promise<{ [x: string]: ITicker }>;
-        fetchMarkets(): Promise<IMarket[]>;
+        fetchMarkets(): Promise<IMarketInfo[]>;
         fetchOrderBook(symbol: string): Promise<IOrderBook>;
         fetchOrderStatus(id: string, market: string): Promise<string>;
         encode(str: string): string;
         decode(str: string): string;
         account(): IBalance;
         commonCurrencyCode(currency: string): string;
-        market(symbol: string): IMarket;
+        market(symbol: string): IMarketInfo;
         marketId(symbol: string): string;
         marketIds(symbols: string[]): string[];
         symbol(symbol: string): string;

--- a/transpile.js
+++ b/transpile.js
@@ -674,7 +674,8 @@ const pythonRegexes = [
 
     const classes = transpileDerivedExchangeFiles ('./js/')
 
-    exportTypeScriptDeclarations (classes)
+    // HINT: if we're going to support specific class definitions this process won't work anymore as it will override the definitions.
+    // exportTypeScriptDeclarations (classes)
 
     transpilePythonAsyncToSync ('./python/test/test_async.py', './python/test/test.py')
 


### PR DESCRIPTION
@kroitor, on second thoughts... I'm still working in a `typescript` port of this library but for the moment I'm providing this typings file with more API support. 

I've also merged #764 and #705 as per your [previous request](https://github.com/ccxt/ccxt/pull/771#issuecomment-349820321).

**IMPORTANT**: #705 makes it not possible to use the `exportTypeScriptDeclarations` method in `transpile.js` as it would completely override specific exchange typings. I've left a comment there to remind us why it's not working.

I hope this gets merged soon so all typescripters can be happier while using your amazing and awesome library! 😜 

**Note**:  this PR is related to #771