### PR TITLE
Bitcoincoid orders

### DIFF
--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -19,7 +19,7 @@ module.exports = class bitcoincoid extends Exchange {
             'hasFetchTickers': false,
             'hasFetchOHLCV': false,
             'hasFetchOrder': true,
-            'hasFetchOrders': false,
+            'hasFetchOrders': true,
             'hasFetchClosedOrders': false,
             'hasFetchOpenOrders': true,
             'hasFetchMyTrades': false,
@@ -30,7 +30,7 @@ module.exports = class bitcoincoid extends Exchange {
                 'fetchTickers': false,
                 'fetchOHLCV': false,
                 'fetchOrder': true,
-                'fetchOrders': false,
+                'fetchOrders': true,
                 'fetchClosedOrders': false,
                 'fetchOpenOrders': true,
                 'fetchMyTrades': false,
@@ -67,6 +67,7 @@ module.exports = class bitcoincoid extends Exchange {
                         'getOrder',
                         'openOrders',
                         'cancelOrder',
+                        'orderHistory'
                     ],
                 },
             },
@@ -248,6 +249,18 @@ module.exports = class bitcoincoid extends Exchange {
         let orders = response['return'];
         let order = this.parseOrder (this.extend ({ 'id': id }, orders['order']), market);
         return this.extend ({ 'info': response }, order);
+    }
+
+    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        let request = {};
+        let market = undefined;
+        if (symbol) {
+            market = this.market (symbol);
+            request['pair'] = market['id'];
+        }
+        let response = await this.privatePostOrderHistory (this.extend (request, params));
+        let orders = this.parseOrders (response['return']['orders'], market, since, limit);
+        return this.filterOrdersBySymbol (orders, symbol);
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -241,6 +241,9 @@ module.exports = class bitcoincoid extends Exchange {
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {
+        if (!symbol)
+            throw new ExchangeError (this.id + ' fetchOrder requires a symbol');
+        await this.loadMarkets ();
         let market = this.market (symbol);
         let response = await this.privatePostGetOrder (this.extend ({
             'pair': market['id'],
@@ -252,6 +255,9 @@ module.exports = class bitcoincoid extends Exchange {
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        if (!symbol)
+            throw new ExchangeError (this.id + ' fetchOrders requires a symbol');
+        await this.loadMarkets ();
         let request = {};
         let market = undefined;
         if (symbol) {

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -20,7 +20,7 @@ module.exports = class bitcoincoid extends Exchange {
             'hasFetchOHLCV': false,
             'hasFetchOrder': true,
             'hasFetchOrders': true,
-            'hasFetchClosedOrders': false,
+            'hasFetchClosedOrders': true,
             'hasFetchOpenOrders': true,
             'hasFetchMyTrades': false,
             'hasFetchCurrencies': false,
@@ -31,7 +31,7 @@ module.exports = class bitcoincoid extends Exchange {
                 'fetchOHLCV': false,
                 'fetchOrder': true,
                 'fetchOrders': true,
-                'fetchClosedOrders': false,
+                'fetchClosedOrders': true,
                 'fetchOpenOrders': true,
                 'fetchMyTrades': false,
                 'fetchCurrencies': false,
@@ -280,6 +280,11 @@ module.exports = class bitcoincoid extends Exchange {
         let response = await this.privatePostOpenOrders (this.extend (request, params));
         let orders = this.parseOrders (response['return']['orders'], market, since, limit);
         return this.filterOrdersBySymbol (orders, symbol);
+    }
+
+    async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        let orders = await this.fetchOrders (symbol, params);
+        return this.filterBy (orders, 'status', 'filled');
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {


### PR DESCRIPTION
- fetchOrder

Got inconsistent in IDR symbol response, so parseOrder need detect this. Sample response [here](https://pastebin.com/BEkBmrgQ)

- fetchOrders

Working smothly.

- fetchClosedOrders

However, `status` with value `filled` are not filtered. Still got empty array. Sample response [here](https://pastebin.com/x4ZY02ZJ)