### PR TITLE
Fix error when creating market orders

### DIFF
--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -90,6 +90,8 @@ const decimalToPrecision = (x, roundingMode
 
     if (numPrecisionDigits < 0) throw new Error ('negative precision is not yet supported')
 
+    if (typeof x === 'undefined') return x;
+
 /*  Convert to a string (if needed), skip leading minus sign (if any)   */
 
     const str          = numberToString (x)


### PR DESCRIPTION
Fix error when creating market orders
- ccxt tries to call toString on the price var which is undefined for market orders

Full error stack:
```
TypeError: Cannot read property 'toString' of undefined
    at numberToString (.../node_modules/ccxt/js/base/functions/number.js:55:29)                                                                                
    at bitfinex.decimalToPrecision (.../node_modules/ccxt/js/base/functions/number.js:96:26)                                                                   
    at bitfinex.priceToPrecision (.../node_modules/ccxt/js/bitfinex.js:370:21)                                                                                 
    at bitfinex.createOrder (.../node_modules/ccxt/js/bitfinex.js:566:22)                                                                                      
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
```