### PR TITLE
kucoin: fix order status

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -580,10 +580,13 @@ module.exports = class kucoin extends Exchange {
         let timestamp = this.safeValue (order, 'createdAt');
         let remaining = this.safeFloat (order, 'pendingAmount');
         let status = undefined;
-        if (this.safeValue (order, 'isActive', true)) {
-            status = 'open';
-        } else {
-            status = 'closed';
+        if ('status' in order) {
+            status = order['status'];
+         } else {
+            if (this.safeValue (order, 'isActive', true))
+                status = 'open';
+            else
+                status = 'closed';
         }
         let filled = this.safeFloat (order, 'dealAmount');
         let amount = this.safeFloat (order, 'amount');

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -583,10 +583,11 @@ module.exports = class kucoin extends Exchange {
         if ('status' in order) {
             status = order['status'];
          } else {
-            if (this.safeValue (order, 'isActive', true))
-                status = 'open';
-            else
-                status = 'closed';
+             if (this.safeValue (order, 'isActive', true)) {
+                 status = 'open';
+             } else {
+                 status = 'closed';
+             }
         }
         let filled = this.safeFloat (order, 'dealAmount');
         let amount = this.safeFloat (order, 'amount');


### PR DESCRIPTION
- Proposed change , respects status if provided, otherwise  falls back to previously used `isActive`

- `isActive` flag is present when calling `fetchOrder`, absent in `fetchOpenOrders` and `fetchClosedOrders`

- when calling eg `fetchOpenOrders` or `fetchClosedOrders`, the `status: 'closed'` is set by `parseOrdersByStatus`.
without this fix, the previous `parseOrder` logic then ignores this status, can can arrive at incorrect status, eg reporting `open` for `closed`:
```python
{'info': {'oid': 'xxxx',
   'userOid': 'xxxx',
   'coinType': 'DOCK',
   'coinTypePair': 'BTC',
   'direction': 'SELL',
   'price': 1.081e-05,
   'dealAmount': 0.0,
   'dealValue': 0.0,
   'pendingAmount': 1515.0296,
   'dealAveragePrice': 0.0,
   'createdAt': 1532946506000,
   'updatedAt': 1532946506000,
   'status': 'open'},
  'id': '5b5ee849e8595d2ac9f59cfb',
  'timestamp': 1532946506000,
  'datetime': '2018-07-30T10:28:26.000Z',
  'lastTradeTimestamp': None,
  'symbol': 'DOCK/BTC',
  'type': 'limit',
  'side': 'sell',
  'price': 1.081e-05,
  'amount': 1515.0296,
  'cost': 0.016377469976,
  'filled': 0.0,
  'remaining': 1515.0296,
  'status': 'open',
  'fee': {'cost': None, 'rate': None, 'currency': 'BTC'},
  'trades': None},
```
