### PR TITLE
bitFlyer: Add getboardstate endpoint

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -40,6 +40,7 @@ module.exports = class bitflyer extends Exchange {
                         'getticker',
                         'getexecutions',
                         'gethealth',
+                        'getboardstate',
                         'getchats',
                     ],
                 },


### PR DESCRIPTION
`getboardstate` allows to determine the current status of the board.

It is described only in Japanese documentation.
https://lightning.bitflyer.jp/docs?lang=ja#%E6%9D%BF%E3%81%AE%E7%8A%B6%E6%85%8B
It can be used in the playground.
https://lightning.bitflyer.jp/docs/playground?lang=en
