### PR TITLE
kucoin2 cancel order exception fix

### DIFF
--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -1079,9 +1079,9 @@ module.exports = class kucoin2 extends Exchange {
         // good
         //     { code: '200000', data: { ... }}
         //
-        let errorCode = this.safeString (response, 'code');
-        let message = this.safeString (response, 'msg', '');
-        let ExceptionClass = this.safeValue2 (this.exceptions, message, errorCode);
+        const errorCode = this.safeString (response, 'code');
+        const message = this.safeString (response, 'msg');
+        const ExceptionClass = this.safeValue2 (this.exceptions, message, errorCode);
         if (ExceptionClass !== undefined) {
             throw new ExceptionClass (this.id + ' ' + message);
         }

--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -144,6 +144,7 @@ module.exports = class kucoin2 extends Exchange {
                 '411100': AccountSuspended,
                 '500000': ExchangeError,
                 'order_not_exist': OrderNotFound,  // {"code":"order_not_exist","msg":"order_not_exist"} ¯\_(ツ)_/¯
+                'order_not_exist_or_not_allow_to_cancel': InvalidOrder,
             },
             'fees': {
                 'trading': {
@@ -1079,13 +1080,10 @@ module.exports = class kucoin2 extends Exchange {
         //     { code: '200000', data: { ... }}
         //
         let errorCode = this.safeString (response, 'code');
-        if (errorCode in this.exceptions) {
-            const message = this.safeString (response, 'msg', '');
-            if (message === 'order_not_exist_or_not_allow_to_cancel') {
-                throw new InvalidOrder (this.id + ' ' + message);
-            }
-            let Exception = this.exceptions[errorCode];
-            throw new Exception (this.id + ' ' + message);
+        let message = this.safeString (response, 'msg', '');
+        let ExceptionClass = this.safeValue2 (this.exceptions, message, errorCode);
+        if (ExceptionClass !== undefined) {
+            throw new ExceptionClass (this.id + ' ' + message);
         }
     }
 };

--- a/js/kucoin2.js
+++ b/js/kucoin2.js
@@ -144,7 +144,6 @@ module.exports = class kucoin2 extends Exchange {
                 '411100': AccountSuspended,
                 '500000': ExchangeError,
                 'order_not_exist': OrderNotFound,  // {"code":"order_not_exist","msg":"order_not_exist"} ¯\_(ツ)_/¯
-                'order_not_exist_or_not_allow_to_cancel': InvalidOrder,
             },
             'fees': {
                 'trading': {
@@ -1081,8 +1080,11 @@ module.exports = class kucoin2 extends Exchange {
         //
         let errorCode = this.safeString (response, 'code');
         if (errorCode in this.exceptions) {
+            const message = this.safeString (response, 'msg', '');
+            if (message === 'order_not_exist_or_not_allow_to_cancel') {
+                throw new InvalidOrder (this.id + ' ' + message);
+            }
             let Exception = this.exceptions[errorCode];
-            let message = this.safeString (response, 'msg', '');
             throw new Exception (this.id + ' ' + message);
         }
     }


### PR DESCRIPTION
The exception was a message, not a code.
```
{"code":"400100","msg":"order_not_exist_or_not_allow_to_cancel"} 
```