### PR TITLE
Go support base models

### DIFF
--- a/go/config.go
+++ b/go/config.go
@@ -1,0 +1,6 @@
+package ccxt
+
+type APIKey struct {
+	Key    string
+	Secret string
+}

--- a/go/errors.go
+++ b/go/errors.go
@@ -1,0 +1,81 @@
+package ccxt
+
+import (
+	"fmt"
+)
+
+// This file does some wannabe inheritage nonsense with error types,
+// errors should probably be a simple struct{msg, type, detail} instead,
+// but I went this road. todo
+
+type BaseError string
+type ExchangeError BaseError
+type NotSupportedError ExchangeError
+type AuthenticationError ExchangeError
+type InvalidNonce ExchangeError
+type InsufficientFunds ExchangeError
+type InvalidOrder ExchangeError
+type OrderNotFound InvalidOrder
+type OrderNotCached InvalidOrder
+type CancelPending InvalidOrder
+type NetworkError BaseError
+type DDoSProtection NetworkError
+type RequestTimeout NetworkError
+type ExchangeNotAvailable NetworkError
+
+func (err BaseError) Error() string            { return ErrString("BaseError", string(err)) }
+func (err ExchangeError) Error() string        { return ErrString("ExchangeError", string(err)) }
+func (err NotSupportedError) Error() string    { return ErrString("NotSupportedError", string(err)) }
+func (err AuthenticationError) Error() string  { return ErrString("AuthenticationError", string(err)) }
+func (err InvalidNonce) Error() string         { return ErrString("InvalidNonce", string(err)) }
+func (err InsufficientFunds) Error() string    { return ErrString("InsufficientFunds", string(err)) }
+func (err InvalidOrder) Error() string         { return ErrString("InvalidOrder", string(err)) }
+func (err OrderNotFound) Error() string        { return ErrString("OrderNotFound", string(err)) }
+func (err OrderNotCached) Error() string       { return ErrString("OrderNotCached", string(err)) }
+func (err CancelPending) Error() string        { return ErrString("CancelPending", string(err)) }
+func (err NetworkError) Error() string         { return ErrString("NetworkError", string(err)) }
+func (err DDoSProtection) Error() string       { return ErrString("DDoSProtection", string(err)) }
+func (err RequestTimeout) Error() string       { return ErrString("RequestTimeout", string(err)) }
+func (err ExchangeNotAvailable) Error() string { return ErrString("ExchangeNotAvailable", string(err)) }
+
+func ErrString(t, msg string) string {
+	if msg != "" {
+		return fmt.Sprintf("%s: %s", t, msg)
+	}
+	return t
+}
+
+// TypedError creates a typed error from type t and message, if type does
+// not match a known error type, fmt.Errorf will be used
+func TypedError(t string, msg string) error {
+	switch t {
+	case "ExchangeError":
+		return ExchangeError(msg)
+	case "NotSupportedError":
+		return NotSupportedError(msg)
+	case "AuthenticationError":
+		return AuthenticationError(msg)
+	case "InvalidNonce":
+		return InvalidNonce(msg)
+	case "InsufficientFunds":
+		return InsufficientFunds(msg)
+	case "InvalidOrder":
+		return InvalidOrder(msg)
+	case "OrderNotFound":
+		return OrderNotFound(msg)
+	case "OrderNotCached":
+		return OrderNotCached(msg)
+	case "CancelPending":
+		return CancelPending(msg)
+	case "NetworkError":
+		return NetworkError(msg)
+	case "DDoSProtection":
+		return DDoSProtection(msg)
+	case "RequestTimeout":
+		return RequestTimeout(msg)
+	case "ExchangeNotAvailable":
+		return ExchangeNotAvailable(msg)
+	default:
+		return fmt.Errorf(msg)
+	}
+}

--- a/go/exchange.go
+++ b/go/exchange.go
@@ -1,0 +1,46 @@
+package ccxt
+
+import (
+	"github.com/ccxt/ccxt/go/util"
+)
+
+type Exchange interface {
+	FetchTickers(symbols []string, params map[string]interface{}) (map[string]Ticker, error)
+	FetchTicker(symbol string, params map[string]interface{}) (Ticker, error)
+	FetchOHLCV(symbol, tf string, since *util.JSONTime, limit *int, params map[string]interface{}) ([]OHLCV, error)
+	FetchOrderBook(symbol string, limit *int, params map[string]interface{}) (OrderBook, error)
+	FetchL2OrderBook(symbol string, limit *int, params map[string]interface{}) (OrderBook, error)
+	FetchTrades(symbol string, since *util.JSONTime, params map[string]interface{}) ([]Trade, error)
+	FetchOrder(id string, symbol *string, params map[string]interface{}) (Order, error)
+	FetchOrders(symbol *string, since *util.JSONTime, limit *int, params map[string]interface{}) ([]Order, error)
+	FetchOpenOrders(symbol *string, since *util.JSONTime, limit *int, params map[string]interface{}) ([]Order, error)
+	FetchClosedOrders(symbol *string, since *util.JSONTime, limit *int, params map[string]interface{}) ([]Order, error)
+	FetchMyTrades(symbol *string, since *util.JSONTime, limit *int, params map[string]interface{}) ([]Trade, error)
+	FetchBalance(params map[string]interface{}) (Balances, error)
+	FetchCurrencies() ([]Currency, error)
+	FetchMarkets() ([]Market, error)
+
+	CreateOrder(symbol, t, side string, amount float64, price *float64, params map[string]interface{}) (Order, error)
+	CancelOrder(id string, symbol *string, params map[string]interface{}) error
+
+	Info() ExchangeInfo
+	LoadMarkets(reload bool) (map[string]Market, error)
+	GetMarket(symbol string) (Market, error)
+	CreateLimitBuyOrder(symbol string, amount float64, price *float64, params map[string]interface{}) (Order, error)
+	CreateLimitSellOrder(symbol string, amount float64, price *float64, params map[string]interface{}) (Order, error)
+	CreateMarketBuyOrder(symbol string, amount float64, params map[string]interface{}) (Order, error)
+	CreateMarketSellOrder(symbol string, amount float64, params map[string]interface{}) (Order, error)
+}
+
+func LoadMarkets(x Exchange) (map[string]Market, error) {
+	markets, err := x.FetchMarkets()
+	if err != nil {
+		return nil, err
+	}
+	mmap := make(map[string]Market, len(markets))
+	for _, v := range markets {
+		v.Exchange = x
+		mmap[v.Symbol] = v
+	}
+	return mmap, nil
+}

