### PR TITLE
liqui: handleErrors: fixed error code for InsufficientFunds

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -74,14 +74,14 @@ module.exports = class liqui extends Exchange {
                 'funding': 0.0,
             },
             'exceptions': {
-                '803': InvalidOrder, // "Count could not be less than 1000000." (misleading message on price > maxPrice, thrown on sellOrder('LTC/USDT', 0.00001, 100000') which violates maxPrice)
-                '804': InvalidOrder, // "Count could not be more than 10000." ('count' is 'amount', thrown on createLimitBuyOrder('BTC/USDT', 100000, 1))
-                '805': InvalidOrder, // "price could not be less than X."
-                '806': InvalidOrder, // "price could not be more than X."
-                '807': InvalidOrder, // "cost could not be less than X."
-                '831': InsufficientFunds, // "Not enougth X to create buy order."
-                '836': InsufficientFunds, // "Not enougth X to create sell order."
-                '833': OrderNotFound, // "Order with id X was not found."
+                '803': InvalidOrder, // "Count could not be less than 0.001." (selling below minAmount)
+                '804': InvalidOrder, // "Count could not be more than 10000." (buying above maxAmount)
+                '805': InvalidOrder, // "price could not be less than X." (minPrice violation on buy & sell)
+                '806': InvalidOrder, // "price could not be more than X." (maxPrice violation on buy & sell)
+                '807': InvalidOrder, // "cost could not be less than X." (minCost violation on buy & sell)
+                '831': InsufficientFunds, // "Not enougth X to create buy order." (buying with balance.quote < order.cost)
+                '832': InsufficientFunds, // "Not enougth X to create sell order." (selling with balance.base < order.amount)
+                '833': OrderNotFound, // "Order with id X was not found." (cancelling non-existent, closed and cancelled order)
             },
         });
     }
@@ -670,7 +670,7 @@ module.exports = class liqui extends Exchange {
                         throw new AuthenticationError (feedback);
                     } else if (message === 'api key dont have trade permission') {
                         throw new AuthenticationError (feedback);
-                    } else if (message.indexOf ('invalid parameter') >= 0) { // errorCode 0
+                    } else if (message.indexOf ('invalid parameter') >= 0) { // errorCode 0, returned on buy(symbol, 0, 0)
                         throw new InvalidOrder (feedback);
                     } else if (message === 'Requests too often') {
                         throw new DDoSProtection (feedback);


### PR DESCRIPTION
It looks like I mistyped the code.

It's really strange because that time I noticed that this code is out of order and I vividly remember that I double checked it. At the same time, I can't find it in my logs. Really strange.

The reason it passed my testsuite that time is that... it didn't.

Well, I switched to ccxt keys for checks against max/min limits and insufficient funds. The reason is that it's quite risky to test on real balances in case my testsuite has bugs itself (e.g. mistake in the test that would sell something valuable on minPrice )).

But as ccxt's liqui keys have no trading permissions I switched that "sell really big amount" test off...