### PR TITLE
Cobinhood order cost should respect filled amount

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -426,7 +426,9 @@ module.exports = class cobinhood extends Exchange {
             if (typeof filled !== 'undefined') {
                 remaining = amount - filled;
             }
-            if (typeof price !== 'undefined') {
+            if (typeof filled !== 'undefined' && typeof price !== 'undefined') {
+                cost = price * filled;
+            } else if (typeof price !== 'undefined') {
                 cost = price * amount;
             }
         }


### PR DESCRIPTION
Imagine this order:

```
{
    "id": "efdd2453-f415-46d6-92f1-13dbac888565",
    "datetime": "2018-06-23T12:39:30.152Z",
    "timestamp": 1529757570152,
    "lastTradeTimestamp": null,
    "status": "canceled",
    "symbol": "ETH/USDT",
    "type": "limit",
    "side": "sell",
    "price": 469.69,
    "cost": 92.91219704,
    "amount": 0.197816,
    "filled": 0.10610126,
    "remaining": 0.09171473999999999,
    "trades": null,
    "fee": null,
    "info": {
        "id": "efdd2453-f415-46d6-92f1-13dbac888565",
        "trading_pair_id": "ETH-USDT",
        "side": "ask",
        "type": "limit",
        "price": "469.65",
        "size": "0.197816",
        "filled": "0.10610126",
        "state": "cancelled",
        "timestamp": 1529757570152,
        "eq_price": "469.69",
        "completed_at": "2018-06-23T12:39:55.65166Z",
        "source": "exchange"
    }
}
```

Here, the cost calculated by ccxt is wrong, because the order is only half-filled.