### PR TITLE
Fix 'since' argument handling in fetchTrades() of LBank

### DIFF
--- a/js/lbank.js
+++ b/js/lbank.js
@@ -285,7 +285,7 @@ module.exports = class lbank extends Exchange {
             'size': 100,
         };
         if (since !== undefined)
-            request['time'] = parseInt (since / 1000);
+            request['time'] = parseInt (since);
         if (limit !== undefined)
             request['size'] = limit;
         let response = await this.publicGetTrades (this.extend (request, params));


### PR DESCRIPTION
The following code should yield a non-zero result:
```
>>> import ccxt
>>> trades = ccxt.lbank().fetchTrades('BTC/USDT')
>>> len(ccxt.lbank().fetchTrades('BTC/USDT', since=trades[0]['timestamp']))
0
```
The patch fixes the problem: the LBank API parameter 'time' in historical transactions query expected to be a timestamp in milliseconds.