### PR TITLE
BITFINEX change price precision to 8

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -329,7 +329,7 @@ module.exports = class bitfinex extends Exchange {
             let quote = this.commonCurrencyCode (quoteId);
             let symbol = base + '/' + quote;
             let precision = {
-                'price': market['price_precision'],
+                'price': 8,
                 'amount': market['price_precision'],
             };
             let limits = {


### PR DESCRIPTION
current code uses 'price_precision' returned by the exchange. However, as Biftinex explains here
https://support.bitfinex.com/hc/en-us/articles/115000371105-How-is-precision-calculated-using-Significant-Digits
when they return 5 (for all markets) they mean 5 significant figures, eg `0.00012340` is still '5'.
Looking at low-priced markets like 
https://www.bitfinex.com/t/TNB:BTC
https://www.bitfinex.com/t/FUN:BTC
we see that both order book and trading history have only precision of 8, with trailing zeroes in some displays.
Otoh, a market like
https://www.bitfinex.com/t/BTC:USD
has precision of only 1 decimal, eg 6,497.2
and https://www.bitfinex.com/t/BTC:JPY is in 10 JPY increments.

For now, I propose to update price precision to 8.
A better solution would be to query all prices and calculate each precision based on price