### PR TITLE
livecoin commonCurrency standard

### DIFF
--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -232,7 +232,7 @@ module.exports = class livecoin extends Exchange {
         let currencies = [
             { 'id': 'USD', 'code': 'USD', 'name': 'US Dollar' },
             { 'id': 'EUR', 'code': 'EUR', 'name': 'Euro' },
-            { 'id': 'RUR', 'code': 'RUR', 'name': 'Russian ruble' },
+            { 'id': 'RUR', 'code': 'RUB', 'name': 'Russian ruble' },
         ];
         for (let i = 0; i < currencies.length; i++) {
             let currency = currencies[i];


### PR DESCRIPTION
For some reason livecoin reports different currencies in its `fetchMarkets` and `fetchCurrencies`, namely CTR.

```
livecoin.markets['CTR/ETH']
{'fee_loaded': False, 'percentage': True, 'tierBased': False, 'maker': 0.0018, 'taker': 0.0018, 'precision': {'price': 8, 'amount': 8, 'cost': 8}, 'limits': {'amount': {'min': 70.0001, 'max': 100000000.0}, 'price': {'min': ...
livecoin.currencies['CTR']
Traceback (most recent call last):
  File "<input>", line 1, in <module>
KeyError: 'CTR'
```

Output from one of my functions:
```
RUB not loaded in LiveCoin.currencies but loaded in markets?
CTR not loaded in LiveCoin.currencies but loaded in markets?
```