### PR TITLE
Fix poloniex hasCors

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -15,7 +15,7 @@ module.exports = class poloniex extends Exchange {
             'name': 'Poloniex',
             'countries': 'US',
             'rateLimit': 1000, // up to 6 calls per second
-            'hasCORS': true,
+            'hasCORS': false,
             // obsolete metainfo interface
             'hasFetchMyTrades': true,
             'hasFetchOrder': true,


### PR DESCRIPTION
Hi,

The poloiex trading api has no cors.
You can check it here  [test-cors.org](https://www.test-cors.org/#?client_method=POST&client_credentials=false&server_url=https%3A%2F%2Fpoloniex.com%2FtradingApi&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote)