### PR TITLE
Update typo in manual

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2630,7 +2630,7 @@ As the price and amount of the incoming sell (ask) order cover more than one bid
 
 1. Order ``b`` is matched against the incoming sell because their prices intersect. Their volumes *“mutually annihilate”* each other, so, the bidder gets 100 for a price of 0.800. The seller (asker) will have his sell order partially filled by bid volume 100 for a price of 0.800. Note that for this filled part of the order the seller gets a better price than he asked for initially (0.8 instead of 0.7). Most conventional exchanges fill orders for the best price available.
 
-2. A trade is generated for the order ``b`` against the incoming sell order. That trade *“fills”* the entire order ``b`` and most of the sell order. One trade is generated pear each pair of matched orders, whether the amount was filled completely or partially. In this example the amount of 100 fills order ``b`` completely (closed the order ``b``) and also fills the selling order partially (leaves it open in the orderbook).
+2. A trade is generated for the order ``b`` against the incoming sell order. That trade *“fills”* the entire order ``b`` and most of the sell order. One trade is generated per each pair of matched orders, whether the amount was filled completely or partially. In this example the amount of 100 fills order ``b`` completely (closed the order ``b``) and also fills the selling order partially (leaves it open in the orderbook).
 
 3. Order ``b`` now has a status of ``closed`` and a filled volume of 100. It contains one trade against the selling order. The selling order has ``open`` status and a filled volume of 100. It contains one trade against order ``b``. Thus each order has just one fill-trade so far.
 


### PR DESCRIPTION
Fix small typo in the [How Orders are Related to Trades](https://github.com/ccxt/ccxt/blob/master/doc/manual.rst#how-orders-are-related-to-trades) section of the manual