### PR TITLE
parseOrderBook() should use existing "nonce"

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -969,7 +969,7 @@ module.exports = class Exchange {
             'asks': sortBy ((asksKey in orderbook) ? this.parseBidsAsks (orderbook[asksKey], priceKey, amountKey) : [], 0),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'nonce': orderbook.nonce || undefined,
+            'nonce': undefined,
         }
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -969,7 +969,7 @@ module.exports = class Exchange {
             'asks': sortBy ((asksKey in orderbook) ? this.parseBidsAsks (orderbook[asksKey], priceKey, amountKey) : [], 0),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'nonce': undefined,
+            'nonce': orderbook.nonce || undefined,
         }
     }
 

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -344,7 +344,7 @@ module.exports = class huobipro extends Exchange {
             }
             let orderbook = response['tick'];
             let result = this.parseOrderBook (orderbook, orderbook['ts']);
-            result['nonce'] = response['tick']['version'];
+            result['nonce'] = orderbook['version'];
             return result;
         }
         throw new ExchangeError (this.id + ' fetchOrderBook() returned unrecognized response: ' + this.json (response));

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -343,9 +343,9 @@ module.exports = class huobipro extends Exchange {
                 throw new ExchangeError (this.id + ' fetchOrderBook() returned empty response: ' + this.json (response));
             }
             let orderbook = response['tick'];
-            let timestamp = orderbook['ts'];
-            orderbook['nonce'] = orderbook['version'];
-            return this.parseOrderBook (orderbook, timestamp);
+            let result = this.parseOrderBook (orderbook, orderbook['ts']);
+            result['nonce'] = response['tick']['version'];
+            return result;
         }
         throw new ExchangeError (this.id + ' fetchOrderBook() returned unrecognized response: ' + this.json (response));
     }


### PR DESCRIPTION
There are Exchange implementations that set the "nonce" value to the orderbook object passed to the parseOrderBook method, but this gets discarded, being huobipro one of such exchanges. Other implementations set the "nonce" value after calling this method.

The proposed change allows for implementations like huobipro's to properly work, where they directly return the result of parseOrderBook()