### PR TITLE
fix binance withdraw - The label must not exceed 20 characters

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -773,7 +773,7 @@ module.exports = class binance extends Exchange {
             'asset': this.currencyId (currency),
             'address': address,
             'amount': parseFloat (amount),
-            'name': address,
+            'name': address.substr(0, 20),
         };
         if (tag)
             request['addressTag'] = tag;


### PR DESCRIPTION
Hi,

i'm testing the binance withdraw method atm. I tried to withdraw LTC but got the following error `The label must not exceed 20 characters`.

It seems what they refer to as `label` is called `name` in their API docs. See https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#withdraw. They also claim that a name parameter isn't mandatory but deleting the name parameter leads to another error.

I propose that we limit the `name` parameter to 20 characters. With this fix I was able to withdraw my LTC. What do you think?

Cheers,
Fabian