### PR TITLE
fix poloniex ohlcv volume data

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -165,7 +165,7 @@ module.exports = class poloniex extends Exchange {
             ohlcv['high'],
             ohlcv['low'],
             ohlcv['close'],
-            ohlcv['volume'],
+            ohlcv['quoteVolume'],
         ];
     }
 


### PR DESCRIPTION
Same reason as my previous commit (fix_hitbtc), some exchanges have different information in 'volume' parameter of ohlcv data. 'volume' in poloniex means total btc volume of that coin, whereas 'quoteVolume' is its own volume.

To be consistent with others, i made it `quoteVolume`.

Just a simple question, why didn't you put both type of volumes to fetchOhlcv method rather than only one of them ? I think most exchanges give both values.