### PR TITLE
kucoin: handleErrors: InsufficientFunds, OrderNotFound

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -663,14 +663,14 @@ module.exports = class kucoin extends Exchange {
                 throw new InvalidNonce (feedback);
             throw new AuthenticationError (feedback);
         } else if (code === 'ERROR') {
-            if (message.indexOf ('The precision of amount') >= 0) // amount violates precision.amount
-                throw new InvalidOrder (feedback);
-            if (message.indexOf ('Min amount each order') >= 0) // amount < limits.amount.min
-                throw new InvalidOrder (feedback);
-            if (message.indexOf ('Min price:') >= 0) // price < limits.price.min
-                throw new InvalidOrder (feedback);
-            if (message.indexOf ('The precision of price') >= 0) // price violates precision.price
-                throw new InvalidOrder (feedback);
+            if (message.indexOf ('The precision of amount') >= 0)
+                throw new InvalidOrder (feedback); // amount violates precision.amount
+            if (message.indexOf ('Min amount each order') >= 0)
+                throw new InvalidOrder (feedback); // amount < limits.amount.min
+            if (message.indexOf ('Min price:') >= 0)
+                throw new InvalidOrder (feedback); // price < limits.price.min
+            if (message.indexOf ('The precision of price') >= 0)
+                throw new InvalidOrder (feedback); // price violates precision.price
         } else if (code === 'NO_BALANCE') {
             if (message.indexOf ('Insufficient balance') >= 0)
                 throw new InsufficientFunds (feedback);

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, InvalidNonce, InvalidOrder, AuthenticationError } = require ('./base/errors');
+const { ExchangeError, InvalidNonce, InvalidOrder, AuthenticationError, InsufficientFunds } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -644,23 +644,35 @@ module.exports = class kucoin extends Exchange {
     }
 
     throwExceptionOnError (response) {
-        if ('success' in response) {
-            if (!response['success']) {
-                if ('code' in response) {
-                    let message = this.safeString (response, 'msg');
-                    if (response['code'] === 'UNAUTH') {
-                        if (message === 'Invalid nonce')
-                            throw new InvalidNonce (this.id + ' ' + message);
-                        throw new AuthenticationError (this.id + ' ' + this.json (response));
-                    } else if (response['code'] === 'ERROR') {
-                        if (message.indexOf ('precision of amount') >= 0)
-                            throw new InvalidOrder (this.id + ' ' + message);
-                        if (message.indexOf ('Min amount each order') >= 0)
-                            throw new InvalidOrder (this.id + ' ' + message);
-                    }
-                }
-            }
+        // { success: false, code: "ERROR", msg: "Min price:100.0" }
+        // { success: true,  code: "OK",    msg: "Operation succeeded." }
+        if (!('success' in response))
+            throw new ExchangeError (this.id + ': malformed response: ' + this.json (response));
+        if (response['success'] === true)
+            return; // not an error
+        if (!('code' in response) || !('msg' in response))
+            throw new ExchangeError (this.id + ': malformed response: ' + this.json (response));
+        const code = this.safeString (response, 'code');
+        const message = this.safeString (response, 'msg');
+        const feedback = this.id + ' ' + this.json (response);
+        if (code === 'UNAUTH') {
+            if (message === 'Invalid nonce')
+                throw new InvalidNonce (feedback);
+            throw new AuthenticationError (feedback);
+        } else if (code === 'ERROR') {
+            if (message.indexOf ('The precision of amount') >= 0) // amount violates precision.amount
+                throw new InvalidOrder (feedback);
+            if (message.indexOf ('Min amount each order') >= 0) // amount < limits.amount.min
+                throw new InvalidOrder (feedback);
+            if (message.indexOf ('Min price:') >= 0) // price < limits.price.min
+                throw new InvalidOrder (feedback);
+            if (message.indexOf ('The precision of price') >= 0) // price violates precision.price
+                throw new InvalidOrder (feedback);
+        } else if (code === 'NO_BALANCE') {
+            if (message.indexOf ('Insufficient balance') >= 0)
+                throw new InsufficientFunds (feedback);
         }
+        throw new ExchangeError (this.id + ': unknown response: ' + this.json (response));
     }
 
     handleErrors (code, reason, url, method, headers, body) {

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -382,7 +382,7 @@ module.exports = class kucoin extends Exchange {
         };
         let response = await this.privateGetOrderDetail (this.extend (request, params));
         let order = response['data'];
-        if (order === null)
+        if (!order)
             throw new OrderNotFound (this.id + ' ' + this.json (response));
         return this.parseOrder (response['data'], market);
     }


### PR DESCRIPTION
@kornrunner , @wannesdemaeght , @hippylover , @gre , @marcvdm ,
I see you, guys did contributions to this file.

Have you happened to have some trades/funds on kucoin? If you do you can help me with making kucoin's error handling a little bit more robust.

What I do is run this exchange through a test suite which tries to trigger error responses and checks that for every error response an appropriate exception is thrown by ccxt.

One of the checks is to cancel an order which surely does not exist and ensure that `OrderNotFound` is thrown.
So I try `cancelOrder (1)`, `cancelOrder ('1')`, `cancelOrder ('a')` and for all that kucoin responds with:
```
{   success:  true,
       code: "OK",
        msg: "Operation succeeded.",
  timestamp:  1517487048613,
       data:  null                   }
```
while I'd expect `success: false` indeed.

So the question is: what it responds with if you cancel an existing order? If it fills `data` with the order id (instead of `null` which is returned currently) then we could rely on this property to check for order existence.