### PR TITLE
okcoinusd: hasFetchOrders is false now - won't work without extra params

### DIFF
--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -20,7 +20,7 @@ module.exports = class okcoinusd extends Exchange {
             // obsolete metainfo interface
             'hasFetchOHLCV': true,
             'hasFetchOrder': true,
-            'hasFetchOrders': true,
+            'hasFetchOrders': false,
             'hasFetchOpenOrders': true,
             'hasFetchClosedOrders': true,
             'hasWithdraw': true,
@@ -28,7 +28,7 @@ module.exports = class okcoinusd extends Exchange {
             'has': {
                 'fetchOHLCV': true,
                 'fetchOrder': true,
-                'fetchOrders': true,
+                'fetchOrders': false,
                 'fetchOpenOrders': true,
                 'fetchClosedOrders': true,
                 'withdraw': true,


### PR DESCRIPTION
If hasFetchOrders is for automatic discovery then it would better be switched off: one won't be able to execute it automatically anyway.
Related to #1148 
  