### PR TITLE
Get appropriate bibox baseVolume

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -148,7 +148,7 @@ module.exports = class bibox extends Exchange {
             'change': undefined,
             'percentage': this.safeString (ticker, 'percent'),
             'average': undefined,
-            'baseVolume': this.safeFloat (ticker, 'vol'),
+            'baseVolume': this.safeFloat (ticker, 'vol24H'),
             'quoteVolume': undefined,
             'info': ticker,
         };


### PR DESCRIPTION
bibox uses 'vol24H', not 'vol', so it was returning None for all volumes. This should fix that.