### PR TITLE
Poloniex precision fix

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -241,7 +241,7 @@ module.exports = class poloniex extends Exchange {
             let quote = this.commonCurrencyCode (quoteId);
             let symbol = base + '/' + quote;
             let minCost = this.safeFloat (this.options['limits']['cost']['min'], quote, 0.0);
-            let precision = this.extend (precision);
+            let precision = this.extend (this.precision);
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -242,7 +242,7 @@ module.exports = class poloniex extends Exchange {
             let symbol = base + '/' + quote;
             let minCost = this.safeFloat (this.options['limits']['cost']['min'], quote, 0.0);
             let precision = {
-                'amount': 6,
+                'amount': 8,
                 'price': 8,
             };
             result.push (this.extend (this.fees['trading'], {

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -240,8 +240,6 @@ module.exports = class poloniex extends Exchange {
             const base = this.commonCurrencyCode (baseId);
             const quote = this.commonCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
-            const limits = this.extend (this.limits);
-            const precision = this.extend (this.precision);
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -250,8 +248,6 @@ module.exports = class poloniex extends Exchange {
                 'base': base,
                 'quote': quote,
                 'active': market['isFrozen'] !== '1',
-                'precision': precision,
-                'limits': limits,
                 'info': market,
             }));
         }

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -112,7 +112,7 @@ module.exports = class poloniex extends Exchange {
             },
             'limits': {
                 'amount': {
-                    'min': 0.00000001,
+                    'min': 0.000001,
                     'max': 1000000000,
                 },
                 'price': {
@@ -230,18 +230,18 @@ module.exports = class poloniex extends Exchange {
     }
 
     async fetchMarkets (params = {}) {
-        let markets = await this.publicGetReturnTicker ();
-        let keys = Object.keys (markets);
-        let result = [];
+        const markets = await this.publicGetReturnTicker ();
+        const keys = Object.keys (markets);
+        const result = [];
         for (let p = 0; p < keys.length; p++) {
-            let id = keys[p];
-            let market = markets[id];
-            let [ quoteId, baseId ] = id.split ('_');
-            let base = this.commonCurrencyCode (baseId);
-            let quote = this.commonCurrencyCode (quoteId);
-            let symbol = base + '/' + quote;
-            let minCost = this.safeFloat (this.options['limits']['cost']['min'], quote, 0.0);
-            let precision = this.extend (this.precision);
+            const id = keys[p];
+            const market = markets[id];
+            const [ quoteId, baseId ] = id.split ('_');
+            const base = this.commonCurrencyCode (baseId);
+            const quote = this.commonCurrencyCode (quoteId);
+            const symbol = base + '/' + quote;
+            const limits = this.extend (this.limits);
+            const precision = this.extend (this.precision);
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -251,20 +251,7 @@ module.exports = class poloniex extends Exchange {
                 'quote': quote,
                 'active': market['isFrozen'] !== '1',
                 'precision': precision,
-                'limits': {
-                    'amount': {
-                        'min': Math.pow (10, -precision['amount']),
-                        'max': undefined,
-                    },
-                    'price': {
-                        'min': Math.pow (10, -precision['price']),
-                        'max': undefined,
-                    },
-                    'cost': {
-                        'min': minCost,
-                        'max': undefined,
-                    },
-                },
+                'limits': limits,
                 'info': market,
             }));
         }

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -241,10 +241,7 @@ module.exports = class poloniex extends Exchange {
             let quote = this.commonCurrencyCode (quoteId);
             let symbol = base + '/' + quote;
             let minCost = this.safeFloat (this.options['limits']['cost']['min'], quote, 0.0);
-            let precision = {
-                'amount': 8,
-                'price': 8,
-            };
+            let precision = this.extend (precision);
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,


### PR DESCRIPTION
The `amount` precision of Poloniex is actually `8`. The minimum amount is not really known per market. It is more sensible to use the correct amount precision.

With the precision of `6`, trades leave dust currencies with an amount of 2 decimals, while the entire amount could have been traded.

References:
https://github.com/ccxt/ccxt/issues/3706
https://github.com/ccxt/ccxt/commit/f8ab469b78dd36eacd57c07fe9c53e9290a30d6e
https://github.com/ccxt/ccxt/issues/3986
https://github.com/ccxt/ccxt/issues/4006