### PR TITLE
kraken: Support more parseTrade formats.

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -524,7 +524,7 @@ module.exports = class kraken extends Exchange {
             market = this.findMarketByAltnameOrId (trade['pair']);
         if ('ordertxid' in trade) {
             order = trade['ordertxid'];
-            id = trade['id'];
+            id = this.safeString2 (trade, 'id', 'postxid');
             timestamp = parseInt (trade['time'] * 1000);
             side = trade['type'];
             type = trade['ordertype'];


### PR DESCRIPTION
Kraken's QueryTrades API returns trades in the following format:

```
{'ordertxid': 'OAECDR-64FLC-O3MSJE', 'postxid': 'TKH2SE-M7IF5-CFI7LT', 'pair': 'XETHZUSD', 'time': 1528665448.7311, 'type': 'buy', 'ordertype': 'limit', 'price': '516.67000', 'cost': '3.63303', 'fee': '0.00581', 'vol': '0.00703162', 'margin': '0.00000', 'misc': ''}
```

`parseTrade` can now handle this because it no longer requires an `id` key.