### PR TITLE
JBC is JubaoCoin in coinegg

### DIFF
--- a/js/coinegg.js
+++ b/js/coinegg.js
@@ -144,6 +144,9 @@ module.exports = class coinegg extends Exchange {
             'options': {
                 'quoteIds': [ 'btc', 'eth', 'usc', 'usdt' ],
             },
+            'commonCurrencies': {
+                'JBC': 'JubaoCoin',
+            },
         });
     }
 


### PR DESCRIPTION
there is name under each coin in coinegg. the translate of the JBC name (from chinese) is Jubao.

since it's the first commonCurrency for coinegg, maybe it's needed additional code. 
in qryptos.js I saw that in parseTicker:
```
 if (marketId in this.markets_by_id) {
                market = this.markets_by_id[marketId];
            } else {
                let baseId = this.safeString (ticker, 'base_currency');
                let quoteId = this.safeString (ticker, 'quoted_currency');
                let base = this.commonCurrencyCode (baseId);
                let quote = this.commonCurrencyCode (quoteId);
                if (symbol in this.markets) {
                    market = this.markets[symbol];
                } else {
                    symbol = base + '/' + quote;
                }
            }
```
