### PR TITLE
gateio: require symbol in cancelOrder

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -462,6 +462,8 @@ module.exports = class gateio extends Exchange {
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
+        if (typeof symbol === 'undefined')
+            throw new ExchangeError (this.id + ' cancelOrder requires symbol param');
         await this.loadMarkets ();
         return await this.privatePostCancelOrder ({
             'orderNumber': id,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -463,7 +463,7 @@ module.exports = class gateio extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         if (typeof symbol === 'undefined')
-            throw new ExchangeError (this.id + ' cancelOrder requires symbol param');
+            throw new ExchangeError (this.id + ' cancelOrder requires symbol argument');
         await this.loadMarkets ();
         return await this.privatePostCancelOrder ({
             'orderNumber': id,


### PR DESCRIPTION
`cancelOrder` does not work without symbol of the original order