### PR TITLE
create a folder for static dependencies

### DIFF
--- a/js/static_dependencies/README.md
+++ b/js/static_dependencies/README.md
@@ -1,0 +1,1 @@
+// TODO: add web3 and cryptoJS here

--- a/php/static_dependencies/README.md
+++ b/php/static_dependencies/README.md
@@ -1,0 +1,1 @@
+// TODO: add web3 here

--- a/python/static_dependencies/README.md
+++ b/python/static_dependencies/README.md
@@ -1,1 +1,1 @@
-// TODO: add web3 (and make it python2 compatible)
+// TODO: add web3

--- a/python/static_dependencies/README.md
+++ b/python/static_dependencies/README.md
@@ -1,0 +1,1 @@
+// TODO: add web3 (and make it python2 compatible)


### PR DESCRIPTION
also made me think about the php lack of organisation

AFAIK we can include from other `__DIR__`s so I'm not sure why it is set up how it is