### PR TITLE
add costLimits to cryptopia.py

### DIFF
--- a/python/ccxt/cryptopia.py
+++ b/python/ccxt/cryptopia.py
@@ -141,9 +141,14 @@ class cryptopia (Exchange):
                 'min': market['MinimumPrice'],
                 'max': market['MaximumPrice'],
             }
+            costLimits = {
+                'min': market['MinimumBaseTrade'],
+                'max': market['MaximumBaseTrade'],
+            }
             limits = {
                 'amount': amountLimits,
                 'price': priceLimits,
+                'cost': costLimits,
             }
             active = market['Status'] == 'OK'
             result.append({


### PR DESCRIPTION
I realized (too late) that I made a mistake in https://github.com/ccxt/ccxt/pull/1335.

However, I see that this changed was reversed https://github.com/ccxt/ccxt/commit/cd417d753605e641f7961a46fc65c3d5a5e6a825#diff-633e26334bffa59e393da2371d032e9f anyway (for a reason I don't understand.)

I actually needed to add `costLimits` to the `markets`.