### PR TITLE
fix: Poloniex markets inconsistency

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -574,7 +574,7 @@ module.exports = class poloniex extends Exchange {
                             result.push (trades[j]);
                         }
                     } else {
-                        let [ baseId, quoteId ] = id.split ('_');
+                        let [ quoteId, baseId ] = id.split ('_');
                         let base = this.commonCurrencyCode (baseId);
                         let quote = this.commonCurrencyCode (quoteId);
                         let symbol = base + '/' + quote;


### PR DESCRIPTION
Poloniex define markets' IDs this way:  QUOTE_BASE

This is just a small fix to ensure consistency with all others markets

Thanks !