### PR TITLE
Fix when an order fills immediately, 'filled' should be set to the amount.

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -451,7 +451,7 @@ module.exports = class cryptopia extends Exchange {
             'price': price,
             'cost': price * amount,
             'amount': amount,
-            'remaining': amount,
+            'remaining': amount - filled,
             'filled': filled,
             'fee': undefined,
             // 'trades': this.parseTrades (order['trades'], market),

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -437,7 +437,7 @@ module.exports = class cryptopia extends Exchange {
                 let filledOrders = response['Data']['FilledOrders'];
                 let filledOrdersLength = filledOrders.length;
                 if (filledOrdersLength) {
-                    filled = undefined;
+                    filled = amount;
                 }
             }
         }

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -427,19 +427,16 @@ module.exports = class cryptopia extends Exchange {
             throw new ExchangeError (this.id + ' createOrder returned unknown error: ' + this.json (response));
         let id = undefined;
         let filled = 0.0;
+        let status = 'open';
         if ('Data' in response) {
             if ('OrderId' in response['Data']) {
                 if (response['Data']['OrderId']) {
                     id = response['Data']['OrderId'].toString ();
-                }
-            }
-            if ('FilledOrders' in response['Data']) {
-                let filledOrders = response['Data']['FilledOrders'];
-                let filledOrdersLength = filledOrders.length;
-                if (filledOrdersLength) {
+                } else {
                     filled = amount;
+                    status = 'closed';
                 }
-            }
+            }            
         }
         let timestamp = this.milliseconds ();
         let order = {
@@ -447,7 +444,7 @@ module.exports = class cryptopia extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': undefined,
-            'status': 'open',
+            'status': status,
             'symbol': symbol,
             'type': type,
             'side': side,


### PR DESCRIPTION
When an order is immediately filled, the current behaviour is to set the orders 'filled' attribute to None. 

IMO it makes more sense, since we know that it filled completely to set 'filled' to the 'amount' value.