### PR TITLE
In fetchTickers, check to make sure it's not a list. The exchange cur…

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -223,8 +223,10 @@ module.exports = class bithumb extends Exchange {
                 symbol = market['symbol'];
             }
             let ticker = tickers[id];
-            ticker['date'] = timestamp;
-            result[symbol] = this.parseTicker (ticker, market);
+            if (!Array.isArray (ticker)) {
+                ticker['date'] = timestamp;
+                result[symbol] = this.parseTicker (ticker, market);
+            }
         }
         return result;
     }


### PR DESCRIPTION
…rently return empty list for coins that are not yet implemented, which cause the ticker['date'] = timestamp; to fail, as 'date' is not an allowed index.