### PR TITLE
Fix private url of okcoinusd module.

### DIFF
--- a/js/okcoinusd.js
+++ b/js/okcoinusd.js
@@ -120,7 +120,7 @@ module.exports = class okcoinusd extends Exchange {
                 'api': {
                     'web': 'https://www.okcoin.com/v2',
                     'public': 'https://www.okcoin.com/api',
-                    'private': 'https://www.okcoin.com/api',
+                    'private': 'https://www.okcoin.com',
                 },
                 'www': 'https://www.okcoin.com',
                 'doc': [


### PR DESCRIPTION
```javascript
ccxt = require ('ccxt')
Vendor = ccxt['okcoinusd']
exchangeInstance = new Vendor({
    apiKey: 'your_key',
    secret: 'your_secret'
})
exchangeInstance.fetchBalance().then(console.log).catch(console.log)
```

The code snippet above won't be executed successfully. But it works well if we change the private url to `https://www.okcoin.com`.