### PR TITLE
Must provide limit value for fetchOrderBook, otherwise Bibox returns an empty order book.

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -209,15 +209,14 @@ module.exports = class bibox extends Exchange {
         return this.parseTrades (response['result'], market, since, limit);
     }
 
-    async fetchOrderBook (symbol, limit = undefined, params = {}) {
+    async fetchOrderBook (symbol, limit = 200, params = {}) {
         await this.loadMarkets ();
         let market = this.market (symbol);
         let request = {
             'cmd': 'depth',
             'pair': market['id'],
         };
-        if (typeof limit !== 'undefined')
-            request['size'] = limit; // default = 200 ?
+        request['size'] = limit; // default = 200 ?
         let response = await this.publicGetMdata (this.extend (request, params));
         return this.parseOrderBook (response['result'], this.safeFloat (response['result'], 'update_time'), 'bids', 'asks', 'price', 'volume');
     }


### PR DESCRIPTION
The documentation implies it will give 200 by default if you don't give it a value; the documentation is wrong. It returns an empty order book if the "size" field isn't specified. Try it yourself to make sure it's not some strange issue on my end.