### PR TITLE
bittrex: handle errors

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -690,30 +690,28 @@ module.exports = class bittrex extends Exchange {
         if (body[0] === '{') {
             let response = JSON.parse (body);
             // { success: false, message: "message" }
-            if ('success' in response && 'message' in response) {
-                let success = response['success'];
-                if (typeof success === 'string')
-                    // bleutrade uses string instead of boolean
-                    success = (success === 'true') ? true : false;
-                if (!success) {
-                    const message = this.safeString (response, 'message');
-                    const feedback = this.id + ' ' + this.json (response);
-                    const exceptions = this.exceptions;
-                    if (message in exceptions)
-                        throw new exceptions[message] (feedback);
-                    if (message === 'APIKEY_INVALID') {
-                        if (this.hasAlreadyAuthenticatedSuccessfully) {
-                            throw new DDoSProtection (feedback);
-                        } else {
-                            throw new AuthenticationError (feedback);
-                        }
-                    }
-                    if (message === 'DUST_TRADE_DISALLOWED_MIN_VALUE_50K_SAT')
-                        throw new InvalidOrder (this.id + ' order cost should be over 50k satoshi ' + this.json (response));
-                    throw new ExchangeError (this.id + ' ' + this.json (response));
-                }
-            } else {
+            let success = this.safeValue (response, 'success');
+            if (typeof success === 'undefined')
                 throw new ExchangeError (this.id + ': malformed response: ' + this.json (response));
+            if (typeof success === 'string')
+                // bleutrade uses string instead of boolean
+                success = (success === 'true') ? true : false;
+            if (!success) {
+                const message = this.safeString (response, 'message');
+                const feedback = this.id + ' ' + this.json (response);
+                const exceptions = this.exceptions;
+                if (message in exceptions)
+                    throw new exceptions[message] (feedback);
+                if (message === 'APIKEY_INVALID') {
+                    if (this.hasAlreadyAuthenticatedSuccessfully) {
+                        throw new DDoSProtection (feedback);
+                    } else {
+                        throw new AuthenticationError (feedback);
+                    }
+                }
+                if (message === 'DUST_TRADE_DISALLOWED_MIN_VALUE_50K_SAT')
+                    throw new InvalidOrder (this.id + ' order cost should be over 50k satoshi ' + this.json (response));
+                throw new ExchangeError (this.id + ' ' + this.json (response));
             }
         }
     }

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -147,7 +147,6 @@ module.exports = class bittrex extends Exchange {
                 'ORDER_NOT_OPEN': InvalidOrder,
                 'UUID_INVALID': OrderNotFound,
                 'RATE_NOT_PROVIDED': InvalidOrder, // createLimitBuyOrder ('ETH/BTC', 1, 0)
-                'Insufficient funds!': InsufficientFunds, // bluetrade
             },
         });
     }

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -136,6 +136,18 @@ module.exports = class bittrex extends Exchange {
                     },
                 },
             },
+            'exceptions': {
+                'APISIGN_NOT_PROVIDED': AuthenticationError,
+                'INVALID_SIGNATURE': AuthenticationError,
+                'INVALID_CURRENCY': ExchangeError,
+                'INVALID_PERMISSION': AuthenticationError,
+                'INSUFFICIENT_FUNDS': InsufficientFunds,
+                'QUANTITY_NOT_PROVIDED': InvalidOrder,
+                'MIN_TRADE_REQUIREMENT_NOT_MET': InvalidOrder,
+                'ORDER_NOT_OPEN': InvalidOrder,
+                'UUID_INVALID': OrderNotFound,
+                'Insufficient funds!': InsufficientFunds, // bluetrade
+            },
         });
     }
 
