### PR TITLE
Fix for fetch_orders marking as closed all orders with other symbols

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -558,12 +558,14 @@ module.exports = class cryptopia extends Exchange {
             } else {
                 let order = this.orders[id];
                 if (order['status'] === 'open') {
-                    this.orders[id] = this.extend (order, {
-                        'status': 'closed',
-                        'cost': order['amount'] * order['price'],
-                        'filled': order['amount'],
-                        'remaining': 0.0,
-                    });
+                    if ((typeof symbol === 'undefined') || (order['symbol'] === symbol)) {
+                        this.orders[id] = this.extend (order, {
+                            'status': 'closed',
+                            'cost': order['amount'] * order['price'],
+                            'filled': order['amount'],
+                            'remaining': 0.0,
+                        });
+                    }
                 }
             }
             let order = this.orders[id];


### PR DESCRIPTION
fetch_orders erroneously marks as closed all open orders from other symbols. In the following example code:

```
wc_oid = cpia.ex.create_limit_buy_order('WC/BTC', 75000, 0.00000001)['id']
time.sleep(1)
divx_oid = cpia.ex.create_limit_buy_order('DIVX/BTC', 70000, 0.00000001)['id']

wc = cpia.ex.fetch_order(wc_oid, symbol='WC/BTC')
divx = cpia.ex.fetch_order(divx_oid, symbol='DIVX/BTC')
```

after running `wc = cpia.ex.fetch_order(wc_oid, symbol='WC/BTC')` the order for `'DIVX/BTC'` is marked as 'closed' in the order cache.

This example is not the best because after the line `divx = cpia.ex.fetch_order(divx_oid, symbol='DIVX/BTC')` you still get the correct DIVX order because it is fetched from the exchange and the order is marked as 'open' again. So the effect is not always visible from the outside.

But there are some effects in some edge cases which I'm not able to describe in a repeateable way, but I've seen cases of orders marked as fillled when they were not, which I believe is related to this bug in combination with more complex usage of the library.