### PR TITLE
braziliex: handle tag in fetchDepositAddress #1348

### DIFF
--- a/js/braziliex.js
+++ b/js/braziliex.js
@@ -416,12 +416,14 @@ module.exports = class braziliex extends Exchange {
         let response = await this.privatePostDepositAddress (this.extend ({
             'currency': currency['id'],
         }, params));
-        let address = this.safeString (response['deposit_address'], 'address');
+        let address = this.safeString (response, 'deposit_address');
         if (!address)
             throw new ExchangeError (this.id + ' fetchDepositAddress failed: ' + this.last_http_response);
+        let tag = this.safeString (response, 'payment_id');
         return {
             'currency': currencyCode,
             'address': address,
+            'tag': tag,
             'status': 'ok',
             'info': response,
         };


### PR DESCRIPTION
This one goes separately because I think there was a mistake in original implementation, specifically in line 419 (vs current [docs](https://braziliex.com/exchange/api.php))

Also, I think we could fix livecoin as well, but they return tag within address field, delimited by `::`.
I wasn't sure about JS syntax to use which would transpile correctly, so I haven't attempted to sort that one out. (same format is used both for fetching deposit address and withdrawal).