### PR TITLE
Reduce rate limit from 10 to 1 seconds

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -13,7 +13,7 @@ module.exports = class luno extends Exchange {
             'id': 'luno',
             'name': 'luno',
             'countries': [ 'GB', 'SG', 'ZA' ],
-            'rateLimit': 10000,
+            'rateLimit': 1000,
             'version': '1',
             'has': {
                 'CORS': false,


### PR DESCRIPTION
Calls to the Market Data APIs are rate limited to 1 call per second per IP address. All other API calls are rate limited to 1 call per second per customer. API call rate limits allow bursts of up to five consecutive calls. Exceeding the limit causes HTTP error code 429 to be returned.