### PR TITLE
[KuCoin2] fetchOrder will throw error when parsing order because markets not loaded

### DIFF
--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -611,6 +611,7 @@ module.exports = class kucoin2 extends Exchange {
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {
+        await this.loadMarkets ();
         const request = {
             'orderId': id,
         };


### PR DESCRIPTION
fetchOrder will throw error when parsing order because markets not loaded (see error below).

```node:21117) UnhandledPromiseRejectionWarning: TypeError: Cannot use 'in' operator to search for 'BTC-USD' in undefined
    at kucoin2.parseOrder (/ccxt/js/kucoin2.js:540:26)
    at /kucoin/test.js:39:19
    at Generator.next (<anonymous>)
    at step (/kucoin/test.js:24:191)
    at /kucoin/test.js:24:437
    at new Promise (<anonymous>)
    at /kucoin/test.js:24:99
    at main (/kucoin/test.js:14:17)
    at Object.<anonymous> (/kucoin/test.js:43:1)
    at Module._compile (module.js:649:30)
    at loader (/usr/local/lib/node_modules/babel-cli/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/usr/local/lib/node_modules/babel-cli/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
    at Function.Module.runMain (module.js:690:10)
    at Object.<anonymous> (/usr/local/lib/node_modules/babel-cli/lib/_babel-node.js:154:22)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)```