### PR TITLE
Bitz - Fix incremenet for PHP

### DIFF
--- a/js/bitz.js
+++ b/js/bitz.js
@@ -386,7 +386,7 @@ module.exports = class bitz extends Exchange {
             this.options['lastNonceTimestamp'] = currentTimestamp;
             this.options['lastNonce'] = 100000;
         }
-        this.options['lastNonce'] += 1;
+        this.options['lastNonce'] = this.options['lastNonce'] + 1;
         return this.options['lastNonce'];
     }
 


### PR DESCRIPTION
The transpiler interprets "+=" as ".=" when converting to PHP which appends "1" instead of incrementing by 1.