### PR TITLE
Update hitbtc2 ETH withdraw fee

### DIFF
--- a/js/hitbtc2.js
+++ b/js/hitbtc2.js
@@ -122,7 +122,7 @@ module.exports = class hitbtc2 extends hitbtc {
                     'withdraw': {
                         'BTC': 0.00085,
                         'BCC': 0.0018,
-                        'ETH': 0.00215,
+                        'ETH': 0.00958,
                         'BCH': 0.0018,
                         'USDT': 100,
                         'DASH': 0.03,


### PR DESCRIPTION
Withdraw fee for ETH at hitbtc wasn't correct. Correct value is 0.00958

Here's a screenshot from the hitbtc withdraw page: https://ibb.co/dEpDyb