### PR TITLE
add fetchOHLCV support for gemini #5576

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -164,7 +164,6 @@ const pythonRegexes = [
     [ /this\.stringToBase64\s/g, 'base64.b64encode' ],
     [ /this\.base64ToBinary\s/g, 'base64.b64decode' ],
     [ /\.shift\s*\(\)/g, '.pop(0)' ],
-    [ /\.startsWith/g, '.startswith' ],
 
 // insert common regexes in the middle (critical)
 ].concat (commonRegexes).concat ([
@@ -337,7 +336,6 @@ const phpRegexes = [
     [ /this\[([^\]+]+)\]/g, '$$this->$$$1' ],
     [ /([^\s\(]+).slice \(([^\)\:,]+)\)/g, 'mb_substr($1, $2)' ],
     [ /([^\s\(]+).slice \(([^\,\)]+)\,\s*([^\)]+)\)/g, 'mb_substr($1, $2, $3 - $2)' ],
-    [ /('?\w+'?)\.startsWith\s*\(('?\w+'?)\)/g, 'mb_substr($1, 0, strlen($2)) === $2' ],
     [ /([^\s\(]+).split \(('[^']*'|[^\,]+?)\)/g, 'explode($2, $1)' ],
     [ /Math\.floor\s*\(([^\)]+)\)/g, '(int) floor($1)' ],
     [ /Math\.abs\s*\(([^\)]+)\)/g, 'abs ($1)' ],

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -164,6 +164,7 @@ const pythonRegexes = [
     [ /this\.stringToBase64\s/g, 'base64.b64encode' ],
     [ /this\.base64ToBinary\s/g, 'base64.b64decode' ],
     [ /\.shift\s*\(\)/g, '.pop(0)' ],
+    [ /\.startsWith/g, '.startswith' ],
 
 // insert common regexes in the middle (critical)
 ].concat (commonRegexes).concat ([
@@ -336,6 +337,7 @@ const phpRegexes = [
     [ /this\[([^\]+]+)\]/g, '$$this->$$$1' ],
     [ /([^\s\(]+).slice \(([^\)\:,]+)\)/g, 'mb_substr($1, $2)' ],
     [ /([^\s\(]+).slice \(([^\,\)]+)\,\s*([^\)]+)\)/g, 'mb_substr($1, $2, $3 - $2)' ],
+    [ /('?\w+'?)\.startsWith\s*\(('?\w+'?)\)/g, 'mb_substr($1, 0, strlen($2)) === $2' ],
     [ /([^\s\(]+).split \(('[^']*'|[^\,]+?)\)/g, 'explode($2, $1)' ],
     [ /Math\.floor\s*\(([^\)]+)\)/g, '(int) floor($1)' ],
     [ /Math\.abs\s*\(([^\)]+)\)/g, 'abs ($1)' ],

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -67,6 +67,7 @@ module.exports = class gemini extends Exchange {
                         'v1/auction/{symbol}',
                         'v1/auction/{symbol}/history',
                         'v2/candles/{symbol}/{timeframe}',
+                        'v2/ticker/{symbol}',
                     ],
                 },
                 'private': {


### PR DESCRIPTION
also a sidenote: why do we pass `limit` and `timeframe` to `parseOHLCV`, should we not only pass `market` like the other parsers?