### PR TITLE
Support all params for Bitfinex2 fetchOrderBook

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -172,7 +172,7 @@ module.exports = class bitfinex2 extends bitfinex {
                 },
             },
             'options': {
-                'precision': 'R0', // P0, P1, P2, P3, P4, R0 
+                'precision': 'R0', // P0, P1, P2, P3, P4, R0
                 'orderTypes': {
                     'MARKET': undefined,
                     'EXCHANGE MARKET': 'market',


### PR DESCRIPTION
Bitfinex supports the limit parameter for orderbooks (but only the
values 25 or 100), so this pull request includes that parameter.
Additionally, the precision can be passed in, but this changes the
output format, so we have to get the right piece of data.

Reference at https://docs.bitfinex.com/v2/reference#rest-public-books