### PR TITLE
gate.io parseTicker fix

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -327,8 +327,8 @@ module.exports = class gateio extends Exchange {
             'change': change,
             'percentage': percentage,
             'average': average,
-            'baseVolume': this.safeFloat (ticker, 'quoteVolume'),
-            'quoteVolume': this.safeFloat (ticker, 'baseVolume'),
+            'baseVolume': this.safeFloat (ticker, 'baseVolume'),
+            'quoteVolume': this.safeFloat (ticker, 'quoteVolume'),
             'info': ticker,
         };
     }
@@ -379,7 +379,12 @@ module.exports = class gateio extends Exchange {
                 market = this.markets[symbol];
             if (id in this.markets_by_id)
                 market = this.markets_by_id[id];
-            result[symbol] = this.parseTicker (ticker, market);
+            const ticker = this.parseTicker (ticker, market);
+            // https://github.com/ccxt/ccxt/pull/5138
+            const quoteVolume = ticker['quoteVolume'];
+            ticker['baseVolume'] = ticker['quoteVolume'];
+            ticker['quoteVolume'] = quoteVolume;
+            result[symbol] = ticker;
         }
         return result;
     }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -373,13 +373,12 @@ module.exports = class gateio extends Exchange {
             base = this.commonCurrencyCode (base);
             quote = this.commonCurrencyCode (quote);
             let symbol = base + '/' + quote;
-            let ticker = tickers[id];
             let market = undefined;
             if (symbol in this.markets)
                 market = this.markets[symbol];
             if (id in this.markets_by_id)
                 market = this.markets_by_id[id];
-            const ticker = this.parseTicker (ticker, market);
+            const ticker = this.parseTicker (tickers[id], market);
             // https://github.com/ccxt/ccxt/pull/5138
             const baseVolume = ticker['baseVolume'];
             ticker['baseVolume'] = ticker['quoteVolume'];

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -327,8 +327,8 @@ module.exports = class gateio extends Exchange {
             'change': change,
             'percentage': percentage,
             'average': average,
-            'baseVolume': this.safeFloat (ticker, 'baseVolume'),
-            'quoteVolume': this.safeFloat (ticker, 'quoteVolume'),
+            'baseVolume': this.safeFloat (ticker, 'quoteVolume'),
+            'quoteVolume': this.safeFloat (ticker, 'baseVolume'),
             'info': ticker,
         };
     }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -381,9 +381,9 @@ module.exports = class gateio extends Exchange {
                 market = this.markets_by_id[id];
             const ticker = this.parseTicker (ticker, market);
             // https://github.com/ccxt/ccxt/pull/5138
-            const quoteVolume = ticker['quoteVolume'];
+            const baseVolume = ticker['baseVolume'];
             ticker['baseVolume'] = ticker['quoteVolume'];
-            ticker['quoteVolume'] = quoteVolume;
+            ticker['quoteVolume'] = baseVolume;
             result[symbol] = ticker;
         }
         return result;


### PR DESCRIPTION
Strange, but in Gate.io API it is so.

```
 'MXC/ETH':
   { symbol: 'MXC/ETH',
     timestamp: 1558093035217,
     datetime: '2019-05-17T11:37:15.217Z',
     high: 0.00003023,
     low: 0.00002502,
     bid: 0.00003016,
     bidVolume: undefined,
     ask: 0.00003106,
     askVolume: undefined,
     vwap: undefined,
     open: 0.000026971028791819894,
     close: 0.00003007,
     last: 0.00003007,
     previousClose: undefined,
     change: 0.0000030989712081801047,
     percentage: 11.49,
     average: 0.000028520514395909946,
     baseVolume: 47.67463396,
     quoteVolume: 1765854.03526205,
     info:
      { result: 'true',
        last: '0.00003007',
        lowestAsk: '0.00003106',
        highestBid: '0.00003016',
        percentChange: '11.49',
        baseVolume: '47.67463396',
        quoteVolume: '1765854.03526205',
        high24hr: '0.00003023',
        low24hr: '0.00002502' } }
```

![image](https://user-images.githubusercontent.com/38309641/57926597-5fe80b80-78b4-11e9-82b0-6661445330f5.png)
