### PR TITLE
Error in considering the market id as a 3+3 symbol

### DIFF
--- a/php/therock.php
+++ b/php/therock.php
@@ -104,8 +104,14 @@ class therock extends Exchange {
         for ($p = 0; $p < count ($markets['tickers']); $p++) {
             $market = $markets['tickers'][$p];
             $id = $market['fund_id'];
-            $base = mb_substr ($id, 0, 3);
-            $quote = mb_substr ($id, 3);
+			if (mb_strlen($id)==6):
+				$base = mb_substr ($id, 0, 3);
+				$quote = mb_substr ($id, 3);
+			else:
+				$info = $this->publicGetFundsId(array('id' => $id));
+				$base = $info["trade_currency"];
+				$quote = $info["base_currency"];
+			endif;
             $symbol = $base . '/' . $quote;
             $result[] = array (
                 'id' => $id,


### PR DESCRIPTION
I'm developing code in collaboration with NOKU, and I found this bug:

The market id isn't always a 3+3 char code, since there are already on the rock trading symbols made of 4 chars such as NOKU and EURN.
So, the fetch_markets function should be changed to consider this, otherwise the base/quote symbols will be wrong.
I propose using another public TRT api endpoint to explicitly ask the exchange the base and quote symbols of the market.

It seems to me that many other exchange drivers in ccxt may have similar problems, since they consider the market code as a 3+3 chars symbol couple, which isn't always true.