### PR TITLE
Fixed aiohttp_trust_env var not being passed to async_support.Exchange (python). fix #5403 fix #3854

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -49,6 +49,7 @@ class Exchange(BaseExchange):
         if 'asyncio_loop' in config:
             self.asyncio_loop = config['asyncio_loop']
         self.asyncio_loop = self.asyncio_loop or asyncio.get_event_loop()
+        self.aiohttp_trust_env = config.get('aiohttp_trust_env', self.aiohttp_trust_env)
         self.verify = config.get('verify', self.verify)
         self.own_session = 'session' not in config
         self.cafile = config.get('cafile', certifi.where())


### PR DESCRIPTION
Fixed bug for issue #5403. Followed same logic @kroitor used on [212872a](https://github.com/ccxt/ccxt/commit/212872a8d63effda3097d110d0b243a34330dda7).