### PR TITLE
Bitstamp: Add Withdrawal Requests URL to API private post list

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -68,6 +68,7 @@ module.exports = class bitstamp extends Exchange {
                         'xrp_address/',
                         'transfer-to-main/',
                         'transfer-from-main/',
+                        'withdrawal-requests/',
                         'withdrawal/open/',
                         'withdrawal/status/',
                         'withdrawal/cancel/',


### PR DESCRIPTION
Add Bitstamp's Private API POST endpoint for withdrawal requests to get withdrawal status
- For Endpoint: https://www.bitstamp.net/api/v2/withdrawal-requests/


#### Screenshot after testing ####
![ccxt_bitstamp_wdl_requests](https://user-images.githubusercontent.com/6790008/37197668-99cff06e-23b6-11e8-90eb-99b99e8ab6e1.jpg)



