### PR TITLE
new exchange: ethfinex

### DIFF
--- a/js/ethfinex.js
+++ b/js/ethfinex.js
@@ -1,0 +1,60 @@
+'use strict';
+
+//  ---------------------------------------------------------------------------
+
+const bitfinex = require ('./bitfinex.js');
+
+//  ---------------------------------------------------------------------------
+
+module.exports = class ethfinex extends bitfinex {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'ethfinex',
+            'name': 'Ethfinex',
+            'countries': 'VG',
+            'version': 'v1',
+            'rateLimit': 1500,
+            // new metainfo interface
+            'has': {
+                'CORS': false,
+                'createDepositAddress': true,
+                'deposit': true,
+                'fetchClosedOrders': true,
+                'fetchDepositAddress': true,
+                'fetchFees': true,
+                'fetchFundingFees': true,
+                'fetchMyTrades': true,
+                'fetchOHLCV': true,
+                'fetchOpenOrders': true,
+                'fetchOrder': true,
+                'fetchTickers': true,
+                'fetchTradingFees': true,
+                'withdraw': true,
+            },
+            'timeframes': {
+                '1m': '1m',
+                '5m': '5m',
+                '15m': '15m',
+                '30m': '30m',
+                '1h': '1h',
+                '3h': '3h',
+                '6h': '6h',
+                '12h': '12h',
+                '1d': '1D',
+                '1w': '7D',
+                '2w': '14D',
+                '1M': '1M',
+            },
+            'urls': {
+                'logo': 'https://i.imgur.com/ZDcwJWe.png',
+                'api': 'https://api.ethfinex.com',
+                'www': 'https://www.ethfinex.com',
+                'doc': [
+                    'https://bitfinex.readme.io/v1/docs',
+                    'https://github.com/bitfinexcom/bitfinex-api-node',
+                    'https://www.ethfinex.com/api_docs',
+                ],
+            },
+        });
+    }
+};

--- a/python/ccxt/__init__.py
+++ b/python/ccxt/__init__.py
@@ -103,6 +103,7 @@ from ccxt.coinspot import coinspot                          # noqa: F401
 from ccxt.coolcoin import coolcoin                          # noqa: F401
 from ccxt.cryptopia import cryptopia                        # noqa: F401
 from ccxt.dsx import dsx                                    # noqa: F401
+from ccxt.ethfinex import ethfinex                          # noqa: F401
 from ccxt.exmo import exmo                                  # noqa: F401
 from ccxt.flowbtc import flowbtc                            # noqa: F401
 from ccxt.foxbit import foxbit                              # noqa: F401
@@ -131,7 +132,6 @@ from ccxt.luno import luno                                  # noqa: F401
 from ccxt.lykke import lykke                                # noqa: F401
 from ccxt.mercado import mercado                            # noqa: F401
 from ccxt.mixcoins import mixcoins                          # noqa: F401
-from ccxt.ethfinex import ethfinex                          # noqa: F401
 from ccxt.nova import nova                                  # noqa: F401
 from ccxt.okcoincny import okcoincny                        # noqa: F401
 from ccxt.okcoinusd import okcoinusd                        # noqa: F401

--- a/python/ccxt/__init__.py
+++ b/python/ccxt/__init__.py
@@ -131,6 +131,7 @@ from ccxt.luno import luno                                  # noqa: F401
 from ccxt.lykke import lykke                                # noqa: F401
 from ccxt.mercado import mercado                            # noqa: F401
 from ccxt.mixcoins import mixcoins                          # noqa: F401
+from ccxt.ethfinex import ethfinex                          # noqa: F401
 from ccxt.nova import nova                                  # noqa: F401
 from ccxt.okcoincny import okcoincny                        # noqa: F401
 from ccxt.okcoinusd import okcoinusd                        # noqa: F401


### PR DESCRIPTION
Uses the same api as bitfinex. Has a subset of markets ATM but still in beta. I think they are adding more ETH pairs in the future. Some limited testing:

```
>>> len(bitfinex.markets)
105
>>> len(ethfinex.markets)
71
>>> set(bitfinex.markets) - set(ethfinex.markets)
{'IOTA/ETH', 'QTUM/BTC', 'NEO/BTC', 'BCH/ETH', 'LTC/USD', 'ETP/ETH', 'ZEC/USD', 'NEO/USD', 'DASH/USD', 'ETP/USD', 'BTG/USD', 'EOS/BTC', 'RRT/USD', 'DASH/BTC', 'ZEC/BTC', 'XRP/BTC', 'EOS/USD', 'XMR/USD', 'BTG/BTC', 'ETC/USD', 'BTC/EUR', 'BTC/USD', 'EOS/ETH', 'LTC/BTC', 'ETC/BTC', 'XRP/USD', 'XMR/BTC', 'NEO/ETH', 'IOTA/USD', 'IOTA/BTC', 'BCH/BTC', 'ETP/BTC', 'RRT/BTC', 'BCH/USD', 'QTUM/ETH', 'QTUM/USD', 'IOTA/EUR'}
>>> set(ethfinex.markets) - set(bitfinex.markets)
{'NEC/USD', 'NEC/ETH', 'NEC/BTC'}
>>> ethfinex.fetch_order_book('NEC/ETH')
{'bids': [[0.00125, 100.0], [0.00123, 4032.0], [0.00121, 100.0], [0.001202, 2000.0], [0.0012, 10100.0], [0.00115, 100.0], [0.0011, 22100.0], [0.00105, 100.0], [0.001001, 2000.0], [0.001, 52934.51011738], ...
```