### PR TITLE
ZB add fetchClosedOrders()

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -22,6 +22,7 @@ module.exports = class zb extends Exchange {
                 'fetchOrder': true,
                 'fetchOrders': true,
                 'fetchOpenOrders': true,
+                'fetchClosedOrders': true,
                 'fetchOHLCV': true,
                 'fetchTickers': true,
                 'withdraw': true,
@@ -456,6 +457,11 @@ module.exports = class zb extends Exchange {
             throw e;
         }
         return this.parseOrders (response, market, since, limit);
+    }
+
+    async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        let orders = await this.fetchOrders (symbol, since, limit, params);
+        return this.filterBy (orders, 'status', 'closed');
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = 10, params = {}) {


### PR DESCRIPTION
Works with filled and partially filled
```
{ info:
   { total_amount: 378.55,
     id: '20190408122089243',
     price: 0.00006029,
     trade_date: 1554687626086,
     status: 2,
     trade_money: 0.0042203,
     trade_amount: 70,
     type: 0,
     currency: 'zb_btc' },
  id: '20190408122089243',
  timestamp: 1554687626086,
  datetime: '2019-04-08T01:40:26.086Z',
  lastTradeTimestamp: undefined,
  symbol: 'ZB/BTC',
  type: 'limit',
  side: 'sell',
  price: 0.00006029,
  average: 0.000060289999999999994,
  cost: 0.0042203,
  amount: 378.55,
  filled: 70,
  remaining: 308.55,
  status: 'closed',
  fee: undefined }
{ info:
   { total_amount: 308.55,
     id: '20190408122103456',
     price: 0.00005985,
     trade_date: 1554690276205,
     status: 2,
     trade_money: 0.0184667175,
     trade_amount: 308.55,
     type: 0,
     currency: 'zb_btc' },
  id: '20190408122103456',
  timestamp: 1554690276205,
  datetime: '2019-04-08T02:24:36.205Z',
  lastTradeTimestamp: undefined,
  symbol: 'ZB/BTC',
  type: 'limit',
  side: 'sell',
  price: 0.00005985,
  average: 0.00005985,
  cost: 0.0184667175,
  amount: 308.55,
  filled: 308.55,
  remaining: 0,
  status: 'closed',
  fee: undefined }

```