### PR TITLE
Allow milliseconds to be overridden

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -157,7 +157,6 @@ module.exports = class Exchange {
 
         this.iso8601          = timestamp => new Date (timestamp).toISOString ()
         this.parse8601        = x => Date.parse (((x.indexOf ('+') >= 0) || (x.slice (-1) === 'Z')) ? x : (x + 'Z'))
-        this.milliseconds     = now
         this.microseconds     = () => now () * 1000 // TODO: utilize performance.now for that purpose
         this.seconds          = () => Math.floor (now () / 1000)
 
@@ -231,6 +230,10 @@ module.exports = class Exchange {
 
     nonce () {
         return this.seconds ()
+    }
+    
+    milliseconds () {
+        return now ()
     }
 
     encodeURIComponent (...args) {


### PR DESCRIPTION
Currently, binance has an optional mechanism as a workaround to their strict time synchronization requirement. However [milliseconds](https://github.com/ccxt/ccxt/blob/62a2e86fee0e88e374c08864f2afb498050861dc/js/binance.js#L309) as defined on `binance.js` is currently dead code because the `Exchange` class sets `this.milliseconds` in the constructor, preventing it from being overridden unless you hack the child constructor to rebind the function.