### PR TITLE
getbtc: .has.fetchTrades = false, their API won't work

### DIFF
--- a/js/getbtc.js
+++ b/js/getbtc.js
@@ -20,7 +20,7 @@ module.exports = class getbtc extends _1btcxe {
                 'doc': 'https://getbtc.org/api-docs.php',
             },
             'has': {
-                fetchTrades: false,
+                'fetchTrades': false,
             },
             'fees': {
                 'trading': {

--- a/js/getbtc.js
+++ b/js/getbtc.js
@@ -19,6 +19,9 @@ module.exports = class getbtc extends _1btcxe {
                 'www': 'https://getbtc.org',
                 'doc': 'https://getbtc.org/api-docs.php',
             },
+            'has': {
+                fetchTrades: false,
+            },
             'fees': {
                 'trading': {
                     'taker': 0.20 / 100,


### PR DESCRIPTION
They return negative amounts/prices for trades in "BTW" currency:
```
{        id:   "1007438",
       info: {         id: "1007438",
                     date: "2018-02-19 14:07:01",
                timestamp: "1519038421",
                      btc: "0.00430000",
               maker_type: "buy",
                    price: "-195300.60",
                   amount: "-839.79",
                 currency: "BTW"                  },
  timestamp:    1519038421000,
   datetime:   "2018-02-19T11:07:01.000Z",
     symbol:   "BTC/USD",
      order:    undefined,
       type:    undefined,
       side:   "buy",
      price:    -195300.6,
     amount:    -839.79                              }
```

I'd assume that negative values mean `side === 'sell'` but I don't see any negative values and 'sell' trades in other currencies to check this hypothesis.

So I guess this endpoint simply does not properly work.