### PR TITLE
Arguments of fetch_order_book should keep consistent

### DIFF
--- a/php/exx.php
+++ b/php/exx.php
@@ -189,7 +189,7 @@ class exx extends Exchange {
         return $result;
     }
 
-    public function fetch_order_book ($symbol, $params = array ()) {
+    public function fetch_order_book ($symbol, $limit = null, $params = array ()) {
         $this->load_markets();
         $orderbook = $this->publicGetDepth (array_merge (array (
             'currency' => $this->market_id($symbol),


### PR DESCRIPTION
When we call fetchOrderBook, it will pass arguments with symbol/limit/params format.  We will need add limit here so it doesn't return empty result. 