### PR TITLE
fixed invalid ticker

### DIFF
--- a/examples/py/minimal-2-lines.py
+++ b/examples/py/minimal-2-lines.py
@@ -1,2 +1,2 @@
 import ccxt
-print(ccxt.bitfinex().fetch_ticker('BTC/USD'))
+print(ccxt.bitfinex().fetch_ticker('BTC/USDT'))


### PR DESCRIPTION
Finex no longer has USD pairs and uses USDT instead.