### PR TITLE
Luno fix no trades since time

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -325,7 +325,8 @@ module.exports = class luno extends Exchange {
         if (typeof since !== 'undefined')
             request['since'] = since;
         let response = await this.publicGetTrades (this.extend (request, params));
-        return this.parseTrades (response['trades'], market, since, limit);
+        let trades = this.safeValue (response, 'trades', []);
+        return this.parseTrades (trades, market, since, limit);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
@@ -341,7 +342,8 @@ module.exports = class luno extends Exchange {
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
         let response = await this.privateGetListtrades (this.extend (request, params));
-        return this.parseTrades (response['trades'], market, since, limit);
+        let trades = this.safeValue (response, 'trades', []);
+        return this.parseTrades (trades, market, since, limit);
     }
 
     async fetchTradingFees (params = {}) {


### PR DESCRIPTION
When fetching all trades since time X, it is possible to receive no trades back. Code is updated to account for this.