### PR TITLE
Fix bitmex fetch_orders functions

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -251,7 +251,8 @@ module.exports = class bitmex extends Exchange {
         // why the hassle? urlencode in python is kinda broken for nested dicts.
         // E.g. self.urlencode({"filter": {"open": True}}) will return "filter={'open':+True}"
         // Bitmex doesn't like that. Hence resorting to this hack.
-        request['filter'] = this.json (request['filter']);
+        if ('filter' in request)
+            request['filter'] = this.json (request['filter']);
         let response = await this.privateGetOrder (request);
         return this.parseOrders (response, market, since, limit);
     }

--- a/python/ccxt/bitmex.py
+++ b/python/ccxt/bitmex.py
@@ -245,7 +245,10 @@ class bitmex (Exchange):
         # why the hassle? urlencode in python is kinda broken for nested dicts.
         # E.g. self.urlencode({"filter": {"open": True}}) will return "filter={'open':+True}"
         # Bitmex doesn't like that. Hence resorting to self hack.
-        request['filter'] = self.json(request['filter'])
+        
+        # There would be no 'filter' key in request when you call self.fetch_closed_orders or fetch_orders directly.
+        if 'filter' in request:
+            request['filter'] = self.json(request['filter'])
         response = self.privateGetOrder(request)
         return self.parse_orders(response, market, since, limit)
 
@@ -255,6 +258,7 @@ class bitmex (Exchange):
 
     def fetch_closed_orders(self, symbol=None, since=None, limit=None, params={}):
         # Bitmex barfs if you set 'open': False in the filter...
+        # fetch_closed_orders doesn't set a 'filter' param.
         orders = self.fetch_orders(symbol, since, limit, params)
         return self.filter_by(orders, 'status', 'closed')
 

--- a/python/ccxt/bitmex.py
+++ b/python/ccxt/bitmex.py
@@ -245,10 +245,7 @@ class bitmex (Exchange):
         # why the hassle? urlencode in python is kinda broken for nested dicts.
         # E.g. self.urlencode({"filter": {"open": True}}) will return "filter={'open':+True}"
         # Bitmex doesn't like that. Hence resorting to self hack.
-        
-        # There would be no 'filter' key in request when you call self.fetch_closed_orders or fetch_orders directly.
-        if 'filter' in request:
-            request['filter'] = self.json(request['filter'])
+        request['filter'] = self.json(request['filter'])
         response = self.privateGetOrder(request)
         return self.parse_orders(response, market, since, limit)
 
@@ -258,7 +255,6 @@ class bitmex (Exchange):
 
     def fetch_closed_orders(self, symbol=None, since=None, limit=None, params={}):
         # Bitmex barfs if you set 'open': False in the filter...
-        # fetch_closed_orders doesn't set a 'filter' param.
         orders = self.fetch_orders(symbol, since, limit, params)
         return self.filter_by(orders, 'status', 'closed')
 


### PR DESCRIPTION
fix `fetch_orders` and `fetch_closed_orders` cause they do not set a `filter` key by default.