### PR TITLE
Cryptopia: handle_errors fix

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -758,7 +758,8 @@ module.exports = class cryptopia extends Exchange {
             let response = JSON.parse (fixedJSONString);
             if ('Success' in response) {
                 const success = this.safeString (response, 'Success');
-                if (success === 'false') {
+                const lowercaseSuccess = success.toLowerCase ();
+                if (lowercaseSuccess === 'false') {
                     let error = this.safeString (response, 'Error');
                     let feedback = this.id;
                     if (typeof error === 'string') {

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -757,26 +757,27 @@ module.exports = class cryptopia extends Exchange {
         if (fixedJSONString[0] === '{') {
             let response = JSON.parse (fixedJSONString);
             if ('Success' in response) {
-                const success = this.safeString (response, 'Success');
-                const lowercaseSuccess = success.toLowerCase ();
-                if (lowercaseSuccess === 'false') {
-                    let error = this.safeString (response, 'Error');
-                    let feedback = this.id;
-                    if (typeof error === 'string') {
-                        feedback = feedback + ' ' + error;
-                        if (error.indexOf ('does not exist') >= 0) {
-                            throw new OrderNotFound (feedback);
+                const success = this.safeValue (response, 'Success');
+                if (typeof success !== 'undefined') {
+                    if (!success) {
+                        let error = this.safeString (response, 'Error');
+                        let feedback = this.id;
+                        if (typeof error === 'string') {
+                            feedback = feedback + ' ' + error;
+                            if (error.indexOf ('does not exist') >= 0) {
+                                throw new OrderNotFound (feedback);
+                            }
+                            if (error.indexOf ('Insufficient Funds') >= 0) {
+                                throw new InsufficientFunds (feedback);
+                            }
+                            if (error.indexOf ('Nonce has already been used') >= 0) {
+                                throw new InvalidNonce (feedback);
+                            }
+                        } else {
+                            feedback = feedback + ' ' + fixedJSONString;
                         }
-                        if (error.indexOf ('Insufficient Funds') >= 0) {
-                            throw new InsufficientFunds (feedback);
-                        }
-                        if (error.indexOf ('Nonce has already been used') >= 0) {
-                            throw new InvalidNonce (feedback);
-                        }
-                    } else {
-                        feedback = feedback + ' ' + fixedJSONString;
+                        throw new ExchangeError (feedback);
                     }
-                    throw new ExchangeError (feedback);
                 }
             }
         }


### PR DESCRIPTION
In Python, `False` is spelled with a capital F. So a cryptopia error is like:
`{'Success': False, 'Error': 'ERROR: Insufficient Funds.', 'Data': None}`
`self.safe_string(response, 'Success')` then is `'False'` which should get lowercased before comparing to 'false'.

Proposed fix is to lowercase in all languages before checking equality.