### PR TITLE
Fix gateio order id in parseTrade

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -326,6 +326,8 @@ module.exports = class gateio extends Exchange {
         let id = this.safeString (trade, 'tradeID');
         id = this.safeString (trade, 'id', id);
         let orderId = this.safeString (trade, 'orderid');
+        if (typeof orderId !== 'undefined')
+            orderId = this.safeString (trade, 'orderNumber');
         let price = this.safeFloat (trade, 'rate');
         let amount = this.safeFloat (trade, 'amount');
         let cost = undefined;


### PR DESCRIPTION
This is an example of a response received from gateio when calling `fetchMyTrades`:

```
{'amount': 21.631,
  'cost': 201.1401797,
  'datetime': '2018-06-22T10:10:58.000Z',
  'fee': None,
  'id': '69662608',
  'info': {'amount': '21.631',
   'date': '2018-06-22 18:10:58',
   'orderNumber': 921212192,
   'pair': 'eos_usdt',
   'rate': '9.2987',
   'time_unix': 1529662258,
   'total': 201.1401797,
   'tradeID': 69662608,
   'type': 'sell'},
  'order': None,
  'price': 9.2987,
  'side': 'sell',
  'symbol': 'EOS/USDT',
  'timestamp': 1529662258000,
  'type': None}
```

Note that the field is called `orderNumber`. Currently, the code is checking `orderid`. Since @kroitor only made this change 3 days ago, I am assuming that there is an inconsistency here, and different API responses return different fields. I have thus chosen to leave the existing code and read both fields.