### PR TITLE
Added custom params parameter to fetchMarkets and loadMarkets everywhere

### DIFF
--- a/js/_1btcxe.js
+++ b/js/_1btcxe.js
@@ -56,7 +56,7 @@ module.exports = class _1btcxe extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         return [
             { 'id': 'USD', 'symbol': 'BTC/USD', 'base': 'BTC', 'quote': 'USD' },
             { 'id': 'EUR', 'symbol': 'BTC/EUR', 'base': 'BTC', 'quote': 'EUR' },

--- a/js/acx.js
+++ b/js/acx.js
@@ -99,7 +99,7 @@ module.exports = class acx extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetMarkets ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/allcoin.js
+++ b/js/allcoin.js
@@ -57,7 +57,7 @@ module.exports = class allcoin extends okcoinusd {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let result = [];
         let response = await this.webGetHomeMarketOverViewDetail ();
         let coins = response['marketCoins'];

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -696,14 +696,14 @@ module.exports = class Exchange {
         return this.markets
     }
 
-    async loadMarkets (reload = false) {
+    async loadMarkets (reload = false, params = {}) {
         if (!reload && this.markets) {
             if (!this.markets_by_id) {
                 return this.setMarkets (this.markets)
             }
             return this.markets
         }
-        const markets = await this.fetchMarkets ()
+        const markets = await this.fetchMarkets (params)
         let currencies = undefined
         if (this.has.fetchCurrencies) {
             currencies = await this.fetchCurrencies ()
@@ -827,7 +827,7 @@ module.exports = class Exchange {
         return new Promise ((resolve, reject) => resolve (this.currencies));
     }
 
-    fetchMarkets () {
+    fetchMarkets (params = {}) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons

--- a/js/bcex.js
+++ b/js/bcex.js
@@ -285,7 +285,7 @@ module.exports = class bcex extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetApiMarketGetPriceList ();
         let result = [];
         let keys = Object.keys (response);

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -100,7 +100,7 @@ module.exports = class bigone extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarkets ();
         let markets = response['data'];
         let result = [];

--- a/js/binance.js
+++ b/js/binance.js
@@ -299,7 +299,7 @@ module.exports = class binance extends Exchange {
         return this.options['timeDifference'];
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetExchangeInfo ();
         if (this.options['adjustForTimeDifference'])
             await this.loadTimeDifference ();

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -407,7 +407,7 @@ module.exports = class bitfinex extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetSymbolsDetails ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -177,7 +177,7 @@ module.exports = class bitfinex2 extends bitfinex {
         return 'f' + code;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.v1GetSymbolsDetails ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -83,7 +83,7 @@ module.exports = class bitflyer extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let jp_markets = await this.publicGetGetmarkets ();
         let us_markets = await this.publicGetGetmarketsUsa ();
         let eu_markets = await this.publicGetGetmarketsEu ();

--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -215,7 +215,7 @@ module.exports = class bitforex extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetApiV1MarketSymbols ();
         let data = response['data'];
         let result = [];

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -70,7 +70,7 @@ module.exports = class bithumb extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTickerAll ();
         let currencies = Object.keys (markets['data']);
         let result = [];

--- a/js/bitlish.js
+++ b/js/bitlish.js
@@ -122,7 +122,7 @@ module.exports = class bitlish extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetPairs ();
         let result = [];
         let keys = Object.keys (markets);

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -146,7 +146,7 @@ module.exports = class bitmex extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetInstrumentActiveAndIndices ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/bitsane.js
+++ b/js/bitsane.js
@@ -128,7 +128,7 @@ module.exports = class bitsane extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetAssetsPairs ();
         let result = [];
         let marketIds = Object.keys (markets);

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -88,7 +88,7 @@ module.exports = class bitso extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetAvailableBooks ();
         let result = [];
         for (let i = 0; i < markets['payload'].length; i++) {

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -160,7 +160,7 @@ module.exports = class bitstamp extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTradingPairsInfo ();
         let result = [];
         for (let i = 0; i < markets.length; i++) {

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -182,7 +182,7 @@ module.exports = class bittrex extends Exchange {
         return this.decimalToPrecision (fee, TRUNCATE, this.markets[symbol]['precision']['price'], DECIMAL_PLACES);
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.v2GetMarketsGetMarketSummaries ();
         let result = [];
         for (let i = 0; i < response['result'].length; i++) {

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -201,7 +201,7 @@ module.exports = class bitz extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.marketGetSymbolList ();
         //
         //     {    status:    200,

--- a/js/bleutrade.js
+++ b/js/bleutrade.js
@@ -117,7 +117,7 @@ module.exports = class bleutrade extends bittrex {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetMarkets ();
         let result = [];
         for (let p = 0; p < markets['result'].length; p++) {

--- a/js/braziliex.js
+++ b/js/braziliex.js
@@ -131,7 +131,7 @@ module.exports = class braziliex extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTicker ();
         let ids = Object.keys (markets);
         let result = [];

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -105,7 +105,7 @@ module.exports = class btcalpha extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetPairs ();
         let result = [];
         for (let i = 0; i < markets.length; i++) {

--- a/js/btcchina.js
+++ b/js/btcchina.js
@@ -85,7 +85,7 @@ module.exports = class btcchina extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTicker ({
             'market': 'all',
         });

--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -85,7 +85,7 @@ module.exports = class btcmarkets extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetV2MarketActive ();
         let result = [];
         let markets = response['markets'];

--- a/js/btcturk.js
+++ b/js/btcturk.js
@@ -58,7 +58,7 @@ module.exports = class btcturk extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetTicker ();
         let result = [];
         for (let i = 0; i < response.length; i++) {

--- a/js/buda.js
+++ b/js/buda.js
@@ -147,7 +147,7 @@ module.exports = class buda extends Exchange {
         return undefined;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let marketsResponse = await this.publicGetMarkets ();
         let markets = marketsResponse['markets'];
         let currenciesResponse = await this.publicGetCurrencies ();

--- a/js/bxinth.js
+++ b/js/bxinth.js
@@ -75,7 +75,7 @@ module.exports = class bxinth extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetPairing ();
         let keys = Object.keys (markets);
         let result = [];

--- a/js/ccex.js
+++ b/js/ccex.js
@@ -80,7 +80,7 @@ module.exports = class ccex extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let result = {};
         let response = await this.webGetPairs ();
         let markets = response['pairs'];

--- a/js/cex.js
+++ b/js/cex.js
@@ -122,7 +122,7 @@ module.exports = class cex extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetCurrencyLimits ();
         let result = [];
         for (let p = 0; p < markets['data']['pairs'].length; p++) {

--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -237,7 +237,7 @@ module.exports = class cobinhood extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarketTradingPairs ();
         let markets = response['result']['trading_pairs'];
         let result = [];

--- a/js/coinegg.js
+++ b/js/coinegg.js
@@ -150,7 +150,7 @@ module.exports = class coinegg extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let quoteIds = this.options['quoteIds'];
         let result = [];
         for (let b = 0; b < quoteIds.length; b++) {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -120,7 +120,7 @@ module.exports = class coinex extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.webGetResMarket ();
         let markets = response['data']['market_info'];
         let result = [];

--- a/js/coinexchange.js
+++ b/js/coinexchange.js
@@ -603,7 +603,7 @@ module.exports = class coinexchange extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetGetmarkets ();
         let markets = response['result'];
         let result = [];

--- a/js/coinfalcon.js
+++ b/js/coinfalcon.js
@@ -64,7 +64,7 @@ module.exports = class coinfalcon extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarkets ();
         let markets = response['data'];
         let result = [];

--- a/js/coingi.js
+++ b/js/coingi.js
@@ -89,7 +89,7 @@ module.exports = class coingi extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = undefined;
         try {
             this.parseJsonResponse = false;

--- a/js/coinmarketcap.js
+++ b/js/coinmarketcap.js
@@ -135,7 +135,7 @@ module.exports = class coinmarketcap extends Exchange {
         return base;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTicker ({
             'limit': 0,
         });

--- a/js/coinnest.js
+++ b/js/coinnest.js
@@ -72,7 +72,7 @@ module.exports = class coinnest extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let quote = 'KRW';
         let quoteId = quote.toLowerCase ();
         // todo: rewrite this for web endpoint

--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -120,7 +120,7 @@ module.exports = class cointiger extends huobipro {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         const response = await this.v2publicGetCurrencys ();
         //
         //     {

--- a/js/crex24.js
+++ b/js/crex24.js
@@ -137,7 +137,7 @@ module.exports = class crex24 extends Exchange {
         return this.milliseconds ();
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetInstruments ();
         //
         //     [ {              symbol:   "$PAC-BTC",

--- a/js/crypton.js
+++ b/js/crypton.js
@@ -69,7 +69,7 @@ module.exports = class crypton extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarkets ();
         let markets = response['result'];
         let result = [];

--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -130,7 +130,7 @@ module.exports = class cryptopia extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetGetTradePairs ();
         let result = [];
         let markets = response['Data'];

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -82,7 +82,7 @@ module.exports = class deribit extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let marketsResponse = await this.publicGetGetinstruments ();
         let markets = marketsResponse['result'];
         let result = [];

--- a/js/dsx.js
+++ b/js/dsx.js
@@ -88,7 +88,7 @@ module.exports = class dsx extends liqui {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetInfo ();
         let markets = response['pairs'];
         let keys = Object.keys (markets);

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -329,7 +329,7 @@ module.exports = class exmo extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let fees = await this.fetchTradingFees ();
         let markets = await this.publicGetPairSettings ();
         let keys = Object.keys (markets);

--- a/js/exx.js
+++ b/js/exx.js
@@ -91,7 +91,7 @@ module.exports = class exx extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetMarkets ();
         let ids = Object.keys (markets);
         let result = [];

--- a/js/fcoin.js
+++ b/js/fcoin.js
@@ -128,7 +128,7 @@ module.exports = class fcoin extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetSymbols ();
         let result = [];
         let markets = response['data'];

--- a/js/flowbtc.js
+++ b/js/flowbtc.js
@@ -69,7 +69,7 @@ module.exports = class flowbtc extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicPostGetProductPairs ();
         let markets = response['productPairs'];
         let result = {};

--- a/js/gatecoin.js
+++ b/js/gatecoin.js
@@ -206,7 +206,7 @@ module.exports = class gatecoin extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetReferenceCurrencyPairs ();
         let markets = response['currencyPairs'];
         let result = [];

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -129,7 +129,7 @@ module.exports = class gateio extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarketinfo ();
         let markets = this.safeValue (response, 'pairs');
         if (!markets)

--- a/js/gdax.js
+++ b/js/gdax.js
@@ -147,7 +147,7 @@ module.exports = class gdax extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetProducts ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -85,7 +85,7 @@ module.exports = class gemini extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetSymbols ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -502,7 +502,7 @@ module.exports = class hitbtc extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetSymbols ();
         let result = [];
         for (let p = 0; p < markets['symbols'].length; p++) {

--- a/js/hitbtc2.js
+++ b/js/hitbtc2.js
@@ -550,7 +550,7 @@ module.exports = class hitbtc2 extends hitbtc {
         return this.decimalToPrecision (fee, TRUNCATE, 8, DECIMAL_PLACES);
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetSymbol ();
         let result = [];
         for (let i = 0; i < markets.length; i++) {

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -217,7 +217,7 @@ module.exports = class huobipro extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let method = this.options['fetchMarketsMethod'];
         let response = await this[method] ();
         let markets = response['data'];

--- a/js/ice3x.js
+++ b/js/ice3x.js
@@ -121,7 +121,7 @@ module.exports = class ice3x extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         if (!Object.keys (this.currencies).length) {
             this.currencies = await this.fetchCurrencies ();
         }

--- a/js/independentreserve.js
+++ b/js/independentreserve.js
@@ -72,7 +72,7 @@ module.exports = class independentreserve extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let baseCurrencies = await this.publicGetGetValidPrimaryCurrencyCodes ();
         let quoteCurrencies = await this.publicGetGetValidSecondaryCurrencyCodes ();
         let result = [];

--- a/js/jubi.js
+++ b/js/jubi.js
@@ -27,7 +27,7 @@ module.exports = class jubi extends btcbox {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetAllticker ();
         let keys = Object.keys (markets);
         let result = [];

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -246,7 +246,7 @@ module.exports = class kraken extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetAssetPairs ();
         let limits = await this.fetchMinOrderAmounts ();
         let keys = Object.keys (markets['result']);

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -519,7 +519,7 @@ module.exports = class kucoin extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarketOpenSymbols ();
         if (this.options['adjustForTimeDifference'])
             await this.loadTimeDifference ();

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -56,7 +56,7 @@ module.exports = class kuna extends acx {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         const quotes = [ 'btc', 'eth', 'eurs', 'gbg', 'uah' ];
         const pricePrecisions = {
             'UAH': 0,

--- a/js/lakebtc.js
+++ b/js/lakebtc.js
@@ -58,7 +58,7 @@ module.exports = class lakebtc extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTicker ();
         let result = [];
         let keys = Object.keys (markets);

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -106,7 +106,7 @@ module.exports = class lbank extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetAccuracy ();
         let result = [];
         for (let i = 0; i < markets.length; i++) {

--- a/js/liqui.js
+++ b/js/liqui.js
@@ -124,7 +124,7 @@ module.exports = class liqui extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetInfo ();
         let markets = response['pairs'];
         let keys = Object.keys (markets);

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -163,7 +163,7 @@ module.exports = class liquid extends Exchange {
         return result;
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetProducts ();
         //
         //     [

--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -121,7 +121,7 @@ module.exports = class livecoin extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetExchangeTicker ();
         let restrictions = await this.publicGetExchangeRestrictions ();
         let restrictionsById = this.indexBy (restrictions['restrictions'], 'currencyPair');

--- a/js/luno.js
+++ b/js/luno.js
@@ -82,7 +82,7 @@ module.exports = class luno extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTickers ();
         let result = [];
         for (let p = 0; p < markets['tickers'].length; p++) {

--- a/js/lykke.js
+++ b/js/lykke.js
@@ -139,7 +139,7 @@ module.exports = class lykke extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetAssetPairs ();
         //
         //     [ {                Id: "AEBTC",

--- a/js/nova.js
+++ b/js/nova.js
@@ -62,7 +62,7 @@ module.exports = class nova extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetMarkets ();
         let markets = response['markets'];
         let result = [];

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -326,7 +326,7 @@ module.exports = class okcoinusd extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.webGetSpotMarketsProducts ();
         let markets = response['data'];
         let result = [];

--- a/js/okex.js
+++ b/js/okex.js
@@ -59,8 +59,8 @@ module.exports = class okex extends okcoinusd {
         };
     }
 
-    async fetchMarkets () {
-        let markets = await super.fetchMarkets ();
+    async fetchMarkets (params = {}) {
+        let markets = await super.fetchMarkets (params);
         // TODO: they have a new fee schedule as of Feb 7
         // the new fees are progressive and depend on 30-day traded volume
         // the following is the worst case

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -227,7 +227,7 @@ module.exports = class poloniex extends Exchange {
         return this.parseOHLCVs (response, market, timeframe, since, limit);
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetReturnTicker ();
         let keys = Object.keys (markets);
         let result = [];

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -132,7 +132,7 @@ module.exports = class rightbtc extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetTradingPairs ();
         // let zh = await this.publicGetGetAssetsTradingPairsZh ();
         let markets = this.extend (response['status']['message']);

--- a/js/southxchange.js
+++ b/js/southxchange.js
@@ -64,7 +64,7 @@ module.exports = class southxchange extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetMarkets ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/theocean.js
+++ b/js/theocean.js
@@ -115,7 +115,7 @@ module.exports = class theocean extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetTokenPairs ();
         //
         //     [

--- a/js/therock.js
+++ b/js/therock.js
@@ -98,7 +98,7 @@ module.exports = class therock extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetFunds ();
         //
         //     { funds: [ {                      id:   "BTCEUR",

--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -137,7 +137,7 @@ module.exports = class tidebit extends Exchange {
         }
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetMarkets ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/uex.js
+++ b/js/uex.js
@@ -172,7 +172,7 @@ module.exports = class uex extends Exchange {
         };
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let response = await this.publicGetCommonSymbols ();
         //
         //     { code:   "0",

--- a/js/vaultoro.js
+++ b/js/vaultoro.js
@@ -58,7 +58,7 @@ module.exports = class vaultoro extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let result = [];
         let markets = await this.publicGetMarkets ();
         let market = markets['data'];

--- a/js/virwox.js
+++ b/js/virwox.js
@@ -81,7 +81,7 @@ module.exports = class virwox extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetGetInstruments ();
         let keys = Object.keys (markets['result']);
         let result = [];

--- a/js/xbtce.js
+++ b/js/xbtce.js
@@ -104,7 +104,7 @@ module.exports = class xbtce extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.privateGetSymbol ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/zaif.js
+++ b/js/zaif.js
@@ -108,7 +108,7 @@ module.exports = class zaif extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetCurrencyPairsAll ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {

--- a/js/zb.js
+++ b/js/zb.js
@@ -164,7 +164,7 @@ module.exports = class zb extends Exchange {
         });
     }
 
-    async fetchMarkets () {
+    async fetchMarkets (params = {}) {
         let markets = await this.publicGetMarkets ();
         let keys = Object.keys (markets);
         let result = [];

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1295,18 +1295,18 @@ class Exchange {
         return $this->set_markets ($markets);
     }
 
-    public function loadMarkets ($reload = false) {
-        return $this->load_markets ($reload);
+    public function loadMarkets ($reload = false, $params = array()) {
+        return $this->load_markets ($reload, $params);
     }
 
-    public function load_markets ($reload = false) {
+    public function load_markets ($reload = false, $params = array()) {
         if (!$reload && $this->markets) {
             if (!$this->markets_by_id) {
                 return $this->set_markets ($this->markets);
             }
             return $this->markets;
         }
-        $markets = $this->fetch_markets ();
+        $markets = $this->fetch_markets ($params);
         $currencies = null;
         if (array_key_exists ('fetchCurrencies', $this->has) && $this->has['fetchCurrencies'])
             $currencies = $this->fetch_currencies ();
@@ -1682,7 +1682,7 @@ class Exchange {
         throw new NotSupported ($this->id . ' fetch_withdrawals() not implemented yet');
     }
 
-    public function fetch_markets () {
+    public function fetch_markets ($params = array()) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons
@@ -1690,8 +1690,8 @@ class Exchange {
         return $this->markets ? array_values ($this->markets) : array ();
     }
 
-    public function fetchMarkets  () {
-        return $this->fetch_markets ();
+    public function fetchMarkets  ($params = array()) {
+        return $this->fetch_markets ($params);
     }
 
     public function fetch_currencies ($params = array ()) {


### PR DESCRIPTION
I updated base php class Exchange and base js class Exchange plus all the fetchMarkets functions in the js source drivers to accept the added custom params parameter (I think this will make the correction pass down to the php drivers, am I right?).

Naturally, I did not really implement reaction to the new parameter in each and every driver, but this can be done driver by driver, in time, by someone who does need it; with this patch of mine, even if passed, the parameter gets silently ignored, just as it happened before when the parameter was missing; I will for sure begin writing code to react to this parameter in the exchange drivers I'm using, but I don't have enough time to implement it in each and every driver.

I did NOT do this in python base class since I'm not a python programmer; I think making this kind of correction also in the python codebase is needed before the patch can be released... :)