### PR TITLE
bibox deposits/withdrawals set limit to 100 if not passed

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -446,7 +446,9 @@ module.exports = class bibox extends Exchange {
             request['symbol'] = currency['id'];
         }
         if (limit !== undefined) {
-            request['size'] = limit; // default = 100
+            request['size'] = limit;
+        } else {
+            request['size'] = 100;
         }
         const response = await this.privatePostTransfer ({
             'cmd': 'transfer/transferInList',
@@ -470,7 +472,9 @@ module.exports = class bibox extends Exchange {
             request['symbol'] = currency['id'];
         }
         if (limit !== undefined) {
-            request['size'] = limit; // default = 100
+            request['size'] = limit;
+        } else {
+            request['size'] = 100;
         }
         const response = await this.privatePostTransfer ({
             'cmd': 'transfer/transferOutList',


### PR DESCRIPTION
Calling the function without a limit results in an error
exchange.fetch_deposits()

Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/ccxt/bibox.py", line 435, in fetch_deposits
    'body': self.extend(request, params),
  File "/ccxt/base/exchange.py", line 404, in inner
    return entry(_self, **inner_kwargs)
  File "/ccxt/bibox.py", line 809, in request
    response = self.fetch2(path, api, method, params, headers, body)
  File "ccxt/base/exchange.py", line 429, in fetch2
    return self.fetch(request['url'], request['method'], request['headers'], request['body'])
  File "ccxt/base/exchange.py", line 532, in fetch
    self.handle_errors(response.status_code, response.reason, url, method, headers, http_response, json_response)
  File "/ccxt/bibox.py", line 803, in handle_errors
    raise ExchangeError(feedback)
ccxt.base.errors.ExchangeError: bibox {"error":{"code":"3000","msg":"请求参数错误"},"cmd":"transfer/transferInList"}

passing a limit works fine.
exchange.fetch_deposits(limit=100)

[{'info': {'id': 1023291, 'coin_symbol': 'ETH', 'to_address': '0xxxxx', 'amount': '0.49170000', 'confirmCount': '16', 'createdAt': 1553123867000, 'status': 2, 'type': 'deposit'}, 'id': '1023291', 'txid': None, 'timestamp': '1553123867000', 'datetime': None, 'address': '0xxxxx', 'tag': None, 'type': 'deposit', 'amount': 0.4917, 'currency': 'ETH', 'status': 'ok', 'updated': None, 'fee': {'cost': 0, 'currency': 'ETH'}}, {'info': {'id': 1027149, 'coin_symbol': 'ETH', 'to_address': '0xxxxx', 'amount': '0.40052750', 'confirmCount': '18', 'createdAt': 1553226602000, 'status': 2, 'type': 'deposit'}, 'id': '1027149', 'txid': None, 'timestamp': '1553226602000', 'datetime': None, 'address': '0xxxxx', 'tag': None, 'type': 'deposit', 'amount': 0.4005275, 'currency': 'ETH', 'status': 'ok', 'updated': None, 'fee': {'cost': 0, 'currency': 'ETH'}}]

So there is no default if limit is not passed and it should be set to 100 if not set)
