### PR TITLE
Load Markets before fetch deposits/withdrawals.  Check object is empt…

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -923,7 +923,7 @@ module.exports = class Exchange {
 
     currencyId (commonCode) {
 
-        if (this.currencies === undefined) {
+        if (this.isEmpty (this.currencies)) {
             throw new ExchangeError (this.id + ' currencies not loaded')
         }
 
@@ -943,7 +943,7 @@ module.exports = class Exchange {
 
     currency (code) {
 
-        if (this.currencies === undefined)
+        if (this.isEmpty (this.currencies))
             throw new ExchangeError (this.id + ' currencies not loaded')
 
         if ((typeof code === 'string') && (code in this.currencies))

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -923,7 +923,7 @@ module.exports = class Exchange {
 
     currencyId (commonCode) {
 
-        if (this.isEmpty (this.currencies)) {
+        if (this.currencies === undefined) {
             throw new ExchangeError (this.id + ' currencies not loaded')
         }
 
@@ -943,7 +943,7 @@ module.exports = class Exchange {
 
     currency (code) {
 
-        if (this.isEmpty (this.currencies))
+        if (this.currencies === undefined)
             throw new ExchangeError (this.id + ' currencies not loaded')
 
         if ((typeof code === 'string') && (code in this.currencies))

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -1186,6 +1186,7 @@ module.exports = class kraken extends Exchange {
     }
 
     async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
         // https://www.kraken.com/en-us/help/api#deposit-status
         if (code === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchDeposits requires a currency code argument');
@@ -1212,6 +1213,7 @@ module.exports = class kraken extends Exchange {
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
         // https://www.kraken.com/en-us/help/api#withdraw-status
         if (code === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchWithdrawals requires a currency code argument');


### PR DESCRIPTION
- `currencies` is instantiated as an empty object (https://github.com/ccxt/ccxt/blob/master/js/base/Exchange.js#L153). Checking if it is undefined will have no effect.
- Also need to load markets before `fetchDeposits` or `fetchWithdrawals` otherwise those call will fail (if markets aren't loaded prior).

