### PR TITLE
BIBOX -- change precision for amount to 4 from 8

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -116,7 +116,7 @@ module.exports = class bibox extends Exchange {
             let symbol = base + '/' + quote;
             let id = base + '_' + quote;
             let precision = {
-                'amount': 8,
+                'amount': 4,
                 'price': 8,
             };
             result.push ({


### PR DESCRIPTION
the increment and min lot size is 1e-4 -- for the several currencies I tired (AT/BTC, BIX/BTC, GTC/BTC, LEND/BTC,
MT/BIX, HPB/BIX,  GTC/ETH, BTC/USDT, ETH/DAI, I get back:
{"error":{"code":"2068","msg":"下单数量不能低于0.0001"},"cmd":"orderpending/trade"}
(which translates to "Order quantity cannot be less than 0.0001")
if order quantity is eg 0.00011, no error is returned, but amount is silently changed to 0.0001.
The UI does not allow entering numbers that are not an integer multiple of 0.0001 for any of the above tested pairs.