### PR TITLE
Fix bitstamp fee in case no transactions.

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -468,14 +468,13 @@ module.exports = class bitstamp extends Exchange {
         let cost = undefined;
         if (typeof transactions !== 'undefined') {
             if (Array.isArray (transactions)) {
+                feeCost = 0.0;
                 for (let i = 0; i < transactions.length; i++) {
                     let trade = this.parseTrade (this.extend ({
                         'order_id': id,
                         'side': side,
                     }, transactions[i]), market);
                     filled += trade['amount'];
-                    if (typeof feeCost === 'undefined')
-                        feeCost = 0.0;
                     feeCost += trade['fee']['cost'];
                     if (typeof cost === 'undefined')
                         cost = 0.0;


### PR DESCRIPTION
If an order is cancelled before there can be any transactions, the structure currently looks like this, which is a bit unexpected:

```
{'cost': None, 'currency': 'EUR'}
```

Full response:

```
{'id': '1777642340', 'datetime': None, 'timestamp': None, 'lastTradeTimestamp': None, 'status': 'Canceled', 'symbol': 'BTC/EUR', 'type': None, 'side': None, 'price': None, 'cost': None, 'amount': None, 'filled': 0.0, 'remaining': None, 'trades': [], 'fee': {'cost': None, 'currency': 'EUR'}, 'info': {'status': 'Canceled', 'id': 1777642340, 'transactions': []}}
```

Since the parsing logic is assuming that the result contains a transaction list with the fees, if there is such a list, but the list is empty, it  seem reasonable to assume that the fee then is 0.