### PR TITLE
TV in exx is Ti-Value

### DIFF
--- a/js/exx.js
+++ b/js/exx.js
@@ -82,7 +82,7 @@ module.exports = class exx extends Exchange {
             },
             'commonCurrencies': {
                 'CAN': 'Content and AD Network',
-                'TV': 'TIV',
+                'TV': 'TIV', // Ti-Value
             },
             'exceptions': {
                 '103': AuthenticationError,

--- a/js/exx.js
+++ b/js/exx.js
@@ -82,6 +82,7 @@ module.exports = class exx extends Exchange {
             },
             'commonCurrencies': {
                 'CAN': 'Content and AD Network',
+                'TV': 'TIV',
             },
             'exceptions': {
                 '103': AuthenticationError,


### PR DESCRIPTION
in hitbtc: 
TV -> tokenville
TIV -> Ti-Value 

none exists on CMC, so I wuold take hitbtc naming.
also, Ti-Value not updated their twitter since january, so probably its dying, so IMO better give TV to tokenville