### PR TITLE
PHP: Exchange: decimal_to_precision

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1674,16 +1674,81 @@ abstract class Exchange {
         return array_key_exists ($old_feature, $old_feature_map) ? $old_feature_map[$old_feature] : false;
     }
 
-    public static function decimalToPrecision ($n, $rounding_mode = ROUND, $precision = null, $counting_mode = AFTER_POINT, $padding_mode = NO_PADDING) {
-        if ($precision < 0) {
+    public static function decimalToPrecision ($x, $roundingMode = ROUND, $numPrecisionDigits = null, $countingMode = AFTER_POINT, $paddingMode = NO_PADDING) {
+        return static::decimal_to_precision ($x, $roundingMode, $numPrecisionDigits, $countingMode, $paddingMode);
+    }
+
+    public static function decimal_to_precision ($x, $roundingMode = ROUND, $numPrecisionDigits = null, $countingMode = AFTER_POINT, $paddingMode = NO_PADDING) {
+        if ($numPrecisionDigits < 0) {
             throw new BaseError ('Negative precision is not yet supported');
         }
 
-        if (!is_numeric ($n)) {
+        if (!is_int ($numPrecisionDigits)) {
+            throw new BaseError ('Precision must be an integer');
+        }
+
+        if (!is_numeric ($x)) {
             throw new BaseError ('Invalid number');
         }
 
-        return (string) round ($n, $precision);
+        $result = '';
+        if ($roundingMode === ROUND) {
+            if ($countingMode === AFTER_POINT) {
+                $result = (string) round ($x, $numPrecisionDigits, PHP_ROUND_HALF_EVEN);
+            } elseif ($countingMode === SIGNIFICANT_DIGITS) {
+                $significantPosition = log (abs ($x), 10) % 10;
+                if ($significantPosition > 0) {
+                    $significantPosition += 1;
+                }
+                $result = (string) round ($x, $numPrecisionDigits - $significantPosition, PHP_ROUND_HALF_EVEN);
+            }
+        } elseif ($roundingMode === TRUNCATE) {
+            $dotPosition = strpos ($x, '.') ?: 0;
+            if ($countingMode === AFTER_POINT) {
+                $result = substr ($x, 0, ($dotPosition ? $dotPosition + 1 : 0) + $numPrecisionDigits);
+            } elseif ($countingMode === SIGNIFICANT_DIGITS) {
+                $significantPosition = log (abs ($x), 10) % 10;
+                $start = $dotPosition - $significantPosition;
+                $end   = $start + $numPrecisionDigits;
+                if ($dotPosition >= $end) {
+                    $end -= 1;
+                }
+                if ($significantPosition < 0) {
+                    $end += 1;
+                }
+                $result = str_pad (substr ($x, 0, $end), $dotPosition, '0');
+            }
+        }
+
+        $hasDot = strpos ($result, '.') !== false;
+        if ($paddingMode === NO_PADDING) {
+            if ($hasDot) {
+                $result = rtrim ($result, '0.');
+            }
+        } elseif ($paddingMode === PAD_WITH_ZERO) {
+            if ($hasDot) {
+                if ($countingMode === AFTER_POINT) {
+                    list ($before, $after) = explode ('.', $result, 2);
+                    $result = $before . '.' . str_pad ($after, $numPrecisionDigits, '0');
+                } elseif ($countingMode === SIGNIFICANT_DIGITS) {
+                    if ($result < 1) {
+                        $result = str_pad ($result, strcspn ($result, '123456789') + $numPrecisionDigits, '0');
+                    }
+                }
+            } else {
+                if ($countingMode === AFTER_POINT) {
+                    if ($numPrecisionDigits > 0) {
+                        $result = $result . '.' . str_repeat ('0', $numPrecisionDigits);
+                    }
+                } elseif ($countingMode === SIGNIFICANT_DIGITS) {
+                    if ($numPrecisionDigits > strlen ($result)) {
+                        $result = $result . '.' . str_repeat ('0', ($numPrecisionDigits - strlen ($result)));
+                    }
+                }
+            }
+        }
+
+        return $result;
     }
 
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -32,6 +32,18 @@ namespace ccxt;
 
 $version = '1.11.44';
 
+// rounding mode
+const TRUNCATE = 0;
+const ROUND = 1;
+
+// digits counting mode
+const AFTER_POINT = 0;
+const SIGNIFICANT_DIGITS = 1;
+
+// padding mode
+const NO_PADDING = 0;
+const PAD_WITH_ZERO = 1;
+
 abstract class Exchange {
 
     public static $exchanges = array (
@@ -1660,6 +1672,18 @@ abstract class Exchange {
 
         $old_feature = "has{$feature}";
         return array_key_exists ($old_feature, $old_feature_map) ? $old_feature_map[$old_feature] : false;
+    }
+
+    public static function decimalToPrecision ($n, $rounding_mode = ROUND, $precision = null, $counting_mode = AFTER_POINT, $padding_mode = NO_PADDING) {
+        if ($precision < 0) {
+            throw new BaseError ('Negative precision is not yet supported');
+        }
+
+        if (!is_numeric ($n)) {
+            throw new BaseError ('Invalid number');
+        }
+
+        return (string) round ($n, $precision);
     }
 
 }

--- a/php/test/ExchangeTest.php
+++ b/php/test/ExchangeTest.php
@@ -2,6 +2,12 @@
 
 use ccxt\Exchange;
 use PHPUnit\Framework\TestCase;
+use const ccxt\AFTER_POINT;
+use const ccxt\NO_PADDING;
+use const ccxt\PAD_WITH_ZERO;
+use const ccxt\ROUND;
+use const ccxt\SIGNIFICANT_DIGITS;
+use const ccxt\TRUNCATE;
 
 class ExchangeTest extends TestCase {
 
@@ -10,5 +16,142 @@ class ExchangeTest extends TestCase {
         $this->assertSame (2,   Exchange::sum (2));
         $this->assertSame (432, Exchange::sum (2, 30, 400));
         $this->assertSame (439, Exchange::sum (2, null, [88], 30, '7', 400, null));
+    }
+
+    public function testDecimalToPrecisionErrorHandling () {
+        $this->expectException ('ccxt\\BaseError');
+        $this->expectExceptionMessageRegExp ('/Negative precision is not yet supported/');
+        Exchange::decimalToPrecision ('123456.789', TRUNCATE, -2, AFTER_POINT);
+
+        $this->expectException ('ccxt\\BaseError');
+        $this->expectExceptionMessageRegExp ('/Invalid number/');
+        Exchange::decimalToPrecision ('foo');
+    }
+
+    /**
+     * @dataProvider truncationToNDigitsAfterDot
+     */
+    public function testDecimalToPrecisionTruncationToNDigitsAfterDot ($n, $rounding_mode, $precision, $counting_mode, $expected) {
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $counting_mode));
+    }
+
+    public function truncationToNDigitsAfterDot () {
+        Exchange::sum(); // hack for constants :|
+        return [
+            ['12.3456000', TRUNCATE, 100, AFTER_POINT,  '12.3456'],
+            ['12.3456',    TRUNCATE, 100, AFTER_POINT,  '12.3456'],
+            ['12.3456',    TRUNCATE,   4, AFTER_POINT,  '12.3456'],
+            ['12.3456',    TRUNCATE,   3, AFTER_POINT,  '12.345'],
+            ['12.3456',    TRUNCATE,   2, AFTER_POINT,  '12.34'],
+            ['12.3456',    TRUNCATE,   1, AFTER_POINT,  '12.3'],
+            ['12.3456',    TRUNCATE,   0, AFTER_POINT,  '12'],
+//            ['12.3456',    TRUNCATE,  -1, AFTER_POINT,  '10'],   // not yet supported
+//            ['123.456',    TRUNCATE,  -2, AFTER_POINT,  '120'],  // not yet supported
+//            ['123.456',    TRUNCATE,  -3, AFTER_POINT,  '100'],  // not yet supported
+        ];
+    }
+
+    /**
+     * @dataProvider truncationToNSignificantDigits
+     */
+    public function testDecimalToPrecisionTruncationToNSignificantDigits ($n, $rounding_mode, $precision, $counting_mode, $padding_mode, $expected) {
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $padding_mode, $counting_mode));
+    }
+
+    public function truncationToNSignificantDigits () {
+        return [
+            ['0.000123456700', TRUNCATE, 100, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001234567'],
+            ['0.0001234567',   TRUNCATE, 100, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001234567'],
+            ['0.0001234567',   TRUNCATE,   7, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001234567'],
+
+            ['0.000123456',    TRUNCATE,   6, SIGNIFICANT_DIGITS,    NO_PADDING, '0.000123456'],
+            ['0.00012345',     TRUNCATE,   5, SIGNIFICANT_DIGITS,    NO_PADDING, '0.00012345'],
+            ['0.00012',        TRUNCATE,   2, SIGNIFICANT_DIGITS,    NO_PADDING, '0.00012'],
+            ['0.0001',         TRUNCATE,   1, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001'],
+
+            ['123.0000987654', TRUNCATE,  10, SIGNIFICANT_DIGITS,    NO_PADDING, '123.0000987'],
+            ['123.0000987654', TRUNCATE,   8, SIGNIFICANT_DIGITS,    NO_PADDING, '123.00009'],
+            ['123.0000987654', TRUNCATE,   7, SIGNIFICANT_DIGITS,    NO_PADDING, '123'],
+            ['123.0000987654', TRUNCATE,   7, SIGNIFICANT_DIGITS, PAD_WITH_ZERO, '123.0000'],
+            ['123.0000987654', TRUNCATE,   4, SIGNIFICANT_DIGITS, PAD_WITH_ZERO, '123.0'],
+
+            ['123.0000987654', TRUNCATE,   2, SIGNIFICANT_DIGITS,    NO_PADDING, '120'],
+            ['123.0000987654', TRUNCATE,   1, SIGNIFICANT_DIGITS,    NO_PADDING, '100'],
+            ['123.0000987654', TRUNCATE,   1, SIGNIFICANT_DIGITS, PAD_WITH_ZERO, '100'],
+        ];
+    }
+
+    /**
+     * @dataProvider roundingToNDigitsAfterDot
+     */
+    public function testDecimalToPrecisionRoundingToNDigitsAfterDot ($n, $rounding_mode, $precision, $counting_mode, $padding_mode, $expected) {
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $padding_mode, $counting_mode));
+    }
+
+    public function roundingToNDigitsAfterDot () {
+        return [
+            ['12.3456000', ROUND, 100, AFTER_POINT,    NO_PADDING,  '12.3456'],
+            ['12.3456',    ROUND, 100, AFTER_POINT,    NO_PADDING,  '12.3456'],
+            ['12.3456',    ROUND,   4, AFTER_POINT,    NO_PADDING,  '12.3456'],
+            ['12.3456',    ROUND,   3, AFTER_POINT,    NO_PADDING,  '12.346'],
+            ['12.3456',    ROUND,   2, AFTER_POINT,    NO_PADDING,  '12.35'],
+            ['12.3456',    ROUND,   1, AFTER_POINT,    NO_PADDING,  '12.3'],
+            ['12.3456',    ROUND,   0, AFTER_POINT,    NO_PADDING,  '12'],
+//            ['12.3456',    ROUND,  -1, AFTER_POINT,    NO_PADDING,  '10'],  // not yet supported
+//            ['123.456',    ROUND,  -1, AFTER_POINT,    NO_PADDING,  '120'],  // not yet supported
+//            ['123.456',    ROUND,  -2, AFTER_POINT,    NO_PADDING,  '100'],  // not yet supported
+
+            [ '9.999',     ROUND,   3, AFTER_POINT,    NO_PADDING,  '9.999'],
+            [ '9.999',     ROUND,   2, AFTER_POINT,    NO_PADDING,  '10'],
+            [ '9.999',     ROUND,   2, AFTER_POINT, PAD_WITH_ZERO,  '10.00'],
+            [ '99.999',    ROUND,   2, AFTER_POINT, PAD_WITH_ZERO,  '100.00'],
+            ['-99.999',    ROUND,   2, AFTER_POINT, PAD_WITH_ZERO, '-100.00'],
+        ];
+    }
+
+    /**
+     * @dataProvider roundingToNSignificantDigits
+     */
+    public function testDecimalToPrecisionRoundingToNSignificantDigits ($n, $rounding_mode, $precision, $counting_mode, $padding_mode, $expected) {
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $padding_mode, $counting_mode));
+    }
+
+    public function roundingToNSignificantDigits () {
+        return [
+            ['0.000123456700', ROUND, 100, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001234567'],
+            ['0.0001234567',   ROUND, 100, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001234567'],
+            ['0.0001234567',   ROUND,   7, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001234567'],
+
+            ['0.000123456',    ROUND,   6, SIGNIFICANT_DIGITS,    NO_PADDING, '0.000123456'],
+            ['0.000123456',    ROUND,   5, SIGNIFICANT_DIGITS,    NO_PADDING, '0.00012346'],
+            ['0.000123456',    ROUND,   4, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001235'],
+            ['0.00012',        ROUND,   2, SIGNIFICANT_DIGITS,    NO_PADDING, '0.00012'],
+            ['0.0001',         ROUND,   1, SIGNIFICANT_DIGITS,    NO_PADDING, '0.0001'],
+
+            ['123.0000987654', ROUND,   7, SIGNIFICANT_DIGITS,    NO_PADDING, '123.0001'],
+            ['123.0000987654', ROUND,   6, SIGNIFICANT_DIGITS,    NO_PADDING, '123'],
+
+            ['0.00098765',     ROUND,   2, SIGNIFICANT_DIGITS,    NO_PADDING, '0.00099'],
+            ['0.00098765',     ROUND,   2, SIGNIFICANT_DIGITS, PAD_WITH_ZERO, '0.00099'],
+
+            ['0.00098765',     ROUND,   1, SIGNIFICANT_DIGITS,    NO_PADDING, '0.001'],
+            ['0.00098765',     ROUND,  10, SIGNIFICANT_DIGITS, PAD_WITH_ZERO, '0.0009876500000'],
+
+            ['0.098765',       ROUND,   1, SIGNIFICANT_DIGITS, PAD_WITH_ZERO, '0.1'],
+        ];
+    }
+
+    /**
+     * @dataProvider negativeNumbers
+     */
+    public function testDecimalToPrecisionNegativeNumbers ($n, $rounding_mode, $precision, $counting_mode, $expected) {
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $counting_mode));
+    }
+
+    public function negativeNumbers () {
+        return [
+            ['-0.123456', TRUNCATE, 5, AFTER_POINT, '-0.12345'],
+            ['-0.123456', ROUND,    5, AFTER_POINT, '-0.12346'],
+        ];
     }
 }

--- a/php/test/ExchangeTest.php
+++ b/php/test/ExchangeTest.php
@@ -55,7 +55,7 @@ class ExchangeTest extends TestCase {
      * @dataProvider truncationToNSignificantDigits
      */
     public function testDecimalToPrecisionTruncationToNSignificantDigits ($n, $rounding_mode, $precision, $counting_mode, $padding_mode, $expected) {
-        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $padding_mode, $counting_mode));
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $counting_mode, $padding_mode));
     }
 
     public function truncationToNSignificantDigits () {
@@ -85,7 +85,7 @@ class ExchangeTest extends TestCase {
      * @dataProvider roundingToNDigitsAfterDot
      */
     public function testDecimalToPrecisionRoundingToNDigitsAfterDot ($n, $rounding_mode, $precision, $counting_mode, $padding_mode, $expected) {
-        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $padding_mode, $counting_mode));
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $counting_mode, $padding_mode));
     }
 
     public function roundingToNDigitsAfterDot () {
@@ -113,7 +113,7 @@ class ExchangeTest extends TestCase {
      * @dataProvider roundingToNSignificantDigits
      */
     public function testDecimalToPrecisionRoundingToNSignificantDigits ($n, $rounding_mode, $precision, $counting_mode, $padding_mode, $expected) {
-        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $padding_mode, $counting_mode));
+        $this->assertSame ($expected, Exchange::decimalToPrecision ($n, $rounding_mode, $precision, $counting_mode, $padding_mode));
     }
 
     public function roundingToNSignificantDigits () {


### PR DESCRIPTION
Here's the PHP port of #1635, based on #2121

I've put new constants in the `ccxt` namespace to avoid polluting global state.
Constants have values based on #1635 (they differ in #2121).

I've tried to stick to the variables nomenclature (camelCase) based on #1635

There might be more uncovered / edge cases that need to be handled (negative precision isn't handled in existing PRs neither). Code is covered by same tests that already exist in previous PRs:

```
PHPUnit 6.5.7 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.3
Configuration: /home/work/github/kornrunner/ccxt-origin/phpunit.xml.dist

.....................................................             53 / 53 (100%)

Time: 6.12 seconds, Memory: 4.00MB

OK (53 tests, 57 assertions)
```

I haven't checked it against previous versions (7.1, 7.0, 5.6 etc) - but this is all basic code without any new/shiny/fancy stuff. To be honest - code might be suboptimal - as I've mostly ported Py implementation to PHP. There might be better ways to achieve the same functionality.

Oh, and a bit offtopic: PHPUnit 6 is there because of PHP 5 support, as PHPUnit 7 requires PHP 7 and newer (and switching to newest versions is encouraged by whole community, but that's a topic for another thread).

Let me know if anything. Thank you.