### PR TITLE
Fixup HCash (HC / HSR) and HarvestCoin (HC) mappings

### DIFF
--- a/js/coinmarketcap.js
+++ b/js/coinmarketcap.js
@@ -115,6 +115,7 @@ module.exports = class coinmarketcap extends Exchange {
             'Global Tour Coin': 'Global Tour Coin', // conflict with GTC (Game.com)
             'GuccioneCoin': 'GuccioneCoin', // conflict with GCC (Global Cryptocurrency)
             'HarmonyCoin': 'HarmonyCoin', // conflict with HMC (Hi Mutual Society)
+            'Harvest Masternode Coin': 'Harvest Masternode Coin', // conflict with HC (HyperCash)
             'Hydro Protocol': 'Hydro Protocol', // conflict with HOT (Holo)
             'Huncoin': 'Huncoin', // conflict with HNC (Helleniccoin)
             'iCoin': 'iCoin',

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -108,6 +108,8 @@ module.exports = class cryptopia extends Exchange {
                 'FT': 'Fabric Token',
                 'FUEL': 'FC2', // FuelCoin != FUEL
                 'HAV': 'Havecoin',
+                'HC': 'HarvestCoin',
+                'HSR': 'HC',
                 'KARM': 'KARMA',
                 'LBTC': 'LiteBitcoin',
                 'LDC': 'LADACoin',

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -108,7 +108,7 @@ module.exports = class cryptopia extends Exchange {
                 'FT': 'Fabric Token',
                 'FUEL': 'FC2', // FuelCoin != FUEL
                 'HAV': 'Havecoin',
-                'HC': 'HarvestCoin',
+                'HC': 'Harvest Masternode Coin', // != HyperCash
                 'HSR': 'HC',
                 'KARM': 'KARMA',
                 'LBTC': 'LiteBitcoin',

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -490,6 +490,7 @@ module.exports = class hitbtc extends Exchange {
                 'DRK': 'DASH',
                 'EMGO': 'MGO',
                 'GET': 'Themis',
+                'HSR': 'HC',
                 'LNC': 'LinkerCoin',
                 'UNC': 'Unigame',
                 'USD': 'USDT',

--- a/js/okex.js
+++ b/js/okex.js
@@ -31,6 +31,7 @@ module.exports = class okex extends okcoinusd {
             'commonCurrencies': {
                 'FAIR': 'FairGame',
                 'HOT': 'Hydro Protocol',
+                'HSR': 'HC',
                 'MAG': 'Maggie',
                 'YOYO': 'YOYOW',
             },


### PR DESCRIPTION
Some of the mappings for HCash (formerly HSR, there was a swap from HSR to HC) are confusing between exchanges.  Cryptopia also lists HC for HarvestCoin, so this standardizes all HCash variants as HC, and then makes a separate entry for HarvestCoin on Cryptopia.
* OKEx announcement: https://support.okex.com/hc/en-us/articles/115002632611-OKEx-List-QTUM-HSR-NEO-GAS
* Cryptopia HSR: https://www.cryptopia.co.nz/Exchange?market=HSR_BTC
* Cryptopia HC: https://www.cryptopia.co.nz/Exchange?market=HC_BTC
* HSR to HC annoucement: https://medium.com/@media_30378/an-important-hsr-token-announcement-acc9e08516ce