### PR TITLE
huobi: market-order min error handling

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -113,6 +113,7 @@ module.exports = class huobipro extends Exchange {
             'exceptions': {
                 'account-frozen-balance-insufficient-error': InsufficientFunds, // {"status":"error","err-code":"account-frozen-balance-insufficient-error","err-msg":"trade account balance is not enough, left: `0.0027`","data":null}
                 'order-limitorder-amount-min-error': InvalidOrder, // limit order amount error, min: `0.001`
+                'order-marketorder-amount-min-error': InvalidOrder, // market order amount error, min: `0.01`
                 'order-orderstate-error': OrderNotFound, // canceling an already canceled order
                 'order-queryorder-invalid': OrderNotFound, // querying a non-existent order
                 'order-update-error': ExchangeNotAvailable, // undocumented error


### PR DESCRIPTION
Properly raises an `InvalidOrder` exception if a too-small market order is submitted in Huobi. previously, this raised an `ExchangeError`.