### PR TITLE
Yobit handle errors

### DIFF
--- a/js/yobit.js
+++ b/js/yobit.js
@@ -193,10 +193,6 @@ module.exports = class yobit extends liqui {
         };
     }
 
-    async fetchMyTrades (symbol, since = undefined, limit = undefined, params = {}) {
-        return this.fetchTrades (symbol, since, limit, params);
-    }
-
     handleErrors (code, reason, url, method, headers, body) {
         if (body[0] === '{') {
             let response = JSON.parse (body);

--- a/js/yobit.js
+++ b/js/yobit.js
@@ -193,6 +193,13 @@ module.exports = class yobit extends liqui {
         };
     }
 
+    async fetchMyTrades (symbol, since = undefined, limit = undefined, params = {}) {
+        this.loadMarkets ();
+        let market = this.market (symbol);
+        let trades = this.fetchTrades (symbol, since, limit, params);
+        return this.parseTrades (trades, market, since, limit);
+    }
+
     handleErrors (code, reason, url, method, headers, body) {
         if (body[0] === '{') {
             let response = JSON.parse (body);

--- a/js/yobit.js
+++ b/js/yobit.js
@@ -194,10 +194,7 @@ module.exports = class yobit extends liqui {
     }
 
     async fetchMyTrades (symbol, since = undefined, limit = undefined, params = {}) {
-        this.loadMarkets ();
-        let market = this.market (symbol);
-        let trades = this.fetchTrades (symbol, since, limit, params);
-        return this.parseTrades (trades, market, since, limit);
+        return this.fetchTrades (symbol, since, limit, params);
     }
 
     handleErrors (code, reason, url, method, headers, body) {


### PR DESCRIPTION
handleErrors now works a little better -

```
yobit {"success":0,"error":1,"error_log":"Insufficient funds in wallet."} isinstance of <class 'ccxt.base.errors.InsufficientFunds'>
```

`parseOrder` is very broken it needs to subclass parseOrder. I make add commits to this branch or make another for that.