--- a/go/exchange_test.go
+++ b/go/exchange_test.go
@@ -1,0 +1,315 @@
+package ccxt
+
+import (
+	"flag"
+	"github.com/ccxt/ccxt/go/util"
+	u "github.com/rkjdid/util"
+	"log"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	exchangeName = flag.String("testExchange", "bitfinex", "exchange to test")
+	testREST     = flag.Bool("testREST", true, "test via ccxt-rest")
+	testCfg      = flag.String("testCfg", "config.toml",
+		"toml or json config file with api keys for exchanges (see config.go)")
+
+	Config map[string]APIKey
+	x      Exchange
+	err    error
+)
+
+func init() {
+	flag.Parse()
+
+	if !*testREST {
+		log.Fatal("only -testREST supported for now")
+	}
+
+	var key, sec string
+	_ = u.ReadGenericFile(&Config, *testCfg)
+	if cfg, ok := Config[*exchangeName]; ok {
+		key = cfg.Key
+		sec = cfg.Secret
+	}
+
+	x, err = NewExchangeREST(*exchangeName, *exchangeName, key, sec, nil)
+	if err != nil {
+		log.Fatalf("couldn't create exchange %s: %s", *exchangeName, err)
+	}
+	log.Println(*exchangeName)
+}
+
+func skipAuthError(t *testing.T, err error) {
+	if _, ok := err.(AuthenticationError); ok {
+		t.Skip(err)
+	}
+}
+
+func skipNotSupportedError(t *testing.T, err error) {
+	if _, ok := err.(NotSupportedError); ok {
+		t.Skip(err)
+	}
+}
+
+func getAnyMarket(t *testing.T, x Exchange) (m Market) {
+	markets, err := x.LoadMarkets(false)
+	if err != nil {
+		t.Fatal("LoadMarkets: ", err)
+	}
+	for _, v := range markets {
+		// avoid weird instruments starting with "." on bitmex
+		if *exchangeName == "bitmex" && strings.HasPrefix(v.Symbol, ".") {
+			continue
+		}
+		return v
+	}
+	t.Fatalf("%s: no markets available", x.Info().Name)
+	return
+}
+
+// TestListExchangeREST cannot fail, it tries to instanciate each available exchanges listed by
+// ccxt and logs error for those who failed and the list of those who succeeded (needs go test -v)
+// An error is always an unmarshalling error, it means the info we get from ccxt implementation
+// of the exchange doesn't match expected type structure.
+func TestListExchangesREST(t *testing.T) {
+	exchanges, err := ListExchangesREST(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%d available exchanges\n", len(exchanges))
+
+	var ok []string
+	for _, v := range exchanges {
+		// init each exchange
+		_, err := NewExchangeREST(v, "test"+v, "", "", nil)
+		if err != nil {
+			t.Logf("couldnt create %s: %s", v, err)
+		} else {
+			ok = append(ok, v)
+		}
+	}
+	t.Logf("successfully created %d/%d exchange instances", len(ok), len(exchanges))
+	t.Logf("\t%v", ok)
+}
+
+func TestExchangeREST_LoadMarkets(t *testing.T) {
+	markets, err := x.LoadMarkets(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%d markets available\n", len(markets))
+}
+
+func TestExchangeREST_FetchOpenOrders(t *testing.T) {
+	m := getAnyMarket(t, x)
+	openOrders, err := x.FetchOpenOrders(&m.Symbol, nil, nil, nil)
+	if err != nil {
+		skipAuthError(t, err)
+		skipNotSupportedError(t, err)
+		t.Fatal(err)
+	}
+	t.Logf("%s: %d open orders\n", m.Symbol, len(openOrders))
+}
+
+func TestExchangeREST_FetchClosedOrders(t *testing.T) {
+	m := getAnyMarket(t, x)
+	orders, err := x.FetchClosedOrders(&m.Symbol, nil, nil, nil)
+	if err != nil {
+		skipAuthError(t, err)
+		skipNotSupportedError(t, err)
+		t.Fatal(err)
+	}
+	t.Logf("%s: %d closed orders", m.Symbol, len(orders))
+}
+
+func TestExchangeREST_FetchOrders(t *testing.T) {
+	m := getAnyMarket(t, x)
+	orders, err := x.FetchOrders(&m.Symbol, nil, nil, nil)
+	if err != nil {
+		skipAuthError(t, err)
+		skipNotSupportedError(t, err)
+		t.Fatal(err)
+	}
+	t.Logf("%s: %d orders", m.Symbol, len(orders))
+}
+
+func TestExchangeREST_FetchTickers(t *testing.T) {
+	tickers, err := x.FetchTickers(nil, nil)
+	if err != nil {
+		skipNotSupportedError(t, err)
+		t.Fatal(err)
+	}
+	t.Logf("%d tickers\n", len(tickers))
+}
+
+func TestExchangeREST_FetchTicker(t *testing.T) {
+	m := getAnyMarket(t, x)
+	ticker, err := x.FetchTicker(m.Symbol, nil)
+	if err != nil {
+		skipNotSupportedError(t, err)
+		t.Fatal(err)
+	}
+	t.Logf("%s (%.2f%%): %f / %f\n", ticker.Symbol, ticker.Change, ticker.Ask, ticker.Bid)
+}
+
+func TestExchangeREST_FetchOHLCV(t *testing.T) {
+	m := getAnyMarket(t, x)
+	info := x.Info()
+	if !info.Has["fetchOHLCV"] {
+		t.Skip("NotSupported: fetchOHLCV")
+	}
+	var tf string
+	for k := range info.Timeframes {
+		tf = k
+	}
+	if tf == "" {
+		t.Fatalf("%s: no timeframe available", info.Name)
+	}
+	candles, err := x.FetchOHLCV(m.Symbol, tf, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candles) == 0 {
+		t.Fatalf("%s: fetched 0 candles", m.Symbol)
+	}
+	t.Logf("%s: %d candles for tf %s - from %s to %s",
+		m.Symbol, len(candles), tf, candles[0].Timestamp, candles[len(candles)-1].Timestamp)
+}
+
+func TestExchangeREST_FetchOrderBook(t *testing.T) {
+	m := getAnyMarket(t, x)
+	book, err := x.FetchOrderBook(m.Symbol, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s: %d asks / %d bids\n", m.Symbol, len(book.Asks), len(book.Bids))
+}
+
+func TestExchangeREST_FetchTrades(t *testing.T) {
+	m := getAnyMarket(t, x)
+	trades, err := x.FetchTrades(m.Symbol, util.Time(time.Now().Add(-time.Minute)), nil)
+	if err != nil {
+		skipNotSupportedError(t, err)
+		t.Fatal(err)
+	}
+	t.Logf("%s: %d trades the last minute", m.Symbol, len(trades))
+}
+
+func TestExchangeREST_FetchBalance(t *testing.T) {
+	b, err := x.FetchBalance(nil)
+	if err != nil {
+		skipAuthError(t, err)
+		t.Fatal(err)
+	}
+	b.FilterZeros()
+	t.Logf("balance totals: %v", b.Total)
+}
+
+func TestExchangeREST_OrdersBasics(t *testing.T) {
+	markets, err := x.LoadMarkets(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(markets) == 0 {
+		t.Fatal("no markets available")
+	}
+	balances, err := x.FetchBalance(nil)
+	if err != nil {
+		skipAuthError(t, err)
+		t.Fatal(err)
+	}
+	balances.FilterZeros()
+
+	var market Market
+	var free float64
+	for _, v := range markets {
+		// avoid weird instruments starting with "." on bitmex
+		if *exchangeName == "bitmex" && strings.HasPrefix(v.Symbol, ".") {
+			continue
+		}
+		if free = balances.Free[v.Base]; free > 0 {
+			market = v
+			break
+		}
+	}
+
+	if market.Symbol == "" {
+		t.Skipf("no ca$h available for placing test order")
+	}
+	t.Logf("market %s", market.Symbol)
+
+	book, err := x.FetchOrderBook(market.Symbol, nil, nil)
+	if err != nil {
+		t.Fatalf("couldn't fetch order book for %s:%s: %s",
+			*exchangeName, market.Symbol, err)
+	}
+	if len(book.Asks) == 0 {
+		t.Fatalf("empty book.Asks")
+	}
+
+	// setup order for 10% of available balance @10*highest ask
+	ask := book.Asks[len(book.Asks)-1].Price * 10
+	amount := free * 0.1
+
+	// mex contracts are pegged to USD
+	if *exchangeName == "bitmex" {
+		amount = math.Floor(amount * book.Asks[0].Price)
+	}
+
+	// place our optimistic ask
+	order, err := x.CreateOrder(market.Symbol, "limit", "sell", amount, &ask, nil)
+	if err != nil {
+		t.Fatal("CreateOrder: ", err)
+	}
+	t.Logf("created order %s: %s", order.ID, order)
+
+	// look for it in our orders
+	myOrders, err := x.FetchOrders(&market.Symbol, nil, nil, nil)
+	if err != nil {
+		t.Errorf("FetchOrders: %s", err)
+	} else {
+		var found bool
+		for _, o := range myOrders {
+			if o.ID == order.ID {
+				found = true
+				if o.String() != order.String() {
+					t.Errorf(
+						"found order ID from FetchOrders but mismatch on .String methods:\n  %s\n  %s",
+						o.String(), order.String())
+				}
+			}
+		}
+		if !found {
+			t.Errorf("didn't find created order %s from FetchOrders", order.ID)
+		}
+	}
+
+	if o, err := x.FetchOrder(order.ID, nil, nil); err != nil {
+		t.Error("FetchOrder: ", err)
+	} else if o.ID != order.ID {
+		t.Errorf("FetchOrder: unexpected order ID : %s vs %s", o.ID, order.ID)
+	} else if o.String() != order.String() {
+		t.Errorf("found order ID but mismatch on .String methods:\n  %s\n  %s",
+			o.String(), order.String())
+	}
+
+	// cancel it
+	for i := 0; i < 5; i++ {
+		err = x.CancelOrder(order.ID, &market.Symbol, nil)
+		if err == nil {
+			t.Logf("canceled order %s", order.ID)
+			break
+		}
+		if err != nil {
+			t.Error("CancelOrder: ", err)
+		}
+		time.Sleep(time.Second * 5)
+		i++
+		t.Fatalf("Couldn't cancel order %s on %s after 5 tries, do something human",
+			order.ID, order.Symbol)
+	}
+}

--- a/go/market.go
+++ b/go/market.go
@@ -1,0 +1,31 @@
+package ccxt
+
+type Market struct {
+	Exchange Exchange
+
+	ID        string // exchange specific
+	Symbol    string // ccxt unified
+	Base      string
+	Quote     string
+	Lot       float64
+	Precision Precision
+	Limits    Limits
+	Info      interface{}
+}
+
+type Precision struct {
+	Amount int
+	Price  int
+	Cost   int
+}
+
+type Limits struct {
+	Amount MinMax
+	Price  MinMax
+	Cost   MinMax
+}
+
+type MinMax struct {
+	Min float64
+	Max float64
+}

--- a/go/models.go
+++ b/go/models.go
@@ -1,0 +1,304 @@
+package ccxt
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ccxt/ccxt/go/util"
+	"net/http"
+	"time"
+)
+
+type ExchangeInfo struct {
+	ID              string
+	Name            string
+	Countries       StringSlice
+	EnableRateLimit bool
+	RateLimit       int
+	Has             map[string]bool
+	URLs            URLs
+	API             map[string]map[string][]string
+	Timeframes      map[string]interface{}
+	Fees            Fees
+	UserAgents      map[string]string
+	Header          http.Header
+	Proxy           string
+	Origin          string
+	Verbose         bool
+	Limits          Limits
+	Precision       Precision
+}
+
+type URLs struct {
+	API  APIURLs
+	Logo StringSlice
+	WWW  StringSlice
+	Doc  StringSlice
+	Fees StringSlice
+}
+
+type StringSlice []string
+
+// UnmarshalJSON accepts both forms for StringSlice:
+//   - ["s1", "s2"...]
+//   - "s"
+// For the latter, ss will hold a single element "s"
+// todo: unify to array form ?
+func (ss *StringSlice) UnmarshalJSON(b []byte) (err error) {
+	// try slice unmarshal
+	var slice []string
+	err = json.Unmarshal(b, &slice)
+	if err == nil {
+		*ss = slice
+		return nil
+	}
+	// try string unmarshal
+	var s string
+	err2 := json.Unmarshal(b, &s)
+	if err2 == nil {
+		*ss = append(*ss, s)
+		return nil
+	}
+	// return original error
+	return err
+}
+
+type APIURLs struct {
+	Public, Private string
+}
+
+// UnmarshalJSON accepts both forms for APIURLs:
+//   - {"public": "urlpub", "private": "urlpriv"} or
+//   - "url"
+// For the latter, "url" is assigned to both a.Private and a.Public
+// todo: unify to struct form ?
+func (a *APIURLs) UnmarshalJSON(b []byte) (err error) {
+	// default struct unmarshal to compatible type
+	type t APIURLs
+	err = json.Unmarshal(b, (*t)(a))
+	if err == nil {
+		return nil
+	}
+	// string unmarshal
+	var s string
+	err2 := json.Unmarshal(b, &s)
+	if err2 == nil {
+		a.Private = s
+		a.Public = s
+		return nil
+	}
+	// return original error
+	return err
+}
+
+type Fees struct {
+	Trading TradingFees
+	Funding FundingFees
+}
+
+type TradingFees struct {
+	TierBased  bool
+	Percentage bool
+	Maker      float64
+	Taker      float64
+	Tiers      TradingFeesTiers
+}
+
+type TradingFeesTiers struct {
+	Taker [][2]float64
+	Maker [][2]float64
+}
+
+type FundingFees struct {
+	TierBased  bool
+	Percentage bool
+	Deposit    map[string]float64
+	Withdraw   map[string]float64
+}
+
+type Account struct {
+	Free,
+	Used,
+	Total float64
+}
+
+type Balance struct {
+	Free,
+	Used,
+	Total float64
+}
+
+type Balances struct {
+	Currencies map[string]Balance
+	Free       map[string]float64
+	Used       map[string]float64
+	Total      map[string]float64
+	Info       interface{}
+}
+
+// UnmarshalJSON retreives unified values from "free", "used" and "total",
+// then generates Currencies map from these 3 maps.
+func (b *Balances) UnmarshalJSON(s []byte) (err error) {
+	// default json unmarshal
+	type t Balances
+	if err = json.Unmarshal(s, (*t)(b)); err != nil {
+		return err
+	}
+
+	b.Currencies = make(map[string]Balance, len(b.Total))
+	for k := range b.Total {
+		b.Currencies[k] = Balance{
+			Total: b.Total[k],
+			Free:  b.Free[k],
+			Used:  b.Used[k],
+		}
+	}
+	return nil
+}
+
+// FilterZeroes remove Balances entries which equal to 0
+func (b *Balances) FilterZeros() {
+	for k, v := range b.Currencies {
+		if v.Total == 0.0 && v.Used == 0.0 && v.Free == 0.0 {
+			delete(b.Total, k)
+			delete(b.Used, k)
+			delete(b.Free, k)
+			delete(b.Currencies, k)
+		}
+	}
+}
+
+type Order struct {
+	ID        string
+	Timestamp util.JSONTime
+	Datetime  string
+	Symbol    string
+	Status    string
+	Type      string
+	Side      string
+	Price     float64
+	Cost      float64
+	Amount    float64
+	Filled    float64
+	Remaining float64
+	Fee       float64
+	Info      interface{}
+}
+
+func (o Order) String() string {
+	return fmt.Sprintf("%s %f %s @%f (filled: %f)",
+		o.Side, o.Amount, o.Symbol, o.Price, o.Filled)
+}
+
+type OrderBook struct {
+	Asks      []BookEntry
+	Bids      []BookEntry
+	Timestamp time.Time
+	Datetime  string
+	Nonce     int
+}
+
+type BookEntry struct {
+	Price, Amount float64
+}
+
+// UnmarshalJSON accepts both forms for BookEntry:
+//   - []float64 of size 2 or
+//   - default BookEntry struct
+func (o *BookEntry) UnmarshalJSON(b []byte) (err error) {
+	// []float64 unmarshal
+	var f []float64
+	err = json.Unmarshal(b, &f)
+	if err == nil {
+		if len(f) != 2 {
+			return fmt.Errorf("UnmarshalJSON: expected 2 floats for BookEntry, got %d", len(f))
+		}
+		o.Price, o.Amount = f[0], f[1]
+		return nil
+	}
+	// default struct unmarshal to compatible type
+	type t BookEntry
+	err2 := json.Unmarshal(b, (*t)(o))
+	if err2 == nil {
+		return nil
+	}
+	return err
+}
+
+type Trade struct {
+	ID        string
+	Symbol    string
+	Amount    float64
+	Price     float64
+	Timestamp util.JSONTime
+	Datetime  string
+	Order     string
+	Type      string
+	Side      string
+	Info      interface{}
+}
+
+type Ticker struct {
+	Symbol      string
+	Ask         float64
+	Bid         float64
+	High        float64
+	Low         float64
+	Average     float64
+	BaseVolume  float64
+	QuoteVolume float64
+	Change      float64
+	Open        float64
+	Close       float64
+	First       float64
+	Last        float64
+	Percentage  float64
+	VWAP        float64
+	Timestamp   util.JSONTime
+	Datetime    string
+	Info        interface{}
+}
+
+type Currency struct {
+	ID   string
+	Code string
+}
+
+type DepositAddress struct {
+	Currency string
+	Address  string
+	Status   string
+	Info     interface{}
+}
+
+type OHLCV struct {
+	Timestamp     util.JSONTime
+	O, H, L, C, V float64
+}
+
+// UnmarshalJSON accepts both forms for OHLCV:
+//   - default struct or
+//   - []float64 of size 6
+func (o *OHLCV) UnmarshalJSON(b []byte) (err error) {
+	// default struct unmarshal to compatible type
+	type t OHLCV
+	err = json.Unmarshal(b, (*t)(o))
+	if err == nil {
+		return nil
+	}
+	// []float64 unmarshal
+	var f []float64
+	err2 := json.Unmarshal(b, &f)
+	if err2 != nil {
+		return err2 // return float64 unmarshal error as it's the expected form
+	}
+	if len(f) != 6 {
+		return fmt.Errorf("UnmarshalJSON: expected 6 floats for OHLCV, got %d", len(f))
+	}
+
+	err2 = json.Unmarshal([]byte(fmt.Sprintf("%f", f[0])), &o.Timestamp)
+	if err2 != nil {
+		return fmt.Errorf("UnmarshalJSON: couldn't unmarshal timestamp: %s", err2)
+	}
+	o.O, o.H, o.L, o.C, o.V = f[1], f[2], f[3], f[4], f[5]
+	return nil
+}

--- a/go/rest.go
+++ b/go/rest.go
@@ -1,0 +1,343 @@
+package ccxt
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/ccxt/ccxt/go/util"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+var (
+	debug    = flag.Bool("ccxt-rest-debug", false, "Log outgoing requests and responses to ccxt-rest")
+	ccxtREST = flag.String("ccxt-rest", "http://localhost:3000/", "ccxt-rest server url")
+)
+
+const (
+	endpointExchanges = "exchanges"
+)
+
+func ListExchangesREST(cli *http.Client) ([]string, error) {
+	if cli == nil {
+		cli = http.DefaultClient
+	}
+	resp, err := cli.Get(*ccxtREST + endpointExchanges)
+	if err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(resp.Body)
+	var exchanges []string
+	return exchanges, dec.Decode(&exchanges)
+}
+
+// ExchangeREST implements the Exchange interface. It is intended to be
+// used in conjunction with https://github.com/franz-see/ccxt-rest
+// We forward requests to ccxt-rest and unwrap responses to relevant structs.
+type ExchangeREST struct {
+	ExchangeInfo
+	Key     string
+	ID      string
+	Markets map[string]Market
+
+	BaseURL string
+	*http.Client
+}
+
+func NewExchangeREST(exchange string, id string, key, secret string, cli *http.Client) (*ExchangeREST, error) {
+	x := &ExchangeREST{
+		Client:  cli,
+		Key:     exchange,
+		ID:      id,
+		BaseURL: *ccxtREST,
+	}
+	if x.Client == nil {
+		x.Client = http.DefaultClient
+	}
+	return x, x.Init(key, secret)
+}
+
+func (x *ExchangeREST) Init(key, secret string) error {
+	params := map[string]string{
+		"id":     x.ID,
+		"apiKey": key,
+		"secret": secret,
+	}
+	return x.Post(path.Join(endpointExchanges, x.Key), &x.ExchangeInfo, params)
+}
+
+func (x *ExchangeREST) Info() ExchangeInfo {
+	return x.ExchangeInfo
+}
+
+func (x *ExchangeREST) FetchCurrencies() (c []Currency, err error) {
+	return c, x.Post(x.Path("fetchCurrencies"), &c, nil)
+}
+
+func (x *ExchangeREST) FetchMarkets() (m []Market, err error) {
+	return m, x.Post(x.Path("fetchMarkets"), &m, nil)
+}
+
+func (x *ExchangeREST) LoadMarkets(reload bool) (m map[string]Market, err error) {
+	if reload || x.Markets == nil {
+		x.Markets, err = LoadMarkets(x)
+	}
+	return x.Markets, err
+}
+
+func (x *ExchangeREST) GetMarket(id string) (m Market, err error) {
+	if x.Markets == nil {
+		_, err := x.LoadMarkets(false)
+		if err != nil {
+			return m, err
+		}
+	}
+	m, ok := x.Markets[id]
+	if !ok {
+		err = NotSupportedError(fmt.Sprintf("market %s not found for %s", id, x.Key))
+	}
+	return m, err
+}
+
+func (x *ExchangeREST) FetchTickers(
+	symbols []string,
+	params map[string]interface{},
+) (t map[string]Ticker, err error) {
+	return t, x.Post(x.Path("fetchTickers"), &t, []interface{}{symbols, params})
+}
+
+func (x *ExchangeREST) FetchTicker(
+	symbol string,
+	params map[string]interface{},
+) (t Ticker, err error) {
+	return t, x.Post(x.Path("fetchTicker"), &t, []interface{}{symbol, params})
+}
+
+func (x *ExchangeREST) FetchOHLCV(
+	symbol string,
+	timeframe string,
+	since *util.JSONTime,
+	limit *int,
+	params map[string]interface{},
+) (o []OHLCV, err error) {
+	return o, x.Post(x.Path("fetchOHLCV"), &o, []interface{}{symbol, timeframe, since, limit, params})
+}
+
+func (x *ExchangeREST) FetchOrderBook(
+	symbol string,
+	limit *int,
+	params map[string]interface{},
+) (o OrderBook, err error) {
+	return o, x.Post(x.Path("fetchOrderBook"), &o, []interface{}{symbol, limit, params})
+}
+
+func (x *ExchangeREST) FetchL2OrderBook(
+	symbol string,
+	limit *int,
+	params map[string]interface{},
+) (o OrderBook, err error) {
+	return o, x.Post(x.Path("fetchL2OrderBook"), &o, []interface{}{symbol, limit, params})
+}
+
+func (x *ExchangeREST) FetchTrades(
+	symbol string,
+	since *util.JSONTime,
+	params map[string]interface{},
+) (t []Trade, err error) {
+	return t, x.Post(x.Path("fetchTrades"), &t, []interface{}{symbol, since, params})
+}
+
+func (x *ExchangeREST) FetchOrder(
+	id string,
+	symbol *string,
+	params map[string]interface{},
+) (o Order, err error) {
+	return o, x.Post(x.Path("fetchOrder"), &o, []interface{}{id, symbol, params})
+}
+
+func (x *ExchangeREST) FetchOrders(
+	symbol *string,
+	since *util.JSONTime,
+	limit *int,
+	params map[string]interface{},
+) (o []Order, err error) {
+	return o, x.Post(x.Path("fetchOrders"), &o, []interface{}{symbol, since, limit, params})
+}
+
+func (x *ExchangeREST) FetchOpenOrders(
+	symbol *string,
+	since *util.JSONTime,
+	limit *int,
+	params map[string]interface{},
+) (o []Order, err error) {
+	return o, x.Post(x.Path("fetchOpenOrders"), &o, []interface{}{symbol, since, limit, params})
+}
+
+func (x *ExchangeREST) FetchClosedOrders(
+	symbol *string,
+	since *util.JSONTime,
+	limit *int,
+	params map[string]interface{},
+) (o []Order, err error) {
+	return o, x.Post(x.Path("fetchClosedOrders"), &o, []interface{}{symbol, since, limit, params})
+}
+
+func (x *ExchangeREST) FetchMyTrades(
+	symbol *string,
+	since *util.JSONTime,
+	limit *int,
+	params map[string]interface{},
+) (t []Trade, err error) {
+	return t, x.Post(x.Path("fetchMyTrades"), &t, []interface{}{symbol, since, limit, params})
+}
+
+func (x *ExchangeREST) FetchBalance(params map[string]interface{}) (b Balances, err error) {
+	return b, x.Post(x.Path("fetchBalance"), &b, []interface{}{params})
+}
+
+func (x *ExchangeREST) CreateOrder(
+	symbol, t, side string,
+	amount float64,
+	price *float64,
+	params map[string]interface{},
+) (o Order, err error) {
+	return o, x.Post(x.Path("createOrder"), &o, []interface{}{symbol, t, side, amount, price, params})
+}
+
+func (x *ExchangeREST) CancelOrder(
+	id string,
+	symbol *string,
+	params map[string]interface{}) error {
+	return x.Post(x.Path("cancelOrder"), nil, []interface{}{id, symbol, params})
+}
+
+func (x *ExchangeREST) CreateLimitBuyOrder(
+	symbol string,
+	amount float64,
+	price *float64,
+	params map[string]interface{},
+) (Order, error) {
+	return x.CreateOrder(symbol, "limit", "buy", amount, price, params)
+}
+
+func (x *ExchangeREST) CreateLimitSellOrder(
+	symbol string,
+	amount float64,
+	price *float64,
+	params map[string]interface{},
+) (Order, error) {
+	return x.CreateOrder(symbol, "limit", "sell", amount, price, params)
+}
+
+func (x *ExchangeREST) CreateMarketBuyOrder(
+	symbol string,
+	amount float64,
+	params map[string]interface{},
+) (Order, error) {
+	return x.CreateOrder(symbol, "market", "buy", amount, nil, params)
+}
+
+func (x *ExchangeREST) CreateMarketSellOrder(
+	symbol string,
+	amount float64,
+	params map[string]interface{},
+) (Order, error) {
+	return x.CreateOrder(symbol, "market", "sell", amount, nil, params)
+}
+
+func (x *ExchangeREST) Path(endpoint string) string {
+	return path.Join(endpointExchanges, x.Key, x.ID, endpoint)
+}
+
+func (x *ExchangeREST) Post(endpoint string, dest interface{}, params interface{}) error {
+	return x.Do(http.MethodPost, endpoint, dest, params)
+}
+
+func (x *ExchangeREST) Get(endpoint string, dest interface{}) error {
+	return x.Do(http.MethodGet, endpoint, dest, nil)
+}
+
+func (x *ExchangeREST) Do(method, endpoint string, dest interface{}, params interface{}) error {
+	if s := path.Base(endpoint); s != x.Key && !x.Has[s] {
+		return NotSupportedError(s)
+	}
+
+	u, err := url.Parse(x.BaseURL)
+	if err != nil {
+		return fmt.Errorf("couldn't parse BaseURL for %s: %s", x.ID, err)
+	}
+	u.Path = path.Join(u.Path, endpoint)
+	var body io.Reader
+	if params != nil {
+		body = new(bytes.Buffer)
+		enc := json.NewEncoder(body.(*bytes.Buffer))
+		err := enc.Encode(params)
+		if err != nil {
+			return fmt.Errorf("couldn't json encode params: %s", err)
+		}
+	}
+	rq, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return fmt.Errorf("error making request: %s", err)
+	}
+
+	if *debug {
+		s := fmt.Sprintf("%s %s", method, u.String())
+		if params != nil {
+			pparams, _ := json.MarshalIndent(params, "", "  ")
+			s += "\n" + string(pparams)
+		}
+		log.Println(s)
+	}
+
+	resp, err := x.Client.Do(rq)
+	if err != nil {
+		return err
+	}
+
+	// read body
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading body: %s", err)
+	}
+
+	if *debug {
+		s := fmt.Sprint(resp.StatusCode)
+		if len(respBody) > 0 {
+			prettyBody := bytes.NewBuffer(nil)
+			_ = json.Indent(prettyBody, respBody, "", "  ")
+			s += "\n" + string(prettyBody.Bytes())
+		} else {
+			s += " - empty body"
+		}
+		log.Println(s)
+	}
+
+	if resp.StatusCode > 299 || resp.StatusCode < 200 {
+		// unpack ccxt-rest error message & type
+		var ccxtErr = struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		}{}
+		err = json.Unmarshal(respBody, &ccxtErr)
+		if err == nil && ccxtErr.Message != "" {
+			return TypedError(ccxtErr.Type, ccxtErr.Message)
+		}
+		return fmt.Errorf("%s: %d - %s", u, resp.StatusCode, respBody)
+	}
+
+	if dest == nil {
+		return nil
+	}
+
+	err = json.Unmarshal(respBody, dest)
+	if err != nil {
+		return fmt.Errorf("error decoding ccxt-rest response: %s\n", err)
+	}
+	return nil
+}

