### PR TITLE
liqui: handleErrors: throw on unknow erorrs

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -678,6 +678,8 @@ module.exports = class liqui extends Exchange {
                         throw new DDoSProtection (feedback);
                     } else if (message === 'external service unavailable') {
                         throw new DDoSProtection (feedback);
+                    } else {
+                        throw new ExchangeError (this.id + ' unknown "error" value: ' + this.json (response));
                     }
                 }
             }


### PR DESCRIPTION
First, thanks for your time and for the updated version, it's now much better than it was before.

I hope soon to switch other exchanges to this style of error handling as well.

Still, I set up accounts on children exchanges and ran existing implementation through my extended testsuite.

```
> :air:~/src/ccxt max$ node examples/js/cli.js dsx createLimitBuyOrder BTC/USD 0 0
[TypeError] Cannot use 'in' operator to search for 'received' in undefined
    at safeFloat      js/base/functions.js:179           if (key in object) {                                              
    at createOrder    js/liqui.js:364                    let filled = this.safeFloat (response['return'], 'received', 0.0);
    at _tickCallback  internal/process/next_tick.js:160                                                                    
```

This patch fixes this bug.

Now:
```
:air:~/src/ccxt max$ node examples/js/cli.js dsx createLimitBuyOrder BTC/USD 0 0
[ExchangeError] dsx unknown "error" value: {"success":0,"error":"Order was rejected. Incorrect price."}
    at handleErrors   js/liqui.js:682                    throw new ExchangeError (this.id + ' unknown "error" value: ' + this.json (resp…
    at text           js/base/Exchange.js:446            this.handleErrors (...args)                                                     
    at _tickCallback  internal/process/next_tick.js:160
```