### PR TITLE
Exchange: naming and indenting verbose logging

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -350,7 +350,7 @@ module.exports = class Exchange {
         headers = extend (this.headers, headers)
 
         if (this.verbose)
-            console.log (this.id, method, url, "\nRequest:\n", headers, body)
+            console.log ('fetch: ', this.id, method, url, "\n Request:\n ", headers, body)
 
         return this.executeRestRequest (url, method, headers, body)
     }
@@ -420,7 +420,7 @@ module.exports = class Exchange {
             const args = [ response.status, response.statusText, url, method, headers, text ]
 
             if (this.verbose)
-                console.log (this.id, method, url, response.status, response.statusText, headers, text ? ("\nResponse:\n" + text) : '')
+                console.log ('handleRestErrors: ', this.id, method, url, response.status, response.statusText, headers, text ? ("\n Response:\n " + text) : '')
 
             this.handleErrors (...args)
             return this.defaultErrorHandler (...args)
@@ -458,7 +458,7 @@ module.exports = class Exchange {
             }
 
             if (this.verbose)
-                console.log (this.id, method, url, 'error', e, "response body:\n'" + response + "'")
+                console.log ('handleRestResponse: ', this.id, method, url, 'error', e, "response body:\n '" + response + "'")
 
             throw e
         }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -350,7 +350,7 @@ module.exports = class Exchange {
         headers = extend (this.headers, headers)
 
         if (this.verbose)
-            console.log ('fetch: ', this.id, method, url, "\n  Request:\n  ", headers, body)
+            console.log ("fetch:\n", this.id, method, url, "\nRequest:\n", headers, body, "\n")
 
         return this.executeRestRequest (url, method, headers, body)
     }
@@ -420,7 +420,7 @@ module.exports = class Exchange {
             const args = [ response.status, response.statusText, url, method, headers, text ]
 
             if (this.verbose)
-                console.log ('handleRestErrors: ', this.id, method, url, response.status, response.statusText, headers, text ? ("\n  Response:\n  " + text) : '')
+                console.log ("handleRestErrors:\n", this.id, method, url, response.status, response.statusText, headers, text ? ("\nResponse:\n" + text) : '', "\n")
 
             this.handleErrors (...args)
             return this.defaultErrorHandler (...args)
@@ -458,7 +458,7 @@ module.exports = class Exchange {
             }
 
             if (this.verbose)
-                console.log ('handleRestResponse: ', this.id, method, url, 'error', e, "response body:\n  '" + response + "'")
+                console.log ('handleRestResponse:\n', this.id, method, url, 'error', e, "response body:\n'" + response + "'\n")
 
             throw e
         }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -350,7 +350,7 @@ module.exports = class Exchange {
         headers = extend (this.headers, headers)
 
         if (this.verbose)
-            console.log ('fetch: ', this.id, method, url, "\n Request:\n ", headers, body)
+            console.log ('fetch: ', this.id, method, url, "\n  Request:\n  ", headers, body)
 
         return this.executeRestRequest (url, method, headers, body)
     }
@@ -420,7 +420,7 @@ module.exports = class Exchange {
             const args = [ response.status, response.statusText, url, method, headers, text ]
 
             if (this.verbose)
-                console.log ('handleRestErrors: ', this.id, method, url, response.status, response.statusText, headers, text ? ("\n Response:\n " + text) : '')
+                console.log ('handleRestErrors: ', this.id, method, url, response.status, response.statusText, headers, text ? ("\n  Response:\n  " + text) : '')
 
             this.handleErrors (...args)
             return this.defaultErrorHandler (...args)
@@ -458,7 +458,7 @@ module.exports = class Exchange {
             }
 
             if (this.verbose)
-                console.log ('handleRestResponse: ', this.id, method, url, 'error', e, "response body:\n '" + response + "'")
+                console.log ('handleRestResponse: ', this.id, method, url, 'error', e, "response body:\n  '" + response + "'")
 
             throw e
         }


### PR DESCRIPTION
Before:
```
bitfinex2.fetchBalance ()
bitfinex2 POST https://api.bitfinex.com/v2/auth/r/wallets 
Request:
 { 'bfx-nonce': '1516875609267',
  'bfx-apikey': 'VM9UCkrumj7VRMeRwRdTDxNudfaVLcknvbSVCsbSNTH',
  'bfx-signature': 'be0c856e30706235400065e99f63f8b3f0ff3305be61f98968cdf0e2f7c39dadaec33c0bca2f348016558dba22de9c61',
  'Content-Type': 'application/json' } {}
bitfinex2 POST https://api.bitfinex.com/v2/auth/r/wallets 500 Internal Server Error { 'bfx-nonce': '1516875609267',
  'bfx-apikey': 'VM9UCkrumj7VRMeRwRdTDxNudfaVLcknvbSVCsbSNTH',
  'bfx-signature': 'be0c856e30706235400065e99f63f8b3f0ff3305be61f98968cdf0e2f7c39dadaec33c0bca2f348016558dba22de9c61',
  'Content-Type': 'application/json' } 
Response:
["error",10114,"nonce: small"]
```

After:
```
bitfinex2.fetchBalance ()
fetch:  bitfinex2 POST https://api.bitfinex.com/v2/auth/r/wallets 
  Request:
   { 'bfx-nonce': '1516876963213',
  'bfx-apikey': 'VM9UCkrumj7VRMeRwRdTDxNudfaVLcknvbSVCsbSNTH',
  'bfx-signature': '6e8905a17c5a98488a5730d6a835381bcefde79dd34efa3d164a087bba20ebb0cf03255096934397c3765f8c06a7cf53',
  'Content-Type': 'application/json' } {}
handleRestErrors:  bitfinex2 POST https://api.bitfinex.com/v2/auth/r/wallets 500 Internal Server Error { 'bfx-nonce': '1516876963213',
  'bfx-apikey': 'VM9UCkrumj7VRMeRwRdTDxNudfaVLcknvbSVCsbSNTH',
  'bfx-signature': '6e8905a17c5a98488a5730d6a835381bcefde79dd34efa3d164a087bba20ebb0cf03255096934397c3765f8c06a7cf53',
  'Content-Type': 'application/json' } 
  Response:
  ["error",10114,"nonce: small"]
```