### PR TITLE
huobipro: map 'invalid-amount' to InvalidOrder

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -112,6 +112,7 @@ module.exports = class huobipro extends Exchange {
             },
             'exceptions': {
                 'account-frozen-balance-insufficient-error': InsufficientFunds, // {"status":"error","err-code":"account-frozen-balance-insufficient-error","err-msg":"trade account balance is not enough, left: `0.0027`","data":null}
+                'invalid-amount': InvalidOrder, // eg "Paramemter `amount` is invalid."
                 'order-limitorder-amount-min-error': InvalidOrder, // limit order amount error, min: `0.001`
                 'order-marketorder-amount-min-error': InvalidOrder, // market order amount error, min: `0.01`
                 'order-limitorder-price-min-error': InvalidOrder, // limit order price error


### PR DESCRIPTION
map error like
```
ExchangeError('huobipro {"status":"error","err-code":"invalid-amount","err-msg":"Paramemter `amount` is invalid.","data":null}',)
```
to `InvalidOrder`