### PR TITLE
fix truncate_to_string, closes #1441

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -451,7 +451,7 @@ class Exchange(object):
     @staticmethod
     def truncate_to_string(num, precision=0):
         if precision > 0:
-            parts = ('%.20f' % Decimal(num)).split('.')
+            parts = ('%f' % Decimal(num)).split('.')
             decimal_digits = parts[1][:precision].rstrip('0')
             decimal_digits = decimal_digits if len(decimal_digits) else '0'
             return parts[0] + '.' + decimal_digits


### PR DESCRIPTION
Now `truncate_to_string(1.73, 2)` actually returns '1.73' instead of '1.72'. There was no need to perform rounding on the formatted string here.