### PR TITLE
liqui: no such endpoint TransHistory

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -58,7 +58,6 @@ module.exports = class liqui extends Exchange {
                         'OrderInfo',
                         'CancelOrder',
                         'TradeHistory',
-                        'TransHistory',
                         'CoinDepositAddress',
                         'WithdrawCoin',
                         'CreateCoupon',


### PR DESCRIPTION
At least not according to https://liqui.io/api (and requests to it fail, as well)