### PR TITLE
fix_getting_right_value_for_change_on_binance

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -475,7 +475,7 @@ module.exports = class binance extends Exchange {
             'close': this.safeFloat (ticker, 'prevClosePrice'),
             'first': undefined,
             'last': this.safeFloat (ticker, 'lastPrice'),
-            'change': this.safeFloat (ticker, 'priceChange'),
+            'change': this.safeFloat (ticker, 'priceChangePercent'),
             'percentage': this.safeFloat (ticker, 'priceChangePercent'),
             'average': undefined,
             'baseVolume': this.safeFloat (ticker, 'volume'),


### PR DESCRIPTION
Hi. I simply changed change to get the same as percentage. I'm a bit unsure how change and percentage is supposed to differ honestly but this is just making it consistent with what poloniex and bittrex atleast report in their 'change' variable.

Could be that those are wrong though and maybe change is meant for how much in btc something has decreased or increased, but then we have to change those exchanges and probably more because they currently show in 'change' 24h change in percent.