### PR TITLE
kucoin: one less yellow: switching off OHLCV (accessed from different urls)

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -8,7 +8,6 @@ const { ExchangeError, InvalidNonce, InvalidOrder, AuthenticationError } = requi
 //  ---------------------------------------------------------------------------
 
 module.exports = class kucoin extends Exchange {
-
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'kucoin',
@@ -616,4 +615,4 @@ module.exports = class kucoin extends Exchange {
         this.throwExceptionOnError (response);
         return response;
     }
-}
+};

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -20,7 +20,7 @@ module.exports = class kucoin extends Exchange {
             'has': {
                 'CORS': false,
                 'fetchTickers': true,
-                'fetchOHLCV': true, // see the method implementation below
+                'fetchOHLCV': false, // see the method implementation below
                 'fetchOrder': false,
                 'fetchOrders': true,
                 'fetchClosedOrders': true,


### PR DESCRIPTION
As per #602 OHLCV is accessible at a different host (kitchen.kucoin.com, not api.kucoin.com).

Don't know if it's possible to support two different hosts in one implementation but the method is not working anyway.