### PR TITLE
kraken fix missing tag/memo in fetchDepositAddress

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -997,10 +997,12 @@ module.exports = class kraken extends Exchange {
         if (numResults < 1)
             throw new InvalidAddress (this.id + ' privatePostDepositAddresses() returned no addresses');
         let address = this.safeString (result[0], 'address');
+        let tag = this.safeString (result[0], 'tag') || this.safeString (result[0], 'memo');
         this.checkAddress (address);
         return {
             'currency': code,
             'address': address,
+            'tag': tag,
             'info': response,
         };
     }


### PR DESCRIPTION
I found and fixed quite an important issue here: on kraken, when fetching the deposit address for currencies like:
- xrp
- xlm
- eos
- etc. (monero too)

The tag / memo was missing! This may lead to potential loss of money! I lost in the past ripple sent to the wrong tag, here the tag is completely missing.

@kroitor as follow up can you add maybe some unit tests that can check at least if the implementation of all exchanges' fetchDepositAddress at least populate the tag field for these currencies? If the tag is missing, either do not return the address at all (like for the **cex** exchange). Else populate it. But forgetting about it is quite dangerous.