### PR TITLE
zb: remove average from parseOrder

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -432,7 +432,7 @@ module.exports = class zb extends Exchange {
         if (market)
             symbol = market['symbol'];
         let price = order['price'];
-        let average = order['trade_price'];
+        let average = undefined;
         let filled = order['trade_amount'];
         let amount = order['total_amount'];
         let remaining = amount - filled;


### PR DESCRIPTION
parse_order causes such error(python):

  File "/usr/local/lib/python3.5/dist-packages/ccxt/zb.py", line 415, in fetch_open_orders
    return self.parse_orders(response, market, since, limit)
  File "/usr/local/lib/python3.5/dist-packages/ccxt/base/exchange.py", line 1139, in parse_orders
    array = [self.parse_order(order, market) for order in array]
  File "/usr/local/lib/python3.5/dist-packages/ccxt/base/exchange.py", line 1139, in <listcomp>
    array = [self.parse_order(order, market) for order in array]
  File "/usr/local/lib/python3.5/dist-packages/ccxt/zb.py", line 431, in parse_order
    average = order['trade_price']
KeyError: 'trade_price'

**Then I found in [ZB API reference](https://www.zb.com/i/developer/restApi#trade), there is no average in order data structure:**
{
    "currency": "btc",
    "id": "20150928158614292",
    "price": 1560,
    "status": 3,
    "total_amount": 0.1,
    "trade_amount": 0,
    "trade_date": 1443410396717,
    "trade_money": 0,
    "type": 0,
}

I also consulted ZB offical, they gave the same answer.