### PR TITLE
"Exchange is not available" feature for livecoin

### DIFF
--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange')
-const { ExchangeError, AuthenticationError, NotSupported, InvalidOrder, OrderNotFound } = require ('./base/errors')
+const { ExchangeError, AuthenticationError, NotSupported, InvalidOrder, OrderNotFound, ExchangeNotAvailable } = require ('./base/errors')
 
 //  ---------------------------------------------------------------------------
 
@@ -543,7 +543,10 @@ module.exports = class livecoin extends Exchange {
                         throw new InvalidOrder (this.id + ': Invalid amount ' + this.json (response));
                     } else if (error == 105) {
                         throw new InvalidOrder (this.id + ': Unable to block funds ' + this.json (response));
-                    } else {
+                    } else if (error == 503) {
+                        throw new ExchangeNotAvailable (this.id + ': Exchange is not available ' + this.json (response));
+                    }
+                    else {
                         throw new ExchangeError (this.id + ' ' + this.json (response));
                     }
                 }

--- a/python/ccxt/livecoin.py
+++ b/python/ccxt/livecoin.py
@@ -9,6 +9,7 @@ from ccxt.base.errors import NotSupported
 from ccxt.base.errors import AuthenticationError
 from ccxt.base.errors import InvalidOrder
 from ccxt.base.errors import OrderNotFound
+from ccxt.base.errors import ExchangeNotAvailable
 
 
 class livecoin (Exchange):
@@ -509,6 +510,8 @@ class livecoin (Exchange):
                         raise InvalidOrder(self.id + ': Invalid amount ' + self.json(response))
                     elif error == 105:
                         raise InvalidOrder(self.id + ': Unable to block funds ' + self.json(response))
+                    elif error == 503:
+                        raise ExchangeNotAvailable(self.id + ': Exchange is not available ' + self.json(response))
                     else:
                         raise ExchangeError(self.id + ' ' + self.json(response))
             raise ExchangeError(self.id + ' ' + body)


### PR DESCRIPTION
Sometimes livecoin.net may return object like this: livecoin {"success":false,"errorMessage":"Service is under maintenance","errorCode":503}. So, this patch bring right exception type for that case