### PR TITLE
bitfinex: fix sort parameter

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -629,7 +629,7 @@ module.exports = class bitfinex extends Exchange {
         let request = {
             'symbol': v2id,
             'timeframe': this.timeframes[timeframe],
-            'sort': 1,
+            'sort': '-1',
             'limit': limit,
         };
         if (typeof since !== 'undefined')

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -353,7 +353,7 @@ module.exports = class bitfinex2 extends bitfinex {
         let market = this.market (symbol);
         let request = {
             'symbol': market['id'],
-            'sort': 1,
+            'sort': '-1',
             'limit': limit, // default = max = 120
         };
         if (typeof since !== 'undefined')
@@ -369,7 +369,7 @@ module.exports = class bitfinex2 extends bitfinex {
         let request = {
             'symbol': market['id'],
             'timeframe': this.timeframes[timeframe],
-            'sort': 1,
+            'sort': '-1',
             'limit': limit,
         };
         if (typeof since !== 'undefined')


### PR DESCRIPTION
According to [wiki](https://github.com/ccxt/ccxt/wiki/Manual#ohlcv-candlestick-charts) of this repo, fetchOHLCV() must return the list of most ___recent___ OHLCV candles. however current implementation returns oldest candle stick datas by default.

related document:
https://docs.bitfinex.com/v2/reference#rest-public-candles