### PR TITLE
Check the length of $body properly

### DIFF
--- a/php/binance.php
+++ b/php/binance.php
@@ -826,7 +826,7 @@ class binance extends Exchange {
             if (mb_strpos ($body, 'Order does not exist') !== false)
                 throw new OrderNotFound ($this->id . ' ' . $body);
         }
-        if ($body[0] == "{") {
+        if (strlen($body) > 0 && $body[0] == "{") {
             $response = json_decode ($body, $as_associative_array = true);
             $error = $this->safe_value($response, 'code');
             if ($error !== null) {


### PR DESCRIPTION
This commit adds a check before accessing the first character of $body
to ensure that this character does exist.

Without this, we get PHP Notice errors complaining about `Uninitialized
string offset: 0' when receiving an empty response from Binance.