### PR TITLE
I capitalize all orderId because createOrder will store an orderId th…

### DIFF
--- a/js/coinone.js
+++ b/js/coinone.js
@@ -257,7 +257,7 @@ module.exports = class coinone extends Exchange {
         };
         let method = 'privatePostOrder' + this.capitalize (type) + this.capitalize (side);
         let response = await this[method] (this.extend (request, params));
-        let id = this.safeString (response, 'orderId');
+        let id = (this.safeString (response, 'orderId')).toUpperCase ();
         let timestamp = this.milliseconds ();
         let cost = price * amount;
         let order = {
@@ -330,7 +330,7 @@ module.exports = class coinone extends Exchange {
 
     parseOrder (order, market = undefined) {
         let info = this.safeValue (order, 'info');
-        let id = this.safeString (info, 'orderId');
+        let id = this.safeString (info, 'orderId').toUpperCase ();
         let timestamp = parseInt (info['timestamp']) * 1000;
         let status = this.safeString (order, 'status');
         status = this.parseOrderStatus (status);


### PR DESCRIPTION
…at is lower case, and fetchOrder will get back the same order but with orderId with upper case. The exchange does not care about case, however this.orders gets all messed up because there are duplicate of the same order (upper and lower case).

Example:

order = co.create_order(symbol='IOTA/KRW',type='limit', side='buy', amount=30, price=500)
order
Out[5]:
{'info': {'errorCode': '0',
  'orderId': '7e5a98ed-c8af-4eff-8029-0799e06f91d9',
  'result': 'success'},
 'id': '7e5a98ed-c8af-4eff-8029-0799e06f91d9',
 'timestamp': 1534099267912,
 'datetime': '2018-08-12T18:41:07.912Z',
 'lastTradeTimestamp': None,
 'symbol': 'IOTA/KRW',
 'type': 'limit',
 'side': 'buy',
 'price': 500,
 'cost': 15000,
 'average': None,
 'amount': 30,
 'filled': None,
 'remaining': 30,
 'status': 'open',
 'fee': None}
order2 = co.fetch_order('7e5a98ed-c8af-4eff-8029-0799e06f91d9')
order2
Out[7]:
{'info': {'errorCode': '0',
  'status': 'live',
  'info': {'orderId': '7E5A98ED-C8AF-4EFF-8029-0799E06F91D9',
   'feeRate': '0.0008',
   'fee': '0',
   'remainQty': '30.0000',
   'timestamp': '1534099267',
   'price': '500',
   'currency': 'IOTA',
   'type': 'bid',
   'qty': '30.0000'},
  'result': 'success'},
 'id': '7E5A98ED-C8AF-4EFF-8029-0799E06F91D9',
 'timestamp': 1534099267000,
 'datetime': '2018-08-12T18:41:07.000Z',
 'lastTradeTimestamp': None,
 'symbol': 'IOTA/KRW',
 'type': 'limit',
 'side': 'buy',
 'price': 500.0,
 'cost': 15000.0,
 'amount': 30.0,
 'filled': 0.0,
 'remaining': 30.0,
 'status': 'open',
 'fee': {'currency': 'IOTA', 'cost': 0.0, 'rate': 0.0008}}