@@ -674,71 +686,43 @@ module.exports = class bittrex extends Exchange {
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 
-    throwExceptionOnError (response) {
-        if ('message' in response) {
-            let message = this.safeString (response, 'message');
-            let error = this.id + ' ' + this.json (response);
-            if (message === 'APISIGN_NOT_PROVIDED')
-                throw new AuthenticationError (error);
-            if (message === 'INVALID_SIGNATURE')
-                throw new AuthenticationError (error);
-            if (message === 'INVALID_CURRENCY')
-                throw new ExchangeError (error);
-            if (message === 'INVALID_PERMISSION')
-                throw new AuthenticationError (error);
-            if (message === 'INSUFFICIENT_FUNDS')
-                throw new InsufficientFunds (error);
-            if (message === 'QUANTITY_NOT_PROVIDED')
-                throw new InvalidOrder (error);
-            if (message === 'MIN_TRADE_REQUIREMENT_NOT_MET')
-                throw new InvalidOrder (error);
-            if (message === 'APIKEY_INVALID') {
-                if (this.hasAlreadyAuthenticatedSuccessfully) {
-                    throw new DDoSProtection (error);
-                } else {
-                    throw new AuthenticationError (error);
-                }
-            }
-            if (message === 'DUST_TRADE_DISALLOWED_MIN_VALUE_50K_SAT')
-                throw new InvalidOrder (this.id + ' order cost should be over 50k satoshi ' + this.json (response));
-            if (message === 'ORDER_NOT_OPEN')
-                throw new InvalidOrder (error);
-            if (message === 'UUID_INVALID')
-                throw new OrderNotFound (error);
-        }
-    }
-
     handleErrors (code, reason, url, method, headers, body) {
-        if (code >= 400) {
-            if (body[0] === '{') {
-                let response = JSON.parse (body);
-                this.throwExceptionOnError (response);
-                if ('success' in response) {
-                    let success = response['success'];
-                    if (typeof success === 'string')
-                        success = (success === 'true') ? true : false;
-                    if (!success) {
-                        this.throwExceptionOnError (response);
-                        throw new ExchangeError (this.id + ' ' + this.json (response));
+        if (body[0] === '{') {
+            let response = JSON.parse (body);
+            // { success: false, message: "message" }
+            if ('success' in response && 'message' in response) {
+                let success = response['success'];
+                if (typeof success === 'string')
+                    // bleutrade uses string instead of boolean
+                    success = (success === 'true') ? true : false;
+                if (!success) {
+                    const message = this.safeString (response, 'message');
+                    const feedback = this.id + ' ' + this.json (response);
+                    const exceptions = this.exceptions;
+                    if (message in exceptions)
+                        throw new exceptions[message] (feedback);
+                    if (message === 'APIKEY_INVALID') {
+                        if (this.hasAlreadyAuthenticatedSuccessfully) {
+                            throw new DDoSProtection (feedback);
+                        } else {
+                            throw new AuthenticationError (feedback);
+                        }
                     }
+                    if (message === 'DUST_TRADE_DISALLOWED_MIN_VALUE_50K_SAT')
+                        throw new InvalidOrder (this.id + ' order cost should be over 50k satoshi ' + this.json (response));
+                    throw new ExchangeError (this.id + ' ' + this.json (response));
                 }
+            } else {
+                throw new ExchangeError (this.id + ': malformed response: ' + this.json (response));
             }
         }
     }
 
     async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let response = await this.fetch2 (path, api, method, params, headers, body);
-        if ('success' in response) {
-            let success = response['success'];
-            if (typeof success === 'string')
-                success = (success === 'true') ? true : false;
-            if (success) {
-                // a workaround for APIKEY_INVALID
-                if ((api === 'account') || (api === 'market'))
-                    this.hasAlreadyAuthenticatedSuccessfully = true;
-                return response;
-            }
-        }
-        this.throwExceptionOnError (response);
+        // a workaround for APIKEY_INVALID
+        if ((api === 'account') || (api === 'market'))
+            this.hasAlreadyAuthenticatedSuccessfully = true;
+        return response;
     }
 };

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -146,6 +146,7 @@ module.exports = class bittrex extends Exchange {
                 'MIN_TRADE_REQUIREMENT_NOT_MET': InvalidOrder,
                 'ORDER_NOT_OPEN': InvalidOrder,
                 'UUID_INVALID': OrderNotFound,
+                'RATE_NOT_PROVIDED': InvalidOrder, // createLimitBuyOrder ('ETH/BTC', 1, 0)
                 'Insufficient funds!': InsufficientFunds, // bluetrade
             },
         });

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -172,7 +172,6 @@ module.exports = class bittrex extends Exchange {
                 'quoteId': quoteId,
                 'active': active,
                 'info': market,
-                'lot': Math.pow (10, -precision['amount']),
                 'precision': precision,
                 'limits': {
                     'amount': {
@@ -180,7 +179,7 @@ module.exports = class bittrex extends Exchange {
                         'max': undefined,
                     },
                     'price': {
-                        'min': undefined,
+                        'min': Math.pow (10, -precision['price']),
                         'max': undefined,
                     },
                 },

--- a/js/bleutrade.js
+++ b/js/bleutrade.js
@@ -82,6 +82,9 @@ module.exports = class bleutrade extends bittrex {
                     },
                 },
             },
+            'exceptions': {
+                'Insufficient funds!': InsufficientFunds,
+            },
         });
     }
 

