### PR TITLE
Change bit-z api endpoint

### DIFF
--- a/js/bitz.js
+++ b/js/bitz.js
@@ -40,9 +40,9 @@ module.exports = class bitz extends Exchange {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/35862606-4f554f14-0b5d-11e8-957d-35058c504b6f.jpg',
                 'api': {
-                    'market': 'https://apiv2.bitz.com',
-                    'trade': 'https://apiv2.bitz.com',
-                    'assets': 'https://apiv2.bitz.com',
+                    'market': 'https://apiv2.bit-z.pro',
+                    'trade': 'https://apiv2.bit-z.pro',
+                    'assets': 'https://apiv2.bit-z.pro',
                 },
                 'www': 'https://www.bit-z.com',
                 'doc': 'https://apidoc.bit-z.com/en/',


### PR DESCRIPTION
The endpoint apiv2.bitz.com cannot use now, will get ssl error.
We should switch to another domain according the [api doc](https://apidoc.bit-z.pro/en/).