### PR TITLE
Exchange: buildOHLCV: account for reversed fetchTrades order

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -565,6 +565,15 @@ module.exports = class Exchange {
         throw new NotSupported (this.id + ' fetchBidsAsks not supported yet')
     }
 
+    async fetchOHLCVC (symbol, timeframe = '1m', since = undefined, limits = undefined, params = {}) {
+        if (!this.has['fetchTrades'])
+            throw new NotSupported (this.id + ' fetchOHLCV() not supported yet')
+        await this.loadMarkets ()
+        let trades = await this.fetchTrades (symbol, since, limits, params)
+        let ohlcvc = buildOHLCVC (trades, timeframe, since, limits)
+        return ohlcvc
+    }
+
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limits = undefined, params = {}) {
         if (!this.has['fetchTrades'])
             throw new NotSupported (this.id + ' fetchOHLCV() not supported yet')

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -23,16 +23,17 @@ const parseTimeframe = (timeframe) => {
     return amount * scale
 }
 
-// given a sorted arrays of trades (recent first) and a timeframe builds an array of OHLCV candles
+// given a sorted arrays of trades (recent last) and a timeframe builds an array of OHLCV candles
 const buildOHLCVC = (trades, timeframe = '1m', since = -Infinity, limit = Infinity) => {
     let ms = parseTimeframe (timeframe) * 1000;
     let ohlcvs = [];
     const [ timestamp, /* open */, high, low, close, volume, count ] = [ 0, 1, 2, 3, 4, 5, 6 ];
     let oldest = Math.min (trades.length - 1, limit);
 
-    for (let i = oldest; i >= 0; i--) {
+    for (let i = 0; i <= oldest; i++) {
         let trade = trades[i];
-        if (trade.timestamp < since) continue;
+        if (trade.timestamp < since)
+            continue;
         let openingTime = Math.floor (trade.timestamp / ms) * ms; // shift to the edge of m/h/d (but not M)
         let candle = ohlcvs.length - 1;
 


### PR DESCRIPTION
1. Looks like the order of `fetchTrades` got changed. Emulated `fetchOHLCV` adapted accordingly.
2. `count` from OHLCVC got removed too. Created a new `fetchOHLCVC` method to recover from that... Hope it won't hurt. Still, didn't expose it through `.has` property... Not sure if there are any tensions around it.
3. Having a fresh look at this method I also noticed that we might treat the `limits` wrong. Right now it's a number of trades but probably it should be a number of candles? Not reflected in Manual, left it as is until it's clear.