### PR TITLE
livecoin: map errors to InvalidOrder

### DIFF
--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -665,6 +665,10 @@ module.exports = class livecoin extends Exchange {
                 if (message.indexOf ('Cannot find order') >= 0) {
                     throw new OrderNotFound (this.id + ' ' + body);
                 }
+                const exception = this.safeString (response, 'exception', '');
+                if (exception.indexOf ('Minimal amount is') >= 0) {
+                    throw new InvalidOrder (this.id + ' ' + body);
+                }
                 throw new ExchangeError (this.id + ' ' + body);
             }
         }

--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -661,13 +661,17 @@ module.exports = class livecoin extends Exchange {
             // returns status code 200 even if success === false
             let success = this.safeValue (response, 'success', true);
             if (!success) {
-                const message = this.safeString (response, 'message', '');
-                if (message.indexOf ('Cannot find order') >= 0) {
-                    throw new OrderNotFound (this.id + ' ' + body);
+                const message = this.safeString (response, 'message');
+                if (typeof message !== 'undefined') {
+                    if (message.indexOf ('Cannot find order') >= 0) {
+                        throw new OrderNotFound (this.id + ' ' + body);
+                    }
                 }
-                const exception = this.safeString (response, 'exception', '');
-                if (exception.indexOf ('Minimal amount is') >= 0) {
-                    throw new InvalidOrder (this.id + ' ' + body);
+                const exception = this.safeString (response, 'exception');
+                if (typeof exception !== 'undefined') {
+                    if (exception.indexOf ('Minimal amount is') >= 0) {
+                        throw new InvalidOrder (this.id + ' ' + body);
+                    }
                 }
                 throw new ExchangeError (this.id + ' ' + body);
             }


### PR DESCRIPTION
map exception like
```
ExchangeError('livecoin {"success":false,"added":false,"orderId":null,"exception":"|Minimal amount is {PARAM:0} BTC|0.0001"}',)
```
to `InvalidOrder` instead