### PR TITLE
Support for level-2 orderbook retrieval on Kucoin2

### DIFF
--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -445,8 +445,9 @@ module.exports = class kucoin2 extends Exchange {
         //
         const data = response['data'];
         const timestamp = this.safeInteger (data, 'sequence');
-        // when requesting level-2 order book, order id won't be there
-        return this.parseOrderBook (data, timestamp, 'bids', 'asks', request['level'] - 2, request['level'] - 1);
+        // level can be a string such as 2_20 or 2_100
+        const level = this.safeInteger (request, 'level');
+        return this.parseOrderBook (data, timestamp, 'bids', 'asks', level - 2, level - 1);
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -446,7 +446,9 @@ module.exports = class kucoin2 extends Exchange {
         const data = response['data'];
         const timestamp = this.safeInteger (data, 'sequence');
         // level can be a string such as 2_20 or 2_100
-        const level = this.safeInteger (request, 'level');
+        const levelString = this.safeString (request, 'level');
+        const levelParts = levelString.split ('_');
+        const level = parseInt (levelParts[0]);
         return this.parseOrderBook (data, timestamp, 'bids', 'asks', level - 2, level - 1);
     }
 

--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -437,7 +437,8 @@ module.exports = class kucoin2 extends Exchange {
         await this.loadMarkets ();
         const marketId = this.marketId (symbol);
         const request = { 'symbol': marketId, 'level': 3 };
-        const response = await this.publicGetMarketOrderbookLevelLevel (this.extend (request, params));
+        const requestParams = this.extend (request, params);
+        const response = await this.publicGetMarketOrderbookLevelLevel (requestParams);
         //
         // { sequence: '1547731421688',
         //   asks: [ [ '5c419328ef83c75456bd615c', '0.9', '0.09' ], ... ],
@@ -445,7 +446,12 @@ module.exports = class kucoin2 extends Exchange {
         //
         const responseData = response['data'];
         const timestamp = this.safeInteger (responseData, 'sequence');
-        return this.parseOrderBook (responseData, timestamp, 'bids', 'asks', 1, 2);
+        // when requesting level-2 order book, order id won't be there
+        if (3 == requestParams.level)
+        {
+            return this.parseOrderBook (responseData, timestamp, 'bids', 'asks', 1, 2);
+        }
+        return this.parseOrderBook (responseData, timestamp, 'bids', 'asks', 0, 1);
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -436,22 +436,17 @@ module.exports = class kucoin2 extends Exchange {
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const marketId = this.marketId (symbol);
-        const request = { 'symbol': marketId, 'level': 3 };
-        const requestParams = this.extend (request, params);
-        const response = await this.publicGetMarketOrderbookLevelLevel (requestParams);
+        const request = this.extend ({ 'symbol': marketId, 'level': 2 }, params);
+        const response = await this.publicGetMarketOrderbookLevelLevel (request);
         //
         // { sequence: '1547731421688',
         //   asks: [ [ '5c419328ef83c75456bd615c', '0.9', '0.09' ], ... ],
         //   bids: [ [ '5c419328ef83c75456bd615c', '0.9', '0.09' ], ... ], }
         //
-        const responseData = response['data'];
-        const timestamp = this.safeInteger (responseData, 'sequence');
+        const data = response['data'];
+        const timestamp = this.safeInteger (data, 'sequence');
         // when requesting level-2 order book, order id won't be there
-        if (3 == requestParams.level)
-        {
-            return this.parseOrderBook (responseData, timestamp, 'bids', 'asks', 1, 2);
-        }
-        return this.parseOrderBook (responseData, timestamp, 'bids', 'asks', 0, 1);
+        return this.parseOrderBook (data, timestamp, 'bids', 'asks', request['level'] - 2, request['level'] - 1);
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {


### PR DESCRIPTION
When retrieving `level-2` order book, result is as below
```json
{
    "sequence":"3262786978",
    "bids":[
        [
            "6500.12", // price
            "0.45054140" // size
        ],
        [
            "6500.11",
            "0.45054140"
        ]
    ],
    "asks":[
        [
            "6500.16",
            "0.57753524"
        ],
        [
            "6500.15",
            "0.57753524"
        ]
    ]
}
```
When retrieving `level-3` order book, result is as below

```json
{
    "sequence":"1545896707028",
    "bids":[
        [
            "5c2477e503aa671a745c4057", // orderId
            "6", // price
            "0.999" // size
        ],
        [
            "5c2477e103aa671a745c4054",
            "5",
            "0.999"
        ]
    ],
    "asks":[
        [
            "5c24736703aa671a745c401e",
            "200",
            "1"
        ],
        [
            "5c2475c903aa671a745c4033",
            "201",
            "1"
        ]
    ]
}
```
`ccxt` assumes entries will contain 3 fields (orderId, price & size) and requesting ` fetchOrderBook(pair, limit, {level:2})` will result in `NaN` entries for `size`