### PR TITLE
Livecoin: support 'CANCELLED' order status

### DIFF
--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -393,6 +393,7 @@ module.exports = class livecoin extends Exchange {
             'OPEN': 'open',
             'PARTIALLY_FILLED': 'open',
             'EXECUTED': 'closed',
+            'CANCELLED': 'canceled',
             'PARTIALLY_FILLED_AND_CANCELLED': 'canceled',
         };
         if (status in statuses)


### PR DESCRIPTION
Current implementation maps
`'PARTIALLY_FILLED_AND_CANCELLED': 'canceled',`
but reports  `'CANCELLED'` as is.
Added a mapping
`'CANCELLED': 'canceled',`