### PR TITLE
coolcoin only have btc and usdt

### DIFF
--- a/js/coolcoin.js
+++ b/js/coolcoin.js
@@ -61,6 +61,9 @@ module.exports = class coolcoin extends coinegg {
                     },
                 },
             },
+            'options': {
+                'quoteIds': ['btc', 'usdt'],
+            },
         });
     }
 };


### PR DESCRIPTION
Coolcoin only have btc and usdt quote ids. (But coinegg have eth and usc)

 https://www.coolcoin.com/