### PR TITLE
huobi: min price error

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -114,6 +114,7 @@ module.exports = class huobipro extends Exchange {
                 'account-frozen-balance-insufficient-error': InsufficientFunds, // {"status":"error","err-code":"account-frozen-balance-insufficient-error","err-msg":"trade account balance is not enough, left: `0.0027`","data":null}
                 'order-limitorder-amount-min-error': InvalidOrder, // limit order amount error, min: `0.001`
                 'order-marketorder-amount-min-error': InvalidOrder, // market order amount error, min: `0.01`
+                'order-limitorder-price-min-error': InvalidOrder, // limit order price order
                 'order-orderstate-error': OrderNotFound, // canceling an already canceled order
                 'order-queryorder-invalid': OrderNotFound, // querying a non-existent order
                 'order-update-error': ExchangeNotAvailable, // undocumented error

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -114,7 +114,7 @@ module.exports = class huobipro extends Exchange {
                 'account-frozen-balance-insufficient-error': InsufficientFunds, // {"status":"error","err-code":"account-frozen-balance-insufficient-error","err-msg":"trade account balance is not enough, left: `0.0027`","data":null}
                 'order-limitorder-amount-min-error': InvalidOrder, // limit order amount error, min: `0.001`
                 'order-marketorder-amount-min-error': InvalidOrder, // market order amount error, min: `0.01`
-                'order-limitorder-price-min-error': InvalidOrder, // limit order price order
+                'order-limitorder-price-min-error': InvalidOrder, // limit order price error
                 'order-orderstate-error': OrderNotFound, // canceling an already canceled order
                 'order-queryorder-invalid': OrderNotFound, // querying a non-existent order
                 'order-update-error': ExchangeNotAvailable, // undocumented error


### PR DESCRIPTION
the following should raise an `InvalidOrder`, not an `ExchangeError`:
```python
>>> huobipro.create_limit_sell_order("WAX/ETH", 1.0, 0.000229)
ccxt.base.errors.ExchangeError: huobipro {"status":"error","err-code":"order-limitorder-price-min-error","err-msg":"limit order price error, min: `0.000229`","data":null}
```
this min price is specific to the pair `WAX/ETH`, so i didn't leave an exact minimum in the comment.