### PR TITLE
implement lbank withdraw

### DIFF
--- a/js/lbank.js
+++ b/js/lbank.js
@@ -474,7 +474,7 @@ module.exports = class lbank extends Exchange {
             'amount': amount,
             'account': address,
         };
-        if (typeof tag !== 'undefined'){
+        if (typeof tag !== 'undefined') {
             request['memo'] = tag;
         }
         let response = this.privatePostWithdraw (this.extend (request, params));
@@ -482,7 +482,7 @@ module.exports = class lbank extends Exchange {
             'id': response['id'],
             'info': response,
         };
-    };
+    }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let query = this.omit (params, this.extractParams (path));

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -61,6 +61,10 @@ module.exports = class lbank extends Exchange {
                         'cancel_order',
                         'orders_info',
                         'orders_info_history',
+                        'withdraw',
+                        'withdrawCancel',
+                        'withdraws',
+                        'withdrawConfigs',
                     ],
                 },
             },
@@ -460,6 +464,26 @@ module.exports = class lbank extends Exchange {
         return closed + cancelled;
     }
 
+    async withdraw (code, amount, address, tag = undefined, params = {}) {
+        // mark and fee are optional params, mark is a note and must be less than 255 characters
+        this.checkAddress (address);
+        await this.loadMarkets ();
+        let currency = this.currency (code);
+        let request = {
+            'assetCode': currency['id'],
+            'amount': amount,
+            'account': address,
+        };
+        if (typeof tag !== 'undefined'){
+            request['memo'] = tag;
+        }
+        let response = this.privatePostWithdraw (this.extend (request, params));
+        return {
+            'id': response['id'],
+            'info': response,
+        };
+    };
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let query = this.omit (params, this.extractParams (path));
         let url = this.urls['api'] + '/' + this.version + '/' + this.implodeParams (path, params);
@@ -508,6 +532,7 @@ module.exports = class lbank extends Exchange {
                 '10018': 'order inquiry can not be more than 50 less than one',
                 '10019': 'withdrawal orders can not be more than 3 less than one',
                 '10020': 'less than the minimum amount of the transaction limit of 0.001',
+                '10022': 'Insufficient key authority',
             }, errorCode, this.json (response));
             let ErrorClass = this.safeValue ({
                 '10002': AuthenticationError,
@@ -523,6 +548,7 @@ module.exports = class lbank extends Exchange {
                 '10014': InvalidOrder,
                 '10015': InvalidOrder,
                 '10016': InvalidOrder,
+                '10022': AuthenticationError,
             }, errorCode, ExchangeError);
             throw new ErrorClass (message);
         }


### PR DESCRIPTION
Haven't tested it with real money, however I get the correct error message and it conforms to the API docs

> ccxt.base.errors.InvalidOrder: Account balance is not enough