### PR TITLE
Add fetchPermissions to Binance

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -205,26 +205,6 @@ module.exports = class Exchange {
         }
     }
 
-    getPrivateReadMethods () {
-        const privateReadMethods = ['fetchBalance', 'fetchOrder', 'fetchOrders', 'fetchOpenOrders', 'fetchClosedOrders' , 'fetchMyTrades', 'fetchDepositAddress'];
-        return this.filterImplementedMethods (privateReadMethods);
-    }
-
-    getPrivateTradingMethods () {
-        const privateTradingMethods = ['createOrder', 'createLimitBuyOrder', 'createLimitSellOrder', 'createMarketBuyOrder', 'createMarketSellOrder' , 'cancelOrder'];
-        return this.filterImplementedMethods (privateTradingMethods);
-    }
-
-    filterImplementedMethods (methods = []) {
-        const implemented = [];
-        for (let i = 0; i < methods.length; i++) {
-            if (this.has[methods[i]]) {
-                implemented.push (methods[i]);
-            }
-        }
-        return implemented;
-    }
-
     defaults () {
         return { /* override me */ }
     }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -170,12 +170,15 @@ module.exports = class Exchange {
             'fetchOrder': false,
             'fetchOrderBook': true,
             'fetchOrders': false,
+            'fetchPermissions': false,
             'fetchTicker': true,
             'fetchTickers': false,
             'fetchBidsAsks': false,
             'fetchTrades': true,
             'withdraw': false,
         }
+
+        this.allows = {}
 
         // merge configs
         const config = deepExtend (this.describe (), userConfig)
@@ -200,6 +203,26 @@ module.exports = class Exchange {
         if (this.debug && journal) {
             journal (() => this.journal, this, Object.keys (this.has))
         }
+    }
+
+    getPrivateReadMethods () {
+        const privateReadMethods = ['fetchBalance', 'fetchOrder', 'fetchOrders', 'fetchOpenOrders', 'fetchClosedOrders' , 'fetchMyTrades', 'fetchDepositAddress'];
+        return this.filterImplementedMethods (privateReadMethods);
+    }
+
+    getPrivateTradingMethods () {
+        const privateTradingMethods = ['createOrder', 'createLimitBuyOrder', 'createLimitSellOrder', 'createMarketBuyOrder', 'createMarketSellOrder' , 'cancelOrder'];
+        return this.filterImplementedMethods (privateTradingMethods);
+    }
+
+    filterImplementedMethods(methods = []) {
+        const implemented = [];
+        for (let i = 0; i < methods.length; i++) {
+            if (this.has[methods[i]]) {
+                implemented.push (methods[i]);
+            }
+        }
+        return implemented;
     }
 
     defaults () {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -215,7 +215,7 @@ module.exports = class Exchange {
         return this.filterImplementedMethods (privateTradingMethods);
     }
 
-    filterImplementedMethods(methods = []) {
+    filterImplementedMethods (methods = []) {
         const implemented = [];
         for (let i = 0; i < methods.length; i++) {
             if (this.has[methods[i]]) {

--- a/js/binance.js
+++ b/js/binance.js
@@ -765,7 +765,7 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchPermissions (params = {}) {
-        const readMethods = ['fetchBalance', 'fetchOrder', 'fetchOrders', 'fetchOpenOrders', 'fetchClosedOrders' , 'fetchMyTrades'];
+        const readMethods = ['fetchBalance', 'fetchOrder', 'fetchOrders', 'fetchOpenOrders', 'fetchClosedOrders', 'fetchMyTrades'];
         for (let i = 0; i < readMethods.length; i++) {
             this.allows[readMethods[i]] = true;
         }

--- a/js/binance.js
+++ b/js/binance.js
@@ -765,7 +765,7 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchPermissions (params = {}) {
-        const readMethods = this.getPrivateReadMethods ();
+        const readMethods = ['fetchBalance', 'fetchOrder', 'fetchOrders', 'fetchOpenOrders', 'fetchClosedOrders' , 'fetchMyTrades'];
         for (let i = 0; i < readMethods.length; i++) {
             this.allows[readMethods[i]] = true;
         }
@@ -775,7 +775,7 @@ module.exports = class binance extends Exchange {
         } catch (e) {
             tradingPermission = !e['message'].includes ('"code":-2015');
         }
-        const tradingMethods = this.getPrivateTradingMethods ();
+        const tradingMethods = ['createOrder', 'cancelOrder'];
         for (let i = 0; i < tradingMethods.length; i++) {
             this.allows[tradingMethods[i]] = tradingPermission;
         }

--- a/js/binance.js
+++ b/js/binance.js
@@ -770,15 +770,17 @@ module.exports = class binance extends Exchange {
             this.allows[readMethods[i]] = true;
         }
         let tradingPermission = false;
-        await this.privatePostOrder ().catch (e => {
-            tradingPermission = !e.message.includes ('"code":-2015');
-        });
+        try {
+            await this.privatePostOrder ();
+        } catch (e) {
+            tradingPermission = !e['message'].includes ('"code":-2015');
+        }
         const tradingMethods = this.getPrivateTradingMethods ();
         for (let i = 0; i < tradingMethods.length; i++) {
             this.allows[tradingMethods[i]] = tradingPermission;
         }
         const withdrawRes = await this.wapiPostWithdraw ();
-        this.allows.withdraw = withdrawRes.msg !== 'You don\'t have permission.';
+        this.allows['withdraw'] = withdrawRes.msg != 'You don\'t have permission.';
     }
 
     async withdraw (currency, amount, address, tag = undefined, params = {}) {
@@ -864,4 +866,4 @@ module.exports = class binance extends Exchange {
             }
         }
     }
-}
+};


### PR DESCRIPTION
Hey,
As discussed in gitter, I added, for Binance, the method `fetchPermissions` which populates the  `allows`
For example, the `allows` object after the call
```
{ fetchBalance: true,
  fetchOrder: true,
  fetchOrders: true,
  fetchOpenOrders: true,
  fetchClosedOrders: true,
  fetchMyTrades: true,
  createOrder: false,
  cancelOrder: false,
  withdraw: false }
```
If this seems good to you, I will implement the `fetchPermissions` on more exchanges :smiley: