### PR TITLE
coinmarketcap: Fix IOTA symbol rewrite

### DIFF
--- a/js/coinmarketcap.js
+++ b/js/coinmarketcap.js
@@ -117,7 +117,7 @@ module.exports = class coinmarketcap extends Exchange {
             'KingN Coin': 'KingN Coin', // conflict with KNC (Kyber Network)
             'LiteBitcoin': 'LiteBitcoin', // conflict with LBTC (LightningBitcoin)
             'Maggie': 'Maggie',
-            'MIOTA': 'IOTA', // a special case, most exchanges list it as IOTA, therefore we change just the Coinmarketcap instead of changing them all
+            'IOTA': 'IOTA', // a special case, most exchanges list it as IOTA, therefore we change just the Coinmarketcap instead of changing them all
             'NetCoin': 'NetCoin',
             'Polcoin': 'Polcoin',
             'PutinCoin': 'PutinCoin', // conflict with PUT (Profile Utility Token)


### PR DESCRIPTION
On coinmarket cap, the symbol is MIOTA and the name is IOTA. Because the function maps from CMC NAME -> CCXt SYMBOL, it has to be IOTA-> IOTA.

I actually think it would be better to have a mapping CMC SYMBOL -> CCXT SYMBOL, since coinmarketcap I think is more likely to change a currencies label / pretty name, than the symbol. It would also be less confusing.