### PR TITLE
parseIfJsonEncodedObject is now the standard - redundant function

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -620,10 +620,6 @@ module.exports = class Exchange {
         throw new error ([ this.id, method, url, code, reason, details ].join (' '))
     }
 
-    parseIfJsonEncodedObject (input) {
-        return (this.isJsonEncodedObject (input) ? JSON.parse (input) : input)
-    }
-
     isJsonEncodedObject (object) {
         return ((typeof object === 'string') &&
                 (object.length >= 2) &&

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -636,18 +636,6 @@ class Exchange {
         return json_encode ($data, $flags);
     }
 
-    public static function parse_if_json_encoded_object ($input) {
-        if ((gettype ($input) !== 'string') || (strlen ($input) < 2)) {
-            return $input;
-        }
-        if ($input[0] === '{') {
-            return json_decode ($input, $as_associative_array = true);
-        } else if ($input[1] === '[') {
-            return json_decode ($input);
-        }
-        return $input;
-    }
-
     public static function is_json_encoded_object ($input) {
         return (gettype ($input) === 'string') &&
                 (strlen ($input) >= 2) &&

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -490,8 +490,7 @@ class Exchange(object):
                 self.raise_error(ExchangeNotAvailable, method, url, None, message)
             self.raise_error(ExchangeError, method, url, ValueError('failed to decode json'), response)
 
-    @staticmethod
-    def parse_json(http_response):
+    def parse_json(self, http_response):
         try:
             if Exchange.is_json_encoded_object(http_response):
                 return json.loads(http_response)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -490,9 +490,11 @@ class Exchange(object):
                 self.raise_error(ExchangeNotAvailable, method, url, None, message)
             self.raise_error(ExchangeError, method, url, ValueError('failed to decode json'), response)
 
-    def parse_json(self, http_response):
+    @staticmethod
+    def parse_json(http_response):
         try:
-            return json.loads(http_response)
+            if Exchange.is_json_encoded_object(http_response):
+                return json.loads(http_response)
         except ValueError:  # superclass of JsonDecodeError (python2)
             pass
 
@@ -898,10 +900,6 @@ class Exchange(object):
     @staticmethod
     def json(data, params=None):
         return json.dumps(data, separators=(',', ':'))
-
-    @staticmethod
-    def parse_if_json_encoded_object(input):
-        return json.loads(input) if Exchange.is_json_encoded_object(input) else input
 
     @staticmethod
     def is_json_encoded_object(input):

--- a/transpile.js
+++ b/transpile.js
@@ -130,7 +130,6 @@ const commonRegexes = [
     [ /\.convertOHLCVToTradingView\s/g, '.convert_ohlcv_to_trading_view'],
     [ /\.signBodyWithSecret\s/g, '.sign_body_with_secret'],
     [ /\.isJsonEncodedObject\s/g, '.is_json_encoded_object'],
-    [ /\.parseIfJsonEncodedObject\s/g, '.parse_if_json_encoded_object'],
 ]
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
If you wrote this method for a reason, I am sorry. It just seemed out of place and was unused. 

Especially considering that we should check the `handleErrors` arguments instead of doing this; it is an antipattern. https://github.com/ccxt/ccxt/pull/4370#discussion_r243808071