### PR TITLE
Change full name Atonomi to official ticker ATMI

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -246,7 +246,7 @@ module.exports = class bitfinex extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'ATM': 'Atonomi', // issue #3383
+                'ATM': 'ATMI', // Bitfinex uses ATM instead of the official ATMI
                 'BCC': 'CST_BCC',
                 'BCU': 'CST_BCU',
                 'CTX': 'CTXC',


### PR DESCRIPTION
 Feel free to reject this, but looking at Bitfinex's comment on ATM (Atonomi), it seems like the official ticker is ATMI, so we can map to that instead of the full name.

"Atonomi
Please note that ATMI is listed as ATM on Bitfinex.

The Atonomi (ATMI) token enables a decentralized, immutable security infrastructure and creates a system of consistently increasing engagement in the Atonomi Network. The Atonomi Token is used within the security protocol for device registration, activation, reputation management and commerce transactions. Trust and reputation enable security which enables interoperability among IoT devices. In the absence of digital tokens, devices would need to be equipped with credit card processing capabilities that require a far larger footprint on resource-constrained devices. With the Atonomi Network and Token, we can unleash the power of IoT. "