### PR TITLE
bitfinex: add DDoSProtection message

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -276,6 +276,7 @@ module.exports = class bitfinex extends Exchange {
                     'Key price should be a decimal number, e.g. "123.456"': InvalidOrder, // on isNaN (price)
                     'Key amount should be a decimal number, e.g. "123.456"': InvalidOrder, // on isNaN (amount)
                     'ERR_RATE_LIMIT': DDoSProtection,
+                    'Ratelimit': DDoSProtection,
                     'Nonce is too small.': InvalidNonce,
                     'No summary found.': ExchangeError, // fetchTradingFees (summary) endpoint can give this vague error message
                     'Cannot evaluate your available balance, please try again': ExchangeNotAvailable,


### PR DESCRIPTION
bitfinex sent a response like: 
```json
{"message":"Ratelimit"}
```
presumably in addition to or instead of `ERR_RATE_LIMIT`
Adding this text to error message interpretation