### PR TITLE
Added url endpoint for gdax to retrieve deposit address

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -83,6 +83,7 @@ module.exports = class gdax extends Exchange {
                     'post': [
                         'deposits/coinbase-account',
                         'deposits/payment-method',
+                        'coinbase-accounts/{id}/addresses',
                         'funding/repay',
                         'orders',
                         'position/close',


### PR DESCRIPTION
GDAX has an undocumented endpoint that allows you to retrieve the deposit address for your cryptocurrency of choice.

Example:
```
client.privateGetCoinbaseAccounts()
[{'id': '111111111-1111-111111-1111111-11111111', 'name': 'BTC Wallet', 'balance': '0.00000000', 'currency': 'BTC', 'type': 'wallet', 'primary': True, 'active': True}]

client.privatePostCoinbaseAccountsIdAddresses({'id': '111111111-1111-111111-1111111-11111111'})
{'id': '8ghjfghjgfhj-dfsgdsfgdfgdfg-dfgsdfgdf', 'address': 'sdfgdfshdfghdfghghjghfgdsfgdfsgdfsg', 'name': 'New exchange deposit address', 'created_at': '2018-02-23T05:40:59Z', 'updated_at': '2018-02-23T05:40:59Z', 'network': 'bitcoin_cash', 'uri_scheme': 'bitcoincash', 'resource': 'address', 'resource_path': '/v2/accounts111111111-1111-111111-1111111-11111111'/addresses/fghdfghdfgh-dfgh-fg-dh-fdgh-dfghdf', 'warning_title': 'Only send Bitcoin Cash (BCH) to this address', 'warning_details': 'Sending any other digital asset, including Bitcoin (BTC), will result in permanent loss.', 'legacy_address': 'sdfgdfgdfghfgjfghjghjghjfghjfghjgfhj, 'callback_url': None, 'exchange_deposit_address': True}
```
