### PR TITLE
Fix python logging

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -24,6 +24,7 @@ __all__ = [
 # -----------------------------------------------------------------------------
 
 # Python 2 & 3
+import logging
 import base64
 import calendar
 import collections
@@ -232,6 +233,7 @@ class Exchange(object):
         }, getattr(self, 'tokenBucket') if hasattr(self, 'tokenBucket') else {})
 
         self.session = self.session if self.session else Session()
+        self._logger = logging.getLogger(__name__)
 
     def __del__(self):
         if self.session:
@@ -334,8 +336,7 @@ class Exchange(object):
         request_headers = self.prepare_request_headers(headers)
         url = self.proxy + url
 
-        if self.verbose:
-            print(method, url, "\nRequest:", request_headers, "\n", body)
+        self._logger.debug("%s %s, Request: %s %s", method, url, request_headers, body)
 
         if body:
             body = body.encode()
@@ -370,8 +371,7 @@ class Exchange(object):
             self.handle_rest_errors(e, response.status_code, self.last_http_response, url, method)
             self.raise_error(ExchangeError, url, method, e, self.last_http_response)
 
-        if self.verbose:
-            print(method, url, str(response.status_code), "\nResponse:", str(response.headers), "\n", self.last_http_response)
+        self._logger.debug("%s %s, Response: %s %s %s", method, url, response.status_code, response.headers, self.last_http_response)
 
         self.handle_errors(response.status_code, response.reason, url, method, None, self.last_http_response)
         return self.handle_rest_response(self.last_http_response, url, method, headers, body)


### PR DESCRIPTION
When I run:
```
import asyncio
import ccxt
from ccxt import async as async_ccxt
import logging


logging.basicConfig(level=logging.DEBUG)

bitmex = ccxt.bitmex()
bitmex.fetch_ticker("BTC/USD")

async_bimtex = async_ccxt.bitmex()
loop = asyncio.get_event_loop()
loop.run_until_complete(async_bimtex.fetch_ticker("BTC/USD"))
```
I get:
```
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): www.bitmex.com
DEBUG:urllib3.connectionpool:https://www.bitmex.com:443 "GET /api/v1/instrument/activeAndIndices HTTP/1.1" 200 None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Response: 200 {'Strict-Transport-Security': 'max-age=31536000; includeSubDomains', 'X-RateLimit-Res
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:urllib3.connectionpool:https://www.bitmex.com:443 "GET /api/v1/quote/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True HTTP/1.1" 200 None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Response: 200 {'Strict-Transport-Security': 'max-age=
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:urllib3.connectionpool:https://www.bitmex.com:443 "GET /api/v1/trade/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True HTTP/1.1" 200 None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Response: 200 {'Strict-Transport-Security': 'max-age=
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:ccxt.async.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:ccxt.async.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Response: 200 <CIMultiDictProxy('Date': 'Sat, 17 Feb 2018 23:21:04 GMT', 'Content-Type': 'app
DEBUG:ccxt.async.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Request: {'Accept-Encoding': 'gzip, deflate'} N
DEBUG:ccxt.async.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Response: 200 <CIMultiDictProxy('Date': 'Sat, 1
DEBUG:ccxt.async.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Request: {'Accept-Encoding': 'gzip, deflate'} N
DEBUG:ccxt.async.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?count=1&binSize=1d&symbol=XBTUSD&reverse=True&partial=True, Response: 200 <CIMultiDictProxy('Date': 'Sat, 1
/home/vladimir/code/ccxt/python/ccxt/base/exchange.py:240: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
ERROR:asyncio:Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f9151b37dd8>
ERROR:asyncio:Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7f91550ec2b0>, 26057.708845146)]']

```