### PR TITLE
cli: now handles 'params' arg

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -68,8 +68,11 @@ async function main () {
 
     } else {
 
-        let args = params.map (param =>
-            param.match (/[a-zA-Z]/g) ? param : parseFloat (param))
+        let args = params.map (param => {
+            if (param[0] === '{')
+                return JSON.parse (param)
+            return param.match (/[a-zA-Z]/g) ? param : parseFloat (param)
+        })
 
         if (typeof exchange[methodName] == 'function') {
             log (await exchange[methodName] (... args))


### PR DESCRIPTION
Now one is able to provide extra params object:
```
> node examples/js/cli okex fetchOrders ETH/BTC 0 0 '{"status":"0"}'
```