### PR TITLE
array_key_exists wrong order

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1007,7 +1007,7 @@ abstract class Exchange {
         }
         $markets = $this->fetch_markets ();
         $currencies = null;
-        if (array_key_exists ($this->has, 'fetchCurrencies') && $this->has['fetchCurrencies'])
+        if (array_key_exists ('fetchCurrencies', $this->has) && $this->has['fetchCurrencies'])
             $currencies = $this->fetch_currencies ();
         return $this->set_markets ($markets, $currencies);
     }


### PR DESCRIPTION
I get another error, I believe the order of the arguments should be switched.