### PR TITLE
Manual: Implicit API Methods: with an example

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -661,13 +661,38 @@ The endpoint URLs are predefined in the `api` property for each exchange. You do
 
 ## Implicit API Methods
 
-In the code for each exchange, you'll notice that functions that make API requests aren't explicitly defined. This is because the `api` definition in the exchange description JSON is used to create *magic functions* (aka *partial functions* or *closures*) inside the exchange subclass. That implicit injection is done by the `defineRestApi/define_rest_api` base exchange method.
+ccxt uses a declarative approach for defining exchange's native (non-unified) API methods.
+These methods are declared in exchange's `api` property in the following manner:
+```
+'api': {
+    'public': {          // type
+        'get': [         // http method
+            'products',  // path
+            'open/tick', // another path
+            ...
+        ],
+    },
+    'private': {
+        'post': [
+            'order/{id}',
+            ...
+        ],
+        'put': [
+            'order/{id}/cancel',
+            ...
+        ],
+    },
+},
+```
 
-Each partial function takes a dictionary of `params` and returns the API response. For example, if an exchange offers a HTTP GET URL for querying prices like `https://example.com/public/quotes`, it is converted to a method named `example.publicGetQuotes (params = {}) / $example->publicGetQuotes ($params = array ())`.
+Upon exchange instantiation `defineRestApi/define_rest_api` base exchange method will use these declarations to create
+*magic functions* (aka *partial functions* or *closures*) inside the exchange subclass.
 
-Upon instantiation the base exchange class takes each URL from its list of endpoints, splits it into words, and then makes up a callable function name from those words by using a partial construct.
+Taken the example above these magic functions will take the names of `publicGetProducts`, `publicGetOpenTick`, `privatePostOrderId`, `privatePutOrdersIdCancel`.
 
-The endpoint definition is a **full list of ALL API URLs** exposed by an exchange. This list gets converted to callable methods upon exchange instantiation. Each URL in the API endpoint list gets a corresponding callable method. This is done automatically for all exchanges, therefore the ccxt library supports **all possible URLs** offered by crypto exchanges.
+When you call one of these magic functions (e.g. `privatePutOrdersIdCancel ({ id: 100 })`), it will call ccxt's `request` method with `type`, `http method`, `path` and `params` arguments. In turn, `request` then implodes `params` into `path` (and `query` if necessary), adds `scheme` ([http|https]) / `host` and performs actual `fetch` which will return raw API response.
+
+The endpoints definition is a **full list of ALL API URLs** exposed by an exchange. This list gets converted to callable methods upon exchange instantiation. Each URL in the API endpoint list gets a corresponding callable method. This is done automatically for all exchanges, therefore the ccxt library supports **all possible URLs** offered by crypto exchanges.
 
 ## Public/Private API
 


### PR DESCRIPTION
I made several attempts at understanding this part of ccxt but all of them failed until I stumbled upon your kraken 'scraping' commit.

I don't wanna say that I'm a better writer, just think that more examples will help to grasp such a difficult concept.

Also, the current example is misleading:
```
https://example.com/public/quotes, it is converted to a method named example.publicGetQuotes (params = {})
```

This "public" which is a part of URL path is clashing with that "public" which is a `type` property of `api`, so `publicGetQuotes` will probably be converted to just '/quotes', not '/public/quotes'.