### PR TITLE
Fix Cryptopia fetch order

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -524,7 +524,7 @@ module.exports = class cryptopia extends Exchange {
 
     async fetchOrder (id, symbol = undefined, params = {}) {
         id = id.toString ();
-        let orders = await this.fetchOrders (symbol, params);
+        let orders = await this.fetchOrders (symbol, undefined, undefined, params);
         for (let i = 0; i < orders.length; i++) {
             if (orders[i]['id'] == id)
                 return orders[i];


### PR DESCRIPTION
I ran into the same issue as described in https://github.com/ccxt/ccxt/issues/951
While debugging, I found that the fetchOrders call within fetchOrder passes an empty object as second parameter. This object should be the `params` for the call, but the fetchOrders second argument is the `since` variable. 

This leads to the resultset being wrongly filtered an the orders not being found. 

I mainly wanted to point it out. The PR is not complete, since the other programming languages, might have the same issue.