### PR TITLE
Substitution for symbol BON > BonPeKaO

### DIFF
--- a/js/coinexchange.js
+++ b/js/coinexchange.js
@@ -538,6 +538,8 @@ module.exports = class coinexchange extends Exchange {
         let substitutions = {
             'HNC': 'Huncoin',
             'BON': 'BonPeKaO',
+            'MARS': 'MarsBux',
+            'ETN': 'Ethernex'
         };
         if (currency in substitutions)
             return substitutions[currency];

--- a/js/coinexchange.js
+++ b/js/coinexchange.js
@@ -536,10 +536,10 @@ module.exports = class coinexchange extends Exchange {
 
     commonCurrencyCode (currency) {
         let substitutions = {
-            'HNC': 'Huncoin',
             'BON': 'BonPeKaO',
+            'ETN': 'Ethernex',
+            'HNC': 'Huncoin',
             'MARS': 'MarsBux',
-            'ETN': 'Ethernex'
         };
         if (currency in substitutions)
             return substitutions[currency];

--- a/js/coinexchange.js
+++ b/js/coinexchange.js
@@ -535,8 +535,12 @@ module.exports = class coinexchange extends Exchange {
     }
 
     commonCurrencyCode (currency) {
-        if (currency === 'HNC')
-            return 'Huncoin';
+        let substitutions = {
+            'HNC': 'Huncoin',
+            'BON': 'BonPeKaO',
+        };
+        if (currency in substitutions)
+            return substitutions[currency];
         return currency;
     }
 

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -94,6 +94,7 @@ module.exports = class cryptopia extends Exchange {
     currencyId (currency) {
         const currencies = {
             'AdCoin': 'ACC',
+            'BatCoin': 'BAT',
             'CCX': 'CC',
             'Comet': 'CMT',
             'Cubits': 'QBT',

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -77,6 +77,7 @@ module.exports = class cryptopia extends Exchange {
     commonCurrencyCode (currency) {
         const currencies = {
             'ACC': 'AdCoin',
+            'BAT': 'BatCoin',
             'CC': 'CCX',
             'CMT': 'Comet',
             'FCN': 'Facilecoin',


### PR DESCRIPTION
Bonpay has higher market cap than Bon PeKaO, therefore BonPeKaO is substituted for BON in CoinExchange.