### PR TITLE
Map HOT to HOTNOW

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -165,6 +165,9 @@ module.exports = class kucoin extends Exchange {
                     'deposit': {},
                 },
             },
+            'commonCurrencies': {
+                'HOT': 'HOTNOW',
+            },
             'options': {
                 'version': 'v1',
                 'symbolSeparator': '-',


### PR DESCRIPTION
HOT in Kucoin is HotNow, not HOT(HOLO) like it is in Binance.  

https://www.kucoin.com/news/782-20