### PR TITLE
LIVECOIN: parse_order error

### DIFF
--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -452,7 +452,7 @@ module.exports = class livecoin extends Exchange {
         }
         const feeRate = this.safeFloat (order, 'commission_rate');
         let feeCost = undefined;
-        if (typeof cost !== 'undefined') {
+        if (typeof cost !== 'undefined' && typeof feeRate !== 'undefined') {
             feeCost = cost * feeRate;
         }
         let feeCurrency = undefined;


### PR DESCRIPTION
in Python, `None * float` is a type error, so better to check both args before multiplying.
Encountered an error when feeRate was None.