### PR TITLE
Change Bitfinex OHLCV to Descending Order

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -620,7 +620,7 @@ module.exports = class bitfinex extends Exchange {
         let request = {
             'symbol': v2id,
             'timeframe': this.timeframes[timeframe],
-            'sort': 1,
+            'sort': 0,
         };
         if (typeof limit !== 'undefined')
             request['limit'] = limit;

--- a/python/ccxt/bitfinex.py
+++ b/python/ccxt/bitfinex.py
@@ -594,7 +594,7 @@ class bitfinex (Exchange):
         request = {
             'symbol': v2id,
             'timeframe': self.timeframes[timeframe],
-            'sort': 1,
+            'sort': 0,
         }
         if limit is not None:
             request['limit'] = limit

--- a/python/ccxt/bitfinex.py
+++ b/python/ccxt/bitfinex.py
@@ -594,7 +594,7 @@ class bitfinex (Exchange):
         request = {
             'symbol': v2id,
             'timeframe': self.timeframes[timeframe],
-            'sort': 0,
+            'sort': 1,
         }
         if limit is not None:
             request['limit'] = limit


### PR DESCRIPTION
It seems more practical for the Bitfinex OHLCV API to pull from the most recent dates instead of from the first data points (2013). May be better to have this as a parameter in the API.