### PR TITLE
safer safeMethods, + handle 0 and empty string

### DIFF
--- a/js/base/functions.js
+++ b/js/base/functions.js
@@ -186,15 +186,23 @@ const safeFloat = (object, key, defaultValue = undefined) => {
 }
 
 const safeString = (object, key, defaultValue = undefined) => {
-    return (object && (key in object) && object[key]) ? object[key].toString () : defaultValue
+    if (!object || !(key in object))
+        return defaultValue;
+    let stringVal = object[key];
+    if (!stringVal && typeof stringVal != 'string' && typeof stringVal != 'number')
+        return defaultValue;
+    return stringVal.toString ();
 }
 
 const safeInteger = (object, key, defaultValue = undefined) => {
-    return ((key in object) && object[key]) ? parseInt (object[key]) : defaultValue
+    if (!object || !(key in object))
+        return defaultValue;
+    let intVal = parseInt (object[key], 10);
+    return isNaN (intVal) ? defaultValue : intVal;
 }
 
 const safeValue = (object, key, defaultValue = undefined) => {
-    return ((key in object) && object[key]) ? object[key] : defaultValue
+    return (object && (key in object) && object[key]) ? object[key] : defaultValue
 }
 
 const uuid = a => a ?

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -141,15 +141,15 @@ abstract class Exchange {
     }
 
     public static function safe_float ($object, $key, $default_value = null) {
-        return (is_array ($object) && array_key_exists ($key, $object) && $object[$key]) ? floatval ($object[$key]) : $default_value;
+        return (isset ($object[$key]) && is_numeric ($object[$key])) ? floatval ($object[$key]) : $default_value;
     }
 
     public static function safe_string ($object, $key, $default_value = null) {
-        return (is_array ($object) && array_key_exists ($key, $object) && $object[$key]) ? strval ($object[$key]) : $default_value;
+        return (isset ($object[$key]) && is_scalar ($object[$key])) ? strval ($object[$key]) : $default_value;
     }
 
     public static function safe_integer ($object, $key, $default_value = null) {
-        return (is_array ($object) && array_key_exists ($key, $object) && $object[$key]) ? intval ($object[$key]) : $default_value;
+        return (isset ($object[$key]) && is_numeric ($object[$key])) ? intval ($object[$key]) : $default_value;
     }
 
     public static function safe_value ($object, $key, $default_value = null) {


### PR DESCRIPTION
For example:
obj.key = '0';
Old:
`this.safeFloat (obj, 'key')` -> `undefined`
New:
`this.safeFloat (obj, 'key')` -> `0`

Haven't done it for Python...
  