### PR TITLE
fix costToPrecision to use the correct value

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -837,7 +837,7 @@ module.exports = class Exchange {
     }
 
     costToPrecision (symbol, cost) {
-        return parseFloat (cost).toFixed (this.markets[symbol].precision.price)
+        return parseFloat (cost).toFixed (this.markets[symbol].precision.quote)
     }
 
     priceToPrecision (symbol, price) {


### PR DESCRIPTION
the cost is always expressed in units of the quote coin

This was using the price precision, which is wrong because `cost = amount * price` .

If this gets merged, will it be propagated to the Python files?