### PR TITLE
Cryptopia: Using FilledOrders if OrderId does not exist

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -621,6 +621,13 @@ module.exports = class cryptopia extends Exchange {
                     status = 'closed';
                 }
             }
+            if (
+                !id &&
+                'FilledOrders' in response['Data'] &&
+                response['Data']['FilledOrders'].length > 0
+            ) {
+                id = response['Data']['FilledOrders'][0].toString ();
+            }
         }
         let order = {
             'id': id,


### PR DESCRIPTION
For some trades cryptopia does not return the order id but instead an array `FilledOrders`. This pull request will return the first of the ids in `FilledOrders` if `OrderId` was not returned.