### PR TITLE
BTCMarkets: Fix fetchOrders, fetchOpenOrders, fetchMyTrades

### DIFF
--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -332,7 +332,7 @@ module.exports = class btcmarkets extends Exchange {
         return this.parseOrder (order);
     }
 
-    async prepareHistoryRequest (market, since = undefined, limit = undefined) {
+    prepareHistoryRequest (market, since = undefined, limit = undefined) {
         let request = this.ordered ({
             'currency': market['quote'],
             'instrument': market['base'],


### PR DESCRIPTION
`prepareHistoryRequest` is declared as `async` function, but used synchronously, which makes `fetchOrders`, `fetchOpenOrders`, `fetchMyTrades` fail. Removing `async` fixes the error.