### PR TITLE
gdax fetchTransactions fixes

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -26,6 +26,7 @@ module.exports = class gdax extends Exchange {
                 'fetchClosedOrders': true,
                 'fetchDepositAddress': true,
                 'fetchMyTrades': true,
+                'fetchTransactions': true,
             },
             'timeframes': {
                 '1m': 60,
@@ -573,9 +574,11 @@ module.exports = class gdax extends Exchange {
             throw new ExchangeError (this.id + ' fetchTransactions() could not find account id for ' + code);
         }
         let request = {
-            'limit': limit,
             'id': accountId,
         };
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
         let response = await this.privateGetAccountsIdTransfers (this.extend (request, params));
         for (let i = 0; i < response.length; i++) {
             response[i]['currency'] = code;
@@ -596,7 +599,8 @@ module.exports = class gdax extends Exchange {
     }
 
     parseTransaction (transaction, currency = undefined) {
-        let timestamp = this.safeInteger (transaction, 'created_at');
+        let timestamp = this.parse8601 (transaction['created_at']);
+        let processed = this.parse8601 (transaction['processed_at']);
         let code = undefined;
         let currencyId = this.safeString (transaction, 'currency');
         if (currencyId in this.currencies_by_id) {
@@ -606,19 +610,28 @@ module.exports = class gdax extends Exchange {
             code = currency['code'];
         }
         let fee = undefined;
+        let details = transaction['details'];
+        let fromAddress = undefined;
+        let toAddress = undefined;
+        if (details !== undefined) {
+            if ('crypto_address' in details)
+                fromAddress = details['crypto_address'];
+            if ('sent_to_address' in details)
+                toAddress = details['sent_to_address'];
+        }
         return {
             'info': transaction,
             'id': this.safeString (transaction, 'id'),
             'txid': this.safeString (transaction['details'], 'crypto_transaction_hash'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'address': undefined, // or is it defined?
-            'tag': undefined, // or is it defined?
-            'type': this.safeString (transaction, 'type'), // direction of the transaction, ('deposit' | 'withdraw')
+            'address': toAddress || fromAddress,
+            'tag': undefined,
+            'type': this.safeString (transaction, 'type'),
             'amount': this.safeFloat (transaction, 'amount'),
             'currency': code,
             'status': this.parseTransactionStatus (transaction),
-            'updated': undefined,
+            'updated': processed,
             'fee': fee,
         };
     }


### PR DESCRIPTION
This fixes the limit & also parseTransaction (which was incomplete)

The limit needs to be a positive integer (or should not be set). I was getting this error: `gdax Invalid positive integer value for parameter - limit`.

After further investigation I also noticed that the parseTransaction method was incomplete and had some issues, so I fixed them too.

And `'fetchTransactions': true,` was missing in the `has` dictionary. Added as well.