### PR TITLE
crex24.py parse8601 error in parse_transaction

### DIFF
--- a/python/ccxt/crex24.py
+++ b/python/ccxt/crex24.py
@@ -1030,8 +1030,8 @@ class crex24 (Exchange):
         if currency is not None:
             code = currency['code']
         type = self.safe_string(transaction, 'type')
-        timestamp = self.parse8601(transaction, 'createdAt')
-        updated = self.parse8601(transaction, 'processedAt')
+        timestamp = self.parse8601(self.safe_string(transaction, 'createdAt'))
+        updated = self.parse8601(self.safe_string(transaction, 'processedAt'))
         status = self.parse_transaction_status(self.safe_string(transaction, 'status'))
         amount = self.safe_float(transaction, 'amount')
         feeCost = self.safe_float(transaction, 'fee')


### PR DESCRIPTION
Running withdraw() or fetch_transactions() results in "parse8601() takes from 0 to 1 positional arguments but 2 were given". Checked other exchange Python files and noticed that these two calls did not pass in a safe_string.