### PR TITLE
latoken parseOrder fix

### DIFF
--- a/js/latoken.js
+++ b/js/latoken.js
@@ -582,7 +582,7 @@ module.exports = class latoken extends Exchange {
         //     }
         //
         const id = this.safeString (order, 'orderId');
-        const timestamp = this.safeValue (order, 'timeCreated');
+        const timestamp = this.safeValue (order, 'timeCreated') * 1000;
         const marketId = this.safeString (order, 'symbol');
         let symbol = marketId;
         if (marketId in this.markets_by_id) {
@@ -596,7 +596,7 @@ module.exports = class latoken extends Exchange {
         const price = this.safeFloat (order, 'price');
         const amount = this.safeFloat (order, 'amount');
         const filled = this.safeFloat (order, 'executedAmount');
-        const remaining = this.safeFloat (order, 'reaminingAmount');
+        const remaining = amount - filled;
         const status = this.parseOrderStatus (this.safeString (order, 'orderStatus'));
         let cost = undefined;
         if (filled !== undefined) {


### PR DESCRIPTION
timestamp must be multiplied by 1000

`remaining` don't works properly now, example of closed order:
```
[ { id: '1564223032.671436.707548@1379:1',
    info:
     { orderId: '1564223032.671436.707548@1379:1',
       cliOrdId: '',
       pairId: 1379,
       symbol: 'ZECETH',
       side: 'buy',
       orderType: 'limit',
       price: 0.32874,
       amount: 0.607,
       orderStatus: 'filled',
       executedAmount: 0.607,
       reaminingAmount: 0.607,
       timeCreated: 1564223032,
       timeFilled: 1564223033 },
    timestamp: 1564223032000,
    datetime: '2019-07-27T10:23:52.000Z',
    lastTradeTimestamp: 1564223033,
    status: 'closed',
    symbol: 'ZEC/ETH',
    type: 'limit',
    side: 'buy',
    price: 0.32874,
    cost: 0.19954518,
    amount: 0.607,
    filled: 0.607,
    average: undefined,
    remaining: 0.607,
    fee: undefined } ]
```
I think exchange send the same numbers in `executedAmount` and `reaminingAmount`. In open order I see the same:
```
[ { id: '1564235272.123152.707548@1379:2',
    info:
     { orderId: '1564235272.123152.707548@1379:2',
       cliOrdId: null,
       pairId: 1379,
       symbol: 'ZECETH',
       side: 'sell',
       orderType: 'limit',
       price: 0.33997,
       amount: 0.607,
       orderStatus: 'active',
       executedAmount: 0,
       reaminingAmount: 0,
       timeCreated: 1564235272,
       timeFilled: null },
    timestamp: 1564235272000,
    datetime: '2019-07-27T13:47:52.000Z',
    lastTradeTimestamp: undefined,
    status: 'open',
    symbol: 'ZEC/ETH',
    type: 'limit',
    side: 'sell',
    price: 0.33997,
    cost: 0,
    amount: 0.607,
    filled: 0,
    average: undefined,
    remaining: 0,
    fee: undefined } ]
```

