### PR TITLE
Use fetch-ponyfill always when fetch is unavailable

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -39,7 +39,7 @@ const {
 
 const { DECIMAL_PLACES } = functions.precisionConstants
 
-const defaultFetch = isNode ? require ('fetch-ponyfill') ().fetch : fetch
+const defaultFetch = typeof (fetch) === "undefined" ? require ('fetch-ponyfill') ().fetch : fetch
 
 const journal = undefined // isNode && require ('./journal') // stub until we get a better solution for Webpack and React
 


### PR DESCRIPTION
Original code had 2 issues

1) When use [jest](https://facebook.github.io/jest/), tests fail with
```
 ReferenceError: fetch is not defined
```
error.

2) As per https://github.com/qubyte/fetch-ponyfill the package is *primarily* intended for use in  browser (and delegates to `node-fetch` when ran in Node). It was confusing to use such package only in Node.

The proposed fix checks if fetch is defined and falls back to  `fetch-ponyfill` regardless the environment. This code arguably makes more sense and definitely fixes `jest` issues.

I tested this code
* `npm run build` passes
* `node run-tests --js` does not report errors
* My `jest` tests pass

In latest Chrome 
```
exchange.fetchImplementation === window.fetch
true
```

### Note
I also considered using ``fetch-ponyfill` unconditionally. That would yield to
```
exchange.fetchImplementation === window.fetch
false
```
