### PR TITLE
Add endpoint to retrieve deposit/withdrawal records from Huobipro

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -77,6 +77,7 @@ module.exports = class huobipro extends Exchange {
                         'order/matchresults', // 查询当前成交、历史成交
                         'dw/withdraw-virtual/addresses', // 查询虚拟币提现地址
                         'dw/deposit-virtual/addresses',
+                        'query/deposit-withdraw',
                     ],
                     'post': [
                         'order/orders/place', // 创建并执行一个新订单 (一步下单， 推荐使用)


### PR DESCRIPTION
Straightforward PR to add the endpoint `/query/deposit-withdraw`.

API doc section relevant to that endpoint: https://github.com/huobiapi/API_Docs_en/wiki/REST_Reference#get-v1querydeposit-withdraw---get-deposit-or-withdraw-records