### PR TITLE
Filter out bitfinex-only markets in Ethfinex fetchMarkets

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -439,10 +439,11 @@ module.exports = class bitfinex extends Exchange {
     }
 
     async fetchMarkets (params = {}) {
-        let markets = await this.publicGetSymbolsDetails ();
+        let allMarkets = await this.publicGetSymbolsDetails ();
+        let markets = await this.publicGetSymbols ();
         let result = [];
         for (let p = 0; p < markets.length; p++) {
-            let market = markets[p];
+            let market = allMarkets.find (m => m.pair === markets[p]);
             let id = market['pair'].toUpperCase ();
             let baseId = id.slice (0, 3);
             let quoteId = id.slice (3, 6);

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -445,7 +445,7 @@ module.exports = class bitfinex extends Exchange {
         for (let i = 0; i < details.length; i++) {
             const market = details[i];
             let id = this.safeString (market, 'pair');
-            if (!this.inArray (id, ids) {
+            if (!this.inArray (id, ids)) {
                 continue;
             }
             id = id.toUpperCase ();

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -439,22 +439,26 @@ module.exports = class bitfinex extends Exchange {
     }
 
     async fetchMarkets (params = {}) {
-        let allMarkets = await this.publicGetSymbolsDetails ();
-        let markets = await this.publicGetSymbols ();
-        let result = [];
-        for (let p = 0; p < markets.length; p++) {
-            let market = allMarkets.find (m => m.pair === markets[p]);
-            let id = market['pair'].toUpperCase ();
-            let baseId = id.slice (0, 3);
-            let quoteId = id.slice (3, 6);
-            let base = this.commonCurrencyCode (baseId);
-            let quote = this.commonCurrencyCode (quoteId);
-            let symbol = base + '/' + quote;
-            let precision = {
+        const ids = await this.publicGetSymbols ();
+        const details = await this.publicGetSymbolsDetails ();
+        const result = [];
+        for (let i = 0; i < details.length; i++) {
+            const market = details[i];
+            let id = this.safeString (market, 'pair');
+            if (!this.inArray (id, ids) {
+                continue;
+            }
+            id = id.toUpperCase ();
+            const baseId = id.slice (0, 3);
+            const quoteId = id.slice (3, 6);
+            const base = this.commonCurrencyCode (baseId);
+            const quote = this.commonCurrencyCode (quoteId);
+            const symbol = base + '/' + quote;
+            const precision = {
                 'price': market['price_precision'],
                 'amount': undefined,
             };
-            let limits = {
+            const limits = {
                 'amount': {
                     'min': this.safeFloat (market, 'minimum_order_size'),
                     'max': this.safeFloat (market, 'maximum_order_size'),


### PR DESCRIPTION
Ethfinex module uses API v1, when only v2 is officially supported now.
symbols_details includes results for all markets on both ethfinex and bitfinex while symbols limits results to the relevant site.
This fixes #5085.