### PR TITLE
fix empty params used for signing

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -257,7 +257,8 @@ module.exports = class bitflyer extends Exchange {
         if (api === 'private') {
             this.checkRequiredCredentials ();
             let nonce = this.nonce ().toString ();
-            body = this.json (params);
+            if (Object.keys (params).length)
+                body = this.json (params);
             let auth = [ nonce, method, request, body ].join ('');
             headers = {
                 'ACCESS-KEY': this.apiKey,


### PR DESCRIPTION
caused 
{ Error: bitflyer GET https://api.bitflyer.jp/v1/me/getbalance 401 Unauthorized {"status":-500,"error_message":"Invalid signature","data":null}
    at bitflyer.defaultErrorHandler (C:\Users\P\PhpstormProjects\ptradex\node_modules\ccxt\js\base\Exchange.js:438:15)
    at response.text.then.responseBody (C:\Users\P\PhpstormProjects\ptradex\node_modules\ccxt\js\base\Exchange.js:455:18)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7) constructor: [Function: AuthenticationError] }