### PR TITLE
bittrex populate timestamp, fixes #2705

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -534,6 +534,8 @@ module.exports = class bittrex extends Exchange {
             lastTradeTimestamp = this.parse8601 (order['TimeStamp'] + '+00:00');
         if (('Closed' in order) && (typeof order['Closed'] !== 'undefined'))
             lastTradeTimestamp = this.parse8601 (order['Closed'] + '+00:00');
+        if (typeof timestamp === 'undefined')
+            timestamp = lastTradeTimestamp;
         let fee = undefined;
         let commission = undefined;
         if ('Commission' in order) {


### PR DESCRIPTION
```
    past_orders = self.fetch_closed_orders(symbol=symbol, since=since)  # oldest first
  File "/home/carlo/arbitrage/ccxt/bittrex.py", line 589, in fetch_closed_orders
    orders = self.parse_orders(response['result'], market, since, limit)
  File "/home/carlo/arbitrage/ccxt/base/exchange.py", line 1151, in parse_orders
    return self.filter_by_symbol_since_limit(array, symbol, since, limit)
  File "/home/carlo/arbitrage/ccxt/base/exchange.py", line 1158, in filter_by_symbol_since_limit
    array = [entry for entry in array if entry['timestamp'] >= since]
  File "/home/carlo/arbitrage/ccxt/base/exchange.py", line 1158, in <listcomp>
    array = [entry for entry in array if entry['timestamp'] >= since]
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```
if timestamp is not populate I get this error