### PR TITLE
Bitmex native editOrder and order cache fixes

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -449,21 +449,21 @@ module.exports = class bitmex extends Exchange {
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         await this.loadMarkets ();
-        let order = {
+        let request = {
             'symbol': this.marketId (symbol),
             'side': this.capitalize (side),
             'orderQty': amount,
             'ordType': this.capitalize (type),
         };
         if (type === 'limit')
-            order['price'] = price;
-        let response = await this.privatePostOrder (this.extend (order, params));
-        return {
-            'info': response,
-            'id': response['orderID'],
-        };
+            request['price'] = price;
+        let response = await this.privatePostOrder (this.extend (request, params));
+        let order = this.parseOrder (request);
+        let id = order['id'];
+        this.orders[id] = order;
+        return this.extend ({ 'info': response }, order);
     }
-
+    
     async cancelOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
         let response = await this.privateDeleteOrder ({ 'orderID': id });

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -472,6 +472,8 @@ module.exports = class bitmex extends Exchange {
         if (typeof error !== 'undefined')
             if (error.indexOf ('Unable to cancel order due to existing state') >= 0)
                 throw new OrderNotFound (this.id + ' cancelOrder() failed: ' + error);
+        if (id in this.orders)
+            this.orders[id]['status'] = 'canceled';
         return this.parseOrder (order);
     }
 

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -463,7 +463,7 @@ module.exports = class bitmex extends Exchange {
         this.orders[id] = order;
         return this.extend ({ 'info': response }, order);
     }
- 
+
     async editOrder (id, symbol, type, side, amount = undefined, price = undefined, params = {}) {
         await this.loadMarkets ();
         let request = {

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -458,7 +458,7 @@ module.exports = class bitmex extends Exchange {
         if (type === 'limit')
             request['price'] = price;
         let response = await this.privatePostOrder (this.extend (request, params));
-        let order = this.parseOrder (request);
+        let order = this.parseOrder (response);
         let id = order['id'];
         this.orders[id] = order;
         return this.extend ({ 'info': response }, order);

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -474,26 +474,9 @@ module.exports = class bitmex extends Exchange {
         if (typeof price !== 'undefined')
             request['price'] = price;
         let response = await this.privatePutOrder (this.extend (request, params));
-        let result = undefined;
-        if (id in this.orders) {
-            this.orders[id]['status'] = 'canceled';
-            let newid = response['orderID'];
-            this.orders[newid] = this.extend (this.orders[id], {
-                'id': newid,
-                'price': price,
-                'status': 'open',
-            });
-            if (typeof amount !== 'undefined')
-                this.orders[newid]['amount'] = amount;
-            result = this.extend (this.orders[newid], { 'info': response });
-        } else {
-            let market = undefined;
-            if (symbol)
-                market = this.market (symbol);
-            result = this.parseOrder (response, market);
-            this.orders[result['id']] = result;
-        }
-        return result;
+        let order = this.parseOrder (response);
+        this.orders[order['id']] = order;
+        return this.extend ({ 'info': response }, order);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
@@ -504,9 +487,9 @@ module.exports = class bitmex extends Exchange {
         if (typeof error !== 'undefined')
             if (error.indexOf ('Unable to cancel order due to existing state') >= 0)
                 throw new OrderNotFound (this.id + ' cancelOrder() failed: ' + error);
-        if (id in this.orders)
-            this.orders[id]['status'] = 'canceled';
-        return this.parseOrder (order);
+        order = this.parseOrder (order);
+        this.orders[order['id']] = order;
+        return this.extend ({ 'info': response }, order);
     }
 
     isFiat (currency) {


### PR DESCRIPTION
These fixes add native editOrder support on the BitMEX exchange. Along with this addition are various smaller fixes to the order workflow to enable cache support.