### PR TITLE
Add V3 Test Order Endpoint and sign the request

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -85,6 +85,9 @@ module.exports = class binance extends Exchange {
                         'ticker/price',
                         'ticker/bookTicker',
                     ],
+                    'post':[
+                        'order/test'
+                    ]
                 },
                 'public': {
                     'get': [
@@ -808,7 +811,7 @@ module.exports = class binance extends Exchange {
                 'X-MBX-APIKEY': this.apiKey,
                 'Content-Type': 'application/x-www-form-urlencoded',
             };
-        } else if ((api === 'private') || (api === 'wapi')) {
+        } else if ((api === 'private') || (api === 'wapi') || (method === 'POST')) {
             this.checkRequiredCredentials ();
             let query = this.urlencode (this.extend ({
                 'timestamp': this.nonce (),


### PR DESCRIPTION
This adds one of the still missing v3 Binance endpoints. I don't have an application to properly test the other endpoints, but I was able to test the order/test endpoint.

