### PR TITLE
Fix for Quoinex/Qryptos in create_order

### DIFF
--- a/js/qryptos.js
+++ b/js/qryptos.js
@@ -231,9 +231,7 @@ module.exports = class qryptos extends Exchange {
         };
         if (type === 'limit')
             order['price'] = price;
-        let response = await this.privatePostOrders (this.extend ({
-            'order': order,
-        }, params));
+        let response = await this.privatePostOrders (this.extend (order, params));
         return this.parseOrder(response);
     }
 

--- a/php/qryptos.php
+++ b/php/qryptos.php
@@ -226,9 +226,7 @@ class qryptos extends Exchange {
         );
         if ($type === 'limit')
             $order['price'] = $price;
-        $response = $this->privatePostOrders (array_merge (array (
-            'order' => $order,
-        ), $params));
+        $response = $this->privatePostOrders (array_merge ($order, $params));
         return $this->parse_order ($response);
     }
 

--- a/python/ccxt/qryptos.py
+++ b/python/ccxt/qryptos.py
@@ -220,9 +220,7 @@ class qryptos (Exchange):
         }
         if type == 'limit':
             order['price'] = price
-        response = self.privatePostOrders(self.extend({
-            'order': order,
-        }, params))
+        response = self.privatePostOrders(self.extend(order, params))
         return self.parse_order(response)
 
     def cancel_order(self, id, symbol=None, params={}):


### PR DESCRIPTION
Removed the property "order" which is not needed in the post. Fixed in JS and Python/PHP copied after npm run build. Tested live on Quoinex.