### PR TITLE
Fix Binance withdraw errors

### DIFF
--- a/php/binance.php
+++ b/php/binance.php
@@ -766,7 +766,7 @@ class binance extends Exchange {
             'asset' => $this->currency_id ($currency),
             'address' => $address,
             'amount' => floatval ($amount),
-            'name' => $address,
+            'name' => substr( $address, 0, 20 ),
         ), $params));
         return array (
             'info' => $response,


### PR DESCRIPTION
This fixes the "The label must not exceed 20 characters" errors thrown by Binance when withdrawing.

This is the PHP version of https://github.com/ccxt/ccxt/pull/1386.