### PR TITLE
Fix False Exception for Blank OHLCV Response

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -448,7 +448,6 @@ module.exports = class bittrex extends Exchange {
             if (response['result'])
                 return this.parseOHLCVs (response['result'], market, timeframe, since, limit);
         }
-        throw new ExchangeError (this.id + ' returned an empty or unrecognized response: ' + this.json (response));
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
If there is no volume during a period, Bittrex does not return explicit entries for zero volume.  If the since parameter is used and no volume has occurred, a completely blank body is returned and ccxt incorrectly threw an exception for this non-error response.