### PR TITLE
Remove old raise_error in preparation for new raise_error invoked in handle_errors

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -581,8 +581,7 @@ module.exports = class Exchange {
         // override me
     }
 
-    defaultErrorHandler (response, responseBody, url, method) {
-        const { status: code, statusText: reason } = response
+    defaultErrorHandler (code, reason, responseBody, url, method) {
         if ((code >= 200) && (code <= 299))
             return
         let ErrorClass = undefined
@@ -648,7 +647,7 @@ module.exports = class Exchange {
                 console.log ("handleRestResponse:\n", this.id, method, url, response.status, response.statusText, "\nResponse:\n", responseHeaders, "\n", responseBody, "\n")
 
             this.handleErrors (response.status, response.statusText, url, method, responseHeaders, responseBody, json)
-            this.defaultErrorHandler (response, responseBody, url, method)
+            this.defaultErrorHandler (response.status, response.statusText, responseBody, url, method)
 
             return json || responseBody
         })

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1284,8 +1284,6 @@ class Exchange {
                 throw new RequestTimeout(implode(' ', array($url, $method, $curl_errno, $curl_error)));
             }
 
-            // var_dump ($result);
-
             // all sorts of SSL problems, accessibility
             throw new ExchangeNotAvailable(implode(' ', array($url, $method, $curl_errno, $curl_error)));
         }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1281,34 +1281,35 @@ class Exchange {
 
         if ($result === false) {
             if ($curl_errno == 28) { // CURLE_OPERATION_TIMEDOUT
-                throw new RequestTimeout(join(' ', array($url, $method, $curl_errno, $curl_error)));
+                throw new RequestTimeout(implode(' ', array($url, $method, $curl_errno, $curl_error)));
             }
 
             // var_dump ($result);
 
             // all sorts of SSL problems, accessibility
-            throw new ExchangeNotAvailable(join(' ', array($url, $method, $curl_errno, $curl_error)));
+            throw new ExchangeNotAvailable(implode(' ', array($url, $method, $curl_errno, $curl_error)));
         }
 
         $string_code = (string) $http_status_code;
 
         if (array_key_exists($string_code, $this->httpExceptions)) {
-            $details = '(possible reasons: ' . implode(', ', array(
-                    'invalid API keys',
-                    'bad or old nonce',
-                    'exchange is down or offline',
-                    'on maintenance',
-                    'DDoS protection',
-                    'rate-limiting in effect',
-                )) . ')';
             $error_class = $this->httpExceptions[$string_code];
             if ($error_class === 'ExchangeNotAvailable') {
                 if (preg_match('#cloudflare|incapsula|overload|ddos#i', $result)) {
-                    throw new DDoSProtection(join(' ', array($url, $method, $http_status_code, $result, $details)));
+                    throw new DDoSProtection(implode(' ', array($url, $method, $http_status_code, $result)));
                 }
+                $details = '(possible reasons: ' . implode(', ', array(
+                        'invalid API keys',
+                        'bad or old nonce',
+                        'exchange is down or offline',
+                        'on maintenance',
+                        'DDoS protection',
+                        'rate-limiting in effect',
+                    )) . ')';
+                throw new ExchangeNotAvailable(implode(' ', array($url, $method, $http_status_code, $result, $details)));
             }
             $namespaced = 'ccxt\\' . $error_class;
-            throw new $namespaced(join(' ', array($url, $method, $http_status_code, $result)));
+            throw new $namespaced(implode(' ', array($url, $method, $http_status_code, $result)));
         }
 
         if (!$json_response) {
@@ -1328,7 +1329,7 @@ class Exchange {
             }
             if ($error_class !== null) {
                 $namespaced = 'ccxt\\' . $error_class;
-                throw new $namespaced(join(' ', array($url, $method, $http_status_code, 'not accessible from this location at the moment', $details)));
+                throw new $namespaced(implode(' ', array($url, $method, $http_status_code, 'not accessible from this location at the moment', $details)));
             }
         }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1307,7 +1307,8 @@ class Exchange {
                     throw new DDoSProtection(join(' ', array($url, $method, $http_status_code, $result, $details)));
                 }
             }
