### PR TITLE
http_build_query third param defaults to a user changeable ini setting

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -531,11 +531,11 @@ class Exchange {
     }
 
     public static function urlencode ($string) {
-        return http_build_query ($string,"","&");
+        return http_build_query ($string, "", $this->urlencode_glue);
     }
 
     public static function rawencode ($string) {
-        return urldecode (http_build_query ($string,"","&"));
+        return urldecode (http_build_query ($string, "", $this->urlencode_glue));
     }
 
     public static function encode_uri_component ($string) {
@@ -874,6 +874,9 @@ class Exchange {
             'BCC' => 'BCH',
             'DRK' => 'DASH'
         );
+        
+        $this->urlencode_glue = ini_get ('arg_separator.output'); // can be overrided by exchange constructor params
+        $this->urlencode_glue_warning = true;
 
         $options = array_replace_recursive ($this->describe(), $options);
 
@@ -883,6 +886,16 @@ class Exchange {
                     (property_exists ($this, $key) && is_array ($this->{$key}) && is_array ($value)) ?
                         array_replace_recursive ($this->{$key}, $value) :
                         $value;
+
+        if ($this->urlencode_glue !== '&') {
+            if ($this->urlencode_glue_warning) {
+                throw new ExchangeError (this.id . " warning! The glue symbol for HTTP queries " .
+                    " is changed from its default value & to " .  $this->urlencode_glue . " in php.ini" .
+                    " (arg_separator.output) or with a call to ini_set prior to this message. If that" .
+                    " was the intent, you can acknowledge this warning and silence it by setting" . 
+                    " 'urlencode_glue_warning' => false or 'urlencode_glue' => '&' with exchange constructor params");
+            }
+        }
 
         if ($this->api)
             $this->define_rest_api ($this->api, 'request');

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -531,11 +531,11 @@ class Exchange {
     }
 
     public static function urlencode ($string) {
-        return http_build_query ($string);
+        return http_build_query ($string,"","&");
     }
 
     public static function rawencode ($string) {
-        return urldecode (http_build_query ($string));
+        return urldecode (http_build_query ($string,"","&"));
     }
 
     public static function encode_uri_component ($string) {


### PR DESCRIPTION
The third parameter of http_build_query, if omitted, defaults to a setting in php.ini which can be changed by user's code.

So it should not be relied upon, but instead it should be explicitly set to "&" as many exchanges DO NOT accept &amp; or other separators.