### PR TITLE
Fixing plus operator which caused OHLCV failue

### DIFF
--- a/php/gdax.php
+++ b/php/gdax.php
@@ -292,7 +292,7 @@ class gdax extends Exchange {
             $request['start'] = $this->iso8601 ($since);
             if (!$limit)
                 $limit = 200; // max = 200
-            $request['end'] = $this->iso8601 ($limit * $granularity * 1000 . $since);
+            $request['end'] = $this->iso8601 ($limit * $granularity * 1000 + $since);
         }
         $response = $this->publicGetProductsIdCandles (array_merge ($request, $params));
         return $this->parse_ohlcvs($response, $market, $timeframe, $since, $limit);


### PR DESCRIPTION
Fixes issue with passing in a "since" timestamp will cause the request "end" to look like
    [id] => BTC-USD
    [granularity] => 60
    [start] => 2017-12-23T18:50:59.000+00:00
    [end] => 57041747-04-17T02:50:59.000+00:00

Which throws this error
ccxt\ExchangeError: gdax {"message":"Invalid interval"}