### PR TITLE
Fix CoinbasePro transaction status

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -672,14 +672,16 @@ module.exports = class gdax extends Exchange {
     parseTransactionStatus (transaction) {
         if ('canceled_at' in transaction && transaction['canceled_at']) {
             return 'canceled';
-        } else if ('completed_at' in transaction && transaction['completed_at']) {
+        }
+
+        const processed = ('processed_at' in transaction && transaction['processed_at']);
+        const completed = ('completed_at' in transaction && transaction['completed_at']);
+        if (processed && completed) {
             return 'ok';
-        } else if ((('canceled_at' in transaction) && !transaction['canceled_at']) && (('completed_at' in transaction) && !transaction['completed_at']) && (('processed_at' in transaction) && !transaction['processed_at'])) {
-            return 'pending';
-        } else if ('processed_at' in transaction && transaction['processed_at']) {
-            return 'pending';
-        } else {
+        } else if (processed && !completed) {
             return 'failed';
+        } else {
+            return 'pending';
         }
     }
 

--- a/js/gdax.js
+++ b/js/gdax.js
@@ -673,7 +673,6 @@ module.exports = class gdax extends Exchange {
         if ('canceled_at' in transaction && transaction['canceled_at']) {
             return 'canceled';
         }
-
         const processed = ('processed_at' in transaction && transaction['processed_at']);
         const completed = ('completed_at' in transaction && transaction['completed_at']);
         if (processed && completed) {

--- a/js/gdax.js
+++ b/js/gdax.js
@@ -670,11 +670,12 @@ module.exports = class gdax extends Exchange {
     }
 
     parseTransactionStatus (transaction) {
-        if ('canceled_at' in transaction && transaction['canceled_at']) {
+        const canceled = this.safeValue (transaction, 'canceled_at');
+        if (canceled) {
             return 'canceled';
         }
-        const processed = ('processed_at' in transaction && transaction['processed_at']);
-        const completed = ('completed_at' in transaction && transaction['completed_at']);
+        const processed = this.safeValue (transaction, 'processed_at');
+        const completed = this.safeValue (transaction, 'completed_at');
         if (processed && completed) {
             return 'ok';
         } else if (processed && !completed) {


### PR DESCRIPTION
Here's what I noticed.  Immediately upon submitting a withdrawal, the response from the Coinbase Pro API looked like this:

```
{
    id: '1dc2e9c1-x3b5-3011-bc21-17b1013027db',
    type: 'withdraw',
    created_at: '2019-05-31 22:37:18.21103+00',
    completed_at: '2019-05-31 22:37:18.563731+00',
    canceled_at: null,
    processed_at: null,
    user_nonce: null,
    amount: '0.02000000',
    currency: 'ETH',
}
```

When calling `.fetchTransactions('ETH');` on the `ccxt.coinbasepro` object, the status of the transaction was 'ok', not the expected 'pending'.  

Once the withdrawal was actually sent out, the `processed_at` was populated in Coinbase Pro. This PR updates the code so the transaction is only marked as 'ok' if it is _both_ "completed" and "processed". 