-            throw new ('ccxt\\' . $error_class)(join(' ', array($url, $method, $http_status_code, $result)));
+            $namespaced = 'ccxt\\' . $error_class;
+            throw new $namespaced(join(' ', array($url, $method, $http_status_code, $result)));
         }
 
         if (!$json_response) {
@@ -1326,7 +1327,8 @@ class Exchange {
                 $error_class = 'DDosProtection';
             }
             if ($error_class !== null) {
-                throw new ('ccxt\\' . $error_class)(join(' ', array($url, $method, $http_status_code, 'not accessible from this location at the moment', $details)));
+                $namespaced = 'ccxt\\' . $error_class;
+                throw new $namespaced(join(' ', array($url, $method, $http_status_code, 'not accessible from this location at the moment', $details)));
             }
         }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1307,7 +1307,7 @@ class Exchange {
                     throw new DDoSProtection(join(' ', array($url, $method, $http_status_code, $result, $details)));
                 }
             }
-            throw new $error_class(join(' ', array($url, $method, $http_status_code, $result)));
+            throw new ('ccxt\\' . $error_class)(join(' ', array($url, $method, $http_status_code, $result)));
         }
 
         if (!$json_response) {
@@ -1326,7 +1326,7 @@ class Exchange {
                 $error_class = 'DDosProtection';
             }
             if ($error_class !== null) {
-                throw new $error_class(join(' ', array($url, $method, $http_status_code, 'not accessible from this location at the moment', $details)));
+                throw new ('ccxt\\' . $error_class)(join(' ', array($url, $method, $http_status_code, 'not accessible from this location at the moment', $details)));
             }
         }
 

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -153,16 +153,16 @@ class Exchange(BaseExchange):
                 self.logger.debug("%s %s, Response: %s %s %s", method, url, http_status_code, headers, http_response)
 
         except socket.gaierror as e:
-            raise ExchangeNotAvailable(method + ' ' + url) from e
+            raise ExchangeNotAvailable(method + ' ' + url)
 
         except concurrent.futures._base.TimeoutError as e:
-            raise RequestTimeout(method + ' ' + url) from e
+            raise RequestTimeout(method + ' ' + url)
 
         except aiohttp.client_exceptions.ClientConnectionError as e:
-            raise ExchangeNotAvailable(method + ' ' + url) from e
+            raise ExchangeNotAvailable(method + ' ' + url)
 
         except aiohttp.client_exceptions.ClientError as e:  # base exception class
-            raise ExchangeError(method + ' ' + url) from e
+            raise ExchangeError(method + ' ' + url)
 
         self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
         self.handle_rest_errors(http_status_code, http_status_text, http_response, url, method)

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -127,6 +127,10 @@ class Exchange(BaseExchange):
         encoded_body = body.encode() if body else None
         session_method = getattr(self.session, method.lower())
 
