### PR TITLE
Bitmarket Crash on Create Order

### DIFF
--- a/js/bitmarket.js
+++ b/js/bitmarket.js
@@ -293,7 +293,7 @@ module.exports = class bitmarket extends Exchange {
         let result = {
             'info': response,
         };
-        if ('id' in response['order'])
+        if ('id' in response['data'])
             result['id'] = response['id'];
         return result;
     }


### PR DESCRIPTION
The Exchange throws an error because of wrong json structure.
It tries to access 'order' element but theres only the 'data' element.

The response is like this:

```
{
  "success": true,
  "data": {
    "id": 121234322,
    "order": { ...},
    "balances": { ... }
  },
  "time": 1534581619,
  "limit": { ... }
}
```