### PR TITLE
common currency: PLC is Polcoin in cryptopia

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -112,6 +112,7 @@ module.exports = class cryptopia extends Exchange {
                 'LDC': 'LADACoin',
                 'MARKS': 'Bitmark',
                 'NET': 'NetCoin',
+                'PLC': 'Polcoin',
                 'RED': 'RedCoin',
                 'STC': 'StopTrumpCoin',
                 'QBT': 'Cubits',


### PR DESCRIPTION
PLC is PlusCoin in qryptos (https://medium.com/@QUOINE/pluscoin-is-now-live-on-qryptos-d9af137aeb9c)

although PlusCoin still not exists in CMC, it's volume is bigger than polcoin, and it's look like polcoin project is dying