### PR TITLE
bitstamp: Submit order with correct precision.

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -379,12 +379,12 @@ module.exports = class bitstamp extends Exchange {
         let method = 'privatePost' + this.capitalize (side);
         let order = {
             'pair': this.marketId (symbol),
-            'amount': amount,
+            'amount': this.amountToPrecision(symbol, amount),
         };
         if (type === 'market')
             method += 'Market';
         else
-            order['price'] = price;
+            order['price'] = this.priceToPrecision(symbol, price);
         method += 'Pair';
         let response = await this[method] (this.extend (order, params));
         return {

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -379,12 +379,12 @@ module.exports = class bitstamp extends Exchange {
         let method = 'privatePost' + this.capitalize (side);
         let order = {
             'pair': this.marketId (symbol),
-            'amount': this.amountToPrecision(symbol, amount),
+            'amount': this.amountToPrecision (symbol, amount),
         };
         if (type === 'market')
             method += 'Market';
         else
-            order['price'] = this.priceToPrecision(symbol, price);
+            order['price'] = this.priceToPrecision (symbol, price);
         method += 'Pair';
         let response = await this[method] (this.extend (order, params));
         return {


### PR DESCRIPTION
I received from bitstamp:
```
ccxt.base.errors.ExchangeError: bitstamp {"status":"error","reason":{"amount":["Ensure that there are no more than 8 decimal places."],"__all__":[""]}}
```

I noticed that many other exchanges call these conversion helpers on the user provided input data, which makes sense, so I added it here as well.