### PR TITLE
liqui/yobit: handle empty fetchTrades response

### DIFF
--- a/js/liqui.js
+++ b/js/liqui.js
@@ -363,6 +363,11 @@ module.exports = class liqui extends Exchange {
             request['limit'] = limit;
         }
         let response = await this.publicGetTradesPair (this.extend (request, params));
+        if (Array.isArray (response)) {
+            if (response.length === 0) {
+                return [];
+            }
+        }
         return this.parseTrades (response[market['id']], market, since, limit);
     }
 


### PR DESCRIPTION
- when trade history is empty (but the pair is valid) yobit returns an empty array, rather than a dict from market id to trades. This requires special handling so that `response[market['id']]` does not raise an error

eg currently for https://yobit.net/api/3/trades/poly_btc (response is `[]`) -- cf dict returned by https://yobit.net/api/3/trades/eth_btc
- note that v3 api supports multiple symbols, eg https://yobit.net/api/3/trades/eth_btc-ltc_btc but we don't use that