### PR TITLE
Fix for wrong Cobinhood volumes in fetchOrderBook

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -263,7 +263,7 @@ module.exports = class cobinhood extends Exchange {
         if (typeof limit !== 'undefined')
             request['limit'] = limit; // 100
         let response = await this.publicGetMarketOrderbooksTradingPairId (this.extend (request, params));
-        return this.parseOrderBook (response['result']['orderbook']);
+        return this.parseOrderBook (response['result']['orderbook'], undefined, 'bids', 'asks', 0, 2);
     }
 
     parseTrade (trade, market = undefined) {


### PR DESCRIPTION
For each order book entry, `fetchOrderBook` was returning the `count` instead of the `size`

This was caused by the cobinhood API docs being wrong, they were fixed yesterday:
https://github.com/cobinhood/api-public/pull/20/files