### PR TITLE
Fix kucoin order status.

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -569,7 +569,12 @@ module.exports = class kucoin extends Exchange {
         }
         let timestamp = this.safeValue (order, 'createdAt');
         let remaining = this.safeFloat (order, 'pendingAmount');
-        let status = this.safeValue (order, 'status');
+        let status = undefined;
+        if (this.safeValue (order, 'isActive', true)) {
+            status = 'open';
+        } else {
+            status = 'closed';
+        }
         let filled = this.safeFloat (order, 'dealAmount');
         let amount = this.safeFloat (order, 'amount');
         let cost = this.safeFloat (order, 'dealValue');


### PR DESCRIPTION
When I query a kucoin order after creating it, this is the result:

```
{
    "info": {
        "coinType": "ETH",
        "dealValueTotal": 0,
        "feeTotal": 0,
        "userOid": "5a7ae81903d6440e9981c7b4",
        "dealAmount": 0,
        "coinTypePair": "USDT",
        "type": "BUY",
        "orderOid": "5b35c6579350c87d96523742",
        "createdAt": 1530250839000,
        "dealOrders": {
            "total": 0,
            "firstPage": true,
            "lastPage": false,
            "datas": [],
            "currPageNo": 1,
            "limit": 20,
            "pageNos": 1
        },
        "dealPriceAverage": 0,
        "orderPrice": 410.867406,
        "pendingAmount": 1.2393974
    },
    "id": "5b35c6579350c87d96523742",
    "timestamp": 1530250839000,
    "datetime": "2018-06-29T05:40:39.000Z",
    "lastTradeTimestamp": null,
    "symbol": "ETH/USDT",
    "type": "limit",
    "side": "buy",
    "price": 410.867406,
    "amount": 1.2393974,
    "cost": 509.22799474114447,
    "filled": 0,
    "remaining": 1.2393974,
    "status": "open",
    "fee": {
        "cost": 0,
        "rate": null,
        "currency": "ETH"
    },
    "trades": []
}
```

And this is the order status after canceling it:

```
{
    "info": {
        "coinType": "ETH",
        "dealValueTotal": 0,
        "feeTotal": 0,
        "userOid": "5a7ae81903d6440e9981c7b4",
        "dealAmount": 0,
        "coinTypePair": "USDT",
        "type": "BUY",
        "isActive": false,
        "orderOid": "5b35c6579350c87d96523742",
        "createdAt": 1530250839000,
        "dealOrders": {
            "total": 0,
            "firstPage": true,
            "lastPage": false,
            "datas": [],
            "currPageNo": 1,
            "limit": 20,
            "pageNos": 1
        },
        "dealPriceAverage": 0,
        "orderPrice": 410.867406,
        "pendingAmount": 1.2393974
    },
    "id": "5b35c6579350c87d96523742",
    "timestamp": 1530250839000,
    "datetime": "2018-06-29T05:40:39.000Z",
    "lastTradeTimestamp": null,
    "symbol": "ETH/USDT",
    "type": "limit",
    "side": "buy",
    "price": 410.867406,
    "amount": 1.2393974,
    "cost": 509.22799474114447,
    "filled": 0,
    "remaining": 1.2393974,
    "status": "open",
    "fee": {
        "cost": 0,
        "rate": null,
        "currency": "ETH"
    },
    "trades": []
}
```

Note that the `info` dict does not contain any `status` key. The first response contains no status information it seems. The second one has an `isActive=false` flag.

I changed the way we are reading the status then.