### PR TITLE
Add in a pending status for ACH Transfers

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -591,6 +591,8 @@ module.exports = class gdax extends Exchange {
             return 'canceled';
         } else if ('completed_at' in transaction && transaction['completed_at']) {
             return 'ok';
+        } else if (('canceled_at' in transaction && !transaction['canceled_at']) && ('completed_at' in transaction && !transaction['completed_at']) && ('processed_at' in transaction && !transaction['processed_at'])) {
+            return 'pending';
         } else if ('procesed_at' in transaction && transaction['procesed_at']) {
             return 'pending';
         } else {


### PR DESCRIPTION
I did an `ACH` transfer of funds to Coinbase Pro, and it didn't set any properties to have data. 

There was a record, but specifically `processed_at` in the case of pending transfer was not set. I am not sure if that is the case for a wire transfer or not so I left in `processed_at` being populated is also pending.

When the account transfer did finally come through it showed up had both `processed_at` and `completed_at` set to the exact same timestamp.

This is a frustrating api endpoint as it is an undocumented endpoint so there isn't anything to read to get the correct settings. Seems to be trial and error.

