### PR TITLE
eslint: added '===' and '!==' rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,5 +21,6 @@
     "block-spacing": [2, "always"],
     "keyword-spacing": [2, { "before": true, "after": true }],
     "object-curly-spacing": [2, "always"],
+    "eqeqeq": "error",
   }
 }


### PR DESCRIPTION
Recently you switched to this kind of style but as I still see '==' and '!=' here and there I wonder: is it still WIP (and this PR will help) or you want these '===' in some specific cases (in this case I'll try to tune the linter to address them exactly)?