### PR TITLE
Bitfinex: Support getting all symbols history

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -100,6 +100,7 @@ module.exports = class bitfinex2 extends bitfinex {
                         'auth/r/orders/{symbol}/new',
                         'auth/r/orders/{symbol}/hist',
                         'auth/r/order/{symbol}:{id}/trades',
+                        'auth/r/trades/hist',
                         'auth/r/trades/{symbol}/hist',
                         'auth/r/positions',
                         'auth/r/funding/offers/{symbol}',


### PR DESCRIPTION
https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist

The "symbol" path fragment can be omitted to get history for *all* symbols.