### PR TITLE
gateio: 'rate' cast to float type from str in 'fetch_trades'

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -233,7 +233,7 @@ module.exports = class gateio extends Exchange {
             'symbol': market['symbol'],
             'type': undefined,
             'side': trade['type'],
-            'price': trade['rate'],
+            'price': parseFloat (trade['rate']),
             'amount': this.safeFloat (trade, 'amount'),
         };
     }

--- a/php/gateio.php
+++ b/php/gateio.php
@@ -234,7 +234,7 @@ class gateio extends Exchange {
             'symbol' => $market['symbol'],
             'type' => null,
             'side' => $trade['type'],
-            'price' => $trade['rate'],
+            'price' => floatval ($trade['rate']),
             'amount' => $this->safe_float($trade, 'amount'),
         );
     }

--- a/python/ccxt/async/gateio.py
+++ b/python/ccxt/async/gateio.py
@@ -228,7 +228,7 @@ class gateio (Exchange):
             'symbol': market['symbol'],
             'type': None,
             'side': trade['type'],
-            'price': trade['rate'],
+            'price': float(trade['rate']),
             'amount': self.safe_float(trade, 'amount'),
         }
 

--- a/python/ccxt/gateio.py
+++ b/python/ccxt/gateio.py
@@ -228,7 +228,7 @@ class gateio (Exchange):
             'symbol': market['symbol'],
             'type': None,
             'side': trade['type'],
-            'price': trade['rate'],
+            'price': float(trade['rate']),
             'amount': self.safe_float(trade, 'amount'),
         }
 


### PR DESCRIPTION
In gateio, 'rate' should be float in 'fetch_trades' response.

<a href="https://gyazo.com/45586a5d6819ff166c87be7e87daafb3"><img src="https://i.gyazo.com/45586a5d6819ff166c87be7e87daafb3.png" alt="https://gyazo.com/45586a5d6819ff166c87be7e87daafb3" width="1886"/></a>