### PR TITLE
Add explicit .close() method to async exchange class

### DIFF
--- a/python/ccxt/async/base/exchange.py
+++ b/python/ccxt/async/base/exchange.py
@@ -61,7 +61,14 @@ class Exchange(BaseExchange):
         }, self.tokenBucket))
 
     def __del__(self):
-        asyncio.ensure_future(self.session.close(), loop=self.asyncio_loop)
+        if self.session is not None:
+            self.logger.warning("CCXT Exchange object was not closed before destruction. To close an exchange object "
+                                "and release the resources used by it you need to explicitly run the .close() coroutine.")
+
+    async def close(self):
+        if self.session is not None:
+            await self.session.close()
+            self.session = None
 
     async def wait_for_token(self):
         while self.rateLimitTokens <= 1:


### PR DESCRIPTION
Manual tests executed:
```
import asyncio
from ccxt import async as async_ccxt
import logging


logging.basicConfig(level=logging.DEBUG)


async def fetch_tickers(correctly):
    async_bimtex = async_ccxt.bitmex()
    await async_bimtex.fetch_ticker("BTC/USD")
    if correctly:
        await async_bimtex.close()


loop = asyncio.get_event_loop()

loop.run_until_complete(fetch_tickers(correctly=True))
```
Output:
```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Response: 200 <CIMultiDictProxy('Date': 'Fri, 23 Feb 2018 16:00:45 GMT'
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?reverse=True&count=1&binSize=1d&partial=True&symbol=XBTUSD, Request: {'Accept-Encodin
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?reverse=True&count=1&binSize=1d&partial=True&symbol=XBTUSD, Response: 200 <CIMultiDic
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?reverse=True&count=1&binSize=1d&partial=True&symbol=XBTUSD, Request: {'Accept-Encodin
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?reverse=True&count=1&binSize=1d&partial=True&symbol=XBTUSD, Response: 200 <CIMultiDic
```

```
import asyncio
from ccxt import async as async_ccxt
import logging


logging.basicConfig(level=logging.DEBUG)


async def fetch_tickers(correctly):
    async_bimtex = async_ccxt.bitmex()
    await async_bimtex.fetch_ticker("BTC/USD")
    if correctly:
        await async_bimtex.close()


loop = asyncio.get_event_loop()

loop.run_until_complete(fetch_tickers(correctly=False))
```
Output:
```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Response: 200 <CIMultiDictProxy('Date': 'Fri, 23 Feb 2018 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?binSize=1d&symbol=XBTUSD&partial=True&reverse=True&count=1, Request: {'A
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?binSize=1d&symbol=XBTUSD&partial=True&reverse=True&count=1, Response: 20
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?binSize=1d&symbol=XBTUSD&partial=True&reverse=True&count=1, Request: {'A
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?binSize=1d&symbol=XBTUSD&partial=True&reverse=True&count=1, Response: 20
WARNING:ccxt.base.exchange:CCXT Exchange object was not closed before destruction. To close an exchange object and release the resources used by i
ERROR:asyncio:Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f95136375f8>
ERROR:asyncio:Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7f95157c9f60>, 55120.968293128)]']
connector: <aiohttp.connector.TCPConnector object at 0x7f95147a7ef0>
```