### PR TITLE
Adds Bequant exchange

### DIFF
--- a/js/bequant.js
+++ b/js/bequant.js
@@ -12,7 +12,7 @@ module.exports = class bequant extends hitbtc2 {
             'name': 'Bequant',
             'countries': [ 'HK' ],
             'urls': {
-                'logo': 'https://i.imgur.com/WK3S28s.jpg',
+                'logo': 'https://user-images.githubusercontent.com/1294454/55248342-a75dfe00-525a-11e9-8aa2-05e9dca943c6.jpg',
                 'api': 'https://api.bequant.io',
                 'www': 'https://bequant.io',
                 'doc': [

--- a/js/bequant.js
+++ b/js/bequant.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+
+const hitbtc2 = require ('./hitbtc2');
+// ---------------------------------------------------------------------------
+
+module.exports = class bequant extends hitbtc2 {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'bequant',
+            'name': 'Bequant',
+            'countries': [ 'HK' ],
+            'urls': {
+                'logo': 'https://i.imgur.com/WK3S28s.jpg',
+                'api': 'https://api.bequant.io',
+                'www': 'https://bequant.io',
+                'doc': [
+                    'https://api.bequant.io/',
+                ],
+                'fees': [
+                    'https://bequant.io/fees-and-limits',
+                ],
+            },
+        });
+    }
+};


### PR DESCRIPTION
Bequant and HitBTC are essentially the same exchange.
Therefore, the only thing required is to subclass the hitbtc2 module.
Pretty straight forward! This is tested and working. Related issue: https://github.com/ccxt/ccxt/issues/4239.