### PR TITLE
update python callchain so json is passed to handleErrors

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -137,7 +137,7 @@ class Exchange(BaseExchange):
                                       timeout=(self.timeout / 1000),
                                       proxy=self.aiohttp_proxy) as response:
                 http_response = await response.text()
-                json_response = self.parseJSON(http_response)
+                json_response = self.parse_json(http_response)
                 headers = response.headers
                 if self.enableLastHttpResponse:
                     self.last_http_response = http_response

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -117,37 +117,37 @@ class Exchange(BaseExchange):
 
     async def fetch(self, url, method='GET', headers=None, body=None):
         """Perform a HTTP request and return decoded JSON data"""
-        headers = self.prepare_request_headers(headers)
-
+        request_headers = self.prepare_request_headers(headers)
         url = self.proxy + url
 
         if self.verbose:
             print("\nRequest:", method, url, headers, body)
-
         self.logger.debug("%s %s, Request: %s %s", method, url, headers, body)
 
         encoded_body = body.encode() if body else None
         session_method = getattr(self.session, method.lower())
-        http_status_code = None
 
+        response = None
+        http_response = None
+        json_response = None
         try:
             async with session_method(yarl.URL(url, encoded=True),
                                       data=encoded_body,
-                                      headers=headers,
+                                      headers=request_headers,
                                       timeout=(self.timeout / 1000),
                                       proxy=self.aiohttp_proxy) as response:
-                http_status_code = response.status
-                text = await response.text()
-                if self.enableLastHttpResponse:
-                    self.last_http_response = text
+                http_response = await response.text()
+                json_response = self.parseJSON(http_response)
                 headers = response.headers
+                if self.enableLastHttpResponse:
+                    self.last_http_response = http_response
                 if self.enableLastResponseHeaders:
                     self.last_response_headers = headers
-                self.handle_errors(http_status_code, text, url, method, headers, text)
-                self.handle_rest_errors(None, http_status_code, text, url, method)
+                if self.enableLastJsonResponse:
+                    self.last_json_response = json_response
                 if self.verbose:
-                    print("\nResponse:", method, url, str(http_status_code), str(headers), text)
-                self.logger.debug("%s %s, Response: %s %s %s", method, url, response.status, headers, text)
+                    print("\nResponse:", method, url, response.status, headers, http_response)
+                self.logger.debug("%s %s, Response: %s %s %s", method, url, response.status, headers, http_response)
 
         except socket.gaierror as e:
             self.raise_error(ExchangeNotAvailable, url, method, e, None)
@@ -158,11 +158,12 @@ class Exchange(BaseExchange):
         except aiohttp.client_exceptions.ClientConnectionError as e:
             self.raise_error(ExchangeNotAvailable, url, method, e, None)
 
-        except aiohttp.client_exceptions.ClientError as e:
+        except aiohttp.client_exceptions.ClientError as e:  # base exception class
             self.raise_error(ExchangeError, url, method, e, None)
 
-        self.handle_errors(http_status_code, text, url, method, headers, text)
-        return self.handle_rest_response(text, url, method, headers, body)
+        self.handle_errors(response.status, response.reason, url, method, headers, http_response, json_response)
+        self.handle_rest_response(http_response, json_response, url, method, headers, body)
+        return json_response
 
     async def load_markets(self, reload=False, params={}):
         if not reload:

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -490,6 +490,8 @@ class Exchange(object):
         try:
             if self.parseJsonResponse:
                 return json.loads(http_response)
+            else:
+                return http_response
         except ValueError:  # superclass of JsonDecodeError (python2)
             pass
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -427,7 +427,7 @@ class Exchange(object):
             http_response = response.text
             json_response = self.parse_json(http_response)
             headers = response.headers
-            # FIXME remove lastXResponses from subclasses
+            # FIXME remove last_x_responses from subclasses
             if self.enableLastHttpResponse:
                 self.last_http_response = http_response
             if self.enableLastJsonResponse:

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -415,7 +415,6 @@ class Exchange(object):
         response = None
         http_response = None
         json_response = None
-        headers = None
         try:
             response = self.session.request(
                 method,
@@ -426,7 +425,7 @@ class Exchange(object):
                 proxies=self.proxies
             )
             http_response = response.text
-            json_response = self.parseJSON(http_response)
+            json_response = self.parse_json(http_response)
             headers = response.headers
             # FIXME remove lastXResponses from subclasses
             if self.enableLastHttpResponse:
@@ -487,7 +486,7 @@ class Exchange(object):
                 self.raise_error(ExchangeNotAvailable, method, url, None, message)
             self.raise_error(ExchangeError, method, url, ValueError('failed to decode json'), response)
 
