### PR TITLE
Bitfinex symbol mismatch - AMPL token

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -276,6 +276,7 @@ module.exports = class bitfinex extends Exchange {
             'commonCurrencies': {
                 'ABS': 'ABYSS',
                 'AIO': 'AION',
+                'AMP': 'AMPL',
                 'ATM': 'ATMI',
                 'ATO': 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
                 'BAB': 'BCH',

--- a/php/bitfinex.php
+++ b/php/bitfinex.php
@@ -278,6 +278,7 @@ class bitfinex extends Exchange {
                 'AIO' => 'AION',
                 'ATM' => 'ATMI',
                 'ATO' => 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
+                'AMP' => 'AMPL',
                 'BAB' => 'BCH',
                 'CTX' => 'CTXC',
                 'DAD' => 'DADI',

--- a/python/ccxt/bitfinex.py
+++ b/python/ccxt/bitfinex.py
@@ -290,6 +290,7 @@ class bitfinex (Exchange):
             'commonCurrencies': {
                 'ABS': 'ABYSS',
                 'AIO': 'AION',
+                'AMP': 'AMPL',
                 'ATM': 'ATMI',
                 'ATO': 'ATOM',  # https://github.com/ccxt/ccxt/issues/5118
                 'BAB': 'BCH',


### PR DESCRIPTION
The symbol `AMP` listed on bitfinex corresponds to the AMPL (Ampleforth protocol) token.

https://etherscan.io/token/0xd46ba6d942050d489dbd938a2c909a5d5039a161
ampleforth.org