### PR TITLE
the cancelOrder call doesn't have the required parameter fund_id

### DIFF
--- a/js/therock.js
+++ b/js/therock.js
@@ -310,6 +310,7 @@ module.exports = class therock extends Exchange {
         await this.loadMarkets ();
         return await this.privateDeleteFundsFundIdOrdersId (this.extend ({
             'id': id,
+            'fund_id': this.marketId (symbol),
         }, params));
     }
 


### PR DESCRIPTION
The cancelOrder call to privateDeleteFundsFundIdOrdersId needs to pass the required fund_id parameter, which is missing...