### PR TITLE
Parse EXMO responses if needed

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -1059,4 +1059,9 @@ module.exports = class exmo extends Exchange {
             }
         }
     }
+
+    async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+        let response = await this.fetch2 (path, api, method, params, headers, body);
+        return this.parseIfJsonEncodedObject (response);
+    }
 };


### PR DESCRIPTION
I don't know exactly why this happens, but in one environment responses are sent as string (resulting in for example `loadMarkets` returning one nonsense market per character in the response string).
This ensures that responses are parsed properly.