### PR TITLE
Only close aiohttp session if it is owned by the ccxt exchange object

### DIFF
--- a/python/ccxt/async/base/exchange.py
+++ b/python/ccxt/async/base/exchange.py
@@ -47,7 +47,8 @@ class Exchange(BaseExchange):
         if 'asyncio_loop' in config:
             self.asyncio_loop = config['asyncio_loop']
         self.asyncio_loop = self.asyncio_loop or asyncio.get_event_loop()
-        if 'session' not in config:
+        self.own_session = 'session' not in config
+        if self.own_session:
             # Create out SSL context object with our CA cert file
             context = ssl.create_default_context(cafile=certifi.where())
             # Pass this SSL context to aiohttp and create a TCPConnector
@@ -67,7 +68,8 @@ class Exchange(BaseExchange):
 
     async def close(self):
         if self.session is not None:
-            await self.session.close()
+            if self.own_session:
+                await self.session.close()
             self.session = None
 
     async def wait_for_token(self):


### PR DESCRIPTION
We don't want to close a session created by the user since they might want to keep it open after the exchange is closed. Here is a manual test I ran:

```
import asyncio
import ssl
import aiohttp
import certifi
from ccxt import async as async_ccxt
import logging


logging.basicConfig(level=logging.DEBUG)


async def fetch_tickers(own_session):
    params = dict()
    if own_session:
        context = ssl.create_default_context(cafile=certifi.where())
        connector = aiohttp.TCPConnector(ssl_context=context, limit=1)
        params["session"] = aiohttp.ClientSession(connector=connector)
    async_bimtex = async_ccxt.bitmex(params)
    await async_bimtex.fetch_ticker("BTC/USD")
    await async_bimtex.close()
    if own_session:
        await params["session"].close()


loop = asyncio.get_event_loop()

loop.run_until_complete(fetch_tickers(True))
loop.run_until_complete(fetch_tickers(False))
```

output:
```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Response: 200 <CIMultiDictProxy('Date': 'Tue, 27 Feb 2018 18:46:35 GMT', 'Content-Type': 'ap
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Request: {'Accept-Encoding': 'gzip, deflate'} 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Response: 200 <CIMultiDictProxy('Date': 'Tue, 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Request: {'Accept-Encoding': 'gzip, deflate'} 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Response: 200 <CIMultiDictProxy('Date': 'Tue, 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Request: {'Accept-Encoding': 'gzip, deflate'} None
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/instrument/activeAndIndices, Response: 200 <CIMultiDictProxy('Date': 'Tue, 27 Feb 2018 18:46:36 GMT', 'Content-Type': 'ap
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Request: {'Accept-Encoding': 'gzip, deflate'} 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/quote/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Response: 200 <CIMultiDictProxy('Date': 'Tue, 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Request: {'Accept-Encoding': 'gzip, deflate'} 
DEBUG:ccxt.base.exchange:GET https://www.bitmex.com/api/v1/trade/bucketed?partial=True&count=1&symbol=XBTUSD&reverse=True&binSize=1d, Response: 200 <CIMultiDictProxy('Date': 'Tue, 
```