### PR TITLE
PHP: nonce override / hack

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -474,10 +474,6 @@ abstract class Exchange {
         return $input;
     }
 
-    public function nonce () {
-        return $this->seconds ();
-    }
-
     public function check_required_credentials () {
         $keys = array_keys ($this->requiredCredentials);
         foreach ($this->requiredCredentials as $key => $value) {
@@ -494,6 +490,9 @@ abstract class Exchange {
     public function __construct ($options = array ()) {
 
         $this->curl        = curl_init ();
+        $this->nonce       = function () {
+           return $this->seconds ();
+        };
         $this->id          = null;
 
         // rate limiter params
@@ -603,6 +602,9 @@ abstract class Exchange {
         if ($options)
             foreach ($options as $key => $value)
                 $this->$key = $value;
+
+        if (array_key_exists ('nonce', $options))
+            $this->nonce_override = true;
 
         if ($this->api)
             $this->define_rest_api ($this->api, 'request');
@@ -792,7 +794,7 @@ abstract class Exchange {
 
         // we probably only need to set it once on startup
         if ($this->curlopt_interface) {
-			curl_setopt ($this->curl, CURLOPT_INTERFACE, $this->curlopt_interface);
+            curl_setopt ($this->curl, CURLOPT_INTERFACE, $this->curlopt_interface);
         }
 
         /*
@@ -1482,6 +1484,9 @@ abstract class Exchange {
 
     public function __wakeup () {
         $this->curl = curl_init ();
+        $this->nonce = function () {
+           return $this->seconds ();
+        };
         if ($this->api)
             $this->define_rest_api ($this->api, 'request');
     }

--- a/transpile.js
+++ b/transpile.js
@@ -528,8 +528,13 @@ const pythonRegexes = [
             // compile signature + body for PHP
             php.push ('');
             php.push ('    public function ' + method + ' (' + phpArgs + ') {');
+            if (method === 'nonce') {
+                php.push ('        if (!empty ($this->nonce_override))');
+                php.push ('            return call_user_func_array ("parent::nonce", func_get_args ());');
+                php.push ('');
+            }
             php.push (phpBody);
-            php.push ('    }')
+            php.push ('    }');
 
         }
 


### PR DESCRIPTION
This is related to https://github.com/ccxt/ccxt/pull/1133#issuecomment-357007335

In short, PHP itself does not allow you to override methods with closures/anonymous functions. The only `legal` way would be using class inheritance.

PHP does provide magic `__call` and `__callStatic`, and that's already used in `Exchange.php`, but:
- this method is invoked only when method in question does not exist (not defined at all), or is not accessible (trying to access private method from parent), so it can't really work when `nonce` method already has implementation within `Exchange` itself.

To use it, we need to remove `nonce` implementation from `Exchange`, but since child classes sometimes define their own implementation of `nonce` method - it wouldn't work for children.
Also, there's no way to determine if we had an override passed during `__construct`, and whether it is called from parent/super or not.

Some similar approach could be made with `ReflectionClass`/`ReflectionMethod` classes, which are available by default in most installations, but that would still be hacky.

Illegal way would be installing a third party extension such as https://github.com/krakjoe/uopz which isn't recommended for production purposes (meant to help with testing PHP).

So, I've finally decided to give it a try (hack) by:
- removing base implementation of `nonce` in `Exchange` class and replace it with closure within `nonce` property
- add a new dynamic flag property to denote if we've overriden `nonce` during construct
- changed transpiler to look for `nonce` method implementations and inject some code into body to call overriden nonce closure if we know there is one

Bad stuff about this is:
- it's a hack
- it adds some pretty specific stuff to PHP transpiler
- it won't work for `__wakeup` out of the box if `nonce` was overriden - calee will have to override `nonce` once again (and `nonce_override` flag too, unless I think of a way to improve that)

Good stuff is:
- it works (as far as I've tested)
- it's backwards compatible

Will leave it up to you to decide if you wish to merge this in. Let me know if anything. Thanks!