### PR TITLE
Update luno.js - balance calculation

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -105,14 +105,14 @@ module.exports = class luno extends Exchange {
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
         let response = await this.privateGetBalance ();
-        let balances = response['balance'];
+        let wallets = response['balance'];
         let result = { 'info': response };
-        for (let b = 0; b < balances.length; b++) {
-            let balance = balances[b];
-            let currency = this.commonCurrencyCode (balance['asset']);
-            let reserved = parseFloat (balance['reserved']);
-            let unconfirmed = parseFloat (balance['unconfirmed']);
-            let balance = parseFloat (balance['balance']);
+        for (let b = 0; b < wallets.length; b++) {
+            let wallet = wallets[b];
+            let currency = this.commonCurrencyCode (wallet['asset']);
+            let reserved = parseFloat (wallet['reserved']);
+            let unconfirmed = parseFloat (wallet['unconfirmed']);
+            let balance = parseFloat (wallet['balance']);
             let account = {
                 'free': 0.0,
                 'used': this.sum (reserved, unconfirmed),

--- a/js/luno.js
+++ b/js/luno.js
@@ -112,10 +112,11 @@ module.exports = class luno extends Exchange {
             let currency = this.commonCurrencyCode (balance['asset']);
             let reserved = parseFloat (balance['reserved']);
             let unconfirmed = parseFloat (balance['unconfirmed']);
+            let balance = parseFloat (balance['balance']);
             let account = {
                 'free': 0.0,
                 'used': this.sum (reserved, unconfirmed),
-                'total': parseFloat (balance['balance']),
+                'total': this.sum (balance, unconfirmed),
             };
             account['free'] = account['total'] - account['used'];
             result[currency] = account;


### PR DESCRIPTION
Total should include unconfirmed values which are also included in used values otherwise we end up with negative free value.
i.e. 
reserved = 0.5, unconfirmed (incoming) = 1, balance = 0.75, resulting in total = 1.75, used = 1.5 and free = 0.25. I believe this lines up with the manual intention.

    'BTC':   {           // string, three-letter currency code, uppercase
        'free': 321.00   // float, money available for trading
        'used': 234.00,  // float, money on hold, locked, frozen or pending
        'total': 555.00, // float, total balance (free + used)
    },