### PR TITLE
common currency: FT is Fabric Token in cryptopia

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -105,6 +105,7 @@ module.exports = class cryptopia extends Exchange {
                 'CMT': 'Comet',
                 'EPC': 'ExperienceCoin',
                 'FCN': 'Facilecoin',
+                'FT': 'Fabric Token',
                 'FUEL': 'FC2', // FuelCoin != FUEL
                 'HAV': 'Havecoin',
                 'KARM': 'KARMA',


### PR DESCRIPTION
but FCoin Token in fcoin.
maybe the Fabric Token should be the default ft, since fcoin token probably will be trade only in fcoin, 
but if we are going by the volume - fcoin win