### PR TITLE
Don't throw errors on bittrex empty trade response. 

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -435,9 +435,12 @@ module.exports = class bittrex extends Exchange {
         let response = await this.publicGetMarkethistory (this.extend ({
             'market': market['id'],
         }, params));
+        if (!response.success) {
+            throw new ExchangeError (this.id + ' fetchTrades() returned error: ' + response.message);
+        }
         if ('result' in response) {
             if (response['result'] !== undefined)
-                return this.parseTrades (response['result'], market, since, limit);
+                return this.parseTrades (response['result'] || [], market, since, limit);
         }
         throw new ExchangeError (this.id + ' fetchTrades() returned undefined response');
     }


### PR DESCRIPTION
With the change in 55d3df6d464fbacd399b1584eaa53bb1fa3509aa, errors are thrown for empty responses in bittrex and bleutrade (since they return `null` instead of `[]` in case of empty results).
This also adds a check for success and propagates any error messages for unsuccessful responses.