### PR TITLE
Fix "remaining" field in gate.io order status.

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -485,7 +485,7 @@ module.exports = class gateio extends Exchange {
             'currency': currency.toLowerCase (),
             'amount': amount,
             'address': address, // Address must exist in you AddressBook in security settings
-        }, params))
+        }, params));
         return {
             'info': response,
             'id': undefined,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -365,7 +365,7 @@ module.exports = class gateio extends Exchange {
         let amount = this.safeFloat (order, 'initialAmount');
         let filled = this.safeFloat (order, 'filledAmount');
         let remaining = this.safeFloat (order, 'leftAmount');
-        if (typeof remaining !== 'undefined') {
+        if (typeof remaining === 'undefined') {
             // In the order status response, this field has a different name.
             remaining = this.safeFloat (order, 'left');
         }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -365,6 +365,10 @@ module.exports = class gateio extends Exchange {
         let amount = this.safeFloat (order, 'initialAmount');
         let filled = this.safeFloat (order, 'filledAmount');
         let remaining = this.safeFloat (order, 'leftAmount');
+        if (typeof remaining !== 'undefined') {
+            // In the order status response, this field has a different name.
+            remaining = this.safeFloat (order, 'left');
+        }
         let feeCost = this.safeFloat (order, 'feeValue');
         let feeCurrency = this.safeString (order, 'feeCurrency');
         if (typeof feeCurrency !== 'undefined') {
@@ -481,7 +485,7 @@ module.exports = class gateio extends Exchange {
             'currency': currency.toLowerCase (),
             'amount': amount,
             'address': address, // Address must exist in you AddressBook in security settings
-        }, params));
+        }, params))
         return {
             'info': response,
             'id': undefined,


### PR DESCRIPTION
Here is an example of gate.io order result I am seeing in fetchOrder:

```
{'amount': '0.00000000',
  'currencyPair': 'eos_usdt',
  'fee': '0 USDT',
  'feeCurrency': 'USDT',
  'feePercentage': 0.2,
  'feeValue': '0',
  'filledAmount': '0',
  'filledRate': '14.6201',
  'initialAmount': '16.68270983',
  'initialRate': '14.6201',
  'left': 16.68270983,
  'orderNumber': '837545296',
  'rate': '14.6201',
  'status': 'cancelled',
  'timestamp': 1528048660,
  'type': 'buy'}
```

But note the structure when submitting an order:

```
{'code': 0,
  'filledAmount': '0',
  'filledRate': '5',
  'initialAmount': 5,
  'leftAmount': '5.00000000',
  'message': 'Success',
  'orderNumber': 837670400,
  'rate': '5',
  'result': 'true',
  'status': 'open',
  'type': 'buy'}
```

It seems that in the order status, they carelessly named the field `left` instead of `leftAmount`.