### PR TITLE
Bug: Coinfloor uses password, not secret

### DIFF
--- a/js/coinfloor.js
+++ b/js/coinfloor.js
@@ -28,7 +28,8 @@ module.exports = class coinfloor extends Exchange {
             },
             'requiredCredentials': {
                 'apiKey': true,
-                'secret': true,
+                'secret': false,
+                'password': true,
                 'uid': true,
             },
             'api': {

--- a/js/coinfloor.js
+++ b/js/coinfloor.js
@@ -181,7 +181,7 @@ module.exports = class coinfloor extends Exchange {
             let nonce = this.nonce ();
             body = this.urlencode (this.extend ({ 'nonce': nonce }, query));
             let auth = this.uid + '/' + this.apiKey + ':' + this.password;
-            let signature = this.stringToBase64 (auth);
+            let signature = this.decode (this.stringToBase64 (this.encode (auth)));
             headers = {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Authorization': 'Basic ' + signature,


### PR DESCRIPTION
The `requiredCredentials` for coinfloor specified a secret, but the `sign` method used password. This meant the exchange was not would not work for any private methods.

Fix: Coinfloor uses password, so I updated requiredCredentials.

There was also an issue affecting Python when constructing the signature: `TypeError: must be str, not bytes`.

Fix: encode back to a string before appending to the request.