### PR TITLE
cli: fixed a bug with 'printSupportedExchanges' not called on unknown exchange

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -105,7 +105,7 @@ Object.assign (exchange, settings)
 
 //-----------------------------------------------------------------------------
 
-let printSupportedExchanges = function () {
+function printSupportedExchanges () {
     log ('Supported exchanges:', ccxt.exchanges.join (', ').green)
 }
 


### PR DESCRIPTION
Function expressions are not hoisted so not yet known at line 90.

```
> node examples/js/cli.js asdf
[TypeError] ccxt[exchangeId] is not a constructor

    at <anonymous>    examples/js/cli.js:85  exchange = new (ccxt)[exchangeId] ({ verbose, timeout, enableRateLimit })
    at _compile       module.js:649                                                                                   
    at js             module.js:663                                                                                   
    at load           module.js:565                                                                                   
    at tryModuleLoad  module.js:505                                                                                   
    at _load          module.js:497                                                                                   
    at runMain        module.js:693                                                                                   
    at startup        bootstrap_node.js:191                                                                           
    at                bootstrap_node.js:612                                                                           

This is an example of a basic command-line interface to all exchanges
Usage: node /Users/max/src/ccxt/examples/js/cli.js id method "param1" param2 "param3" param4 ...
Examples:
node /Users/max/src/ccxt/examples/js/cli.js okcoinusd fetchOHLCV BTC/USD 15m
node /Users/max/src/ccxt/examples/js/cli.js bitfinex fetchBalance
node /Users/max/src/ccxt/examples/js/cli.js kraken fetchOrderBook ETH/BTC
[ReferenceError] printSupportedExchanges is not defined

    at printUsage     examples/js/cli.js:121  printSupportedExchanges ()
    at <anonymous>    examples/js/cli.js:90   printUsage ()             
    at _compile       module.js:649                                     
    at js             module.js:663                                     
    at load           module.js:565                                     
    at tryModuleLoad  module.js:505                                     
    at _load          module.js:497                                     
    at runMain        module.js:693                                     
    at startup        bootstrap_node.js:191                             
    at                bootstrap_node.js:612 
```