### PR TITLE
kucoin parseTrade timestamp fix

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -918,6 +918,24 @@ module.exports = class kucoin extends Exchange {
         //         "createdAt":1547026472000
         //     }
         //
+        // fetchMyTrades v2 alternative format since 2019-05-21 https://github.com/ccxt/ccxt/pull/5162
+        //
+        //     {
+        //         symbol: "OPEN-BTC",
+        //         forceTaker:  false,
+        //         orderId: "5ce36420054b4663b1fff2c9",
+        //         fee: "0",
+        //         feeCurrency: "",
+        //         type: "",
+        //         feeRate: "0",
+        //         createdAt: 1558417615000,
+        //         size: "12.8206",
+        //         stop: "",
+        //         price: "0",
+        //         funds: "0",
+        //         tradeId: "5ce390cf6e0db23b861c6e80"
+        //     }
+        //
         // fetchMyTrades (private) v1 (historical)
         //
         //     {
@@ -962,7 +980,7 @@ module.exports = class kucoin extends Exchange {
         } else {
             timestamp = this.safeInteger (trade, 'createdAt');
             // if it's a historical v1 trade, the exchange returns timestamp in seconds
-            if (takerOrMaker === undefined && timestamp !== undefined) {
+            if (('dealValue' in trade) && (timestamp !== undefined)) {
                 timestamp = timestamp * 1000;
             }
         }

--- a/python/ccxt/kucoin.py
+++ b/python/ccxt/kucoin.py
@@ -915,8 +915,8 @@ class kucoin (Exchange):
         else:
             timestamp = self.safe_integer(trade, 'createdAt')
             # if it's a historical v1 trade, the exchange returns timestamp in seconds
-#            if takerOrMaker is None and timestamp is not None:
-#                timestamp = timestamp * 1000
+            if takerOrMaker is None and timestamp is not None:
+                timestamp = timestamp * 1000
         price = self.safe_float_2(trade, 'price', 'dealPrice')
         side = self.safe_string(trade, 'side')
         fee = None

--- a/python/ccxt/kucoin.py
+++ b/python/ccxt/kucoin.py
@@ -915,8 +915,8 @@ class kucoin (Exchange):
         else:
             timestamp = self.safe_integer(trade, 'createdAt')
             # if it's a historical v1 trade, the exchange returns timestamp in seconds
-            if takerOrMaker is None and timestamp is not None:
-                timestamp = timestamp * 1000
+#            if takerOrMaker is None and timestamp is not None:
+#                timestamp = timestamp * 1000
         price = self.safe_float_2(trade, 'price', 'dealPrice')
         side = self.safe_string(trade, 'side')
         fee = None


### PR DESCRIPTION
myTrades = self.api_wrapper.fetch_my_trades(limit=300, params={param_key: param_value})
  File "/usr/local/lib/python3.7/dist-packages/ccxt/kucoin.py", line 816, in fetch_my_trades
    return self.parse_trades(trades, market, since, limit)
  File "/usr/local/lib/python3.7/dist-packages/ccxt/base/exchange.py", line 1388, in parse_trades
    array = [self.parse_trade(trade, market) for trade in array]
  File "/usr/local/lib/python3.7/dist-packages/ccxt/base/exchange.py", line 1388, in <listcomp>
    array = [self.parse_trade(trade, market) for trade in array]
  File "/usr/local/lib/python3.7/dist-packages/ccxt/kucoin.py", line 946, in parse_trade
    'datetime': self.iso8601(timestamp),
  File "/usr/local/lib/python3.7/dist-packages/ccxt/base/exchange.py", line 848, in iso8601
    utc = datetime.datetime.utcfromtimestamp(timestamp // 1000)
ValueError: year 51354 is out of range