### PR TITLE
Mention how to add path parameters to implicit methods

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -663,13 +663,15 @@ The endpoint URLs are predefined in the `api` property for each exchange. You do
 
 Most of exchange-specific API methods are implicit, meaning that they aren't defined explicitly anywhere in code. The library implements a declarative approach for defining implicit (non-unified) exchanges' API methods.
 
-Each method of the API usually has its own endpoint, the library defines all endpoints for each particular exchange in the `.api` property. Upon exchange construction an implicit *magic* method (aka *partial function* or *closure*) will be created inside `defineRestApi()/define_rest_api()` on the exchange instance for each endpoint from the list of `.api` endpoints. Ths is performed for all exchanges universally. Each generated method will be accessible in both `camelCase` and `under_score` notations.
-
-Each implicit method gets a unique name which is constructed from the `.api` definition. For example, with a private HTTPS PUT `https://api.exchange.com/order/{id}/cancel` endpoint the corresponding exchange method would be named `.privatePutOrderIdCancel()`/`.private_put_order_id_cancel()`, having a public HTTPS GET `https://api.exchange.com/market/ticker/{pair}` endpoint would result in the corresponding method named `.publicGetTickerPair()`/`.public_get_ticker_pair()`, and so on...
+Each method of the API usually has its own endpoint. The library defines all endpoints for each particular exchange in the `.api` property. Upon exchange construction an implicit *magic* method (aka *partial function* or *closure*) will be created inside `defineRestApi()/define_rest_api()` on the exchange instance for each endpoint from the list of `.api` endpoints. This is performed for all exchanges universally. Each generated method will be accessible in both `camelCase` and `under_score` notations.
 
 The endpoints definition is a **full list of ALL API URLs** exposed by an exchange. This list gets converted to callable methods upon exchange instantiation. Each URL in the API endpoint list gets a corresponding callable method. This is done automatically for all exchanges, therefore the ccxt library supports **all possible URLs** offered by crypto exchanges.
 
-An implicit method takes a dictionary of `params`, sends the request to the exchange and returns an exchange-specific JSON result from the API **as is, unparsed**. The recommended way of working with exchanges is not using exchange-specific implicit methods but using the unified ccxt methods instead. The exchange-specific methods should be used as a fallback in cases when a corresponding unified method isn't available (yet).
+Each implicit method gets a unique name which is constructed from the `.api` definition. For example, a private HTTPS PUT `https://api.exchange.com/order/{id}/cancel` endpoint will have a corresponding exchange method named `.privatePutOrderIdCancel()`/`.private_put_order_id_cancel()`. A public HTTPS GET `https://api.exchange.com/market/ticker/{pair}` endpoint would result in the corresponding method named `.publicGetTickerPair()`/`.public_get_ticker_pair()`, and so on.
+
+An implicit method takes a dictionary of parameters, sends the request to the exchange and returns an exchange-specific JSON result from the API **as is, unparsed**. To pass a parameter, add it to the dictionary explicitly under a key equal to the parameter's name. For the examples above, this would look like `.privatePutOrderIdCancel({ id: '41987a2b-...' })` and `.publicGetTickerPair({ pair: 'BTC/USD' })`.
+
+The recommended way of working with exchanges is not using exchange-specific implicit methods but using the unified ccxt methods instead. The exchange-specific methods should be used as a fallback in cases when a corresponding unified method isn't available (yet).
 
 To get a list of all available methods with an exchange instance, including implicit methods and unified methods you can simply do the following:
 


### PR DESCRIPTION
+ some English fixes and moving a paragraph to a more logical order.

(I tried passing the parameter directly to the method, since there's only one parameter, but that resulted in the request signing to fail, so I think it's worth mentioning how exactly to pass path parameters.)