### PR TITLE
Small fix in luno parseOrder

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -202,15 +202,15 @@ module.exports = class luno extends Exchange {
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        return this.fetchOrdersByState (undefined, symbol, since, limit, params);
+        return await this.fetchOrdersByState (undefined, symbol, since, limit, params);
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        return this.fetchOrdersByState ('PENDING', symbol, since, limit, params);
+        return await this.fetchOrdersByState ('PENDING', symbol, since, limit, params);
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        return this.fetchOrdersByState ('COMPLETE', symbol, since, limit, params);
+        return await this.fetchOrdersByState ('COMPLETE', symbol, since, limit, params);
     }
 
     parseTicker (ticker, market = undefined) {


### PR DESCRIPTION
Correctly matching filled value to API response "base"
