### PR TITLE
Cryptopia: response does not have timestamp

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -502,11 +502,10 @@ module.exports = class cryptopia extends Exchange {
                 }
             }
         }
-        let timestamp = this.milliseconds ();
         let order = {
             'id': id,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'lastTradeTimestamp': undefined,
             'status': status,
             'symbol': symbol,


### PR DESCRIPTION
the timestamp is being added by the code. I think the policy is to only report what the exchange reports.