### PR TITLE
Kucoin cancel order exception

### DIFF
--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -144,6 +144,7 @@ module.exports = class kucoin2 extends Exchange {
                 '411100': AccountSuspended,
                 '500000': ExchangeError,
                 'order_not_exist': OrderNotFound,  // {"code":"order_not_exist","msg":"order_not_exist"} ¯\_(ツ)_/¯
+                'order_not_exist_or_not_allow_to_cancel': InvalidOrder,
             },
             'fees': {
                 'trading': {


### PR DESCRIPTION
Canceling invalid or already canceled orders results in this exception.