### PR TITLE
Fix #3250: the .iso8601() millisecond's leading zeros

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -680,7 +680,7 @@ class Exchange(object):
 
         try:
             utc = datetime.datetime.utcfromtimestamp(timestamp // 1000)
-            return utc.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-6] + "{:<03d}".format(int(timestamp) % 1000) + 'Z'
+            return utc.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-6] + "{:03d}".format(int(timestamp) % 1000) + 'Z'
         except (TypeError, OverflowError, OSError):
             return None
 


### PR DESCRIPTION
Fix the #3250. Tested the changes on both python 2 and 3.