### PR TITLE
Parse CLI-example command-line arguments

### DIFF
--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -32,9 +32,9 @@ if (count ($argv) > 2) {
         $exchange = new $exchange ($config);
 
         $args = array_map (function ($arg) {
-			global $exchange;
+            global $exchange;
             if ($arg[0] === '{' || $arg[0] === '[')
-				return json_decode ($arg, true);
+                return json_decode ($arg, true);
             if ($arg === 'NULL' || $arg === 'null')
                 return null;
             if (preg_match ('/^[+-]?[0-9]+$/', $arg))

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -22,7 +22,7 @@ if (count ($argv) > 2) {
         $keys_file = file_exists ($keys_local) ? $keys_local : $keys_global;
 
         $config = json_decode (file_get_contents ($keys_file), true);
-		$settings = array_key_exists ($id, $config) ? $config[$id] : array ();
+	$settings = array_key_exists ($id, $config) ? $config[$id] : array ();
         $config = array_merge ($settings, array (
             'verbose' => $verbose, // set to true for debugging
         ));

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -11,16 +11,11 @@ if (count ($argv) > 2) {
     $id = $argv[1];
     $member = $argv[2];
     $args = array_slice ($argv, 3);
-    $verbose = count (array_filter ($args, function ($option) { return strstr ($option, '--verbose') !== false; })) > 0;
-    $args = array_filter ($args, function ($option) { return strstr ($option, '--verbose') === false; });
-    $args = array_map (function ($arg) {
-        return ($arg[0] === '{' || $arg[0] === '[') ? json_decode ($arg) :
-            (preg_match ('/[a-zA-Z]/', $arg) ? $arg : floatval ($arg));
-    }, $args);
-
     $exchange_found = in_array ($id, \ccxt\Exchange::$exchanges);
 
     if ($exchange_found) {
+        $verbose = count (array_filter ($args, function ($option) { return strstr ($option, '--verbose') !== false; })) > 0;
+        $args = array_filter ($args, function ($option) { return strstr ($option, '--verbose') === false; });
 
         $keys_global = './keys.json';
         $keys_local = './keys.local.json';
@@ -28,18 +23,29 @@ if (count ($argv) > 2) {
 
         $config = json_decode (file_get_contents ($keys_file), true);
 
-        echo print_r ($keys_file, true) . "\n";
-        // echo print_r ($config[$id]) . "\n";
-
-        $settings = array_key_exists ($id, $config) ? $config[$id] : array ();
-
-        $config = array_merge ($settings, array (
+        $config = array_merge ($config[$id], array (
             'verbose' => $verbose, // set to true for debugging
         ));
 
         // instantiate the exchange by id
         $exchange = '\\ccxt\\' . $id;
         $exchange = new $exchange ($config);
+
+        $args = array_map (function ($arg) {
+			global $exchange;
+            if ($arg[0] === '{' || $arg[0] === '[')
+				return json_decode ($arg, true);
+            if ($arg === 'NULL' || $arg === 'null')
+                return null;
+            if (preg_match ('/^[+-]?[0-9]+$/', $arg))
+                return intval ($arg);
+            if (preg_match ('/^[.eE0-9+-]+$/', $arg))
+                return floatval ($arg);
+            if (preg_match ('/^[0-9]{4}[-]?[0-9]{2}[-]?[0-9]{2}[T\s]?[0-9]{2}[:]?[0-9]{2}[:]?[0-9]{2}/', $arg))
+                return $exchange->parse8601 ($arg);
+            else
+                return $arg;
+        }, $args);
 
         $exchange->load_markets ();
 

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -22,7 +22,7 @@ if (count ($argv) > 2) {
         $keys_file = file_exists ($keys_local) ? $keys_local : $keys_global;
 
         $config = json_decode (file_get_contents ($keys_file), true);
-	$settings = array_key_exists ($id, $config) ? $config[$id] : array ();
+        $settings = array_key_exists ($id, $config) ? $config[$id] : array ();
         $config = array_merge ($settings, array (
             'verbose' => $verbose, // set to true for debugging
         ));

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -22,8 +22,8 @@ if (count ($argv) > 2) {
         $keys_file = file_exists ($keys_local) ? $keys_local : $keys_global;
 
         $config = json_decode (file_get_contents ($keys_file), true);
-
-        $config = array_merge ($config[$id], array (
+		$settings = array_key_exists ($id, $config) ? $config[$id] : array ();
+        $config = array_merge ($settings, array (
             'verbose' => $verbose, // set to true for debugging
         ));
 

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -109,6 +109,8 @@ for arg in argv.args:
         args.append(int(arg))
     elif re.match(r'^[.eE0-9+-]+$', arg):
         args.append(float(arg))
+    elif re.match(r'^[0-9]{4}[-]?[0-9]{2}[-]?[0-9]{2}[T\s]?[0-9]{2}[:]?[0-9]{2}[:]?[0-9]{2}', arg):
+        args.append(exchange.parse8601(arg))
     else:
         args.append(arg)
 


### PR DESCRIPTION
While testing the implementation of a new exchange, I found the CLI example very valuable. However I noticed the Python and PHP implementations were not as powerful as the JavaScript implementation.
Especially parsing parameters formatted as ISO8601-dates or JSON-objects (for the custom parameters).

So, I went in and made the parsing of integers, floats, dates and JSON-objects consistent in all 3 languages of the example.

Hope this will be helpful for other devs ;)

Marco