### PR TITLE
Bitmex: fix trade volume

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -413,7 +413,7 @@ module.exports = class bitmex extends Exchange {
             'type': undefined,
             'side': trade['side'].toLowerCase (),
             'price': trade['price'],
-            'amount': trade['size'],
+            'amount': trade['size'] / trade['price'],
         };
     }
 


### PR DESCRIPTION
Bitmex appears to return the amount in a the 2nd currency, different from other exhanges.
For example selling 2 BTC for 6500USD in other exchanges looks like:
`BTC/USD`
`{ "price": 6500, "amount": 2}`
On bitmex this would be
`{"price" 6500, "amount": 13000}`


