### PR TITLE
Copy commonCurrencies from bitfinex to bitfinex2.

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -155,6 +155,23 @@ module.exports = class bitfinex2 extends bitfinex {
                     },
                 },
             },
+            'commonCurrencies': {
+                'BCC': 'CST_BCC',
+                'BCU': 'CST_BCU',
+                'CTX': 'CTXC',
+                'DAT': 'DATA',
+                'DSH': 'DASH', // Bitfinex names Dash as DSH, instead of DASH
+                'IOS': 'IOST',
+                'IOT': 'IOTA',
+                'MNA': 'MANA',
+                'QSH': 'QASH',
+                'QTM': 'QTUM',
+                'SNG': 'SNGLS',
+                'SPK': 'SPANK',
+                'STJ': 'STORJ',
+                'YYW': 'YOYOW',
+                'USD': 'USDT',
+            },
         });
     }
 


### PR DESCRIPTION
I noticed that bitfinex2 calls `IOTA` `IOT`. I checked some of the other currencies, and they also seem to match what the v1 of the API uses.