### PR TITLE
Make binance fetch_ticker use recent last price data

### DIFF
--- a/php/binance.php
+++ b/php/binance.php
@@ -386,6 +386,14 @@ class binance extends Exchange {
         $response = $this->publicGetTicker24hr (array_merge (array (
             'symbol' => $market['id'],
         ), $params));
+	// 24hr data is too old, lets get more recent last price.
+	$response2 = $this->publicGetTickerAllPrices();
+	foreach($response2 as $r) {
+		if ($r['symbol'] == $market['id']) {
+			$response['lastPrice'] = $r['price'];
+			break;
+		}
+	}
         return $this->parse_ticker($response, $market);
     }
 


### PR DESCRIPTION
Binance fetch_ticker is using an API call that retrieves 24hr summary data. This means that the last price returned is not the true last price.  Unfortunately it doesn't look like Binance has a great API and requires us to make 2 api calls. One for the 24hour data and one for more recent data.

Just a note, this means the other data returned like askprice, bidprice, etc is all 24 hour summary info.