### PR TITLE
Mercado Bitcoin new market ETH/BRL

### DIFF
--- a/js/mercado.js
+++ b/js/mercado.js
@@ -64,6 +64,7 @@ module.exports = class mercado extends Exchange {
                 'LTC/BRL': { 'id': 'BRLLTC', 'symbol': 'LTC/BRL', 'base': 'LTC', 'quote': 'BRL', 'suffix': 'Litecoin' },
                 'BCH/BRL': { 'id': 'BRLBCH', 'symbol': 'BCH/BRL', 'base': 'BCH', 'quote': 'BRL', 'suffix': 'BCash' },
                 'XRP/BRL': { 'id': 'BRLXRP', 'symbol': 'XRP/BRL', 'base': 'XRP', 'quote': 'BRL', 'suffix': 'Ripple' },
+                'ETH/BRL': { 'id': 'BRLETH', 'symbol': 'ETH/BRL', 'base': 'ETH', 'quote': 'BRL', 'suffix': 'Ethereum' },
             },
             'fees': {
                 'trading': {


### PR DESCRIPTION
Hi, @kroitor.

Mercado Bitcoin is about to launch a new market tomorrow, on December 12, ETH/BRL. Please, include it in the library.