### PR TITLE
CoinEx safeFloat volume

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -193,7 +193,7 @@ module.exports = class coinex extends Exchange {
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeFloat (ticker, 'volume'),
+            'baseVolume': this.safeFloat2 (ticker, 'vol', 'volume'),
             'quoteVolume': undefined,
             'info': ticker,
         };


### PR DESCRIPTION
They change again `volume` to `vol`

` { buy: '0.00013245',
buy_amount: '24577',
sell: '0.0001334',
sell_amount: '1',
vol: '2006899.34776541',
low: '0.00013052',
open: '0.00013052',
high: '0.00013798',
last: '0.00013289' }`