### PR TITLE
Fix invalid typescript definition for fetch OHLCV

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -282,7 +282,7 @@ declare module 'ccxt' {
         fetchTicker (symbol: string): Promise<Ticker>;
         fetchTickers (symbols?: string[]): Promise<Tickers>;
         fetchTrades (symbol: string, since?: number, limit?: number, params?: {}): Promise<Trade[]>;
-        fetchOHLCV? (symbol: string, timeframe?: string, since?: number, limit?: number, params?: any = {}): Promise<OHLCV[]>;
+        fetchOHLCV? (symbol: string, timeframe?: string, since?: number, limit?: number, params?: any): Promise<OHLCV[]>;
         fetchOrders (symbol?: string, since?: number, limit?: number, params?: {}): Promise<Order[]>;
         fetchOpenOrders (symbol?: string, since?: number, limit?: number, params?: {}): Promise<Order[]>;
         cancelOrder (id: string, symbol?: string, params?: {}): Promise<any>;


### PR DESCRIPTION
Related to #1749 

The typescript compiler was generating the following errors:

```
ccxt.d.ts(285,90): error TS1015: Parameter cannot have question mark and initializer.
ccxt.d.ts(285,90): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
```

Here's the offending line: https://github.com/ccxt/ccxt/blob/a5bdc0909451957b81ba9545ff10704b220b726f/ccxt.d.ts#L285