### PR TITLE
Correctly parse bitstamp trade side in parseTrade

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -332,13 +332,13 @@ module.exports = class bitstamp extends Exchange {
     parseTrade (trade, market = undefined) {
         let timestamp = undefined;
         let symbol = undefined;
+        let side = undefined;
         if ('date' in trade) {
             timestamp = parseInt (trade['date']) * 1000;
         } else if ('datetime' in trade) {
             timestamp = this.parse8601 (trade['datetime']);
         }
-        // only if overrided externally
-        let side = this.safeString (trade, 'side');
+        let type = this.safeString (trade, 'type');
         let orderId = this.safeString (trade, 'order_id');
         let price = this.safeFloat (trade, 'price');
         let amount = this.safeFloat (trade, 'amount');
@@ -369,12 +369,12 @@ module.exports = class bitstamp extends Exchange {
             symbol = market['symbol'];
         }
         if (amount !== undefined) {
-            if (amount < 0) {
-                side = 'sell';
-            } else {
-                side = 'buy';
-            }
             amount = Math.abs (amount);
+        }
+        if (type === '1') {
+            side = 'sell';
+        } else if (type === '0') {
+            side = 'buy';
         }
         if (cost === undefined) {
             if (price !== undefined) {


### PR DESCRIPTION
I note that `fetchMyTrades` and `fetchTrades` both use this function but feed it with data from different endpoints.

Tangential but related question: What is the motivation behind having both `fetchMyTrades` and `fetchTransactions` - what is the intended difference between them? Am I guessing correct in that they get the same data but that `fetchMyTrades` is part of the unified API whereas `fetchTransactions` has exchange-specific format in the result?

Regardless, it seems prudent that `parseMytrades` and `parseTrades` should use different parsing functions rather than trying to make both formats handled by `parseTrade`.