### PR TITLE
Coss parseOrderStatus fix

### DIFF
--- a/js/coss.js
+++ b/js/coss.js
@@ -763,7 +763,7 @@ module.exports = class coss extends Exchange {
             'OPEN': 'open',
             'CANCELLED': 'canceled',
             'FILLED': 'closed',
-            'PARTIAL_FILL': 'open',
+            'PARTIAL_FILL': 'closed',
             'CANCELLING': 'open',
         };
         return this.safeString (statuses, status.toUpperCase (), status);


### PR DESCRIPTION
Due my research I found that even partitially filled open order  stay with "open" status.

```
 { info:
     { hex_id: '5ce45e9bbc236865ca4282a5',
       order_id: '0eed5b65-698a-40c4-8704-64ed18d08fa7',
       account_id: '2fcf9476-52cf-4746-979e-f67cc51bcddf',
       order_symbol: 'LTC_BTC',
       order_side: 'SELL',
       status: 'open',
       createTime: 1558470299480,
       type: 'limit',
       timeMatching: 0,
       order_price: '0.01159000',
       order_size: '0.1',
       executed: '0.05',
       stop_price: '0.00000000',
       avg: '0.01159000',
       total: '0.00115900 BTC' },
    id: '0eed5b65-698a-40c4-8704-64ed18d08fa7',
    timestamp: 1558470299480,
    datetime: '2019-05-21T20:24:59.480Z',
    lastTradeTimestamp: undefined,
    symbol: 'LTC/BTC',
    type: 'limit',
    side: 'sell',
    price: 0.01159,
    amount: 0.1,
    cost: 0.001159,
    average: 0.01159,
    filled: 0.05,
    remaining: 0.05,
    status: 'open',
    fee: undefined,
    trades: undefined }
```

When this order is cancelled it becomes "partial_fill", So all 'partial_fill' are closed. This one after closing (stays with "open" status in CCXT now):

```
{ info:
     { hex_id: '5ce45e9bbc236865ca4282a5',
       order_id: '0eed5b65-698a-40c4-8704-64ed18d08fa7',
       account_id: '2fcf9476-52cf-4746-979e-f67cc51bcddf',
       order_symbol: 'LTC_BTC',
       order_side: 'SELL',
       status: 'partial_fill',
       createTime: 1558470299480,
       type: 'limit',
       timeMatching: 0,
       order_price: '0.01159000',
       order_size: '0.1',
       executed: '0.05',
       stop_price: '0.00000000',
       avg: '0.01159000',
       total: '0.00057950 BTC' },
    id: '0eed5b65-698a-40c4-8704-64ed18d08fa7',
    timestamp: 1558470299480,
    datetime: '2019-05-21T20:24:59.480Z',
    lastTradeTimestamp: undefined,
    symbol: 'LTC/BTC',
    type: 'limit',
    side: 'sell',
    price: 0.01159,
    amount: 0.1,
    cost: 0.0005795,
    average: 0.01159,
    filled: 0.05,
    remaining: 0.05,
    status: 'open',
    fee: undefined,
    trades: undefined }
```