### PR TITLE
fix typo in fcoin: tradble -> tradeable

### DIFF
--- a/js/fcoin.js
+++ b/js/fcoin.js
@@ -226,7 +226,7 @@ module.exports = class fcoin extends Exchange {
                     'max': undefined,
                 },
             };
-            const active = this.safeValue (market, 'tradable', false);
+            const active = this.safeValue (market, 'tradeable', false);
             result.push ({
                 'id': id,
                 'symbol': symbol,

--- a/php/fcoin.php
+++ b/php/fcoin.php
@@ -227,7 +227,7 @@ class fcoin extends Exchange {
                     'max' => null,
                 ),
             );
-            $active = $this->safe_value($market, 'tradable', false);
+            $active = $this->safe_value($market, 'tradeable', false);
             $result[] = array (
                 'id' => $id,
                 'symbol' => $symbol,

--- a/python/ccxt/async_support/fcoin.py
+++ b/python/ccxt/async_support/fcoin.py
@@ -236,7 +236,7 @@ class fcoin (Exchange):
                     'max': None,
                 },
             }
-            active = self.safe_value(market, 'tradable', False)
+            active = self.safe_value(market, 'tradeable', False)
             result.append({
                 'id': id,
                 'symbol': symbol,

--- a/python/ccxt/fcoin.py
+++ b/python/ccxt/fcoin.py
@@ -236,7 +236,7 @@ class fcoin (Exchange):
                     'max': None,
                 },
             }
-            active = self.safe_value(market, 'tradable', False)
+            active = self.safe_value(market, 'tradeable', False)
             result.append({
                 'id': id,
                 'symbol': symbol,


### PR DESCRIPTION
there is a small typo in fcoin : )

`tradble` should be `tradeable`
which would make all markets `active` is false