### PR TITLE
cryptopia load markets for fetching transactions

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -492,6 +492,7 @@ module.exports = class cryptopia extends Exchange {
     }
 
     async fetchTransactionsByType (type, code = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
         let request = {
             'type': (type === 'deposit') ? 'Deposit' : 'Withdraw',
         };


### PR DESCRIPTION
load markets in fetch_transactions_by_type

File "/ccxt/cryptopia.py", line 483, in fetch_withdrawals
    return self.fetch_transactions_by_type('withdrawal', code, since, limit, params)
  File "/ccxt/cryptopia.py", line 480, in fetch_transactions_by_type
    return self.parseTransactions(response['Data'], code, since, limit)
  File "/ccxt/base/exchange.py", line 1402, in parse_transactions
    array = [self.extend(self.parse_transaction(transaction, currency), params) for transaction in array]
  File "/ccxt/base/exchange.py", line 1402, in <listcomp>
    array = [self.extend(self.parse_transaction(transaction, currency), params) for transaction in array]
  File "/ccxt/cryptopia.py", line 427, in parse_transaction
    currency = self.safe_value(self.currencies_by_id, currencyId)
  File "/ccxt/base/exchange.py", line 594, in safe_value
    return dictionary[key] if key is not None and (key in dictionary) and dictionary[key] is not None else default_value
TypeError: argument of type 'NoneType' is not iterable
