### PR TITLE
Cryptopia ensure secret is properly padded before base64 decoding

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -849,6 +849,9 @@ module.exports = class cryptopia extends Exchange {
             let nonce = this.nonce ().toString ();
             body = this.json (query, { 'convertArraysToObjects': true });
             let hash = this.hash (this.encode (body), 'md5', 'base64');
+            if (this.secret.length % 4) {
+                this.secret += '=' * (4 - this.secret.length % 4);
+            }
             let secret = this.base64ToBinary (this.secret);
             let uri = this.encodeURIComponent (url);
             let lowercase = uri.toLowerCase ();


### PR DESCRIPTION
Fix padding for secret if incorrect.

File "/ccxt/cryptopia.py", line 789, in sign
    secret = base64.b64decode(self.secret)
  File "/python3.7/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding