### PR TITLE
QuadrigaCX: Throw AuthenticationError in case of authentication failure

### DIFF
--- a/js/quadrigacx.js
+++ b/js/quadrigacx.js
@@ -3,12 +3,11 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError } = require ('./base/errors');
+const { ExchangeError, AuthenticationError } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
 module.exports = class quadrigacx extends Exchange {
-
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'quadrigacx',
@@ -234,6 +233,13 @@ module.exports = class quadrigacx extends Exchange {
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 
+    handleErrors (statusCode, statusText, url, method, headers, body) {
+        let response = JSON.parse (body);
+        if (response.error.message === 'Invalid API Code or Invalid Signature') {
+            throw new AuthenticationError (this.id + ' ' + body);
+        }
+    }
+
     async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let response = await this.fetch2 (path, api, method, params, headers, body);
         if (typeof response === 'string')
@@ -242,4 +248,4 @@ module.exports = class quadrigacx extends Exchange {
             throw new ExchangeError (this.id + ' ' + this.json (response));
         return response;
     }
-}
+};

--- a/js/quadrigacx.js
+++ b/js/quadrigacx.js
@@ -234,8 +234,11 @@ module.exports = class quadrigacx extends Exchange {
     }
 
     handleErrors (statusCode, statusText, url, method, headers, body) {
-        let response = JSON.parse (body);
-        if (response.error.message === 'Invalid API Code or Invalid Signature') {
+        if ((typeof body !== 'string') || (body.length < 2))
+            return; // fallback to default error handler
+        // Here is a sample QuadrigaCX response in case of authentication failure:
+        // {"error":{"code":101,"message":"Invalid API Code or Invalid Signature"}}
+        if (statusCode === 200 &&  body.indexOf ('Invalid API Code or Invalid Signature') >= 0) {
             throw new AuthenticationError (this.id + ' ' + body);
         }
     }

--- a/js/quadrigacx.js
+++ b/js/quadrigacx.js
@@ -238,7 +238,7 @@ module.exports = class quadrigacx extends Exchange {
             return; // fallback to default error handler
         // Here is a sample QuadrigaCX response in case of authentication failure:
         // {"error":{"code":101,"message":"Invalid API Code or Invalid Signature"}}
-        if (statusCode === 200 &&  body.indexOf ('Invalid API Code or Invalid Signature') >= 0) {
+        if (statusCode === 200 && body.indexOf ('Invalid API Code or Invalid Signature') >= 0) {
             throw new AuthenticationError (this.id + ' ' + body);
         }
     }


### PR DESCRIPTION
Instead of throwing generic `ExchangeException`, throw the more specific `AuthenticationError` when error message equals `Invalid API Code or Invalid Signature`.

`npm run build` runs successfully.