### PR TITLE
populate GDAX fetch_ticker last price

### DIFF
--- a/php/gdax.php
+++ b/php/gdax.php
@@ -223,7 +223,7 @@ class gdax extends Exchange {
             'open' => null,
             'close' => null,
             'first' => null,
-            'last' => null,
+            'last' => floatval ($ticker['price']),
             'change' => null,
             'percentage' => null,
             'average' => null,


### PR DESCRIPTION
When using fetch_ticker with GDAX the returned array had the last key set to null. This pull request sets the value correctly.