### PR TITLE
bittrex filter closed orders

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -851,18 +851,9 @@ module.exports = class bittrex extends Exchange {
     parseOrders (orders, market = undefined, since = undefined, limit = undefined, params = {}) {
         if (this.options['fetchClosedOrdersFilterBySince']) {
             return super.parseOrders (orders, market, since, limit, params);
+        } else {
+            return super.parseOrders (orders, market, undefined, limit, params);
         }
-        const filtered = [];
-        for (let i = 0; i < orders.length; i++) {
-            const order = orders[i];
-            const parsed = this.extend (this.parseOrder (order, market));
-            if (parsed['lastTradeTimestamp'] >= since) {
-                filtered.push (parsed);
-            }
-        }
-        const result = this.sortBy (filtered, 'timestamp');
-        const symbol = (market !== undefined) ? market['symbol'] : undefined;
-        return this.filterBySymbolSinceLimit (result, symbol, undefined, limit);
     }
 
     parseOrderStatus (status) {


### PR DESCRIPTION
took into consideration what you said [here](https://github.com/ccxt/ccxt/pull/5419#issuecomment-507664683).

adds an option to filter by `closed_at` which is the same as the filtering done by bittrex, allowing pagination by date like specified in the manual.