### PR TITLE
Updated fetchOrder to provide unified response via parseOrder

### DIFF
--- a/js/itbit.js
+++ b/js/itbit.js
@@ -266,9 +266,9 @@ module.exports = class itbit extends Exchange {
         let walletIdInParams = ('walletId' in params);
         if (!walletIdInParams)
             throw new ExchangeError (this.id + ' fetchOrder requires a walletId parameter');
-        return await this.privateGetWalletsWalletIdOrdersId (this.extend ({
-            'id': id,
-        }, params));
+        let response = await this.privateGetWalletsWalletIdOrdersId (this.extend ({
+            'id': id,}, params));
+        return (this.parseOrder(response));
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {


### PR DESCRIPTION
I've tested this a few times and it appears to work. Other modules, eg, Bittrex & GDAX, already parse the output via parseOrder. 