### PR TITLE
throttle.js adaptive delay.

### DIFF
--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -43,11 +43,18 @@ module.exports = {
                                     }
                                 }
                             }
+                            let timeToSleep = cfg.delay;
+                            let nextCost = (queue.length > 0 && queue[0]['cost']) ? queue[0]['cost'] : cfg.defaultCost;
+                            let neededTokens = nextCost - numTokens
+                            if (neededTokens > 0) {
+                                timeToSleep = Math.max (cfg.delay, neededTokens / cfg.refillRate);
+                            }
+                            await sleep (timeToSleep);
+                            //update numTokens AFTER sleep.
                             const t = now ()
                                 , elapsed = t - lastTimestamp
                             lastTimestamp = t
-                            numTokens = Math.min (cfg.capacity, numTokens + elapsed * cfg.refillRate)
-                            await sleep (cfg.delay)
+                            numTokens = Math.min (cfg.capacity, numTokens + elapsed * cfg.refillRate);
                         }
                         running = false
                     }


### PR DESCRIPTION
Currently, the default throttle delay is too low (1 ms) [Exchange.js#L375](https://github.com/ccxt/ccxt/blob/e91aa4570d792f5b960026ec53fd208346992d1c/js/base/Exchange.js#L375), which causes the application to loop very fast in the `while` loop, uselessly. The delay should be proportional to the rate.

A bit more detail. I experimented with different tokenBuckets.

 - `{capacity:1, delay:1, rate:1/1000}`: 1 function call per second, ~500  loops (checks for numTokens) per second. This is the default for a lot of exchanges.
 - `{capacity:1, delay:500, rate:1/1000}`: 1 call/second, 2 loops/second
 - `{capacity:5, delay:500, rate:1/1000}`: first 5 calls => 500ms gap, then 1 call/second, 2 loops/second.
 - `{capacity:5, delay:50, rate:1/1000}`: first 5 calls => 50ms gap, then 1 call/second, 20 loops/second.

This PR calculates the time needed to accumulate sufficient tokens for the next cost in queue, and then sleep exactly that (1 loop per call). If this time is 0, then `sleep(delay)`.