### PR TITLE
PHP: Exchange: has method

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1492,4 +1492,19 @@ abstract class Exchange {
             $this->define_rest_api ($this->api, 'request');
     }
 
+    public function has ($feature) {
+        $feature = strtolower ($feature);
+        $new_feature_map = array_change_key_case ($this->has, CASE_LOWER);
+        if (array_key_exists ($feature, $new_feature_map)) {
+            return $new_feature_map[$feature];
+        }
+
+        $old_feature_map = array_change_key_case (array_filter (get_object_vars ($this), function ($key) {
+            return strpos($key, 'has') !== false && $key !== 'has';
+        }, ARRAY_FILTER_USE_KEY), CASE_LOWER);
+
+        $old_feature = "has{$feature}";
+        return array_key_exists ($old_feature, $old_feature_map) ? $old_feature_map[$old_feature] : false;
+    }
+
 }


### PR DESCRIPTION
A suggestion for a PHP helper method in base `Exchange` for checking metainfo stuff.

Currently, there are two metainfos: old and new implementation. User has to check both to make sure, and they have different names. PHP is case sensitive for both array key lookups and property names, so this helper tries to lowercase everything first and minimize chance of a mistake.

Method prefers new metainfo interface.
Typos will still be typos.