### PR TITLE
Allow override of http agent for https requests

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -437,6 +437,8 @@ module.exports = class Exchange {
 
             if (url.indexOf ('http://') < 0) {
                 params['agent'] = this.agent || null;
+            } else if (url.indexOf ('https://') < 0) {
+                params['agent'] = this.httpsAgent || null;
             }
 
             let promise =


### PR DESCRIPTION
There is already an override for the agent for http requests, but since almost all requests will be https, this is not very useful. This adds an override for https requests.
I chose to keep the current `agent` instead of renaming it to `httpAgent` to not break forwards-compatability.
`node-fetch` seems to ignore `https.globalAgent`, which is why this is necessary.