### PR TITLE
Short array syntax has been added with version 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -226,7 +226,7 @@
         }
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-iconv": "*",


### PR DESCRIPTION
php code use short array syntax but she has been added in version 5.4 http://php.net/manual/en/migration54.new-features.php