### PR TITLE
Add bithumb checking market activation

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -93,13 +93,17 @@ module.exports = class bithumb extends Exchange {
                 let base = id;
                 let quote = 'KRW';
                 let symbol = id + '/' + quote;
+                let active = true;
+                if (market.length === 0) {
+                    active = false;
+                }
                 result.push ({
                     'id': id,
                     'symbol': symbol,
                     'base': base,
                     'quote': quote,
                     'info': market,
-                    'active': true,
+                    'active': active,
                     'precision': {
                         'amount': undefined,
                         'price': undefined,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3365053/49938478-592c2580-ff1d-11e8-9ef7-ec56974cb9ba.png)

Currently bithumb is printing untradable currency at Ticker API.
Therefore, I used `active` variable for check to tradable.
