### PR TITLE
Ignoring generated files when manually committing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then npm config set git-tag-version=false && NPM_VERSION=$(npm version patch); fi
 - cp package.json LICENSE.txt keys.json python
 - npm run build
+- node git-ignore-generated-files --unignore
 - cd python
 - tox -e doc
 - cd ..

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -8,7 +8,7 @@
     Once a file has been added to the repository, it cannot be ignored, all further changes will
     be tracked by Git.
 
-    There is an another mechanism that supresses the tracking of the file locally:
+    There is an another mechanism that suppresses the tracking of the file locally:
 
         git update-index --assume-unchanged <file>
 
@@ -17,7 +17,7 @@
 
 */
 
-"use strict";
+"use strict"
 
 const { execSync } = require ('child_process')
 const log          = require ('ololog')

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -24,7 +24,7 @@ const log          = require ('ololog')
 
 const files = [
 
-    'build/ccxt.browser.js'
+    'build/ccxt.browser.js',
 
     'python/test/test_decimal_to_precision.py',
     'php/test/decimal_to_precision.php',
@@ -34,7 +34,15 @@ const files = [
 
     'python/test/test.py',
 
-    // NB: Add more transpiled files here
+    'doc/FAQ.rst',
+    'doc/README.rst',
+    'doc/exchanges-by-country.rst',
+    'doc/exchanges.rst',
+    'doc/install.rst',
+    'doc/manual.rst',
+    'python/README.rst',
+
+    // NB: Add more generated files here
 ]
 
 for (const id of require ('./exchanges.json').ids) {

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -36,6 +36,14 @@ for (const id of require ('./exchanges.json').ids) {
     files.push (`php/${id}.php`)
 }
 
-log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
-execSync (`git update-index --assume-unchanged ` + files.join (' '))
+if (process.argv.includes ('--unignore')) {
+
+    log.bright.green (`Re-enabling the git changes tracking for ${files.length} generated files...`)
+    execSync (`git update-index --no-assume-unchanged ` + files.join (' '))
+
+} else {
+    
+    log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
+    execSync (`git update-index --assume-unchanged ` + files.join (' '))
+}
 

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -26,6 +26,14 @@ const files = [
 
     'build/ccxt.browser.js'
 
+    'python/test/test_decimal_to_precision.py',
+    'php/test/decimal_to_precision.php',
+
+    'python/test/test_exchange_datetime_functions.py',
+    'php/test/test_exchange_datetime_functions.php',
+
+    'python/test/test.py',
+
     // NB: Add more transpiled files here
 ]
 

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -55,11 +55,11 @@ for (const id of require ('./exchanges.json').ids) {
 if (process.argv.includes ('--unignore')) {
 
     log.bright.green (`Re-enabling the git changes tracking for ${files.length} generated files...`)
-    execSync (`git update-index --no-assume-unchanged ` + files.join (' '))
+    execSync ('git update-index --no-assume-unchanged ' + files.join (' '))
 
 } else {
     
     log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
-    execSync (`git update-index --assume-unchanged ` + files.join (' '))
+    execSync ('git update-index --assume-unchanged ' + files.join (' '))
 }
 

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -52,16 +52,22 @@ for (const id of require ('./exchanges.json').ids) {
     files.push (`php/${id}.php`)
 }
 
-if (process.argv.includes ('--unignore')) {
+try {
 
-    log.bright.green (`Re-enabling the git changes tracking for ${files.length} generated files...`)
-        
-    files.forEach (file => execSync ('git update-index --no-assume-unchanged ' + file))
+    if (process.argv.includes ('--unignore')) {
 
-} else {
-    
-    log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
+        log.bright.green (`Re-enabling the git changes tracking for ${files.length} generated files...`)
+        execSync ('git update-index --no-assume-unchanged ' + files.join (' '))
+
+    } else {
         
-    files.forEach (file => execSync ('git update-index --assume-unchanged ' + file))
+        log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
+        execSync ('git update-index --assume-unchanged ' + files.join (' '))
+    }
+
+} catch (e) {
+
+    // There is a legit case when we're not in a git repo (happens on AppVeyor)
+    if (!e.message.toLowerCase ().includes ('not a git repository')) throw e
 }
 

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -1,0 +1,41 @@
+/*  Preambule:
+
+        1.  Our build scripts generate a lot of files (e.g. Python and PHP code for exchanges)
+        2.  We want them to be ignored from the manual commits.
+        3.  But at the same time, we want them to be persisting in the repo (committed by the CI tool)
+
+    The standard `.gitignore` does not allow to do that, because it is only for untracked files.
+    Once a file has been added to the repository, it cannot be ignored, all further changes will
+    be tracked by Git.
+
+    There is an another mechanism that supresses the tracking of the file locally:
+
+        git update-index --assume-unchanged <file>
+
+    But this thing is not a server-side setting, it is a local client-side thing, and has to be
+    executed on each client individually. Luckily, we can easily do it, hence that script.
+
+*/
+
+"use strict";
+
+const { execSync } = require ('child_process')
+const log          = require ('ololog')
+
+const files = [
+
+    'build/ccxt.browser.js'
+
+    // NB: Add more transpiled files here
+]
+
+for (const id of require ('./exchanges.json').ids) {
+
+    files.push (`python/ccxt/${id}.py`)
+    files.push (`python/ccxt/async_support/${id}.py`)
+    files.push (`php/${id}.php`)
+}
+
+log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
+execSync (`git update-index --assume-unchanged ` + files.join (' '))
+

--- a/git-ignore-generated-files.js
+++ b/git-ignore-generated-files.js
@@ -55,11 +55,13 @@ for (const id of require ('./exchanges.json').ids) {
 if (process.argv.includes ('--unignore')) {
 
     log.bright.green (`Re-enabling the git changes tracking for ${files.length} generated files...`)
-    execSync ('git update-index --no-assume-unchanged ' + files.join (' '))
+        
+    files.forEach (file => execSync ('git update-index --no-assume-unchanged ' + file))
 
 } else {
     
     log.bright.cyan (`Disabling the git changes tracking for ${files.length} generated files...`)
-    execSync ('git update-index --assume-unchanged ' + files.join (' '))
+        
+    files.forEach (file => execSync ('git update-index --assume-unchanged ' + file))
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "docker": "docker-compose run --rm ccxt",
     "build": "npm run build-without-docs && npm run pandoc-all && npm run update-badges",
-    "build-without-docs": "npm run export-exchanges && npm run vss && npm run check-js-syntax && npm run browserify && npm run transpile && npm run qa",
+    "build-without-docs": "npm run export-exchanges && npm run git-ignore-generated-files && npm run vss && npm run check-js-syntax && npm run browserify && npm run transpile && npm run qa",
     "test": "npm run build && node run-tests",
     "fast-test": "node run-tests --js",
     "test-base": "npm run test-js-base && npm run test-python-base && npm run test-php-base",
@@ -23,6 +23,7 @@
     "test-python-base": "python python/test/test_decimal_to_precision.py",
     "test-php-base": "php -f php/test/decimal_to_precision.php",
     "export-exchanges": "node export-exchanges",
+    "git-ignore-generated-files": "node git-ignore-generated-files",
     "update-badges": "node update-badges",
     "convert-md-2-rst": "bash ./convert-md-2-rst",
     "transpile": "node transpile",


### PR DESCRIPTION
Preambule:

1.  Our build scripts generate a lot of files (e.g. Python and PHP code for exchanges)
2.  We want them to be _ignored_ from the manual commits.
3.  But at the same time, we want them to be persisting in the repo (a CI tool commits them)

The standard `.gitignore` does not allow to do that, because it is only for untracked files. Once a file has been added to the repository, it cannot be ignored (unless you delete it, which is not what we want to do) and all its further changes will be tracked by Git.

There is an another mechanism that suppresses the tracking of the file locally:

```
git update-index --assume-unchanged <file>
```

But this thing is not a server-side setting, it is a local client-side thing, and has to be executed on each client individually, for each file we need to ignore. Luckily, we can easily do it in our `npm run build` scripts.