### PR TITLE
Add fetchTransactions, fetchWithdrawals, fetchDeposits to poloniex

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -932,7 +932,7 @@ module.exports = class poloniex extends Exchange {
         let transactions = await this.fetchTransactions (code, since, limit, params);
         return this.filterBy (transactions, 'type', 'withdrawal');
     }
-    
+
     async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
         let transactions = await this.fetchTransactions (code, since, limit, params);
         return this.filterBy (transactions, 'type', 'deposit');

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -910,11 +910,6 @@ module.exports = class poloniex extends Exchange {
         return deposits;
     }
 
-    parseTransactions (transactions, currency = undefined, since = undefined, limit = undefined) {
-        let result = Object.values (transactions || []).map (transaction => this.parseTransaction (transaction, currency));
-        return this.sortBy (result, 'timestamp');
-    }
-
     parseTransaction (transaction, currency = undefined) {
         let timestamp = transaction['timestamp'] * 1000;
         let code = undefined;

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -928,11 +928,18 @@ module.exports = class poloniex extends Exchange {
         let type = this.safeString (transaction, 'type');
         if (type !== undefined)
             type = type.toLowerCase ();
-        let status = this.parseTransactionStatus (this.safeString (transaction, 'status', 'pending'));
+        let statusString = this.safeString (transaction, 'status', 'pending');
+        let parts = statusString.split (':');
+        let numParts = parts.length;
+        let txid = this.safeString (transaction, 'txid');
+        if ((txid === undefined) && (numParts > 1)) {
+            txid = parts[numParts - 1];
+        }
+        let status = this.parseTransactionStatus (parts[0]);
         return {
             'info': transaction,
             'id': undefined,
-            'txid': this.safeString (transaction, 'txid'),
+            'txid': txid,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'address': this.safeString (transaction, 'address'),

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -32,8 +32,8 @@ module.exports = class poloniex extends Exchange {
                 'fetchCurrencies': true,
                 'withdraw': true,
                 'fetchTransactions': true,
-                'fetchWithdrawals': true,
-                'fetchDeposits': true,
+                'fetchWithdrawals': 'emulated', // but almost true )
+                'fetchDeposits': 'emulated',
             },
             'timeframes': {
                 '5m': 300,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -948,7 +948,7 @@ module.exports = class poloniex extends Exchange {
         return deposits;
     }
 
-    parseTransactionStatus function (status) {
+    parseTransactionStatus (status) {
         const statuses = {
             'COMPLETE': 'ok',
         };

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -877,6 +877,46 @@ module.exports = class poloniex extends Exchange {
         if (limit !== undefined)
             request['limit'] = limit;
         let response = await this.privatePostReturnDepositsWithdrawals (this.extend (request, params));
+        //
+        //     {    deposits: [ {      currency: "BTC",
+        //                              address: "1MEtiqJWru53FhhHrfJPPvd2tC3TPDVcmW",
+        //                               amount: "0.01063000",
+        //                        confirmations:  1,
+        //                                 txid: "952b0e1888d6d491591facc0d37b5ebec540ac1efb241fdbc22bcc20d1822fb6",
+        //                            timestamp:  1507916888,
+        //                               status: "COMPLETE"                                                          },
+        //                      {      currency: "ETH",
+        //                              address: "0x20108ba20b65c04d82909e91df06618107460197",
+        //                               amount: "4.00000000",
+        //                        confirmations:  38,
+        //                                 txid: "0x4be260073491fe63935e9e0da42bd71138fdeb803732f41501015a2d46eb479d",
+        //                            timestamp:  1525060430,
+        //                               status: "COMPLETE"                                                            }  ],
+        //       withdrawals: [ { withdrawalNumber:  8224394,
+        //                                currency: "EMC2",
+        //                                 address: "EYEKyCrqTNmVCpdDV8w49XvSKRP9N3EUyF",
+        //                                  amount: "63.10796020",
+        //                                     fee: "0.01000000",
+        //                               timestamp:  1510819838,
+        //                                  status: "COMPLETE: d37354f9d02cb24d98c8c4fc17aa42f475530b5727effdf668ee5a43ce667fd6",
+        //                               ipAddress: "5.220.220.200"                                                               },
+        //                      { withdrawalNumber:  9290444,
+        //                                currency: "ETH",
+        //                                 address: "0x191015ff2e75261d50433fbd05bd57e942336149",
+        //                                  amount: "0.15500000",
+        //                                     fee: "0.00500000",
+        //                               timestamp:  1514099289,
+        //                                  status: "COMPLETE: 0x12d444493b4bca668992021fd9e54b5292b8e71d9927af1f076f554e4bea5b2d",
+        //                               ipAddress: "5.228.227.214"                                                                 },
+        //                      { withdrawalNumber:  11518260,
+        //                                currency: "BTC",
+        //                                 address: "8JoDXAmE1GY2LRK8jD1gmAmgRPq54kXJ4t",
+        //                                  amount: "0.20000000",
+        //                                     fee: "0.00050000",
+        //                               timestamp:  1527918155,
+        //                                  status: "COMPLETE: 1864f4ebb277d90b0b1ff53259b36b97fa1990edc7ad2be47c5e0ab41916b5ff",
+        //                               ipAddress: "211.8.195.26"                                                                }    ] }
+        //
         for (let i = 0; i < response['deposits'].length; i++) {
             response['deposits'][i]['type'] = 'deposit';
         }

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -981,7 +981,7 @@ module.exports = class poloniex extends Exchange {
         if (currency !== undefined) {
             code = currency['code'];
         }
-        let status = this.safeString (transaction, 'status');
+        let status = this.safeString (transaction, 'status', 'pending');
         let txid = this.safeString (transaction, 'txid');
         if (status !== undefined) {
             let parts = status.split (': ');

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -930,22 +930,12 @@ module.exports = class poloniex extends Exchange {
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
         let transactions = await this.fetchTransactions (code, since, limit, params);
-        let withdrawals = [];
-        for (let i = 0; i < transactions.length; i++) {
-            if (transactions[i]['type'] === 'withdrawal')
-                withdrawals.push (transactions[i]);
-        }
-        return withdrawals;
+        return this.filterBy (transactions, 'type', 'withdrawal');
     }
-
+    
     async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
         let transactions = await this.fetchTransactions (code, since, limit, params);
-        let deposits = [];
-        for (let i = 0; i < transactions.length; i++) {
-            if (transactions[i]['type'] === 'deposit')
-                deposits.push (transactions[i]);
-        }
-        return deposits;
+        return this.filterBy (transactions, 'type', 'deposit');
     }
 
     parseTransactionStatus (status) {

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -908,6 +908,13 @@ module.exports = class poloniex extends Exchange {
         return deposits;
     }
 
+    parseTransactionStatus function (status) {
+        const statuses = {
+            'COMPLETE': 'ok',
+        };
+        return this.safeString (statuses, status, status);
+    }
+
     parseTransaction (transaction, currency = undefined) {
         let timestamp = transaction['timestamp'] * 1000;
         let code = undefined;
@@ -921,9 +928,7 @@ module.exports = class poloniex extends Exchange {
         let type = this.safeString (transaction, 'type');
         if (type !== undefined)
             type = type.toLowerCase ();
-        let status = 'pending';
-        if (transaction['status'].startsWith ('COMPLETE'))
-            status = 'ok';
+        let status = this.parseTransactionStatus (this.safeString (transaction, 'status', 'pending'));
         return {
             'info': transaction,
             'id': undefined,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1002,7 +1002,7 @@ module.exports = class poloniex extends Exchange {
                 // according to https://poloniex.com/fees/
                 feeCost = 0; // FIXME: remove hardcoded value that may change any time
             } else if (type === 'withdrawal') {
-                throw new ccxt.ExchangeError ('Withdrawal without fee detected!');
+                throw new ExchangeError ('Withdrawal without fee detected!');
             }
         }
         return {


### PR DESCRIPTION
I am still learning some of the best practices of code in ccxt. Please let me know what to improve.

A couple of notes. 
1. Poloniex does not have separate endpoints for withdrawals and deposits. So you have to use the single endpoint. To keep things slimmed down I have the seperate `fetchWithdrawals` and `fetchDeposits` calling `fetchTransactions`.
2. `start` and `end` are required so I kind of add and assumption that if you only add a `since` then you want to start at that time and get until `now`. Not sure if we should add assumptions like that. However, it can override by adding`end` to `params`.
3. I am not sure about using `type` in the JS since `type` is a reserved word in python. Should I change it to `_type`?

Please let me know what if anything I did wrong and I'll make changes.