### PR TITLE
Exchange: drop unused $version

### DIFF
--- a/ccxt.php
+++ b/ccxt.php
@@ -30,8 +30,6 @@ SOFTWARE.
 
 namespace ccxt;
 
-$version = '1.10.429';
-
 define('PATH_TO_CCXT', __DIR__ . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR);
 
 spl_autoload_register (function ($class_name) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -30,7 +30,7 @@ SOFTWARE.
 
 namespace ccxt;
 
-$version = '1.9.282';
+$version = '1.10.429';
 
 abstract class Exchange {
 
@@ -467,8 +467,6 @@ abstract class Exchange {
     }
 
     public function __construct ($options = array ()) {
-
-        global $version;
 
         $this->curl        = curl_init ();
         $this->id          = null;

--- a/vss.js
+++ b/vss.js
@@ -38,7 +38,7 @@ function vss (filename, regex, replacement) {
 
 //-----------------------------------------------------------------------------
 
-vss ('./ccxt.php',                           /\$version \= \'[^\']+\'/, "$version = '")
+vss ('./php/Exchange.php',                   /\$version \= \'[^\']+\'/, "$version = '")
 vss ('./ccxt.js',                            /const version \= \'[^\']+\'/, "const version = '")
 vss ('./python/ccxt/__init__.py',            /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
 vss ('./python/ccxt/async/__init__.py',      /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")


### PR DESCRIPTION
Drop unused variable (and avoid pollution).

Variable is still available at `ccxt.php`, and existence in Exchange would override it anyway (plus it was not updated in Exchange)