### PR TITLE
PHP: fix incorrect parsing bittrex timestamp

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -236,7 +236,7 @@ module.exports = class bittrex extends Exchange {
     }
 
     parseTicker (ticker, market = undefined) {
-        let timestamp = this.parse8601 (ticker['TimeStamp']);
+        let timestamp = this.parse8601 (ticker['TimeStamp'] + '+00:00');
         let symbol = undefined;
         if (market)
             symbol = market['symbol'];
@@ -344,7 +344,7 @@ module.exports = class bittrex extends Exchange {
     }
 
     parseTrade (trade, market = undefined) {
-        let timestamp = this.parse8601 (trade['TimeStamp']);
+        let timestamp = this.parse8601 (trade['TimeStamp'] + '+00:00');
         let side = undefined;
         if (trade['OrderType'] === 'BUY') {
             side = 'buy';
@@ -381,7 +381,7 @@ module.exports = class bittrex extends Exchange {
     }
 
     parseOHLCV (ohlcv, market = undefined, timeframe = '1d', since = undefined, limit = undefined) {
-        let timestamp = this.parse8601 (ohlcv['T']);
+        let timestamp = this.parse8601 (ohlcv['T'] + '+00:00');
         return [
             timestamp,
             ohlcv['O'],
@@ -503,11 +503,11 @@ module.exports = class bittrex extends Exchange {
             symbol = market['symbol'];
         let timestamp = undefined;
         if ('Opened' in order)
-            timestamp = this.parse8601 (order['Opened']);
+            timestamp = this.parse8601 (order['Opened'] + '+00:00');
         if ('TimeStamp' in order)
-            timestamp = this.parse8601 (order['TimeStamp']);
+            timestamp = this.parse8601 (order['TimeStamp'] + '+00:00');
         if ('Created' in order)
-            timestamp = this.parse8601 (order['Created']);
+            timestamp = this.parse8601 (order['Created'] + '+00:00');
         let fee = undefined;
         let commission = undefined;
         if ('Commission' in order) {


### PR DESCRIPTION
In PHP strtotime() use  current timezone if it not set in string. Bittrex sent timestamp in GMT without time zone.