### PR TITLE
BugFixed for exchange qryptos

### DIFF
--- a/js/qryptos.js
+++ b/js/qryptos.js
@@ -319,8 +319,13 @@ module.exports = class qryptos extends Exchange {
         };
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
+        let queryByTimestamp = false;
+        if (typeof since !== 'undefined') {
+            request['timestamp'] = since;
+            queryByTimestamp = true;
+        }
         let response = await this.publicGetExecutions (this.extend (request, params));
-        return this.parseTrades (response['models'], market, since, limit);
+        return this.parseTrades((queryByTimestamp ? response : response['models']), market, since, limit);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/qryptos.js
+++ b/js/qryptos.js
@@ -319,13 +319,12 @@ module.exports = class qryptos extends Exchange {
         };
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
-        let queryByTimestamp = false;
         if (typeof since !== 'undefined') {
-            request['timestamp'] = since;
-            queryByTimestamp = true;
+            // timestamp should be in seconds, whereas we use milliseconds in since and everywhere
+            request['timestamp'] = parseInt (since / 1000);
         }
         let response = await this.publicGetExecutions (this.extend (request, params));
-        let result = queryByTimestamp ? response : response['models'];
+        let result = (typeof since !== 'undefined') ? response : response['models'];
         return this.parseTrades (result, market, since, limit);
     }
 

--- a/js/qryptos.js
+++ b/js/qryptos.js
@@ -325,7 +325,8 @@ module.exports = class qryptos extends Exchange {
             queryByTimestamp = true;
         }
         let response = await this.publicGetExecutions (this.extend (request, params));
-        return this.parseTrades((queryByTimestamp ? response : response['models']), market, since, limit);
+        let result = queryByTimestamp ? response : response['models'];
+        return this.parseTrades (result, market, since, limit);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/php/qryptos.php
+++ b/php/qryptos.php
@@ -320,8 +320,14 @@ class qryptos extends Exchange {
         );
         if ($limit !== null)
             $request['limit'] = $limit;
+        $queryByTimestamp = false;
+        if ($since !== null) {
+            $request['timestamp'] = $since;
+            $queryByTimestamp = true;
+        }
         $response = $this->publicGetExecutions (array_merge ($request, $params));
-        return $this->parse_trades($response['models'], $market, $since, $limit);
+        $result = $queryByTimestamp ? $response : $response['models'];
+        return $this->parse_trades($result, $market, $since, $limit);
     }
 
     public function fetch_my_trades ($symbol = null, $since = null, $limit = null, $params = array ()) {

--- a/python/ccxt/async_support/qryptos.py
+++ b/python/ccxt/async_support/qryptos.py
@@ -305,8 +305,13 @@ class qryptos (Exchange):
         }
         if limit is not None:
             request['limit'] = limit
+        queryByTimestamp = False
+        if since is not None:
+            request['timestamp'] = since
+            queryByTimestamp = True
         response = await self.publicGetExecutions(self.extend(request, params))
-        return self.parse_trades(response['models'], market, since, limit)
+        result = response if queryByTimestamp else response['models']
+        return self.parse_trades(result, market, since, limit)
 
     async def fetch_my_trades(self, symbol=None, since=None, limit=None, params={}):
         await self.load_markets()

--- a/python/ccxt/qryptos.py
+++ b/python/ccxt/qryptos.py
@@ -305,10 +305,13 @@ class qryptos (Exchange):
         }
         if limit is not None:
             request['limit'] = limit
+        queryByTimestamp = False
         if since is not None:
             request['timestamp'] = since
+            queryByTimestamp = True
         response = self.publicGetExecutions(self.extend(request, params))
-        return self.parse_trades(response['models'] if since is None else response, market, since, limit)
+        result = response if queryByTimestamp else response['models']
+        return self.parse_trades(result, market, since, limit)
 
     def fetch_my_trades(self, symbol=None, since=None, limit=None, params={}):
         self.load_markets()

--- a/python/ccxt/qryptos.py
+++ b/python/ccxt/qryptos.py
@@ -305,8 +305,10 @@ class qryptos (Exchange):
         }
         if limit is not None:
             request['limit'] = limit
+        if since is not None:
+            request['timestamp'] = since
         response = self.publicGetExecutions(self.extend(request, params))
-        return self.parse_trades(response['models'], market, since, limit)
+        return self.parse_trades(response['models'] if since is None else response, market, since, limit)
 
     def fetch_my_trades(self, symbol=None, since=None, limit=None, params={}):
         self.load_markets()


### PR DESCRIPTION
'Get Executions by Timestamp' lose timestamp parameter and response parse error due to the format different from 'Get Executions'.

More details check:
https://developers.quoine.com/v2?ruby#get-executions
https://developers.quoine.com/v2?ruby#get-executions-by-timestamp

