### PR TITLE
Improve bitmex error handling.

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -596,7 +596,7 @@ module.exports = class bitmex extends Exchange {
                         throw new broad[broadKey] (feedback);
                     }
                     if (code === 400) {
-                        throw new BadRequest (this.id + ' ' + body);
+                        throw new BadRequest (feedback);
                     }
                     throw new ExchangeError (feedback); // unknown message
                 }

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ExchangeNotAvailable, DDoSProtection, OrderNotFound, AuthenticationError, PermissionDenied } = require ('./base/errors');
+const { AuthenticationError, BadRequest, DDoSProtection, ExchangeError, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -134,6 +134,7 @@ module.exports = class bitmex extends Exchange {
                 'exact': {
                     'Invalid API Key.': AuthenticationError,
                     'Access Denied': PermissionDenied,
+                    'Duplicate clOrdID': InvalidOrder,
                 },
                 'broad': {
                     'overloaded': ExchangeNotAvailable,
@@ -593,6 +594,9 @@ module.exports = class bitmex extends Exchange {
                     const broadKey = this.findBroadlyMatchedKey (broad, message);
                     if (broadKey !== undefined) {
                         throw new broad[broadKey] (feedback);
+                    }
+                    if (code === 400) {
+                        throw new BadRequest (this.id + ' ' + body);
                     }
                     throw new ExchangeError (feedback); // unknown message
                 }


### PR DESCRIPTION
I need to check if custom client order id is duplicated when creating orders in my application, so I send this PR.

This commit adds error handlings for two cases:
1. If duplicated client order id is used to create a new order, throw
`InvalidOrder` exception. [Reference](https://testnet.bitmex.com/app/restAPIMessages#POST-order-PUT-order-POST-orderclosePosition).
2. If http response code is 400, throw `BadRequest` exception.

A side note: I'm wondering if using `BadRequest` for duplicated client order id is more appropriate. If so, then what falls under the `InvalidOrder` category? Also, I propose to add `OrderIdDuplicated` error to deal with aforementioned situation.

A quick link to [errors.js](https://github.com/ccxt/ccxt/blob/master/js/base/errors.js) for you