### PR TITLE
Fix: Bithumb Bad Request(Auth Data) - Convert header value to string

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -298,8 +298,10 @@ module.exports = class bithumb extends Exchange {
             let auth = endpoint + "\0" + body + "\0" + nonce;
             let signature = this.hmac (this.encode (auth), this.encode (this.secret), 'sha512');
             headers = {
+                'Accept': 'application/json,*/*;q=0.9',
+                'Content-Type': 'application/x-www-form-urlencoded',
                 'Api-Key': this.apiKey,
-                'Api-Sign': this.decode (this.stringToBase64 (this.encode (signature))),
+                'Api-Sign': this.decode (this.stringToBase64 (this.encode (signature))).toString (),
                 'Api-Nonce': nonce,
             };
         }

--- a/python/ccxt/async/bithumb.py
+++ b/python/ccxt/async/bithumb.py
@@ -278,8 +278,10 @@ class bithumb (Exchange):
             auth = endpoint + "\0" + body + "\0" + nonce
             signature = self.hmac(self.encode(auth), self.encode(self.secret), hashlib.sha512)
             headers = {
+                'Accept': 'application/json,*/*;q=0.9',
+                'Content-Type': 'application/x-www-form-urlencoded',
                 'Api-Key': self.apiKey,
-                'Api-Sign': self.decode(base64.b64encode(self.encode(signature))),
+                'Api-Sign': str(self.decode(base64.b64encode(self.encode(signature)))),
                 'Api-Nonce': nonce,
             }
         return {'url': url, 'method': method, 'body': body, 'headers': headers}

--- a/python/ccxt/bithumb.py
+++ b/python/ccxt/bithumb.py
@@ -278,8 +278,10 @@ class bithumb (Exchange):
             auth = endpoint + "\0" + body + "\0" + nonce
             signature = self.hmac(self.encode(auth), self.encode(self.secret), hashlib.sha512)
             headers = {
+                'Accept': 'application/json,*/*;q=0.9',
+                'Content-Type': 'application/x-www-form-urlencoded',
                 'Api-Key': self.apiKey,
-                'Api-Sign': self.decode(base64.b64encode(self.encode(signature))),
+                'Api-Sign': str(self.decode(base64.b64encode(self.encode(signature)))),
                 'Api-Nonce': nonce,
             }
         return {'url': url, 'method': method, 'body': body, 'headers': headers}


### PR DESCRIPTION
There's a problem in python code. It occurs `Bad Request` error because of `Api-Sign` value. Check below:

```python
ExchangeNotAvailable: bithumb POST https://api.bithumb.com/info/balance 400 Client Error: Bad Request for url: https://api.bithumb.com/info/balance {"status":"5100","message":"Bad Request.(Auth Data)"}
```

I fixed python code before I read the contributing guide. Some commits will be overwritten automatically, but you can drop it. I checked python code what I fixed, **but I can't checked transcompiled python code.** Please review my code.

Anyway, I'll add another bithumb API if I have more time.
Thank you for your great project. 🎉 👍 