### PR TITLE
qryptos: cancelOrder: returns OrderNotFound on closed (filled) orders

### DIFF
--- a/js/qryptos.js
+++ b/js/qryptos.js
@@ -237,7 +237,7 @@ module.exports = class qryptos extends Exchange {
             'id': id,
         }, params));
         let order = this.parseOrder(result);
-        if (!order['type'])
+        if (order['status'] == 'closed')
             throw new OrderNotFound (this.id + ' ' + order);
         return order;
     }


### PR DESCRIPTION
My testcases started failing on this one - seems that the exchange fixed their response (they were responding with `null` which was quite stupid, IMHO).