### PR TITLE
bitfinex throw error on withdraw insufficient funds

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -781,8 +781,15 @@ module.exports = class bitfinex extends Exchange {
         let responses = await this.privatePostWithdraw (this.extend (request, params));
         let response = responses[0];
         let id = response['withdrawal_id'];
-        if (id === 0)
+        let message = response['message'];
+        let errorMessage = this.findBroadlyMatchedKey (this.exceptions['broad'], message);
+        if (id === 0) {
+            if (typeof errorMessage !== 'undefined') {
+                let Exception = this.exceptions['broad'][errorMessage];
+                throw new Exception (this.id + ' ' + message);
+            }
             throw new ExchangeError (this.id + ' withdraw returned an id of zero: ' + this.json (response));
+        }
         return {
             'info': response,
             'id': id,


### PR DESCRIPTION
```
bitfinex.withdraw('ETH', 100, addr)
ccxt.base.errors.InsufficientFunds: bitfinex Cannot withdraw 100.0027 ETH from your exchange wallet. The available balance is only 0.0 ETH. If you have limit orders, open positions, unused or active margin funding, this will decrease your available balance. To increase it, you can cancel limit orders or reduce/close your positions.
```