### PR TITLE
Add number to string method for python and php

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -925,6 +925,7 @@ from ccxt.base.decimal_to_precision import DECIMAL_PLACES        # noqa F401\n\
 from ccxt.base.decimal_to_precision import SIGNIFICANT_DIGITS    # noqa F401\n\
 from ccxt.base.decimal_to_precision import PAD_WITH_ZERO         # noqa F401\n\
 from ccxt.base.decimal_to_precision import NO_PADDING            # noqa F401\n\
+from ccxt.base.decimal_to_precision import number_to_string      # noqa F401\n\
 \n\
 # ----------------------------------------------------------------------------\n\
 \n\
@@ -946,6 +947,9 @@ from ccxt.base.decimal_to_precision import NO_PADDING            # noqa F401\n\
 \n\
 function decimal_to_precision ($x, $roundingMode = ROUND, $numPrecisionDigits = null, $countingMode = DECIMAL_PLACES, $paddingMode = NO_PADDING) {\n\
     return Exchange::decimal_to_precision ($x, $roundingMode, $numPrecisionDigits, $countingMode, $paddingMode);\n\
+}\n\
+function number_to_string ($x) {\n\
+    return Exchange::number_to_string ($x);\n\
 }\n\
 "
 

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -4,13 +4,19 @@ const { numberToString, decimalToPrecision, ROUND, TRUNCATE, DECIMAL_PLACES, PAD
 const assert = require ('assert');
 
 // ----------------------------------------------------------------------------
-// numberToString works, not supported in Python and PHP yet
+// numberToString
 
-// assert (numberToString (-7.9e-7) === '-0.0000007899999999999999');
-// assert (numberToString ( 7.9e-7) ===  '0.0000007899999999999999');
-// assert (numberToString (-12.345) === '-12.345');
-// assert (numberToString ( 12.345) === '12.345');
-// assert (numberToString (0) === '0');
+assert (numberToString (-7.8e-7) === '-0.00000078');
+assert (numberToString (7.8e-7) === '0.00000078');
+assert (numberToString (-17.805e-7) === '-0.0000017805');
+assert (numberToString (17.805e-7) === '0.0000017805');
+assert (numberToString (-7.0005e27) === '-7000500000000000000000000000');
+assert (numberToString (7.0005e27) === '7000500000000000000000000000');
+assert (numberToString (-7.9e27) === '-7900000000000000000000000000');
+assert (numberToString (7.9e27) === '7900000000000000000000000000');
+assert (numberToString (-12.345) === '-12.345');
+assert (numberToString (12.345) === '12.345');
+assert (numberToString (0) === '0');
 
 // ----------------------------------------------------------------------------
 // testDecimalToPrecisionTruncationToNDigitsAfterDot

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2314,26 +2314,26 @@ class Exchange {
 
     public static function number_to_string ($x) {
         # avoids scientific notation for too large and too small numbers
-        $s = (string)$x;
-        if (strpos($x, 'E') === false) {
+        $s = (string) $x;
+        if (strpos ($x, 'E') === false) {
             return $s;
         }
-        $splitted = explode('E', $s);
+        $splitted = explode ('E', $s);
         $number = $splitted[0];
-        $exp = (int)$splitted[1];
+        $exp = (int) $splitted[1];
         $len_after_dot = 0;
-        if (strpos($number, '.') !== false) {
-            $splitted = explode('.', $number);
-            $len_after_dot = strlen($splitted[1]);
+        if (strpos ($number, '.') !== false) {
+            $splitted = explode ('.', $number);
+            $len_after_dot = strlen ($splitted[1]);
         }
-        $number = str_replace(['.', '-'], '', $number);
+        $number = str_replace (array ('.', '-'), '', $number);
         $sign = ($x < 0) ? '-' : '';
         if ($exp > 0) {
-            $zeros = str_repeat('0', abs($exp) - $len_after_dot);
-            $s = $sign.$number.$zeros;
+            $zeros = str_repeat ('0', abs ($exp) - $len_after_dot);
+            $s = $sign . $number . $zeros;
         } else {
-            $zeros = str_repeat('0', abs($exp) - 1);
-            $s = $sign.'0.'.$zeros.$number;
+            $zeros = str_repeat ('0', abs ($exp) - 1);
+            $s = $sign . '0.' . $zeros . $number;
         }
         return $s;
     }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2312,6 +2312,32 @@ class Exchange {
         return $result;
     }
 
+    public static function number_to_string ($x) {
+        # avoids scientific notation for too large and too small numbers
+        $s = (string)$x;
+        if (strpos($x, 'E') === false) {
+            return $s;
+        }
+        $splitted = explode('E', $s);
+        $number = $splitted[0];
+        $exp = (int)$splitted[1];
+        $len_after_dot = 0;
+        if (strpos($number, '.') !== false) {
+            $splitted = explode('.', $number);
+            $len_after_dot = strlen($splitted[1]);
+        }
+        $number = str_replace(['.', '-'], '', $number);
+        $sign = ($x < 0) ? '-' : '';
+        if ($exp > 0) {
+            $zeros = str_repeat('0', abs($exp) - $len_after_dot);
+            $s = $sign.$number.$zeros;
+        } else {
+            $zeros = str_repeat('0', abs($exp) - 1);
+            $s = $sign.'0.'.$zeros.$number;
+        }
+        return $s;
+    }
+
     // ------------------------------------------------------------------------
     // web3 / 0x methods
 

--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -114,3 +114,27 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
                 if precision > 0:
                     return precise + '.' + precision * '0'
             return precise
+
+
+def number_to_string(x):
+    # avoids scientific notation for too large and too small numbers
+    s = str(x)
+    if 'e' not in s:
+        return s
+    number, exp = s.split('e')
+    exp = int(exp)
+    len_after_dot = 0
+    if '.' in number:
+        before_dot, after_dot = number.split('.')
+        len_after_dot = len(after_dot)
+    number = number.replace('.', '').replace('-', '')
+    sign = '-' if x < 0 else ''
+    if exp > 0:
+        zeros = '0' * (abs(exp) - len_after_dot)
+        s = '{sign}{number}{zeros}'.format(
+            sign=sign, number=number, zeros=zeros)
+    else:
+        zeros = '0' * (abs(exp) - 1)
+        s = '{sign}0.{zeros}{number}'.format(
+            sign=sign, number=number, zeros=zeros)
+    return s

--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -118,23 +118,5 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
 
 def number_to_string(x):
     # avoids scientific notation for too large and too small numbers
-    s = str(x)
-    if 'e' not in s:
-        return s
-    number, exp = s.split('e')
-    exp = int(exp)
-    len_after_dot = 0
-    if '.' in number:
-        before_dot, after_dot = number.split('.')
-        len_after_dot = len(after_dot)
-    number = number.replace('.', '').replace('-', '')
-    sign = '-' if x < 0 else ''
-    if exp > 0:
-        zeros = '0' * (abs(exp) - len_after_dot)
-        s = '{sign}{number}{zeros}'.format(
-            sign=sign, number=number, zeros=zeros)
-    else:
-        zeros = '0' * (abs(exp) - 1)
-        s = '{sign}0.{zeros}{number}'.format(
-            sign=sign, number=number, zeros=zeros)
-    return s
+    d = decimal.Decimal(str(x))
+    return '{:f}'.format(d)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -21,6 +21,7 @@ from ccxt.base.errors import InvalidAddress
 
 from ccxt.base.decimal_to_precision import decimal_to_precision
 from ccxt.base.decimal_to_precision import DECIMAL_PLACES, TRUNCATE, ROUND
+from ccxt.base.decimal_to_precision import number_to_string
 
 # -----------------------------------------------------------------------------
 
@@ -294,6 +295,7 @@ class Exchange(object):
         self.currencies = dict() if self.currencies is None else self.currencies
         self.options = dict() if self.options is None else self.options  # Python does not allow to define properties in run-time with setattr
         self.decimal_to_precision = decimal_to_precision
+        self.number_to_string = number_to_string
 
         # version = '.'.join(map(str, sys.version_info[:3]))
         # self.userAgent = {


### PR DESCRIPTION
As discussed in #4942 I implemented number to string method for python and php.
I added some testcases, I thought are necessary.
I removed the testcase with `-0.000000789999999999999` because in python it evaluated to `-0.00000079`.