-    def parseJSON(self, http_response):
+    def parse_json(self, http_response):
         try:
             if self.parseJsonResponse:
                 return json.loads(http_response)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -405,7 +405,6 @@ class Exchange(object):
 
         if self.verbose:
             print("\nRequest:", method, url, request_headers, body)
-
         self.logger.debug("%s %s, Request: %s %s", method, url, request_headers, body)
 
         if body:
@@ -415,6 +414,8 @@ class Exchange(object):
 
         response = None
         http_response = None
+        json_response = None
+        headers = None
         try:
             response = self.session.request(
                 method,
@@ -425,13 +426,17 @@ class Exchange(object):
                 proxies=self.proxies
             )
             http_response = response.text
+            json_response = self.parseJSON(http_response)
+            headers = response.headers
+            # FIXME remove lastXResponses from subclasses
             if self.enableLastHttpResponse:
                 self.last_http_response = http_response
-            headers = response.headers
+            if self.enableLastJsonResponse:
+                self.last_json_response = json_response
             if self.enableLastResponseHeaders:
                 self.last_response_headers = headers
             if self.verbose:
-                print("\nResponse:", method, url, str(response.status_code), str(headers), http_response)
+                print("\nResponse:", method, url, response.status_code, headers, http_response)
             self.logger.debug("%s %s, Response: %s %s %s", method, url, response.status_code, headers, http_response)
             response.raise_for_status()
 
@@ -456,8 +461,9 @@ class Exchange(object):
             else:
                 self.raise_error(ExchangeError, url, method, e)
 
-        self.handle_errors(response.status_code, response.reason, url, method, None, http_response)
-        return self.handle_rest_response(http_response, url, method, headers, body)
+        self.handle_errors(response.status_code, response.reason, url, method, headers, http_response, json_response)
+        self.handle_rest_response(http_response, json_response, url, method, headers, body)
+        return json_response
 
     def handle_rest_errors(self, exception, http_status_code, response, url, method='GET'):
         error = None
@@ -470,16 +476,8 @@ class Exchange(object):
         if error:
             self.raise_error(error, url, method, exception if exception else http_status_code, response)
 
-    def handle_rest_response(self, response, url, method='GET', headers=None, body=None):
-        try:
-            if self.parseJsonResponse:
-                json_response = json.loads(response) if len(response) > 1 else None
-                if self.enableLastJsonResponse:
-                    self.last_json_response = json_response
-                return json_response
-            else:
-                return response
-        except ValueError as e:  # ValueError == JsonDecodeError
+    def handle_rest_response(self, response, json_response, url, method='GET', headers=None, body=None):
+        if json_response is None and self.parseJsonResponse:
             ddos_protection = re.search('(cloudflare|incapsula|overload|ddos)', response, flags=re.IGNORECASE)
             exchange_not_available = re.search('(offline|busy|retry|wait|unavailable|maintain|maintenance|maintenancing)', response, flags=re.IGNORECASE)
             if ddos_protection:
@@ -487,7 +485,14 @@ class Exchange(object):
             if exchange_not_available:
                 message = response + ' exchange downtime, exchange closed for maintenance or offline, DDoS protection or rate-limiting in effect'
                 self.raise_error(ExchangeNotAvailable, method, url, None, message)
-            self.raise_error(ExchangeError, method, url, e, response)
+            self.raise_error(ExchangeError, method, url, ValueError('failed to decode json'), response)
+
+    def parseJSON(self, http_response):
+        try:
+            if self.parseJsonResponse:
+                return json.loads(http_response)
+        except ValueError:  # superclass of JsonDecodeError (python2)
+            pass
 
     @staticmethod
     def safe_float(dictionary, key, default_value=None):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -476,7 +476,7 @@ class Exchange(object):
             self.raise_error(error, url, method, exception if exception else http_status_code, response)
 
     def handle_rest_response(self, response, json_response, url, method='GET', headers=None, body=None):
-        if json_response is None and self.parseJsonResponse:
+        if json_response is None:
             ddos_protection = re.search('(cloudflare|incapsula|overload|ddos)', response, flags=re.IGNORECASE)
             exchange_not_available = re.search('(offline|busy|retry|wait|unavailable|maintain|maintenance|maintenancing)', response, flags=re.IGNORECASE)
             if ddos_protection:


### PR DESCRIPTION
The async `fetch` method was a mess. I am surprised at how well it has been working despite calling `handleErrors` and `handleRestResponse` twice, and passing some wrong arguments. 

Due to my previous commit #4213 this can be merged before we implement the php version. 

Nonetheless check the code thoroughly since changes to the base class affect all exchanges. 