### PR TITLE
Add new method convert currency code for bitcoincoid

### DIFF
--- a/python/ccxt/bitcoincoid.py
+++ b/python/ccxt/bitcoincoid.py
@@ -68,7 +68,17 @@ class bitcoincoid (Exchange):
                 'XRP/BTC': {'id': 'xrp_btc', 'symbol': 'XRP/BTC', 'base': 'XRP', 'quote': 'BTC', 'baseId': 'xrp', 'quoteId': 'btc'},
             },
         })
-
+    
+    def old_currency_code(self, currency):
+        if (currency == 'xlm'):
+            return 'str'
+        elif (currency == 'dash'):
+            return 'drk'
+        elif (currency == 'xem'):
+            return 'nem'
+        else:
+            return currency
+    
     def fetch_balance(self, params={}):
         response = self.privatePostGetInfo()
         balance = response['return']
@@ -76,7 +86,7 @@ class bitcoincoid (Exchange):
         currencies = list(self.currencies.keys())
         for i in range(0, len(currencies)):
             currency = currencies[i]
-            lowercase = currency.lower()
+            lowercase = self.old_currency_code(currency.lower())
             account = self.account()
             account['free'] = self.safe_float(balance['balance'], lowercase, 0.0)
             account['used'] = self.safe_float(balance['balance_hold'], lowercase, 0.0)


### PR DESCRIPTION
**Language:** Python
**Exchange:** Bitcoincoid

Add new method to convert currency code to old currency code, because in fetch_balance the server response is using old currency code like xlm -> str and give some currency balance is zero

**Example Server response:**
```
{'BCH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'BTC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'BTG': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'BTS': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'DASH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'DOGE': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ETC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ETH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'IDR': {'free': 9744.0, 'total': 209744.0, 'used': 200000.0},
 'LTC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'NXT': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'WAVES': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'XEM': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'XLM': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'XRP': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'XZC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
'info': {'address': {'bch': '',
                      'btc': '',
                      'btg': '',
                      'bts': '',
                      'doge': '',
                      'drk': '',
                      'etc': '',
                      'eth': '',
                      'ltc': '',
                      'nem': '',
                      'nxt': '',
                      'str': '',
                      'waves': '',
                      'xrp': '',
                      'xzc': ''},
          'balance': {'bch': '0.00000000',
                      'btc': '0.00000000',
                      'btg': '0.00000000',
                      'bts': '0.00000000',
                      'doge': '0.00000000',
                      'drk': '0.00000000',
                      'etc': '0.00000000',
                      'eth': '0.00000000',
                      'idr': 9744,
                      'ltc': '0.00000000',
                      'nem': '0.00000000',
                      'nxt': '0.00000000',
                      'str': '48.87053049',
                      'waves': '0.00000000',
                      'xrp': '0.00000000',
                      'xzc': '0.00000000'},
```