### PR TITLE
FIX: acx.fetch_ohlcv handled since parameter incorrect

### DIFF
--- a/js/acx.js
+++ b/js/acx.js
@@ -303,7 +303,7 @@ module.exports = class acx extends Exchange {
             'limit': limit,
         };
         if (since !== undefined) {
-            request['timestamp'] = since;
+            request['timestamp'] = parseInt (since / 1000);
         }
         const response = await this.publicGetK (this.extend (request, params));
         return this.parseOHLCVs (response, market, timeframe, since, limit);


### PR DESCRIPTION
@kroitor I see a pattern there. Is there a reason for this? Was the parameter in seconds before?