### PR TITLE
fix getting price and cost with fetchorder on kucoin

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -302,6 +302,8 @@ module.exports = class kucoin extends Exchange {
             price = this.safeFloat (order, 'dealPrice');
         if (typeof price === 'undefined')
             price = this.safeFloat (order, 'dealPriceAverage');
+        if (price === 0.0)
+            price = this.safeFloat (order, 'orderPrice');
         let remaining = this.safeFloat (order, 'pendingAmount');
         let status = this.safeValue (order, 'status');
         let filled = this.safeFloat (order, 'dealAmount');
@@ -333,6 +335,8 @@ module.exports = class kucoin extends Exchange {
                 remaining = amount - filled;
             }
         }
+        if (cost === 0.0)
+            cost = price * amount;
         let side = this.safeValue (order, 'direction');
         if (typeof side === 'undefined')
             side = order['type'].toLowerCase ();


### PR DESCRIPTION
details: fetchorder returns other keys than fetchclosedorders and fetchopenorders so to get price and cost with it some variation of this is neccessary.