### PR TITLE
btcalpha parseTrade fix

### DIFF
--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -169,6 +169,12 @@ module.exports = class btcalpha extends Exchange {
         let amount = parseFloat (trade['amount']);
         let cost = this.costToPrecision (symbol, price * amount);
         let id = this.safeString (trade, 'id');
+        let side = undefined;
+        if ('my_side' in trade) {
+            side = this.safeString (trade, 'my_side');
+        } else {
+            side = this.safeString (trade, 'side');
+        }
         if (!id)
             id = this.safeString (trade, 'tid');
         return {
@@ -178,7 +184,7 @@ module.exports = class btcalpha extends Exchange {
             'id': id,
             'order': this.safeString (trade, 'o_id'),
             'type': 'limit',
-            'side': this.safeString (trade, 'my_side'),
+            'side': side,
             'price': price,
             'amount': amount,
             'cost': parseFloat (cost),

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -178,7 +178,7 @@ module.exports = class btcalpha extends Exchange {
             'id': id,
             'order': this.safeString (trade, 'o_id'),
             'type': 'limit',
-            'side': trade['type'],
+            'side': trade['my_side'],
             'price': price,
             'amount': amount,
             'cost': parseFloat (cost),

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -178,7 +178,7 @@ module.exports = class btcalpha extends Exchange {
             'id': id,
             'order': this.safeString (trade, 'o_id'),
             'type': 'limit',
-            'side': trade['my_side'],
+            'side': this.safeString (trade, 'my_side'),
             'price': price,
             'amount': amount,
             'cost': parseFloat (cost),


### PR DESCRIPTION
"type" property is, as I understand, the side where order has been created. fetchMyTrades side means our side, so we should use "my_side" property

[ { timestamp: 1543257698845,
    datetime: '2018-11-26T18:41:38.845Z',
    symbol: 'HQX/ETH',
    id: '18546016',
    order: undefined,
    type: 'limit',
    side: 'sell',
    price: 0.000048,
    amount: 527.01291574,
    cost: 0.025297,
    fee: undefined,
    info:
     { id: 18546016,
       timestamp: 1543257698.845597,
       pair: 'HQX_ETH',
       price: '0.00004800',
       amount: '527.01291574',
       type: 'sell',
       my_side: 'buy' } }]