### PR TITLE
bitcoincoid: less strict error checking for public API

### DIFF
--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -256,15 +256,20 @@ module.exports = class bitcoincoid extends Exchange {
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
-        let market = symbol ? this.market (symbol) : undefined;
-        let request = market ? { 'pair': market['id'] } : {};
+        let market = undefined;
+        let pair = undefined;
+        if (symbol) {
+            market = this.market (symbol);
+            pair = market['id'];
+        }
+        let request = pair ? { pair } : {};
         let response = await this.privatePostOpenOrders (this.extend (request, params));
         // { success: 1, return: { orders: null }}
         let raw = response['return']['orders'];
         if (!raw)
             return [];
         let orders = this.parseOrders (raw, market, since, limit);
-        return market ? this.filterOrdersBySymbol (orders, symbol) : orders;
+        return this.filterOrdersBySymbol (orders, symbol);
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -36,7 +36,6 @@ module.exports = class bitcoincoid extends Exchange {
                 'www': 'https://www.bitcoin.co.id',
                 'doc': [
                     'https://vip.bitcoin.co.id/downloads/BITCOINCOID-API-DOCUMENTATION.pdf',
-                    'https://vip.bitcoin.co.id/trade_api',
                 ],
             },
             'api': {

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -255,16 +255,12 @@ module.exports = class bitcoincoid extends Exchange {
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        if (!symbol)
-            throw new ExchangeError (this.id + ' fetchOpenOrders requires a symbol');
         await this.loadMarkets ();
-        let market = this.market (symbol);
-        let request = {
-            'pair': market['id'],
-        };
+        let market = symbol ? this.market (symbol) : undefined;
+        let request = market ? { 'pair': market['id'] } : {};
         let response = await this.privatePostOpenOrders (this.extend (request, params));
         let orders = this.parseOrders (response['return']['orders'], market, since, limit);
-        return this.filterOrdersBySymbol (orders, symbol);
+        return market ? this.filterOrdersBySymbol (orders, symbol) : orders;
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -262,6 +262,8 @@ module.exports = class bitcoincoid extends Exchange {
         // { success: 1, return: { orders: null }}
         let raw = response['return']['orders'];
         let orders = this.parseOrders (raw, market, since, limit);
+        if (!orders)
+            return [];
         return market ? this.filterOrdersBySymbol (orders, symbol) : orders;
     }
 

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -350,7 +350,7 @@ module.exports = class bitcoincoid extends Exchange {
             if (body[0] === '{')
                 response = JSON.parse (body);
         if (!('success' in response))
-            throw new ExchangeError (this.id + ': malformed response: ' + this.json (response));
+            return; // no 'success' property on public responses
         if (response['success'] === 1) {
             // { success: 1, return: { orders: [] }}
             if (!('return' in response))

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -261,9 +261,9 @@ module.exports = class bitcoincoid extends Exchange {
         let response = await this.privatePostOpenOrders (this.extend (request, params));
         // { success: 1, return: { orders: null }}
         let raw = response['return']['orders'];
-        let orders = this.parseOrders (raw, market, since, limit);
-        if (!orders)
+        if (!raw)
             return [];
+        let orders = this.parseOrders (raw, market, since, limit);
         return market ? this.filterOrdersBySymbol (orders, symbol) : orders;
     }
 

--- a/js/bitcoincoid.js
+++ b/js/bitcoincoid.js
@@ -259,7 +259,9 @@ module.exports = class bitcoincoid extends Exchange {
         let market = symbol ? this.market (symbol) : undefined;
         let request = market ? { 'pair': market['id'] } : {};
         let response = await this.privatePostOpenOrders (this.extend (request, params));
-        let orders = this.parseOrders (response['return']['orders'], market, since, limit);
+        // { success: 1, return: { orders: null }}
+        let raw = response['return']['orders'];
+        let orders = this.parseOrders (raw, market, since, limit);
         return market ? this.filterOrdersBySymbol (orders, symbol) : orders;
     }
 


### PR DESCRIPTION
Properly fixes #1707 .
Actually, I checked that PR against private API only... and Travis skipped checks for public API too.