### PR TITLE
Exmo: set fiat funding fees

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -245,6 +245,13 @@ module.exports = class exmo extends Exchange {
                 }
             }
         }
+        // sets fiat fees to undefined
+        const fiatGroups = this.toArray (this.omit (groupsByGroup, 'crypto'));
+        for (let i = 0; i < fiatGroups.length; i++) {
+            const code = this.safeString (fiatGroups[i], 'title');
+            withdraw[code] = undefined;
+            deposit[code] = undefined;
+        }
         const result = {
             'info': response,
             'withdraw': withdraw,


### PR DESCRIPTION
This pull requests sets the funding fees for fiat currencies on exmo. Fees are set to `undefined` as there are multiple deposit and withdrawal methods per fiat currency, so that there would be no clear mapping possible.

Although there is no real value in having `undefined` fees, this solves https://github.com/ccxt/ccxt/issues/4421