### PR TITLE
hitbtc2: precision for lots > 1

### DIFF
--- a/js/hitbtc2.js
+++ b/js/hitbtc2.js
@@ -555,7 +555,9 @@ module.exports = class hitbtc2 extends hitbtc {
             let step = this.safeFloat (market, 'tickSize');
             let precision = {
                 'price': this.precisionFromString (market['tickSize']),
-                'amount': this.precisionFromString (market['quantityIncrement']),
+                // FIXME: for lots > 1 the following line returns 0
+                // 'amount': this.precisionFromString (market['quantityIncrement']),
+                'amount': -1 * Math.log10 (lot),
             };
             let taker = this.safeFloat (market, 'takeLiquidityRate');
             let maker = this.safeFloat (market, 'provideLiquidityRate');
@@ -568,8 +570,6 @@ module.exports = class hitbtc2 extends hitbtc {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'active': true,
-                'lot': lot,
-                'step': step,
                 'taker': taker,
                 'maker': maker,
                 'precision': precision,


### PR DESCRIPTION
I'm not sure what was the purpose of `precisionFromString`. Suppose a sort of value cleansing.
I put a FIXME there as the fix actually can break something I'm not aware of.

The current implementation sets precision.amount to zero for lots which are greater than 1 (in the case below amount precision should be -2, not 0:
```
{  
    info:
        {                                    id: "CFIETH",
                         baseCurrency: "CFI",
                       quoteCurrency: "ETH",
                  quantityIncrement: "100",
                                    tickSize: "0.0000001",
                   takeLiquidityRate: "0.001",
              provideLiquidityRate: "-0.0001",
                            feeCurrency: "ETH"        },
             id:   "CFIETH",
    symbol:   "CFI/ETH",
        base:   "CFI",
       quote:   "ETH",
      baseId:   "CFI",
    quoteId:   "ETH",
       active:    true,
             lot:    100,
          step:   0.0000001,
   precision: { price: 7, amount: 0 },
      limits: { amount: { min: 100, max: undefined },
                 price: { min: 1e-7, max: undefined },
                  cost: { min: 0.000009999999999999999, max: undefined } }
}
```