+        http_response = None
+        http_status_code = None
+        http_status_text = None
+        json_response = None
         try:
             async with session_method(yarl.URL(url, encoded=True),
                                       data=encoded_body,

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -127,9 +127,6 @@ class Exchange(BaseExchange):
         encoded_body = body.encode() if body else None
         session_method = getattr(self.session, method.lower())
 
-        response = None
-        http_response = None
-        json_response = None
         try:
             async with session_method(yarl.URL(url, encoded=True),
                                       data=encoded_body,
@@ -137,7 +134,9 @@ class Exchange(BaseExchange):
                                       timeout=(self.timeout / 1000),
                                       proxy=self.aiohttp_proxy) as response:
                 http_response = await response.text()
-                json_response = self.parse_json(http_response) if self.is_json_encoded_object(http_response) else None
+                http_status_code = response.status
+                http_status_text = response.reason
+                json_response = self.parse_json(http_response)
                 headers = response.headers
                 if self.enableLastHttpResponse:
                     self.last_http_response = http_response
@@ -146,23 +145,23 @@ class Exchange(BaseExchange):
                 if self.enableLastJsonResponse:
                     self.last_json_response = json_response
                 if self.verbose:
-                    print("\nResponse:", method, url, response.status, headers, http_response)
-                self.logger.debug("%s %s, Response: %s %s %s", method, url, response.status, headers, http_response)
+                    print("\nResponse:", method, url, http_status_code, headers, http_response)
+                self.logger.debug("%s %s, Response: %s %s %s", method, url, http_status_code, headers, http_response)
 
         except socket.gaierror as e:
-            self.raise_error(ExchangeNotAvailable, url, method, e, None)
+            raise ExchangeNotAvailable(method + ' ' + url) from e
 
         except concurrent.futures._base.TimeoutError as e:
-            self.raise_error(RequestTimeout, method, url, e, None)
+            raise RequestTimeout(method + ' ' + url) from e
 
         except aiohttp.client_exceptions.ClientConnectionError as e:
-            self.raise_error(ExchangeNotAvailable, url, method, e, None)
+            raise ExchangeNotAvailable(method + ' ' + url) from e
 
         except aiohttp.client_exceptions.ClientError as e:  # base exception class
-            self.raise_error(ExchangeError, url, method, e, None)
+            raise ExchangeError(method + ' ' + url) from e
 
-        self.handle_errors(response.status, response.reason, url, method, headers, http_response, json_response)
-        self.handle_rest_errors(None, response.status, http_response, url, method)
+        self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
+        self.handle_rest_errors(http_status_code, http_status_text, http_response, url, method)
         self.handle_rest_response(http_response, json_response, url, method, headers, body)
         if json_response is not None:
             return json_response
@@ -245,7 +244,7 @@ class Exchange(BaseExchange):
 
     async def fetch_ohlcv(self, symbol, timeframe='1m', since=None, limit=None, params={}):
         if not self.has['fetchTrades']:
-            self.raise_error(NotSupported, details='fetch_ohlcv() not implemented yet')
+            raise NotSupported('fetch_ohlcv() not implemented yet')
         await self.load_markets()
         trades = await self.fetch_trades(symbol, since, limit, params)
         return self.build_ohlcv(trades, timeframe, since, limit)
@@ -258,16 +257,16 @@ class Exchange(BaseExchange):
 
     async def edit_order(self, id, symbol, *args):
         if not self.enableRateLimit:
-            self.raise_error(ExchangeError, details='updateOrder() requires enableRateLimit = true')
+            raise ExchangeError('updateOrder() requires enableRateLimit = true')
         await self.cancel_order(id, symbol)
         return await self.create_order(symbol, *args)
 
     async def fetch_trading_fees(self, params={}):
-        self.raise_error(NotSupported, details='fetch_trading_fees() not supported yet')
+        raise NotSupported('fetch_trading_fees() not supported yet')
 
     async def fetch_trading_fee(self, symbol, params={}):
         if not self.has['fetchTradingFees']:
-            self.raise_error(NotSupported, details='fetch_trading_fee() not supported yet')
+            raise NotSupported('fetch_trading_fee() not supported yet')
         return await self.fetch_trading_fees(params)
 
     async def load_trading_limits(self, symbols=None, reload=False, params={}):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -570,7 +570,7 @@ class Exchange(object):
                 if re.search('(cloudflare|incapsula|overload|ddos)', body, flags=re.IGNORECASE):
                     error = DDoSProtection
         if error:
-            raise error(method + ' ' + url + ' ' + string_code + ' ' + http_status_text + ' ' + body)
+            raise error(' '.join([method, url, string_code, http_status_text, body]))
 
     def handle_rest_response(self, response, json_response, url, method='GET', headers=None, body=None):
         if self.is_json_encoded_object(response) and json_response is None:

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -556,7 +556,7 @@ class Exchange(object):
                 raise ExchangeError(method + ' ' + url) from e
 
         self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
-        self.handle_rest_response(http_response, json_response, url, method, headers, body)
+        self.handle_rest_response(http_response, json_response, url, method)
         if json_response is not None:
             return json_response
         return http_response
@@ -572,7 +572,7 @@ class Exchange(object):
         if error:
             raise error(' '.join([method, url, string_code, http_status_text, body]))
 
-    def handle_rest_response(self, response, json_response, url, method='GET', headers=None, body=None):
+    def handle_rest_response(self, response, json_response, url, method):
         if self.is_json_encoded_object(response) and json_response is None:
             ddos_protection = re.search('(cloudflare|incapsula|overload|ddos)', response, flags=re.IGNORECASE)
             exchange_not_available = re.search('(offline|busy|retry|wait|unavailable|maintain|maintenance|maintenancing)', response, flags=re.IGNORECASE)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -503,6 +503,10 @@ class Exchange(object):
 
         self.session.cookies.clear()
 
+        http_response = None
+        http_status_code = None
+        http_status_text = None
+        json_response = None
         try:
             response = self.session.request(
                 method,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -248,7 +248,6 @@ class Exchange(object):
         'fetchCurrencies': False,
         'fetchDepositAddress': False,
         'fetchDeposits': False,
-        'fetchFundingFees': False,
         'fetchL2OrderBook': True,
         'fetchLedger': False,
         'fetchMarkets': True,
@@ -436,12 +435,6 @@ class Exchange(object):
                     setattr(cls, camelcase, to_bind)
                     setattr(cls, underscore, to_bind)
 
-    def raise_error(self, exception_type, url=None, method=None, error=None, details=None):
-        if error:
-            error = str(error)
-        output = ' '.join([self.id] + [var for var in (url, method, error, details) if var is not None])
-        raise exception_type(output)
-
     def throttle(self):
         now = float(self.milliseconds())
         elapsed = now - self.lastRestRequestTimestamp
@@ -510,9 +503,6 @@ class Exchange(object):
 
         self.session.cookies.clear()
 
-        response = None
-        http_response = None
-        json_response = None
         try:
             response = self.session.request(
                 method,
@@ -524,7 +514,9 @@ class Exchange(object):
                 verify=self.verify
             )
             http_response = response.text
-            json_response = self.parse_json(http_response) if self.is_json_encoded_object(http_response) else None
+            http_status_code = response.status_code
+            http_status_text = response.reason
+            json_response = self.parse_json(http_response)
             headers = response.headers
             # FIXME remove last_x_responses from subclasses
             if self.enableLastHttpResponse:
@@ -534,58 +526,58 @@ class Exchange(object):
             if self.enableLastResponseHeaders:
                 self.last_response_headers = headers
             if self.verbose:
-                print("\nResponse:", method, url, response.status_code, headers, http_response)
-            self.logger.debug("%s %s, Response: %s %s %s", method, url, response.status_code, headers, http_response)
+                print("\nResponse:", method, url, http_status_code, headers, http_response)
+            self.logger.debug("%s %s, Response: %s %s %s", method, url, http_status_code, headers, http_response)
             response.raise_for_status()
 
         except Timeout as e:
-            self.raise_error(RequestTimeout, method, url, e)
+            raise RequestTimeout(method + ' ' + url) from e
 
         except TooManyRedirects as e:
-            self.raise_error(ExchangeError, url, method, e)
+            raise ExchangeError(method + ' ' + url) from e
 
         except SSLError as e:
-            self.raise_error(ExchangeError, url, method, e)
+            raise ExchangeError(method + ' ' + url) from e
 
         except HTTPError as e:
-            self.handle_errors(response.status_code, response.reason, url, method, headers, http_response, json_response)
-            self.handle_rest_errors(e, response.status_code, http_response, url, method)
-            self.raise_error(ExchangeError, url, method, e, http_response)
+            self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
+            self.handle_rest_errors(http_status_code, http_status_text, http_response, url, method)
+            raise ExchangeError(method + ' ' + url) from e
 
         except RequestException as e:  # base exception class
             error_string = str(e)
             if ('ECONNRESET' in error_string) or ('Connection aborted.' in error_string):
-                self.raise_error(NetworkError, url, method, e)
+                raise NetworkError(method + ' ' + url) from e
             else:
-                self.raise_error(ExchangeError, url, method, e)
+                raise ExchangeError(method + ' ' + url) from e
 
-        self.handle_errors(response.status_code, response.reason, url, method, headers, http_response, json_response)
+        self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
         self.handle_rest_response(http_response, json_response, url, method, headers, body)
         if json_response is not None:
             return json_response
         return http_response
 
-    def handle_rest_errors(self, exception, http_status_code, response, url, method='GET'):
+    def handle_rest_errors(self, http_status_code, http_status_text, body, url, method):
         error = None
         string_code = str(http_status_code)
         if string_code in self.httpExceptions:
             error = self.httpExceptions[string_code]
             if error == ExchangeNotAvailable:
-                if re.search('(cloudflare|incapsula|overload|ddos)', response, flags=re.IGNORECASE):
+                if re.search('(cloudflare|incapsula|overload|ddos)', body, flags=re.IGNORECASE):
                     error = DDoSProtection
         if error:
-            self.raise_error(error, url, method, exception if exception else http_status_code, response)
+            raise error(method + ' ' + url + ' ' + string_code + ' ' + http_status_text + ' ' + body)
 
     def handle_rest_response(self, response, json_response, url, method='GET', headers=None, body=None):
         if self.is_json_encoded_object(response) and json_response is None:
             ddos_protection = re.search('(cloudflare|incapsula|overload|ddos)', response, flags=re.IGNORECASE)
             exchange_not_available = re.search('(offline|busy|retry|wait|unavailable|maintain|maintenance|maintenancing)', response, flags=re.IGNORECASE)
             if ddos_protection:
-                self.raise_error(DDoSProtection, method, url, None, response)
+                raise DDoSProtection(' '.join([method, url, response]))
             if exchange_not_available:
                 message = response + ' exchange downtime, exchange closed for maintenance or offline, DDoS protection or rate-limiting in effect'
-                self.raise_error(ExchangeNotAvailable, method, url, None, message)
-            self.raise_error(ExchangeError, method, url, ValueError('failed to decode json'), response)
+                raise ExchangeNotAvailable(' '.join([method, url, response, message]))
+            raise ExchangeError(' '.join([method, url, response])) from ValueError('failed to decode json')
 
     def parse_json(self, http_response):
         try:
@@ -1042,16 +1034,16 @@ class Exchange(object):
         for key in keys:
             if self.requiredCredentials[key] and not getattr(self, key):
                 if error:
-                    self.raise_error(AuthenticationError, details='requires `' + key + '`')
+                    raise AuthenticationError('requires `' + key + '`')
                 else:
                     return error
 
     def check_address(self, address):
         """Checks an address is not the same character repeated or an empty sequence"""
         if address is None:
-            self.raise_error(InvalidAddress, details='address is None')
+            raise InvalidAddress('address is None')
         if all(letter == address[0] for letter in address) or len(address) < self.minFundingAddressLength or ' ' in address:
-            self.raise_error(InvalidAddress, details='address is invalid or has less than ' + str(self.minFundingAddressLength) + ' characters: "' + str(address) + '"')
+            raise InvalidAddress('address is invalid or has less than ' + str(self.minFundingAddressLength) + ' characters: "' + str(address) + '"')
         return address
 
     def account(self):
@@ -1192,16 +1184,16 @@ class Exchange(object):
         }
 
     def create_order(self, symbol, type, side, amount, price=None, params={}):
-        self.raise_error(NotSupported, details='create_order() not supported yet')
+        raise NotSupported('create_order() not supported yet')
 
     def cancel_order(self, id, symbol=None, params={}):
-        self.raise_error(NotSupported, details='cancel_order() not supported yet')
+        raise NotSupported('cancel_order() not supported yet')
 
     def fetch_bids_asks(self, symbols=None, params={}):
-        self.raise_error(NotSupported, details='API does not allow to fetch all prices at once with a single call to fetch_bids_asks() for now')
+        raise NotSupported('API does not allow to fetch all prices at once with a single call to fetch_bids_asks() for now')
 
     def fetch_tickers(self, symbols=None, params={}):
-        self.raise_error(NotSupported, details='API does not allow to fetch all tickers at once with a single call to fetch_tickers() for now')
+        raise NotSupported('API does not allow to fetch all tickers at once with a single call to fetch_tickers() for now')
 
     def fetch_order_status(self, id, symbol=None, params={}):
         order = self.fetch_order(id, symbol, params)
@@ -1214,31 +1206,31 @@ class Exchange(object):
         return self.orders
 
     def fetch_order(self, id, symbol=None, params={}):
-        self.raise_error(NotSupported, details='fetch_order() is not supported yet')
+        raise NotSupported('fetch_order() is not supported yet')
 
     def fetch_orders(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_orders() is not supported yet')
+        raise NotSupported('fetch_orders() is not supported yet')
 
     def fetch_open_orders(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_open_orders() is not supported yet')
+        raise NotSupported('fetch_open_orders() is not supported yet')
 
     def fetch_closed_orders(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_closed_orders() is not supported yet')
+        raise NotSupported('fetch_closed_orders() is not supported yet')
 
     def fetch_my_trades(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_my_trades() is not supported yet')
+        raise NotSupported('fetch_my_trades() is not supported yet')
 
     def fetch_order_trades(self, id, symbol=None, params={}):
-        self.raise_error(NotSupported, details='fetch_order_trades() is not supported yet')
+        raise NotSupported('fetch_order_trades() is not supported yet')
 
     def fetch_transactions(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_transactions() is not supported yet')
+        raise NotSupported('fetch_transactions() is not supported yet')
 
     def fetch_deposits(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_deposits() is not supported yet')
+        raise NotSupported('fetch_deposits() is not supported yet')
 
     def fetch_withdrawals(self, symbol=None, since=None, limit=None, params={}):
-        self.raise_error(NotSupported, details='fetch_withdrawals() is not supported yet')
+        raise NotSupported('fetch_withdrawals() is not supported yet')
 
     def parse_ohlcv(self, ohlcv, market=None, timeframe='1m', since=None, limit=None):
         return ohlcv[0:6] if isinstance(ohlcv, list) else ohlcv
@@ -1273,7 +1265,7 @@ class Exchange(object):
                     if (price_key in bidask) and (amount_key in bidask) and (bidask[price_key] and bidask[amount_key]):
                         result.append(self.parse_bid_ask(bidask, price_key, amount_key))
             else:
-                self.raise_error(ExchangeError, details='unrecognized bidask format: ' + str(bidasks[0]))
+                raise ExchangeError('unrecognized bidask format: ' + str(bidasks[0]))
         return result
 
     def fetch_l2_order_book(self, symbol, limit=None, params={}):
@@ -1332,19 +1324,19 @@ class Exchange(object):
         return self.fetch_partial_balance('total', params)
 
     def fetch_trading_fees(self, symbol, params={}):
-        self.raise_error(NotSupported, details='fetch_trading_fees() not supported yet')
+        raise NotSupported('fetch_trading_fees() not supported yet')
 
     def fetch_trading_fee(self, symbol, params={}):
         if not self.has['fetchTradingFees']:
-            self.raise_error(NotSupported, details='fetch_trading_fee() not supported yet')
+            raise NotSupported('fetch_trading_fee() not supported yet')
         return self.fetch_trading_fees(params)
 
     def fetch_funding_fees(self, params={}):
-        self.raise_error(NotSupported, details='fetch_funding_fees() not supported yet')
+        raise NotSupported('fetch_funding_fees() not supported yet')
 
     def fetch_funding_fee(self, code, params={}):
         if not self.has['fetchFundingFees']:
-            self.raise_error(NotSupported, details='fetch_funding_fee() not supported yet')
+            raise NotSupported('fetch_funding_fee() not supported yet')
         return self.fetch_funding_fees(params)
 
     def load_trading_limits(self, symbols=None, reload=False, params={}):
@@ -1359,7 +1351,7 @@ class Exchange(object):
 
     def fetch_ohlcv(self, symbol, timeframe='1m', since=None, limit=None, params={}):
         if not self.has['fetchTrades']:
-            self.raise_error(NotSupported, details='fetch_ohlcv() not supported yet')
+            raise NotSupported('fetch_ohlcv() not supported yet')
         self.load_markets()
         trades = self.fetch_trades(symbol, since, limit, params)
         return self.build_ohlcv(trades, timeframe, since, limit)
@@ -1543,14 +1535,14 @@ class Exchange(object):
 
     def currency(self, code):
         if not self.currencies:
-            self.raise_error(ExchangeError, details='Currencies not loaded')
+            raise ExchangeError('Currencies not loaded')
         if isinstance(code, basestring) and (code in self.currencies):
             return self.currencies[code]
-        self.raise_error(ExchangeError, details='Does not have currency code ' + str(code))
+        raise ExchangeError('Does not have currency code ' + str(code))
 
     def find_market(self, string):
         if not self.markets:
-            self.raise_error(ExchangeError, details='Markets not loaded')
+            raise ExchangeError('Markets not loaded')
         if isinstance(string, basestring):
             if string in self.markets_by_id:
                 return self.markets_by_id[string]
@@ -1567,10 +1559,10 @@ class Exchange(object):
 
     def market(self, symbol):
         if not self.markets:
-            self.raise_error(ExchangeError, details='Markets not loaded')
+            raise ExchangeError('Markets not loaded')
         if isinstance(symbol, basestring) and (symbol in self.markets):
             return self.markets[symbol]
-        self.raise_error(ExchangeError, details='No market symbol ' + str(symbol))
+        raise ExchangeError('No market symbol ' + str(symbol))
 
     def market_ids(self, symbols):
         return [self.market_id(symbol) for symbol in symbols]
@@ -1601,7 +1593,7 @@ class Exchange(object):
 
     def edit_order(self, id, symbol, *args):
         if not self.enableRateLimit:
-            self.raise_error(ExchangeError, details='edit_order() requires enableRateLimit = true')
+            raise ExchangeError('edit_order() requires enableRateLimit = true')
         self.cancel_order(id, symbol)
         return self.create_order(symbol, *args)
 
@@ -1683,7 +1675,7 @@ class Exchange(object):
 
     def fromWei(self, amount, unit='ether', decimals=18):
         if Web3 is None:
-            self.raise_error(NotSupported, details="ethereum web3 methods require Python 3: https://pythonclock.org")
+            raise NotSupported("ethereum web3 methods require Python 3: https://pythonclock.org")
         if amount is None:
             return amount
         if decimals != 18:
@@ -1695,7 +1687,7 @@ class Exchange(object):
 
     def toWei(self, amount, unit='ether', decimals=18):
         if Web3 is None:
-            self.raise_error(NotSupported, details="ethereum web3 methods require Python 3: https://pythonclock.org")
+            raise NotSupported("ethereum web3 methods require Python 3: https://pythonclock.org")
         if amount is None:
             return amount
         if decimals != 18:

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -582,6 +582,7 @@ class Exchange(object):
                 message = response + ' exchange downtime, exchange closed for maintenance or offline, DDoS protection or rate-limiting in effect'
                 raise ExchangeNotAvailable(' '.join([method, url, response, message]))
             raise ExchangeError(' '.join([method, url, response]))
+
     def parse_json(self, http_response):
         try:
             if Exchange.is_json_encoded_object(http_response):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -535,25 +535,25 @@ class Exchange(object):
             response.raise_for_status()
 
         except Timeout as e:
-            raise RequestTimeout(method + ' ' + url) from e
+            raise RequestTimeout(method + ' ' + url)
 
         except TooManyRedirects as e:
-            raise ExchangeError(method + ' ' + url) from e
+            raise ExchangeError(method + ' ' + url)
 
         except SSLError as e:
-            raise ExchangeError(method + ' ' + url) from e
+            raise ExchangeError(method + ' ' + url)
 
         except HTTPError as e:
             self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
             self.handle_rest_errors(http_status_code, http_status_text, http_response, url, method)
-            raise ExchangeError(method + ' ' + url) from e
+            raise ExchangeError(method + ' ' + url)
 
         except RequestException as e:  # base exception class
             error_string = str(e)
             if ('ECONNRESET' in error_string) or ('Connection aborted.' in error_string):
-                raise NetworkError(method + ' ' + url) from e
+                raise NetworkError(method + ' ' + url)
             else:
-                raise ExchangeError(method + ' ' + url) from e
+                raise ExchangeError(method + ' ' + url)
 
         self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response)
         self.handle_rest_response(http_response, json_response, url, method)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -581,8 +581,7 @@ class Exchange(object):
             if exchange_not_available:
                 message = response + ' exchange downtime, exchange closed for maintenance or offline, DDoS protection or rate-limiting in effect'
                 raise ExchangeNotAvailable(' '.join([method, url, response, message]))
-            raise ExchangeError(' '.join([method, url, response])) from ValueError('failed to decode json')
-
+            raise ExchangeError(' '.join([method, url, response]))
     def parse_json(self, http_response):
         try:
             if Exchange.is_json_encoded_object(http_response):

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -11,12 +11,12 @@ commands =
 
 [testenv:qa]
 basepython = python3
-changedir=..
+changedir = {toxinidir}
 commands = flake8
 deps = .[qa]
 
 [testenv:doc]
-changedir=../doc
+changedir = {toxinidir}/../doc
 deps = .[doc]
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -11,12 +11,12 @@ commands =
 
 [testenv:qa]
 basepython = python3
-changedir = {toxinidir}
+changedir=..
 commands = flake8
 deps = .[qa]
 
 [testenv:doc]
-changedir = {toxinidir}/../doc
+changedir=../doc
 deps = .[doc]
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
the old code was not present in javascript and was not unified. the new raise_error will add properties from the arguments of `handle_errors` to the errors so that they can be read by the user.

i also think the old `raise_error` was useless and made the code harder to read.