### PR TITLE
lbank not all markets have timestamp data - keyerror in python

### DIFF
--- a/js/lbank.js
+++ b/js/lbank.js
@@ -144,7 +144,7 @@ module.exports = class lbank extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         let symbol = market['symbol'];
-        let timestamp = ticker['timestamp'];
+        let timestamp = this.safeInteger (ticker, 'timestamp');
         let info = ticker;
         ticker = info['ticker'];
         let last = this.safeFloat (ticker, 'latest');


### PR DESCRIPTION
```
>>>pprint(lbank.fetch_ticker('DBC/ETH'))
{'ask': None,
 'askVolume': None,
 'average': None,
 'baseVolume': 1893388.338,
 'bid': None,
 'bidVolume': None,
 'change': 12.88,
 'close': 0.00013071,
 'datetime': None,
 'high': 0.00013677,
 'info': {'symbol': 'dbc_eth',
          'ticker': {'change': '12.88',
                     'high': '0.00013677',
                     'latest': '0.00013071',
                     'low': '0.00011263',
                     'turnover': '228.72284155',
                     'vol': '1893388.33800000'}},
 'last': 0.00013071,
 'low': 0.00011263,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 228.72284155,
 'symbol': 'DBC/ETH',
 'timestamp': None,
 'vwap': None}
>>>pprint(lbank.fetch_ticker('IIC/ETH'))
{'ask': None,
 'askVolume': None,
 'average': None,
 'baseVolume': 61878751.0,
 'bid': None,
 'bidVolume': None,
 'change': -7.78,
 'close': 1.706e-05,
 'datetime': '2018-05-15T13:18:45.802Z',
 'high': 3.561e-05,
 'info': {'symbol': 'iic_eth',
          'ticker': {'change': '-7.78',
                     'high': '0.00003561',
                     'latest': '0.00001706',
                     'low': '0.00001459',
                     'turnover': '1174.03145510',
                     'vol': '61878751.00000000'},
          'timestamp': 1526390324802},
 'last': 1.706e-05,
 'low': 1.459e-05,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 1174.0314551,
 'symbol': 'IIC/ETH',
 'timestamp': 1526390324802,
 'vwap': None}
```