### PR TITLE
Added jsDelivr CDN (along with unpkg) + fixed version number in CDN urls + refactored vss.js script

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ All-in-one browser bundle (dependencies included), served from a CDN of your cho
 * jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js
 * unpkg: https://unpkg.com/ccxt@1.18.456/dist/ccxt.browser.js
 
-If you want to use the most recent version by default, remove the version number from the CDN URL. Please keep in mind that we are not responsible for the correct operation of those CDN servers.
+You can obtain a live-updated version of the bundle by removing the version number from the URL (the `@a.b.c` thing) — however, we do not recommend to do that, as it may break your app eventually. Also, please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>

--- a/README.md
+++ b/README.md
@@ -224,10 +224,12 @@ console.log (ccxt.exchanges) // print all available exchanges
 
 ### JavaScript (for use with the `<script>` tag):
 
-All-in-one browser bundle (dependencies included), served from a CDN of your choice. Please keep in mind that we are not responsible for the correct operation of those CDN servers:
+All-in-one browser bundle (dependencies included), served from a CDN of your choice:
 
 * jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js
 * unpkg: https://unpkg.com/ccxt@1.18.456/dist/ccxt.browser.js
+
+Please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>
@@ -238,8 +240,6 @@ Creates a global `ccxt` object:
 ```JavaScript
 console.log (ccxt.exchanges) // print all available exchanges
 ```
-
-You can also use 
 
 ### Python
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ All-in-one browser bundle (dependencies included), served from a CDN of your cho
 * jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js
 * unpkg: https://unpkg.com/ccxt@1.18.456/dist/ccxt.browser.js
 
-Please keep in mind that we are not responsible for the correct operation of those CDN servers.
+If you want to use the most recent version by default, remove the version number from the CDN URL. Please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>

--- a/README.md
+++ b/README.md
@@ -224,10 +224,13 @@ console.log (ccxt.exchanges) // print all available exchanges
 
 ### JavaScript (for use with the `<script>` tag):
 
