### PR TITLE
fix baseId for REM/ETH market

### DIFF
--- a/js/kuna.js
+++ b/js/kuna.js
@@ -87,6 +87,7 @@ module.exports = class kuna extends acx {
                 let baseId = id.replace ('btc', '');
                 baseId = baseId.replace ('uah', '');
                 baseId = baseId.replace ('gbg', '');
+                baseId = baseId.replace ('eth', '');
                 if (baseId.length > 0) {
                     let baseIdLength = baseId.length - 0; // a transpiler workaround
                     let quoteId = id.slice (baseIdLength);


### PR DESCRIPTION
    // REM/ETH in fetchMarkets() response before fix:
    25 => array:6 [
        "id" => "remeth"
        "symbol" => "REMETH/"
        "base" => "REMETH"
        "quote" => ""
        "baseId" => "remeth"
        "quoteId" => ""
    ]

    // REM/ETH in fetchMarkets() response after fix:
    25 => array:6 [
        "id" => "remeth"
        "symbol" => "REM/ETH"
        "base" => "REM"
        "quote" => "ETH"
        "baseId" => "rem"
        "quoteId" => "eth"
  ]