### PR TITLE
transpile: warn if no files transpiled

### DIFF
--- a/transpile.js
+++ b/transpile.js
@@ -601,6 +601,9 @@ const pythonRegexes = [
             .filter (file => file.includes (pattern))
             .map (file => transpileDerivedExchangeFile (folder, file))
 
+        if (classNames.length === 0)
+            return null
+
         let classes = {}
         classNames.forEach (({ className, baseClass }) => {
             classes[className] = baseClass
@@ -705,6 +708,11 @@ const pythonRegexes = [
     createFolderRecursively (phpFolder)
 
     const classes = transpileDerivedExchangeFiles ('./js/', filename)
+
+    if (classes === null) {
+      log.bright.yellow ('0 files transpiled.')
+      return;
+    }
 
     // HINT: if we're going to support specific class definitions this process won't work anymore as it will override the definitions.
     exportTypeScriptDeclarations (classes)


### PR DESCRIPTION
When troubleshooting transpilation issues I need to transpile just one file in question.
I do it like:
```
> node transpile exchange.js
Transpiling from exchange.js (transpileDerivedExchangeFile @ transpile.js:580)
Transpiling ./python/test/test_async.py → ./python/test/test.py (transpilePythonAsyncToSync @ transpile.js:659)
Transpiled successfully. (<anonymous> @ transpile.js:724)
```

Sometimes I mistype `exchange.js` so effectively nothing is transpiled... but transpiler says "transpiled successfully" anyway. This fix warns if there was no transpilation.