### PR TITLE
bibox: missing base/quote in order

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -455,8 +455,8 @@ module.exports = class bibox extends Exchange {
         let symbol = undefined;
         if (typeof market === 'undefined') {
             let marketId = undefined;
-            let baseId = this.safeString (trade, 'coin_symbol');
-            let quoteId = this.safeString (trade, 'currency_symbol');
+            let baseId = this.safeString (order, 'coin_symbol');
+            let quoteId = this.safeString (order, 'currency_symbol');
             if ((typeof baseId !== 'undefined') && (typeof quoteId !== 'undefined'))
                 marketId = baseId + '_' + quoteId;
             if (marketId in this.markets_by_id)

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -465,7 +465,6 @@ module.exports = class bibox extends Exchange {
         if (typeof market !== 'undefined') {
             symbol = market['symbol'];
         }
-
         let type = (order['order_type'] === 1) ? 'market' : 'limit';
         let timestamp = order['createdAt'];
         let price = this.safeFloat (order, 'price');

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -454,11 +454,11 @@ module.exports = class bibox extends Exchange {
     parseOrder (order, market = undefined) {
         let symbol = undefined;
         if (typeof market === 'undefined') {
+            let marketId = undefined;
             let baseId = this.safeString (trade, 'coin_symbol');
             let quoteId = this.safeString (trade, 'currency_symbol');
             if ((typeof baseId !== 'undefined') && (typeof quoteId !== 'undefined'))
                 marketId = baseId + '_' + quoteId;
-            }
             if (marketId in this.markets_by_id)
                 market = this.markets_by_id[marketId];
         }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -453,11 +453,19 @@ module.exports = class bibox extends Exchange {
 
     parseOrder (order, market = undefined) {
         let symbol = undefined;
-        if (market) {
-            symbol = market['symbol'];
-        } else {
-            symbol = order['coin_symbol'] + '/' + order['currency_symbol'];
+        if (typeof market === 'undefined') {
+            let baseId = this.safeString (trade, 'coin_symbol');
+            let quoteId = this.safeString (trade, 'currency_symbol');
+            if ((typeof baseId !== 'undefined') && (typeof quoteId !== 'undefined'))
+                marketId = baseId + '_' + quoteId;
+            }
+            if (marketId in this.markets_by_id)
+                market = this.markets_by_id[marketId];
         }
+        if (typeof market !== 'undefined') {
+            symbol = market['symbol'];
+        }
+
         let type = (order['order_type'] === 1) ? 'market' : 'limit';
         let timestamp = order['createdAt'];
         let price = this.safeFloat (order, 'price');


### PR DESCRIPTION
Bibox occasionally fails to include `coin_symbol` and `currency_symbol` in the results of `orderpending/order` (i.e., `fetchOrder`). This led to unhandled `KeyError`s in e.g. `bibox.fetchOrder`. This should now yield a null value for `symbol` instead.