### PR TITLE
crex24 parse8601 error in parse_transaction

### DIFF
--- a/js/crex24.js
+++ b/js/crex24.js
@@ -1085,8 +1085,8 @@ module.exports = class crex24 extends Exchange {
             code = currency['code'];
         }
         let type = this.safeString (transaction, 'type');
-        let timestamp = this.parse8601 (transaction, 'createdAt');
-        let updated = this.parse8601 (transaction, 'processedAt');
+        let timestamp = this.parse8601 (this.safeString (transaction, 'createdAt'));
+        let updated = this.parse8601 (this.safeString (transaction, 'processedAt'));
         let status = this.parseTransactionStatus (this.safeString (transaction, 'status'));
         let amount = this.safeFloat (transaction, 'amount');
         const feeCost = this.safeFloat (transaction, 'fee');


### PR DESCRIPTION
Running withdraw() or fetch_transactions() results in "parse8601() takes from 0 to 1 positional arguments but 2 were given". Checked other exchange Python files and noticed that these two calls did not pass in a safe_string.

Issue discovered in crex24.py. Modifying JS file as requested for transpiling.