### PR TITLE
Millisecond's leading zeros

### DIFF
--- a/js/test/base/functions/test.datetime.js
+++ b/js/test/base/functions/test.datetime.js
@@ -11,6 +11,7 @@ const exchange = new ccxt.Exchange ({
 
 assert (exchange.iso8601 (514862627000) === '1986-04-26T01:23:47.000Z');
 assert (exchange.iso8601 (514862627559) === '1986-04-26T01:23:47.559Z');
+assert (exchange.iso8601 (514862627062) === '1986-04-26T01:23:47.062Z');
 
 assert (exchange.iso8601 (0) === '1970-01-01T00:00:00.000Z');
 
@@ -25,6 +26,7 @@ assert (typeof exchange.iso8601 ({}) === 'undefined');
 
 assert (exchange.parse8601 ('1986-04-26T01:23:47.000Z') === 514862627000);
 assert (exchange.parse8601 ('1986-04-26T01:23:47.559Z') === 514862627559);
+assert (exchange.parse8601 ('1986-04-26T01:23:47.062Z') === 514862627062);
 
 assert (typeof exchange.parse8601 ('1977-13-13T00:00:00.000Z') === 'undefined');
 assert (typeof exchange.parse8601 ('1986-04-26T25:71:47.000Z') === 'undefined');


### PR DESCRIPTION
Python (both 2 and 3) `exchange.iso8601()` still fails in cases of timestamp having leading zeros in milliseconds. 

```
exchange.iso8601 (514862627062)
>>>'1986-04-26T01:23:47.620Z'
```

 (should be `'1986-04-26T01:23:47.062Z'` )