### PR TITLE
Fixed livecoin order cancel

### DIFF
--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -356,7 +356,9 @@ module.exports = class livecoin extends Exchange {
         };
     }
 
-    async cancelOrder (id, symbol, params = {}) {
+    async cancelOrder (id, symbol = undefined, params = {}) {
+        if (!symbol)
+            throw new ExchangeError (this.id + ' cancelOrder requires a symbol argument');
         await this.loadMarkets ();
         let market = this.market (symbol);
         return await this.privatePostExchangeCancellimit (this.extend ({

--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -356,10 +356,12 @@ module.exports = class livecoin extends Exchange {
         };
     }
 
-    async cancelOrder (id, symbol = undefined, params = {}) {
+    async cancelOrder (id, symbol, params = {}) {
         await this.loadMarkets ();
+        let market = this.market (symbol);
         return await this.privatePostExchangeCancellimit (this.extend ({
             'orderId': id,
+            'currencyPair': market['id'],
         }, params));
     }
 


### PR DESCRIPTION
The `currencyPair` parameter is required for livecoin: https://www.livecoin.net/api/orders#exchangecancellimit