### PR TITLE
convert amount to string

### DIFF
--- a/js/fcoin.js
+++ b/js/fcoin.js
@@ -341,7 +341,7 @@ module.exports = class fcoin extends Exchange {
         let orderType = type;
         let request = {
             'symbol': this.marketId (symbol),
-            'amount': this.amountToPrecision (symbol, amount),
+            'amount': this.amountToString (symbol, amount),
             'side': side,
             'type': orderType,
         };


### PR DESCRIPTION
fcoin requires both amount and price to be sent in string. o/w signature will have unpredictable results.