### PR TITLE
 okcoinusd: handleErrors & InsufficientFunds and InvalidOrder exceptions

### DIFF
--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -525,12 +525,15 @@ module.exports = class okcoinusd extends Exchange {
                 status = params['status'];
             } else {
                 let name = order_id_in_params ? 'type' : 'status';
-                throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 or "open" for unfilled orders, 1 or "closed" for filled orders)');
+                // throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 or "open" for unfilled orders, 1 or "closed" for filled orders)');
+                throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 - for unfilled orders, 1 - for filled/canceled orders)');
             }
-            if (status == 'open')
-                status = 0;
-            if (status == 'closed')
-                status = 1;
+            // mkutny:
+            // found the next lines really confusing - expected only exchange-specific values for params
+            // if (status == 'open')
+            //    status = 0;
+            // if (status == 'closed')
+            //    status = 1;
             if (order_id_in_params) {
                 method += 'OrdersInfo';
                 request = this.extend (request, {

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange')
-const { ExchangeError, InsufficientFunds, InvalidOrder } = require ('./base/errors')
+const { ExchangeError, InsufficientFunds, InvalidOrder, OrderNotFound } = require ('./base/errors')
 
 //  ---------------------------------------------------------------------------
 
@@ -627,10 +627,14 @@ module.exports = class okcoinusd extends Exchange {
         let response = JSON.parse (body);
         if ('error_code' in response) {
             switch (response['error_code']) {
+                case 1009:
+                    throw new OrderNotFound (this.id + ' ' + this.json (response));
                 case 1003: // no order type
                 case 1027: // returned on createLimitBuyOrder(symbol, 0, 0)
+                case 10000: // createLimitBuyOrder(symbol, undefined, undefined)
                     throw new InvalidOrder (this.id + ' ' + this.json (response));
                 case 10008:
+                case 1002:
                     throw new InsufficientFunds (this.id + ' ' + this.json (response));
                 default:
                     throw new ExchangeError (this.id + ' ' + this.json (response));

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -624,8 +624,6 @@ module.exports = class okcoinusd extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body) {
-        if (this.verbose)
-            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '');
         let response = JSON.parse (body);
         if ('error_code' in response) {
             if (!this.errorCodes) {

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -479,7 +479,7 @@ module.exports = class okcoinusd extends Exchange {
 
     async fetchOrder (id, symbol = undefined, params = {}) {
         if (!symbol)
-            throw new ExchangeError (this.id + 'fetchOrders requires a symbol parameter');
+            throw new ExchangeError (this.id + ' fetchOrder requires a symbol parameter');
         await this.loadMarkets ();
         let market = this.market (symbol);
         let method = 'privatePost';
@@ -504,7 +504,7 @@ module.exports = class okcoinusd extends Exchange {
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         if (!symbol)
-            throw new ExchangeError (this.id + 'fetchOrders requires a symbol parameter');
+            throw new ExchangeError (this.id + ' fetchOrders requires a symbol parameter');
         await this.loadMarkets ();
         let market = this.market (symbol);
         let method = 'privatePost';

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -628,7 +628,7 @@ module.exports = class okcoinusd extends Exchange {
             console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '');
         let response = JSON.parse (body);
         if ('error_code' in response) {
-            if (this.errorCodes === undefined) {
+            if (!this.errorCodes) {
                 this.errorCodes = {
                     '1009': OrderNotFound,
                     '1003': InvalidOrder, // no order type (was left by previous author)
@@ -638,9 +638,9 @@ module.exports = class okcoinusd extends Exchange {
                     '10008': ExchangeError, // Illegal URL parameter
                 };
             }
-            let Exception = this.errorCodes[response['error_code']];
-            if (Exception)
-                throw new Exception (this.id + ' ' + this.json (response));
+            let ExceptionRef = this.errorCodes[response['error_code']];
+            if (ExceptionRef)
+                throw new ExceptionRef (this.id + ' ' + this.json (response));
             else
                 throw new ExchangeError (this.id + ' ' + this.json (response));
         }

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -153,6 +153,8 @@ module.exports = class okcoinusd extends Exchange {
                 'price': markets[i]['maxPriceDigit'],
             };
             let lot = Math.pow (10, -precision['amount']);
+            let minAmount = markets[i]['minTradeSize'];
+            let minPrice = 1 / (10 ** precision['price']);
             let market = this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -167,15 +169,15 @@ module.exports = class okcoinusd extends Exchange {
                 'precision': precision,
                 'limits': {
                     'amount': {
-                        'min': markets[i]['minTradeSize'],
+                        'min': minAmount,
                         'max': undefined,
                     },
                     'price': {
-                        'min': 1 / (10 ** precision['price']),
+                        'min': minPrice,
                         'max': undefined,
                     },
                     'cost': {
-                        'min': undefined,
+                        'min': minAmount * minPrice,
                         'max': undefined,
                     },
                 },

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -624,18 +624,20 @@ module.exports = class okcoinusd extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body) {
+        if (this.verbose)
+            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '')
         let response = JSON.parse (body);
         if ('error_code' in response) {
             switch (response['error_code']) {
                 case 1009:
                     throw new OrderNotFound (this.id + ' ' + this.json (response));
                 case 1003: // no order type
-                case 1027: // returned on createLimitBuyOrder(symbol, 0, 0)
+                case 1027: // returned on createLimitBuyOrder(symbol, 0, 0): Incorrect parameter may exceeded limits
                 case 10000: // createLimitBuyOrder(symbol, undefined, undefined)
                     throw new InvalidOrder (this.id + ' ' + this.json (response));
-                case 10008:
-                case 1002:
+                case 1002: // The transaction amount exceed the balance
                     throw new InsufficientFunds (this.id + ' ' + this.json (response));
+                case 10008: // Illegal URL parameter
                 default:
                     throw new ExchangeError (this.id + ' ' + this.json (response));
             }

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -525,15 +525,8 @@ module.exports = class okcoinusd extends Exchange {
                 status = params['status'];
             } else {
                 let name = order_id_in_params ? 'type' : 'status';
-                // throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 or "open" for unfilled orders, 1 or "closed" for filled orders)');
                 throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 - for unfilled orders, 1 - for filled/canceled orders)');
             }
-            // FIXME:
-            // found the next lines really confusing - expected only exchange-specific values for params
-            // if (status == 'open')
-            //    status = 0;
-            // if (status == 'closed')
-            //    status = 1;
             if (order_id_in_params) {
                 method += 'OrdersInfo';
                 request = this.extend (request, {
@@ -646,13 +639,13 @@ module.exports = class okcoinusd extends Exchange {
                 };
             }
             let Exception = this.errorCodes[response['error_code']];
-            if (Exception === undefined)
-                throw new ExchangeError (this.id + ' ' + this.json (response));
-            else
+            if (Exception)
                 throw new Exception (this.id + ' ' + this.json (response));
+            else
+                throw new ExchangeError (this.id + ' ' + this.json (response));
         }
         if ('result' in response)
-            if (response['result'] === false)
+            if (!response['result'])
                 throw new ExchangeError (this.id + ' ' + this.json (response));
     }
 };

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -154,7 +154,7 @@ module.exports = class okcoinusd extends Exchange {
             };
             let lot = Math.pow (10, -precision['amount']);
             let minAmount = markets[i]['minTradeSize'];
-            let minPrice = 1 / (10 ** precision['price']);
+            let minPrice = Math.pow (10, -precision['price']);
             let market = this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -631,11 +631,11 @@ module.exports = class okcoinusd extends Exchange {
             if (this.errorCodes === undefined) {
                 this.errorCodes = {
                     '1009': OrderNotFound,
-                    '1003': InvalidOrder,      // no order type (was left by previous author)
-                    '1027': InvalidOrder,      // createLimitBuyOrder(symbol, 0, 0): Incorrect parameter may exceeded limits
+                    '1003': InvalidOrder, // no order type (was left by previous author)
+                    '1027': InvalidOrder, // createLimitBuyOrder(symbol, 0, 0): Incorrect parameter may exceeded limits
                     '1002': InsufficientFunds, // The transaction amount exceed the balance
-                    '10000': ExchangeError,    // createLimitBuyOrder(symbol, undefined, undefined)
-                    '10008': ExchangeError,    // Illegal URL parameter
+                    '10000': ExchangeError, // createLimitBuyOrder(symbol, undefined, undefined)
+                    '10008': ExchangeError, // Illegal URL parameter
                 };
             }
             let Exception = this.errorCodes[response['error_code']];

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -1,9 +1,9 @@
-"use strict"
+"use strict";
 
 //  ---------------------------------------------------------------------------
 
-const Exchange = require ('./base/Exchange')
-const { ExchangeError, InsufficientFunds, InvalidOrder, OrderNotFound } = require ('./base/errors')
+const Exchange = require ('./base/Exchange');
+const { ExchangeError, InsufficientFunds, InvalidOrder, OrderNotFound } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -528,7 +528,7 @@ module.exports = class okcoinusd extends Exchange {
                 // throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 or "open" for unfilled orders, 1 or "closed" for filled orders)');
                 throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 - for unfilled orders, 1 - for filled/canceled orders)');
             }
-            // mkutny:
+            // FIXME:
             // found the next lines really confusing - expected only exchange-specific values for params
             // if (status == 'open')
             //    status = 0;
@@ -632,7 +632,7 @@ module.exports = class okcoinusd extends Exchange {
 
     handleErrors (code, reason, url, method, headers, body) {
         if (this.verbose)
-            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '')
+            console.log (this.id, method, url, code, reason, body ? ("\nResponse:\n" + body) : '');
         let response = JSON.parse (body);
         if ('error_code' in response) {
             if (this.errorCodes === undefined) {
@@ -643,7 +643,7 @@ module.exports = class okcoinusd extends Exchange {
                     '1002': InsufficientFunds, // The transaction amount exceed the balance
                     '10000': ExchangeError,    // createLimitBuyOrder(symbol, undefined, undefined)
                     '10008': ExchangeError,    // Illegal URL parameter
-                }
+                };
             }
             let Exception = this.errorCodes[response['error_code']];
             if (Exception === undefined)
@@ -655,4 +655,4 @@ module.exports = class okcoinusd extends Exchange {
             if (response['result'] === false)
                 throw new ExchangeError (this.id + ' ' + this.json (response));
     }
-}
+};

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -563,9 +563,10 @@ module.exports = class okcoinusd extends Exchange {
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         let closed = 1; // 0 for unfilled orders, 1 for filled orders
-        return await this.fetchOrders (symbol, undefined, undefined, this.extend ({
+        let orders = await this.fetchOrders (symbol, undefined, undefined, this.extend ({
             'status': closed,
         }, params));
+        return this.filterBy (orders, 'status', 'closed');
     }
 
     async withdraw (currency, amount, address, params = {}) {

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -447,7 +447,7 @@ module.exports = class okcoinusd extends Exchange {
         let cost = average * filled;
         let result = {
             'info': order,
-            'id': order['order_id'],
+            'id': order['order_id'].toString(),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'symbol': symbol,

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -524,7 +524,8 @@ module.exports = class okcoinusd extends Exchange {
             } else if ('status' in params) {
                 status = params['status'];
             } else {
-                throw new ExchangeError (this.id + ' fetchOrders() requires type param or status param for spot market ' + symbol + ' (0 or "open" for unfilled orders, 1 or "closed" for filled orders)');
+                let name = order_id_in_params ? 'type' : 'status';
+                throw new ExchangeError (this.id + ' fetchOrders() requires ' + name + ' param for spot market ' + symbol + ' (0 or "open" for unfilled orders, 1 or "closed" for filled orders)');
             }
             if (status == 'open')
                 status = 0;

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -171,7 +171,7 @@ module.exports = class okcoinusd extends Exchange {
                         'max': undefined,
                     },
                     'price': {
-                        'min': precision['price'],
+                        'min': 1 / (10 ** precision['price']),
                         'max': undefined,
                     },
                     'cost': {

--- a/keys.json
+++ b/keys.json
@@ -53,7 +53,7 @@
     "mercado":       { "skip": true },
     "okcoincny":     { "skip": true },
     "okcoinusd":     { "apiKey": "da83cf1b-6fdc-495a-af55-f809bec64e2b", "secret": "614D2E6D3428C2C5E54C81139A500BE0" },
-    "okex":          { "skip": true, "apiKey": "da83cf1b-6fdc-495a-af55-f809bec64e2b", "secret": "614D2E6D3428C2C5E54C81139A500BE0" },
+    "okex":          { "skip": false, "apiKey": "da83cf1b-6fdc-495a-af55-f809bec64e2b", "secret": "614D2E6D3428C2C5E54C81139A500BE0" },
     "paymium":       { "skip": true },
     "poloniex":      { "skip": true, "timeout": 20000 },
     "quadrigacx":    { "apiKey": "qvFrjjJEEF", "secret": "f18f8f178696d36a760a6c4f13bc6fa7", "uid": "395037" },


### PR DESCRIPTION
Tested on okex.

If you uncomment error testing from #1141 this PR will now pass.

Along the way, I explicitly set price min limits - it's much easier to handle them on the client side if they are set.

I also enabled okex keys for testing as they passed all the tests on my side.