### PR TITLE
[bitmex] update rate limit to match docs

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -15,7 +15,7 @@ module.exports = class bitmex extends Exchange {
             'countries': 'SC', // Seychelles
             'version': 'v1',
             'userAgent': undefined,
-            'rateLimit': 1500,
+            'rateLimit': 2000,
             'has': {
                 'CORS': false,
                 'fetchOHLCV': true,


### PR DESCRIPTION
BitMEX's rate limit for unauthenticated clients is 150/5mins, or 2 seconds per request, per [the BitMEX docs.](https://testnet.bitmex.com/app/restAPI#Request-Rate-Limits) Updated the `rateLimit` value to match.

Couple semi-related questions: would you accept having `enableRateLimit` default to on for BitMEX?
And has there been progress on programmatically using response headers to check rate limits? (https://github.com/ccxt/ccxt/issues/1284#issuecomment-357716581)