--- a/js/bleutrade.js
+++ b/js/bleutrade.js
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 const bittrex = require ('./bittrex.js');
-const { AuthenticationError, InvalidOrder, InsufficientFunds, DDoSProtection } = require ('./base/errors');
+const { AuthenticationError, InvalidOrder, InsufficientFunds } = require ('./base/errors');
 
 // ---------------------------------------------------------------------------
 
@@ -84,6 +84,8 @@ module.exports = class bleutrade extends bittrex {
             },
             'exceptions': {
                 'Insufficient funds!': InsufficientFunds,
+                'Invalid Order ID': InvalidOrder,
+                'Invalid apikey or apisecret': AuthenticationError,
             },
         });
     }

--- a/js/bleutrade.js
+++ b/js/bleutrade.js
@@ -145,22 +145,4 @@ module.exports = class bleutrade extends bittrex {
         let orderbook = response['result'];
         return this.parseOrderBook (orderbook, undefined, 'buy', 'sell', 'Rate', 'Quantity');
     }
-
-    throwExceptionOnError (response) {
-        if ('message' in response) {
-            if (response['message'] === 'Insufficient funds!')
-                throw new InsufficientFunds (this.id + ' ' + this.json (response));
-            if (response['message'] === 'MIN_TRADE_REQUIREMENT_NOT_MET')
-                throw new InvalidOrder (this.id + ' ' + this.json (response));
-            if (response['message'] === 'APIKEY_INVALID') {
-                if (this.hasAlreadyAuthenticatedSuccessfully) {
-                    throw new DDoSProtection (this.id + ' ' + this.json (response));
-                } else {
-                    throw new AuthenticationError (this.id + ' ' + this.json (response));
-                }
-            }
-            if (response['message'] === 'DUST_TRADE_DISALLOWED_MIN_VALUE_50K_SAT')
-                throw new InvalidOrder (this.id + ' order cost should be over 50k satoshi ' + this.json (response));
-        }
-    }
 };


### PR DESCRIPTION
Bittrex returns HTTP 200 on errors but `handleErrors` expected ` >= 400`.

As such, error handling didn't work for unknown errors:
```
ccxt> node examples/js/cli.js bittrex createLimitBuyOrder ETH/BTC 1 
bittrex.createLimitBuyOrder (ETH/BTC, 1, 0)
---------------------------------------------------
[TypeError] Cannot read property 'result' of undefined

    at createOrder    js/bittrex.js:447                  'id': response['result'][orderIdField],
    at _tickCallback  internal/process/next_tick.js:160                                         
```