### PR TITLE
add String, Decimal, and Integer methods to base class

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -27,7 +27,10 @@ const {
     , timeout
     , TimedOut
     , buildOHLCVC
-    , decimalToPrecision } = functions
+    , decimalToPrecision
+    , asString
+    , asInteger
+    , asFloat } = functions
 
 const {
     ExchangeError
@@ -297,6 +300,11 @@ module.exports = class Exchange {
 
         // do not delete this line, it is needed for users to be able to define their own fetchImplementation
         this.fetchImplementation = defaultFetch
+
+        // types
+        this.String = asString
+        this.Integer = asInteger
+        this.Decimal = asFloat
 
         this.timeout       = 10000 // milliseconds
         this.verbose       = false

--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -21,6 +21,7 @@ const hasProps = o => (o !== undefined) &&
 
 const asFloat   = x => ((isNumber (x) || isString (x)) ? parseFloat (x)     : NaN)
     , asInteger = x => ((isNumber (x) || isString (x)) ? parseInt   (x, 10) : NaN)
+    , asString  = x => (isStringCoercible (x) ? String (x) : undefined)
 
 /*  .............................................   */
 
@@ -38,6 +39,7 @@ module.exports =
 
     , asFloat
     , asInteger
+    , asString
 
     , safeFloat:   (o, k, $default, n =   asFloat (prop (o, k))) => isNumber (n)          ? n          : $default
     , safeInteger: (o, k, $default, n = asInteger (prop (o, k))) => isNumber (n)          ? n          : $default

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -218,20 +218,28 @@ class Exchange {
         return explode ($delimiters[0], str_replace ($delimiters, $delimiters[0], $string));
     }
 
-    public static function decimal ($number) {
-        return '' + $number;
+    public static function Decimal ($x) {
+        return (float) $x;
+    }
+
+    public static function String ($x) {
+        return (string) $x;
+    }
+
+    public static function Integer ($x) {
+        return (int) $x;
     }
 
     public static function safe_float ($object, $key, $default_value = null) {
-        return (isset ($object[$key]) && is_numeric ($object[$key])) ? floatval ($object[$key]) : $default_value;
+        return (isset ($object[$key]) && is_numeric ($object[$key])) ? static::Decimal ($object[$key]) : $default_value;
     }
 
     public static function safe_string ($object, $key, $default_value = null) {
-        return (isset ($object[$key]) && is_scalar ($object[$key])) ? strval ($object[$key]) : $default_value;
+        return (isset ($object[$key]) && is_scalar ($object[$key])) ? static::String ($object[$key]) : $default_value;
     }
 
     public static function safe_integer ($object, $key, $default_value = null) {
-        return (isset ($object[$key]) && is_numeric ($object[$key])) ? intval ($object[$key]) : $default_value;
+        return (isset ($object[$key]) && is_numeric ($object[$key])) ? static::Integer ($object[$key]) : $default_value;
     }
 
     public static function safe_value ($object, $key, $default_value = null) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -237,6 +237,11 @@ class Exchange(object):
     last_json_response = None
     last_response_headers = None
 
+    # types
+    String = str
+    Integer = int
+    Decimal = float
+
     requiresWeb3 = False
     web3 = None
 
@@ -497,29 +502,26 @@ class Exchange(object):
         except ValueError:  # superclass of JsonDecodeError (python2)
             pass
 
-    @staticmethod
-    def safe_float(dictionary, key, default_value=None):
+    def safe_float(self, dictionary, key, default_value=None):
         value = default_value
         try:
             if isinstance(dictionary, list) and isinstance(key, int) and len(dictionary) > key:
-                value = float(dictionary[key])
+                value = self.Decimal(dictionary[key])
             else:
-                value = float(dictionary[key]) if (key is not None) and (key in dictionary) and (dictionary[key] is not None) else default_value
+                value = self.Decimal(dictionary[key]) if (key is not None) and (key in dictionary) and (dictionary[key] is not None) else default_value
         except ValueError as e:
             value = default_value
         return value
 
-    @staticmethod
-    def safe_string(dictionary, key, default_value=None):
-        return str(dictionary[key]) if key is not None and (key in dictionary) and dictionary[key] is not None else default_value
+    def safe_string(self, dictionary, key, default_value=None):
+        return self.String(dictionary[key]) if key is not None and (key in dictionary) and dictionary[key] is not None else default_value
 
-    @staticmethod
-    def safe_integer(dictionary, key, default_value=None):
+    def safe_integer(self, dictionary, key, default_value=None):
         if key is None or (key not in dictionary):
             return default_value
         value = dictionary[key]
         if isinstance(value, Number) or (isinstance(value, basestring) and value.isnumeric()):
-            return int(value)
+            return self.Integer(value)
         return default_value
 
     @staticmethod

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -502,26 +502,29 @@ class Exchange(object):
         except ValueError:  # superclass of JsonDecodeError (python2)
             pass
 
-    def safe_float(self, dictionary, key, default_value=None):
+    @staticmethod
+    def safe_float(dictionary, key, default_value=None):
         value = default_value
         try:
             if isinstance(dictionary, list) and isinstance(key, int) and len(dictionary) > key:
-                value = self.Decimal(dictionary[key])
+                value = Exchange.Decimal(dictionary[key])
             else:
-                value = self.Decimal(dictionary[key]) if (key is not None) and (key in dictionary) and (dictionary[key] is not None) else default_value
+                value = Exchange.Decimal(dictionary[key]) if (key is not None) and (key in dictionary) and (dictionary[key] is not None) else default_value
         except ValueError as e:
             value = default_value
         return value
 
-    def safe_string(self, dictionary, key, default_value=None):
-        return self.String(dictionary[key]) if key is not None and (key in dictionary) and dictionary[key] is not None else default_value
+    @staticmethod
+    def safe_string(dictionary, key, default_value=None):
+        return Exchange.String(dictionary[key]) if key is not None and (key in dictionary) and dictionary[key] is not None else default_value
 
-    def safe_integer(self, dictionary, key, default_value=None):
+    @staticmethod
+    def safe_integer(dictionary, key, default_value=None):
         if key is None or (key not in dictionary):
             return default_value
         value = dictionary[key]
         if isinstance(value, Number) or (isinstance(value, basestring) and value.isnumeric()):
-            return self.Integer(value)
+            return Exchange.Integer(value)
         return default_value
 
     @staticmethod


### PR DESCRIPTION
We can avoid using regex to convert between types, in a sense a unified typesystem without the need for typescript, and this can be extended to more languages easily. 

If we go this route it will help us greatly in the future when we want to convert to `decimal.Decimal`  and users can define their own types, (for example if a user did not want to switch to `decimal.Decimal` and use floats instead it would be as easy as `exchange.Decimal = float`)