### PR TITLE
Pass 'limit' argument to Kucoin when retrieving order books & last trades

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -828,6 +828,7 @@ module.exports = class kucoin extends Exchange {
         let market = this.market (symbol);
         let response = await this.publicGetOpenDealOrders (this.extend ({
             'symbol': market['id'],
+            'limit': limit,
         }, params));
         return this.parseTrades (response['data'], market, since, limit);
     }

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -329,6 +329,7 @@ module.exports = class kucoin extends Exchange {
         let market = this.market (symbol);
         let response = await this.publicGetOpenOrders (this.extend ({
             'symbol': market['id'],
+            'limit': limit,
         }, params));
         let dataInResponse = ('data' in response);
         let orderbook = undefined;


### PR DESCRIPTION
In current _master_ 7bfff9c6507161e07a34c12d79743613254b91a8 :

- _limit_ argument is not passed to _Kucoin_'s method _publicGetOpenOrders_
- _limit_ argument is not passed to _Kucoin_'s method _publicGetOpenDealOrders_ (If _limit_ parameter is not specified, _Kucoin_ will only return 10 entries)
