### PR TITLE
Python: Add support for async context manager to auto-close connections

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -50,12 +50,7 @@ class Exchange(BaseExchange):
             self.asyncio_loop = config['asyncio_loop']
         self.asyncio_loop = self.asyncio_loop or asyncio.get_event_loop()
         self.own_session = 'session' not in config
-        if self.own_session:
-            # Create our SSL context object with our CA cert file
-            context = ssl.create_default_context(cafile=certifi.where())
-            # Pass this SSL context to aiohttp and create a TCPConnector
-            connector = aiohttp.TCPConnector(ssl_context=context, loop=self.asyncio_loop)
-            self.session = aiohttp.ClientSession(loop=self.asyncio_loop, connector=connector)
+        self.open()
         super(Exchange, self).__init__(config)
         self.init_rest_rate_limiter()
 
@@ -70,10 +65,19 @@ class Exchange(BaseExchange):
 
     if sys.version_info >= (3, 5):
         async def __aenter__(self):
+            self.open()
             return self
 
         async def __aexit__(self, exc_type, exc, tb):
             await self.close()
+
+    def open(self):
+        if self.own_session and self.session is None:
+            # Create our SSL context object with our CA cert file
+            context = ssl.create_default_context(cafile=certifi.where())
+            # Pass this SSL context to aiohttp and create a TCPConnector
+            connector = aiohttp.TCPConnector(ssl_context=context, loop=self.asyncio_loop)
+            self.session = aiohttp.ClientSession(loop=self.asyncio_loop, connector=connector)
 
     async def close(self):
         if self.session is not None:

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -15,6 +15,7 @@ import random
 import certifi
 import aiohttp
 import ssl
+import sys
 import yarl
 
 # -----------------------------------------------------------------------------
@@ -66,6 +67,13 @@ class Exchange(BaseExchange):
     def __del__(self):
         if self.session is not None:
             self.logger.warning(self.id + " requires to release all resources with an explicit call to the .close() coroutine. If you are creating the exchange instance from within your async coroutine, add exchange.close() to your code into a place when you're done with the exchange and don't need the exchange instance anymore (at the end of your async coroutine).")
+
+    if sys.version_info >= (3, 5):
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await self.close()
 
     async def close(self):
         if self.session is not None:


### PR DESCRIPTION
Since `.close` is required to close the aiohttp session, we can make the code simpler (and automatically close on all error cases) by using an [async context manager](https://www.python.org/dev/peps/pep-0492/#asynchronous-context-managers-and-async-with):

```
# this
try:
    exchange = ccxt.exchange({})
    return await exchange.fetch_balance()
finally:
    await exchange.close()

# becomes
async with ccxt.exchange({}) as exchange:
    return await exchange.fetch_balance()
```

This is opt-in, of course, so allows current usages to continue as normal.