### PR TITLE
BitMart parseTicker fix

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -282,8 +282,8 @@ module.exports = class bitmart extends Exchange {
             'change': undefined,
             'percentage': percentage * 100,
             'average': undefined,
-            'baseVolume': this.safeFloat (ticker, 'base_volume'),
-            'quoteVolume': this.safeFloat (ticker, 'volume'),
+            'baseVolume': this.safeFloat (ticker, 'volume'),
+            'quoteVolume': this.safeFloat (ticker, 'base_volume'),
             'info': ticker,
         };
     }


### PR DESCRIPTION
They are swapped here

```
{ volume: '194004.8254', //in ETH
     ask_1: '0.018749',
     base_volume: '3599.0080', //in BTC
     lowest_price: '0.018198',
     bid_1: '0.018694',
     highest_price: '0.018800',
     ask_1_amount: '0.9044',
     current_price: '0.018731',
     fluctuation: '+0.0066',
     symbol_id: 'ETH_BTC',
     url: 'https://www.bitmart.com/trade?symbol=ETH_BTC',
     bid_1_amount: '0.8004' }
```