### PR TITLE
Manual: fetchMyTrades: separate section, ordering (aka sorting)

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1575,7 +1575,7 @@ As such, `cancelOrder()` can throw an `OrderNotFound` exception in these cases:
 A trade is a result of order execution. Note, that orders and trades have 1-n relationship: execution of 1 order may result in several trades.
 
 
-##### Recent Trades
+### Recent Trades
 
 ```JavaScript
 exchange.fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {})
@@ -1583,7 +1583,7 @@ exchange.fetchMyTrades (symbol = undefined, since = undefined, limit = undefined
 
 Returns ordered array of trades (most recent trade first).
 
-##### Trades By Order Id
+### Trades By Order Id
 
 ```UNDER CONSTRUCTION```
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1142,7 +1142,7 @@ The fetchOHLCV method shown above returns a list (a flat array) of OHLCV candles
 ]
 ```
 
-## Trades, Orders, Executions, Transactions
+## Trades, Executions, Transactions
 
 ```diff
 - this is under heavy development right now, contributions appreciated
@@ -1432,24 +1432,6 @@ many exchanges propagate those properties to the orders as well.
 exchange.fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {})
 ```
 
-#### Trades / Transactions / Fills / Executions
-
-```
-- this part of the unified API is currenty a work in progress
-- there may be some issues and missing implementations here and there
-- contributions, pull requests and feedback appreciated
-```
-
-##### Recent Trades
-
-```JavaScript
-exchange.fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {})
-```
-
-##### Trades By Order Id
-
-```UNDER CONSTRUCTION```
-
 ### Order Structure
 
 Most of methods returning orders within ccxt unified API will usually yield an order structure as described below:
@@ -1580,6 +1562,31 @@ A cancel-request might also throw a `NetworkError` indicating that the order mig
 As such, `cancelOrder()` can throw an `OrderNotFound` exception in these cases:
 - canceling an already-closed order
 - canceling an already-canceled order
+
+
+## Trades / Transactions / Fills / Executions
+
+```
+- this part of the unified API is currenty a work in progress
+- there may be some issues and missing implementations here and there
+- contributions, pull requests and feedback appreciated
+```
+
+A trade is a result of order execution. Note, that orders and trades have 1-n relationship: execution of 1 order may result in several trades.
+
+
+##### Recent Trades
+
+```JavaScript
+exchange.fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {})
+```
+
+Returns ordered array of trades (most recent trade first).
+
+##### Trades By Order Id
+
+```UNDER CONSTRUCTION```
+
 
 ## Funding Your Account
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -46,13 +46,13 @@ Welcome to the ccxt wiki!
         - [All Orders](https://github.com/ccxt-dev/ccxt/wiki/Manual#all-orders)
         - [Open Orders](https://github.com/ccxt-dev/ccxt/wiki/Manual#open-orders)
         - [Closed Orders](https://github.com/ccxt-dev/ccxt/wiki/Manual#closed-orders)
-        - [Trades / Transactions / Fills / Executions](https://github.com/ccxt-dev/ccxt/wiki/Manual#trades--transactions--fills--executions)
       - [Order Structure](https://github.com/ccxt/ccxt/wiki/Manual#order-structure)
       - [Placing Orders](https://github.com/ccxt/ccxt/wiki/Manual#placing-orders)
         - [Market Orders](https://github.com/ccxt/ccxt/wiki/Manual#market-orders)
         - [Limit Orders](https://github.com/ccxt/ccxt/wiki/Manual#limit-orders)
         - [Custom Params](https://github.com/ccxt/ccxt/wiki/Manual#custom-order-params)
       - [Cancelling Orders](https://github.com/ccxt/ccxt/wiki/Manual#cancelling-orders)
+    - [Trades / Transactions / Fills / Executions](https://github.com/ccxt-dev/ccxt/wiki/Manual#trades--transactions--fills--executions)
     - [Funding Your Account](https://github.com/ccxt/ccxt/wiki/Manual#funding-your-account)
       - [Deposit](https://github.com/ccxt/ccxt/wiki/Manual#deposit)
       - [Withdraw](https://github.com/ccxt/ccxt/wiki/Manual#withdraw)
@@ -74,5 +74,3 @@ Welcome to the ccxt wiki!
 ## API Reference
 
 - API Reference (under construction right now!)
-
-


### PR DESCRIPTION
To my surprise, I noticed that fetchMyTrades started to return ordered array (recent trades first). Reflected that in the Manual.

Also moved 'Trades / Transactions / Fills / Executions' to a separate section.