### PR TITLE
bitfinex2: Do not return null in balance response.

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -246,7 +246,7 @@ module.exports = class bitfinex2 extends bitfinex {
                         account['free'] = 0;
                         account['used'] = total;
                     } else {
-                        account['free'] = undefined;
+                        account['free'] = total;
                     }
                 } else {
                     account['free'] = available;


### PR DESCRIPTION
Out of half a dozen exchanges I experimented with, `bitfinex` is the only one where I cannot use the `free` balances, because they are `null`.

The balance response from bitfinex:

```
{'BTC': {'free': None, 'total': 0.0028705, 'used': 0.0},
 'ETH': {'free': None, 'total': 3.269e-05, 'used': 0.0},
 'IOT': {'free': None, 'total': 16.32420707, 'used': 0.0},
 'free': {'BTC': None, 'ETH': None, 'IOT': None},
 'info': [['exchange', 'BTC', 0.0028705, 0, None],
  ['exchange', 'ETH', 3.269e-05, 0, None],
  ['exchange', 'IOT', 16.32420707, 0, None]],
 'total': {'BTC': 0.0028705, 'ETH': 3.269e-05, 'IOT': 16.32420707},
 'used': {'BTC': 0.0, 'ETH': 0.0, 'IOT': 0.0}}
```
 
I do not have any open orders on bitfinex. There is no reason why those balances should not be free. The bitfinex docs say `null` may be returned if the value is "not fresh enough". In my case, as best as I can tell, this simply means that I may not have traded for a long time?

In any case, ccxt already sets `used` to `0`, and it makes sense to my to see free to the full amount in that case; this is certainly what is true in my case.