### PR TITLE
yobit fetchMyTrades fix

### DIFF
--- a/js/yobit.js
+++ b/js/yobit.js
@@ -216,6 +216,42 @@ module.exports = class yobit extends liqui {
             'info': response,
         };
     }
+    
+    async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        let market = undefined;
+        // some derived classes use camelcase notation for request fields
+        let request = {
+            // 'from': 123456789, // trade ID, from which the display starts numerical 0 (test result: liqui ignores this field)
+            // 'count': 1000, // the number of trades for display numerical, default = 1000
+            // 'from_id': trade ID, from which the display starts numerical 0
+            // 'end_id': trade ID on which the display ends numerical ∞
+            // 'order': 'ASC', // sorting, default = DESC (test result: liqui ignores this field, most recent trade always goes last)
+            // 'since': 1234567890, // UTC start time, default = 0 (test result: liqui ignores this field)
+            // 'end': 1234567890, // UTC end time, default = ∞ (test result: liqui ignores this field)
+            // 'pair': 'eth_btc', // default = all markets
+        };
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['pair'] = market['id'];
+        }
+        if (limit !== undefined) {
+            request['count'] = parseInt (limit);
+        }
+        if (since !== undefined) {
+            request['since'] = parseInt (since / 1000);
+        }
+        let method = this.options['fetchMyTradesMethod'];
+        let response = await this[method] (this.extend (request, params));
+        let trades = [];
+        if ('return' in response) {
+            trades = response['return'];
+            for (let id in trades) {
+                trades[id].trade_id = id
+            }    
+        }
+        return this.parseTrades (trades, market, since, limit);
+    }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
         this.checkAddress (address);


### PR DESCRIPTION
now it inherits fetchMyTrades from liqui, but liqui has "trade_id" in response and in yobit response "id" is  property name:

```
{
	"success":1,
	"return":{
		"24523":{
			"pair":"ltc_btc",
			"type":"sell",
			"amount":11.4,
			"rate":0.145,
			"order_id":100025362,
			"is_your_order":1,
			"timestamp":1418654530
		}
		...
	}
}
```

and we get "undefined" instead of trade ids