### PR TITLE
Bitmex fetchOrder support and fixes

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -20,6 +20,7 @@ module.exports = class bitmex extends Exchange {
                 'CORS': false,
                 'fetchOHLCV': true,
                 'withdraw': true,
+                'fetchOrder': true,
                 'fetchOrders': true,
                 'fetchOpenOrders': true,
                 'fetchClosedOrders': true,
@@ -224,7 +225,15 @@ module.exports = class bitmex extends Exchange {
         return result;
     }
 
-     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+    async fetchOrder (id, symbol = undefined, params = {}) {
+        let filter_params = { 'filter': { 'orderID': id }};
+        let result = await this.fetchOrders (symbol, undefined, undefined, this.deepExtend (filter_params, params));
+        if (result.length === 1)
+            return result[0]
+        throw new OrderNotFound (this.id + ': The order ' + id + ' does not exist.');
+    }
+
+    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         let market = undefined;
         let request = {};

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -249,7 +249,7 @@ module.exports = class bitmex extends Exchange {
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         let filter_params = { 'filter': { 'open': true }};
-        return await this.fetchOrders (symbol, since, limit, this.extend (filter_params, params));
+        return await this.fetchOrders (symbol, since, limit, this.deepExtend (filter_params, params));
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -224,17 +224,21 @@ module.exports = class bitmex extends Exchange {
         return result;
     }
 
-    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         let market = undefined;
-        let filter = {};
+        let request = {};
         if (typeof symbol !== 'undefined') {
             market = this.market (symbol);
-            filter['symbol'] = market['id'];
+            request['symbol'] = market['id'];
         }
-        let request = this.deepExtend ({
-            'filter': filter,
-        }, params);
+        if (typeof since !== 'undefined') {
+            request['startTime'] = this.iso8601(since);
+        }
+        if (typeof limit !== 'undefined') {
+            request['count'] = limit
+        }
+        request = this.deepExtend (request, params);
         // why the hassle? urlencode in python is kinda broken for nested dicts.
         // E.g. self.urlencode({"filter": {"open": True}}) will return "filter={'open':+True}"
         // Bitmex doesn't like that. Hence resorting to this hack.

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -229,7 +229,7 @@ module.exports = class bitmex extends Exchange {
         let filter_params = { 'filter': { 'orderID': id }};
         let result = await this.fetchOrders (symbol, undefined, undefined, this.deepExtend (filter_params, params));
         if (result.length === 1)
-            return result[0]
+            return result[0];
         throw new OrderNotFound (this.id + ': The order ' + id + ' does not exist.');
     }
 
@@ -242,10 +242,10 @@ module.exports = class bitmex extends Exchange {
             request['symbol'] = market['id'];
         }
         if (typeof since !== 'undefined') {
-            request['startTime'] = this.iso8601(since);
+            request['startTime'] = this.iso8601 (since);
         }
         if (typeof limit !== 'undefined') {
-            request['count'] = limit
+            request['count'] = limit;
         }
         request = this.deepExtend (request, params);
         // why the hassle? urlencode in python is kinda broken for nested dicts.


### PR DESCRIPTION
These commits does the following:

In fetchOrders, BitMEX natively supports both symbol, since and limit parameters, so we might as well have that, and not use the filter parameter for symbol.

In fetchOpenOrders, deepExtend the params object, otherwise user supplied filter parameters are discarded.

Finally add support for fetchOrder (by id).