### PR TITLE
Fix poloniex minimal cost

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -192,7 +192,7 @@ module.exports = class poloniex extends Exchange {
                 'XMR': 0.0001,
                 'USDT': 1.0,
             }[quote];
-            if (minimalCost === undefined) {
+            if (type minimalCost === 'undefined') {
                 minimalCost = 0.00000000;
             }
             result.push (this.extend (this.fees['trading'], {

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -187,14 +187,14 @@ module.exports = class poloniex extends Exchange {
             quote = this.commonCurrencyCode (quote);
             let symbol = base + '/' + quote;
             let minimalCost = {
-                'BTC': 0.0001, 
-                'ETH': 0.0001, 
-                'XMR': 0.0001, 
-                'USDT': 1.0
+                'BTC': 0.0001,
+                'ETH': 0.0001,
+                'XMR': 0.0001,
+                'USDT': 1.0,
             }[quote];
             if (minimalCost === undefined) {
-                minimalCost == 0.00000000;
-            };
+                minimalCost = 0.00000000;
+            }
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -186,6 +186,15 @@ module.exports = class poloniex extends Exchange {
             base = this.commonCurrencyCode (base);
             quote = this.commonCurrencyCode (quote);
             let symbol = base + '/' + quote;
+            let minimalCost = {
+                'BTC': 0.0001, 
+                'ETH': 0.0001, 
+                'XMR': 0.0001, 
+                'USDT': 1.0
+            }[quote];
+            if (minimalCost === undefined) {
+                minimalCost == 0.00000000;
+            };
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -206,7 +215,7 @@ module.exports = class poloniex extends Exchange {
                         'max': 1000000000,
                     },
                     'cost': {
-                        'min': 0.00000000,
+                        'min': minimalCost,
                         'max': 1000000000,
                     },
                 },

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -192,7 +192,7 @@ module.exports = class poloniex extends Exchange {
                 'XMR': 0.0001,
                 'USDT': 1.0,
             }[quote];
-            if (type minimalCost === 'undefined') {
+            if (typeof minimalCost === 'undefined') {
                 minimalCost = 0.00000000;
             }
             result.push (this.extend (this.fees['trading'], {


### PR DESCRIPTION
It is currently possible to receive this exception from poloniex:

```
ccxt.base.errors.InvalidOrder: poloniex {"error":"Total must be at least 0.0001."}
```

Inspired by https://github.com/askmike/gekko/pull/2167/, and specifically https://github.com/askmike/gekko/pull/2167/files#diff-c212a282e676846ba239680f7a180455R255, I copied the known minimums based on the market quote currency.