### PR TITLE
Add check for symbol on Bitfinex fetchMyTrades

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -614,6 +614,8 @@ module.exports = class bitfinex extends Exchange {
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        if (typeof symbol === 'undefined')
+            throw new ExchangeError (this.id + ' fetchMyTrades requires a symbol argument');
         await this.loadMarkets ();
         let market = this.market (symbol);
         let request = { 'symbol': market['id'] };


### PR DESCRIPTION
Other exchanges that require a symbol on the `fetchMyTrades` endpoint have a check (see binance.js for an example) for a passed in symbol.  Bitfinex currently just errors, so this check will make it more consistent with the other exchanges.