-[All-in-one browser bundle](https://unpkg.com/ccxt) (dependencies included), served from [unpkg CDN](https://unpkg.com/), which is a fast, global content delivery network for everything on NPM.
+All-in-one browser bundle (dependencies included), served from a CDN of your choice. Please keep in mind that we are not responsible for the correct operation of those CDN servers:
+
+* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js
+* unpkg: https://unpkg.com/ccxt@1.18.456/dist/ccxt.browser.js
 
 ```HTML
-<script type="text/javascript" src="https://unpkg.com/ccxt"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>
 ```
 
 Creates a global `ccxt` object:
@@ -235,6 +238,8 @@ Creates a global `ccxt` object:
 ```JavaScript
 console.log (ccxt.exchanges) // print all available exchanges
 ```
+
+You can also use 
 
 ### Python
 

--- a/build/vss.js
+++ b/build/vss.js
@@ -28,24 +28,24 @@ let [ major, minor, patch ] = version.split ('.')
 version = [ major, minor, patch ].join ('.')
 log.bright ('New version: '.cyan, version)
 
-function vss (filename, regex, replacement) {
+function vss (filename, template) {
     log.bright.cyan ('Single-sourcing version', version, './package.json → ' + filename.yellow)
-    let oldContent = fs.readFileSync (filename, 'utf8')
-    let parts = oldContent.split (regex)
-    let newContent = parts[0] + replacement + version + "'" + parts[1]
-    fs.truncateSync (filename)
-    fs.writeFileSync (filename, newContent)
+    const content = fs.readFileSync (filename, 'utf8')
+    const regexp  = new RegExp (template.replace (/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') // escape string for use in regexp
+                                        .replace ('\\{version\\}', '\\d+\\.\\d+\\.\\d+'), 'g')
+    fs.truncateSync  (filename)
+    fs.writeFileSync (filename, content.replace (regexp, template.replace ('{version}', version)))
 }
 
 //-----------------------------------------------------------------------------
 
-vss ('./php/Exchange.php',                           /\$version \= \'[^\']+\'/, "$version = '")
-vss ('./php/Exchange.php',                           /VERSION \= \'[^\']+\'/, "VERSION = '")
-vss ('./ccxt.js',                                    /const version \= \'[^\']+\'/, "const version = '")
-vss ('./python/ccxt/__init__.py',                    /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
-vss ('./python/ccxt/async_support/__init__.py',      /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
-vss ('./python/ccxt/base/exchange.py',               /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
-vss ('./python/ccxt/async_support/base/exchange.py', /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
+vss ('./php/Exchange.php',                           "$version = '{version}")
+vss ('./php/Exchange.php',                           "VERSION = '{version}'")
+vss ('./ccxt.js',                                    "const version = '{version}'")
+vss ('./python/ccxt/__init__.py',                    "__version__ = '{version}'")
+vss ('./python/ccxt/async_support/__init__.py',      "__version__ = '{version}'")
+vss ('./python/ccxt/base/exchange.py',               "__version__ = '{version}'")
+vss ('./python/ccxt/async_support/base/exchange.py', "__version__ = '{version}'")
 
 //-----------------------------------------------------------------------------
 

--- a/build/vss.js
+++ b/build/vss.js
@@ -47,6 +47,9 @@ vss ('./python/ccxt/async_support/__init__.py',      "__version__ = '{version}'"
 vss ('./python/ccxt/base/exchange.py',               "__version__ = '{version}'")
 vss ('./python/ccxt/async_support/base/exchange.py', "__version__ = '{version}'")
 
+vss ('./README.md',       "ccxt@{version}")
+vss ('./wiki/Install.md', "ccxt@{version}")
+
 //-----------------------------------------------------------------------------
 
 execSync ('cp ./package.json ./LICENSE.txt ./keys.json ./python/')

--- a/build/vss.js
+++ b/build/vss.js
@@ -39,7 +39,7 @@ function vss (filename, template) {
 
 //-----------------------------------------------------------------------------
 
-vss ('./php/Exchange.php',                           "$version = '{version}")
+vss ('./php/Exchange.php',                           "$version = '{version}'")
 vss ('./php/Exchange.php',                           "VERSION = '{version}'")
 vss ('./ccxt.js',                                    "const version = '{version}'")
 vss ('./python/ccxt/__init__.py',                    "__version__ = '{version}'")

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -56,10 +56,15 @@ If that does not help, please, follow here: https://github.com/nodejs/node-gyp#o
 
 ### JavaScript (for use with the `<script>` tag):
 
-[All-in-one browser bundle](https://unpkg.com/ccxt) (dependencies included), served from [unpkg CDN](https://unpkg.com/), which is a fast, global content delivery network for everything on NPM.
+All-in-one browser bundle (dependencies included), served from a CDN of your choice:
+
+* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js
+* unpkg: https://unpkg.com/ccxt@1.18.456/dist/ccxt.browser.js
+
+Please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
-<script type="text/javascript" src="https://unpkg.com/ccxt"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>
 ```
 
 Creates a global `ccxt` object:

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -61,7 +61,7 @@ All-in-one browser bundle (dependencies included), served from a CDN of your cho
 * jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js
 * unpkg: https://unpkg.com/ccxt@1.18.456/dist/ccxt.browser.js
 
-Please keep in mind that we are not responsible for the correct operation of those CDN servers.
+You can obtain a live-updated version of the bundle by removing the version number from the URL (the `@a.b.c` thing) — however, we do not recommend to do that, as it may break your app eventually. Also, please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>


### PR DESCRIPTION
CDN urls in our README.md now include the (current) version number:

```javascript
<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.18.456/dist/ccxt.browser.js"></script>
```

vss.js had to be refactored, to allow more sane templating:

```javascript
vss ('./php/Exchange.php',                           "$version = '{version}'")
vss ('./php/Exchange.php',                           "VERSION = '{version}'")
vss ('./ccxt.js',                                    "const version = '{version}'")
vss ('./python/ccxt/__init__.py',                    "__version__ = '{version}'")
vss ('./python/ccxt/async_support/__init__.py',      "__version__ = '{version}'")
vss ('./python/ccxt/base/exchange.py',               "__version__ = '{version}'")
vss ('./python/ccxt/async_support/base/exchange.py', "__version__ = '{version}'")

vss ('./README.md',       "ccxt@{version}")
vss ('./wiki/Install.md', "ccxt@{version}")
```

Instead of that verbosity (that didn't allow handling of something like `ccxt@1.18.456` because of a hard-coded comma in that function):

```javascript
vss ('./php/Exchange.php',                           /\$version \= \'[^\']+\'/, "$version = '")
vss ('./php/Exchange.php',                           /VERSION \= \'[^\']+\'/, "VERSION = '")
vss ('./ccxt.js',                                    /const version \= \'[^\']+\'/, "const version = '")
vss ('./python/ccxt/__init__.py',                    /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
vss ('./python/ccxt/async_support/__init__.py',      /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
vss ('./python/ccxt/base/exchange.py',               /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
vss ('./python/ccxt/async_support/base/exchange.py', /\_\_version\_\_ \= \'[^\']+\'/, "__version__ = '")
```