### PR TITLE
create binance fetchFundingFees

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -725,8 +725,8 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchFundingFees (params = {}) {
-        // by default it will try load withdrawal fees of all currencies (with separate requests)
-        // however if you define { 'currencies': [ 'ETH', 'BTC' ] } in params it will only load those
+        //  by default it will try load withdrawal fees of all currencies (with separate requests)
+        //  however if you define { 'currencies': [ 'ETH', 'BTC' ] } in params it will only load those
         await this.loadMarkets ();
         let withdrawFees = {};
         let info = {};

--- a/js/binance.js
+++ b/js/binance.js
@@ -131,7 +131,8 @@ module.exports = class binance extends Exchange {
                     'taker': 0.001,
                     'maker': 0.001,
                 },
-                'funding': {  // should be deleted, these are outdated and inaccurate
+                // should be deleted, these are outdated and inaccurate
+                'funding': {
                     'tierBased': false,
                     'percentage': false,
                     'withdraw': {


### PR DESCRIPTION
I know you are not a fan of functions that do more than one request at a time but I thought this was an exception since it had to conform to the `fetchFundingFees` standard which loads all the funding fees. It still runs in less than 30 seconds on my computer and people should not call this directly but rather via an optional `load_fees` once, then cache them forever. They added fees via API two days ago so they may add a single request method to load them all in the future.

An issue that I am noticing is that the https://github.com/frosty00/ccxt/blob/be58f13c39c42ae930efa956d02a9d3057974e79/python/ccxt/binance.py#L809 is plain wrong for all wapi endpoints, and we should check the 'success' value instead. However this requires parsing json in all languages...