### PR TITLE
kucoin fetchOrderBook fix

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -326,10 +326,13 @@ module.exports = class kucoin extends Exchange {
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let response = await this.publicGetOpenOrders (this.extend ({
+        let request = {
             'symbol': market['id'],
-            'limit': limit,
-        }, params));
+        };
+        if (typeof limit !== 'undefined') {
+            request['limit'] = limit;
+        }
+        let response = await this.publicGetOpenOrders (this.extend (request, params));
         let dataInResponse = ('data' in response);
         let orderbook = undefined;
         let timestamp = undefined;


### PR DESCRIPTION
```
Kucoin TFL/ETH failed to load - kucoin https://api.kucoin.com/v1/open/orders?symbol=TFL-ETH&limit=None GET 400 {"t
imestamp":1527677125616,"status":400,"error":"Bad Request","exception":"org.springframework.web.method.annotation.Meth
odArgumentTypeMismatchException","message":"Failed to convert value of type 'java.lang.String' to required type 'java.
lang.Integer'; nested exception is java.lang.NumberFormatException: For input string: \"None\"","path":"/open/orders"}
 <class 'ccxt.base.errors.ExchangeNotAvailable'>
```

When limit=None in the request it throws an error (presumably they are using java to parse the int)