### PR TITLE
binance edit handleErrors

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -847,26 +847,26 @@ module.exports = class binance extends Exchange {
             throw new InvalidOrder (this.id + ' order price exceeds allowed price precision or invalid, use this.priceToPrecision (symbol, amount) ' + body);
         if (body.indexOf ('Order does not exist') >= 0)
             throw new OrderNotFound (this.id + ' ' + body);
-        let response = JSON.parse (body);
-        // checks against error codes
         if (body.length > 0) {
             if (body[0] === '{') {
+                let response = JSON.parse (body);
+                // checks against error codes
                 let error = this.safeString (response, 'code');
                 if (typeof error !== 'undefined') {
                     const exceptions = this.exceptions;
                     if (error in exceptions) {
                         throw new exceptions[error] (this.id + ' ' + body);
                     } else {
-                        throw new ExchangeError (this.id + ': unknown error code: ' + body);
+                        throw new ExchangeError (this.id + ': unknown error code: ' + body + ' ' + error);
                     }
                 }
+                // check success value for wapi endpoints
+                // response in format {'msg': 'The coin does not exist.', 'success': true/false}
+                let success = this.safeString (response, 'success', 'true');
+                if (success === 'false') {
+                    throw new ExchangeError (this.id + ': unknown error code: ' + body);
+                }
             }
-        }
-        // check success value for wapi endpoints
-        // response in format {'msg': 'The coin does not exist.', 'success': true/false}
-        let success = this.safeString (response, 'success', 'true');
-        if (success === 'false') {
-            throw new ExchangeError (this.id + ': unknown error code: ' + body);
         }
     }
 };

--- a/js/binance.js
+++ b/js/binance.js
@@ -849,21 +849,21 @@ module.exports = class binance extends Exchange {
             throw new OrderNotFound (this.id + ' ' + body);
         let response = JSON.parse (body);
         // checks against error codes
-        if (typeof body === 'string') {  // is this necessary?
-            if (body.length > 0) {
-                if (body[0] === '{') {
-                    let error = this.safeString (response, 'code');
-                    if (typeof error !== 'undefined') {
-                        const exceptions = this.exceptions;
-                        if (error in exceptions) {
-                            throw new exceptions[error] (this.id + ' ' + body);
-                        } else {
-                            throw new ExchangeError (this.id + ': unknown error code: ' + body);
-                        }
+        if (body.length > 0) {
+            if (body[0] === '{') {
+                let error = this.safeString (response, 'code');
+                if (typeof error !== 'undefined') {
+                    const exceptions = this.exceptions;
+                    if (error in exceptions) {
+                        throw new exceptions[error] (this.id + ' ' + body);
+                    } else {
+                        throw new ExchangeError (this.id + ': unknown error code: ' + body);
                     }
                 }
             }
         }
+        // check success value for wapi endpoints
+        // response in format {'msg': 'The coin does not exist.', 'success': true/false}
         let success = this.safeString (response, 'success', 'true');
         if (success === 'false') {
             throw new ExchangeError (this.id + ': unknown error code: ' + body);


### PR DESCRIPTION
Simillar to #2210 for the wapi endpoint.

```
>>> b.wapi_get_withdrawfee()
Request: GET https://api.binance.com/wapi/v3/withdrawFee.html?timestamp=1521562209825&recvWindow=5000&signature=6335
Response: GET https://api.binance.com/wapi/v3/withdrawFee.html?timestamp=1521562209825&recvWindow=5000&signature=6335 200 {'Date': 'Tue, 20 Mar 2018 16:10:10 GMT' {"msg":"The coin does not exist.","success":false}
{'msg': 'The coin does not exist.', 'success': False}
>>> b.wapi_get_withdrawfee({'asset': 'ETH'})
Request: GET https://api.binance.com/wapi/v3/withdrawFee.html?timestamp=1521562309839&recvWindow=5000&asset=ETH&signature=b30927
Response: GET https://api.binance.com/wapi/v3/withdrawFee.html?timestamp=1521562309839&recvWindow=5000&asset=ETH&signature=b30927 200 {'Date': 'Tue, 20 Mar 2018 16:11:50 GMT', {"success":true,"withdrawFee":0.01}
{'success': True, 'withdrawFee': 0.01}
>>> b.public_get_time()
Request: GET https://api.binance.com/api/v1/time {'User-Agent': 'python-requests/2.18.4', 'Accept-Encoding': 'gzip, deflate'} None
Response: GET https://api.binance.com/api/v1/time 200 {'Date': 'Tue, 20 Mar 2018 16:12:36 GMT', 'Content-Type': 'application/json', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Server': 'nginx', 'Vary': 'Accept-Encoding', 'Strict-Transport-Security': 'max-age=31536000; includeSubdomains', 'X-Frame-Options': 'SAMEORIGIN', 'X-Xss-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'Content-Security-Policy': "default-src 'self'", 'X-Content-Security-Policy': "default-src 'self'", 'X-WebKit-CSP': "default-src 'self'", 'Cache-Control': 'no-cache, no-store, must-revalidate', 'Pragma': 'no-cache', 'Expires': '0', 'Content-Encoding': 'gzip'} {"serverTime":1521562356006}
{'serverTime': 1521562356006}
```

We always raise errors for http status codes above 400 in the python and javascript base classes regardless.
