### PR TITLE
bittrex since filters too many orders

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1122,7 +1122,7 @@ module.exports = class Exchange {
         if (valueIsDefined || sinceIsDefined)
             array = Object.values (array).filter (entry =>
                 ((valueIsDefined ? (entry[field] === value)   : true) &&
-                 (sinceIsDefined ? (entry.timestamp >= since) : true)))
+                    (sinceIsDefined ? (entry.timestamp >= since || entry.lastTradeTimestamp >= since) : true)))
 
         if (limit !== undefined && limit !== null)
             array = Object.values (array).slice (0, limit)

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1121,8 +1121,8 @@ module.exports = class Exchange {
         // single-pass filter for both symbol and since
         if (valueIsDefined || sinceIsDefined)
             array = Object.values (array).filter (entry =>
-                ((valueIsDefined ? (entry[field] === value)   : true) &&
-                    (sinceIsDefined ? (entry.timestamp >= since || entry.lastTradeTimestamp >= since) : true)))
+                (valueIsDefined ? (entry[field] === value) : true) &&
+                (sinceIsDefined ? (entry.timestamp >= since || entry.lastTradeTimestamp >= since) : true))
 
         if (limit !== undefined && limit !== null)
             array = Object.values (array).slice (0, limit)

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1734,7 +1734,8 @@ class Exchange {
         $sinceIsSet = isset($since);
         $array = array_filter($array, function ($element) use ($valueIsSet, $value, $sinceIsSet, $since, $field) {
             return ($valueIsSet ? ($element[$field] === $value) : true) &&
-                    ($sinceIsSet ? ($element['timestamp'] >= $since) : true);
+                    ($sinceIsSet ? ($element['timestamp'] >= $since ||
+                        (array_key_exists ('lastTradeTimestamp', $element) && $element['lastTradeTimestamp'] >= $since)) : true);
         });
         return array_slice($array, 0, isset($limit) ? $limit : count($array));
     }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1500,7 +1500,8 @@ class Exchange(object):
         if value:
             array = [entry for entry in array if entry[field] == value]
         if since:
-            array = [entry for entry in array if entry['timestamp'] >= since]
+            array = [entry for entry in array if entry['timestamp'] >= since
+                     or entry.get('lastTradeTimestamp', -1) >= since]
         if limit:
             array = array[0:limit]
         return array


### PR DESCRIPTION
its a bit tacky, however I couldn't think of a better way to solve this issue. I think it may help with the same issue of since using closedAt on other exchanges. And ultimately I wanted to retain the created time information in the `timestamp`. 