### PR TITLE
Parse coinone trade side

### DIFF
--- a/js/coinone.js
+++ b/js/coinone.js
@@ -221,6 +221,13 @@ module.exports = class coinone extends Exchange {
     parseTrade (trade, market = undefined) {
         let timestamp = parseInt (trade['timestamp']) * 1000;
         let symbol = (market !== undefined) ? market['symbol'] : undefined;
+        let is_ask = this.safeString(trade, 'is_ask');
+        let side = undefined;
+        if (is_ask === '1') {
+            side = 'sell';
+        } else if (is_ask === '0') {
+            side = 'buy';
+        }
         return {
             'id': undefined,
             'timestamp': timestamp,
@@ -228,7 +235,7 @@ module.exports = class coinone extends Exchange {
             'order': undefined,
             'symbol': symbol,
             'type': undefined,
-            'side': undefined,
+            'side': side,
             'price': this.safeFloat (trade, 'price'),
             'amount': this.safeFloat (trade, 'qty'),
             'fee': undefined,

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -221,7 +221,7 @@ module.exports = class coinone extends Exchange {
     parseTrade (trade, market = undefined) {
         let timestamp = parseInt (trade['timestamp']) * 1000;
         let symbol = (market !== undefined) ? market['symbol'] : undefined;
-        let is_ask = this.safeString(trade, 'is_ask');
+        let is_ask = this.safeString (trade, 'is_ask');
         let side = undefined;
         if (is_ask === '1') {
             side = 'sell';


### PR DESCRIPTION
Coinone has now added trade side to their trades endpoint.
From [docs](https://doc.coinone.co.kr/#api-Public-RecentTransactions):
> 1 if order is sell.

Looking at some data, it looks like this is from the takers perspective, so `1` should be `sell`.
