### PR TITLE
example script ohlcv-sequential should not use kraken

### DIFF
--- a/examples/py/fetch-ohlcv-sequentially.py
+++ b/examples/py/fetch-ohlcv-sequentially.py
@@ -22,15 +22,15 @@ hold = 30
 
 # -----------------------------------------------------------------------------
 
-exchange = ccxt.kraken({
-    'rateLimit': 3000,
+exchange = ccxt.binance({
+    'rateLimit': 1000,
     'enableRateLimit': True,
     # 'verbose': True,
 })
 
 # -----------------------------------------------------------------------------
 
-from_datetime = '2017-01-01 00:00:00'
+from_datetime = '2018-01-01 00:00:00'
 from_timestamp = exchange.parse8601(from_datetime)
 
 # -----------------------------------------------------------------------------
@@ -46,7 +46,7 @@ while from_timestamp < now:
     try:
 
         print(exchange.milliseconds(), 'Fetching candles starting from', exchange.iso8601(from_timestamp))
-        ohlcvs = exchange.fetch_ohlcv('BTC/USD', '1m', from_timestamp)
+        ohlcvs = exchange.fetch_ohlcv('ETH/BTC', '1m', from_timestamp)
         print(exchange.milliseconds(), 'Fetched', len(ohlcvs), 'candles')
         first = ohlcvs[0][0]
         last = ohlcvs[-1][0]


### PR DESCRIPTION
Don't use kraken as sample for ohlcv sequential

Kraken is a very bad example for this, since their ohlcv endpoint does not offer any history, only giving back the last 7xx candles (720 per their documentation - but it varies as seen below).

### changes made:
* change exchange from kraken to binance
* change pair to ETH/BTC 
* lower ratelimit for binance (binance accepts async calls with rate-limits as low as `200` - so 1000 will work on the ohlcv endpoint)

Output from kraken (before modification):

```
python examples/py/fetch-ohlcv-sequentially.py 
1565758938698 Fetching candles starting from 2017-01-01T00:00:00.000Z
1565758949173 Fetched 711 candles
First candle epoch 1565715780000 2019-08-13T17:03:00.000Z
Last candle epoch 1565758920000 2019-08-14T05:02:00.000Z
1565758949173 Fetching candles starting from 2017-01-01T11:51:00.000Z
1565758952244 Fetched 707 candles
First candle epoch 1565715780000 2019-08-13T17:03:00.000Z
Last candle epoch 1565758920000 2019-08-14T05:02:00.000Z
1565758952244 Fetching candles starting from 2017-01-01T23:38:00.000Z
1565758954918 Fetched 709 candles
First candle epoch 1565715780000 2019-08-13T17:03:00.000Z
Last candle epoch 1565758920000 2019-08-14T05:02:00.000Z
1565758954918 Fetching candles starting from 2017-01-02T11:27:00.000Z
[...]
```

### output now (from binance)
```
python examples/py/fetch-ohlcv-sequentially.py 
1565758983590 Fetching candles starting from 2018-01-01T00:00:00.000Z
1565758984910 Fetched 500 candles
First candle epoch 1514764800000 2018-01-01T00:00:00.000Z
Last candle epoch 1514794740000 2018-01-01T08:19:00.000Z
1565758984910 Fetching candles starting from 2018-01-01T08:20:00.000Z
1565758986347 Fetched 500 candles
First candle epoch 1514794800000 2018-01-01T08:20:00.000Z
Last candle epoch 1514824740000 2018-01-01T16:39:00.000Z
1565758986348 Fetching candles starting from 2018-01-01T16:40:00.000Z
1565758986962 Fetched 500 candles
First candle epoch 1514824800000 2018-01-01T16:40:00.000Z
Last candle epoch 1514854740000 2018-01-02T00:59:00.000Z
[...]
```