### PR TITLE
Allow override of fetch agents regardless of protocol

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -435,12 +435,16 @@ module.exports = class Exchange {
 
             const params = { method, headers, body, timeout: this.timeout }
 
-            if (url.indexOf ('http://') === 0) {
-                params['agent'] = this.httpAgent || null;
-            } else if (url.indexOf ('https://') === 0) {
-                params['agent'] = this.httpsAgent || this.agent || null;
-            } else {
-                params['agent'] = this.agent || null;
+            if (this.httpAgent && url.indexOf ('http://') === 0) {
+                params['agent'] = this.httpAgent;
+            } else if (this.httpsAgent && url.indexOf ('https://') === 0) {
+                params['agent'] = this.httpsAgent;
+            } else if (this.agent) {
+                const [ protocol, ... rest ] = url.split ('//')
+                // this.agent.protocol contains a colon ('https:' or 'http:')
+                if (protocol === this.agent.protocol) {
+                    params['agent'] = this.agent;
+                }
             }
 
             let promise =

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -435,7 +435,11 @@ module.exports = class Exchange {
 
             const params = { method, headers, body, timeout: this.timeout }
 
-            if (url.indexOf ('http://') < 0) {
+            if (url.indexOf ('http://') === 0) {
+                params['agent'] = this.httpAgent || null;
+            } else if (url.indexOf ('https://') === 0) {
+                params['agent'] = this.httpsAgent || this.agent || null;
+            } else {
                 params['agent'] = this.agent || null;
             }
 


### PR DESCRIPTION
Allow override of fetch agents regardless of protocol.
Use `httpAgent` for HTTP requests and `httpsAgent` for HTTPS requests.
The previous `agent` is kept for non-HTTP requests for forwards-compatability.