### PR TITLE
Ticker Symbol correction

### DIFF
--- a/examples/py/builtin-rate-limiting-long-poller.py
+++ b/examples/py/builtin-rate-limiting-long-poller.py
@@ -19,4 +19,4 @@ exchange = ccxt.bitfinex({
 
 for i in range(0, 10):
     # this can be any call instead of fetch_ticker, really
-    print(exchange.fetch_ticker('BTC/USD'))
+    print(exchange.fetch_ticker('BTC/USDT'))


### PR DESCRIPTION
Ticker Symbol  'BTC/USD' in ``` exchange.fetch_ticker('BTC/USD')```  throws an error ```ccxt.base.errors.ExchangeError: bitfinex No market symbol BTC/USD``` ,  correcting to 'BTC/USDT' so that it does not.