### PR TITLE
Add support for 'limit' parameter in fetchTrades() of Coincheck

### DIFF
--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -166,14 +166,18 @@ module.exports = class coincheck extends Exchange {
         };
     }
 
-    async fetchTrades (symbol, since = undefined, limit = 10, params = {}) {
-        if (symbol !== 'BTC/JPY')
+    async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
+        if (symbol !== 'BTC/JPY') {
             throw new NotSupported (this.id + ' fetchTrades () supports BTC/JPY only');
-        let market = this.market (symbol);
-        let response = await this.publicGetTrades (this.extend ({
+        }
+        const market = this.market (symbol);
+        const request = {
             'pair': market['id'],
-            'limit': limit,
-        }, params));
+        };
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const response = await this.publicGetTrades (this.extend (, params));
         if ('success' in response)
             if (response['success'])
                 if (response['data'] !== undefined)

--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -177,7 +177,7 @@ module.exports = class coincheck extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.publicGetTrades (this.extend (, params));
+        const response = await this.publicGetTrades (this.extend (request, params));
         if ('success' in response)
             if (response['success'])
                 if (response['data'] !== undefined)

--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -166,12 +166,13 @@ module.exports = class coincheck extends Exchange {
         };
     }
 
-    async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
+    async fetchTrades (symbol, since = undefined, limit = 10, params = {}) {
         if (symbol !== 'BTC/JPY')
             throw new NotSupported (this.id + ' fetchTrades () supports BTC/JPY only');
         let market = this.market (symbol);
         let response = await this.publicGetTrades (this.extend ({
             'pair': market['id'],
+            'limit': limit,
         }, params));
         if ('success' in response)
             if (response['success'])


### PR DESCRIPTION
This adds support for 'limit' parameter in fetchTrades() method of Coincheck exchange.

```
>>> import ccxt
>>> len(ccxt.coincheck().fetch_trades('BTC/JPY', limit=100))
100
```