### PR TITLE
CoinTiger fetchTickers() fix to supply found market to parseTicker

### DIFF
--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -213,6 +213,7 @@ module.exports = class cointiger extends huobipro {
             if (id in this.options['marketsByUppercaseId']) {
                 // this endpoint returns uppercase ids
                 symbol = this.options['marketsByUppercaseId'][id]['symbol'];
+                market = this.options['marketsByUppercaseId'][id];
             }
             result[symbol] = this.parseTicker (response[id], market);
         }


### PR DESCRIPTION
@kroitor quick tweak post 275a1bc98e619d8b93b8b7c29ff6070234485b71 so the symbol is available in the ticker object as well.