### PR TITLE
UTNP as UTN on bitfinex/ethfinex

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -272,6 +272,7 @@ module.exports = class bitfinex extends Exchange {
                 'STJ': 'STORJ',
                 'YYW': 'YOYOW',
                 'USD': 'USDT',
+                'UTN': 'UTNP',
             },
             'exceptions': {
                 'exact': {


### PR DESCRIPTION
Due to the 3 letter ticker policy, UTNP is listed as UTN on bitfinex/ethfinex

More info here:
https://medium.com/universablockchain/universa-to-be-listed-on-bitfinex-and-ethfinex-ed383cdd456d