### PR TITLE
Add Transfer To/From bank on Hitbtc2

### DIFF
--- a/js/hitbtc2.js
+++ b/js/hitbtc2.js
@@ -1369,6 +1369,36 @@ module.exports = class hitbtc2 extends hitbtc {
         };
     }
 
+    async transferToExchange (code, amount, params = {}) {
+        await this.loadMarkets ();
+        let currency = this.currency (code);
+        let request = {
+            'currency': currency['id'],
+            'amount': parseFloat (amount),
+            'type': 'bankToExchange',
+        };
+        let response = await this.privatePostAccountTransfer (this.extend (request, params));
+        return {
+            'info': response,
+            'id': response['id'],
+        };
+    }
+
+    async transferToBank (code, amount, params = {}) {
+        await this.loadMarkets ();
+        let currency = this.currency (code);
+        let request = {
+            'currency': currency['id'],
+            'amount': parseFloat (amount),
+            'type': 'exchangeToBank',
+        };
+        let response = await this.privatePostAccountTransfer (this.extend (request, params));
+        return {
+            'info': response,
+            'id': response['id'],
+        };
+    }
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = '/api/' + this.version + '/';
         let query = this.omit (params, this.extractParams (path));


### PR DESCRIPTION
Not sure what the CCXT standard is on this, but on HitBTC its separated "bank" for withdrawal and deposits, and an "exchange bank" for funds to use on trading..