### PR TITLE
Fix for ZB.com private API error 1003 Verification does not pass

### DIFF
--- a/php/zb.php
+++ b/php/zb.php
@@ -310,11 +310,9 @@ class zb extends Exchange {
                 $url .= '?' . $this->urlencode ($params);
         } else {
             $this->check_required_credentials();
-            $paramsLength = is_array ($params) ? count ($params) : 0; // $params should be a string here
             $nonce = $this->nonce ();
-            $auth = 'method=' . $path;
-            $auth .= '&accesskey=' . $this->apiKey;
-            $auth .= $paramsLength ? $params : '';
+            $auth = 'accesskey=' . $this->apiKey;
+            $auth .= '&method=' . $path;
             $secret = $this->hash ($this->encode ($this->secret), 'sha1');
             $signature = $this->hmac ($this->encode ($auth), $this->encode ($secret), 'md5');
             $suffix = 'sign=' . $signature . '&reqTime=' . (string) $nonce;


### PR DESCRIPTION
@kroitor The order of the parameters seems to be important and $auth only needs acceskey and method. 

Taken from this example: https://github.com/zb2017/api/blob/1e86fd1b393631768a064a5c6348d9abd2fff3a5/PHP/zbapi.php#L43

Fixes issue: https://github.com/ccxt/ccxt/issues/1024 
Relates to: https://github.com/ccxt/ccxt/issues/1269 