### PR TITLE
gatecoin: (minor) added proper exception for order already cancelled

### DIFF
--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -200,7 +200,8 @@ module.exports = class gatecoin extends Exchange {
                 '1005': InsufficientFunds,
                 '1008': OrderNotFound,
                 '1057': InvalidOrder,
-                '1044': OrderNotFound, // already canceled
+                '1044': OrderNotFound, // already canceled,
+                '1054': OrderNotFound, // already executed
             },
         });
     }


### PR DESCRIPTION
gatecoin.js is already throwing OrderNotFound for cases where the order was actually existing at some point, so technically it is not "order not found". However this seems like a proper exception to throw along with the case with already canceled order and such.