### PR TITLE
huobi pro add "signature check failed" to errors

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ExchangeNotAvailable, InvalidOrder, OrderNotFound, InsufficientFunds } = require ('./base/errors');
+const { AuthenticationError, ExchangeError, ExchangeNotAvailable, InvalidOrder, OrderNotFound, InsufficientFunds } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -118,6 +118,7 @@ module.exports = class huobipro extends Exchange {
                 'order-orderstate-error': OrderNotFound, // canceling an already canceled order
                 'order-queryorder-invalid': OrderNotFound, // querying a non-existent order
                 'order-update-error': ExchangeNotAvailable, // undocumented error
+                'api-signature-check-failed': AuthenticationError,
             },
             'options': {
                 'createMarketBuyOrderRequiresPrice': true,


### PR DESCRIPTION
```python
>>> huobipro.fetch_balance()
  File "/usr/local/lib/python3.6/site-packages/ccxt/async/huobipro.py", line 461, in fetch_balance
    }, params))
  File "/usr/local/lib/python3.6/site-packages/ccxt/async/base/exchange.py", line 102, in fetch2
    return await self.fetch(request['url'], request['method'], request['headers'], request['body'])
  File "/usr/local/lib/python3.6/site-packages/ccxt/async/base/exchange.py", line 129, in fetch
    self.handle_errors(http_status_code, text, url, method, self.last_response_headers, text)
  File "/usr/local/lib/python3.6/site-packages/ccxt/async/huobipro.py", line 720, in handle_errors
    raise ExchangeError(feedback)
ccxt.base.errors.ExchangeError: huobipro {"status":"error","err-code":"api-signature-check-failed","err-msg":"Api Signature check failed (unknown).","data":null}
```
I'm honestly not sure what this error means, but perhaps it should be an `AuthenticationError`. In any case, it's worth it to include it in the `this.exceptions` list.