### PR TITLE
btcmarkets - Fix typo

### DIFF
--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -670,7 +670,7 @@ module.exports = class btcmarkets extends Exchange {
                 body = this.json (params);
                 auth += body;
             } else {
-                let query = this.ksort (this.omit (params, this.extractParams (path)));
+                let query = this.keysort (this.omit (params, this.extractParams (path)));
                 let queryString = '';
                 if (Object.keys (query).length) {
                     queryString = this.urlencode (query);


### PR DESCRIPTION
updated ccxt and this line was throwing, looked at other exchanges and figured this is the correct function. My btcmarkets post requests are working again.
found the same ksort "typo" in /ccxt/dist/ccxt.browser.js also ...