### PR TITLE
Clear CURLOPT_CUSTOMREQUEST on GET and POST

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -836,6 +836,9 @@ abstract class Exchange {
         $curl_errno = curl_errno ($this->curl);
         $curl_error = curl_error ($this->curl);
 
+        // Reset curl opts
+        curl_reset($this->curl);
+
         if ($result === false) {
 
             if ($curl_errno == 28) // CURLE_OPERATION_TIMEDOUT


### PR DESCRIPTION
If I do a request that sets the `CURLOPT_CUSTOMREQUEST` option, any GET/POST request will still have that option set because it re-uses the curl_init.

```php
$binance->cancelOrder(123, 'ETH/BTC');
$binance->fetchOrder(123, 'ETH/BTC'); // This fails because the underlying CURL does DELETE request.
```

This should fix #1243