### PR TITLE
Fix Bug in which asks or bids are None, which causes the following er…

### DIFF
--- a/python/ccxt/async_support/bit2c.py
+++ b/python/ccxt/async_support/bit2c.py
@@ -209,6 +209,8 @@ class bit2c (Exchange):
         orders = self.safe_value(response, market['id'], {})
         asks = self.safe_value(orders, 'ask', [])
         bids = self.safe_value(orders, 'bid', [])
+        if asks is None: asks = []
+        if bids is None: bids = []
         return self.parse_orders(self.array_concat(asks, bids), market, since, limit)
 
     def parse_order(self, order, market=None):


### PR DESCRIPTION
…ror:

Traceback (most recent call last):
  File "C:/Users/Asaf/PycharmProjects/bit2c/api_caller.py", line 87, in <module>
    main()
  File "C:/Users/Asaf/PycharmProjects/bit2c/api_caller.py", line 71, in main
    open_orders = exchange.fetch_open_orders(market)
  File "C:\Users\Asaf\PycharmProjects\bit2c\venv\lib\site-packages\ccxt\bit2c.py", line 211, in fetch_open_orders
    return self.parse_orders(self.array_concat(asks, bids), market, since, limit)
  File "C:\Users\Asaf\PycharmProjects\bit2c\venv\lib\site-packages\ccxt\base\exchange.py", line 738, in array_concat
    return a + b
TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'

Process finished with exit code 1