### PR TITLE
bibox fetchMyTrades fix

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -578,6 +578,8 @@ module.exports = class bibox extends Exchange {
             throw new ArgumentsRequired (this.id + ' fetchMyTrades requires a symbol argument');
         await this.loadMarkets ();
         let market = this.market (symbol);
+        let base = symbol.split('/')[0]
+        let quote = symbol.split('/')[1]
         let size = (limit) ? limit : 200;
         let response = await this.privatePostOrderpending ({
             'cmd': 'orderpending/orderHistoryList',
@@ -586,6 +588,8 @@ module.exports = class bibox extends Exchange {
                 'account_type': 0, // 0 - regular, 1 - margin
                 'page': 1,
                 'size': size,
+                'coin_symbol': base,
+                'currency_symbol': quote,
             }, params),
         });
         let trades = this.safeValue (response['result'], 'items', []);


### PR DESCRIPTION
It seems that 'pair' is not enough, without 'coin_symbol': base, 'currency_symbol': quote responce include all pairs, for example on request:

```
let pair = 'BTO/ETH'
trades = await exchange.fetchMyTrades(pair)
console.log (trades)
```

I got:

```
{ info:
     { id: 1317532620,
       createdAt: 1543383661000,
       account_type: 0,
       coin_symbol: 'BTO',
      currency_symbol: 'ETH',
       order_side: 1,
       order_type: 2,
       price: '0.00010001',
       amount: '2501.1703',
       money: '0.25014204',
       fee: '0.06923657',
       pay_bix: 1,
       fee_symbol: 'BIX' },
    id: '1317532620',
    order: undefined,
    timestamp: 1543383661000,
    datetime: '2018-11-28T05:41:01.000Z',
    symbol: 'BTO/ETH',
    type: 'limit',
    takerOrMaker: undefined,
    side: 'buy',
    price: 0.00010001,
    amount: 2501.1703,
    cost: 0.25014204170300003,
    fee: { cost: 0.06923657, currency: 'BIX', rate: undefined } },

  { info:
     { id: 1317797312,
       createdAt: 1543388300000,
       account_type: 0,
       coin_symbol: 'BCHSV',
       currency_symbol: 'BTC',
       order_side: 2,
       order_type: 2,
       price: '0.02044172',
       amount: '0.0623',
       money: '0.00127351',
       fee: '0.01233056',
       pay_bix: 1,
       fee_symbol: 'BIX' },
    id: '1317797312',
    order: undefined,
    timestamp: 1543388300000,
    datetime: '2018-11-28T06:58:20.000Z',
    symbol: 'BTO/ETH',
    type: 'limit',
    takerOrMaker: undefined,
    side: 'sell',
    price: 0.02044172,
    amount: 0.0623,
    cost: 0.0012735191560000001,
    fee: { cost: 0.01233056, currency: 'BIX', rate: undefined } }
```


So it includes trade not only on "BTO/ETH" but also "BCHSV/BTC"

It seems it works properly if "coin_symbol" and "currency_symbol" specified