### PR TITLE
gate.io: Include fee rate in order.

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -414,7 +414,8 @@ module.exports = class gateio extends Exchange {
             remaining = this.safeFloat (order, 'left');
         }
         let feeCost = this.safeFloat (order, 'feeValue');
-        let feeCurrency = this.safeString (order, 'feeCurrency');
+        let feeRate = this.safeString (order, 'feeCurrency');
+        let feePercentage = this.safeFloat (order, 'feePercentage');
         if (typeof feeCurrency !== 'undefined') {
             if (feeCurrency in this.currencies_by_id) {
                 feeCurrency = this.currencies_by_id[feeCurrency]['code'];
@@ -437,6 +438,7 @@ module.exports = class gateio extends Exchange {
             'fee': {
                 'cost': feeCost,
                 'currency': feeCurrency,
+                'rate': feeRate
             },
             'info': order,
         };

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -387,6 +387,24 @@ module.exports = class gateio extends Exchange {
     }
 
     parseOrder (order, market = undefined) {
+        //
+        //    {'amount': '0.00000000',
+        //     'currencyPair': 'xlm_usdt',
+        //     'fee': '0.0113766632239302 USDT',
+        //     'feeCurrency': 'USDT',
+        //     'feePercentage': 0.18,
+        //     'feeValue': '0.0113766632239302',
+        //     'filledAmount': '30.14004987',
+        //     'filledRate': 0.2097,
+        //     'initialAmount': '30.14004987',
+        //     'initialRate': '0.2097',
+        //     'left': 0,
+        //     'orderNumber': '998307286',
+        //     'rate': '0.2097',
+        //     'status': 'closed',
+        //     'timestamp': 1531158583,
+        //     'type': 'sell'},
+        //
         let id = this.safeString (order, 'orderNumber');
         let symbol = undefined;
         let marketId = this.safeString (order, 'currencyPair');


### PR DESCRIPTION
Example order:

```
{'id': '998307286', 'datetime': '2018-07-09T17:49:43.000Z', 'timestamp': 1531158583000, 'status': 'closed', 'symbol': 'XLM/USDT', 'type': 'limit', 'side': 'sell', 'price': 0.2097, 'cost': None, 'amount': 30.14004987, 'filled': 30.14004987, 'remaining': 0.0, 'trades': None, 'fee': {'cost': 0.0113766632239302, 'currency': 'USDT'}, 'info': {'orderNumber': '998307286', 'status': 'closed', 'currencyPair': 'xlm_usdt', 'type': 'sell', 'rate': '0.2097', 'left': 0, 'amount': '0.00000000', 'initialRate': '0.2097', 'initialAmount': '30.14004987', 'filledAmount': '30.14004987', 'filledRate': 0.2097, 'feePercentage': 0.18, 'feeValue': '0.0113766632239302', 'feeCurrency': 'USDT', 'fee': '0.0113766632239302 USDT', 'timestamp': 1531158583}}
```