### PR TITLE
replace opencollective with litecollective

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "pandoc-doc-install": "pandoc --wrap=preserve --columns=10000 --from=markdown --to=rst --output=doc/install.rst wiki/Install.md",
     "pandoc-doc-exchanges": "pandoc --wrap=preserve --columns=10000 --from=markdown --to=rst --output=doc/exchanges.rst wiki/Exchange-Markets.md",
     "pandoc-doc-exchanges-by-country": "pandoc --wrap=preserve --columns=10000 --from=markdown --to=rst --output=doc/exchanges-by-country.rst wiki/Exchange-Markets-By-Country.md",
-    "postinstall": "opencollective postinstall && node postinstall.js"
+    "postinstall": "litecollective  && node postinstall.js"
   },
   "types": "./ccxt.d.ts",
   "dependencies": {
     "cloudscraper": "1.4.1",
     "crypto-js": "3.1.9-1",
     "fetch-ponyfill": "4.1.0",
-    "opencollective": "1.0.3",
+    "litecollective": "1.0.4",
     "qs": "6.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The opencollective package is over 24MB, replacing with a much lighter implementation (200KB) having the same functionality for post install script.
