### PR TITLE
ticker change should be in percents, right?

### DIFF
--- a/php/kucoin.php
+++ b/php/kucoin.php
@@ -418,7 +418,7 @@ class kucoin extends Exchange {
             $symbol = $ticker['coinType'] . '/' . $ticker['coinTypePair'];
         }
         // TNC coin doesn't have changerate for some reason
-        $change = $this->safe_float($ticker, 'changeRate');
+        $change = 100 * $this->safe_float($ticker, 'changeRate');
         return array (
             'symbol' => $symbol,
             'timestamp' => $timestamp,


### PR DESCRIPTION
At least other exchange providers seem to return in this fashion.

But it's 100 times smaller on kucoin atm

```
{ "symbol": "OCN/BTC", "high": 0.00000688, "low": 0.00000395, "bid": 0.00000652, "ask": 0.00000655, "vwap": null, "open": null, "close": null, "first": null, "last": 0.00000655, "change": 0.4491, "percentage": null, "average": null, "baseVolume": 139998987.52, "quoteVolume": 743.02009302, "info": { "coinType": "OCN", "trading": true, "symbol": "OCN-BTC", "lastDealPrice": 0.00000655, "buy": 0.00000652, "sell": 0.00000655, "change": 0.00000203, "coinTypePair": "BTC", "sort": 100, "feeRate": 0.001, "volValue": 743.02009302, "high": 0.00000688, "datetime": 1517077842000, "vol": 139998987.52, "low": 0.00000395, "changeRate": 0.4491 } } 
```