### PR TITLE
Adding support for v2/stats1/funding.size and v2/stats1/credits.size endpoints

### DIFF
--- a/python/ccxt/bitfinex2.py
+++ b/python/ccxt/bitfinex2.py
@@ -84,6 +84,7 @@ class bitfinex2 (bitfinex):
                         'book/{symbol}/P3',
                         'book/{symbol}/R0',
                         'stats1/{key}:{size}:{symbol}:{side}/{section}',
+                        'stats1/{key}:{size}:{symbol}/{section}',
                         'stats1/{key}:{size}:{symbol}:long/last',
                         'stats1/{key}:{size}:{symbol}:long/hist',
                         'stats1/{key}:{size}:{symbol}:short/last',


### PR DESCRIPTION
With the existing implicit Bitfinex V2 API methods, v2/stats1/funding.size and v2/stats1/credits.size endpoints cannot be reached. All similar API endpoints force you to add a "side" parameter, which is invalid for these endpoints.  This change adds an implicit API method to bitfinex2 so that these endpoints can be reached