### PR TITLE
Add eslint devDeps required for linting + GDAX fetchMyTrades implementation

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 // ----------------------------------------------------------------------------
 
@@ -8,7 +8,6 @@ const { ExchangeError, InvalidOrder, AuthenticationError, NotSupported } = requi
 // ----------------------------------------------------------------------------
 
 module.exports = class gdax extends Exchange {
-
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'gdax',
@@ -175,10 +174,10 @@ module.exports = class gdax extends Exchange {
                 'price': -Math.log10 (parseFloat (priceLimits['min'])),
             };
             let taker = this.fees['trading']['taker'];
-            if ((base == 'ETH') || (base == 'LTC')) {
+            if ((base === 'ETH') || (base === 'LTC')) {
                 taker = 0.003;
             }
-            let active = market['status'] == 'online';
+            let active = market['status'] === 'online';
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -258,7 +257,7 @@ module.exports = class gdax extends Exchange {
 
     parseTrade (trade, market = undefined) {
         let timestamp = this.parse8601 (trade['time']);
-        let side = (trade['side'] == 'buy') ? 'sell' : 'buy';
+        let side = (trade['side'] === 'buy') ? 'sell' : 'buy';
         let symbol = undefined;
         if (market)
             symbol = market['symbol'];
@@ -427,7 +426,7 @@ module.exports = class gdax extends Exchange {
             'size': amount,
             'type': type,
         };
-        if (type == 'limit')
+        if (type === 'limit')
             order['price'] = price;
         let response = await this.privatePostOrders (this.extend (order, params));
         return {
@@ -501,16 +500,16 @@ module.exports = class gdax extends Exchange {
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let request = '/' + this.implodeParams (path, params);
         let query = this.omit (params, this.extractParams (path));
-        if (method == 'GET') {
+        if (method === 'GET') {
             if (Object.keys (query).length)
                 request += '?' + this.urlencode (query);
         }
         let url = this.urls['api'] + request;
-        if (api == 'private') {
+        if (api === 'private') {
             this.checkRequiredCredentials ();
             let nonce = this.nonce ().toString ();
             let payload = '';
-            if (method != 'GET') {
+            if (method !== 'GET') {
                 if (Object.keys (query).length) {
                     body = this.json (query);
                     payload = body;
@@ -532,15 +531,15 @@ module.exports = class gdax extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body) {
-        if (code == 400) {
-            if (body[0] == "{") {
+        if (code === 400) {
+            if (body[0] === '{') {
                 let response = JSON.parse (body);
                 let message = response['message'];
                 if (message.indexOf ('price too small') >= 0) {
                     throw new InvalidOrder (this.id + ' ' + message);
                 } else if (message.indexOf ('price too precise') >= 0) {
                     throw new InvalidOrder (this.id + ' ' + message);
-                } else if (message == 'Invalid API Key') {
+                } else if (message === 'Invalid API Key') {
                     throw new AuthenticationError (this.id + ' ' + message);
                 }
                 throw new ExchangeError (this.id + ' ' + this.json (response));
@@ -556,4 +555,4 @@ module.exports = class gdax extends Exchange {
         }
         return response;
     }
-}
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "chai-as-promised": "^7.1.1",
     "coveralls": "^2.13.1",
     "eslint": "^4.15.0",
+    "eslint-config-google": "^0.9.1",
+    "eslint-plugin-html": "^4.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.5.3",
     "nyc": "^11.0.3",


### PR DESCRIPTION
Needed those packages when I tried to run `npm run lint` as described in [CONTRIBUTING](https://github.com/ccxt/ccxt/blob/master/CONTRIBUTING.md#derived-exchange-classes). I'm surprised nobody has run into this problem before. But maybe that explains why every single js exchange file I tried, failed the check :)

*UPDATE* sorry for all three commits ending up in the same PR. I'll create separate branches next time.