### PR TITLE
gatecoin: error handling, cancelOrder and createOrder fixes

### DIFF
--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -463,14 +463,7 @@ module.exports = class gatecoin extends Exchange {
     async cancelOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
         const response = await this.privateDeleteTradeOrdersOrderID ({ 'OrderID': id });
-        // At this point response.responseStatus.message has been verified
-        // in handleErrors() to be == 'OK', so we assume the order has
-        // indeed been cancelled.
-        return {
-            'status': 'canceled',
-            'id': id,
-            'info': response,
-        };
+        return response;
     }
 
     parseOrderStatus (status) {

--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -460,6 +460,9 @@ module.exports = class gatecoin extends Exchange {
 
     parseOrderStatus (status) {
         const statuses = {
+            '1': 'open', // New
+            '2': 'open', // Filling
+            '4': 'canceled',
             '6': 'closed',
         };
         if (status in statuses)

--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -458,7 +458,15 @@ module.exports = class gatecoin extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        return await this.privateDeleteTradeOrdersOrderID ({ 'OrderID': id });
+        const response = await this.privateDeleteTradeOrdersOrderID ({ 'OrderID': id });
+        // At this point response.responseStatus.message has been verified
+        // in handleErrors() to be == 'OK', so we assume the order has
+        // indeed been cancelled.
+        return {
+            'status': 'canceled',
+            'id': id,
+            'info': response,
+        };
     }
 
     parseOrderStatus (status) {

--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -606,10 +606,6 @@ module.exports = class gatecoin extends Exchange {
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 
-    request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
-        return this.fetch2 (path, api, method, params, headers, body);
-    }
-
     async withdraw (code, amount, address, tag = undefined, params = {}) {
         this.checkAddress (address);
         await this.loadMarkets ();

--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -450,9 +450,13 @@ module.exports = class gatecoin extends Exchange {
                 throw new AuthenticationError (this.id + ' two-factor authentication requires a missing ValidationCode parameter');
         }
         let response = await this.privatePostTradeOrders (this.extend (order, params));
+        // At this point response.responseStatus.message has been verified
+        // in handleErrors() to be == 'OK', so we assume the order has
+        // indeed been opened.
         return {
             'info': response,
-            'id': response['clOrderId'],
+            'status': 'open',
+            'id': this.safeString (response, 'clOrderId'), // response['clOrderId'],
         };
     }
 


### PR DESCRIPTION
* support more exceptions and error codes
* support more of the order statuses
* cancelOrder returns proper order status
* createOrder returns proper order status

(@kroitor, you were right in the first place. Turns out `responseStatus.message` is indeed returned for all requests and so the way to go is to handle it in `handleErrors()`). 