### PR TITLE
fix_for_no_cost_in_binance_with_fetchOrder

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -642,6 +642,8 @@ module.exports = class binance extends Exchange {
         if (typeof price !== 'undefined')
             if (typeof filled !== 'undefined')
                 cost = price * filled;
+        if (cost === 0.0)
+            cost = price * amount;
         let result = {
             'info': order,
             'id': order['orderId'].toString (),


### PR DESCRIPTION
Binance shows 0.0 previous to patch. I havent tested this patch because when i run npm build install i get:

```
npm ERR! path /home/kris/exchangescripts/ccxt/ccxt/install/package.json
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall open
npm ERR! enoent ENOENT: no such file or directory, open '/home/kris/exchangescripts/ccxt/ccxt/install/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/kris/.npm/_logs/2018-03-10T00_28_01_327Z-debug.log
```

Maybe you can help me with that.