### PR TITLE
parseBalance: take remaining cost when inferring used funds from open orders cache

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -679,11 +679,11 @@ module.exports = class Exchange {
         return Object.values (this.orders).filter (order => (order['status'] === 'open')).reduce ((total, order) => {
             let symbol = order['symbol'];
             let market = this.markets[symbol];
-            let amount = order['remaining']
+            let remaining = order['remaining']
             if (currency === market['base'] && order['side'] === 'sell') {
-                return total + amount
+                return total + remaining
             } else if (currency === market['quote'] && order['side'] === 'buy') {
-                return total + (order['cost'] || (order['price'] * amount))
+                return total + (order['price'] * remaining)
             } else {
                 return total
             }

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1500,8 +1500,9 @@ Most of methods returning orders within ccxt unified API will usually yield an o
     'side':      'buy',          // 'buy', 'sell'
     'price':      0.06917684,    // float price in quote currency
     'amount':     1.5,           // ordered amount of base currency
-    'filled':     1.0,           // filled amount of base currency
-    'remaining':  0.5,           // remaining amount to fill
+    'filled':     1.1,           // filled amount of base currency
+    'remaining':  0.4,           // remaining amount to fill
+    'cost':       0.076094524,   // 'filled' * 'price'
     'trades':   [ ... ],         // a list of order trades/executions
     'fee':      {                // fee info, if available
         'currency': 'BTC',       // which currency the fee is (usually quote)


### PR DESCRIPTION
Related to #1222.

Also updated the Manual for less confusion. While there might be different flavors of costs I nailed down the one which is currently in use.