### PR TITLE
Fix gate.io feeRate

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -435,6 +435,9 @@ module.exports = class gateio extends Exchange {
         let feeCost = this.safeFloat (order, 'feeValue');
         let feeCurrency = this.safeString (order, 'feeCurrency');
         let feeRate = this.safeFloat (order, 'feePercentage');
+        if (typeof feeRate !== 'undefined') {
+            feeRate = feeRate / 100;
+        }
         if (typeof feeCurrency !== 'undefined') {
             if (feeCurrency in this.currencies_by_id) {
                 feeCurrency = this.currencies_by_id[feeCurrency]['code'];


### PR DESCRIPTION
gate.io gives as the fee rate ``0.18``, but they mean ``0.18%``, so it should really be ``0.0018`.