### PR TITLE
Enable users to access the raw response object

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -344,6 +344,7 @@ module.exports = class Exchange {
         this.enableLastJsonResponse = true
         this.enableLastHttpResponse = true
         this.enableLastResponseHeaders = true
+        this.enableLastRawResponse = true
         this.last_http_response    = undefined
         this.last_json_response    = undefined
         this.last_response_headers = undefined
@@ -695,6 +696,10 @@ module.exports = class Exchange {
 
             if (this.enableLastJsonResponse) {
                 this.last_json_response = json         // FIXME: for those classes that haven't switched to handleErrors yet
+            }
+
+            if (this.enableLastRawResponse) {
+                this.last_raw_response = response
             }
 
             if (this.verbose)

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -878,6 +878,7 @@ class Exchange {
         $this->enableLastJsonResponse = true;
         $this->enableLastHttpResponse = true;
         $this->enableLastResponseHeaders = true;
+        $this->enableLastRawResponse = true;
         $this->last_http_response = null;
         $this->last_json_response = null;
         $this->last_response_headers = null;
@@ -1192,6 +1193,10 @@ class Exchange {
 
         if ($this->enableLastResponseHeaders) {
             $this->last_response_headers = $response_headers;
+        }
+
+        if ($this->enableLastRawResponse) {
+            $this->last_raw_response = $result;
         }
 
         $json_response = null;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -251,6 +251,7 @@ class Exchange(object):
     enableLastHttpResponse = True
     enableLastJsonResponse = True
     enableLastResponseHeaders = True
+    enableLastRawResponse = True
     last_http_response = None
     last_json_response = None
     last_response_headers = None
@@ -487,6 +488,8 @@ class Exchange(object):
                 self.last_json_response = json_response
             if self.enableLastResponseHeaders:
                 self.last_response_headers = headers
+            if self.enableLastRawResponse:
+                self.last_raw_response = response
             if self.verbose:
                 print("\nResponse:", method, url, response.status_code, headers, http_response)
             self.logger.debug("%s %s, Response: %s %s %s", method, url, response.status_code, headers, http_response)


### PR DESCRIPTION
This is useful for cases in which a non text or JSON response is provided.

One example is Kraken's report export is an `application/zip`, so the assumption of `response.text` or `response.json` blocks access to that.