### PR TITLE
Exchange: fixup ms in parse8601

### DIFF
--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -368,7 +368,7 @@ class Exchange {
     public static function parse8601 ($timestamp) {
         $time = strtotime ($timestamp) * 1000;
         if (preg_match ('/\.(?<milliseconds>[0-9]{1,3})/', $timestamp, $match)) {
-            $time += $match['milliseconds'];
+            $time += (int) str_pad($match['milliseconds'], 3, '0', STR_PAD_RIGHT);
         }
         return $time;
     }


### PR DESCRIPTION
Another fixup in parse8601 that covers cases such as:
`xx.1`
`xx.01`
and similar