### PR TITLE
Fix to parse real cost

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -398,7 +398,7 @@ module.exports = class cobinhood extends Exchange {
         if (typeof market !== 'undefined')
             symbol = market['symbol'];
         let timestamp = order['timestamp'];
-        let price = this.safeFloat (order, 'price');
+        let price = this.safeFloat (order, 'eq_price');
         let amount = this.safeFloat (order, 'size');
         let filled = this.safeFloat (order, 'filled');
         let remaining = amount - filled;


### PR DESCRIPTION
The 'price' parameter Cobinhood returns is the price you sent to the exchange. But the real price the order was filled may not always be the price you proposed to the order. The real price for the order executed is the parameter 'eq_price'.