### PR TITLE
Python base class remove outdated metainfo

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -15,7 +15,6 @@ module.exports = class okex extends okcoinusd {
             'has': {
                 'CORS': false,
                 'futures': true,
-                'hasFetchTickers': true,
                 'fetchTickers': true,
             },
             'urls': {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -127,21 +127,6 @@ class Exchange(object):
 
     hasPublicAPI = True
     hasPrivateAPI = True
-    hasCORS = False
-    hasFetchTicker = True
-    hasFetchOrderBook = True
-    hasFetchTrades = True
-    hasFetchTickers = False
-    hasFetchOHLCV = False
-    hasDeposit = False
-    hasWithdraw = False
-    hasFetchBalance = True
-    hasFetchOrder = False
-    hasFetchOrders = False
-    hasFetchOpenOrders = False
-    hasFetchClosedOrders = False
-    hasFetchMyTrades = False
-    hasFetchCurrencies = False
     hasCreateOrder = hasPrivateAPI
     hasCancelOrder = hasPrivateAPI
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -93,6 +93,7 @@ class Exchange(object):
     fees = {
         'trading': {
             'fee_loaded': False,
+            'percentage': True,  # subclasses should rarely have to redefine this
         },
         'funding': {
             'fee_loaded': False,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -145,6 +145,7 @@ class Exchange(object):
         'createDepositAddress': False,
         'createOrder': hasPrivateAPI,
         'deposit': False,
+        'edit_order': 'emulated',
         'fetchBalance': True,
         'fetchClosedOrders': False,
         'fetchCurrencies': False,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -146,7 +146,7 @@ class Exchange(object):
         'createDepositAddress': False,
         'createOrder': hasPrivateAPI,
         'deposit': False,
-        'edit_order': 'emulated',
+        'editOrder': 'emulated',
         'fetchBalance': True,
         'fetchClosedOrders': False,
         'fetchCurrencies': False,


### PR DESCRIPTION
I think this should be mirrored in all languanges for clarity.