### PR TITLE
bibox: pending --> open

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -518,7 +518,7 @@ module.exports = class bibox extends Exchange {
     parseOrderStatus (status) {
         let statuses = {
             // original comments from bibox:
-            '1': 'pending', // pending
+            '1': 'open', // pending
             '2': 'open', // part completed
             '3': 'closed', // completed
             '4': 'canceled', // part canceled


### PR DESCRIPTION
as per [Order Structure](https://github.com/ccxt/ccxt/wiki/Manual#order-structure), the status of an order should be one of:
- 'open'
- 'closed'
- 'canceled'

I'm not sure what `'pending'` means in Bibox, but perhaps we should change it to `'open'`.