### PR TITLE
Fix: exmo: publicGetTrades can return empty object

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -761,7 +761,8 @@ module.exports = class exmo extends Exchange {
             'pair': market['id'],
         };
         const response = await this.publicGetTrades (this.extend (request, params));
-        return this.parseTrades (response[market['id']], market, since, limit);
+        const data = this.safeValue (response, market['id'], []);
+        return this.parseTrades (data, market, since, limit);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
This happens with symbol: XTZ/USD