### PR TITLE
bitfinex: fetchOpenOrders: validate symbol

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -634,6 +634,9 @@ module.exports = class bitfinex extends Exchange {
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
+        if (typeof symbol !== 'undefined')
+            if (!(symbol in this.markets))
+                throw new ExchangeError (this.id + ' has no symbol ' + symbol);
         let response = await this.privatePostOrders (params);
         let orders = this.parseOrders (response, undefined, since, limit);
         if (symbol)


### PR DESCRIPTION
If you call `fetchOpenOrders` with some non-existent symbol (e.g. 'BTC/USD') then it will throw an exception instead of returning an empty array.