### PR TITLE
cobinhood: fix parseTrade transpilation

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -313,7 +313,7 @@ module.exports = class cobinhood extends Exchange {
         let price = this.safeFloat (trade, 'price');
         let amount = this.safeFloat (trade, 'size');
         let cost = price * amount;
-        let side = trade['maker_side'] === 'bid' ? 'sell' : 'buy';
+        let side = (trade['maker_side'] === 'bid') ? 'sell' : 'buy';
         return {
             'info': trade,
             'timestamp': timestamp,


### PR DESCRIPTION
without parens js,
```js
        let side = (trade['maker_side'] === 'bid') ? 'sell' : 'buy';
```
incorrectly transpiles to python:
```python
side = trade['maker_side'] == 'sell' if 'bid' else 'buy'
```
which results in a boolean value for `side`
with parens, we get the desired python
```python
        side = 'sell' if (trade['maker_side'] == 'bid') else 'buy'
```