### PR TITLE
cobinhood fix createDepositAddress

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -615,9 +615,13 @@ module.exports = class cobinhood extends Exchange {
     async createDepositAddress (code, params = {}) {
         await this.loadMarkets ();
         let currency = this.currency (code);
-        let response = await this.privatePostWalletDepositAddresses ({
+        // 'ledger_type' is required, see: https://cobinhood.github.io/api-public/#create-new-deposit-address
+        if (!('ledger_type' in params)) {
+            params['ledger_type'] = 'exchange';
+        }
+        let response = await this.privatePostWalletDepositAddresses (this.extend ({
             'currency': currency['id'],
-        });
+        }, params));
         let address = this.safeString (response['result']['deposit_address'], 'address');
         this.checkAddress (address);
         return {

--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -616,12 +616,12 @@ module.exports = class cobinhood extends Exchange {
         await this.loadMarkets ();
         let currency = this.currency (code);
         // 'ledger_type' is required, see: https://cobinhood.github.io/api-public/#create-new-deposit-address
-        if (!('ledger_type' in params)) {
-            params['ledger_type'] = 'exchange';
-        }
-        let response = await this.privatePostWalletDepositAddresses (this.extend ({
+        let ledgerType = this.safeString (params, 'ledger_type', 'exchange');
+        let request = {
             'currency': currency['id'],
-        }, params));
+            'ledger_type': ledgerType,
+        }
+        let response = await this.privatePostWalletDepositAddresses (this.extend (request, params));
         let address = this.safeString (response['result']['deposit_address'], 'address');
         this.checkAddress (address);
         return {

--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -623,10 +623,12 @@ module.exports = class cobinhood extends Exchange {
         }
         let response = await this.privatePostWalletDepositAddresses (this.extend (request, params));
         let address = this.safeString (response['result']['deposit_address'], 'address');
+        let tag = this.safeString (response['result']['deposit_address'], 'memo');
         this.checkAddress (address);
         return {
             'currency': code,
             'address': address,
+            'tag': tag,
             'info': response,
         };
     }

--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -620,7 +620,7 @@ module.exports = class cobinhood extends Exchange {
         let request = {
             'currency': currency['id'],
             'ledger_type': ledgerType,
-        }
+        };
         let response = await this.privatePostWalletDepositAddresses (this.extend (request, params));
         let address = this.safeString (response['result']['deposit_address'], 'address');
         let tag = this.safeString (response['result']['deposit_address'], 'memo');


### PR DESCRIPTION
If you don't specify 'ledger_type' (which is a non-standard thing to do and in fact I called this method for many other exchanges and it went smoothly but not here) you get an error.

With my fix, the address is created.

Bitfinex also offers different kind of addresses, but by default when you call this method, it creates a new address for the 'exchange' wallet. Thus I kept the same behavior here.

Maybe this (if not already) could be documented somewhere (where you specify rules for devsm how to implement things, which structure to follow etc.): if there are several wallets: exchange, margin, funding etc. `createDepositAddress` should create by default the 'exchange' address, unless specified differently in the 'params'.