### PR TITLE
Luno rate limit change

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -13,7 +13,7 @@ module.exports = class luno extends Exchange {
             'id': 'luno',
             'name': 'luno',
             'countries': [ 'GB', 'SG', 'ZA' ],
-            'rateLimit': 10000,
+            'rateLimit': 1000,
             'version': '1',
             'has': {
                 'CORS': false,


### PR DESCRIPTION
Rate limits for market data have been increased to 1 per second. Market data may be cached for up to 1 second. 2018-07-16