### PR TITLE
fetchL2OrderBook method are not supported in coinmarketcap.js

### DIFF
--- a/js/coinmarketcap.js
+++ b/js/coinmarketcap.js
@@ -25,6 +25,7 @@ module.exports = class coinmarketcap extends Exchange {
                 'editOrder': false,
                 'fetchBalance': false,
                 'fetchOrderBook': false,
+                'fetchL2OrderBook': false,
                 'fetchOHLCV': false,
                 'fetchTrades': false,
                 'fetchTickers': true,


### PR DESCRIPTION
Add key to show that `fetchL2OrderBook` method are not supported coinmarketcap.js