### PR TITLE
update binance ratelimit

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -99,7 +99,11 @@ module.exports = class binance extends Exchange {
                         'ticker/allBookTickers',
                         'ticker/price',
                         'ticker/bookTicker',
+                        'exchangeInfo',
                     ],
+                    'put': [ 'userDataStream' ],
+                    'post': [ 'userDataStream' ],
+                    'delete': [ 'userDataStream' ],
                 },
                 'private': {
                     'get': [
@@ -116,12 +120,6 @@ module.exports = class binance extends Exchange {
                     'delete': [
                         'order',
                     ],
-                },
-                'v1': {
-                    'put': [ 'userDataStream' ],
-                    'post': [ 'userDataStream' ],
-                    'delete': [ 'userDataStream' ],
-                    'get': ['exchangeInfo'],
                 },
             },
             'fees': {

--- a/js/binance.js
+++ b/js/binance.js
@@ -121,6 +121,7 @@ module.exports = class binance extends Exchange {
                     'put': [ 'userDataStream' ],
                     'post': [ 'userDataStream' ],
                     'delete': [ 'userDataStream' ],
+                    'get': ['exchangeInfo'],
                 },
             },
             'fees': {

--- a/js/binance.js
+++ b/js/binance.js
@@ -13,7 +13,7 @@ module.exports = class binance extends Exchange {
             'id': 'binance',
             'name': 'Binance',
             'countries': 'JP', // Japan
-            'rateLimit': 1200,
+            'rateLimit': 500,
             // new metainfo interface
             'has': {
                 'fetchDepositAddress': true,
@@ -721,8 +721,8 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        // if (!symbol)
-        //     throw new ExchangeError (this.id + ' fetchOpenOrders requires a symbol param');
+        if (!symbol)
+            throw new ExchangeError (this.id + ' fetchOpenOrders requires a symbol param');
         await this.loadMarkets ();
         let market = undefined;
         let request = {};

--- a/js/binance.js
+++ b/js/binance.js
@@ -13,7 +13,7 @@ module.exports = class binance extends Exchange {
             'id': 'binance',
             'name': 'Binance',
             'countries': 'JP', // Japan
-            'rateLimit': 500,
+            'rateLimit': 1200,
             // new metainfo interface
             'has': {
                 'fetchDepositAddress': true,


### PR DESCRIPTION
Got banned testing a trading algo

```
Network related error: binance 429 Too Many Requests {"code":-1003,"msg":"Too many requests; current limit is 1200 requests per minute. Please use the websocket for live updates to avoid polling the API."} <class 'ccxt.base.errors.DDoSProtection'>
Sleeping for 2 seconds...
Network related error: binance 429 Too Many Requests {"code":-1003,"msg":"Too many requests; current limit is 1200 requests per minute. Please use the websocket for live updates to avoid polling the API."} <class 'ccxt.base.errors.DDoSProtection'>
Sleeping for 4 seconds...
Network related error: binance 418 I'm a Teapot {"code":-1003,"msg":"Way too many requests; IP banned until 1519726649240. Please use the websocket for live updates to avoid bans."} <class 'ccxt.base.errors.DDoSProtection'>
Sleeping for 8 seconds...
Network related error: binance 418 I'm a Teapot {"code":-1003,"msg":"Way too many requests; IP banned until 1519726649240. Please use the websocket for live updates to avoid bans."} <class 'ccxt.base.errors.DDoSProtection'>
Sleeping for 16 seconds...
Network related error: binance 418 I'm a Teapot {"code":-1003,"msg":"Way too many requests; IP banned until 1519726649240. Please use the websocket for live updates to avoid bans."} <class 'ccxt.base.errors.DDoSProtection'>
```

Also a troll use of a http error code by an exchange 👀

---

Can you check that 1200 requests per minute means rateLimit = 1200?