### PR TITLE
Update flowbtc.js

### DIFF
--- a/js/flowbtc.js
+++ b/js/flowbtc.js
@@ -177,7 +177,7 @@ module.exports = class flowbtc extends Exchange {
             'side': side,
             'orderType': orderType,
             'qty': amount,
-            'px': price,
+            'px': price.toFixed(2),
         };
         let response = await this.privatePostCreateOrder (this.extend (order, params));
         return {


### PR DESCRIPTION
Based on:
https://trader.flowbtc.com/#/privateApi

Price requires 2 decimals only. More than 2 gives invalid price error.