### PR TITLE
kucoin: method name fix

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -525,7 +525,7 @@ module.exports = class kucoin extends Exchange {
     async withdraw (code, amount, address, params = {}) {
         await this.loadMarkets ();
         let currency = this.currency (code);
-        let response = await this.privatePostAccountWithdrawApply (this.extend ({
+        let response = await this.privatePostAccountCoinWithdrawApply (this.extend ({
             'coin': currency['id'],
             'amount': amount,
             'address': address,


### PR DESCRIPTION
I believe both (typo and missing `Coin`) in method were my mistakes... Guess I got too lazy with editor autocomplete :/