### PR TITLE
eslint: require quotes around object literal property names

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -15,6 +15,7 @@
     "comma-dangle": ["error", "always-multiline"],
     "brace-style": ["error", "1tbs"],
     "multiline-comment-style": ["error", "separate-lines"],
+    "quote-props": "error",
     "no-whitespace-before-property": "error",
     "space-before-blocks": ["error", "always"],
     "space-before-function-paren": ["error", "always"],


### PR DESCRIPTION
Will pass once #1954 is merged.

Was pretty much sure we discovered all the rules. Still, wonder how many remains.