### PR TITLE
 Map "insufficient permissions" Kraken API error to AuthenticationError instance.

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -209,6 +209,7 @@ module.exports = class kraken extends Exchange {
                 'EQuery:Unknown asset': ExchangeError,
                 'EGeneral:Internal error': ExchangeNotAvailable,
                 'EGeneral:Temporary lockout': DDoSProtection,
+                'EGeneral:Permission denied': AuthenticationError
             },
         });
     }

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeNotAvailable, ArgumentsRequired, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress } = require ('./base/errors');
+const { ExchangeNotAvailable, ArgumentsRequired, AuthenticationError, PermissionDenied, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress } = require ('./base/errors');
 const { TRUNCATE, DECIMAL_PLACES } = require ('./base/functions/number');
 
 //  ---------------------------------------------------------------------------
@@ -209,7 +209,7 @@ module.exports = class kraken extends Exchange {
                 'EQuery:Unknown asset': ExchangeError,
                 'EGeneral:Internal error': ExchangeNotAvailable,
                 'EGeneral:Temporary lockout': DDoSProtection,
-                'EGeneral:Permission denied': AuthenticationError,
+                'EGeneral:Permission denied': PermissionDenied,
             },
         });
     }

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -209,7 +209,7 @@ module.exports = class kraken extends Exchange {
                 'EQuery:Unknown asset': ExchangeError,
                 'EGeneral:Internal error': ExchangeNotAvailable,
                 'EGeneral:Temporary lockout': DDoSProtection,
-                'EGeneral:Permission denied': AuthenticationError
+                'EGeneral:Permission denied': AuthenticationError,
             },
         });
     }

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeNotAvailable, ArgumentsRequired, AuthenticationError, PermissionDenied, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress } = require ('./base/errors');
+const { ExchangeNotAvailable, ArgumentsRequired, PermissionDenied, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress } = require ('./base/errors');
 const { TRUNCATE, DECIMAL_PLACES } = require ('./base/functions/number');
 
 //  ---------------------------------------------------------------------------


### PR DESCRIPTION
This follows a similar pattern of mapping insufficient permissions to ccxt.AuthenticationError, as seen here: https://github.com/ccxt/ccxt/blob/master/js/bittrex.js#L150