### PR TITLE
Improve bitmex exchange

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -995,7 +995,7 @@ module.exports = class bitmex extends Exchange {
             expires = expires.toString ();
             auth += expires;
             headers['api-expires'] = expires;
-            if (method === 'POST' || method === 'PUT') {
+            if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
                 if (Object.keys (params).length) {
                     body = this.json (params);
                     auth += body;

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -137,6 +137,8 @@ module.exports = class bitmex extends Exchange {
                     'Access Denied': PermissionDenied,
                     'Duplicate clOrdID': InvalidOrder,
                     'Signature not valid': AuthenticationError,
+                    'orderQty is invalid': InvalidOrder,
+                    'Invalid price': InvalidOrder,
                 },
                 'broad': {
                     'overloaded': ExchangeNotAvailable,


### PR DESCRIPTION
I added two exceptions for bitmex.

Bitmex supports canceling multiple orders at once with `{"orderID": ["...", "..."]}`
With current master, bitmex returns:
```
{
    "error":{
        "message":"OrderID length must be 36 characters.","name":"ValidationError"
    }
}
```
The second patch fixes this issue.