### PR TITLE
Remove accessible check in coinbase fetchMarkets

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -173,11 +173,7 @@ module.exports = class gdax extends Exchange {
             if ((base === 'ETH') || (base === 'LTC')) {
                 taker = 0.003;
             }
-            let accessible = true;
-            if ('accessible' in market) {
-                accessible = this.safeValue (market, 'accessible');
-            }
-            const active = (market['status'] === 'online') && accessible;
+            const active = market['status'] === 'online';
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,


### PR DESCRIPTION
This field is randomly set to `false` for fiat markets on Coinbase Pro, regardless of market status. It is not mentioned in any documentation from what I can tell and should therefore not be relied upon.