### PR TITLE
btcchina: parseTicker: removed prevClose

### DIFF
--- a/js/btcchina.js
+++ b/js/btcchina.js
@@ -162,8 +162,6 @@ module.exports = class btcchina extends Exchange {
             'ask': parseFloat (ticker['sell']),
             'vwap': parseFloat (ticker['vwap']),
             'open': parseFloat (ticker['open']),
-            'close': parseFloat (ticker['prev_close']),
-            'first': undefined,
             'last': parseFloat (ticker['last']),
             'change': undefined,
             'percentage': undefined,


### PR DESCRIPTION
Apparently, they had two tickers...

Anyway.