### PR TITLE
Fix Poloniex getTicker

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -259,6 +259,16 @@ module.exports = class poloniex extends Exchange {
         let symbol = undefined;
         if (market)
             symbol = market['symbol'];
+        let open = undefined;
+        let change = undefined;
+        let average = undefined;
+        let last = parseFloat (ticker['last']);
+        let relativeChange = parseFloat (ticker['percentChange']);
+        if (1 + relativeChange !== 0) {
+            open = last / (1 + relativeChange);
+            change = last - open;
+            average = (last + open) / 2;
+        }
         return {
             'symbol': symbol,
             'timestamp': timestamp,
@@ -268,13 +278,12 @@ module.exports = class poloniex extends Exchange {
             'bid': parseFloat (ticker['highestBid']),
             'ask': parseFloat (ticker['lowestAsk']),
             'vwap': undefined,
-            'open': undefined,
-            'close': undefined,
-            'first': undefined,
-            'last': parseFloat (ticker['last']),
-            'change': parseFloat (ticker['percentChange']),
-            'percentage': undefined,
-            'average': undefined,
+            'open': open,
+            'close': last,
+            'last': last,
+            'change': change,
+            'percentage': relativeChange * 100,
+            'average': average,
             'baseVolume': parseFloat (ticker['quoteVolume']),
             'quoteVolume': parseFloat (ticker['baseVolume']),
             'info': ticker,


### PR DESCRIPTION
Poloniex 'returnTicker' api  call returns a percentageChange field that is an accurate 24 hr price change. Use this to calculate values needed in ccxt fetchTicker and conform to standard laid out in manual: https://github.com/ccxt/ccxt/wiki/Manual#price-tickers