--- a/go/util/crypto.go
+++ b/go/util/crypto.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"hash"
+)
+
+var hashers = map[string]func() hash.Hash{
+	"sha1":   sha1.New,
+	"sha256": sha256.New,
+	"sha512": sha512.New,
+	"sha384": sha512.New384,
+	"md5":    md5.New,
+}
+
+func Hash(payload, algo, encoding string) (string, error) {
+	if hashers[algo] == nil {
+		return "", fmt.Errorf("hash: unsupported algo \"%s\"", algo)
+	}
+	h := hashers[algo]()
+	_, err := h.Write([]byte(payload))
+	if err != nil {
+		return "", fmt.Errorf("hash: %s", err)
+	}
+	return string(encode(h.Sum(nil), encoding)), nil
+}
+
+func HMAC(payload, key, algo, encoding string) (string, error) {
+	if hashers[algo] == nil {
+		return "", fmt.Errorf("HMAC: unsupported hashing algo \"%s\"", algo)
+	}
+	h := hmac.New(hashers[algo], []byte(key))
+	_, err := h.Write([]byte(payload))
+	if err != nil {
+		return "", fmt.Errorf("hmac: %s", err)
+	}
+	return string(encode(h.Sum(nil), encoding)), nil
+}
+
+func JWT(claims map[string]interface{}, secret string) (string, error) {
+	var signer jwt.SigningMethod = jwt.SigningMethodHS256
+	token := jwt.New(signer)
+	token.Claims = jwt.MapClaims(claims)
+	return token.SignedString([]byte(secret))
+}
+
+func encode(payload []byte, encoding string) []byte {
+	var result []byte
+	switch encoding {
+	case "hex":
+		result = []byte(hex.EncodeToString(payload))
+	case "base64":
+		buf := make([]byte, base64.StdEncoding.EncodedLen(len(payload)))
+		base64.StdEncoding.Encode(buf, payload)
+		result = buf
+	default:
+		result = payload
+	}
+	return result
+}

