### PR TITLE
binance: fetchTrades: limiting to 1h (was 24h)

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -494,7 +494,7 @@ module.exports = class binance extends Exchange {
         };
         if (since) {
             request['startTime'] = since;
-            request['endTime'] = since + 86400000;
+            request['endTime'] = since + 3600000;
         }
         if (limit)
             request['limit'] = limit;


### PR DESCRIPTION
Fixes the change introduced by #856.

Binance does not allow the range to be more than 1h:

```
> node examples/js/cli.js binance fetchTrades BTC/USDT 1
[ExchangeError] binance {"code":-1127,"msg":"More than 1 hours between startTime and endTime."}

    at handleErrors   js/binance.js:752                  throw new ExchangeError (this.id + ' ' + this.json (response));
    at text           js/base/Exchange.js:433            this.handleErrors (...args)                                    
    at _tickCallback  internal/process/next_tick.js:160         
```
