### PR TITLE
kucoin: fetchTrades needs an int limit

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1041,8 +1041,11 @@ module.exports = class kucoin extends Exchange {
         };
     }
 
-    async fetchTrades (symbol, since = undefined, limit = 100, params = {}) {
+    async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
+        if (typeof limit === 'undefined') {
+            limit = 100; // default to 100 even if it was explicitly set to undefined by the user
+        }
         let market = this.market (symbol);
         let response = await this.publicGetOpenDealOrders (this.extend ({
             'symbol': market['id'],


### PR DESCRIPTION
at least from Python, calling `fetchTrades` without specifying a limit, or specifying default limit of `None` results in Kucoin complaining that it got a string when it wanted an int:
```
ExchangeNotAvailable: kucoin https://api.kucoin.com/v1/open/deal-orders?symbol=DOCK-BTC&limit=None GET 400 
Client Error:  for url: https://api.kucoin.com/v1/open/deal-orders?symbol=DOCK-BTC&limit=None 
{"timestamp":xxxx,"status":400,
"error":"Bad Request",
"exception":"org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
"message":"Failed to convert value of type 'java.lang.String' to required type 'int'; nested exception is java.lang.NumberFormatException: For input string: \"None\"",
"path":"/open/deal-orders"}
```
It is possible to address this by not extending with limit when it is undefined/None on line 1049, but perhaps easier to just default to 100, as proposed.
- if provided limit of `0`, kucoin returns 10 results, if provided limit of `100`, it returns 50.