### PR TITLE
bibox: timestamp should be in milliseconds

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -144,7 +144,7 @@ module.exports = class bibox extends Exchange {
     }
 
     parseTicker (ticker, market = undefined) {
-        let timestamp = this.safeInteger (ticker, 'timestamp', this.seconds ());
+        let timestamp = this.safeInteger (ticker, 'timestamp', this.milliseconds ());
         let symbol = undefined;
         if (market) {
             symbol = market['symbol'];


### PR DESCRIPTION
cf eg [huobipro.js timestamp handling](https://github.com/ccxt/ccxt/blob/14355ca3482d68cef4b260601b308055e1d62f6b/js/huobipro.js#L237)