### PR TITLE
Bitstamp: fix error in parsing side (buy/sell) in parseTrade

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -232,7 +232,7 @@ module.exports = class bitstamp extends Exchange {
         } else if ('datetime' in trade) {
             timestamp = this.parse8601 (trade['datetime']);
         }
-        let side = (trade['type'] == 0) ? 'buy' : 'sell';
+        let side = (trade['type'] == '0') ? 'buy' : 'sell';
         let order = undefined;
         if ('order_id' in trade)
             order = trade['order_id'].toString ();


### PR DESCRIPTION
I've noticed all trades were coming back as 'sell' from fetchTrades, even though the type field in the exchange's response denoted they were 'buy'.

Looks like the 'type' field is coming back as a string '0' for a buy, but the code is expecting an integer 0. Have made a change to hopefully correct this.

Please note: this is my first contribution to Github, hope I've done it right. Let me know if you need further info.

Example data from fetchTrades:

# Incorrect: info.type equals "0" -> Should be a buy? side reports it as sell
    {
      "info": {
        "date": "1515053754", 
        "tid": "41463563", 
        "price": "230.94", 
        "type": "0", 
        "amount": "1.00000000"
      }, 
      "amount": 1.0, 
      "side": "sell", 
      "price": 230.94, 
      "timestamp": 1515053754000, 
      "symbol": "LTC/USD", 
      "order": null, 
      "type": null, 
      "id": "41463563", 
      "datetime": "2018-01-04T08:15:54.000Z"
    }, 
# Correct: info.type equals "1" -> Should be a sell. side reports it as sell
    {
      "info": {
        "date": "1515053753", 
        "tid": "41463559", 
        "price": "230.94", 
        "type": "1", 
        "amount": "0.11639061"
      }, 
      "amount": 0.11639061, 
      "side": "sell", 
      "price": 230.94, 
      "timestamp": 1515053753000, 
      "symbol": "LTC/USD", 
      "order": null, 
      "type": null, 
      "id": "41463559", 
      "datetime": "2018-01-04T08:15:53.000Z"
    },