### PR TITLE
Throw OrderNotFound if order not found in fetchOrderTrades

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -814,6 +814,8 @@ module.exports = class poloniex extends Exchange {
             const feedback = this.id + ' ' + this.json (response);
             if (error === 'Invalid order number, or you are not the person who placed the order.') {
                 throw new OrderNotFound (feedback);
+            } else if (error === 'Order not found, or you are not the person who placed it.') {
+                throw new OrderNotFound (feedback);
             } else if (error === 'Invalid API key/secret pair.') {
                 throw new AuthenticationError (feedback);
             } else if (error.indexOf ('Total must be at least') >= 0) {


### PR DESCRIPTION
In case of. Fetching trades,  the error message is not the same as the error message for fetchOrder