### PR TITLE
BTCBOX: remove fetchTickers and use coin name

### DIFF
--- a/js/btcbox.js
+++ b/js/btcbox.js
@@ -48,10 +48,10 @@ module.exports = class btcbox extends Exchange {
                 },
             },
             'markets': {
-                'BTC/JPY': { 'id': 'BTC/JPY', 'symbol': 'BTC/JPY', 'base': 'BTC', 'quote': 'JPY' },
-                'ETH/JPY': { 'id': 'ETH/JPY', 'symbol': 'ETH/JPY', 'base': 'ETH', 'quote': 'JPY' },
-                'LTC/JPY': { 'id': 'LTC/JPY', 'symbol': 'LTC/JPY', 'base': 'LTC', 'quote': 'JPY' },
-                'BCH/JPY': { 'id': 'BCH/JPY', 'symbol': 'BCH/JPY', 'base': 'BCH', 'quote': 'JPY' },
+                'BTC/JPY': { 'id': 'BTC/JPY', 'symbol': 'BTC/JPY', 'base': 'BTC', 'quote': 'JPY', 'baseId': 'btc', 'quoteId': 'jpy' },
+                'ETH/JPY': { 'id': 'ETH/JPY', 'symbol': 'ETH/JPY', 'base': 'ETH', 'quote': 'JPY', 'baseId': 'eth', 'quoteId': 'jpy' },
+                'LTC/JPY': { 'id': 'LTC/JPY', 'symbol': 'LTC/JPY', 'base': 'LTC', 'quote': 'JPY', 'baseId': 'ltc', 'quoteId': 'jpy' },
+                'BCH/JPY': { 'id': 'BCH/JPY', 'symbol': 'BCH/JPY', 'base': 'BCH', 'quote': 'JPY', 'baseId': 'bch', 'quoteId': 'jpy' },
             },
             'exceptions': {
                 '104': AuthenticationError,
@@ -97,7 +97,7 @@ module.exports = class btcbox extends Exchange {
         let request = {};
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['base'].toLowerCase ();
+            request['coin'] = market['baseId'];
         let orderbook = await this.publicGetDepth (this.extend (request, params));
         return this.parseOrderBook (orderbook);
     }
@@ -138,7 +138,7 @@ module.exports = class btcbox extends Exchange {
         let request = {};
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['base'].toLowerCase ();
+            request['coin'] = market['baseId'];
         let ticker = await this.publicGetTicker (this.extend (request, params));
         return this.parseTicker (ticker, market);
     }
@@ -165,7 +165,7 @@ module.exports = class btcbox extends Exchange {
         let request = {};
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['base'].toLowerCase ();
+            request['coin'] = market['baseId'];
         let response = await this.publicGetOrders (this.extend (request, params));
         return this.parseTrades (response, market, since, limit);
     }
@@ -180,7 +180,7 @@ module.exports = class btcbox extends Exchange {
         };
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['base'].toLowerCase ();
+            request['coin'] = market['baseId'];
         let response = await this.privatePostTradeAdd (this.extend (request, params));
         return {
             'info': response,

--- a/js/btcbox.js
+++ b/js/btcbox.js
@@ -20,7 +20,7 @@ module.exports = class btcbox extends Exchange {
                 'fetchOrder': true,
                 'fetchOrders': true,
                 'fetchOpenOrders': true,
-                'fetchTickers': true,
+                'fetchTickers': false,
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/31275803-4df755a8-aaa1-11e7-9abb-11ec2fad9f2d.jpg',
@@ -34,7 +34,6 @@ module.exports = class btcbox extends Exchange {
                         'depth',
                         'orders',
                         'ticker',
-                        'allticker',
                     ],
                 },
                 'private': {
@@ -50,6 +49,9 @@ module.exports = class btcbox extends Exchange {
             },
             'markets': {
                 'BTC/JPY': { 'id': 'BTC/JPY', 'symbol': 'BTC/JPY', 'base': 'BTC', 'quote': 'JPY' },
+                'ETH/JPY': { 'id': 'ETH/JPY', 'symbol': 'ETH/JPY', 'base': 'ETH', 'quote': 'JPY' },
+                'LTC/JPY': { 'id': 'LTC/JPY', 'symbol': 'LTC/JPY', 'base': 'LTC', 'quote': 'JPY' },
+                'BCH/JPY': { 'id': 'BCH/JPY', 'symbol': 'BCH/JPY', 'base': 'BCH', 'quote': 'JPY' },
             },
             'exceptions': {
                 '104': AuthenticationError,
@@ -130,28 +132,13 @@ module.exports = class btcbox extends Exchange {
         };
     }
 
-    async fetchTickers (symbols = undefined, params = {}) {
-        await this.loadMarkets ();
-        let tickers = await this.publicGetAllticker (params);
-        let ids = Object.keys (tickers);
-        let result = {};
-        for (let i = 0; i < ids.length; i++) {
-            let id = ids[i];
-            let market = this.markets_by_id[id];
-            let symbol = market['symbol'];
-            let ticker = tickers[id];
-            result[symbol] = this.parseTicker (ticker, market);
-        }
-        return result;
-    }
-
     async fetchTicker (symbol, params = {}) {
         await this.loadMarkets ();
         let market = this.market (symbol);
         let request = {};
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['id'];
+            request['coin'] = market['base'].toLowerCase ();
         let ticker = await this.publicGetTicker (this.extend (request, params));
         return this.parseTicker (ticker, market);
     }

--- a/js/btcbox.js
+++ b/js/btcbox.js
@@ -97,7 +97,7 @@ module.exports = class btcbox extends Exchange {
         let request = {};
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['id'];
+            request['coin'] = market['base'].toLowerCase ();
         let orderbook = await this.publicGetDepth (this.extend (request, params));
         return this.parseOrderBook (orderbook);
     }
@@ -165,7 +165,7 @@ module.exports = class btcbox extends Exchange {
         let request = {};
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['id'];
+            request['coin'] = market['base'].toLowerCase ();
         let response = await this.publicGetOrders (this.extend (request, params));
         return this.parseTrades (response, market, since, limit);
     }
@@ -180,7 +180,7 @@ module.exports = class btcbox extends Exchange {
         };
         let numSymbols = this.symbols.length;
         if (numSymbols > 1)
-            request['coin'] = market['id'];
+            request['coin'] = market['base'].toLowerCase ();
         let response = await this.privatePostTradeAdd (this.extend (request, params));
         return {
             'info': response,


### PR DESCRIPTION
Implements #3582 

- Remove fetchTickers since the API is no longer available.
- Use coin name in the request parameter e.g. https://www.btcbox.co.jp/api/v1/ticker?coin=ltc
  - [API reference](https://www.btcbox.co.jp/api/doc/v1#Reference)

|Parameter|Description|
|:---:|:---:|
|coin|btc , ltc , eth , bch. Default: btc|

- Add currency pairs ETH/JPY, LTC/JPY, BCH/JPY

Example
```python
import ccxt

btcbox = ccxt.btcbox()
print(btcbox.fetch_ticker(symbol="BCH/JPY"))
```
It returns like this
```
{'symbol': 'BCH/JPY', 'timestamp': 1535714069021, 'datetime': '2018-08-31T11:14:29.021Z', 'high': 60695.0, 'low': 58278.0, 'bid': 59589.0, 'bidVolume': None, 'ask': 60027.0, 'askVolume': None, 'vwap': None, 'open': None, 'close': 59901.0, 'last': 59901.0, 'previousClose': None, 'change': None, 'percentage': None, 'average': None, 'baseVolume': 3959.2535, 'quoteVolume': None, 'info': {'high': 60695, 'low': 58278, 'buy': 59589, 'sell': 60027, 'last': 59901, 'vol': 3959.2535}}
```