### PR TITLE
Fixed bitflyer order canceling

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -224,9 +224,13 @@ module.exports = class bitflyer extends Exchange {
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
+        if (!symbol) {
+          throw new ExchangeError (this.id + ' cancelOrder requires a symbol param');
+        }
         await this.loadMarkets ();
         return await this.privatePostCancelchildorder (this.extend ({
-            'parent_order_id': id,
+            'product_code': this.marketId (symbol),
+            'child_order_acceptance_id': id,
         }, params));
     }
 


### PR DESCRIPTION
It seems that bitflyer needs symbol when canceling the order, also the ID property name was the wrong one.