### PR TITLE
Base Exchange class: new property: precisionMode.

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -145,6 +145,7 @@ module.exports = class Exchange {
                 'BCC': 'BCH',
                 'DRK': 'DASH',
             },
+            'precisionMode': this.DECIMAL_PLACES,
         } // return
     } // describe ()
 

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -246,7 +246,7 @@ module.exports = class bitfinex extends Exchange {
                     'Invalid order': InvalidOrder, // ?
                 },
             },
-            'significantPrecision': true,
+            'precisionMode': this.SIGNIFICANT_DIGITS,
         });
     }
 
@@ -329,19 +329,19 @@ module.exports = class bitfinex extends Exchange {
     }
 
     costToPrecision (symbol, cost) {
-        return this.decimalToPrecision (parseFloat (cost), this.ROUND, this.markets[symbol].precision.price, this.SIGNIFICANT_DIGITS);
+        return this.decimalToPrecision (parseFloat (cost), this.ROUND, this.markets[symbol].precision.price, this.precisionMode);
     }
 
     priceToPrecision (symbol, price) {
-        return this.decimalToPrecision (parseFloat (price), this.ROUND, this.markets[symbol].precision.price, this.SIGNIFICANT_DIGITS);
+        return this.decimalToPrecision (parseFloat (price), this.ROUND, this.markets[symbol].precision.price, this.precisionMode);
     }
 
     amountToPrecision (symbol, amount) {
-        return this.decimalToPrecision (parseFloat (amount), this.ROUND, this.markets[symbol].precision.amount, this.SIGNIFICANT_DIGITS);
+        return this.decimalToPrecision (parseFloat (amount), this.ROUND, this.markets[symbol].precision.amount, this.precisionMode);
     }
 
     feeToPrecision (currency, fee) {
-        return this.decimalToPrecision (parseFloat (fee), this.ROUND, this.currencies[currency]['precision'], this.SIGNIFICANT_DIGITS);
+        return this.decimalToPrecision (parseFloat (fee), this.ROUND, this.currencies[currency]['precision'], this.precisionMode);
     }
 
     calculateFee (symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -672,6 +672,8 @@ abstract class Exchange {
             'withdraw' => false,
         );
 
+        $this->precisionMode = this->DECIMAL_PLACES;
+
         $this->lastRestRequestTimestamp = 0;
         $this->lastRestPollTimestamp    = 0;
         $this->restRequestQueue         = null;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -169,6 +169,8 @@ class Exchange(object):
         'withdraw': False,
     }
 
+    precisionMode = self.DECIMAL_PLACES
+
     minFundingAddressLength = 10  # used in check_address
     substituteCommonCurrencyCodes = True
     lastRestRequestTimestamp = 0


### PR DESCRIPTION
Defaults to DECIMAL_PLACES but is set to SIGNIFICANT_DIGITS for bitfinex.

I also noticed that bitfinex has been switched to `decimalToPrecision` already. I think it might be a bit preliminary, at least until `decimalToPrecision` testcases are unified across languages. Still, left it as is as I suppose it was switched on by someone of the core team.