### PR TITLE
Edit cyptopia.js for fetchTickers symbols parmeter

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -272,7 +272,9 @@ module.exports = class cryptopia extends Exchange {
                 throw new ExchangeError (this.id + ' fetchTickers() returned unrecognized pair id ' + id.toString ());
             let market = this.markets_by_id[id];
             let symbol = market['symbol'];
-            result[symbol] = this.parseTicker (ticker, market);
+            if(symbols.includes(symbol)){
+                result[symbol] = this.parseTicker (ticker, market);
+            }
         }
         return result;
     }


### PR DESCRIPTION
symbols parameter is not used in fetchTickers function. if I call fetchTickers with my symbols it returns all the markets not only my symbols. So I edited it.