### PR TITLE
Fix currency conversion in bitfinex2.fetchBalance

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -238,6 +238,8 @@ module.exports = class bitfinex2 extends bitfinex {
                     currency = currency.slice (1);
                     code = currency.toUpperCase ();
                     code = this.commonCurrencyCode (code);
+                } else {
+                    code = this.commonCurrencyCode (code);
                 }
                 let account = this.account ();
                 account['total'] = total;


### PR DESCRIPTION
A fetchBalance response might look like this:

```
{'info': [['exchange', 'BTC', 0.0028705, 0, None],
  ['exchange', 'ETH', 3.269e-05, 0, None],
  ['exchange', 'IOT', 163.32420707, 0, None]],
 'BTC': {'free': None, 'used': 0.0, 'total': 0.0028705},
 'ETH': {'free': None, 'used': 0.0, 'total': 3.269e-05},
 'IOTA': {'free': None, 'used': 0.0, 'total': 163.32420707},
 'free': {'BTC': None, 'ETH': None, 'IOTA': None},
 'used': {'BTC': 0.0, 'ETH': 0.0, 'IOTA': 0.0},
 'total': {'BTC': 0.0028705, 'ETH': 3.269e-05, 'IOTA': 163.32420707}}
```

As you can see, `IOT` is not properly converted to `IOTA`.  Note that the code as returned from bitfinex is `IOT`, and does not have a `t` prefix. `this.currencies_by_id` looks like this:

``` 
'IOTA': {'id': 'tIOT', 'code': 'IOTA'},
```

Here, the id is prefixed with a `t`. The code in fetchBalance also checks for a prefixed `t`.  Currently then, `commonCurrencyCode` is not called.