### PR TITLE
WIP: Initial skeleton for blockcypher explorer API

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -66,6 +66,7 @@ const exchanges = {
     'bittrex':                 require ('./js/bittrex.js'),
     'bl3p':                    require ('./js/bl3p.js'),
     'bleutrade':               require ('./js/bleutrade.js'),
+    'blockchain':              require ('./js/blockchain.js'),
     'blockcypher':             require ('./js/blockcypher.js'),
     'braziliex':               require ('./js/braziliex.js'),
     'btcbox':                  require ('./js/btcbox.js'),
@@ -140,7 +141,7 @@ const exchanges = {
     'yobit':                   require ('./js/yobit.js'),
     'yunbi':                   require ('./js/yunbi.js'),
     'zaif':                    require ('./js/zaif.js'),
-    'zb':                      require ('./js/zb.js'),    
+    'zb':                      require ('./js/zb.js'),
 }
 
 //-----------------------------------------------------------------------------

--- a/ccxt.js
+++ b/ccxt.js
@@ -66,6 +66,7 @@ const exchanges = {
     'bittrex':                 require ('./js/bittrex.js'),
     'bl3p':                    require ('./js/bl3p.js'),
     'bleutrade':               require ('./js/bleutrade.js'),
+    'blockcypher':             require ('./js/blockcypher.js'),
     'braziliex':               require ('./js/braziliex.js'),
     'btcbox':                  require ('./js/btcbox.js'),
     'btcchina':                require ('./js/btcchina.js'),

--- a/js/blockchain.js
+++ b/js/blockchain.js
@@ -1,0 +1,49 @@
+"use strict";
+
+//  ---------------------------------------------------------------------------
+
+const Exchange = require ('./base/Exchange')
+
+//  ---------------------------------------------------------------------------
+
+module.exports = class blockchain extends Exchange {
+
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'blockchain',
+            'name': 'Blockchain',
+            'countries': 'US',
+            'version': '',
+            'rateLimit': 300,
+            'hasCORS': true,
+            'urls': {
+                'logo': '',
+                'api': {
+                    'public': 'https://blockchain.info/',
+                },
+                'www': 'https://blockchain.info/',
+                'doc': [
+                    'https://blockchain.info/api',
+                ],
+            },
+            'api': {
+                'public': {
+                    'get': [
+                        'rawblock/{block}', // Single block information
+                        'rawtx/{transaction}', // Single transaction information
+                        'charts/{chartType}', // Chart data
+                        'block-height/{blockHeight}', // Block height
+                        'balance', // Address balance information (use active queryparam)
+                        'rawaddr/{address}', // Address information
+                        'multiaddr', // Multiple address information (use active queryparam)
+                        '{currency}/{network}/txs', // Unconfirmed transactions
+                        'unspent', // Unspent outputs (use active queryparam)
+                        'latestblock', // Latest block
+                        'unconfirmed-transactions', // Unconfirmed transactions
+                        'blocks/{timeOrPoolName}', // Blocks for one day or for specific pool
+                    ],
+                },
+            },
+        });
+    }
+}

