### PR TITLE
Exchange: describe: default structure

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -61,7 +61,7 @@ module.exports = class Exchange {
             'name': undefined,
             'countries': undefined,
             'rateLimit': undefined,
-            'hasCORS': undefined,
+            'enableRateLimit': undefined,
             'has': undefined,
             'urls': {
                 'logo': undefined,
@@ -70,10 +70,7 @@ module.exports = class Exchange {
                 'doc': undefined,
                 'fees': undefined,
             },
-            'api': {
-                'public': undefined,
-                'private': undefined,
-            },
+            'api': undefined,
             'fees': {
                 'trading': {
                     'tierBased': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -71,6 +71,7 @@ module.exports = class Exchange {
                 'fees': undefined,
             },
             'api': undefined,
+            'markets': undefined,
             'fees': {
                 'trading': {
                     'tierBased': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -55,7 +55,42 @@ module.exports = class Exchange {
         return marketClass
     }
 
-    describe () { return {} }
+    describe () {
+        return {
+            'id': undefined,
+            'name': undefined,
+            'countries': undefined,
+            'rateLimit': undefined,
+            'hasCORS': undefined,
+            'has': undefined,
+            'urls': {
+                'logo': undefined,
+                'api': undefined,
+                'www': undefined,
+                'doc': undefined,
+                'fees': undefined,
+            },
+            'api': {
+                'public': undefined,
+                'private': undefined,
+            },
+            'fees': {
+                'trading': {
+                    'tierBased': undefined,
+                    'percentage': undefined,
+                    'taker': undefined,
+                    'maker': undefined,
+                },
+                'funding': {
+                    'tierBased': undefined,
+                    'percentage': undefined,
+                    'withdraw': undefined,
+                    'deposit': undefined,
+                },
+            },
+            'exceptions': undefined,
+        } // return
+    } // describe ()
 
     constructor (userConfig = {}) {
 


### PR DESCRIPTION
Without default structure exchange introspection gets a bit clumsy on a client's side:
```
if (exchange.fees) {
    if (exchange.fees.funding) {
        if (exchange.fees.funding.withdrawal) {
            if (exchange.fees.funding.withdrawal[base]) {
                // go with calcs...
```

This patch aims to make such stairs unnecessary.

I see you set some properties right in the `constructor`:
```
this.fees = {}
this.orders = {}
```

I'd put those which are a part of the static configuration (e.g. `fees`) into `describe` so to make these overridable properties explicit for users.

Those which are dynamic (e.g. `orders`) I'd leave in the `constructor` as is.

Let me know if you're ok with this approach.