### PR TITLE
Fix kraken price

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -672,8 +672,7 @@ module.exports = class kraken extends Exchange {
         let fee = undefined;
         let cost = this.safeFloat (order, 'cost');
         let price = this.safeFloat (description, 'price');
-        if (!price)
-            price = this.safeFloat (order, 'price');
+        price = this.safeFloat (order, 'price', price);
         if (typeof market !== 'undefined') {
             symbol = market['symbol'];
             if ('fee' in order) {


### PR DESCRIPTION
An example Kraken response:

```
{
    "info": {
        "id": "...",
        "refid": null,
        "userref": 0,
        "status": "closed",
        "reason": null,
        "opentm": 1531157935.0607,
        "closetm": 1531157935.1508,
        "starttm": 0,
        "expiretm": 0,
        "descr": {
            "pair": "EOSETH",
            "type": "buy",
            "ordertype": "limit",
            "price": "0.017323",
            "price2": "0",
            "leverage": "none",
            "order": "buy 24.99983099 EOSETH @ limit 0.017323",
            "close": ""
        },
        "vol": "24.99983099",
        "vol_exec": "24.99983099",
        "cost": "0.432247",
        "fee": "0.001123",
        "price": "0.017290",
        "stopprice": "0.00000000",
        "limitprice": "0.00000000",
        "misc": "",
        "oflags": "fciq",
        "trades": [
            "..."
        ]
    },
    "id": "...",
    "timestamp": 1531157935060,
    "datetime": "2018-07-09T17:38:55.060Z",
    "lastTradeTimestamp": null,
    "status": "closed",
    "symbol": "EOS/ETH",
    "type": "limit",
    "side": "buy",
    "price": 0.017323,
    "cost": 0.432247,
    "amount": 24.99983099,
    "filled": 24.99983099,
    "remaining": 0,
    "fee": {
        "cost": 0.001123,
        "rate": null,
        "currency": "ETH"
    }
}
```

There are two price fields: ``description.price`` and ``price``. The latter is the actual "fill price". As it stands, the submission price always overrides the filled price. This commit reverses the logic, such that a filled price is taken, and we fallback on the limit price if necessary.