### PR TITLE
Fix getting order id if you take multiple bids/asks

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -238,6 +238,10 @@ module.exports = class bittrex extends Exchange {
         let symbol = undefined;
         if (market)
             symbol = market['symbol'];
+        let prevday = this.safeFloat (ticker, 'PrevDay');
+        let last = this.safeFloat (ticker, 'Last');
+        let percentchangecalc = (last - prevday) / prevday * 100;
+        let change = this.truncate (percentchangecalc, 2);
         return {
             'symbol': symbol,
             'timestamp': timestamp,
@@ -250,8 +254,8 @@ module.exports = class bittrex extends Exchange {
             'open': undefined,
             'close': undefined,
             'first': undefined,
-            'last': this.safeFloat (ticker, 'Last'),
-            'change': undefined,
+            'last': last,
+            'change': change,
             'percentage': undefined,
             'average': undefined,
             'baseVolume': this.safeFloat (ticker, 'Volume'),

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -412,8 +412,17 @@ module.exports = class kucoin extends Exchange {
         let symbol = undefined;
         if (market) {
             symbol = market['symbol'];
+            let changerate = ticker['changeRate'];
+            let change = changerate * 100;
         } else {
             symbol = ticker['coinType'] + '/' + ticker['coinTypePair'];
+        }
+        // NEO markets doesn't have changerate
+        if ('changeRate' in ticker) {
+            let changecalc = this.safeFloat (ticker, 'changeRate') * 100;
+            let change = this.truncate(changecalc, 2);
+        } else {
+            let change = undefined;
         }
         return {
             'symbol': symbol,
@@ -428,7 +437,7 @@ module.exports = class kucoin extends Exchange {
             'close': undefined,
             'first': undefined,
             'last': this.safeFloat (ticker, 'lastDealPrice'),
-            'change': undefined,
+            'change': change,
             'percentage': undefined,
             'average': undefined,
             'baseVolume': this.safeFloat (ticker, 'vol'),

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -415,7 +415,7 @@ module.exports = class kucoin extends Exchange {
         } else {
             symbol = ticker['coinType'] + '/' + ticker['coinTypePair'];
         }
-        // NEO markets doesn't have changerate
+        // TNC coin doesn't have changerate for some reason.
         if ('changeRate' in ticker) {
             let changecalc = this.safeFloat (ticker, 'changeRate') * 100;
             let change = this.truncate(changecalc, 2);

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -412,8 +412,6 @@ module.exports = class kucoin extends Exchange {
         let symbol = undefined;
         if (market) {
             symbol = market['symbol'];
-            let changerate = ticker['changeRate'];
-            let change = changerate * 100;
         } else {
             symbol = ticker['coinType'] + '/' + ticker['coinTypePair'];
         }

--- a/liqui.js
+++ b/liqui.js
@@ -1,0 +1,689 @@
+'use strict';
+
+const Exchange = require ('./base/Exchange');
+const { ExchangeError, InsufficientFunds, OrderNotFound, DDoSProtection, InvalidOrder, AuthenticationError } = require ('./base/errors');
+
+module.exports = class liqui extends Exchange {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'liqui',
+            'name': 'Liqui',
+            'countries': 'UA',
+            'rateLimit': 3000,
+            'version': '3',
+            'userAgent': this.userAgents['chrome'],
+            'has': {
+                'CORS': false,
+                'fetchOrder': true,
+                'fetchOrders': 'emulated',
+                'fetchOpenOrders': true,
+                'fetchClosedOrders': 'emulated',
+                'fetchTickers': true,
+                'fetchMyTrades': true,
+                'withdraw': true,
+            },
+            'urls': {
+                'logo': 'https://user-images.githubusercontent.com/1294454/27982022-75aea828-63a0-11e7-9511-ca584a8edd74.jpg',
+                'api': {
+                    'public': 'https://api.liqui.io/api',
+                    'private': 'https://api.liqui.io/tapi',
+                },
+                'www': 'https://liqui.io',
+                'doc': 'https://liqui.io/api',
+                'fees': 'https://liqui.io/fee',
+            },
+            'api': {
+                'public': {
+                    'get': [
+                        'info',
+                        'ticker/{pair}',
+                        'depth/{pair}',
+                        'trades/{pair}',
+                    ],
+                },
+                'private': {
+                    'post': [
+                        'getInfo',
+                        'Trade',
+                        'ActiveOrders',
+                        'OrderInfo',
+                        'CancelOrder',
+                        'TradeHistory',
+                        'CoinDepositAddress',
+                        'WithdrawCoin',
+                        'CreateCoupon',
+                        'RedeemCoupon',
+                    ],
+                },
+            },
+            'fees': {
+                'trading': {
+                    'maker': 0.001,
+                    'taker': 0.0025,
+                },
+                'funding': {
+                    'tierBased': false,
+                    'percentage': false,
+                    'withdraw': undefined,
+                    'deposit': undefined,
+                },
+            },
+            'exceptions': {
+                '803': InvalidOrder, // "Count could not be less than 0.001." (selling below minAmount)
+                '804': InvalidOrder, // "Count could not be more than 10000." (buying above maxAmount)
+                '805': InvalidOrder, // "price could not be less than X." (minPrice violation on buy & sell)
+                '806': InvalidOrder, // "price could not be more than X." (maxPrice violation on buy & sell)
+                '807': InvalidOrder, // "cost could not be less than X." (minCost violation on buy & sell)
+                '831': InsufficientFunds, // "Not enougth X to create buy order." (buying with balance.quote < order.cost)
+                '832': InsufficientFunds, // "Not enougth X to create sell order." (selling with balance.base < order.amount)
+                '833': OrderNotFound, // "Order with id X was not found." (cancelling non-existent, closed and cancelled order)
+            },
+        });
+    }
+
+    calculateFee (symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {
+        let market = this.markets[symbol];
+        let key = 'quote';
+        let rate = market[takerOrMaker];
+        let cost = parseFloat (this.costToPrecision (symbol, amount * rate));
+        if (side === 'sell') {
+            cost *= price;
+        } else {
+            key = 'base';
+        }
+        return {
+            'type': takerOrMaker,
+            'currency': market[key],
+            'rate': rate,
+            'cost': cost,
+        };
+    }
+
+    commonCurrencyCode (currency) {
+        if (!this.substituteCommonCurrencyCodes)
+            return currency;
+        if (currency === 'XBT')
+            return 'BTC';
+        if (currency === 'BCC')
+            return 'BCH';
+        if (currency === 'DRK')
+            return 'DASH';
+        // they misspell DASH as dsh :/
+        if (currency === 'DSH')
+            return 'DASH';
+        return currency;
+    }
+
+    getBaseQuoteFromMarketId (id) {
+        let uppercase = id.toUpperCase ();
+        let [ base, quote ] = uppercase.split ('_');
+        base = this.commonCurrencyCode (base);
+        quote = this.commonCurrencyCode (quote);
+        return [ base, quote ];
+    }
+
+    async fetchMarkets () {
+        let response = await this.publicGetInfo ();
+        let markets = response['pairs'];
+        let keys = Object.keys (markets);
+        let result = [];
+        for (let p = 0; p < keys.length; p++) {
+            let id = keys[p];
+            let market = markets[id];
+            let [ base, quote ] = this.getBaseQuoteFromMarketId (id);
+            let symbol = base + '/' + quote;
+            let precision = {
+                'amount': this.safeInteger (market, 'decimal_places'),
+                'price': this.safeInteger (market, 'decimal_places'),
+            };
+            let amountLimits = {
+                'min': this.safeFloat (market, 'min_amount'),
+                'max': this.safeFloat (market, 'max_amount'),
+            };
+            let priceLimits = {
+                'min': this.safeFloat (market, 'min_price'),
+                'max': this.safeFloat (market, 'max_price'),
+            };
+            let costLimits = {
+                'min': this.safeFloat (market, 'min_total'),
+            };
+            let limits = {
+                'amount': amountLimits,
+                'price': priceLimits,
+                'cost': costLimits,
+            };
+            let hidden = this.safeInteger (market, 'hidden');
+            let active = (hidden === 0);
+            result.push (this.extend (this.fees['trading'], {
+                'id': id,
+                'symbol': symbol,
+                'base': base,
+                'quote': quote,
+                'active': active,
+                'taker': market['fee'] / 100,
+                'lot': amountLimits['min'],
+                'precision': precision,
+                'limits': limits,
+                'info': market,
+            }));
+        }
+        return result;
+    }
+
+    async fetchBalance (params = {}) {
+        await this.loadMarkets ();
+        let response = await this.privatePostGetInfo ();
+        let balances = response['return'];
+        let result = { 'info': balances };
+        let funds = balances['funds'];
+        let currencies = Object.keys (funds);
+        for (let c = 0; c < currencies.length; c++) {
+            let currency = currencies[c];
+            let uppercase = currency.toUpperCase ();
+            uppercase = this.commonCurrencyCode (uppercase);
+            let total = undefined;
+            let used = undefined;
+            if (balances['open_orders'] === 0) {
+                total = funds[currency];
+                used = 0.0;
+            }
+            let account = {
+                'free': funds[currency],
+                'used': used,
+                'total': total,
+            };
+            result[uppercase] = account;
+        }
+        return this.parseBalance (result);
+    }
+
+    async fetchOrderBook (symbol, params = {}) {
+        await this.loadMarkets ();
+        let market = this.market (symbol);
+        let response = await this.publicGetDepthPair (this.extend ({
+            'pair': market['id'],
+            // 'limit': 150, // default = 150, max = 2000
+        }, params));
+        let market_id_in_reponse = (market['id'] in response);
+        if (!market_id_in_reponse)
+            throw new ExchangeError (this.id + ' ' + market['symbol'] + ' order book is empty or not available');
+        let orderbook = response[market['id']];
+        let result = this.parseOrderBook (orderbook);
+        result['bids'] = this.sortBy (result['bids'], 0, true);
+        result['asks'] = this.sortBy (result['asks'], 0);
+        return result;
+    }
+
+    parseTicker (ticker, market = undefined) {
+        let timestamp = ticker['updated'] * 1000;
+        let symbol = undefined;
+        if (market)
+            symbol = market['symbol'];
+        return {
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'high': this.safeFloat (ticker, 'high'),
+            'low': this.safeFloat (ticker, 'low'),
+            'bid': this.safeFloat (ticker, 'buy'),
+            'ask': this.safeFloat (ticker, 'sell'),
+            'vwap': undefined,
+            'open': undefined,
+            'close': undefined,
+            'first': undefined,
+            'last': this.safeFloat (ticker, 'last'),
+            'change': undefined,
+            'percentage': undefined,
+            'average': this.safeFloat (ticker, 'avg'),
+            'baseVolume': this.safeFloat (ticker, 'vol_cur'),
+            'quoteVolume': this.safeFloat (ticker, 'vol'),
+            'info': ticker,
+        };
+    }
+
+    async fetchTickers (symbols = undefined, params = {}) {
+        await this.loadMarkets ();
+        let ids = undefined;
+        if (!symbols) {
+            // let numIds = this.ids.length;
+            // if (numIds > 256)
+            //     throw new ExchangeError (this.id + ' fetchTickers() requires symbols argument');
+            ids = this.ids.join ('-');
+            if (ids.length > 2083) {
+                let numIds = this.ids.length;
+                throw new ExchangeError (this.id + ' has ' + numIds.toString () + ' symbols exceeding max URL length, you are required to specify a list of symbols in the first argument to fetchTickers');
+            }
+        } else {
+            ids = this.marketIds (symbols);
+            ids = ids.join ('-');
+        }
+        let tickers = await this.publicGetTickerPair (this.extend ({
+            'pair': ids,
+        }, params));
+        let result = {};
+        let keys = Object.keys (tickers);
+        for (let k = 0; k < keys.length; k++) {
+            let id = keys[k];
+            let ticker = tickers[id];
+            let market = this.markets_by_id[id];
+            let symbol = market['symbol'];
+            result[symbol] = this.parseTicker (ticker, market);
+        }
+        return result;
+    }
+
+    async fetchTicker (symbol, params = {}) {
+        let tickers = await this.fetchTickers ([ symbol ], params);
+        return tickers[symbol];
+    }
+
+    parseTrade (trade, market = undefined) {
+        let timestamp = parseInt (trade['timestamp']) * 1000;
+        let side = trade['type'];
+        if (side === 'ask')
+            side = 'sell';
+        if (side === 'bid')
+            side = 'buy';
+        let price = this.safeFloat (trade, 'price');
+        if ('rate' in trade)
+            price = this.safeFloat (trade, 'rate');
+        let id = this.safeString (trade, 'tid');
+        if ('trade_id' in trade)
+            id = this.safeString (trade, 'trade_id');
+        let order = this.safeString (trade, this.getOrderIdKey ());
+        if ('pair' in trade) {
+            let marketId = trade['pair'];
+            market = this.markets_by_id[marketId];
+        }
+        let symbol = undefined;
+        if (market)
+            symbol = market['symbol'];
+        let amount = trade['amount'];
+        let type = 'limit'; // all trades are still limit trades
+        let fee = undefined;
+        // this is filled by fetchMyTrades() only
+        // is_your_order is always false :\
+        // let isYourOrder = this.safeValue (trade, 'is_your_order');
+        // let takerOrMaker = 'taker';
+        // if (isYourOrder)
+        //     takerOrMaker = 'maker';
+        // let fee = this.calculateFee (symbol, type, side, amount, price, takerOrMaker);
+        return {
+            'id': id,
+            'order': order,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'symbol': symbol,
+            'type': type,
+            'side': side,
+            'price': price,
+            'amount': amount,
+            'fee': fee,
+            'info': trade,
+        };
+    }
+
+    async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        let market = this.market (symbol);
+        let request = {
+            'pair': market['id'],
+        };
+        if (limit)
+            request['limit'] = limit;
+        let response = await this.publicGetTradesPair (this.extend (request, params));
+        return this.parseTrades (response[market['id']], market, since, limit);
+    }
+
+    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
+        if (type === 'market')
+            throw new ExchangeError (this.id + ' allows limit orders only');
+        await this.loadMarkets ();
+        let market = this.market (symbol);
+        let request = {
+            'pair': market['id'],
+            'type': side,
+            'amount': this.amountToPrecision (symbol, amount),
+            'rate': this.priceToPrecision (symbol, price),
+        };
+        let response = await this.privatePostTrade (this.extend (request, params));
+        let id = this.safeString (response['return'], this.getInitOrderIdKey ());
+        let timestamp = this.milliseconds ();
+        price = parseFloat (price);
+        amount = parseFloat (amount);
+        let status = 'open';
+        let checkStatus = this.safeString (response['return'], 'order_id');
+        if (checkStatus === '0') {
+            status = 'closed';
+        }
+        let filled = this.safeFloat (response['return'], 'received', 0.0);
+        let remaining = this.safeFloat (response['return'], 'remains', amount);
+        let order = {
+            'id': id,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'status': status,
+            'symbol': symbol,
+            'type': type,
+            'side': side,
+            'price': price,
+            'cost': price * filled,
+            'amount': amount,
+            'remaining': remaining,
+            'filled': filled,
+            'fee': undefined,
+            // 'trades': this.parseTrades (order['trades'], market),
+        };
+        this.orders[id] = order;
+        return this.extend ({ 'info': response }, order);
+    }
+
+    getOrderIdKey () {
+        return 'order_id';
+    }
+
+    getInitOrderIdKey () {
+        return 'init_order_id';
+    }
+
+    async cancelOrder (id, symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        let response = undefined;
+        let request = {};
+        let idKey = this.getOrderIdKey ();
+        request[idKey] = id;
+        response = await this.privatePostCancelOrder (this.extend (request, params));
+        if (id in this.orders)
+            this.orders[id]['status'] = 'canceled';
+        return response;
+    }
+
+    parseOrder (order, market = undefined) {
+        let id = order['id'].toString ();
+        let status = this.safeInteger (order, 'status');
+        if (status === 0) {
+            status = 'open';
+        } else if (status === 1) {
+            status = 'closed';
+        } else if ((status === 2) || (status === 3)) {
+            status = 'canceled';
+        }
+        let timestamp = parseInt (order['timestamp_created']) * 1000;
+        let symbol = undefined;
+        if (!market)
+            market = this.markets_by_id[order['pair']];
+        if (market)
+            symbol = market['symbol'];
+        let remaining = undefined;
+        let amount = undefined;
+        let price = this.safeFloat (order, 'rate');
+        let filled = undefined;
+        let cost = undefined;
+        if ('start_amount' in order) {
+            amount = this.safeFloat (order, 'start_amount');
+            remaining = this.safeFloat (order, 'amount');
+        } else {
+            remaining = this.safeFloat (order, 'amount');
+            if (id in this.orders)
+                amount = this.orders[id]['amount'];
+        }
+        if (typeof amount !== 'undefined') {
+            if (typeof remaining !== 'undefined') {
+                filled = amount - remaining;
+                cost = price * filled;
+            }
+        }
+        let fee = undefined;
+        let result = {
+            'info': order,
+            'id': id,
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'type': 'limit',
+            'side': order['type'],
+            'price': price,
+            'cost': cost,
+            'amount': amount,
+            'remaining': remaining,
+            'filled': filled,
+            'status': status,
+            'fee': fee,
+        };
+        return result;
+    }
+
+    parseOrders (orders, market = undefined, since = undefined, limit = undefined) {
+        let ids = Object.keys (orders);
+        let result = [];
+        for (let i = 0; i < ids.length; i++) {
+            let id = ids[i];
+            let order = orders[id];
+            let extended = this.extend (order, { 'id': id });
+            result.push (this.parseOrder (extended, market));
+        }
+        return this.filterBySinceLimit (result, since, limit);
+    }
+
+    async fetchOrder (id, symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        let response = await this.privatePostOrderInfo (this.extend ({
+            'order_id': parseInt (id),
+        }, params));
+        id = id.toString ();
+        let newOrder = this.parseOrder (this.extend ({ 'id': id }, response['return'][id]));
+        let oldOrder = (id in this.orders) ? this.orders[id] : {};
+        this.orders[id] = this.extend (oldOrder, newOrder);
+        return this.orders[id];
+    }
+
+    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        // if (!symbol)
+        //     throw new ExchangeError (this.id + ' fetchOrders requires a symbol');
+        await this.loadMarkets ();
+        let request = {};
+        let market = undefined;
+        if (symbol) {
+            let market = this.market (symbol);
+            request['pair'] = market['id'];
+        }
+        let response = await this.privatePostActiveOrders (this.extend (request, params));
+        let openOrders = [];
+        if ('return' in response)
+            openOrders = this.parseOrders (response['return'], market);
+        for (let j = 0; j < openOrders.length; j++) {
+            this.orders[openOrders[j]['id']] = openOrders[j];
+        }
+        let openOrdersIndexedById = this.indexBy (openOrders, 'id');
+        let cachedOrderIds = Object.keys (this.orders);
+        let result = [];
+        for (let k = 0; k < cachedOrderIds.length; k++) {
+            let id = cachedOrderIds[k];
+            if (id in openOrdersIndexedById) {
+                this.orders[id] = this.extend (this.orders[id], openOrdersIndexedById[id]);
+            } else {
+                let order = this.orders[id];
+                if (order['status'] === 'open') {
+                    this.orders[id] = this.extend (order, {
+                        'status': 'closed',
+                        'cost': order['amount'] * order['price'],
+                        'filled': order['amount'],
+                        'remaining': 0.0,
+                    });
+                }
+            }
+            let order = this.orders[id];
+            if (symbol) {
+                if (order['symbol'] === symbol)
+                    result.push (order);
+            } else {
+                result.push (order);
+            }
+        }
+        return this.filterBySinceLimit (result, since, limit);
+    }
+
+    async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        let orders = await this.fetchOrders (symbol, since, limit, params);
+        let result = [];
+        for (let i = 0; i < orders.length; i++) {
+            if (orders[i]['status'] === 'open')
+                result.push (orders[i]);
+        }
+        return result;
+    }
+
+    async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        let orders = await this.fetchOrders (symbol, since, limit, params);
+        let result = [];
+        for (let i = 0; i < orders.length; i++) {
+            if (orders[i]['status'] === 'closed')
+                result.push (orders[i]);
+        }
+        return result;
+    }
+
+    async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        let market = undefined;
+        let request = {
+            // 'from': 123456789, // trade ID, from which the display starts numerical 0
+            // 'count': 1000, // the number of trades for display numerical, default = 1000
+            // 'from_id': trade ID, from which the display starts numerical 0
+            // 'end_id': trade ID on which the display ends numerical ∞
+            // 'order': 'ASC', // sorting, default = DESC
+            // 'since': 1234567890, // UTC start time, default = 0
+            // 'end': 1234567890, // UTC end time, default = ∞
+            // 'pair': 'eth_btc', // default = all markets
+        };
+        if (symbol) {
+            market = this.market (symbol);
+            request['pair'] = market['id'];
+        }
+        if (limit)
+            request['count'] = parseInt (limit);
+        if (since)
+            request['since'] = parseInt (since / 1000);
+        let response = await this.privatePostTradeHistory (this.extend (request, params));
+        let trades = [];
+        if ('return' in response)
+            trades = response['return'];
+        return this.parseTrades (trades, market, since, limit);
+    }
+
+    async withdraw (currency, amount, address, tag = undefined, params = {}) {
+        await this.loadMarkets ();
+        let response = await this.privatePostWithdrawCoin (this.extend ({
+            'coinName': currency,
+            'amount': parseFloat (amount),
+            'address': address,
+        }, params));
+        return {
+            'info': response,
+            'id': response['return']['tId'],
+        };
+    }
+
+    signBodyWithSecret (body) {
+        return this.hmac (this.encode (body), this.encode (this.secret), 'sha512');
+    }
+
+    getVersionString () {
+        return '/' + this.version;
+    }
+
+    sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+        let url = this.urls['api'][api];
+        let query = this.omit (params, this.extractParams (path));
+        if (api === 'private') {
+            this.checkRequiredCredentials ();
+            let nonce = this.nonce ();
+            body = this.urlencode (this.extend ({
+                'nonce': nonce,
+                'method': path,
+            }, query));
+            let signature = this.signBodyWithSecret (body);
+            headers = {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Key': this.apiKey,
+                'Sign': signature,
+            };
+        } else {
+            url += this.getVersionString () + '/' + this.implodeParams (path, params);
+            if (Object.keys (query).length)
+                url += '?' + this.urlencode (query);
+        }
+        return { 'url': url, 'method': method, 'body': body, 'headers': headers };
+    }
+
+    handleErrors (httpCode, reason, url, method, headers, body) {
+        if (typeof body !== 'string')
+            return; // fallback to default error handler
+        if (body.length < 2)
+            return; // fallback to default error handler
+        if ((body[0] === '{') || (body[0] === '[')) {
+            let response = JSON.parse (body);
+            if ('success' in response) {
+                //
+                // 1 - Liqui only returns the integer 'success' key from their private API
+                //
+                //     { "success": 1, ... } httpCode === 200
+                //     { "success": 0, ... } httpCode === 200
+                //
+                // 2 - However, exchanges derived from Liqui, can return non-integers
+                //
+                //     It can be a numeric string
+                //     { "sucesss": "1", ... }
+                //     { "sucesss": "0", ... }, httpCode >= 200 (can be 403, 502, etc)
+                //
+                //     Or just a string
+                //     { "success": "true", ... }
+                //     { "success": "false", ... }, httpCode >= 200
+                //
+                //     Or a boolean
+                //     { "success": true, ... }
+                //     { "success": false, ... }, httpCode >= 200
+                //
+                // 3 - Oversimplified, Python PEP8 forbids comparison operator (===) of different types
+                //
+                // 4 - We do not want to copy-paste and duplicate the code of this handler to other exchanges derived from Liqui
+                //
+                // To cover points 1, 2, 3 and 4 combined this handler should work like this:
+                //
+                let success = this.safeValue (response, 'success', false);
+                if (typeof success === 'string') {
+                    if ((success === 'true') || (success === '1'))
+                        success = true;
+                    else
+                        success = false;
+                }
+                if (!success) {
+                    const code = this.safeString (response, 'code');
+                    const message = this.safeString (response, 'error');
+                    const feedback = this.id + ' ' + this.json (response);
+                    const exceptions = this.exceptions;
+                    if (code in exceptions) {
+                        throw new exceptions[code] (feedback);
+                    }
+                    // need a second error map for these messages, apparently...
+                    // in fact, we can use the same .exceptions with string-keys to save some loc here
+                    if (message === 'invalid api key') {
+                        throw new AuthenticationError (feedback);
+                    } else if (message === 'api key dont have trade permission') {
+                        throw new AuthenticationError (feedback);
+                    } else if (message.indexOf ('invalid parameter') >= 0) { // errorCode 0, returned on buy(symbol, 0, 0)
+                        throw new InvalidOrder (feedback);
+                    } else if (message === 'Requests too often') {
+                        throw new DDoSProtection (feedback);
+                    } else if (message === 'not available') {
+                        throw new DDoSProtection (feedback);
+                    } else if (message === 'external service unavailable') {
+                        throw new DDoSProtection (feedback);
+                    } else {
+                        throw new ExchangeError (this.id + ' unknown "error" value: ' + this.json (response));
+                    }
+                }
+            }
+        }
+    }
+};


