### PR TITLE
Update binance withdraw method

### DIFF
--- a/python/ccxt/binance.py
+++ b/python/ccxt/binance.py
@@ -723,6 +723,7 @@ class binance (Exchange):
             'asset': self.currency_id(currency),
             'address': address,
             'amount': float(amount),
+            'name': 'Withdraw',
         }, params))
         return {
             'info': response,


### PR DESCRIPTION
I was trying to execute the following code

```
binance.withdraw(symbol, transfer_vol, dest_address)
```

and kept getting

```
{'id': None, 'info': {'msg': 'Name is empty.', 'success': False}}
```

So I looked through the [python-binance docs](https://python-binance.readthedocs.io/en/latest/withdraw.html)

and noticed that there is supposed to be a `name` defined in the params. I updated my code to:

```
params = {'name': 'Withdraw'}
binance.withdraw(symbol, transfer_vol, dest_address, params=params)
```

and everything worked. This should solve that problem.