### PR TITLE
bitmex PUT signature bugfix

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -412,6 +412,9 @@ module.exports = class bitmex extends Exchange {
             this.checkRequiredCredentials ();
             let nonce = this.nonce ().toString ();
             let auth = method + query + nonce;
+            if (method == 'PUT') {
+                auth += body;
+            }
             if (method == 'POST') {
                 if (Object.keys (params).length) {
                     body = this.json (params);

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -405,17 +405,14 @@ module.exports = class bitmex extends Exchange {
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let query = '/api' + '/' + this.version + '/' + path;
-        if (Object.keys (params).length)
+        if (Object.keys (params).length && method != 'PUT')
             query += '?' + this.urlencode (params);
         let url = this.urls['api'] + query;
         if (api == 'private') {
             this.checkRequiredCredentials ();
             let nonce = this.nonce ().toString ();
             let auth = method + query + nonce;
-            if (method == 'PUT') {
-                auth += body;
-            }
-            if (method == 'POST') {
+            if (method == 'POST' || method == 'PUT') {
                 if (Object.keys (params).length) {
                     body = this.json (params);
                     auth += body;


### PR DESCRIPTION
Just want to point out an issue I'm getting when using bitmex.
The unified methods work fine, but I get an error using PUT endpoints directly.
Example:

```python
result = await bitmex.private_put_order_bulk(params=orders)
```

Returns the error:

```
bitmex {"error":{"message":"Signature not valid.","name":"HTTPError"}}
```

Pull request is suggestion to fix.

PS. Thanks for taking the time to merge my last request!