### PR TITLE
Update API endpoint for Bibox balances

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -404,7 +404,7 @@ module.exports = class bibox extends Exchange {
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
         const request = {
-            'cmd': 'transfer/assets',
+            'cmd': 'transfer/mainAssets',
             'body': this.extend ({
                 'select': 1,
             }, params),


### PR DESCRIPTION
The old endpoint stopped returning any balance data whatsoever. The `mainAssets` endpoint now returns the balances.