### PR TITLE
 Fixed bitstamp cost precision error

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -364,7 +364,7 @@ module.exports = class bitstamp extends Exchange {
         if (market !== undefined) {
             price = this.safeFloat (trade, market['symbolId'], price);
             amount = this.safeFloat (trade, market['baseId'], amount);
-            cost =  this.safeFloat (trade, market['quoteId'], cost);
+            cost = this.safeFloat (trade, market['quoteId'], cost);
             feeCurrency = market['quote'];
             symbol = market['symbol'];
         }

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -342,6 +342,7 @@ module.exports = class bitstamp extends Exchange {
         let orderId = this.safeString (trade, 'order_id');
         let price = this.safeFloat (trade, 'price');
         let amount = this.safeFloat (trade, 'amount');
+        let cost = this.safeFloat (trade, 'cost');
         let id = this.safeString2 (trade, 'tid', 'id');
         if (market === undefined) {
             let keys = Object.keys (trade);
@@ -363,6 +364,7 @@ module.exports = class bitstamp extends Exchange {
         if (market !== undefined) {
             price = this.safeFloat (trade, market['symbolId'], price);
             amount = this.safeFloat (trade, market['baseId'], amount);
+            cost =  this.safeFloat (trade, market['quoteId'], cost);
             feeCurrency = market['quote'];
             symbol = market['symbol'];
         }
@@ -373,12 +375,6 @@ module.exports = class bitstamp extends Exchange {
                 side = 'buy';
             }
             amount = Math.abs (amount);
-        }
-        let cost = undefined;
-        if (price !== undefined) {
-            if (amount !== undefined) {
-                cost = price * amount;
-            }
         }
         if (cost !== undefined) {
             cost = Math.abs (cost);

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -376,6 +376,13 @@ module.exports = class bitstamp extends Exchange {
             }
             amount = Math.abs (amount);
         }
+        if (cost === undefined) {
+            if (price !== undefined) {
+                if (amount !== undefined) {
+                    cost = price * amount;
+                }
+            }
+        }
         if (cost !== undefined) {
             cost = Math.abs (cost);
         }


### PR DESCRIPTION
Bitstamp limits the number of decimal places for particular currencies. For eg, Bitstamp only allows 2 decimal places for USD and during trades, if the cost is calculated using price * amount, there might be necessary decimal places and incorrect values. Therefore I changed, the program to get the cost directly from the trade message received from bitstamp. 