### PR TITLE
set Bibox min lot size to 0.0001

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -132,7 +132,7 @@ module.exports = class bibox extends Exchange {
                 'precision': precision,
                 'limits': {
                     'amount': {
-                        'min': Math.pow (10, -precision['amount']),
+                        'min': Math.pow (10, -4),
                         'max': undefined,
                     },
                     'price': {


### PR DESCRIPTION
the increment is 1e-8 but min lot size is 1e-4 -- for the several currencies I tired, I get back:
{"error":{"code":"2068","msg":"下单数量不能低于0.0001"},"cmd":"orderpending/trade"}
(which translates to "Order quantity cannot be less than 0.0001")