### PR TITLE
Fix 'ExchangeNotAvailable' undefined for poloniex

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, InsufficientFunds, OrderNotFound, OrderNotCached, InvalidOrder } = require ('./base/errors');
+const { ExchangeNotAvailable, ExchangeError, InsufficientFunds, OrderNotFound, OrderNotCached, InvalidOrder } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Hey,

The `ExchangeNotAvailable` error can be thrown, but it was not referenced in `poloniex.js` https://github.com/ccxt/ccxt/blob/master/js/poloniex.js#L774
I added it to the `require` on the top of the file.