### PR TITLE
BitMEX: Add more exception.

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { AuthenticationError, BadRequest, DDoSProtection, ExchangeError, ExchangeNotAvailable, InvalidOrder, OrderNotFound, PermissionDenied } = require ('./base/errors');
+const { AuthenticationError, BadRequest, DDoSProtection, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidOrder, OrderNotFound, PermissionDenied } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -138,6 +138,7 @@ module.exports = class bitmex extends Exchange {
                 },
                 'broad': {
                     'overloaded': ExchangeNotAvailable,
+                    'Account has insufficient Available Balance': InsufficientFunds,
                 },
             },
             'options': {


### PR DESCRIPTION
Reference: [BitMEX API](https://www.bitmex.com/app/restAPIMessages#Reject-reasons-for-orders-created-by-above)