### PR TITLE
[Luno] Fixed GetOrders typo.

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -128,8 +128,8 @@ module.exports = class luno extends Exchange {
 
     async fetchOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        let response = await this.privateGetOrders (this.extend ({
-            'id': id.toString (),
+        let response = await this.privateGetOrdersId (this.extend ({
+            'id': id,
         }, params));
         let state = (response['state'] == 'PENDING') ? 'open' : 'closed';
         let side = (response['type'] == 'ASK') ? 'sell' : 'buy';


### PR DESCRIPTION
The syntax I used for requests seems to be incorrect. This fixes it.