### PR TITLE
bittrex cancellation exception

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -145,7 +145,7 @@ module.exports = class bittrex extends Exchange {
                 'INSUFFICIENT_FUNDS': InsufficientFunds,
                 'QUANTITY_NOT_PROVIDED': InvalidOrder,
                 'MIN_TRADE_REQUIREMENT_NOT_MET': InvalidOrder,
-                'ORDER_NOT_OPEN': InvalidOrder,
+                'ORDER_NOT_OPEN': OrderNotFound,
                 'INVALID_ORDER': InvalidOrder,
                 'UUID_INVALID': OrderNotFound,
                 'RATE_NOT_PROVIDED': InvalidOrder, // createLimitBuyOrder ('ETH/BTC', 1, 0)


### PR DESCRIPTION
The Manual states that when an already-`closed` or -`canceled` order is canceled, `OrderNotFound` should be thrown (not `InvalidOrder`).