### PR TITLE
some consistency with subclass withdraw fees

### DIFF
--- a/js/acx.js
+++ b/js/acx.js
@@ -86,7 +86,7 @@ module.exports = class acx extends Exchange {
                 'funding': {
                     'tierBased': false,
                     'percentage': true,
-                    'withdraw': 0.0, // There is only 1% fee on withdrawals to your bank account.
+                    'withdraw': {}, // There is only 1% fee on withdrawals to your bank account.
                 },
             },
             'exceptions': {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -121,8 +121,8 @@ module.exports = class Exchange {
                 'funding': {
                     'tierBased': undefined,
                     'percentage': undefined,
-                    'withdraw': undefined,
-                    'deposit': undefined,
+                    'withdraw': {},
+                    'deposit': {},
                 },
             },
             'parseJsonResponse': true, // whether a reply is required to be in JSON or not

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -75,9 +75,8 @@ module.exports = class bibox extends Exchange {
                 'funding': {
                     'tierBased': false,
                     'percentage': false,
-                    'withdraw': {
-                    },
-                    'deposit': 0.0,
+                    'withdraw': {},
+                    'deposit': {},
                 },
             },
         });

--- a/js/cex.js
+++ b/js/cex.js
@@ -95,7 +95,6 @@ module.exports = class cex extends Exchange {
                         'BTG': 0.001,
                         'ZEC': 0.001,
                         'XRP': 0.02,
-                        'XLM': undefined,
                     },
                     'deposit': {
                         // 'USD': amount => amount * 0.035 + 0.25,

--- a/js/liqui.js
+++ b/js/liqui.js
@@ -66,8 +66,8 @@ module.exports = class liqui extends Exchange {
                 'funding': {
                     'tierBased': false,
                     'percentage': false,
-                    'withdraw': undefined,
-                    'deposit': undefined,
+                    'withdraw': {},
+                    'deposit': {},
                 },
             },
             'exceptions': {

--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -239,7 +239,7 @@ module.exports = class livecoin extends Exchange {
     async fetchFees (params = {}) {
         let tradingFees = await this.fetchTradingFees (params);
         return this.extend (tradingFees, {
-            'withdraw': 0.0,
+            'withdraw': {},
         });
     }
 

--- a/js/yobit.js
+++ b/js/yobit.js
@@ -58,8 +58,9 @@ module.exports = class yobit extends liqui {
                     'maker': 0.002,
                     'taker': 0.002,
                 },
-                'funding': 0.0,
-                'withdraw': 0.0005,
+                'funding': {
+                    'withdraw': {},
+                },
             },
         });
     }


### PR DESCRIPTION
withdraw cannot be a float because in `set_currencies` I use

    if k in self.fees['funding']['withdraw']:

---

I am currently working on the tests for the base fee refactor I made last week. 

One thing I noticed is that there are literally hundreds of instances where a load_markets should be a load_currencies so that's going to be fun to clean up :-/