--- a/go/util/crypto_test.go
+++ b/go/util/crypto_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHMAC(t *testing.T) {
+	results := map[string]string{
+		"sha256/hex":  "147933218aaabc0b8b10a2b3a5c34684c8d94341bcf10a4736dc7270f7741851",
+		"sha1/base64": "hdFVxV7ShqMAvRzxJN4I2H6RTzo=",
+	}
+	for method, expected := range results {
+		s := strings.Split(method, "/")
+		result, err := HMAC("foo", "bar", s[0], s[1])
+		if err != nil {
+			t.Error(err)
+		} else if result != expected {
+			t.Errorf("sha256/hex:\n     got: %s\nexpected: %s", result, expected)
+		}
+	}
+}
+
+func TestJWT(t *testing.T) {
+	expected := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.sLoOvOXnOK490o8iHakkNCMmsMMUwrZK9prFvjqOtYI"
+	result, err := JWT(map[string]interface{}{
+		"foo": "bar",
+	}, "baz")
+	if err != nil {
+		t.Error(err)
+	} else if result != expected {
+		t.Errorf("\nexpected: %s\n     got: %s", expected, result)
+	}
+}
+
+func TestHash(t *testing.T) {
+	expected := "iEPX+SQWIR3p67lj/0zigSWTKHg="
+	result, _ := Hash("foobar", "sha1", "base64")
+	if expected != result {
+		t.Error("nope" + " " + result)
+	}
+}

