### PR TITLE
Fix hitbtc2 ohlcv

### DIFF
--- a/js/hitbtc2.js
+++ b/js/hitbtc2.js
@@ -690,7 +690,7 @@ module.exports = class hitbtc2 extends hitbtc {
             parseFloat (ohlcv['max']),
             parseFloat (ohlcv['min']),
             parseFloat (ohlcv['close']),
-            parseFloat (ohlcv['volumeQuote']),
+            parseFloat (ohlcv['volume']),
         ];
     }
 


### PR DESCRIPTION
Hitbtc2 ohlcv api returns volume information different than others. Usually quote volume means the volume of the currency itself, whereas base volume means the volume of currency in base currency such as BTC.

For hitbtc2, however ([example](https://api.hitbtc.com/api/2/public/candles/EMCBTC?limit=100&period=D1))
   - volume => quote volume
   - volumeQuote => base volume

So, i've made the neccesary change to make it consistent with other exchanges.