### PR TITLE
eslint: removed noise, enabled for all exchanges ('js/*.js')

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -33,7 +33,7 @@
     "new-cap": ["error"],
     "no-var": "error",
     "prefer-const": "off",
-    "no-warning-comments": "warn",
+    "no-warning-comments": ["warn", { "terms": ["fixme"] }],
     "padded-blocks": ["error", "never"],
     "lines-between-class-members": "error",
     "no-multiple-empty-lines": ["error", { "max": 1 }],

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -28,7 +28,7 @@
     "no-nested-ternary": "error",
     "eqeqeq": "error",
     "quotes": ["error", "single", { "avoidEscape": true }],
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^(symbol|price|tag|since|limit|params|market|timeframe)" }],
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^(symbol|price|tag|since|limit|params|market|timeframe|api)" }],
     "new-parens": "error",
     "new-cap": ["error"],
     "no-var": "error",

--- a/js/_1broker.js
+++ b/js/_1broker.js
@@ -243,7 +243,7 @@ module.exports = class _1broker extends Exchange {
         return await this.privatePostOrderCancel ({ 'order_id': id });
     }
 
-    sign (path, api, method = 'GET', params = {}, headers = undefined, body = undefined) {
+    sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         this.checkRequiredCredentials ();
         let url = this.urls['api'] + '/' + this.version + '/' + path + '.php';
         let query = this.extend ({ 'token': this.apiKey }, params);

--- a/js/_1broker.js
+++ b/js/_1broker.js
@@ -243,7 +243,7 @@ module.exports = class _1broker extends Exchange {
         return await this.privatePostOrderCancel ({ 'order_id': id });
     }
 
-    sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+    sign (path, api, method = 'GET', params = {}, headers = undefined, body = undefined) {
         this.checkRequiredCredentials ();
         let url = this.urls['api'] + '/' + this.version + '/' + path + '.php';
         let query = this.extend ({ 'token': this.apiKey }, params);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint",
     "check-python-syntax": "cd python && tox -e qa && cd ..",
     "check-php-syntax": "php -f php/test/syntax.php",
-    "check-js-syntax": "eslint \"js/[a-z]*.js\" js/bitfinex.js",
+    "check-js-syntax": "eslint 'js/*.js'",
     "browserify": "browserify --debug ./ccxt.browser.js > ./build/ccxt.browser.js",
     "pandoc-python-readme": "pandoc --wrap=preserve --columns=10000 --from=markdown --to=rst --output=python/README.rst README.md",
     "pandoc-doc-readme": "pandoc --wrap=preserve --columns=10000 --from=markdown --to=rst --output=doc/README.rst README.md",


### PR DESCRIPTION
Seems like '_1broker.js' was simply missed due to the underscore.

Also reduced linting noise coming from TODO comments, errors were harder to spot with them on.