### PR TITLE
Adds bitflyer's "List Balance History" endpoint

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -48,6 +48,7 @@ module.exports = class bitflyer extends Exchange {
                     'get': [
                         'getpermissions',
                         'getbalance',
+                        'getbalancehistory',
                         'getcollateral',
                         'getcollateralaccounts',
                         'getaddresses',


### PR DESCRIPTION
Bitflyer has a newer endpoint that appears to expose a more ledger-like view into their data, even indicating that they should expose fiat withdrawals here when they aren't available on any other endpoints.

https://lightning.bitflyer.com/docs?lang=en#list-balance-history