### PR TITLE
eslint: more strict rules

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -6,16 +6,22 @@
     "ecmaVersion": 2017,
     "sourceType": "script"
   },
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended"],
   "rules": {
     "strict": "error",
     "semi": "error",
-    "indent": "error",
+    "indent": ["error", 4],
     "init-declarations": "error",
-    "comma-dangle": ["error", "always-multiline"],
+    "comma-dangle": ["error", {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never"
+    }],
     "brace-style": ["error", "1tbs"],
     "multiline-comment-style": ["error", "separate-lines"],
-    "quote-props": "error",
+    "quote-props": ["error", "always"],
     "no-multi-spaces": ["error", { ignoreEOLComments: true }],
     "no-whitespace-before-property": "error",
     "space-before-blocks": ["error", "always"],
@@ -24,6 +30,7 @@
     "block-spacing": ["error", "always"],
     "keyword-spacing": ["error", { "before": true, "after": true }],
     "object-curly-spacing": ["error", "always", { "objectsInObjects": false }],
+    "object-curly-newline": ["error", { "consistent": true }],
     "space-infix-ops": "error",
     "space-unary-ops": "error",
     "space-in-parens": "error",
@@ -40,11 +47,12 @@
     "lines-between-class-members": "error",
     "no-multiple-empty-lines": ["error", { "max": 1 }],
     "padding-line-between-statements": ["error",
-      {"blankLine": "never", "prev":"*", "next": "*" },
-      {"blankLine": "always", "prev":"directive", "next": "*" },
-      {"blankLine": "always", "prev":"*", "next": "cjs-export" }
+      { "blankLine": "never", "prev":"*", "next": "*" },
+      { "blankLine": "always", "prev":"directive", "next": "*" },
+      { "blankLine": "always", "prev":"*", "next": "cjs-export" }
     ],
     "eol-last": "error",
-    "no-tabs": "error"
+    "no-tabs": "error",
+    "function-paren-newline": "error"
   }
 }


### PR DESCRIPTION
These rules follow few recent linting PRs.

Now what I think about it from the practical perspective. Those rules are hundreds. I figure out new ones on rare occasions if I stumble on some suspicious transpilation error in Travis logs but this is a lengthy process.

We can add few hundred rules in one row by installing an existing JS guide, like this one, for example: https://github.com/airbnb/javascript

This would require one more dev dependency, though. I understand that you may want to keep a list of dependencies concise so I'm absolutely fine if you decide to skip it. Especially in view that existing rules do their job pretty fine too.