### PR TITLE
liqui: fetchOrders: fixed a bug when order erroneously marked as closed

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -508,35 +508,26 @@ module.exports = class liqui extends Exchange {
         return this.orders[id];
     }
 
-    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        // if (!symbol)
-        //     throw new ExchangeError (this.id + ' fetchOrders requires a symbol');
-        await this.loadMarkets ();
-        let request = {};
-        let market = undefined;
-        if (symbol) {
-            let market = this.market (symbol);
-            request['pair'] = market['id'];
-        }
-        let response = await this.privatePostActiveOrders (this.extend (request, params));
-        let openOrders = [];
-        if ('return' in response)
-            openOrders = this.parseOrders (response['return'], market);
-        for (let j = 0; j < openOrders.length; j++) {
-            this.orders[openOrders[j]['id']] = openOrders[j];
-        }
+    updateInactiveCachedOrders (openOrders, symbol) {
         let openOrdersIndexedById = this.indexBy (openOrders, 'id');
         let cachedOrderIds = Object.keys (this.orders);
-        let result = [];
         for (let k = 0; k < cachedOrderIds.length; k++) {
+            // try to find every cached order in open orders array
+            // possible reasons why cached order is not there:
+            // - order was closed or cancelled
+            // - symbol mismatch (e.g. cached BTC/USDT, fetched ETH/USDT)
             let id = cachedOrderIds[k];
-            if (id in openOrdersIndexedById) {
-                this.orders[id] = this.extend (this.orders[id], openOrdersIndexedById[id]);
-            } else {
+            if (!(id in openOrdersIndexedById)) {
+                // cached order is not in open orders array
                 let order = this.orders[id];
+                if (typeof symbol !== 'undefined' && symbol !== order['symbol']) {
+                    // fetched a particular symbol but it doesn't match the order in the cache -> won't update
+                    continue;
+                }
+                // order is cached but not opened -> mark as closed
                 if (order['status'] === 'open') {
                     order = this.extend (order, {
-                        'status': 'closed',
+                        'status': 'closed', // likewise it might have been canceled
                         'cost': undefined,
                         'filled': order['amount'],
                         'remaining': 0.0,
@@ -548,14 +539,31 @@ module.exports = class liqui extends Exchange {
                     this.orders[id] = order;
                 }
             }
-            let order = this.orders[id];
-            if (symbol) {
-                if (order['symbol'] === symbol)
-                    result.push (order);
-            } else {
-                result.push (order);
-            }
         }
+    }
+
+    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        // if (!symbol)
+        //     throw new ExchangeError (this.id + ' fetchOrders requires a symbol');
+        await this.loadMarkets ();
+        let request = {};
+        let market = undefined;
+        if (symbol) {
+            let market = this.market (symbol);
+            request['pair'] = market['id'];
+        }
+        let response = await this.privatePostActiveOrders (this.extend (request, params));
+        // liqui etc can only return 'open' orders (i.e. no way to fetch 'closed' orders)
+        let openOrders = [];
+        if ('return' in response)
+            openOrders = this.parseOrders (response['return'], market);
+        for (let j = 0; j < openOrders.length; j++) {
+            // update local cache with opened orders
+            const id = openOrders[j]['id'];
+            this.orders[id] = openOrders[j];
+        }
+        this.updateInactiveCachedOrders (openOrders, symbol);
+        let result = this.filterOrdersBySymbol (this.orders, symbol);
         return this.filterBySinceLimit (result, since, limit);
     }
 
@@ -583,13 +591,13 @@ module.exports = class liqui extends Exchange {
         await this.loadMarkets ();
         let market = undefined;
         let request = {
-            // 'from': 123456789, // trade ID, from which the display starts numerical 0
+            // 'from': 123456789, // trade ID, from which the display starts numerical 0 (test result: liqui ignores this field)
             // 'count': 1000, // the number of trades for display numerical, default = 1000
             // 'from_id': trade ID, from which the display starts numerical 0
             // 'end_id': trade ID on which the display ends numerical ∞
-            // 'order': 'ASC', // sorting, default = DESC
-            // 'since': 1234567890, // UTC start time, default = 0
-            // 'end': 1234567890, // UTC end time, default = ∞
+            // 'order': 'ASC', // sorting, default = DESC (test result: liqui ignores this field, most recent trade always goes last)
+            // 'since': 1234567890, // UTC start time, default = 0 (test result: liqui ignores this field)
+            // 'end': 1234567890, // UTC end time, default = ∞ (test result: liqui ignores this field)
             // 'pair': 'eth_btc', // default = all markets
         };
         if (typeof symbol !== 'undefined') {

--- a/js/liqui.js
+++ b/js/liqui.js
@@ -508,14 +508,19 @@ module.exports = class liqui extends Exchange {
         return this.orders[id];
     }
 
-    updateInactiveCachedOrders (openOrders, symbol) {
+    updateOrdersCache (openOrders, symbol) {
+        for (let j = 0; j < openOrders.length; j++) {
+            // update local cache with opened orders
+            const id = openOrders[j]['id'];
+            this.orders[id] = openOrders[j];
+        }
         let openOrdersIndexedById = this.indexBy (openOrders, 'id');
         let cachedOrderIds = Object.keys (this.orders);
         for (let k = 0; k < cachedOrderIds.length; k++) {
             // try to find every cached order in open orders array
             // possible reasons why cached order is not there:
-            // - order was closed or cancelled
-            // - symbol mismatch (e.g. cached BTC/USDT, fetched ETH/USDT)
+            // - order was closed or cancelled -> update cache
+            // - symbol mismatch (e.g. cached BTC/USDT, fetched ETH/USDT) -> skip
             let id = cachedOrderIds[k];
             if (!(id in openOrdersIndexedById)) {
                 // cached order is not in open orders array
@@ -557,12 +562,7 @@ module.exports = class liqui extends Exchange {
         let openOrders = [];
         if ('return' in response)
             openOrders = this.parseOrders (response['return'], market);
-        for (let j = 0; j < openOrders.length; j++) {
-            // update local cache with opened orders
-            const id = openOrders[j]['id'];
-            this.orders[id] = openOrders[j];
-        }
-        this.updateInactiveCachedOrders (openOrders, symbol);
+        this.updateOrdersCache (openOrders, symbol);
         let result = this.filterOrdersBySymbol (this.orders, symbol);
         return this.filterBySinceLimit (result, since, limit);
     }


### PR DESCRIPTION
Might be related to #1801 as the code is actually the same but as well it might happen that #1801 shows the effect of another bug.

Steps to reproduce:
```
> liqui.fetchOrders()
{ }
> liqui.createLimitBuyOrder('BTC/USDT', 1, 1)
> liqui.fetchOrders()
> liqui.orders
{...status: 'open' }
> liqui.fetchOrders('ETH/BTC')
> liqui.orders
{...status: 'closed' }
> liqui.fetchOrders('BTC/USDT')
> liqui.orders
{...status: 'open' }
```

I moved cache handling to a separate function so it's easier to share between exchanges.

I also removed the following check:
https://github.com/ccxt/ccxt/blob/07978ac2289a755e66d02da17f11ba8fe0d3ebd1/js/liqui.js#L533-L534

It looks to me that it duplicates what we do few lines above:
https://github.com/ccxt/ccxt/blob/07978ac2289a755e66d02da17f11ba8fe0d3ebd1/js/liqui.js#L526

Can't guess a case when it would be needed but letting you know if it was done on a purpose.