### PR TITLE
bitfinex2: Return the markets in describe

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -315,7 +315,7 @@ module.exports = class bitfinex2 extends bitfinex {
     }
 
     fetchMarkets () {
-        return this.load_markets();
+        return this.loadMarkets ();
     }
     
     parseTicker (ticker, market = undefined) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -314,6 +314,10 @@ module.exports = class bitfinex2 extends bitfinex {
         return result;
     }
 
+    fetchMarkets () {
+        return this.load_markets();
+    }
+    
     parseTicker (ticker, market = undefined) {
         let timestamp = this.milliseconds ();
         let symbol = undefined;


### PR DESCRIPTION
the bitfinex base class has its own fetchMarkets method which does not work for the extended class.

This just loads the markets and returns them