### PR TITLE
virwox: fetchTicker: removed 'close', `fetchOrderBook`

### DIFF
--- a/js/virwox.js
+++ b/js/virwox.js
@@ -157,7 +157,6 @@ module.exports = class virwox extends Exchange {
             'startDate': this.ymdhms (start),
             'HLOC': 1,
         }, params));
-        let marketPrice = await this.fetchMarketPrice (symbol, params);
         let tickers = response['result']['priceVolumeList'];
         let keys = Object.keys (tickers);
         let length = keys.length;
@@ -170,13 +169,11 @@ module.exports = class virwox extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'high': parseFloat (ticker['high']),
             'low': parseFloat (ticker['low']),
-            'bid': marketPrice['bid'],
-            'ask': marketPrice['ask'],
+            'bid': undefined,
+            'ask': undefined,
             'vwap': undefined,
             'open': parseFloat (ticker['open']),
-            'close': parseFloat (ticker['close']),
-            'first': undefined,
-            'last': undefined,
+            'last': parseFloat (ticker['close']),
             'change': undefined,
             'percentage': undefined,
             'average': undefined,


### PR DESCRIPTION
This is the last in the row.

Their symbols look reversed, don't know if it's a bug or not:
```
id  symbol   base  quote  info           
-----------------------------------------
1   EUR/SLL  EUR   SLL    [object Object]
2   GBP/SLL  GBP   SLL    [object Object]
3   CHF/SLL  CHF   SLL    [object Object]
4   USD/SLL  USD   SLL    [object Object]
5   SLL/OMC  SLL   OMC    [object Object]
6   EUR/OMC  EUR   OMC    [object Object]
7   USD/OMC  USD   OMC    [object Object]
8   SLL/ACD  SLL   ACD    [object Object]
9   EUR/ACD  EUR   ACD    [object Object]
10  USD/ACD  USD   ACD    [object Object]
11  BTC/SLL  BTC   SLL    [object Object]
12  EUR/MVC  EUR   MVC    [object Object]
```
