### PR TITLE
CoinTiger fetchMyTrades() v2

### DIFF
--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -413,14 +413,14 @@ module.exports = class cointiger extends huobipro {
             since = this.milliseconds () - week; // week ago
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let from = this.ymd (since);
-        let to = this.ymd (since + week); // one week
+        let start = this.ymd (since);
+        let end = this.ymd (since + week); // one week
         if (limit === undefined)
             limit = 1000;
         let response = await this.v2GetOrderMatchResults (this.extend ({
             'symbol': market['id'],
-            'start-date': from,
-            'end-date': to,
+            'start-date': start,
+            'end-date': end,
             'size': limit,
         }, params));
         return this.parseTrades (response['data'], market, since, limit);

--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -424,7 +424,7 @@ module.exports = class cointiger extends huobipro {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const start = this.ymd (since);
-        const end = this.ymd (since + week); // one week
+        const end = this.ymd (this.sum (since, week)); // one week
         if (limit === undefined) {
             limit = 1000;
         }

--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -405,14 +405,6 @@ module.exports = class cointiger extends huobipro {
         return this.parseTrades (response['data']['list'], market, since, limit);
     }
 
-    convertTimestamp (timestamp) {
-        timestamp = new Date (timestamp);
-        let date = (('0' + (timestamp.getDate ())).slice (-2));
-        let month = (('0' + (timestamp.getMonth () + 1)).slice (-2));
-        let year = timestamp.getFullYear ();
-        return year + '-' + month + '-' + date;
-    }
-
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         let week = 604800000; // milliseconds
         if (symbol === undefined)
@@ -421,8 +413,8 @@ module.exports = class cointiger extends huobipro {
             since = this.milliseconds () - week; // week ago
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let from = this.convertTimestamp (since);
-        let to = this.convertTimestamp (since + week); // one week
+        let from = this.ymd (since);
+        let to = this.ymd (since + week); // one week
         if (limit === undefined)
             limit = 1000;
         let response = await this.v2GetOrderMatchResults (this.extend ({

--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -314,13 +314,13 @@ module.exports = class cointiger extends huobipro {
         //         "id": 138
         //     }
         //
-        let id = this.safeString (trade, 'id');
-        let orderId = this.safeString (trade, 'orderId');
-        let orderType = this.safeString (trade, 'type');
+        const id = this.safeString (trade, 'id');
+        const orderId = this.safeString (trade, 'orderId');
+        const orderType = this.safeString (trade, 'type');
         let type = undefined;
         let side = undefined;
         if (orderType !== undefined) {
-            let parts = orderType.split ('-');
+            const parts = orderType.split ('-');
             side = parts[0];
             type = parts[1];
         }
@@ -338,7 +338,7 @@ module.exports = class cointiger extends huobipro {
             amount = this.safeFloat2 (trade, 'amount', 'volume');
         }
         let fee = undefined;
-        let feeCost = this.safeFloat (trade, 'fee');
+        const feeCost = this.safeFloat (trade, 'fee');
         if (feeCost !== undefined) {
             let feeCurrency = undefined;
             if (market !== undefined) {
@@ -353,15 +353,19 @@ module.exports = class cointiger extends huobipro {
                 'currency': feeCurrency,
             };
         }
-        if (amount !== undefined)
-            if (price !== undefined)
-                if (cost === undefined)
+        if (amount !== undefined) {
+            if (price !== undefined) {
+                if (cost === undefined) {
                     cost = amount * price;
+                }
+            }
+        }
         let timestamp = this.safeInteger2 (trade, 'created_at', 'ts');
         timestamp = this.safeInteger2 (trade, 'created', 'mtime', timestamp);
         let symbol = undefined;
-        if (market !== undefined)
+        if (market !== undefined) {
             symbol = market['symbol'];
+        }
         return {
             'info': trade,
             'id': id,
@@ -380,49 +384,57 @@ module.exports = class cointiger extends huobipro {
 
     async fetchTrades (symbol, since = undefined, limit = 1000, params = {}) {
         await this.loadMarkets ();
-        let market = this.market (symbol);
-        let request = {
+        const market = this.market (symbol);
+        const request = {
             'symbol': market['id'],
         };
-        if (limit !== undefined)
+        if (limit !== undefined) {
             request['size'] = limit;
-        let response = await this.publicGetHistoryTrade (this.extend (request, params));
+        }
+        const response = await this.publicGetHistoryTrade (this.extend (request, params));
         return this.parseTrades (response['data']['trade_data'], market, since, limit);
     }
 
     async fetchMyTradesV1 (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        if (symbol === undefined)
+        if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchMyTrades requires a symbol argument');
+        }
         await this.loadMarkets ();
-        let market = this.market (symbol);
-        if (limit === undefined)
+        const market = this.market (symbol);
+        if (limit === undefined) {
             limit = 100;
-        let response = await this.privateGetOrderTrade (this.extend ({
+        }
+        const request = {
             'symbol': market['id'],
             'offset': 1,
             'limit': limit,
-        }, params));
+        };
+        const response = await this.privateGetOrderTrade (this.extend (request, params));
         return this.parseTrades (response['data']['list'], market, since, limit);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        let week = 604800000; // milliseconds
-        if (symbol === undefined)
+        const week = 604800000; // milliseconds
+        if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchMyTrades requires a symbol argument');
-        if (since === undefined)
+        }
+        if (since === undefined) {
             since = this.milliseconds () - week; // week ago
+        }
         await this.loadMarkets ();
-        let market = this.market (symbol);
-        let start = this.ymd (since);
-        let end = this.ymd (since + week); // one week
-        if (limit === undefined)
+        const market = this.market (symbol);
+        const start = this.ymd (since);
+        const end = this.ymd (since + week); // one week
+        if (limit === undefined) {
             limit = 1000;
-        let response = await this.v2GetOrderMatchResults (this.extend ({
+        }
+        const request = {
             'symbol': market['id'],
             'start-date': start,
             'end-date': end,
             'size': limit,
-        }, params));
+        };
+        const response = await this.v2GetOrderMatchResults (this.extend (request, params));
         return this.parseTrades (response['data'], market, since, limit);
     }
 

--- a/js/cointiger.js
+++ b/js/cointiger.js
@@ -406,23 +406,23 @@ module.exports = class cointiger extends huobipro {
     }
 
     convertTimestamp (timestamp) {
-        timestamp = new Date(timestamp);
-        let date = (('0' + (timestamp.getDate())).slice(-2));
-        let month = (('0' + (timestamp.getMonth() + 1)).slice(-2));
-        let year = timestamp.getFullYear();
+        timestamp = new Date (timestamp);
+        let date = (('0' + (timestamp.getDate ())).slice (-2));
+        let month = (('0' + (timestamp.getMonth () + 1)).slice (-2));
+        let year = timestamp.getFullYear ();
         return year + '-' + month + '-' + date;
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        let week = 604800000; //milliseconds
+        let week = 604800000; // milliseconds
         if (symbol === undefined)
             throw new ArgumentsRequired (this.id + ' fetchMyTrades requires a symbol argument');
         if (since === undefined)
-            since = this.milliseconds () - week; //week ago
+            since = this.milliseconds () - week; // week ago
         await this.loadMarkets ();
         let market = this.market (symbol);
-        let from = this.convertTimestamp(since);
-        let to = this.convertTimestamp(since + week); //one week
+        let from = this.convertTimestamp (since);
+        let to = this.convertTimestamp (since + week); // one week
         if (limit === undefined)
             limit = 1000;
         let response = await this.v2GetOrderMatchResults (this.extend ({


### PR DESCRIPTION
https://github.com/cointiger/api-docs-en/wiki/Get-The-Transaction-Record-(V2)
It's written 'start-date' and 'end-date' are not necessary but it doesn't work without them. Also 'size' over 50 allowed.
API V2 return 'type', 'side' and 'fee' properly.

```
{ info:
   { volume: '4753.00000000',
     symbol: 'xbaseeth',
     orderId: 425180,
     price: '0.00004149',
     fee: '0.00015776',
     id: 199495,
     source: 'api',
     mtime: 1554115469000,
     type: 'sell-limit',
     status: 2 },
  id: '199495',
  order: '425180',
  timestamp: 1554115469000,
  datetime: '2019-04-01T10:44:29.000Z',
  symbol: 'XBASE/ETH',
  type: 'limit',
  side: 'sell',
  price: 0.00004149,
  amount: 4753,
  cost: 0.19720196999999998,
  fee: { cost: 0.00015776, currency: 'ETH' } }
```