### PR TITLE
New exchange: Buda.com

### DIFF
--- a/js/buda.js
+++ b/js/buda.js
@@ -32,7 +32,7 @@ module.exports = class buda extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/4157289/45259478-582aab80-b3a4-11e8-83a5-baa995f53e4d.jpg',
+                'logo': 'https://user-images.githubusercontent.com/1294454/47380619-8a029200-d706-11e8-91e0-8a391fe48de3.jpg',
                 'api': 'https://www.buda.com/api',
                 'www': 'https://www.buda.com',
                 'doc': 'https://api.buda.com',
@@ -683,23 +683,20 @@ module.exports = class buda extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body) {
-        if (typeof body !== 'string')
-            return;  // fallback to default error handler
-        if (body.length < 2)
-            return;  // fallback to default error handler
+        if (!this.isJsonEncodedObject (body)) {
+            return; // fallback to default error handler
+        }
         if (code >= 400) {
-            if (body[0] === '{') {
-                const response = JSON.parse (body);
-                let errorCode = this.safeString (response, 'code');
-                let message = this.safeString (response, 'message', body);
-                let feedback = this.name + ': ' + message;
-                let exceptions = this.exceptions;
-                if (typeof errorCode !== 'undefined') {
-                    if (errorCode in exceptions) {
-                        throw new exceptions[errorCode] (feedback);
-                    } else {
-                        throw new ExchangeError (feedback);
-                    }
+            const response = JSON.parse (body);
+            let errorCode = this.safeString (response, 'code');
+            let message = this.safeString (response, 'message', body);
+            let feedback = this.name + ': ' + message;
+            let exceptions = this.exceptions;
+            if (typeof errorCode !== 'undefined') {
+                if (errorCode in exceptions) {
+                    throw new exceptions[errorCode] (feedback);
+                } else {
+                    throw new ExchangeError (feedback);
                 }
             }
         }

--- a/js/buda.js
+++ b/js/buda.js
@@ -332,9 +332,17 @@ module.exports = class buda extends Exchange {
     async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let response = await this.publicGetMarketsMarketTrades (this.extend ({
+        const request = {
             'market': market['id'],
-        }, params));
+        };
+        // the since argument works backwards – returns trades up to the specified timestamp 
+        // therefore not implemented here
+        // the method is still available for users to be able to traverse backwards in time
+        // by using the timestamp from the first received trade upon each iteration
+        if (limit !== undefined) {
+            request['limit'] = limit; // 50 max
+        }
+        let response = await this.publicGetMarketsMarketTrades (this.extend (request, params));
         //
         //     { trades: {      market_id:   "ETH-BTC",
         //                      timestamp:    null,

--- a/js/buda.js
+++ b/js/buda.js
@@ -675,20 +675,14 @@ module.exports = class buda extends Exchange {
         if (api === 'private') {
             this.checkRequiredCredentials ();
             let nonce = this.nonce ().toString ();
-            let components = [method, '/api/' + this.version + '/' + request];
+            let components = [ method, '/api/' + this.version + '/' + request ];
             if (body) {
                 let base64_body = this.stringToBase64 (this.encode (body));
                 components.push (this.decode (base64_body));
             }
             components.push (nonce);
-            let message = components[0];
-            for (let i = 1; i < components.length; i++) {
-                let component = components[i];
-                message = message + ' ' + component;
-            }
-            message = this.encode (message);
-            let secret = this.encode (this.secret);
-            let signature = this.hmac (message, secret, 'sha384');
+            let message = components.join (' ');
+            let signature = this.hmac (this.encode (message), this.encode (this.secret), 'sha384');
             headers = {
                 'X-SBTC-APIKEY': this.apiKey,
                 'X-SBTC-SIGNATURE': signature,

--- a/js/buda.js
+++ b/js/buda.js
@@ -361,6 +361,7 @@ module.exports = class buda extends Exchange {
         let order = undefined;
         let fee = undefined;
         let symbol = undefined;
+        let cost = undefined;
         if (market) {
             symbol = market['symbol'];
         }
@@ -368,6 +369,7 @@ module.exports = class buda extends Exchange {
             timestamp = parseInt (trade[0]);
             price = parseFloat (trade[1]);
             amount = parseFloat (trade[2]);
+            cost = price * amount;
             side = trade[3];
             id = trade[4].toString ();
         }
@@ -382,7 +384,7 @@ module.exports = class buda extends Exchange {
             'side': side,
             'price': price,
             'amount': amount,
-            'cost': price * amount,
+            'cost': cost,
             'fee': fee,
         };
     }

--- a/js/buda.js
+++ b/js/buda.js
@@ -350,18 +350,7 @@ module.exports = class buda extends Exchange {
             'to': this.seconds (),
         };
         let response = await this.publicGetTvHistory (this.extend (request, params));
-        let ohlcvs = [];
-        for (let i = 0; i < response['t'].length; i++) {
-            ohlcvs.push ([
-                response['t'][i] * 1000,
-                response['o'][i],
-                response['h'][i],
-                response['l'][i],
-                response['c'][i],
-                response['v'][i],
-            ]);
-        }
-        return this.parseOHLCVs (ohlcvs, market, timeframe, since, limit);
+        return this.parseTradingViewOHLCV (response, market, timeframe, since, limit);
     }
 
     async fetchBalance (params = {}) {

--- a/js/buda.js
+++ b/js/buda.js
@@ -487,7 +487,7 @@ module.exports = class buda extends Exchange {
             'amount': amount,
             'filled': filled,
             'remaining': remaining,
-            'trades': [],
+            'trades': undefined,
             'fee': fee,
             'info': order,
         };


### PR DESCRIPTION
![Buda.com](https://user-images.githubusercontent.com/4157289/45259478-582aab80-b3a4-11e8-83a5-baa995f53e4d.jpg)

Adds support for **Buda.com**! an exchange in based in Chile with operations on Peru, Colombia and Argentina.

- Website: https://www.buda.com
- API Doc: https://api.buda.com

Unsupported **Unified API** methods:

- **fetchMyTrades**: The API doesn't allow a user to retrieve their own trades.
- **fetchTrades**: The API endpoints exists, but works backwards. Returns trades *until* the given timestamp.

All other *"standard"* unified methods are implemented.

Thanks for this amazing library! 😁