### PR TITLE
Fix poloniex cors

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -18,7 +18,7 @@ module.exports = class poloniex extends Exchange {
             'has': {
                 'createDepositAddress': true,
                 'fetchDepositAddress': true,
-                'CORS': true,
+                'CORS': false,
                 'fetchOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOrder': 'emulated',


### PR DESCRIPTION
Hello,

The poloniex trading api has no cors. 
I already did a PR here https://github.com/ccxt/ccxt/pull/1382 , but this merge overrided the change 716c72db54366cf5a66359d04ac6dba4d2c54c1c

Thanks!