### PR TITLE
cli: report error when method not found

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -76,7 +76,7 @@ async function main () {
             return param.match (/[a-zA-Z]/g) ? param : parseFloat (param)
         })
 
-        if (typeof exchange[methodName] == 'function') {
+        if (typeof exchange[methodName] === 'function') {
             try {
 
                 log (exchange.id + '.' + methodName, '(' + args.join (', ') + ')')
@@ -116,6 +116,8 @@ async function main () {
                 throw e
 
             }
+        } else if (typeof exchange[methodName] === 'undefined') {
+            log.red (exchange.id + '.' + methodName + ': no such property')
         } else {
             log (exchange[methodName])
         }


### PR DESCRIPTION
As is:
```
$ node examples/js/cli binance asdf
undefined
```
To be:
```
$ node examples/js/cli binance asdf
binance.asdf: no such property
```
