### PR TITLE
Kraken fetch deposit address

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -802,7 +802,7 @@ module.exports = class kraken extends Exchange {
     async fetchDepositAddress (code, params = {}) {
         await this.loadMarkets ();
         let currency = this.currency (code);
-        let noDepositMethod = this.options.noDepositMethod;
+        let noDepositMethod = this.options['noDepositMethod'];
         for (let i = 0; i < noDepositMethod.length; i++) {
             if (code === noDepositMethod[i])
                 throw new ExchangeError (this.id + ' ' + code + ' does not have a deposit method');

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -183,6 +183,9 @@ module.exports = class kraken extends Exchange {
                     ],
                 },
             },
+            'options': {
+                'noDepositMethod': ['DAO', 'NMC', 'XVN', 'GBP', 'KRW'],
+            },
         });
     }
 
@@ -797,11 +800,14 @@ module.exports = class kraken extends Exchange {
     }
 
     async fetchDepositAddress (code, params = {}) {
-        let method = this.safeValue (params, 'method');
-        if (!method)
-            throw new ExchangeError (this.id + ' fetchDepositAddress() requires an extra `method` parameter');
         await this.loadMarkets ();
         let currency = this.currency (code);
+        let noDepositMethod = this.options.noDepositMethod;
+        for (let i = 0; i < noDepositMethod.length; i++) {
+            if (code === noDepositMethod[i])
+                throw new ExchangeError (this.id + ' ' + code + ' does not have a deposit method');
+        }
+        let method = this.fetchDepositMethods (currency)[0]['method'];
         let request = {
             'asset': currency['id'],
             'method': method,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -807,7 +807,7 @@ module.exports = class kraken extends Exchange {
             if (code === noDepositMethod[i])
                 throw new ExchangeError (this.id + ' ' + code + ' does not have a deposit method');
         }
-        let method = this.fetchDepositMethods (currency)[0]['method'];
+        let method = this.fetchDepositMethods (code)[0]['method'];
         let request = {
             'asset': currency['id'],
             'method': method,


### PR DESCRIPTION
instead of making two calls to get the deposit address you can now make just one. Before you have to call `fetchDepositMethods` (even though all currency codes only have one deposit method) to get some arbitary string like "Ether (Hex)" and provide that as a param to to `fetchDepositAddress` now the latter works seemlessly. 

Unfortunetly I could not find a way around some currency's throwing an error on fetch_deposit_method so I hardcoded it. There may be other ways to do this like a try: catch 