### PR TITLE
Manually support gate.io minimum cost

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -145,8 +145,16 @@ module.exports = class gateio extends Exchange {
                 'min': Math.pow (10, -details['decimal_places']),
                 'max': undefined,
             };
+            let minimumCost = {
+                'USDT': 1,
+                'ETH': 0.001,
+                'BTC': 0.0001,
+            }[quote];
+            if (minimumCost === undefined) {
+                minimumCost = amountLimits['min'] * priceLimits['min'];
+            }
             let costLimits = {
-                'min': amountLimits['min'] * priceLimits['min'],
+                'min': minimumCost,
                 'max': undefined,
             };
             let limits = {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -150,7 +150,7 @@ module.exports = class gateio extends Exchange {
                 'ETH': 0.001,
                 'BTC': 0.0001,
             }[quote];
-            if (minimumCost === undefined) {
+            if (typeof minimumCost === 'undefined') {
                 minimumCost = amountLimits['min'] * priceLimits['min'];
             }
             let costLimits = {


### PR DESCRIPTION
gate.io returns a minimum amount via the API, and ccxt uses that + a minim-based derived from the decimal places to set the minimum cost. However, the gate.io API says:

```
ccxt.base.errors.ExchangeError: gateio {"result":"false","message":"Your order size is too small. The minimum is 1 USDT","code":20}
```

It does so when I want to sell 2 XLM on XLM/USDT.  2 XLM is much more than the minimum amount given via the API (0.0001), but clearly not enough. It seems there is a hidden "cost"-based limit from the API that we do not yet know.

I used trial an error here to figure those out.