### PR TITLE
Bittrex: fix getTicker change/percentage

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -243,10 +243,13 @@ module.exports = class bittrex extends Exchange {
         let previous = this.safeFloat (ticker, 'PrevDay');
         let last = this.safeFloat (ticker, 'Last');
         let change = undefined;
+        let percentage = undefined;
         if (typeof last !== 'undefined')
-            if (typeof previous !== 'undefined')
+            if (typeof previous !== 'undefined') {
+                change = last - previous;
                 if (previous > 0)
-                    change = (last - previous) / previous;
+                    percentage = change / previous;
+            }
         return {
             'symbol': symbol,
             'timestamp': timestamp,
@@ -261,7 +264,7 @@ module.exports = class bittrex extends Exchange {
             'first': undefined,
             'last': last,
             'change': change,
-            'percentage': undefined,
+            'percentage': percentage,
             'average': undefined,
             'baseVolume': this.safeFloat (ticker, 'Volume'),
             'quoteVolume': this.safeFloat (ticker, 'BaseVolume'),

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -248,7 +248,7 @@ module.exports = class bittrex extends Exchange {
             if (typeof previous !== 'undefined') {
                 change = last - previous;
                 if (previous > 0)
-                    percentage = change / previous;
+                    percentage = (change / previous) * 100;
             }
         return {
             'symbol': symbol,


### PR DESCRIPTION
Fixing Bittrex getTicker to confirm to standard
'change': should be absolute price change in last 24 hr
percentage': should be relative percentage change in last 24 hr