### PR TITLE
first draft of base class refactor

### DIFF
--- a/python/ccxt/async/base/exchange.py
+++ b/python/ccxt/async/base/exchange.py
@@ -142,12 +142,6 @@ class Exchange(BaseExchange):
             self.check_required_credentials()
             await self.load_private(reload=reload)
 
-    async def load_private(self, fees=True, reload=False):
-        if fees:
-            await self.load_fees(reload=reload)
-
-        #  load other private info
-
     async def load_public(self, markets=True, currencies=True, reload=False):
         if markets:
             await self.load_markets(reload=reload)
@@ -157,6 +151,12 @@ class Exchange(BaseExchange):
 
         if markets and currencies:
             self.populate_fees()
+
+    async def load_private(self, fees=True, reload=False):
+        if fees:
+            await self.load_fees(reload=reload)
+
+        #  load other private info
 
     async def load_markets(self, reload=False):
         if not reload:

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -900,7 +900,6 @@ class Exchange(object):
             return self.set_currencies()
 
     def populate_fees(self):
-
         for currency, data in self.currencies.items():  # try load withdrawal fees from currencies
             if data['fee_loaded']:
                 self.fees['funding']['withdraw'][currency] = data['fee']

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -922,6 +922,9 @@ class Exchange(object):
             self.markets[k] = self.extend(self.markets[k], self.fees['trading'])
             self.markets[k]['info'] = fetch_markets_info
             self.markets[k]['fee_loaded'] = True
+            if 'active' in self.markets[k] and not self.markets[k]['active']:
+                self.markets[k]['fee_loaded'] = False  # sometimes exchanges send strange fees for unlisted markets
+
         for k in self.currencies.keys():
             if k in self.fees['funding']['withdraw']:
                 self.currencies[k]['fee'] = self.fees['funding']['withdraw'][k]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -829,8 +829,6 @@ class Exchange(object):
             self.populate_fees()
 
     def load_private(self, fees=True, reload=False):
-        print(reload)
-
         if fees:
             self.load_fees(reload=reload)
 

--- a/python/test/test_async.py
+++ b/python/test/test_async.py
@@ -254,7 +254,7 @@ async def test_symbol(exchange, symbol):
 
 
 async def load_exchange(exchange):
-    await exchange.load_markets()
+    await exchange.load()
 
 
 async def test_exchange(exchange):


### PR DESCRIPTION
This is pretty hefty refactor. I took into account the things you suggested [here.](https://github.com/ccxt/ccxt/pull/1814#issuecomment-363827160)

The code speaks for itself; it splits loadMarkets into `load`, `loadPublic`, `loadPrivate`, `loadMarkets`, `loadCurrencies`, and `loadFees`. It is more extensible than the current base class. Any number of things can be loaded with a simple call to `load()` and if someone wanted to load something more specific they could any one of the lower down loading functions. It is working really well so far and the `fee_loaded` boolean is super helpful for people (like me) who are adverse to using hardcoded fees. 

--- 

Three new methods are added: `load_fees`, `set_fees`, and `propagate_fees`.

* `load_fees`: calls `fetch_fees` --> `set_fees`

* `set_fees`: `self.fees` --> `markets` and `currencies`

* `propagate_fees`: `markets` and `currencies` --> `self.fees`

---

You may want to play around with this code in a python IDE to check for bugs etc. I tested it with a subset of the exchanges offered by ccxt until I could not find anymore bugs. Is it ok that this is a non-backwards compatible change?

Are maker and taker fees allowed to be negative? hitbtc2 defines a negative maker value and I think we should keep the modulus of the trading fees instead - `abs()` the value in python. 

There are likely going to be more changes to this refactor in the future. Could you possibly make a branch so we can test it out more?
