### PR TITLE
run-tests: no verbose output for skipped exchanges

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -164,6 +164,9 @@ const testExchange = async (exchange) => {
             for (const { language, failed, output, hasWarnings } of completeTests) {
                 if (failed || hasWarnings) {
 
+                    if (!failed && output.indexOf('[Skipped]') >= 0)
+                        continue;
+
                     if (failed) { log.bright ('\nFAILED'.bgBrightRed.white, exchange.red,    '(' + language + '):\n') }
                     else        { log.bright ('\nWARN'.yellow.inverse,      exchange.yellow, '(' + language + '):\n') }
 


### PR DESCRIPTION
We marked skipped exchanges yellow but that got accompanied by a lot of unneeded verbosity. Suppressing it out.