### PR TITLE
fixes invalid nonce for the wapi endpoint

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -821,6 +821,8 @@ module.exports = class binance extends Exchange {
                 throw new InvalidOrder (this.id + ' order amount should be evenly divisible by lot size, use this.amountToLots (symbol, amount) ' + body);
             if (body.indexOf ('PRICE_FILTER') >= 0)
                 throw new InvalidOrder (this.id + ' order price exceeds allowed price precision or invalid, use this.priceToPrecision (symbol, amount) ' + body);
+            if (body.indexOf ('Timestamp for this request is outside of the recvWindow.') >= 0)
+                throw new InvalidNonce (this.id + ' use loadTimeDifference or set adjustForTimeDifference = true in options ' + body);
         }
         if (body.length > 0) {
             if (body[0] === '{') {

--- a/js/binance.js
+++ b/js/binance.js
@@ -821,12 +821,16 @@ module.exports = class binance extends Exchange {
                 throw new InvalidOrder (this.id + ' order amount should be evenly divisible by lot size, use this.amountToLots (symbol, amount) ' + body);
             if (body.indexOf ('PRICE_FILTER') >= 0)
                 throw new InvalidOrder (this.id + ' order price exceeds allowed price precision or invalid, use this.priceToPrecision (symbol, amount) ' + body);
-            if (body.indexOf ('Timestamp for this request is outside of the recvWindow.') >= 0)
-                throw new InvalidNonce (this.id + ' use loadTimeDifference or set adjustForTimeDifference = true in options ' + body);
         }
         if (body.length > 0) {
             if (body[0] === '{') {
                 let response = JSON.parse (body);
+                // check success value for wapi endpoints
+                // response in format {'msg': 'The coin does not exist.', 'success': true/false}
+                let success = this.safeValue (response, 'success', true);
+                if (!success) {
+                    response = response['msg'];
+                }
                 // checks against error codes
                 let error = this.safeString (response, 'code');
                 if (typeof error !== 'undefined') {
@@ -837,9 +841,6 @@ module.exports = class binance extends Exchange {
                         throw new ExchangeError (this.id + ': unknown error code: ' + body + ' ' + error);
                     }
                 }
-                // check success value for wapi endpoints
-                // response in format {'msg': 'The coin does not exist.', 'success': true/false}
-                let success = this.safeValue (response, 'success', true);
                 if (!success) {
                     throw new ExchangeError (this.id + ': success value false: ' + body);
                 }


### PR DESCRIPTION
When calling withdraw (or any other wapi endpoint) and the timestamp is wrong binance raises an ExchangeError instead of the expected InvalidNonce - because the success value is also false #2317. This is because the response body is nested in another unneccessary "msg" parameter.
```
ccxt.base.errors.ExchangeError: binance: success value False: {"msg":"{\"code\":-1021,\"msg\":\"Timestamp for this request is outside of the recvWindow.\"}","success":false}
```