### PR TITLE
Fix the method 'create_order' in gateio.py

### DIFF
--- a/python/ccxt/async/gateio.py
+++ b/python/ccxt/async/gateio.py
@@ -394,7 +394,7 @@ class gateio (Exchange):
             'status': 'open',
             'type': side,
             'initialAmount': amount,
-        }), response, market)
+        }, response), market)
 
     async def cancel_order(self, id, symbol=None, params={}):
         await self.load_markets()

--- a/python/ccxt/gateio.py
+++ b/python/ccxt/gateio.py
@@ -394,7 +394,7 @@ class gateio (Exchange):
             'status': 'open',
             'type': side,
             'initialAmount': amount,
-        }), response, market)
+        }, response), market)
 
     def cancel_order(self, id, symbol=None, params={}):
         self.load_markets()


### PR DESCRIPTION
#3010  Fix the method 'create_order' in gateio.py (wrong arguments for the 'parse_order' method)

