### PR TITLE
Bitfinex has a movements/hist for all symbols

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -112,6 +112,7 @@ module.exports = class bitfinex2 extends bitfinex {
                         'auth/r/funding/trades/{symbol}/hist',
                         'auth/r/info/margin/{key}',
                         'auth/r/info/funding/{key}',
+                        'auth/r/movements/hist',
                         'auth/r/movements/{currency}/hist',
                         'auth/r/stats/perf:{timeframe}/hist',
                         'auth/r/alerts',


### PR DESCRIPTION
Only documented in the (JS code sample)[https://docs.bitfinex.com/v2/reference#movements], `movements/hist` can retrieve all currency movements (avoiding having to ask for each symbol) and takes the same start/end parameters as trades/hist (limit seems to work up to a max of 25).