### PR TITLE
bitcoincoid: Bugfix cancelOrder

### DIFF
--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -311,15 +311,16 @@ module.exports = class bitcoincoid extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         if (!symbol)
-            throw new ExchangeError (this.id + ' cancelOrder requires a symbol argument')
-        if (!params.side)
-            throw new ExchangeError (this.id + ' cancelOrder requires a side as params argument')
+            throw new ExchangeError (this.id + ' cancelOrder requires a symbol argument');
+        if ('side' in params)
+            if (!params['side'])
+                throw new ExchangeError (this.id + ' cancelOrder requires a side as params argument');
         await this.loadMarkets ();
         let market = this.market (symbol);
         return await this.privatePostCancelOrder (this.extend ({
             'order_id': id,
             'pair': market['id'],
-            'type': params.side
+            'type': params['side']
         }, params));
     }
 

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -310,9 +310,16 @@ module.exports = class bitcoincoid extends Exchange {
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
+        if (!symbol)
+            throw new ExchangeError (this.id + ' cancelOrder requires a symbol argument')
+        if (!params.side)
+            throw new ExchangeError (this.id + ' cancelOrder requires a side as params argument')
         await this.loadMarkets ();
+        let market = this.market (symbol);
         return await this.privatePostCancelOrder (this.extend ({
             'order_id': id,
+            'pair': market['id'],
+            'type': params.side
         }, params));
     }
 


### PR DESCRIPTION
```
> node examples/js/cli.js bitcoincoid cancelOrder "4204708" "XRP/IDR" '{"side": "buy"}'
bitcoincoid.cancelOrder (4204708, XRP/IDR, [object Object])
{ success:    1,
   return: { order_id:    4204708,
                 type:   "buy",
                 pair:   "xrp_idr",
              balance: {          idr: "2320857",
                                  btc: "0.00036748",
                                  bch: "0.00000000",
                                  btg: "0.00000000",
                                  bts: "0.00000000",
                                  drk: "0.00000000",
                                 doge: "0.00000000",
                                  eth: "0.00000000",
                                  etc: "0.00000000",
                                ignis: "0.00000000",
                                  ltc: "0.00000000",
                                  nxt: "0.00000000",
                                  nem: "0.00000000",
                                  str: "0.00000000",
                                  ten: "0.00000000",
                                waves: "0.00000000",
                                  xrp: "0.00000000",
                                  xzc: "0.00000000",
                           frozen_idr: "0",
                           frozen_btc: "0.00000000",
                           frozen_bch: "0.00000000",
                           frozen_btg: "0.00000000",
                           frozen_bts: "0.00000000",
                           frozen_drk: "0.00000000",
                          frozen_doge: "0.00000000",
                           frozen_eth: "0.00000000",
                           frozen_etc: "0.00000000",
                         frozen_ignis: "0.00000000",
                           frozen_ltc: "0.00000000",
                           frozen_nxt: "0.00000000",
                           frozen_nem: "0.00000000",
                           frozen_str: "0.00000000",
                           frozen_ten: "0.00000000",
                         frozen_waves: "0.00000000",
                           frozen_xrp: "0.00000000",
                           frozen_xzc: "0.00000000"  } } }
```