### PR TITLE
Trades in descending date order

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -723,6 +723,7 @@ module.exports = class Exchange {
 
     parseTrades (trades, market = undefined, since = undefined, limit = undefined) {
         let result = Object.values (trades).map (trade => this.parseTrade (trade, market))
+        result = sortBy (result, 'timestamp', true)
         return this.filterBySinceLimit (result, since, limit)
     }
 


### PR DESCRIPTION
From the wiki:
> The fetchTrades method shown above returns an ordered list of trades (a flat array, most recent trade first) represented by the following structure

However, this is not true for some exchanges (such as `binance`, `bitbay`, `bitlish`, `gateio`).
Instead of handling them individually, this change will always sort the array.