### PR TITLE
coingi: Mandatory parameters for fetchOrderBook

### DIFF
--- a/js/coingi.js
+++ b/js/coingi.js
@@ -170,18 +170,15 @@ module.exports = class coingi extends Exchange {
         return this.parseBalance (result);
     }
 
-    async fetchOrderBook (symbol, limit = undefined, params = {}) {
+    async fetchOrderBook (symbol, limit = 512, params = {}) {
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let request = {
+        let orderbook = await this.currentGetOrderBookPairAskCountBidCountDepth (this.extend ({
             'pair': market['id'],
             'depth': 32, // maximum number of depth range steps 1-32
-        };
-        if (typeof limit !== 'undefined') {
-            request['askCount'] = limit; // maximum returned number of asks 1-512
-            request['bidCount'] = limit; // maximum returned number of bids 1-512
-        }
-        let orderbook = await this.currentGetOrderBookPairAskCountBidCountDepth (this.extend (request, params));
+            'askCount': limit, // maximum returned number of asks 1-512
+            'bidCount': limit, // maximum returned number of bids 1-512
+        }, params));
         return this.parseOrderBook (orderbook, undefined, 'bids', 'asks', 'price', 'baseAmount');
     }
 


### PR DESCRIPTION
Without these parameters `extractParams` will give an invalid URL. I used 512 as default, as it was before.