### PR TITLE
Unify anxpro side parameter when creating orders

### DIFF
--- a/js/anxpro.js
+++ b/js/anxpro.js
@@ -152,6 +152,10 @@ module.exports = class anxpro extends Exchange {
         };
         if (type == 'limit')
             order['price_int'] = parseInt (price * 100000); // 10^5
+        if (side == 'buy')
+            order['type'] = 'bid';
+        if (side == 'sell')
+            order['type'] = 'ask';
         let result = await this.privatePostCurrencyPairOrderAdd (this.extend (order, params));
         return {
             'info': result,


### PR DESCRIPTION
Anxpro available values for type parameter are bid and ask. According to ccxt docs, side parameter should be buy or sell.