### PR TITLE
add await for huobipro fetchOpenOrders

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -353,7 +353,7 @@ module.exports = class huobipro extends Exchange {
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         let open = 0; // 0 for unfilled orders, 1 for filled orders
-        return this.fetchOrders (symbol, undefined, undefined, this.extend ({
+        return await this.fetchOrders (symbol, undefined, undefined, this.extend ({
             'status': open,
         }, params));
     }


### PR DESCRIPTION
huobipro fetchOpenOrders forgot to await, it's a bug.   So that in python async version, have to use 
asyncio.get_event_loop().run_until_complete(asyncio.get_event_loop().run_until_complete(huobipro.fetch_open_orders()))
