### PR TITLE
fix insufficient funds error not being thrown on withdraw

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -831,6 +831,8 @@ module.exports = class bitfinex extends Exchange {
     }
 
     findBroadlyMatchedKey (map, broadString) {
+        if (typeof broadString === 'undefined')
+            return undefined;
         const partialKeys = Object.keys (map);
         for (let i = 0; i < partialKeys.length; i++) {
             const partialKey = partialKeys[i];
@@ -843,24 +845,25 @@ module.exports = class bitfinex extends Exchange {
     handleErrors (code, reason, url, method, headers, body) {
         if (body.length < 2)
             return;
+        let response = JSON.parse (body);
+        let message = undefined;
+        const feedback = this.id + ' ' + this.json (response);
+        if (this.json (response)[0] === '[' && response.length === 1) {
+            response = response[0];
+        }
+        if ('message' in response)
+            message = response['message'];
+        else if ('error' in response)
+            message = response['error'];
+        const broad = this.exceptions['broad'];
+        const broadKey = this.findBroadlyMatchedKey (broad, message);
+        if (typeof broadKey !== 'undefined')
+            throw new broad[broadKey] (feedback);
         if (code >= 400) {
             if (body[0] === '{') {
-                const response = JSON.parse (body);
-                const feedback = this.id + ' ' + this.json (response);
-                let message = undefined;
-                if ('message' in response)
-                    message = response['message'];
-                else if ('error' in response)
-                    message = response['error'];
-                else
-                    throw new ExchangeError (feedback); // malformed (to our knowledge) response
                 const exact = this.exceptions['exact'];
                 if (message in exact)
                     throw new exact[message] (feedback);
-                const broad = this.exceptions['broad'];
-                const broadKey = this.findBroadlyMatchedKey (broad, message);
-                if (typeof broadKey !== 'undefined')
-                    throw new broad[broadKey] (feedback);
                 throw new ExchangeError (feedback); // unknown message
             }
         }


### PR DESCRIPTION
Previously an ExchangeError was thrown on a `bitfinex.withdraw('ETH', 2, 0x123...)`

This is for multiple reasons. Firstly, the response code returned by bitfinex is 200. Secondly, they wrap the response in a list with `[`

```
Response: POST https://api.bitfinex.com/v1/withdraw 200 [{"status":"error","message":"Cannot withdraw 2.3894987 ETH from your exchange wallet. The available balance is only 2.3867987 ETH. If you have limit orders, open positions, unused or active margin funding, this will decrease your available balance. To increase it, you can cancel limit orders or reduce/close your positions.","withdrawal_id":0,"fees":"0.0027"}]
```
^ The error was caught in `withdraw` but it still raises an `ExchangeError` when the withdrawal_id is 0 for any other reason regardless.

After this PR:

```
bitfinex 
{'fees': '0.0027',
 'message': 'Cannot withdraw 2.0027 ETH from your exchange wallet. The '
            'available balance is only 0.0 ETH. If you have limit orders, open '
            'positions, unused or active margin funding, this will decrease '
            'your available balance. To increase it, you can cancel limit '
            'orders or reduce/close your positions.',
 'status': 'error',
 'withdrawal_id': 0} 
isinstance of <class 'ccxt.base.errors.InsufficientFunds'>
```