### PR TITLE
Fixed Huobipro IOC and Limit-maker orders

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -750,7 +750,7 @@ module.exports = class huobipro extends Exchange {
                 }
             }
         }
-        if (type === 'limit') {
+        if (type === 'limit' || type === 'ioc' || type === 'limit-maker') {
             request['price'] = this.priceToPrecision (symbol, price);
         }
         let method = this.options['createOrderMethod'];


### PR DESCRIPTION
CCXT was not able to process IOC or limit-maker orders for huobipro since these order types were not properly configured. On placing an IOC order or a limit-maker order, the exchange was returning invalid price error as the price was not being configured for these order types. 