### PR TITLE
sprintf format string f is locale dependent, should use F instead

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -269,7 +269,7 @@ class Exchange {
 
     public static function truncate_to_string ($number, $precision = 0) {
         if ($precision > 0) {
-            $string = sprintf ('%.' . ($precision + 1) . 'f', floatval ($number));
+            $string = sprintf ('%.' . ($precision + 1) . 'F', floatval ($number));
             list ($integer, $decimal) = explode ('.', $string);
             $decimal = trim ('.' . substr ($decimal, 0, $precision), '0');
             if (strlen ($decimal) < 2)


### PR DESCRIPTION
I think this call is an error: calling sprintf("%.5f") here in Italy will result in something like 0,00001 (using comma as a decimal separator) while I think this function should always return a string that remains parsable by php as a float, and so it should always use the dot . as a decimal separator.

Changing f to F will use a NON locale aware conversion, so that the output will always be like 0.00001 (using the dot as a decimal separator) which will always be converted correctly to a float when needed.