### PR TITLE
Fix Bitfinex order precision

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -319,7 +319,7 @@ module.exports = class bitfinex2 extends bitfinex {
             'datetime': this.iso8601 (timestamp),
             'nonce': undefined,
         };
-        const priceIndex = (fullRequest['precision'] === precision) ? 1 : 0;
+        const priceIndex = (fullRequest['precision'] === 'R0') ? 1 : 0;
         for (let i = 0; i < orderbook.length; i++) {
             const order = orderbook[i];
             const price = order[priceIndex];


### PR DESCRIPTION
Back in #5175 we fixed all of the options for getting orderbooks with
Bitfinex, but there was one issue with the check against the default
precision, which should actually have checked against 'R0', since all of
the other precision options give the data in a different format.  See https://docs.bitfinex.com/v2/reference#rest-public-books for more info