### PR TITLE
Add symbol check to GDAX fetchMyTrades

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -306,13 +306,12 @@ module.exports = class gdax extends Exchange {
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        if (typeof symbol === 'undefined')
+            throw new ExchangeError (this.id + ' fetchMyTrades requires a symbol argument');
         await this.loadMarkets ();
-        let market = undefined;
+        let market = this.market (symbol);
         let request = {};
-        if (typeof symbol !== 'undefined') {
-            market = this.market (symbol);
-            request['product_id'] = market['id'];
-        }
+        request['product_id'] = market['id'];
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
         let response = await this.privateGetFills (this.extend (request, params));

--- a/js/gdax.js
+++ b/js/gdax.js
@@ -306,12 +306,15 @@ module.exports = class gdax extends Exchange {
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        if (typeof symbol === 'undefined')
+        // as of 2018-08-23
+        if (typeof symbol === 'undefined') {
             throw new ExchangeError (this.id + ' fetchMyTrades requires a symbol argument');
+        }
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let request = {};
-        request['product_id'] = market['id'];
+        let request = {
+            'product_id': market['id'],
+        };
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
         let response = await this.privateGetFills (this.extend (request, params));


### PR DESCRIPTION
Per https://docs.pro.coinbase.com/#fills -- the fills endpoint will require a product_id or order_id very soon, so this code enforces that parameter.