### PR TITLE
Add encode call to avoid hashlib error in Python 3

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -1265,7 +1265,7 @@ module.exports = class bittrex extends Exchange {
             if (Object.keys (params).length) {
                 url += '?' + this.rawencode (params);
             }
-            const contentHash = this.hash ('', 'sha512', 'hex');
+            const contentHash = this.hash (this.encode (''), 'sha512', 'hex');
             const timestamp = this.milliseconds ().toString ();
             let auth = timestamp + url + method + contentHash;
             const subaccountId = this.safeValue (this.options, 'subaccountId');


### PR DESCRIPTION
When calling `hash` with a unicode string in Python 3, hashlib throws an
error saying "Exception TypeError: Unicode-objects must be encoded
before hashing".  This simple fix just adds a call to encode on the
empty string.