### PR TITLE
Fix timezone offset direction in Exchange.parse8601()

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -835,7 +835,7 @@ class Exchange(object):
             ms = ms or '.000'
             msint = int(ms[1:])
             sign = sign or ''
-            sign = int(sign + '1')
+            sign = int(sign + '1') * -1
             hours = int(hours or 0) * sign
             minutes = int(minutes or 0) * sign
             offset = datetime.timedelta(hours=hours, minutes=minutes)


### PR DESCRIPTION
A problem:
```
>>> from ccxt import Exchange
>>> from dateutil.parser import parse
>>> time = '2018-12-14 01:00:34+07:00'
>>> int(Exchange().parse8601(time) // 1000) == int(parse(time).timestamp())
False
```

I'd rather rewrite `parse8601` to use `dateutil.parser.parse` and do not reinvent the wheel.  But here is a quick patch that fixes the original problem.