### PR TITLE
Add fetchMyTrades to Huobi Pro

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -337,8 +337,7 @@ module.exports = class huobipro extends Exchange {
             side = typeParts[0];
             type = typeParts[1];
         }
-        let amount = this.safeFloat (trade, 'amount');
-        amount = this.safeFloat (trade, 'filled-amount', amount);
+        let amount = this.safeFloat2 (trade, 'filled-amount', 'amount');
         return {
             'info': trade,
             'id': this.safeString (trade, 'id'),

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -326,15 +326,16 @@ module.exports = class huobipro extends Exchange {
                     market = this.markets_by_id[marketId];
             }
         }
-        if (market)
+        if (typeof market !== 'undefined)
             symbol = market['symbol'];
-        let timestamp = this.safeInteger (trade, 'ts');
-        timestamp = this.safeInteger (trade, 'created-at', timestamp);
+        let timestamp = this.safeInteger2 (trade, 'ts', 'created-at');
         let order = this.safeString (trade, 'order-id');
         let side = trade['direction'];
-        let type = undefined;
-        if ('type' in trade) {
-            [ side, type ] = trade['type'].split ('-');
+        let type = this.safeString (trade, 'type');
+        if (typeof type !== 'undefined') {
+            let typeParts = type.split ('-');
+            side = typeParts[0];
+            type = typeParts[1];
         }
         let amount = this.safeFloat (trade, 'amount');
         amount = this.safeFloat (trade, 'filled-amount', amount);

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -320,10 +320,9 @@ module.exports = class huobipro extends Exchange {
     parseTrade (trade, market = undefined) {
         let symbol = undefined;
         if (typeof market === 'undefined') {
-            if ('symbol' in trade) {
-                let marketId = trade['symbol'];
-                if (marketId in this.markets_by_id)
-                    market = this.markets_by_id[marketId];
+            let marketId = this.safeString (trade, 'symbol');
+            if (marketId in this.markets_by_id) {
+                market = this.markets_by_id[marketId];
             }
         }
         if (typeof market !== 'undefined')

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -330,7 +330,7 @@ module.exports = class huobipro extends Exchange {
             symbol = market['symbol'];
         let timestamp = this.safeInteger2 (trade, 'ts', 'created-at');
         let order = this.safeString (trade, 'order-id');
-        let side = trade['direction'];
+        let side = this.safeString (trade, 'direction');
         let type = this.safeString (trade, 'type');
         if (typeof type !== 'undefined') {
             let typeParts = type.split ('-');

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -356,9 +356,8 @@ module.exports = class huobipro extends Exchange {
         let response = await this.privateGetOrderMatchresults (params);
         let trades = this.parseTrades (response['data'], undefined, since, limit);
         if (typeof symbol !== 'undefined') {
-            if (!(symbol in this.markets))
-                throw new ExchangeError (this.id + ' has no symbol ' + symbol);
-            trades = this.filterBySymbol (trades, symbol);
+            let market = this.market (symbol);
+            trades = this.filterBySymbol (trades, market['symbol']);
         }
         return trades;
     }

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -326,7 +326,7 @@ module.exports = class huobipro extends Exchange {
                     market = this.markets_by_id[marketId];
             }
         }
-        if (typeof market !== 'undefined)
+        if (typeof market !== 'undefined')
             symbol = market['symbol'];
         let timestamp = this.safeInteger2 (trade, 'ts', 'created-at');
         let order = this.safeString (trade, 'order-id');


### PR DESCRIPTION
This includes a pretty big change to `parseTrade` for Huobi, but the format between market data trades and personal trades is unfortunately very different.  If you prefer that to be in a separate function, let me know!