### PR TITLE
Fix OkCoin / OkEx futures markets

### DIFF
--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -365,8 +365,6 @@ module.exports = class okcoinusd extends Exchange {
                         'max': undefined,
                     },
                 },
-                'maker': 0.0015,
-                'taker': 0.0020,
             }));
         }
         if (this.has['futures']) {
@@ -385,7 +383,6 @@ module.exports = class okcoinusd extends Exchange {
                 let quote = this.commonCurrencyCode (quoteId);
                 for (let j = 0; j < this.options['contractTypes'].length; j++) {
                     let contractType = this.options['contractTypes'][j];
-                    // let id = futuresMarkets[i]['symbol'] + '__' + contractType;
                     let id = baseId.toLowerCase () + '_' + quoteId.toLowerCase () + '__' + contractType;
                     let symbol = id.toUpperCase ();
                     result.push (this.extend (this.fees['trading'], {

--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -321,7 +321,7 @@ module.exports = class okcoinusd extends Exchange {
         // the following is the worst case
         let result = [];
         let spotResponse = await this.webGetSpotMarketsProducts ();
-        let spotMarkets = spotResponse.data;
+        let spotMarkets = spotResponse['data'];
         for (let i = 0; i < spotMarkets.length; i++) {
             let id = spotMarkets[i]['symbol'];
             let precision = {
@@ -330,7 +330,9 @@ module.exports = class okcoinusd extends Exchange {
             };
             let minAmount = spotMarkets[i]['minTradeSize'];
             let minPrice = Math.pow (10, -precision['price']);
-            let [baseId, quoteId] = id.split ('_');
+            let pairPairts = id.split ('_');
+            let baseId = pairPairts[0];
+            let quoteId = pairPairts[1];
             let baseIdUppercase = baseId.toUpperCase ();
             let quoteIdUppercase = quoteId.toUpperCase ();
             let base = this.commonCurrencyCode (baseIdUppercase);
@@ -369,7 +371,7 @@ module.exports = class okcoinusd extends Exchange {
         }
         if (this.has['futures']) {
             let futuresResponse = await this.webPostFuturesPcMarketFuturesCoin ();
-            let futuresMarkets = futuresResponse.data;
+            let futuresMarkets = futuresResponse['data'];
             for (let i = 0; i < futuresMarkets.length; i++) {
                 let precision = {
                     'amount': futuresMarkets[i]['maxSizeDigit'],
@@ -377,8 +379,8 @@ module.exports = class okcoinusd extends Exchange {
                 };
                 let minAmount = futuresMarkets[i]['minTradeSize'];
                 let minPrice = Math.pow (10, -precision['price']);
-                let baseId = futuresMarkets[i].symbolDesc;
-                let quoteId = futuresMarkets[i].quote.toUpperCase ();
+                let baseId = futuresMarkets[i]['symbolDesc'];
+                let quoteId = futuresMarkets[i]['quote'].toUpperCase ();
                 let base = this.commonCurrencyCode (baseId);
                 let quote = this.commonCurrencyCode (quoteId);
                 for (let j = 0; j < this.options['contractTypes'].length; j++) {

--- a/js/okex.js
+++ b/js/okex.js
@@ -28,6 +28,12 @@ module.exports = class okex extends okcoinusd {
                 'doc': 'https://github.com/okcoin-okex/API-docs-OKEx.com',
                 'fees': 'https://www.okex.com/pages/products/fees.html',
             },
+            'fees': {
+                'trading': {
+                    'taker': 0.0020,
+                    'maker': 0.0015,
+                },
+            },
             'commonCurrencies': {
                 'FAIR': 'FairGame',
                 'HOT': 'Hydro Protocol',
@@ -36,7 +42,9 @@ module.exports = class okex extends okcoinusd {
                 'YOYO': 'YOYOW',
             },
             'options': {
+                'contractTypes': ['this_week', 'next_week', 'quarter'],
                 'fetchTickersMethod': 'fetch_tickers_from_api',
+                'fiats': [ ],
             },
         });
     }
@@ -57,23 +65,6 @@ module.exports = class okex extends okcoinusd {
             'rate': rate,
             'cost': parseFloat (this.feeToPrecision (symbol, cost)),
         };
-    }
-
-    async fetchMarkets (params = {}) {
-        let markets = await super.fetchMarkets (params);
-        // TODO: they have a new fee schedule as of Feb 7
-        // the new fees are progressive and depend on 30-day traded volume
-        // the following is the worst case
-        for (let i = 0; i < markets.length; i++) {
-            if (markets[i]['spot']) {
-                markets[i]['maker'] = 0.0015;
-                markets[i]['taker'] = 0.0020;
-            } else {
-                markets[i]['maker'] = 0.0003;
-                markets[i]['taker'] = 0.0005;
-            }
-        }
-        return markets;
     }
 
     async fetchTickersFromApi (symbols = undefined, params = {}) {


### PR DESCRIPTION
Previous version had symbol collisions for different contract periods on same base/quote contracts, making OKEX behave differently from other futures markets in unified API (e.g. bitflyer, bitmex).
Instead of using hardcoded lists for futures (which were out of date),
this calls OkEX V2 API for futures pairs.
 This creates individual instruments per contract period with id as returned from API and symbol of form `BASE_QUOTE__PERIOD`.