### PR TITLE
Bitstamp -- fixed parse trade

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -246,7 +246,7 @@ module.exports = class bitstamp extends Exchange {
         let ids = Object.keys (currencies);
         for (let i = 0; i < ids.length; i++) {
             let k = ids[i];
-            if (k.split('_') == 2) {
+            if (k.split('_').length == 2) {
                 let candidate_sym = k.replace('_', '');
                 if (candidate_sym in this.markets_by_id) {
                     market = this.markets_by_id[marketId];
@@ -274,8 +274,8 @@ module.exports = class bitstamp extends Exchange {
             'price': parseFloat (price),
             'amount': parseFloat (amount),
             'fee': {
-                'cost': parseFloat(trade['fee']),
-                'currency': marker['quote'],
+                'cost': parseFloat (trade['fee']),
+                'currency': marker['quote']
             }
         };
     }

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -245,9 +245,9 @@ module.exports = class bitstamp extends Exchange {
 
         let ids = Object.keys (currencies);
         for (let i = 0; i < ids.length; i++) {
-            let id = ids[i];
-            if (id.split('_') == 2) {
-                let candidate_sym = id.replace('_', '');
+            let k = ids[i];
+            if (k.split('_') == 2) {
+                let candidate_sym = k.replace('_', '');
                 if (candidate_sym in this.markets_by_id) {
                     market = this.markets_by_id[marketId];
                 }

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -242,11 +242,17 @@ module.exports = class bitstamp extends Exchange {
         let order = undefined;
         if ('order_id' in trade)
             order = trade['order_id'].toString ();
-        if ('currency_pair' in trade) {
-            let marketId = trade['currency_pair'];
-            if (marketId in this.markets_by_id)
-                market = this.markets_by_id[marketId];
+
+        let ids = Object.keys (currencies);
+        for (let i = 0; i < ids.length; i++) {
+            let id = ids[i];
+            if (id.split('_') == 2):
+                let candidate_sym = id.replace('_', '');
+                if (candidate_sym in this.markets_by_id) {
+                    market = this.markets_by_id[marketId];
+                }
         }
+
         let price = this.safeFloat (trade, 'price');
         price = this.safeFloat (trade, market['symbolId'], price);
         let amount = this.safeFloat (trade, 'amount');
@@ -266,6 +272,10 @@ module.exports = class bitstamp extends Exchange {
             'side': side,
             'price': parseFloat (price),
             'amount': parseFloat (amount),
+            'fee': {
+                'cost': parseFloat(trade['fee']),
+                'currency': marker['quote'],
+            }
         };
     }
 

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -246,11 +246,12 @@ module.exports = class bitstamp extends Exchange {
         let ids = Object.keys (currencies);
         for (let i = 0; i < ids.length; i++) {
             let id = ids[i];
-            if (id.split('_') == 2):
+            if (id.split('_') == 2) {
                 let candidate_sym = id.replace('_', '');
                 if (candidate_sym in this.markets_by_id) {
                     market = this.markets_by_id[marketId];
                 }
+            }
         }
 
         let price = this.safeFloat (trade, 'price');


### PR DESCRIPTION
I've tested this code in python, and it works properly. There are no collisions in market with candidate symbol. The issue with js is I cannot transpile it (and my js knowledge is slimish). This is equivalent python code (at least what I intended).

```python 
        timestamp = None
        if 'date' in trade:
            timestamp = int(trade['date']) * 1000
        elif 'datetime' in trade:
            timestamp = self.parse8601(trade['datetime'])
        side = 'buy' if (trade['type'] == '0') else 'sell'
        order = None
        if 'order_id' in trade:
            order = str(trade['order_id'])
        market = None
        for key in trade:
            if len(key.split('_')) == 2:
                candidate_sym = key.replace('_', '')
                if candidate_sym in self.markets_by_id:
                    market = self.markets_by_id[candidate_sym]
        price = self.safe_float(trade, 'price')
        price = self.safe_float(trade, market['symbolId'], price)
        amount = self.safe_float(trade, 'amount')
        amount = self.safe_float(trade, market['baseId'], amount)
        id = self.safe_value(trade, 'tid')
        id = self.safe_value(trade, 'id', id)
        if id:
            id = str(id)
        tr = {
            'id': id,
            'info': trade,
            'timestamp': timestamp,
            'datetime': self.iso8601(timestamp),
            'symbol': market['symbol'],
            'order': order,
            'type': None,
            'side': side,
            'price': float(price),
            'amount': float(amount),
            'fee': {
                'cost': self.safe_float(trade, 'fee'),
                'currency': market['quote'],
            }
        }
        print(json.dumps(tr, indent=4))
        return tr
```