### PR TITLE
tests: fetch*Trades and fetch*Orders now deeply tested

### DIFF
--- a/js/test/test.js
+++ b/js/test/test.js
@@ -580,15 +580,15 @@ let testNonce = async (exchange, symbol) => {
         else if (exchange.hasFetchOrders || exchange.has.fetchOrders)
             await exchange.fetchOrders (symbol);
         else
+            exchange.nonce = nonce;
             return;
         exchange.nonce = nonce;
     } catch (e) {
+        exchange.nonce = nonce;
         if (e instanceof ccxt.AuthenticationError) {
             log.green ('AuthenticationError test passed')
-            exchange.nonce = nonce;
             return;
         } else {
-            exchange.nonce = nonce;
             throw e;
         }
     }

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -206,8 +206,9 @@ let testTrades = async (exchange, symbol) => {
         log (symbol.green, 'fetched', Object.values (trades).length.toString ().green, 'trades')
         let now = Date.now()
         for (let i = 0; i < trades.length; i++) {
-            let trade = trades[i]
-            testTrade (trade, symbol, now)
+            testTrade (trade[i], symbol, now)
+            if (i > 0)
+                assert (trades[i].timestamp <= trades[i-1].timestamp)
         }
         // log (asTable (trades))
 
@@ -402,8 +403,9 @@ let testMyTrades = async (exchange, symbol) => {
         log ('fetched', trades.length.toString ().green, 'trades')
         let now = Date.now()
         for (let i = 0; i < trades.length; i++) {
-            let trade = trades[i]
-            testTrade (trade, symbol, now)
+            testTrade (trade[i], symbol, now)
+            if (i > 0)
+                assert (trades[i].timestamp <= trades[i-1].timestamp)
         }
         // trades.forEach (trade => log.dim ('-'.repeat (80), "\n", trade))
         // log (asTable (trades))

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -175,7 +175,7 @@ let testOrderBook = async (exchange, symbol) => {
 
 //-----------------------------------------------------------------------------
 
-let testTrade = (trade, symbol, now) => {
+let testTradeProps = (trade, symbol, now) => {
     assert.isOk (trade)
     assert (typeof trade.id === 'undefined' || typeof trade.id === 'string')
     assert (typeof trade.timestamp === 'number')
@@ -206,7 +206,7 @@ let testTrades = async (exchange, symbol) => {
         log (symbol.green, 'fetched', Object.values (trades).length.toString ().green, 'trades')
         let now = Date.now()
         for (let i = 0; i < trades.length; i++) {
-            testTrade (trades[i], symbol, now)
+            testTradeProps (trades[i], symbol, now)
             if (i > 0)
                 assert (trades[i].timestamp <= trades[i-1].timestamp)
         }
@@ -285,7 +285,7 @@ let testSymbol = async (exchange, symbol) => {
 
 //-----------------------------------------------------------------------------
 
-let testOrder = (order, symbol, now) => {
+let testOrderProps = (order, symbol, now) => {
     assert.isOk (order)
     assert (typeof order.id === 'string')
     assert (typeof order.timestamp === 'number')
@@ -332,7 +332,7 @@ let testOrders = async (exchange, symbol) => {
         let now = Date.now()
         for (let i = 0; i < orders.length; i++) {
             let order = orders[i];
-            testOrder (order, symbol, now)
+            testOrderProps (order, symbol, now)
         }
         // log (asTable (orders))
 
@@ -355,7 +355,7 @@ let testClosedOrders = async (exchange, symbol) => {
         let now = Date.now()
         for (let i = 0; i < orders.length; i++) {
             let order = orders[i];
-            testOrder (order, symbol, now)
+            testOrderProps (order, symbol, now)
             assert (order.status === 'closed')
         }
         // log (asTable (orders))
@@ -379,7 +379,7 @@ let testOpenOrders = async (exchange, symbol) => {
         let now = Date.now()
         for (let i = 0; i < orders.length; i++) {
             let order = orders[i];
-            testOrder (order, symbol, now)
+            testOrderProps (order, symbol, now)
             assert (order.status === 'open')
         }
 
@@ -403,7 +403,7 @@ let testMyTrades = async (exchange, symbol) => {
         log ('fetched', trades.length.toString ().green, 'trades')
         let now = Date.now()
         for (let i = 0; i < trades.length; i++) {
-            testTrade (trades[i], symbol, now)
+            testTradeProps (trades[i], symbol, now)
             if (i > 0)
                 assert (trades[i].timestamp <= trades[i-1].timestamp)
         }

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -269,7 +269,7 @@ let testSymbol = async (exchange, symbol) => {
     await testTickers (exchange, symbol)
     await testOHLCV   (exchange, symbol)
     await testTrades  (exchange, symbol)
-    await testNonce   (exchange, symbol)
+    // await testNonce   (exchange, symbol)
 
     // await testInsufficientFunds (exchange, symbol)
     // await testInvalidOrder (exchange, symbol)
@@ -672,7 +672,7 @@ let testExchange = async exchange => {
     await testOpenOrders   (exchange, symbol)
     await testClosedOrders (exchange, symbol)
     await testMyTrades     (exchange, symbol)
-    await testNonce        (exchange, symbol)
+    // await testNonce        (exchange, symbol)
     // await testInsufficientFunds (exchange, symbol)
     // await testInvalidOrder (exchange, symbol)
 

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -411,7 +411,6 @@ let testMyTrades = async (exchange, symbol) => {
         // log (asTable (trades))
 
     } else {
-
         log ('fetching my trades not supported')
     }
 }

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -177,7 +177,7 @@ let testOrderBook = async (exchange, symbol) => {
 
 let testTrade = (trade, symbol, now) => {
     assert.isOk (trade)
-    assert (typeof trade.id === 'string')
+    assert (typeof trade.id === 'undefined' || typeof trade.id === 'string')
     assert (typeof trade.timestamp === 'number')
     assert (trade.timestamp > 1230940800000) // 03 Jan 2009 - first block
     assert (trade.timestamp < now)
@@ -206,7 +206,7 @@ let testTrades = async (exchange, symbol) => {
         log (symbol.green, 'fetched', Object.values (trades).length.toString ().green, 'trades')
         let now = Date.now()
         for (let i = 0; i < trades.length; i++) {
-            testTrade (trade[i], symbol, now)
+            testTrade (trades[i], symbol, now)
             if (i > 0)
                 assert (trades[i].timestamp <= trades[i-1].timestamp)
         }
@@ -403,7 +403,7 @@ let testMyTrades = async (exchange, symbol) => {
         log ('fetched', trades.length.toString ().green, 'trades')
         let now = Date.now()
         for (let i = 0; i < trades.length; i++) {
-            testTrade (trade[i], symbol, now)
+            testTrade (trades[i], symbol, now)
             if (i > 0)
                 assert (trades[i].timestamp <= trades[i-1].timestamp)
         }

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -189,7 +189,7 @@ let testTrade = (trade, symbol, now) => {
     assert (typeof trade.price === 'number')
     assert (trade.price > 0)
     assert (typeof trade.amount === 'number')
-    assert (trade.amount > 0)
+    assert (trade.amount >= 0)
     assert.isOk (trade.info)
 }
 

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -269,10 +269,6 @@ let testSymbol = async (exchange, symbol) => {
     await testTickers (exchange, symbol)
     await testOHLCV   (exchange, symbol)
     await testTrades  (exchange, symbol)
-    // await testNonce   (exchange, symbol)
-
-    // await testInsufficientFunds (exchange, symbol)
-    // await testInvalidOrder (exchange, symbol)
 
     if (exchange.id == 'coinmarketcap') {
 
@@ -329,8 +325,8 @@ let testOrders = async (exchange, symbol) => {
 
         // log ('fetching orders...')
         let orders = await exchange.fetchOrders (symbol)
-        assert (orders instanceof Array)
         log ('fetched', orders.length.toString ().green, 'orders, asserting each...')
+        assert (orders instanceof Array)
         let now = Date.now()
         for (let i = 0; i < orders.length; i++) {
             let order = orders[i];
@@ -352,8 +348,8 @@ let testClosedOrders = async (exchange, symbol) => {
 
         // log ('fetching closed orders...')
         let orders = await exchange.fetchClosedOrders (symbol)
-        assert (orders instanceof Array)
         log ('fetched', orders.length.toString ().green, 'closed orders, testing each')
+        assert (orders instanceof Array)
         let now = Date.now()
         for (let i = 0; i < orders.length; i++) {
             let order = orders[i];
@@ -448,10 +444,10 @@ let testInvalidOrder = async (exchange, symbol) => {
         assert.fail ();
     } catch (e) {
         if (e instanceof ccxt.InvalidOrder) {
-            log (e.constructor.name.green, ' throwed as expected');
+            log ('InvalidOrder throwed as expected');
             return;
         } else {
-            log (e.constructor.name.red, ' failed, exception follows:');
+            log ('InvalidOrder failed, exception follows:');
             throw e;
         }
     }
@@ -495,17 +491,17 @@ let testInsufficientFunds = async (exchange, symbol) => {
     minAmount = exchange.amountToPrecision (symbol, minAmount);
 
     try {
-        // log ('creating order...')
-        let id = await exchange.createOrder (symbol, minAmount, minPrice);
+        // log ('creating limit buy order...', symbol, minAmount, minPrice);
+        let id = await exchange.createLimitBuyOrder (symbol, minAmount, minPrice);
         log ('order created although it should not had to - cleaning up');
         await exchange.cancelOrder (id, symbol);
         assert.fail ();
         // log (asTable (currencies))
     } catch (e) {
         if (e instanceof ccxt.InsufficientFunds) {
-            log (e.constructor.name.green, ' throwed as expected');
+            log ('InsufficientFunds throwed as expected');
         } else {
-            log (e.constructor.name.red, ' failed, exception follows:');
+            log ('InsufficientFunds failed, exception follows:');
             throw e;
         }
     }
@@ -570,26 +566,26 @@ let testBalance = async (exchange, symbol) => {
 
 let testNonce = async (exchange, symbol) => {
     log.green ('AuthenticationError test...')
-    let nonce = exchange.nonce;
-    exchange.nonce = () => 1;
+    let nonce = exchange.nonce
+    exchange.nonce = () => 1
     try {
         if (exchange.hasFetchBalance || exchange.has.fetchBalance)
             await exchange.fetchBalance ();
         else if (exchange.hasFetchMyTrades || exchange.has.fetchMyTrades)
             await exchange.fetchMyTrades (symbol, 0)
         else if (exchange.hasFetchOrders || exchange.has.fetchOrders)
-            await exchange.fetchOrders (symbol);
+            await exchange.fetchOrders (symbol)
         else
-            exchange.nonce = nonce;
-            return;
-        exchange.nonce = nonce;
+            exchange.nonce = nonce
+            return
+        exchange.nonce = nonce
     } catch (e) {
-        exchange.nonce = nonce;
+        exchange.nonce = nonce
         if (e instanceof ccxt.AuthenticationError) {
             log.green ('AuthenticationError test passed')
-            return;
+            return
         } else {
-            throw e;
+            throw e
         }
     }
     warn (exchange.id + ' ignores nonce')


### PR DESCRIPTION
This will surely help new exchange implementors. At least I was able to discover new errors in exchanges I contributed, fixes will follow.

While testing I also discovered that test coverage was (mistakenly) reduced for exchanges with only new API matainfo. For example, if an exchange has `has.fetchOrders === true` its base class still has `hasFetchOrders === false` and this resulted in test skip.

This commit should now trigger much more tests than were before.
  