### PR TITLE
Updated isNode to take an electron app as a node app too

### DIFF
--- a/js/base/functions/platform.js
+++ b/js/base/functions/platform.js
@@ -4,8 +4,7 @@
 
 module.exports = {
 
-    isNode: (typeof window === 'undefined') &&
-          !((typeof WorkerGlobalScope !== 'undefined') && (self instanceof WorkerGlobalScope))
+    isNode: typeof module !== 'undefined' && typeof module.exports !== 'undefined'
 
     , isWindows: (typeof process !== 'undefined') ? process.platform === "win32" : false
 }

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -285,7 +285,7 @@ module.exports = class bittrex extends Exchange {
             'ask': this.safeFloat (ticker, 'Ask'),
             'askVolume': undefined,
             'vwap': undefined,
-            'open': undefined,
+            'open': previous,
             'close': last,
             'last': last,
             'previousClose': undefined,


### PR DESCRIPTION
Working on an electron app using ccxt, I stumble upon the CORS problem some people trying to integrate Binance already met (https://github.com/ccxt/ccxt/issues/2097)

There is an easy fix in the special case of an electron app, the function isNode was not correctly detecting node inside the electron app.

this pull request, inspired by https://github.com/flexdinesh/browser-or-node/blob/master/src/index.js is solving that problem and more accurately resolves node detection