--- a/go/util/encode.go
+++ b/go/util/encode.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"bytes"
+	"net/url"
+	"sort"
+)
+
+func URLEncode(items map[string]string) string {
+	values := make(url.Values)
+	for k, v := range items {
+		values.Add(k, v)
+	}
+	return values.Encode()
+}
+
+func RawEncode(items map[string]string) string {
+	v := make(url.Values)
+	for k, item := range items {
+		v.Add(k, item)
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := v[k]
+		prefix := k + "="
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			buf.WriteString(string(v))
+		}
+	}
+	return buf.String()
+}

--- a/go/util/encode_test.go
+++ b/go/util/encode_test.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	t.Log("raw encode:", RawEncode(map[string]string{"foo": "ébar"}))
+	t.Log("url encode:", URLEncode(map[string]string{"foo": "ébar"}))
+}

--- a/go/util/numbers.go
+++ b/go/util/numbers.go
@@ -1,0 +1,174 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+const (
+	Round = iota
+	Truncate
+)
+
+const (
+	DecimalPlaces = iota
+	SignificantDigits
+)
+
+const (
+	NoPadding = iota
+	PadWithZero
+)
+
+func NumberToString(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+func DecimalToPrecision(f float64, roundingMode int, numPrecisionDigits int, countingMode int, paddingMode int) (string, error) {
+	if numPrecisionDigits < 0 {
+		return "", fmt.Errorf("negative precision not supported")
+	}
+
+	var str = NumberToString(f)
+	var isNegative = str[0] == '-'
+	var strStart, strEnd = 0, len(str)
+	if isNegative {
+		strStart = 1
+	}
+
+	var hasDot bool
+	for i := 0; i < strEnd; i++ {
+		if str[i] == '.' {
+			hasDot = true
+			break
+		}
+	}
+
+	var sz = strEnd - strStart + 1
+	if hasDot {
+		sz -= 1
+	}
+	var chars = make([]byte, sz)
+	chars[0] = '0'
+
+	var afterDot, digitsStart, digitsEnd = len(chars), -1, -1
+
+	for i, j := 1, strStart; j < strEnd; i, j = i+1, j+1 {
+		c := str[j]
+		if c == '.' {
+			afterDot = i
+			i--
+		} else if c < '0' || c > '9' {
+			return "", fmt.Errorf("bad input: %d", c)
+		} else {
+			chars[i] = c
+			if c != '0' && digitsStart < 0 {
+				digitsStart = i
+			}
+		}
+	}
+
+	if digitsStart < 0 {
+		digitsStart = 1
+	}
+
+	var precisionStart = digitsStart
+	if countingMode == DecimalPlaces {
+		precisionStart = afterDot
+	}
+	var precisionEnd = precisionStart + numPrecisionDigits
+	digitsEnd = -1
+
+	for i, memo := len(chars)-1, false; i >= 0; i-- {
+		c := chars[i]
+		if i != 0 {
+			if memo {
+				c += 1
+			}
+			if i >= precisionStart+numPrecisionDigits {
+				if roundingMode == Round && c >= '5' && !(c == '5' && memo) {
+					c = '9' + 1
+				} else {
+					c = '0'
+				}
+			}
+			if c > '9' {
+				c = '0'
+				memo = true
+			} else {
+				memo = false
+			}
+		} else if memo {
+			c = '1'
+		}
+		chars[i] = c
+
+		if c != '0' {
+			digitsStart = i
+			if digitsEnd < 0 {
+				digitsEnd = i + 1
+			}
+		}
+	}
+
+	if countingMode == SignificantDigits {
+		precisionStart = digitsStart
+		precisionEnd = precisionStart + numPrecisionDigits
+	}
+
+	var readStart = digitsStart
+	if digitsStart >= afterDot {
+		readStart = afterDot - 1
+	}
+	var readEnd = digitsEnd
+	if digitsEnd < afterDot {
+		readEnd = afterDot
+	}
+
+	var nSign = 0
+	if f < 0 {
+		nSign = 1
+	}
+	var nBeforeDot = nSign + afterDot - readStart
+	var nAfterDot = readEnd - afterDot
+	if nAfterDot < 0 {
+		nAfterDot = 0
+	}
+	var actualLength = readEnd - readStart
+	var desiredLength = precisionEnd - readStart
+	if paddingMode == NoPadding {
+		desiredLength = actualLength
+	}
+	var pad = desiredLength - actualLength
+	if pad < 0 {
+		pad = 0
+	}
+	var padStart = nBeforeDot + 1 + nAfterDot
+	var padEnd = padStart + pad
+	var isInteger = (nAfterDot + pad) == 0
+
+	sz = nBeforeDot + nAfterDot + pad
+	if !isInteger {
+		sz++
+	}
+
+	var out = make([]byte, sz)
+	if f < 0 {
+		out[0] = '-'
+	}
+	for i, j := nSign, readStart; i < nBeforeDot; i, j = i+1, j+1 {
+		out[i] = chars[j]
+	}
+	if !isInteger {
+		out[nBeforeDot] = '.'
+	}
+	for i, j := nBeforeDot+1, afterDot; i < padStart; i, j = i+1, j+1 {
+		out[i] = chars[j]
+	}
+	for i := padStart; i < padEnd; i++ {
+		out[i] = '0'
+	}
+
+	return string(bytes.Trim(out, "\x00")), nil
+}

--- a/go/util/numbers_test.go
+++ b/go/util/numbers_test.go
@@ -1,0 +1,110 @@
+package util
+
+import "testing"
+
+func TestNumberToString(t *testing.T) {
+	expected := map[float64]string{
+		-7.9e-7: "-0.00000079",
+		7.9e-7:  "0.00000079",
+		-12.345: "-12.345",
+		36e20:   "3600000000000000000000",
+		0:       "0",
+	}
+
+	for f, v := range expected {
+		if NumberToString(f) != v {
+			t.Errorf("\nexpected: %s\n     got: %s", v, NumberToString(f))
+		}
+	}
+}
+
+func TestDecimalToPrecision(t *testing.T) {
+	var test = func(expectedErr error, expectedResult string, f float64, mode, precision, precisionFirstDigit, padding int) {
+		if r, err := DecimalToPrecision(f, mode, precision, precisionFirstDigit, padding); err != expectedErr {
+			t.Errorf("%d%d%d:%3d: %s", mode, precisionFirstDigit, padding, precision, expectedResult)
+			t.Errorf("    err: got %s, expected %s", err, expectedErr)
+		} else if r != expectedResult {
+			t.Errorf("%d%d%d:%3d: %s", mode, precisionFirstDigit, padding, precision, expectedResult)
+			t.Errorf("      -> %s", r)
+		}
+	}
+
+	// decimalToPrecision: truncation (to N digits after dot)
+	test(nil, "12.3456", 12.3456, Truncate, 100, DecimalPlaces, NoPadding)
+	test(nil, "12.3456", 12.3456000, Truncate, 100, DecimalPlaces, NoPadding)
+	test(nil, "12.3456", 12.3456, Truncate, 100, DecimalPlaces, NoPadding)
+	test(nil, "12.3456", 12.3456, Truncate, 4, DecimalPlaces, NoPadding)
+	test(nil, "12.345", 12.3456, Truncate, 3, DecimalPlaces, NoPadding)
+	test(nil, "12.34", 12.3456, Truncate, 2, DecimalPlaces, NoPadding)
+	test(nil, "12.3", 12.3456, Truncate, 1, DecimalPlaces, NoPadding)
+	test(nil, "12", 12.3456, Truncate, 0, DecimalPlaces, NoPadding)
+	test(nil, "0", 0, Truncate, 0, DecimalPlaces, NoPadding)
+
+	// decimalToPrecision: truncation (to N significant digits)
+	test(nil, "0.0001234567", 0.000123456700, Truncate, 100, SignificantDigits, NoPadding)
+	test(nil, "0.0001234567", 0.0001234567, Truncate, 100, SignificantDigits, NoPadding)
+	test(nil, "0.0001234567", 0.0001234567, Truncate, 7, SignificantDigits, NoPadding)
+	test(nil, "0.000123456", 0.000123456, Truncate, 6, SignificantDigits, NoPadding)
+	test(nil, "0.00012345", 0.000123456, Truncate, 5, SignificantDigits, NoPadding)
+	test(nil, "0.00012", 0.000123456, Truncate, 2, SignificantDigits, NoPadding)
+	test(nil, "0.0001", 0.000123456, Truncate, 1, SignificantDigits, NoPadding)
+	test(nil, "123.0000987", 123.0000987654, Truncate, 10, SignificantDigits, NoPadding)
+	test(nil, "123.00009", 123.0000987654, Truncate, 8, SignificantDigits, NoPadding)
+	test(nil, "123", 123.0000987654, Truncate, 7, SignificantDigits, NoPadding)
+	test(nil, "123.0000", 123.0000987654, Truncate, 7, SignificantDigits, PadWithZero)
+	test(nil, "123.0", 123.0000987654, Truncate, 4, SignificantDigits, PadWithZero)
+	test(nil, "120", 123.0000987654, Truncate, 2, SignificantDigits, NoPadding)
+	test(nil, "100", 123.0000987654, Truncate, 1, SignificantDigits, NoPadding)
+	test(nil, "100", 123.0000987654, Truncate, 1, SignificantDigits, PadWithZero)
+	test(nil, "0", 0, Truncate, 0, SignificantDigits, NoPadding)
+
+	// decimalToPrecision: rounding (to N digits after dot)
+	test(nil, "12.3456", 12.3456000, Round, 100, DecimalPlaces, NoPadding)
+	test(nil, "12.3456", 12.3456, Round, 100, DecimalPlaces, NoPadding)
+	test(nil, "12.3456", 12.3456, Round, 4, DecimalPlaces, NoPadding)
+	test(nil, "12.346", 12.3456, Round, 3, DecimalPlaces, NoPadding)
+	test(nil, "12.35", 12.3456, Round, 2, DecimalPlaces, NoPadding)
+	test(nil, "12.3", 12.3456, Round, 1, DecimalPlaces, NoPadding)
+	test(nil, "12", 12.3456, Round, 0, DecimalPlaces, NoPadding)
+	test(nil, "9.999", 9.999, Round, 3, DecimalPlaces, NoPadding)
+	test(nil, "10", 9.999, Round, 2, DecimalPlaces, NoPadding)
+	test(nil, "10.00", 9.999, Round, 2, DecimalPlaces, PadWithZero)
+	test(nil, "100.00", 99.999, Round, 2, DecimalPlaces, PadWithZero)
+	test(nil, "-100.00", -99.999, Round, 2, DecimalPlaces, PadWithZero)
+
+	// decimalToPrecision: rounding (to N significant digits)
+	test(nil, "0.0001234567", 0.000123456700, Round, 100, SignificantDigits, NoPadding)
+	test(nil, "0.0001234567", 0.0001234567, Round, 100, SignificantDigits, NoPadding)
+	test(nil, "0.0001234567", 0.0001234567, Round, 7, SignificantDigits, NoPadding)
+	test(nil, "0.000123456", 0.000123456, Round, 6, SignificantDigits, NoPadding)
+	test(nil, "0.00012346", 0.000123456, Round, 5, SignificantDigits, NoPadding)
+	test(nil, "0.0001235", 0.000123456, Round, 4, SignificantDigits, NoPadding)
+	test(nil, "0.00012", 0.00012, Round, 2, SignificantDigits, NoPadding)
+	test(nil, "0.0001", 0.0001, Round, 1, SignificantDigits, NoPadding)
+	test(nil, "123.0001", 123.0000987654, Round, 7, SignificantDigits, NoPadding)
+	test(nil, "123", 123.0000987654, Round, 6, SignificantDigits, NoPadding)
+	test(nil, "0.00099", 0.00098765, Round, 2, SignificantDigits, NoPadding)
+	test(nil, "0.00099", 0.00098765, Round, 2, SignificantDigits, PadWithZero)
+	test(nil, "0.001", 0.00098765, Round, 1, SignificantDigits, NoPadding)
+	test(nil, "0.0009876500000", 0.00098765, Round, 10, SignificantDigits, PadWithZero)
+	test(nil, "0.1", 0.098765, Round, 1, SignificantDigits, PadWithZero)
+	test(nil, "0", 0, Round, 0, SignificantDigits, NoPadding)
+
+	// decimalToPrecision: negative numbers
+	test(nil, "-0.12345", -0.123456, Truncate, 5, DecimalPlaces, NoPadding)
+	test(nil, "-0.12346", -0.123456, Round, 5, DecimalPlaces, NoPadding)
+
+	// decimalToPrecision: without dot / trailing dot
+	test(nil, "123", 123, Truncate, 0, DecimalPlaces, NoPadding)
+	test(nil, "123", 123, Truncate, 5, DecimalPlaces, NoPadding)
+	test(nil, "123.00000", 123, Truncate, 5, DecimalPlaces, PadWithZero)
+	test(nil, "123", 123., Truncate, 0, DecimalPlaces, NoPadding)
+	test(nil, "123.00000", 123., Truncate, 5, DecimalPlaces, PadWithZero)
+	test(nil, "0", 0., Truncate, 0, DecimalPlaces, NoPadding)
+	test(nil, "0.00000", 0., Truncate, 5, DecimalPlaces, PadWithZero)
+
+	// decimalToPrecision: rounding for equidistant digits
+	test(nil, "1.4", 1.44, Round, 1, DecimalPlaces, NoPadding)
+	test(nil, "1.5", 1.45, Round, 1, DecimalPlaces, NoPadding)
+	test(nil, "1", 1.45, Round, 0, DecimalPlaces, NoPadding)
+}

--- a/go/util/pointers.go
+++ b/go/util/pointers.go
@@ -1,0 +1,15 @@
+package util
+
+import "time"
+
+func String(v string) *string { return &v }
+
+func Bool(v bool) *bool { return &v }
+
+func Int(v int) *int { return &v }
+
+func Float64(v float64) *float64 { return &v }
+
+func Time(v time.Time) *JSONTime { return JTime(JSONTime(v)) }
+
+func JTime(v JSONTime) *JSONTime { return &v }

--- a/go/util/time.go
+++ b/go/util/time.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// JSONTime allows JSON marshalling from time.Time to string unix epoch,
+// and unmarshalling the other way around.
+type JSONTime time.Time
+
+func (t JSONTime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatInt(time.Time(t).Unix()*1000, 10)), nil
+}
+
+func (t *JSONTime) UnmarshalJSON(s []byte) (err error) {
+	r := strings.Replace(string(s), `"`, ``, -1)
+	r = strings.Split(r, ".")[0]
+
+	q, err := strconv.ParseInt(r, 10, 64)
+	if err != nil {
+		return err
+	}
+	*(*time.Time)(t) = time.Unix(q/1000, 0)
+	return
+}
+
+func (t JSONTime) String() string {
+	return time.Time(t).String()
+}
+
+func ParseTimeFrame(tf string) (d time.Duration, err error) {
+	var amount float64
+	var unit string
+	_, err = fmt.Sscanf(tf, "%f%s", &amount, &unit)
+	if err != nil {
+		return
+	}
+
+	var scale time.Duration
+	switch unit {
+	case "y":
+		scale = time.Hour * 24 * 365
+	case "M":
+		scale = time.Hour * 24 * 30
+	case "w":
+		scale = time.Hour * 24 * 7
+	case "d":
+		scale = time.Hour * 24
+	case "h":
+		scale = time.Hour
+	default:
+		scale = time.Minute
+	}
+
+	return time.Duration(scale.Nanoseconds() * int64(amount)), nil
+}

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -310,7 +310,8 @@ module.exports = class Exchange {
 
         // generate old metainfo interface
         for (const k in this.has) {
-            this['has' + capitalize (k)] = !!this.has[k] // converts 'emulated' to true
+            this.has[k] = !!this.has[k] // converts 'emulated' to true
+            this['has' + capitalize (k)] = this.has[k]
         }
 
         if (this.api)


### PR DESCRIPTION
This is a proposition for the base models in golang (#1952), there is not much more except some of the functions from `js/base/functions` that I started implementing in `go/util` package, none of which are really used so far

It also includes a client for using with https://github.com/franz-see/ccxt-rest (franz-see/ccxt-rest#4) and a basic test suite that allowed me to do some testing on a couple of exchanges

There are a few hacks on json umarshaller methods made as workarounds to type inconsistencies found in several `exchange.describe()`, maybe it calls to better unification instead (e.g.: link). Some of the exchanges still cannot be instantiated because of other type inconsistencies in their base info (11 out of 129)

I also remove the `emulated` value on `exchange.has['feature']` dict in the last commit, to avoid having to deal with a 3-value bool, it clearly has an repercussions on users so it needs to be taken into consideration. There are alternative approaches but that clearly was the cleanest and simplest one for my purpose
