### PR TITLE
Don't attempt to parse unparsable strings in base exchange parse functions

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1126,6 +1126,9 @@ module.exports = class Exchange {
     }
 
     parseTrades (trades, market = undefined, since = undefined, limit = undefined) {
+        if (typeof trades === 'string') {
+            throw new ExchangeError ('Invalid trades: ' + trades);
+        }
         let result = Object.values (trades || []).map (trade => this.parseTrade (trade, market))
         result = sortBy (result, 'timestamp')
         let symbol = (market !== undefined) ? market['symbol'] : undefined
@@ -1133,6 +1136,9 @@ module.exports = class Exchange {
     }
 
     parseTransactions (transactions, currency = undefined, since = undefined, limit = undefined) {
+        if (typeof transactions === 'string') {
+            throw new ExchangeError ('Invalid transactions: ' + trades);
+        }
         let result = Object.values (transactions || []).map (transaction => this.parseTransaction (transaction, currency))
         result = this.sortBy (result, 'timestamp');
         let code = (currency !== undefined) ? currency['code'] : undefined;
@@ -1140,6 +1146,9 @@ module.exports = class Exchange {
     }
 
     parseOrders (orders, market = undefined, since = undefined, limit = undefined) {
+        if (typeof orders === 'string') {
+            throw new ExchangeError ('Invalid orders: ' + trades);
+        }
         let result = Object.values (orders).map (order => this.parseOrder (order, market))
         result = sortBy (result, 'timestamp')
         let symbol = (market !== undefined) ? market['symbol'] : undefined
@@ -1155,6 +1164,9 @@ module.exports = class Exchange {
     }
 
     parseOHLCVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined) {
+        if (typeof ohlcvs === 'string') {
+            throw new ExchangeError ('Invalid ohlcvs: ' + trades);
+        }
         ohlcvs = Object.values (ohlcvs)
         let result = []
         for (let i = 0; i < ohlcvs.length; i++) {


### PR DESCRIPTION
If results from exchange requests are not parsable JSON, raw strings will be iterated over character-wise to yield trades/ohlcv/transactions/orders.
This throws an ExchangeError if that happens.