### PR TITLE
cex disabled XLM fetchDepositAddress

### DIFF
--- a/js/cex.js
+++ b/js/cex.js
@@ -528,9 +528,9 @@ module.exports = class cex extends Exchange {
     }
 
     async fetchDepositAddress (code, params = {}) {
-        if (code === 'XRP') {
+        if (code === 'XRP' || code === 'XLM') {
             // https://github.com/ccxt/ccxt/pull/2327#issuecomment-375204856
-            throw new NotSupported (this.id + ' fetchDepositAddress does not support XRP addresses yet (awaiting docs from CEX.io)');
+            throw new NotSupported (this.id + ' fetchDepositAddress does not support XRP and XLM addresses yet (awaiting docs from CEX.io)');
         }
         await this.loadMarkets ();
         let currency = this.currency (code);


### PR DESCRIPTION
XRP (Ripple) was disabled because the API didn't return the tag.
XLM (Stellar) is very similar to XRP and needs a tag (memo) too, which
is not returned by the cex.io API. Thus: disabling XLM too.