### PR TITLE
Remove non-existing cobinhood sandbox urls

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -42,10 +42,6 @@ module.exports = class cobinhood extends Exchange {
                     'web': 'https://api.cobinhood.com/v1',
                     'ws': 'wss://feed.cobinhood.com',
                 },
-                'test': {
-                    'web': 'https://sandbox-api.cobinhood.com',
-                    'ws': 'wss://sandbox-feed.cobinhood.com',
-                },
                 'www': 'https://cobinhood.com',
                 'doc': 'https://cobinhood.github.io/api-public',
             },


### PR DESCRIPTION
URLS are not responding.

Also checked with their support team:
![image](https://user-images.githubusercontent.com/5610315/37394347-d0502b2a-2773-11e8-8925-c3862d4f445f.png)
