### PR TITLE
improve bit2c fetch_trades

### DIFF
--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -74,6 +74,9 @@ module.exports = class bit2c extends Exchange {
                     'taker': 0.5 / 100,
                 },
             },
+            'options': {
+                'fetchTradesMethod': 'public_get_exchanges_pair_lasttrades',
+            },
         });
     }
 
@@ -137,7 +140,8 @@ module.exports = class bit2c extends Exchange {
 
     async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
         let market = this.market (symbol);
-        let response = await this.publicGetExchangesPairLasttrades (this.extend ({
+        let method = this.options['fetchTradesMethod'];
+        let response = await this[method] (this.extend ({
             'pair': market['id'],
         }, params));
         return this.parseTrades (response, market, since, limit);

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -137,7 +137,7 @@ module.exports = class bit2c extends Exchange {
 
     async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
         let market = this.market (symbol);
-        let response = await this.publicGetExchangesPairTrades (this.extend ({
+        let response = await this.publicGetExchangesPairLasttrades (this.extend ({
             'pair': market['id'],
         }, params));
         return this.parseTrades (response, market, since, limit);
@@ -170,7 +170,9 @@ module.exports = class bit2c extends Exchange {
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = this.urls['api'] + '/' + this.implodeParams (path, params);
         if (api === 'public') {
-            url += '.json';
+            if ( !path.includes ('lasttrades') ) {
+                url += '.json';
+            }
         } else {
             this.checkRequiredCredentials ();
             let nonce = this.nonce ();

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -170,7 +170,8 @@ module.exports = class bit2c extends Exchange {
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = this.urls['api'] + '/' + this.implodeParams (path, params);
         if (api === 'public') {
-            if ( !path.includes ('lasttrades') ) {
+            // lasttrades is the only endpoint that doesn't require the .json extension/suffix
+            if (path.indexOf ('lasttrades') < 0) {
                 url += '.json';
             }
         } else {


### PR DESCRIPTION
bit2c 'noraml' get trades api method is a mess.
by default (no params) it return a huge amount of trades (100,000) and data is returned from the beginning of market.
the 'since' param is also confusing and not complying to ccxt format. 
it takes 'trade id' as the 'since' param and not timestamp. so to work with it you need to iterate multiple times until reaching current time, each time saving the last 'trade id' to move forward
https://bit2c.co.il/home/api

my suggestion is to switch completely to get lasttrades which return according to the api: the 50 last trades.

if some backward comparability is a consideration:
old trade function can be called only if 'params' is not empty (which will always be the case when retrieving current trades) 
else use 'lasttrades'

a small fix to the 'sign' function is needed as 'lasttrades' is the only public get method that doesn't have a suffix of '.json'