### PR TITLE
HitBTC commonCurrencies change (remove old BCH)

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -484,7 +484,6 @@ module.exports = class hitbtc extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'BCH': 'Bitcoin Cash',
                 'BET': 'DAO.Casino',
                 'CAT': 'BitClave',
                 'DRK': 'DASH',


### PR DESCRIPTION
They upgraded their currency ids: 
1. BCHABC -> BCH
2. BCHSV -> BSV
3. deleted the old (pre-fork) BCH, which is {'BCH': 'Bitcoin Cash'} in commonCurrencies
This change is necessary because now the old {'BCH': 'Bitcoin Cash'} overwrites the new BCH.