### PR TITLE
Use str product_id for qryptos/quoine in Python

### DIFF
--- a/python/ccxt/qryptos.py
+++ b/python/ccxt/qryptos.py
@@ -82,7 +82,7 @@ class qryptos (Exchange):
         result = []
         for p in range(0, len(markets)):
             market = markets[p]
-            id = market['id']
+            id = str(market['id'])
             base = market['base_currency']
             quote = market['quoted_currency']
             symbol = base + '/' + quote
@@ -230,7 +230,7 @@ class qryptos (Exchange):
 
     def parse_order(self, order):
         timestamp = order['created_at'] * 1000
-        marketId = order['product_id']
+        marketId = str(order['product_id'])
         market = self.marketsById[marketId]
         status = None
         if 'status' in order:


### PR DESCRIPTION
### Issue
`parse_order` of qryptos/quoine always raise `KeyError` so `create_order` currently not works.

```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    print(q.create_order(symbol="QASH/JPY",type="limit",side="buy",price=1,amount=1))
  File "/usr/local/lib/python3.5/dist-packages/ccxt/qryptos.py", line 219, in create_order
    return self.parse_order(response)
  File "/usr/local/lib/python3.5/dist-packages/ccxt/qryptos.py", line 234, in parse_order
    market = self.marketsById[marketId]
KeyError: 50
```

### Cause
`fetch_markets` returns `id` as string, so mapping from `product_id` to symbol works for string.

```python
q = ccxt.quoine()
q.load_markets()
q.marketsById["50"]  # {'active': True, 'base': 'QASH', 'id': '50', 'info': {...} }
```

On the other hand, `privatePostOrders` returns `product_id` as integer - `marketsById` does not accept it.


### Solution
- use `str()` to make sure `product_id` is string.