### PR TITLE
use 'left' field as 'remaining'

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -381,7 +381,7 @@ module.exports = class coinex extends Exchange {
             symbol = market['symbol'];
             feeCurrency = market['quote'];
         }
-        let remaining = parseFloat (this.amountToPrecision (symbol, amount - filled));
+        let remaining = this.safeFloat (order, 'left');
         let status = this.parseOrderStatus (this.safeString (order, 'status'));
         let type = this.safeString (order, 'order_type');
         let side = this.safeString (order, 'type');


### PR DESCRIPTION
The deal_amount field of coinex order is rounded to 5 decimals. It's a CoinEx API bug which has not been fixed yet.
Currently, remaining = amount - deal_amount. 'remaining' field is not correct if deal_amount is cast. Using the 'left' field as 'remaining' will be just fine.