### PR TITLE
FIX: tidebit fetch_ohlcv can return 'null'

### DIFF
--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -339,6 +339,9 @@ module.exports = class tidebit extends Exchange {
             request['timestamp'] = 1800000;
         }
         const response = await this.publicGetK (this.extend (request, params));
+        if (response === 'null') {
+            return [];
+        }
         return this.parseOHLCVs (response, market, timeframe, since, limit);
     }
 


### PR DESCRIPTION
This can be tested in js with:
`let result = await exchange.fetchOHLCV('CNX/USX', '1m', 12345, 300)`
This will result in:
```
[ [ NaN, undefined, undefined, undefined, undefined, undefined ],                                                             
  [ NaN, undefined, undefined, undefined, undefined, undefined ],                                                             
  [ NaN, undefined, undefined, undefined, undefined, undefined ],                                                             
  [ NaN, undefined, undefined, undefined, undefined, undefined ] ]       
```