### PR TITLE
Fix cobinhood trade "cost".

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -307,7 +307,7 @@ module.exports = class cobinhood extends Exchange {
         let timestamp = trade['timestamp'];
         let price = this.safeFloat (trade, 'price');
         let amount = this.safeFloat (trade, 'size');
-        let cost = parseFloat (this.costToPrecision (symbol, price * amount));
+        let cost = price * amount;
         let side = trade['maker_side'] === 'bid' ? 'sell' : 'buy';
         return {
             'info': trade,


### PR DESCRIPTION
A trade from cobinhood:

```
{
    "id": "...",
    "datetime": "2018-07-08T15:17:03.963Z",
    "timestamp": 1531063023963,
    "lastTradeTimestamp": null,
    "status": "closed",
    "symbol": "BTC/USDT",
    "type": "limit",
    "side": "buy",
    "price": 6741.813581481481,
    "cost": 41.866662341,
    "amount": 0.00621,
    "filled": 0.00621,
    "remaining": 0,
    "trades": null,
    "fee": null,
    "info": {
        "id": "...",
        "trading_pair_id": "BTC-USDT",
        "side": "bid",
        "type": "limit",
        "price": "6742.3",
        "size": "0.00621",
        "filled": "0.00621",
        "state": "filled",
        "timestamp": 1531063023963,
        "eq_price": "6741.8135814814814815",
        "completed_at": "2018-07-08T15:17:03.989569Z",
        "source": "exchange"
    }
}
```

The cost of this trade should be `6741.8135814814814815 *  0.00621 = 41.866662341`. ccxt calculates this correctly:

And the list of trades:
```
[
    {
        "info": {
            "id": "...",
            "maker_side": "ask",
            "trading_pair_id": "BTC-USDT",
            "timestamp": 1531063023989,
            "price": "6740",
            "size": "0.00131333"
        },
        "timestamp": 1531063023989,
        "datetime": "2018-07-08T15:17:03.989Z",
        "symbol": "BTC/USDT",
        "id": "....",
        "order": null,
        "type": null,
        "side": false,
        "price": 6740,
        "amount": 0.00131333,
        "cost": 8.9,
        "fee": null
    },
    {
        "info": {
            "id": "....",
            "maker_side": "ask",
            "trading_pair_id": "BTC-USDT",
            "timestamp": 1531063023989,
            "price": "6742.3",
            "size": "0.00489667"
        },
        "timestamp": 1531063023989,
        "datetime": "2018-07-08T15:17:03.989Z",
        "symbol": "BTC/USDT",
        "id": "...",
        "order": null,
        "type": null,
        "side": false,
        "price": 6742.3,
        "amount": 0.00489667,
        "cost": 33,
        "fee": null
    }
]
```

The sum of the costs of the trades is: `41.9 USDT`, a different value. The reason is that the cost as calulated per trade is restricted to 1 decimal point. That seems wrong. Just because cobinhood has a minimum step of 0.1 USDT on the market, does not mean the cost of buying `0.00489667 BTC` cannot have a finer-grained cost.