### PR TITLE
transpile: now semicolon-friendly

### DIFF
--- a/transpile.js
+++ b/transpile.js
@@ -402,13 +402,13 @@ const pythonRegexes = [
     function transpileDerivedExchangeClass (contents) {
 
         // match all required imports
-        let requireRegex = /^const\s+[^\=]+\=\s*require\s*\(\'[^\']+\'\)$/gm
+        let requireRegex = /^const\s+[^\=]+\=\s*require\s*\(\'[^\']+\'\);*$/gm
         let requireMatches = contents.match (requireRegex)
 
         // log.yellow (requireMatches)
         // process.exit (1)
 
-        let exchangeClassDeclarationMatches = contents.match (/^module\.exports\s*=\s*class\s+([\S]+)\s+extends\s+([\S]+)\s+{([\s\S]+?)^}/m)
+        let exchangeClassDeclarationMatches = contents.match (/^module\.exports\s*=\s*class\s+([\S]+)\s+extends\s+([\S]+)\s+{([\s\S]+?)^};*/m)
 
         // log.green (file, exchangeClassDeclarationMatches[3])
 
@@ -425,7 +425,6 @@ const pythonRegexes = [
 
         // run through all methods
         for (let i = 0; i < methods.length; i++) {
-
             // parse the method signature
             let part = methods[i].trim ()
             let lines = part.split ("\n")
@@ -571,7 +570,6 @@ const pythonRegexes = [
 
             log.red ('\nFailed to transpile source code from', filename.yellow)
             log.red ('See https://github.com/ccxt/ccxt/blob/master/CONTRIBUTING.md on how to build this library properly\n')
-
             throw e // rethrow it
         }
     }


### PR DESCRIPTION
It works now because you don't use `requireMatches` but will fail if you do.