### PR TITLE
lbank fix typeerror

### DIFF
--- a/js/lbank.js
+++ b/js/lbank.js
@@ -124,8 +124,8 @@ module.exports = class lbank extends Exchange {
             let quote = this.commonCurrencyCode (quoteId.toUpperCase ());
             let symbol = base + '/' + quote;
             let precision = {
-                'amount': market['quantityAccuracy'],
-                'price': market['priceAccuracy'],
+                'amount': this.safeInteger(market, 'quantityAccuracy'),
+                'price': this.safeInteger(market, 'priceAccuracy'),
             };
             result.push ({
                 'id': id,

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -124,8 +124,8 @@ module.exports = class lbank extends Exchange {
             let quote = this.commonCurrencyCode (quoteId.toUpperCase ());
             let symbol = base + '/' + quote;
             let precision = {
-                'amount': this.safeInteger(market, 'quantityAccuracy'),
-                'price': this.safeInteger(market, 'priceAccuracy'),
+                'amount': this.safeInteger (market, 'quantityAccuracy'),
+                'price': this.safeInteger (market, 'priceAccuracy'),
             };
             result.push ({
                 'id': id,


### PR DESCRIPTION
```
/ccxt/lbank.py", line 144, in fetch_markets
    'min': math.pow(10, -precision['amount']),
TypeError: bad operand type for unary -: 'str'
```