### PR TITLE
Enable conversion of currencies to 'BTC' 'ETH' and 'LTC'

### DIFF
--- a/js/coinmarketcap.js
+++ b/js/coinmarketcap.js
@@ -79,6 +79,9 @@ module.exports = class coinmarketcap extends Exchange {
                 'MXN',
                 'RUB',
                 'USD',
+                'BTC',
+                'ETH',
+                'LTC',
             ],
         });
     }


### PR DESCRIPTION
Converting a currency to 'BTC', 'ETH' or 'LTC' seems to be not supported at the moment because markets are not created for these currencies;
```
import ccxt

cmc = ccxt.coinmarketcap()
cmc.fetch_tickers('888/ETH')
```

Fails with `ExchangeError: coinmarketcap No market symbol 888/ETH`.

The easy fix is what I did in this PR, just add BTC, ETH, LTC to the currencyCodes list. But I am not sure if this is the best approach because we are creating a market for every coin combination, which doesn't seem like it will scale in the future. Actually, there are more coins supported by the CMC API that are not currently supported by ccxt.coinmarketcap, but I didn't want to include them for this reason.

Perhaps a better approach could be to disable checking that the market exists for coinmarketcap to allow for the conversion to happen, without having to store in the markets dict all the possible conversion combinations.

In any case, conversion to BTC, ETH and LTC is basic, that's why I created this PR.
