### PR TITLE
Add support for 'limit' in fetchTrades() of GetBTC & 1BTCXE

### DIFF
--- a/js/_1btcxe.js
+++ b/js/_1btcxe.js
@@ -182,9 +182,13 @@ module.exports = class _1btcxe extends Exchange {
 
     async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
         let market = this.market (symbol);
-        let response = await this.publicGetTransactions (this.extend ({
+        let request = {
             'currency': market['id'],
-        }, params));
+        };
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        let response = await this.publicGetTransactions (this.extend (request, params));
         let trades = this.toArray (this.omit (response['transactions'], 'request_currency'));
         return this.parseTrades (trades, market, since, limit);
     }


### PR DESCRIPTION
This adds support for 'limit' parameter in fetchTrades() method of GetBTC & 1BTCXE exchanges:
```
>>> import ccxt
>>> len(ccxt.getbtc().fetch_trades('BTC/RUB', limit=100))
100
```