### PR TITLE
fix: parseMarkets() is sync

### DIFF
--- a/js/okex3.js
+++ b/js/okex3.js
@@ -474,7 +474,7 @@ module.exports = class okex3 extends Exchange {
         return result;
     }
 
-    async parseMarkets (markets) {
+    parseMarkets (markets) {
         const result = [];
         for (let i = 0; i < markets.length; i++) {
             result.push (this.parseMarket (markets[i]));


### PR DESCRIPTION
`parseMarkets()` is only called from `fetchMarketsByType()` as sync function but in fact it was declared as coroutine. This lead to an error:

```
>>> import ccxt.async_support as accxt
>>> a = accxt.okex3()
>>> import asyncio
>>> loop = asyncio.get_event_loop()
>>> future = asyncio.ensure_future(a.load_markets())
>>> loop.run_until_complete(future)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/asyncio/base_events.py", line 473, in run_until_complete
    return future.result()
  File "/home/vlado/work/brohedge/tea/e/lib/python3.6/site-packages/ccxt/async_support/base/exchange.py", line 179, in load_markets
    markets = await self.fetch_markets(params)
  File "/home/vlado/work/brohedge/tea/e/lib/python3.6/site-packages/ccxt/async_support/okex3.py", line 495, in fetch_markets
    result = self.array_concat(result, markets)
  File "/home/vlado/work/brohedge/tea/e/lib/python3.6/site-packages/ccxt/base/exchange.py", line 729, in array_concat
    return a + b
TypeError: can only concatenate list (not "coroutine") to list
>>> 
>>> 
>>> 
>>> ccxt.__version__
'1.18.587'
>>>
```

Fix is quite simple. Just need to make `parseMarkets()` synchronous function.