### PR TITLE
Incorrect time Bitz

### DIFF
--- a/js/bitz.js
+++ b/js/bitz.js
@@ -387,7 +387,7 @@ module.exports = class bitz extends Exchange {
         let parts = microtime.split (' ');
         let milliseconds = parseFloat (parts[0]);
         let seconds = parseInt (parts[1]);
-        let total = seconds + milliseconds;
+        let total = this.sum (seconds, milliseconds);
         return parseInt (total * 1000);
     }
 
@@ -426,7 +426,7 @@ module.exports = class bitz extends Exchange {
         //          source:   "api"                             }
         //
         const ticker = this.parseTicker (response['data'], market);
-        let timestamp = this.safeInteger (response, 'time') * 1000;
+        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
         return this.extend (ticker, {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -470,7 +470,7 @@ module.exports = class bitz extends Exchange {
         //          source:   "api"                                                }
         //
         let tickers = response['data'];
-        let timestamp = this.safeInteger (response, 'time') * 1000;
+        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
         let result = {};
         let ids = Object.keys (tickers);
         for (let i = 0; i < ids.length; i++) {
@@ -529,7 +529,7 @@ module.exports = class bitz extends Exchange {
         //          source:   "api"                                                     }
         //
         let orderbook = response['data'];
-        let timestamp = this.safeInteger (response, 'time') * 1000;
+        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
         return this.parseOrderBook (orderbook, timestamp);
     }
 
@@ -799,7 +799,7 @@ module.exports = class bitz extends Exchange {
         //         "source": "api",
         //     }
         //
-        let timestamp = this.safeInteger (response, 'time') * 1000;
+        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
         let order = this.extend ({
             'timestamp': timestamp,
         }, response['data']);

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -426,7 +426,7 @@ module.exports = class bitz extends Exchange {
         //          source:   "api"                             }
         //
         const ticker = this.parseTicker (response['data'], market);
-        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
+        let timestamp = this.safeInteger (response, 'time') * 1000;
         return this.extend (ticker, {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -470,7 +470,7 @@ module.exports = class bitz extends Exchange {
         //          source:   "api"                                                }
         //
         let tickers = response['data'];
-        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
+        let timestamp = this.safeInteger (response, 'time') * 1000;
         let result = {};
         let ids = Object.keys (tickers);
         for (let i = 0; i < ids.length; i++) {
@@ -529,7 +529,7 @@ module.exports = class bitz extends Exchange {
         //          source:   "api"                                                     }
         //
         let orderbook = response['data'];
-        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
+        let timestamp = this.safeInteger (response, 'time') * 1000;
         return this.parseOrderBook (orderbook, timestamp);
     }
 
@@ -799,7 +799,7 @@ module.exports = class bitz extends Exchange {
         //         "source": "api",
         //     }
         //
-        let timestamp = this.parseMicrotime (this.safeString (response, 'microtime'));
+        let timestamp = this.safeInteger (response, 'time') * 1000;
         let order = this.extend ({
             'timestamp': timestamp,
         }, response['data']);


### PR DESCRIPTION
Fix for incorrect timestamp and datetime fields on bitz. Using unix timestamp field instead of microtime.