### PR TITLE
Exchange: filterBySinceLimit: since is inclusive

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -730,7 +730,7 @@ module.exports = class Exchange {
 
     filterBySinceLimit (array, since = undefined, limit = undefined) {
         if (typeof since !== 'undefined')
-            array = array.filter (entry => entry.timestamp > since)
+            array = array.filter (entry => entry.timestamp >= since)
         if (typeof limit !== 'undefined')
             array = array.slice (0, limit)
         return array


### PR DESCRIPTION
This behavior is not explicitly stated in the Manual, still, I find it intuitive if `since` is included in the result set.
So, when I want to fetch trades "starting from Jan 1st", I expect a midnight trade to be fetched as well.

Let me know if you think otherwise.