### PR DESCRIPTION
On liqui.

```
#if you make normal order
{'amount': 0.1,
 'cost': 0.0,
 'datetime': '2018-01-23T23:56:18.789Z',
 'fee': None,
 'filled': 0.0,
 'id': '217142278',
 'info': {'return': {'funds': {'btc': 0.0001960744387532,
                               'eth': 1.465680239375},
                     'init_order_id': 217142278,
                     'order_id': 217142278,
                     'received': 0.0,
                     'remains': 0.1,
                     'trades': []},
          'stat': {'errors': None,
                   'isSuccess': True,
                   'serverTime': '00:00:00.0112449',
                   'time': '00:00:00.0323250'},
          'success': 1},
 'price': 0.09150394,
 'remaining': 0.1,
 'side': 'sell',
 'status': 'open',
 'symbol': 'ETH/BTC',
 'timestamp': 1516751777789,
 'type': 'limit'}

#if you take some asks when you buy:
{'amount': 1.56960425,
 'cost': 0.143332022178525,
 'datetime': '2018-01-23T23:31:37.180Z',
 'fee': None,
 'filled': 1.56960425,
 'id': None, <------------- THIS IS WHAT PATCH FIXES. Now it works both with normal and "multiple" orders
 'info': {'return': {'funds': {'btc': 0.0003592486258058,
                               'eth': 1.565680239375},
                     'init_order_id': 217118690,
                     'order_id': 0,
                     'received': 1.56960425,
                     'remains': 0.0,
                     'trades': [{'amount': 0.6317246,
                                 'is_your_order': True,
                                 'order_id': 217118690,
                                 'pair': None,
                                 'rate': 0.09131726,
                                 'timestamp': 0,
                                 'trade_id': 65885621,
                                 'type': 'buy'},
                                {'amount': 0.93787965,
                                 'is_your_order': True,
                                 'order_id': 217118690,
                                 'pair': None,
                                 'rate': 0.0913173,
                                 'timestamp': 0,
                                 'trade_id': 65885622,
                                 'type': 'buy'}]},
          'stat': {'errors': None,
                   'isSuccess': True,
                   'serverTime': '00:00:00.0575447',
                   'time': '00:00:00.0789572'},
          'success': 1},
 'price': 0.0913173,
 'remaining': 0.0,
 'side': 'buy',
 'status': 'open',
 'symbol': 'ETH/BTC',
 'timestamp': 1516750297180,
 'type': 'limit'}
```
Note i do not know codebase completely so there might be cleaner ways to do it. Maybe.