### PR TITLE
Fixed bitstamp cost precision error during parseTrades

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -342,6 +342,7 @@ module.exports = class bitstamp extends Exchange {
         let orderId = this.safeString (trade, 'order_id');
         let price = this.safeFloat (trade, 'price');
         let amount = this.safeFloat (trade, 'amount');
+        let cost = this.safeFloat (trade, 'cost');
         let id = this.safeString2 (trade, 'tid', 'id');
         if (market === undefined) {
             let keys = Object.keys (trade);
@@ -363,6 +364,7 @@ module.exports = class bitstamp extends Exchange {
         if (market !== undefined) {
             price = this.safeFloat (trade, market['symbolId'], price);
             amount = this.safeFloat (trade, market['baseId'], amount);
+            cost =  this.safeFloat (trade, market['quoteId'], cost);
             feeCurrency = market['quote'];
             symbol = market['symbol'];
         }
@@ -373,12 +375,6 @@ module.exports = class bitstamp extends Exchange {
                 side = 'buy';
             }
             amount = Math.abs (amount);
-        }
-        let cost = undefined;
-        if (price !== undefined) {
-            if (amount !== undefined) {
-                cost = price * amount;
-            }
         }
         if (cost !== undefined) {
             cost = Math.abs (cost);


### PR DESCRIPTION
For certain currencies, Bitstamp limits the number of decimal places like for USD only 2 decimal places are allowed. Calculation of cost by multiplying price and amount can create unnecessary decimal places. Instead, it already provides what the exact cost is. I am directly taking the cost out of the trade message. 