### PR TITLE
Use `this.nonce` instead of `this.milliseconds` for binance nonce

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -797,7 +797,7 @@ module.exports = class binance extends Exchange {
             };
         } else if ((api === 'private') || (api === 'wapi')) {
             this.checkRequiredCredentials ();
-            let nonce = this.milliseconds ();
+            let nonce = this.nonce ();
             let query = this.urlencode (this.extend ({
                 'timestamp': nonce,
                 'recvWindow': this.security['recvWindow'],


### PR DESCRIPTION
Using `this.nonce ()` is functionally equivalent to the current `this.milliseconds ()` by default. However, nonce is more intuitive because `nonce` is the field that the current documentation suggests you should override in order to change this behavior.

It has been bugging me because Binance often rejects signed requests because it's occasionally 1000ms behind me which lead me to override `this.nonce = () => new Date() - 1000;` and simply compensate using `recvWindow`