### PR TITLE
gemini: withdraw

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -16,7 +16,14 @@ module.exports = class gemini extends Exchange {
             'countries': 'US',
             'rateLimit': 1500, // 200 for private API
             'version': 'v1',
+            // obsolete metainfo interface
             'hasCORS': false,
+            'hasWithdraw': true,
+            // new metainfo interface
+            'has': {
+                'CORS': false,
+                'withdraw': true,
+            },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/27816857-ce7be644-6096-11e7-82d6-3c257263229c.jpg',
                 'api': 'https://api.gemini.com',
@@ -194,7 +201,7 @@ module.exports = class gemini extends Exchange {
         await this.loadMarkets ();
         let currency = this.currency (code);
         let response = await this.privatePostWithdrawCurrency (this.extend ({
-            'currency': currency,
+            'currency': currency['id'],
             'amount': amount,
             'address': address,
         }, params));

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -190,6 +190,20 @@ module.exports = class gemini extends Exchange {
         return await this.privatePostCancelOrder ({ 'order_id': id });
     }
 
+    async withdraw (code, amount, address, params = {}) {
+        await this.loadMarkets ();
+        let currency = this.currency (code);
+        let response = await this.privatePostWithdrawCurrency (this.extend ({
+            'currency': currency,
+            'amount': amount,
+            'address': address,
+        }, params));
+        return {
+            'info': response,
+            'id': this.safeString (response, 'txHash'),
+        };
+    }
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = '/' + this.version + '/' + this.implodeParams (path, params);
         let query = this.omit (params, this.extractParams (path));


### PR DESCRIPTION
This is based on: https://docs.gemini.com/rest-api/#withdraw-crypto-funds-to-whitelisted-address

I think we shouldn't be passing `currency` (not sure if it will complain for passing extra stuff), but without it I don't think endpoint URL would be correct.

If this is fine, I'd push another change to metainfo