### PR TITLE
Fixes gemini argument mapping for fetchMyTrades

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -306,7 +306,9 @@ module.exports = class gemini extends Exchange {
             'symbol': market['id'],
         };
         if (typeof limit !== 'undefined')
-            request['limit'] = limit;
+            request['limit_trades'] = limit;
+        if (typeof since !== 'undefined')
+            request['timestamp'] = parseInt (since / 1000);
         let response = await this.privatePostMytrades (this.extend (request, params));
         return this.parseTrades (response, market, since, limit);
     }


### PR DESCRIPTION
* Fixes mapping the limit for Gemini for `fetchMyTrades` from `limit` to `limit_trades` (see [here](https://docs.gemini.com/rest-api/#get-past-trades) for formal API docs).
* Enables using the API to query based on timestamps (`timestamp`), to ensure paging beyond the `limit_trades` limit for any high volume users.