### PR TITLE
Fix gate.io fetchOrders

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -319,7 +319,7 @@ module.exports = class gateio extends Exchange {
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         let response = await this.privatePostOpenOrders (params);
-        return this.parseOrders (response['result']['orders'], undefined, since, limit);
+        return this.parseOrders (response['orders'], undefined, since, limit);
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {


### PR DESCRIPTION
This is what `response` is for me from gate.io at this point:

```
{'result': 'true', 'orders': [], 'message': 'Success', 'code': 0, 'elapsed': '0.892ms'}
```