### PR TITLE
Typescript definitions: make txid optional

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -149,7 +149,7 @@ declare module 'ccxt' {
     export interface Transaction {
         info: {};
         id: string;
-        txid: string;
+        txid?: string;
         timestamp: number;
         datetime: string;
         address: string;


### PR DESCRIPTION
Sometimes (i.e. in the case of a pending withdrawal), the txid is not populated.