### PR TITLE
fix `fetchMyTrades` on bibox

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -536,7 +536,7 @@ module.exports = class bibox extends Exchange {
         let market = this.market (symbol);
         let size = (limit) ? limit : 200;
         let response = await this.privatePostOrderpending ({
-            'cmd': 'orderpending/orderHistoryList',
+            'cmd': 'orderpending/pendingHistoryList',
             'body': this.extend ({
                 'pair': market['id'],
                 'account_type': 0, // 0 - regular, 1 - margin


### PR DESCRIPTION
@kroitor sorry this didn't make it onto the previous PR---but this is also related to #3073.

I mentioned in that issue the unhandled exception on bibox:
```python
>>> bibox.fetch_my_trades("TRX/ETH")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/benjamindiamond/Documents/Chess/ccxt/python/ccxt/bibox.py", line 530, in fetch_my_trades
    return self.parse_orders(trades, market, since, limit)
  File "/Users/benjamindiamond/Documents/Chess/ccxt/python/ccxt/base/exchange.py", line 1192, in parse_orders
    array = [self.parse_order(order, market) for order in array]
  File "/Users/benjamindiamond/Documents/Chess/ccxt/python/ccxt/base/exchange.py", line 1192, in <listcomp>
    array = [self.parse_order(order, market) for order in array]
  File "/Users/benjamindiamond/Documents/Chess/ccxt/python/ccxt/bibox.py", line 457, in parse_order
    'cost': cost if cost else float(price) * filled,
TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'
```
the reason this happens is that the results of the API call `orderpending/orderHistoryList` do _not_ contain the field `deal_amount` needed to populate `filled`, in
https://github.com/ccxt/ccxt/blob/ee07e24b8c1b667f79331d7052466ad04232ac7e/js/bibox.js#L445-L470
I believe the correct API call here is `orderpending/pendingHistoryList`; at least, it appears to produce what we want.

You're right that the [documentation](https://github.com/Biboxcom/api_reference/wiki/home_en) for bibox is poor and vague--it's not clear what the difference between "pending" and "history" is (you mentioned this already). in any case, I think this might at least be an improvement from the current state, where this method is essentially certain to fail (`orderHistoryList` results _never_ contain `deal_amount`). Let me know your thoughts, and again thanks for your work!