### PR TITLE
Get appropriate baseVolume

### DIFF
--- a/python/ccxt/async/bibox.py
+++ b/python/ccxt/async/bibox.py
@@ -153,7 +153,7 @@ class bibox (Exchange):
             'change': None,
             'percentage': self.safe_string(ticker, 'percent'),
             'average': None,
-            'baseVolume': self.safe_float(ticker, 'vol'),
+            'baseVolume': self.safe_float(ticker, 'vol24H'),
             'quoteVolume': None,
             'info': ticker,
         }


### PR DESCRIPTION
bibox uses 'vol24H', not 'vol', so it was returning None for all volumes. This should fix that.