### PR TITLE
Change Bitfinex nonce from milli- to microseconds

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -836,7 +836,7 @@ module.exports = class bitfinex extends Exchange {
     }
 
     nonce () {
-        return this.milliseconds ();
+        return this.microseconds ();
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
Bitfinex can support larger microsecond-level nonces, but the default behavior is for "milliseconds" -- is there a reason to go with one default over another?  I couldn't find an explanation for that in the wiki.