### PR TITLE
Fix fetchTickers to reject funding data

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -338,9 +338,11 @@ module.exports = class bitfinex2 extends bitfinex {
         for (let i = 0; i < tickers.length; i++) {
             let ticker = tickers[i];
             let id = ticker[0];
-            let market = this.markets_by_id[id];
-            let symbol = market['symbol'];
-            result[symbol] = this.parseTicker (ticker, market);
+            if (id in this.markets_by_id) {
+                let market = this.markets_by_id[id];
+                let symbol = market['symbol'];
+                result[symbol] = this.parseTicker (ticker, market);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Bitfinex2's 'fetchTickers' raises an exception when processing a funding ticker,
e.g. 'fUSD', which is included in the 'tickers' endpoint, but is not a valid
symbol in the markets array.  This fails silently in JS, but raises an exception
in Python on line 331:
```
market = self.markets_by_id['fUSD']
```