### PR TITLE
test: fail on ExchangeError

### DIFF
--- a/js/test/test.js
+++ b/js/test/test.js
@@ -963,12 +963,6 @@ let tryAllProxies = async function (exchange, proxies) {
             } else if (e instanceof ccxt.AuthenticationError) {
                 warn ('[Authentication Error] ' + e.message.slice (0, 200))
                 return
-            } else if (e instanceof ccxt.NotSupported) {
-                warn ('[Not Supported] ' + e.message.slice (0, 200))
-                return
-            } else if (e instanceof ccxt.ExchangeError) {
-                warn ('[Exchange Error] ' + e.message.slice (0, 200))
-                return
             } else {
                 throw e
             }


### PR DESCRIPTION
I see that I introduced a bug in #1698 but it remained unnoticed because the current implementation of test swallows Exchange Errors.

I think error reporting is quite precise now so we can strengthen regression.