### PR TITLE
Poloniex: nonce error

### DIFF
--- a/python/ccxt/poloniex.py
+++ b/python/ccxt/poloniex.py
@@ -679,7 +679,7 @@ class poloniex (Exchange):
         }
 
     def nonce(self):
-        return self.milliseconds()
+        return self.microseconds()
 
     def sign(self, path, api='public', method='GET', params={}, headers=None, body=None):
         url = self.urls['api'][api]


### PR DESCRIPTION
The original code of poloniex.py generates nonce error.

After changing the nonce() in poloniex.py into microsecond it worked.

I am not sure if this is a correct change, please help me check it.

Thanks.