### PR TITLE
Fixed XRP withdrawal for Bitstamp

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -469,7 +469,6 @@ module.exports = class bitstamp extends Exchange {
         method += 'Post' + this.capitalize (name) + 'Withdrawal';
         let query = params;
         if (code === 'XRP') {
-            let tag = this.safeString (params, 'destination_tag');
             if (tag) {
                 request['destination_tag'] = tag;
                 query = this.omit (params, 'destination_tag');


### PR DESCRIPTION
Tag was still searched in params, instead of in the tag field.