### PR TITLE
yobit: better handle some InvalidOrder errors

### DIFF
--- a/js/yobit.js
+++ b/js/yobit.js
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 const liqui = require ('./liqui.js');
-const { ExchangeError, InsufficientFunds, DDoSProtection } = require ('./base/errors');
+const { ExchangeError, InsufficientFunds, InvalidOrder, DDoSProtection } = require ('./base/errors');
 
 // ---------------------------------------------------------------------------
 
@@ -240,6 +240,8 @@ module.exports = class yobit extends liqui {
                             throw new DDoSProtection (this.id + ' ' + this.json (response));
                         } else if ((response['error_log'] === 'not available') || (response['error_log'] === 'external service unavailable')) {
                             throw new DDoSProtection (this.id + ' ' + this.json (response));
+                        } else if (response['error_log'] === 'Total transaction amount') { // eg {"success":0,"error":"Total transaction amount is less than minimal total: 0.00010000"}'
+                            throw new InvalidOrder (this.id + ' ' + this.json (response));
                         }
                     }
                     throw new ExchangeError (this.id + ' ' + this.json (response));


### PR DESCRIPTION
For exception like
```
ExchangeError('yobit {"success":0,"error":"Total transaction amount is less than minimal total: 0.00010000"}',)
```
raise `InvalidOrder` instead