### PR TITLE
Bitmex: Only set url params when using GET

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -985,8 +985,10 @@ module.exports = class bitmex extends Exchange {
                 query += '?' + this.urlencode (params);
             }
         } else {
-            if (this.safeString2 (params, '_format', undefined) !== undefined) {
-                query += '?' + this.urlencode ({ '_format': params['_format'] });
+            const format = this.safeString2 (params, '_format');
+            if (format !== undefined) {
+                query += '?' + this.urlencode ({ '_format': format });
+                params = this.omit (params, '_format');
             }
         }
         let url = this.urls['api'] + query;

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -980,9 +980,15 @@ module.exports = class bitmex extends Exchange {
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let query = '/api/' + this.version + '/' + path;
-        if (method !== 'PUT')
-            if (Object.keys (params).length)
+        if (method === 'GET') {
+            if (Object.keys (params).length) {
                 query += '?' + this.urlencode (params);
+            }
+        } else {
+            if (this.safeString2 (params, '_format', undefined) !== undefined) {
+                query += '?' + this.urlencode ({ '_format': params['_format'] });
+            }
+        }
         let url = this.urls['api'] + query;
         if (api === 'private') {
             this.checkRequiredCredentials ();

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -139,6 +139,7 @@ module.exports = class bitmex extends Exchange {
                     'Signature not valid': AuthenticationError,
                     'orderQty is invalid': InvalidOrder,
                     'Invalid price': InvalidOrder,
+                    'Invalid stopPx for ordType': InvalidOrder,
                 },
                 'broad': {
                     'overloaded': ExchangeNotAvailable,


### PR DESCRIPTION
This does not fix anything, but I think it is correct to only set the url params when using GET.