### PR TITLE
NullResponse on bibox

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2566,11 +2566,17 @@ Below is an outline of exception inheritance hierarchy:
     |
     +---+ ExchangeError
     |   |
-    |   +---+ NotSupported
-    |   |
     |   +---+ AuthenticationError
     |   |   |
     |   |   +---+ PermissionDenied
+    |   |   |
+    |   |   +---+ AccountSuspended
+    |   |
+    |   +---+ BadResponse
+    |   |   |
+    |   |   +---+ NullResponse
+    |   |
+    |   +---+ NotSupported
     |   |
     |   +---+ InsufficientFunds
     |   |
@@ -2605,8 +2611,10 @@ This exception is thrown when an exchange server replies with an error in JSON. 
 
 Other exceptions derived from ``ExchangeError``:
 
--  ``NotSupported``: This exception is raised if the endpoint is not offered/not supported by the exchange API.
 -  ``AuthenticationError``: Raised when an exchange requires one of the API credentials that you've missed to specify, or when there's a mistake in the keypair or an outdated nonce. Most of the time you need ``apiKey`` and ``secret``, sometimes you also need ``uid`` and/or ``password``.
+-  ``BadResponse``: Raised when an exchange returns a badly formed or incorrect response to a query.
+-  ``NullResponse``: Raised when an exchange returns an empty response to a query.
+-  ``NotSupported``: This exception is raised if the endpoint is not offered/not supported by the exchange API.
 -  ``PermissionDenied``: Raised when there's no access for specified action or insufficient permissions on the specified ``apiKey``.
 -  ``InsufficientFunds``: This exception is raised when you don't have enough currency on your account balance to place an order.
 -  ``InvalidAddress``: This exception is raised upon encountering a bad funding address or a funding address shorter than ``.minFundingAddressLength`` (10 characters by default) in a call to ``fetchDepositAddress``, ``createDepositAddress`` or ``withdraw``.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2612,10 +2612,11 @@ This exception is thrown when an exchange server replies with an error in JSON. 
 Other exceptions derived from ``ExchangeError``:
 
 -  ``AuthenticationError``: Raised when an exchange requires one of the API credentials that you've missed to specify, or when there's a mistake in the keypair or an outdated nonce. Most of the time you need ``apiKey`` and ``secret``, sometimes you also need ``uid`` and/or ``password``.
+-  ``PermissionDenied``: Raised when there's no access for specified action or insufficient permissions on the specified ``apiKey``.
+-  ``AccountSuspended``: This exception provides additional error handling for frozen accounts.
 -  ``BadResponse``: Raised when an exchange returns a badly formed or incorrect response to a query.
 -  ``NullResponse``: Raised when an exchange returns an empty response to a query.
 -  ``NotSupported``: This exception is raised if the endpoint is not offered/not supported by the exchange API.
--  ``PermissionDenied``: Raised when there's no access for specified action or insufficient permissions on the specified ``apiKey``.
 -  ``InsufficientFunds``: This exception is raised when you don't have enough currency on your account balance to place an order.
 -  ``InvalidAddress``: This exception is raised upon encountering a bad funding address or a funding address shorter than ``.minFundingAddressLength`` (10 characters by default) in a call to ``fetchDepositAddress``, ``createDepositAddress`` or ``withdraw``.
 -  ``InvalidOrder``: This exception is the base class for all exceptions related to the unified order API.

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, AuthenticationError, DDoSProtection, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied, InsufficientFunds, NullResponse } = require ('./base/errors');
+const { ExchangeError, AuthenticationError, DDoSProtection, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied, InsufficientFunds } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -453,7 +453,7 @@ module.exports = class bibox extends Exchange {
 
     parseOrder (order, market = undefined) {
         if (!('order_type' in order) || !('order_side' in order) || !('createdAt' in order))
-            throw new NullResponse (this.id + ' returned an empty response to query on order ' + order);
+            throw new OrderNotFound ('Order ' + order + ' does not exist on ' + self.id + '.');
         let symbol = undefined;
         if (typeof market === 'undefined') {
             let marketId = undefined;

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -452,9 +452,7 @@ module.exports = class bibox extends Exchange {
     }
 
     parseOrder (order, market = undefined) {
-        if (!('order_type' in order) ||
-            !('order_side' in order) ||
-            !('createdAt' in order))
+        if (!('order_type' in order) || !('order_side' in order) || !('createdAt' in order))
             throw new NullResponse (this.id + ' returned an empty response to query on order ' + order);
         let symbol = undefined;
         if (typeof market === 'undefined') {

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, AuthenticationError, DDoSProtection, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied, InsufficientFunds, BadResponse } = require ('./base/errors');
+const { ExchangeError, AuthenticationError, DDoSProtection, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied, InsufficientFunds, NullResponse } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -455,7 +455,7 @@ module.exports = class bibox extends Exchange {
         if (!('order_type' in order) ||
             !('order_side' in order) ||
             !('createdAt' in order))
-            throw new BadResponse (this.id + ' returned an empty response to query on order ' + order);
+            throw new NullResponse (this.id + ' returned an empty response to query on order ' + order);
         let symbol = undefined;
         if (typeof market === 'undefined') {
             let marketId = undefined;

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -452,7 +452,9 @@ module.exports = class bibox extends Exchange {
     }
 
     parseOrder (order, market = undefined) {
-        if (Object.keys (order).length < 1) {
+        let keys = Object.keys (order);
+        let numKeys = keys.length;
+        if (numKeys < 1) {
             throw new OrderNotFound ('Order ' + order + ' does not exist on ' + this.id + '.');
         }
         let symbol = undefined;

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -452,6 +452,10 @@ module.exports = class bibox extends Exchange {
     }
 
     parseOrder (order, market = undefined) {
+        if (!('order_type' in order) ||
+            !('order_side' in order) ||
+            !('createdAt' in order))
+            throw new BadResponse (this.id + ' returned an empty response to query on order ' + order);
         let symbol = undefined;
         if (typeof market === 'undefined') {
             let marketId = undefined;

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, AuthenticationError, DDoSProtection, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied, InsufficientFunds } = require ('./base/errors');
+const { ExchangeError, AuthenticationError, DDoSProtection, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied, InsufficientFunds, BadResponse } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -452,8 +452,9 @@ module.exports = class bibox extends Exchange {
     }
 
     parseOrder (order, market = undefined) {
-        if (!('order_type' in order) || !('order_side' in order) || !('createdAt' in order))
-            throw new OrderNotFound ('Order ' + order + ' does not exist on ' + self.id + '.');
+        if (Object.keys (order).length < 1) {
+            throw new OrderNotFound ('Order ' + order + ' does not exist on ' + this.id + '.');
+        }
         let symbol = undefined;
         if (typeof market === 'undefined') {
             let marketId = undefined;


### PR DESCRIPTION
**EDITED**

Bibox fails to check for / raise `OrderNotFound` in `fetchOrder`, and instead throws a `KeyError`. Working on this

I've also added a few missing errors to the docs.