### PR TITLE
cobinhood: map "invalid_order_size" error

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -130,6 +130,7 @@ module.exports = class cobinhood extends Exchange {
             },
             'exceptions': {
                 'insufficient_balance': InsufficientFunds,
+                'invalid_order_size': InvalidOrder,
                 'invalid_nonce': InvalidNonce,
                 'unauthorized_scope': PermissionDenied,
             },


### PR DESCRIPTION
map errors like
```
ExchangeError('cobinhood {"success":false,"error":{"error_code":"invalid_order_size"},"request_id":"xxxxxxxx"}',)
```
to `InvalidOrder` instead