### PR TITLE
Fix Coinbase Pro withdrawals

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -616,8 +616,8 @@ module.exports = class gdax extends Exchange {
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
         this.checkAddress (address);
-        let currency = this.currency (code);
         await this.loadMarkets ();
+        let currency = this.currency (code);
         let request = {
             'currency': currency['id'],
             'amount': amount,


### PR DESCRIPTION
Without this change, when trying to call `.withdraw` I would get:
`(node:62493) UnhandledPromiseRejectionWarning: Error: gdax does not have currency code USDC`

This fix calls `loadMarkets()` before assigning the currency, so the currencies are loaded by then.

I confirmed `.withdraw` works locally after this change.