### PR TITLE
Improve kraken createOrder by including original order info

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -836,8 +836,13 @@ module.exports = class kraken extends Exchange {
             }
         }
         return {
-            'info': response,
             'id': id,
+            'info': response,
+            'symbol': symbol,
+            'type': type,
+            'side': side,
+            'price': order['price'],
+            'amount': order['volume'],
         };
     }
 

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -838,11 +838,21 @@ module.exports = class kraken extends Exchange {
         return {
             'id': id,
             'info': response,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'lastTradeTimestamp': undefined,
             'symbol': symbol,
             'type': type,
             'side': side,
-            'price': order['price'],
-            'amount': order['volume'],
+            'price': price,
+            'amount': amount,
+            'cost': undefined,
+            'average': undefined,
+            'filled': undefined,
+            'remaining': undefined,
+            'status': undefined,
+            'fee': undefined,
+            'trades': undefined,
         };
     }
 


### PR DESCRIPTION
Most other exchanges implementation include the original order info in addition to new info after creating an order. However Kraken doesn't and only return the id and a raw response. This PR address the issue by including the original info. 

Passed tests. 
<img width="668" alt="Screen Shot 2019-04-25 at 5 50 04 PM" src="https://user-images.githubusercontent.com/29751536/56776701-9681a900-6782-11e9-9202-0e2ec15c9946.png">
