### PR TITLE
BugFixed for exchange qryptos

### DIFF
--- a/js/qryptos.js
+++ b/js/qryptos.js
@@ -319,8 +319,13 @@ module.exports = class qryptos extends Exchange {
         };
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
+        let queryByTimestamp = false;
+        if (typeof since !== 'undefined') {
+            request['timestamp'] = since;
+            queryByTimestamp = true;
+        }
         let response = await this.publicGetExecutions (this.extend (request, params));
-        return this.parseTrades (response['models'], market, since, limit);
+        return this.parseTrades((queryByTimestamp ? response : response['models']), market, since, limit);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/python/ccxt/qryptos.py
+++ b/python/ccxt/qryptos.py
@@ -305,8 +305,10 @@ class qryptos (Exchange):
         }
         if limit is not None:
             request['limit'] = limit
+        if since is not None:
+            request['timestamp'] = since
         response = self.publicGetExecutions(self.extend(request, params))
-        return self.parse_trades(response['models'], market, since, limit)
+        return self.parse_trades(response['models'] if since is None else response, market, since, limit)
 
     def fetch_my_trades(self, symbol=None, since=None, limit=None, params={}):
         self.load_markets()


### PR DESCRIPTION
'Get Executions by Timestamp' lose timestamp parameter and response parse error due to the format different from 'Get Executions'.

More details check:
https://developers.quoine.com/v2?ruby#get-executions
https://developers.quoine.com/v2?ruby#get-executions-by-timestamp