### PR TITLE
Fix issue in createOrder on rightbtc

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -177,6 +177,7 @@ module.exports = class Exchange {
                 '521': ExchangeNotAvailable,
                 '522': ExchangeNotAvailable,
                 '525': ExchangeNotAvailable,
+                '526': ExchangeNotAvailable,
                 '400': ExchangeNotAvailable,
                 '403': ExchangeNotAvailable,
                 '405': ExchangeNotAvailable,

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -429,8 +429,8 @@ module.exports = class rightbtc extends Exchange {
             //   0.036*1e8 === 3599999.9999999995
             // which would get truncated to 3599999 after parseInt
             // which would then be rejected by rightBtc because it's too precise
-            'quantity': this.decimalToPrecision (amount * 1e8, ROUND, 0, DECIMAL_PLACES),
-            'limit': this.decimalToPrecision (price * 1e8, ROUND, 0, DECIMAL_PLACES),
+            'quantity': parseInt (this.decimalToPrecision (amount * 1e8, ROUND, 0, DECIMAL_PLACES)),
+            'limit': parseInt (this.decimalToPrecision (price * 1e8, ROUND, 0, DECIMAL_PLACES)),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),
         };

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -424,12 +424,12 @@ module.exports = class rightbtc extends Exchange {
         let market = this.market (symbol);
         let order = {
             'trading_pair': market['id'],
-            // We need to round here, because e.g.
+            // We need to add an epsilon here, since e.g.
             //   0.036*1e8 === 3599999.9999999995
             // which is 3599999 after parseInt
             // which gets rejected by rightBtc because it's too precise
-            'quantity': parseInt (Math.round (amount * 1e8)),
-            'limit': parseInt (Math.round (price * 1e8)),
+            'quantity': parseInt (amount * 1e8 + 1e-8),
+            'limit': parseInt (price * 1e8 + 1e-8),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),
         };

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Exchange = require ('./base/Exchange');
+const { ROUND, DECIMAL_PLACES } = require ('./base/functions/number');
 const { ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, InvalidOrder, OrderNotFound } = require ('./base/errors');
 
 module.exports = class rightbtc extends Exchange {
@@ -424,12 +425,12 @@ module.exports = class rightbtc extends Exchange {
         let market = this.market (symbol);
         let order = {
             'trading_pair': market['id'],
-            // We need to add an epsilon here, since e.g.
+            // We need to use decimalToPrecision here, since
             //   0.036*1e8 === 3599999.9999999995
-            // which is 3599999 after parseInt
-            // which gets rejected by rightBtc because it's too precise
-            'quantity': parseInt (amount * 1e8 + 1e-8),
-            'limit': parseInt (price * 1e8 + 1e-8),
+            // which would get truncated to 3599999 after parseInt
+            // which would then be rejected by rightBtc because it's too precise
+            'quantity': this.decimalToPrecision (amount * 1e8, ROUND, 0, DECIMAL_PLACES),
+            'limit': this.decimalToPrecision (price * 1e8, ROUND, 0, DECIMAL_PLACES),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),
         };

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Exchange = require ('./base/Exchange');
-const { ROUND, DECIMAL_PLACES } = require ('./base/functions/number');
+const { ROUND, TRUNCATE } = require ('./base/functions/number');
 const { ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, InvalidOrder, OrderNotFound } = require ('./base/errors');
 
 module.exports = class rightbtc extends Exchange {
@@ -429,8 +429,8 @@ module.exports = class rightbtc extends Exchange {
             //   0.036*1e8 === 3599999.9999999995
             // which would get truncated to 3599999 after parseInt
             // which would then be rejected by rightBtc because it's too precise
-            'quantity': parseInt (this.decimalToPrecision (amount * 1e8, ROUND, 0, DECIMAL_PLACES)),
-            'limit': parseInt (this.decimalToPrecision (price * 1e8, ROUND, 0, DECIMAL_PLACES)),
+            'quantity': parseInt (this.decimalToPrecision (amount * 1e8, TRUNCATE, 0, this.precisionMode)),
+            'limit': parseInt (this.decimalToPrecision (price * 1e8, ROUND, 0, this.precisionMode)),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),
         };

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -424,8 +424,11 @@ module.exports = class rightbtc extends Exchange {
         let market = this.market (symbol);
         let order = {
             'trading_pair': market['id'],
-            'quantity': parseInt (amount * 1e8),
-            'limit': parseInt (price * 1e8),
+            'quantity': parseInt (Math.round (amount * 1e8)), // We need to round here, because e.g.
+                                                              //   0.036*1e8 === 3599999.9999999995
+                                                              // which is 3599999 after parseInt
+                                                              // which gets rejected by rightBtc because it's too precise
+            'limit': parseInt (Math.round (price * 1e8)),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),
         };

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Exchange = require ('./base/Exchange');
-const { ROUND, TRUNCATE } = require ('./base/functions/number');
+const { ROUND } = require ('./base/functions/number');
 const { ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, InvalidOrder, OrderNotFound } = require ('./base/errors');
 
 module.exports = class rightbtc extends Exchange {
@@ -429,7 +429,7 @@ module.exports = class rightbtc extends Exchange {
             //   0.036*1e8 === 3599999.9999999995
             // which would get truncated to 3599999 after parseInt
             // which would then be rejected by rightBtc because it's too precise
-            'quantity': parseInt (this.decimalToPrecision (amount * 1e8, TRUNCATE, 0, this.precisionMode)),
+            'quantity': parseInt (this.decimalToPrecision (amount * 1e8, ROUND, 0, this.precisionMode)),
             'limit': parseInt (this.decimalToPrecision (price * 1e8, ROUND, 0, this.precisionMode)),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),

--- a/js/rightbtc.js
+++ b/js/rightbtc.js
@@ -424,10 +424,11 @@ module.exports = class rightbtc extends Exchange {
         let market = this.market (symbol);
         let order = {
             'trading_pair': market['id'],
-            'quantity': parseInt (Math.round (amount * 1e8)), // We need to round here, because e.g.
-                                                              //   0.036*1e8 === 3599999.9999999995
-                                                              // which is 3599999 after parseInt
-                                                              // which gets rejected by rightBtc because it's too precise
+            // We need to round here, because e.g.
+            //   0.036*1e8 === 3599999.9999999995
+            // which is 3599999 after parseInt
+            // which gets rejected by rightBtc because it's too precise
+            'quantity': parseInt (Math.round (amount * 1e8)),
             'limit': parseInt (Math.round (price * 1e8)),
             'type': type.toUpperCase (),
             'side': side.toUpperCase (),

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -769,6 +769,7 @@ class Exchange {
             '521' => 'ExchangeNotAvailable',
             '522' => 'ExchangeNotAvailable',
             '525' => 'ExchangeNotAvailable',
+            '526' => 'ExchangeNotAvailable',
             '400' => 'ExchangeNotAvailable',
             '403' => 'ExchangeNotAvailable',
             '405' => 'ExchangeNotAvailable',

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -153,6 +153,7 @@ class Exchange(object):
         '521': ExchangeNotAvailable,
         '522': ExchangeNotAvailable,
         '525': ExchangeNotAvailable,
+        '526': ExchangeNotAvailable,
         '400': ExchangeNotAvailable,
         '403': ExchangeNotAvailable,
         '405': ExchangeNotAvailable,


### PR DESCRIPTION
This PR fixes an issue with floating point rounding when placing an order on rightbtc.

The comment in the code gives more details.

Without this, we noticed that some of our orders on rightbtc were rejected, even though they would have satisfied all the required criteria.