### PR TITLE
Fix Kuna splitting of quote and base currency

### DIFF
--- a/js/kuna.js
+++ b/js/kuna.js
@@ -61,22 +61,23 @@ module.exports = class kuna extends acx {
         const pricePrecisions = {
             'UAH': 0,
         };
-        let markets = [];
-        let tickers = await this.publicGetTickers ();
-        let ids = Object.keys (tickers);
+        const markets = [];
+        const response = await this.publicGetTickers (params);
+        const ids = Object.keys (response);
         for (let i = 0; i < ids.length; i++) {
-            let id = ids[i];
+            const id = ids[i];
             for (let j = 0; j < quotes.length; j++) {
-                let quoteId = quotes[j];
-                let index = id.indexOf (quoteId);
-                if (index > 0 && id.slice (index) === quoteId) {
-                    let baseId = id.replace (quoteId, '');
+                const quoteId = quotes[j];
+                const index = id.indexOf (quoteId);
+                const slice = id.slice (index);
+                if (index > 0 && slice === quoteId) {
+                    const baseId = id.replace (quoteId, '');
                     let base = baseId.toUpperCase ();
                     let quote = quoteId.toUpperCase ();
                     base = this.commonCurrencyCode (base);
                     quote = this.commonCurrencyCode (quote);
-                    let symbol = base + '/' + quote;
-                    let precision = {
+                    const symbol = base + '/' + quote;
+                    const precision = {
                         'amount': 6,
                         'price': this.safeInteger (pricePrecisions, quote, 6),
                     };

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -70,7 +70,7 @@ module.exports = class kuna extends acx {
                 const quoteId = quotes[j];
                 const index = id.indexOf (quoteId);
                 const slice = id.slice (index);
-                if (index > 0 && slice === quoteId) {
+                if ((index > 0) && (slice === quoteId)) {
                     const baseId = id.replace (quoteId, '');
                     let base = baseId.toUpperCase ();
                     let quote = quoteId.toUpperCase ();

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -57,7 +57,7 @@ module.exports = class kuna extends acx {
     }
 
     async fetchMarkets (params = {}) {
-        const quotes = [ 'btc', 'eth', 'eurs', 'gbg', 'uah' ];
+        const quotes = [ 'btc', 'eth', 'eurs', 'rub', 'uah', 'usd', 'usdt' ];
         const pricePrecisions = {
             'UAH': 0,
         };
@@ -68,7 +68,8 @@ module.exports = class kuna extends acx {
             let id = ids[i];
             for (let j = 0; j < quotes.length; j++) {
                 let quoteId = quotes[j];
-                if (id.indexOf (quoteId) > 0) {
+                let index = id.indexOf (quoteId);
+                if (index > 0 && id.slice (index) === quoteId) {
                     let baseId = id.replace (quoteId, '');
                     let base = baseId.toUpperCase ();
                     let quote = quoteId.toUpperCase ();


### PR DESCRIPTION
Kuna has both USD and USDT denominated markets, so the logic to split up
their markets was failing for certain currencies.  Also, the quote
currencies listed in the file are out of date compared to the current
state of the exchange.  I avoided using `endsWith` because I wasn't sure
if the transpiler can make that expression work.  Let me know if you
have any questions or comments.