### PR TITLE
update  api for huobipro

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ArgumentsRequired, AuthenticationError, ExchangeError, ExchangeNotAvailable, InvalidOrder, OrderNotFound, InsufficientFunds } = require ('./base/errors');
+const { AuthenticationError, ExchangeError, ExchangeNotAvailable, InvalidOrder, OrderNotFound, InsufficientFunds } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -56,7 +56,7 @@ module.exports = class huobipro extends Exchange {
                 },
                 'www': 'https://www.huobi.pro',
                 'referral': 'https://www.huobi.co/en-us/topic/invited/?invite_code=rwrd3',
-                'doc': 'https://github.com/huobiapi/API_Docs/wiki/REST_api_reference',
+                'doc': 'https://huobiapi.github.io/docs/spot/v1/cn/',
                 'fees': 'https://www.huobi.pro/about/fee/',
             },
             'api': {
@@ -91,7 +91,7 @@ module.exports = class huobipro extends Exchange {
                         'account/accounts/{id}/balance', // 查询指定账户的余额
                         'order/orders/{id}', // 查询某个订单详情
                         'order/orders/{id}/matchresults', // 查询某个订单的成交明细
-                        'order/orders', // 查询当前委托、历史委托
+                        'order/history', // 查询当前委托、历史委托
                         'order/matchresults', // 查询当前成交、历史成交
                         'dw/withdraw-virtual/addresses', // 查询虚拟币提现地址
                         'dw/deposit-virtual/addresses',
@@ -647,7 +647,7 @@ module.exports = class huobipro extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const response = await this.privateGetOrderOrders (this.extend (request, params));
+        const response = await this.privateGetOrderHistory (this.extend (request, params));
         //
         //     { status:   "ok",
         //         data: [ {                  id:  13997833014,
@@ -1037,19 +1037,21 @@ module.exports = class huobipro extends Exchange {
     }
 
     async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
-        if (code === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchDeposits() requires a code argument');
-        }
         if (limit === undefined || limit > 100) {
             limit = 100;
         }
         await this.loadMarkets ();
-        const currency = this.currency (code);
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const request = {
-            'currency': currency['id'],
             'type': 'deposit',
             'from': 0, // From 'id' ... if you want to get results after a particular transaction id, pass the id in params.from
         };
+        if (currency !== undefined) {
+            request['currency'] = currency['id'];
+        }
         if (limit !== undefined) {
             request['size'] = limit; // max 100
         }
@@ -1059,19 +1061,21 @@ module.exports = class huobipro extends Exchange {
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
-        if (code === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchWithdrawals() requires a code argument');
-        }
         if (limit === undefined || limit > 100) {
             limit = 100;
         }
         await this.loadMarkets ();
-        const currency = this.currency (code);
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const request = {
-            'currency': currency['id'],
             'type': 'withdraw',
             'from': 0, // From 'id' ... if you want to get results after a particular transaction id, pass the id in params.from
         };
+        if (currency !== undefined) {
+            request['currency'] = currency['id'];
+        }
         if (limit !== undefined) {
             request['size'] = limit; // max 100
         }


### PR DESCRIPTION
* update the latest API doc link
* support fetch deposits and withdrawals without currency args [link doc](https://huobiapi.github.io/docs/spot/v1/cn/#d3612d98d4).
 And I have tested  the api "no need currency" is true.

* replace order/orders with order/history according the
[changelog](https://huobiapi.github.io/docs/spot/v1/cn/#185368440e) of 2019.04.29 19:00:
```
新增最近48小时内历史订单查询节点。新节点的上线后，现有订单查询节点“GET
/v1/order/orders”仍将被保留。然而，新节点“GET
/v1/order/history”被赋予更高服务等级。极端情况下，当服务荷载超过系统既定阈值时，节点“GET
/v1/order/orders”的服务可能会不可用，而新节点“GET
/v1/order/history”仍将继续提供服务。另外，火币正在计划支持另一个新节点专门用于用户48小时外的历史订单查询。此新节点上线的同时，现有节点“GET
/v1/order/orders”将被弃用。火币将及时告知用户这一变更，一旦变更时间确定。
```