### PR TITLE
Bitstamp: Implementation ripple withdrawal V2

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -60,6 +60,8 @@ module.exports = class bitstamp extends Exchange {
                         'ltc_address/',
                         'eth_withdrawal/',
                         'eth_address/',
+                        'xrp_withdrawal/',
+                        'xrp_address/',
                         'transfer-to-main/',
                         'transfer-from-main/',
                         'withdrawal/open/',
@@ -353,8 +355,6 @@ module.exports = class bitstamp extends Exchange {
     getCurrencyName (code) {
         if (code == 'BTC')
             return 'bitcoin';
-        if (code == 'XRP')
-            return 'ripple';
         return code.toLowerCase ();
     }
 
@@ -375,7 +375,7 @@ module.exports = class bitstamp extends Exchange {
             'amount': amount,
             'address': address,
         };
-        let v1 = (code == 'BTC') || (code == 'XRP');
+        let v1 = (code == 'BTC') || (code == 'ripple');
         let method = v1 ? 'v1' : 'private'; // v1 or v2
         method += 'Post' + this.capitalize (name) + 'Withdrawal';
         let query = params;


### PR DESCRIPTION
Coexistent fix for Ripple withdrawal between V1 and V2 for Bitstamp.

V1 seems to not work at all, a  parameter called currency is required and I have not been able to achieve a correct value there.

I tested with: XRP, xrp, Ripple, Ripple and any good response, just the same: 

``` Select a valid choice. X is not one of the available choices. ```