### PR TITLE
Remove fetchOHLCV from Kuna

### DIFF
--- a/js/kuna.js
+++ b/js/kuna.js
@@ -18,6 +18,7 @@ module.exports = class kuna extends acx {
             'has': {
                 'CORS': false,
                 'fetchTickers': true,
+                'fetchOHLCV': false,
                 'fetchOpenOrders': true,
                 'fetchMyTrades': true,
                 'withdraw': false,


### PR DESCRIPTION
According to their API docs at https://kuna.io/documents/api?lang=en
Kuna does not support fetching candles, and since Kuna derives from ACX,
which does support candles, we get errors when trying to call fetchOHLCV
on Kuna.