### PR TITLE
Missing new keyword

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -555,7 +555,7 @@ module.exports = class poloniex extends Exchange {
             if (orders[i]['id'] == id)
                 return orders[i];
         }
-        throw OrderNotCached (this.id + ' order id ' + id.toString () + ' not found in cache');
+        throw new OrderNotCached (this.id + ' order id ' + id.toString () + ' not found in cache');
     }
 
     filterOrdersByStatus (orders, status) {


### PR DESCRIPTION
Hello, 

Seems that `js\poloniex.js` is missing a `new` keyword when throwing an Error OrderNotCached.

Regards,