### PR TITLE
options are now more clever

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -124,7 +124,7 @@ class Exchange(object):
     orders = None
     trades = None
     currencies = None
-    options = {}
+    options = None
 
     requiredCredentials = {
         'apiKey': True,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -124,7 +124,7 @@ class Exchange(object):
     orders = None
     trades = None
     currencies = None
-    options = None  # Python does not allow to define properties in run-time with setattr
+    options = {}
 
     requiredCredentials = {
         'apiKey': True,
@@ -201,11 +201,15 @@ class Exchange(object):
 
         settings = self.deep_extend(self.describe(), config)
 
-        for key in settings:
+        for key in config:
+            if key in settings['options']:
+                settings['options'][key] = config[key]
+
+        for key, value in settings.items():
             if hasattr(self, key) and isinstance(getattr(self, key), dict):
-                setattr(self, key, self.deep_extend(getattr(self, key), settings[key]))
+                setattr(self, key, self.deep_extend(getattr(self, key), value))
             else:
-                setattr(self, key, settings[key])
+                setattr(self, key, value)
 
         if self.api:
             self.define_rest_api(self.api, 'request')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -202,7 +202,7 @@ class Exchange(object):
         settings = self.deep_extend(self.describe(), config)
 
         for key in config:
-            if key in settings['options']:
+            if 'options' in settings and key in settings['options']:
                 settings['options'][key] = config[key]
 
         for key, value in settings.items():


### PR DESCRIPTION
previously:

```
from ccxt import binance
b = binance({'recvWindow':12})
b.options
{'recvWindow': 5000, 'timeDifference': 0, 'adjustForTimeDifference': False}
```

---

now:

```
from ccxt import binance
b = binance({'recvWindow':12})
b.options
{'recvWindow': 12, 'timeDifference': 0, 'adjustForTimeDifference': False}
```