### PR TITLE
Fix truncate function PHP

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -157,7 +157,7 @@ abstract class Exchange {
 
     public static function truncate ($number, $precision = 0) {
         $decimal_precision = pow (10, $precision);
-        return floatval ($number * $decimal_precision) / $decimal_precision;
+        return floor(floatval ($number * $decimal_precision)) / $decimal_precision;
     }
 
     public static function uuid () {


### PR DESCRIPTION
Shouldn't be like this for make a correct truncate?

Awesome work with this library btw!

Programming Language: PHP
CCXT version: 1.10.513
Method: truncate