### PR TITLE
huobipro: decode addl error code

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -117,6 +117,7 @@ module.exports = class huobipro extends Exchange {
                 'order-limitorder-amount-min-error': InvalidOrder, // limit order amount error, min: `0.001`
                 'order-marketorder-amount-min-error': InvalidOrder, // market order amount error, min: `0.01`
                 'order-limitorder-price-min-error': InvalidOrder, // limit order price error
+                'order-limitorder-price-max-error': InvalidOrder, // limit order price error
                 'order-orderstate-error': OrderNotFound, // canceling an already canceled order
                 'order-queryorder-invalid': OrderNotFound, // querying a non-existent order
                 'order-update-error': ExchangeNotAvailable, // undocumented error


### PR DESCRIPTION
seems reasonable to handle `order-limitorder-price-max-error` as well as `order-limitorder-price-min-error` :-)
(these is generated by huobipro when one tries to trade more than 10% away from current price)
I saw:
```
ExchangeError('huobipro {"status":"error","err-code":"order-limitorder-price-max-error",
"err-msg":"limit order price error, max: `0.00006719`","data":null}',)
```