### PR TITLE
Fix Gemini base / quote volume parse

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -301,8 +301,8 @@ module.exports = class gemini extends Exchange {
         };
         const ticker = await this.publicGetPubtickerSymbol (this.extend (request, params));
         const timestamp = this.safeInteger (ticker['volume'], 'timestamp');
-        const baseVolume = this.safeFloat (market, 'base');
-        const quoteVolume = this.safeFloat (market, 'quote');
+        const baseCurrency = this.safeString (market, 'base');
+        const quoteCurrency = this.safeString (market, 'quote');
         const last = this.safeFloat (ticker, 'last');
         return {
             'symbol': symbol,
@@ -322,8 +322,8 @@ module.exports = class gemini extends Exchange {
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeFloat (ticker['volume'], baseVolume),
-            'quoteVolume': this.safeFloat (ticker['volume'], quoteVolume),
+            'baseVolume': this.safeFloat (ticker['volume'], baseCurrency),
+            'quoteVolume': this.safeFloat (ticker['volume'], quoteCurrency),
             'info': ticker,
         };
     }

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -301,8 +301,8 @@ module.exports = class gemini extends Exchange {
         };
         const ticker = await this.publicGetPubtickerSymbol (this.extend (request, params));
         const timestamp = this.safeInteger (ticker['volume'], 'timestamp');
-        const baseCurrency = this.safeString (market, 'base');
-        const quoteCurrency = this.safeString (market, 'quote');
+        const baseCurrency = market['base']; // unified structures are guaranteed to have unified fields
+        const quoteCurrency = market['quote']; // so we don't need safe-methods for unified structures
         const last = this.safeFloat (ticker, 'last');
         return {
             'symbol': symbol,


### PR DESCRIPTION
The format for ticker data from the Gemini API is:
```
{
    "ask": "977.59",
    "bid": "977.35",
    "last": "977.65",
    "volume": {
        "BTC": "2210.505328803",
        "USD": "2135477.463379586263",
        "timestamp": 1483018200000
    }
}
```
so this fixes fetching the market info as a string and not a float and
renames a variable to avoid that type of problem in the future.