### PR TITLE
Shouldn't fetch_markets as all the Unified Functions have a last para…

### DIFF
--- a/php/therock.php
+++ b/php/therock.php
@@ -99,7 +99,7 @@ class therock extends Exchange {
         ));
     }
 
-    public function fetch_markets () {
+    public function fetch_markets ($params = array ()) {
         $response = $this->publicGetFunds ();
         //
         //     { funds => array ( array (                      $id =>   "BTCEUR",


### PR DESCRIPTION
…m array()?

I think the fetch_markets should have a last parameter $params = array () just as any other unified api function, to pass in exchange specific parameters...

Is there a reason why this unified function doesn't have it?

(I proposed this change here in the therock driver just to map it to an example code point, but I think this should be present as a last parameter in all the unified api functions in all the drivers...)

I know that many exchanges do not accept any parameter in the call to fetch markets, but in that case the driver's implementation cuold just ignore this parameter, while in other drivers, such as livecoin for example, the parameters should be passed to the call!