### PR TITLE
Change WEX url to use new domain

### DIFF
--- a/js/wex.js
+++ b/js/wex.js
@@ -22,15 +22,15 @@ module.exports = class wex extends liqui {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/30652751-d74ec8f8-9e31-11e7-98c5-71469fcef03e.jpg',
                 'api': {
-                    'public': 'https://wex.link/api',
-                    'private': 'https://wex.link/tapi',
+                    'public': 'https://wex.fit/api',
+                    'private': 'https://wex.fit/tapi',
                 },
-                'www': 'https://wex.link',
+                'www': 'https://wex.fit',
                 'doc': [
-                    'https://wex.link/api/3/docs',
-                    'https://wex.link/tapi/docs',
+                    'https://wex.fit/api/3/docs',
+                    'https://wex.fit/tapi/docs',
                 ],
-                'fees': 'https://wex.link/fees',
+                'fees': 'https://wex.fit/fees',
             },
             'api': {
                 'public': {


### PR DESCRIPTION
WEX has changed their domain again, old endpoint is down: https://twitter.com/WEXnz/status/1068328600334725125