### PR TITLE
Improve Environment Checks for Petch Polyfill

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -37,7 +37,7 @@ const {
     , RequestTimeout
     , ExchangeNotAvailable } = require ('./errors')
 
-const defaultFetch = isNode ? require ('fetch-ponyfill') ().fetch : fetch
+const defaultFetch = typeof XMLHttpRequest === "undefined" ? require ('fetch-ponyfill') ().fetch : fetch
 
 const journal = undefined // isNode && require ('./journal') // stub until we get a better solution for Webpack and React
 


### PR DESCRIPTION
The original intention is to polyfill fetch in the Node environment. The issue is that some Testing frameworks (e.g. Jest) sets the `window` object to the node global object. Which then leads to the assumption we are in the browser, without having access to `XMLHttpRequest`. 

In order to adequately know whether we need to polyfill fetch, I changed the check to what the actual fetch implementation needs.