### PR TITLE
yobit populate id field in fetch_my_trades

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -526,6 +526,8 @@ module.exports = class liqui extends Exchange {
         let id = this.safeString (trade, 'tid');
         if ('trade_id' in trade)
             id = this.safeString (trade, 'trade_id');
+        if ('order_id' in trade)
+            id = this.safeString (trade, 'order_id');
         let order = this.safeString (trade, this.getOrderIdKey ());
         if ('pair' in trade) {
             let marketId = trade['pair'];


### PR DESCRIPTION
```
yobit.fetch_my_trades('XVG/ETH')

[{'id': '201138728309788', 'order': '201138728309788', 'timestamp': 1525108098000, 'datetime': '2018-04-30T17:08:18.000Z', 'symbol': 'XVG/ETH', 'type': 'limit', 'side': 'sell', 'price': 9.901e-05, 'amount': 13, 'fee': {'type': 'maker', 'currency': 'ETH', 'rate': 0.002, 'cost': 2.57426e-06}, 'info': {'pair': 'xvg_eth', 'type': 'sell', 'amount': 13, 'rate': 9.901e-05, 'order_id': '201138728309788', 'is_your_order': 1, 'timestamp': '1525108098'}}]
```

before 'id' was None