--- a/js/blockcypher.js
+++ b/js/blockcypher.js
@@ -1,0 +1,87 @@
+"use strict";
+
+//  ---------------------------------------------------------------------------
+
+const Exchange = require ('./base/Exchange')
+
+//  ---------------------------------------------------------------------------
+
+/*
+Currently doesn't include the following APIs:
+    * Microtransaction
+    * Confidence Factor
+    * Metadata
+    * Analytics
+    * Asset
+    * Payment Forwarding
+    * Events and Hooks
+*/
+module.exports = class blockcypher extends Exchange {
+
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'blockcypher',
+            'name': 'Blockcypher',
+            'countries': 'US',
+            'version': 'v1',
+            'rateLimit': 300,
+            'hasAlreadyAuthenticatedSuccessfully': false,
+            'hasCORS': false,
+            'urls': {
+                'logo': '',
+                'api': {
+                    'public': 'https://api.blockcypher.com/',
+                },
+                'www': 'https://live.blockcypher.com/',
+                'doc': [
+                    'https://www.blockcypher.com/dev',
+                ],
+            },
+            'api': {
+                'public': {
+                    'get': [
+                        '{currency}/{network}/',  // Blockchain information
+                        '{currency}/{network}/blocks/{block}', // Block information by block hash or height
+                        '{currency}/{network}/feature/{feature}', // Information about adoption of an upgrade feature
+                        '{currency}/{network}/addrs/{address}/balance', // Address balance information
+                        '{currency}/{network}/addrs/{address}', // Address information
+                        '{currency}/{network}/addrs/{address}/full', // Address full information
+                        '{currency}/{network}/txs/{transaction}', // Transaction information
+                        '{currency}/{network}/txs', // Unconfirmed transactions
+                    ],
+                    'post': [
+                        '{currency}/{network}/addrs', // Generate address public/private keypair or multisig address
+                        '{currency}/{network}/txs/new', // Create transaction
+                        '{currency}/{network}/txs/send', // Send transaction
+                    ],
+                },
+                'private': {
+                    'get': [
+                        '{currency}/{network}/wallets', // List wallet information
+                        '{currency}/{network}/wallets/{wallet}', // Wallet information
+                        '{currency}/{network}/wallets/hd/{wallet}', // HD Wallet information
+                        '{currency}/{network}/wallets/{wallet}/addresses', // Wallet addresses
+                        '{currency}/{network}/wallets/hd/{wallet}/addresses', // HD wallet addresses
+                        '{currency}/{network}/txs/{transaction}/propagation', // Transaction propagation information
+                        // Also websocket: wss://socket.blockcypher.com/v1/btc/main/txs/propagation
+                    ],
+                    'post': [
+                        '{currency}/{network}/wallets', // Create wallet
+                        '{currency}/{network}/wallets/hd', // Create HD wallet
+                        '{currency}/{network}/wallets/{wallet}/addresses', // Add addresses to wallet
+                        '{currency}/{network}/wallets/{wallet}/addresses/generate', // Generate and add addresses to wallet
+                        '{currency}/{network}/wallets/hd/{wallet}/addresses/derive', // Derive and add addresses to HD wallet
+                        '{currency}/{network}/txs/push', // Push raw transaction
+                        '{currency}/{network}/txs/decode', // Decode raw transaction
+                        '{currency}/{network}/txs/data', // Embed data onto blockchain (not supported for BTC)
+                    ],
+                    'delete': [
+                        '{currency}/{network}/wallets/{wallet}/addresses', // Delete addresses from wallet
+                        '{currency}/{network}/wallets/{wallet}', // Delete wallet
+                        '{currency}/{network}/wallets/hd/{wallet}', // Delete HD wallet
+                    ],
+                },
+            },
+        });
+    }
+}


### PR DESCRIPTION
Add the blockcypher.com API as an exchange. Work-in-progress...

@kroitor please review and advise a unified structure that makes sense for blockchain explorers so we can iterate.

There are a lot of generated files in this PR that don't seem to be gitignored. I assume that is on purpose. Let me know if they should not be committed.

Note that I included many endpoints that may not have equivalents in other explorer APIs (for instance https://blockchain.info/api/blockchain_api). I think the initial focus should be on public endpoints related to addresses, transactions, and blocks. 

The main things I need are to check the balance and transactions of an address as well as monitoring unconfirmed transactions.

While some block explorers only support one currency, the blockcypher API supports several:

* `btc`
* `ltc`
* `dash`
* `doge`
* `eth`
* `beth` - blockcypher test eth
* `bcy` - blockcypher test btc 

It also supports the following `networks`:

* `main` - the blockchain's mainnet
* `test` - the blockchain's testnet
* `test3` - bitcoin testnet3

https://www.blockcypher.com/dev/bitcoin/
https://www.blockcypher.com/dev/dash/
https://www.blockcypher.com/dev/ethereum/
