### PR TITLE
Remove coinfloor API port

### DIFF
--- a/js/coinfloor.js
+++ b/js/coinfloor.js
@@ -20,7 +20,7 @@ module.exports = class coinfloor extends Exchange {
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/28246081-623fc164-6a1c-11e7-913f-bac0d5576c90.jpg',
-                'api': 'https://webapi.coinfloor.co.uk:8090/bist',
+                'api': 'https://webapi.coinfloor.co.uk/bist',
                 'www': 'https://www.coinfloor.co.uk',
                 'doc': [
                     'https://github.com/coinfloor/api',


### PR DESCRIPTION
Coinfloor made this in this commit:
https://github.com/coinfloor/API/commit/d99a4d743e75b4095112ff4a0291b3e8800949aa