### PR TITLE
definition of cost, esp. on bittrex

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2052,11 +2052,7 @@ Most of methods returning orders within ccxt unified API will usually yield an o
 -  The ``lastTradeTimestamp`` timestamp may have no value and may be ``undefined/None/null`` where not supported by the exchange or in case of an open order (an order that has not been filled nor partially filled yet).
 -  The ``lastTradeTimestamp``, if any, designates the timestamp of the last trade, in case the order is filled fully or partially, otherwise ``lastTradeTimestamp`` is ``undefined/None/null``.
 -  Order ``status`` prevails or has precedence over the ``lastTradeTimestamp``.
--  The ``cost`` of an order is:
-
-   -  ``if (status === 'open' and filled === 0) { amount * price }``
-   -  ``if (status === 'closed' || status === 'canceled') { filled * price }``
-
+-  The ``cost`` of an order is: ``{ filled * price }``
 -  The ``cost`` of an order means the total *quote* volume of the order (whereas the ``amount`` is the *base* volume). The value of ``cost`` should be as close to the actual most recent known order cost as possible. The ``cost`` field itself is there mostly for convenience and can be deduced from other fields.
 
 Placing Orders

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -583,8 +583,8 @@ module.exports = class bittrex extends Exchange {
             filled = amount - remaining;
         }
         if (!cost) {
-            if (price && amount)
-                cost = price * amount;
+            if (price && filled)
+                cost = price * filled;
         }
         if (!price) {
             if (cost && filled)


### PR DESCRIPTION
The stated definition of the `cost` of an order in the Manual is strange---it doesn't cover the case of a partially filled order (i.e., `status === 'open' and filled !== 0`) and also, it's not convenient to use different definitions of `cost` depending on whether the order is filled or not.

In fact, on many exchanges (e.g., bibox, huobipro, probably more) `cost` is simply always `filled * price`, even if the order is open and completely unfilled. I think this definition makes most sense.

Only on Bittrex was the calculation different. Thus I suggest we change the calculation on Bittrex to match the other exchanges and this simpler definition of `cost`.