### PR TITLE
improve zaif nonce

### DIFF
--- a/js/zaif.js
+++ b/js/zaif.js
@@ -358,4 +358,9 @@ module.exports = class zaif extends Exchange {
                 throw new ExchangeError (this.id + ' ' + this.json (response));
         return response;
     }
+
+    nonce () {
+        const micro = this.microseconds ();
+        return (micro / 1000000).toFixed(8);
+    }
 };


### PR DESCRIPTION
According to zaif document, we can use decimal point at nonce.
http://techbureau-api-document.readthedocs.io/ja/latest/trade/1_common.html

```
注意
その他のメソッド毎の固有のパラメータも全てPOSTパラメータにて送信してください。
nonceパラメータの値は実効毎に増分されていないとエラーが発生します。また増分量は少数点以下の値にも対応しております。
```