### PR TITLE
Update fcoin.js

### DIFF
--- a/js/fcoin.js
+++ b/js/fcoin.js
@@ -453,7 +453,7 @@ module.exports = class fcoin extends Exchange {
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        let result = await this.fetchOrders (symbol, since, limit, { 'states': 'submitted' });
+        let result = await this.fetchOrders (symbol, since, limit, { 'states': 'submitted,partial_filled' });
         return result;
     }
 
@@ -467,7 +467,7 @@ module.exports = class fcoin extends Exchange {
         let market = this.market (symbol);
         let request = {
             'symbol': market['id'],
-            'states': 'submitted',
+            'states': 'submitted,partial_filled,partial_canceled,filled,canceled',
         };
         if (typeof limit !== 'undefined')
             request['limit'] = limit;
@@ -521,7 +521,7 @@ module.exports = class fcoin extends Exchange {
             query = this.keysort (query);
             if (method === 'GET') {
                 if (Object.keys (query).length) {
-                    url += '?' + this.urlencode (query);
+                    url += '?' + this.urlencode (query).replace(/%2C/g,',');
                 }
             }
             // HTTP_METHOD + HTTP_REQUEST_URI + TIMESTAMP + POST_BODY


### PR DESCRIPTION
in the previous version, fetchOrders and fetchOpenOrder only get the unfilled (called "submitted" in API doc) orders. Now the fetchOrders returns all orders (submitted, partial_filled, partial_canceled, filled, canceled); fetchOpenOrders returns submitted and partial_filled orders.