### PR TITLE
Adds additional private endpoints for bigone

### DIFF
--- a/js/bigone.js
+++ b/js/bigone.js
@@ -53,6 +53,9 @@ module.exports = class bigone extends Exchange {
                         'accounts',
                         'orders',
                         'orders/{order_id}',
+                        'trades',
+                        'withdrawals',
+                        'deposits',
                     ],
                     'post': [
                         'orders',


### PR DESCRIPTION
BigONE has `trades`, `deposits`, and `withdrawals` available for the [private API](https://open.big.one/docs/api_accounts.html)