### PR TITLE
Bibox: Fix fetchOrderBook, and use public GET API where available

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -41,7 +41,10 @@ module.exports = class bibox extends Exchange {
                 'logo': 'https://user-images.githubusercontent.com/1294454/34902611-2be8bf1a-f830-11e7-91a2-11b2f292e750.jpg',
                 'api': 'https://api.bibox.com',
                 'www': 'https://www.bibox.com',
-                'doc': 'https://github.com/Biboxcom/api_reference/wiki/home_en',
+                'doc': [
+                    'https://github.com/Biboxcom/api_reference/wiki/home_en',
+                    'https://github.com/Biboxcom/api_reference/wiki/api_reference'
+                ],
                 'fees': 'https://bibox.zendesk.com/hc/en-us/articles/115004417013-Fee-Structure-on-Bibox',
             },
             'api': {


### PR DESCRIPTION
So it turns out there's a GET API for Bibox that's undocumented in English. The [English documentation](https://github.com/Biboxcom/api_reference/wiki/home_en) only has POST requests, but the [Chinese documentation](https://github.com/Biboxcom/api_reference/wiki/api_reference) has GET requests for some of them. Furthermore, the POST version of the 'depth' command doesn't work (Always returns a blank order book), so right now fetchOrderBook doesn't work.

This pull request uses the GET version of requests where available to fix fetchOrderBook, and to increase API speed.