### PR TITLE
Fix: Fix fucking ssl-certificate error for huobipro

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -18,7 +18,7 @@ module.exports = class huobipro extends Exchange {
             'version': 'v1',
             'accounts': undefined,
             'accountsById': undefined,
-            'hostname': 'api.huobipro.com',
+            'hostname': 'api.huobi.pro',
             'has': {
                 'CORS': false,
                 'fetchDepositAddress': true,
@@ -44,11 +44,11 @@ module.exports = class huobipro extends Exchange {
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/27766569-15aa7b9a-5edd-11e7-9e7f-44791f4ee49c.jpg',
-                'api': 'https://api.huobipro.com',
-                'www': 'https://www.huobipro.com',
+                'api': 'https://api.huobi.pro',
+                'www': 'https://www.huobi.pro',
                 'referral': 'https://www.huobi.br.com/en-us/topic/invited/?invite_code=rwrd3',
                 'doc': 'https://github.com/huobiapi/API_Docs/wiki/REST_api_reference',
-                'fees': 'https://www.huobipro.com/about/fee/',
+                'fees': 'https://www.huobi.pro/about/fee/',
             },
             'api': {
                 'market': {


### PR DESCRIPTION
Hi,
Nice to see you again, I'm here for a PR again : )

"huobi" makes a fucking change on its domain name, the ssl certificate for "www.huobipro.com" doesn't work.

Now only the domain name "huobi.pro" works well, so I have made a change on it.

If this PR works well, please issue a new release on `PYPI`.

More details about the issue:

Output of curl.
```bash
➜  ccxt git:(master) curl https://www.huobipro.com
curl: (51) SSL: certificate subject name (*.gridserver.com) does not match target host name 'www.huobipro.com'
```
