### PR TITLE
examples: binance server time

### DIFF
--- a/examples/js/binance-server-time.js
+++ b/examples/js/binance-server-time.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const log       = require ('ololog').configure ({ locate: false })
+const log  = require ('ololog').configure ({ locate: false })
 const ccxt = require('../../ccxt')
 
 const binance = new ccxt['binance'] ()

--- a/examples/js/binance-server-time.js
+++ b/examples/js/binance-server-time.js
@@ -17,8 +17,8 @@ async function test () {
 
     log (`request departure time:     ${binance.iso8601 (localStartTime)}`)
     log (`response arrival time:      ${binance.iso8601 (localFinishTime)}`)
-    log (`request landing time (est): ${binance.iso8601 (estimatedLandingTime)}, ${Math.abs (diff)} ms ${Math.sign (diff) > 0 ? 'behind' : 'ahead of'} server`)
     log (`server time:                ${binance.iso8601 (serverTime)}`)
+    log (`request landing time (est): ${binance.iso8601 (estimatedLandingTime)}, ${Math.abs (diff)} ms ${Math.sign (diff) > 0 ? 'behind' : 'ahead of'} server`)
     log ('\n')
 
     if (diff < -aheadWindow) {

--- a/examples/js/binance-server-time.js
+++ b/examples/js/binance-server-time.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const log       = require ('ololog').configure ({ locate: false })
+const ccxt = require('../../ccxt')
+
+const binance = new ccxt['binance'] ()
+const recvWindow = binance.security.recvWindow
+const aheadWindow = 1000
+
+async function test () {
+    const localStartTime = Date.now ()
+    const { serverTime } = await binance.publicGetTime ()
+    const localFinishTime = Date.now ()
+    const estimatedLandingTime = (localFinishTime + localStartTime) / 2
+
+    const diff = serverTime - estimatedLandingTime
+
+    log (`request departure time:     ${binance.iso8601 (localStartTime)}`)
+    log (`response arrival time:      ${binance.iso8601 (localFinishTime)}`)
+    log (`request landing time (est): ${binance.iso8601 (estimatedLandingTime)}, ${Math.abs (diff)} ms ${Math.sign (diff) > 0 ? 'behind' : 'ahead of'} server`)
+    log (`server time:                ${binance.iso8601 (serverTime)}`)
+    log ('\n')
+
+    if (diff < -aheadWindow) {
+        log.error.red (`your request will likely be rejected if local time is ahead of the server's time for more than ${aheadWindow} ms \n`)
+    }
+
+    if (diff > recvWindow) {
+        log.error.red (`your request will likely be rejected if local time is behind server time for more than ${recvWindow} ms\n`)
+    }
+}
+
+test ();

--- a/js/binance.js
+++ b/js/binance.js
@@ -296,6 +296,9 @@ module.exports = class binance extends Exchange {
                     },
                 },
             },
+            'security': {
+                'recvWindow': 100 * 1000, // 100 sec
+            },
         });
     }
 
@@ -799,7 +802,7 @@ module.exports = class binance extends Exchange {
             let nonce = this.milliseconds ();
             let query = this.urlencode (this.extend ({
                 'timestamp': nonce,
-                'recvWindow': 100000,
+                'recvWindow': this['security']['recvWindow'],
             }, params));
             let signature = this.hmac (this.encode (query), this.encode (this.secret));
             query += '&' + 'signature=' + signature;

--- a/js/binance.js
+++ b/js/binance.js
@@ -802,7 +802,7 @@ module.exports = class binance extends Exchange {
             let nonce = this.milliseconds ();
             let query = this.urlencode (this.extend ({
                 'timestamp': nonce,
-                'recvWindow': this['security']['recvWindow'],
+                'recvWindow': this.security['recvWindow'],
             }, params));
             let signature = this.hmac (this.encode (query), this.encode (this.secret));
             query += '&' + 'signature=' + signature;


### PR DESCRIPTION
Binance is pretty strict on the clock so it's quite handy to check how the local time is doing.

As this question was asked several times (and might be asked more) we could point users right to this script so they can check for themselves.

P.S. I'd still reduce `recvWindow` to the default 5000 ms. I understand that it was set to lower the number of issues from careless users who have their clock lag behind. At the same time:
- the number of users with their clock behind should be comparable to those with the clock ahead
- "behind" check is 5 times more relaxed than "ahead" check

As there were not so many issues with clock ahead so for "clock behind" we should have even less.