### PR TITLE
Consistency with subclasses

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -500,6 +500,10 @@ class Exchange(object):
                     result = {}
                 for key in arg:
                     result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
+            elif isinstance(arg, list) and all(isinstance(arg, list) for arg in args):
+                result = []
+                for l in args:
+                    result.extend(l)
             else:
                 result = arg
         return result

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1003,13 +1003,13 @@ class Exchange(object):
         market = self.market(symbol)
         return market['id'] if type(market) is dict else symbol
 
-    def calculate_fee(self, symbol, type, side, amount, price, taker_or_maker='taker', params={}):
+    def calculate_fee(self, symbol, type, side, amount, price, takerOrMaker='taker', params={}):
         market = self.markets[symbol]
-        rate = market[taker_or_maker]
+        rate = market[takerOrMaker]
         cost = float(self.cost_to_precision(symbol, amount * price))
         return {
             'rate': rate,
-            'type': taker_or_maker,
+            'type': takerOrMaker,
             'currency': market['quote'],
             'cost': float(self.fee_to_precision(symbol, rate * cost)),
         }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -500,10 +500,6 @@ class Exchange(object):
                     result = {}
                 for key in arg:
                     result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
-            elif isinstance(arg, list) and all(isinstance(arg, list) for arg in args):
-                result = []
-                for l in args:
-                    result.extend(l)
             else:
                 result = arg
         return result


### PR DESCRIPTION
When subclasses override this method they change a parameter to camelCalse. This is annoying because I do not know which exchange I will be calling this method on in advance and need it to be unified. 