### PR TITLE
bigone fix: fetch order, wrong response format

### DIFF
--- a/js/bigone.js
+++ b/js/bigone.js
@@ -541,8 +541,8 @@ module.exports = class bigone extends Exchange {
         //         }
         //     }
         //
-        let order = self.safeValue (response, 'data');
-        return self.parseOrder (order);
+        let order = this.safeValue (response, 'data');
+        return this.parseOrder (order);
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -528,17 +528,21 @@ module.exports = class bigone extends Exchange {
         let response = await this.privateGetOrdersOrderId (this.extend (request, params));
         //
         //     {
-        //         "id": 10,
-        //         "market_uuid": "d2185614-50c3-4588-b146-b8afe7534da6",
-        //         "price": "10.00",
-        //         "amount": "10.00",
-        //         "filled_amount": "9.0",
-        //         "avg_deal_price": "12.0",
-        //         "side": "ASK",
-        //         "state": "FILLED"
+        //       "data":
+        //         {
+        //           "id": 10,
+        //           "market_uuid": "BTC-EOS",
+        //           "price": "10.00",
+        //           "amount": "10.00",
+        //           "filled_amount": "9.0",
+        //           "avg_deal_price": "12.0",
+        //           "side": "ASK",
+        //           "state": "FILLED"
+        //         }
         //     }
         //
-        return this.parseOrder (response);
+        let order = self.safeValue (response, 'data');
+        return self.parseOrder (order);
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/python/ccxt/bigone.py
+++ b/python/ccxt/bigone.py
@@ -510,7 +510,8 @@ class bigone (Exchange):
         request = {'order_id': id}
         response = self.privateGetOrdersOrderId(self.extend(request, params))
         #
-        #     {
+        #  {
+        #     "data": {
         #         "id": 10,
         #         "market_uuid": "d2185614-50c3-4588-b146-b8afe7534da6",
         #         "price": "10.00",
@@ -520,8 +521,10 @@ class bigone (Exchange):
         #         "side": "ASK",
         #         "state": "FILLED"
         #     }
+        #  }
         #
-        return self.parse_order(response)
+        order = self.safe_value(response, 'data')
+        return self.parse_order(order)
 
     def fetch_orders(self, symbol=None, since=None, limit=None, params={}):
         # NAME      DESCRIPTION                                           EXAMPLE         REQUIRED


### PR DESCRIPTION
The format of response data of fetch_order api has been changed, was wrapped as a sub-object with a key of "data"

#4106