### PR TITLE
Error in considering the market id as a 3+3 symbol

### DIFF
--- a/js/therock.js
+++ b/js/therock.js
@@ -103,8 +103,16 @@ module.exports = class therock extends Exchange {
         for (let p = 0; p < markets['tickers'].length; p++) {
             let market = markets['tickers'][p];
             let id = market['fund_id'];
-            let base = id.slice (0, 3);
-            let quote = id.slice (3);
+            if (id.length==6) {
+                let base = id.slice (0, 3);
+                let quote = id.slice (3);
+                }
+			else {
+				let info = await this.publicGetFundsId(array({'id': id }));
+				let base = info['trade_currency'];
+				let quote = info['base_currency'];
+                }
+			endif;
             let symbol = base + '/' + quote;
             result.push ({
                 'id': id,


### PR DESCRIPTION
I'm developing code in collaboration with NOKU, and I found this bug:

The market id isn't always a 3+3 char code, since there are already on the rock trading symbols made of 4 chars such as NOKU and EURN.
So, the fetch_markets function should be changed to consider this, otherwise the base/quote symbols will be wrong.
I propose using another public TRT api endpoint to explicitly ask the exchange the base and quote symbols of the market.

It seems to me that many other exchange drivers in ccxt may have similar problems, since they consider the market code as a 3+3 chars symbol couple, which isn't always true.

Please do review my code contribution, while I'm very proficient with PHP, I'm not so in JS! :)