### PR TITLE
Bitforex missing "side" property on trades

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -281,7 +281,7 @@ module.exports = class bitforex extends Exchange {
                 cost = amount * price;
             }
         }
-        let sideId = this.safeString (trade, 'direction');
+        let sideId = this.safeInteger (trade, 'direction');
         let side = this.parseSide (sideId);
         return {
             'info': trade,


### PR DESCRIPTION
"sideId" is being pulled as a string (using safeString) while it's being evaluated as a number on the "parseSide" method, thus always returning "undefined"