### PR TITLE
Round timeframe

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -863,6 +863,8 @@ function transpileDateTimeTests () {
     const pythonHeader =
 "\n\
 import ccxt  # noqa: F402\n\
+from ccxt.base.decimal_to_precision import ROUND_UP              # noqa F401\n\
+from ccxt.base.decimal_to_precision import ROUND_DOWN            # noqa F401\n\
 \n\
 # ----------------------------------------------------------------------------\n\
 \n"

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -136,6 +136,7 @@ const commonRegexes = [
     [ /\.isJsonEncodedObject\s/g, '.is_json_encoded_object'],
     [ /\.setSandboxMode\s/g, '.set_sandbox_mode'],
     [ /\.safeCurrencyCode\s/g, '.safe_currency_code'],
+    [ /\.roundTimeframe/g, '.round_timeframe'],
     [ /errorHierarchy/g, 'error_hierarchy'],
     [ /\'use strict\';?\s+/g, '' ],
 ]

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -863,8 +863,7 @@ function transpileDateTimeTests () {
     const pythonHeader =
 "\n\
 import ccxt  # noqa: F402\n\
-from ccxt.base.decimal_to_precision import ROUND_UP              # noqa F401\n\
-from ccxt.base.decimal_to_precision import ROUND_DOWN            # noqa F401\n\
+from ccxt.base.decimal_to_precision import ROUND_UP, ROUND_DOWN  # noqa F401\n\
 \n\
 # ----------------------------------------------------------------------------\n\
 \n"

--- a/examples/py/fetch-ohlcv-on-new-candle.py
+++ b/examples/py/fetch-ohlcv-on-new-candle.py
@@ -12,6 +12,7 @@ sys.path.append(root + '/python')
 # -----------------------------------------------------------------------------
 
 import ccxt  # noqa: E402
+from ccxt.base.decimal_to_precision import ROUND_UP  # noqa: E402
 
 # -----------------------------------------------------------------------------
 # common constants
@@ -37,7 +38,7 @@ while True:
     try:
 
         print(exchange.milliseconds(), 'Fetching candles')
-        since = exchange.round_timeframe(timeframe, exchange.milliseconds(), 'up') - (limit * interval)
+        since = exchange.round_timeframe(timeframe, exchange.milliseconds(), ROUND_UP) - (limit * interval)
         ohlcv = exchange.fetch_ohlcv('ETH/BTC', timeframe, since=since, limit=limit)
         print(exchange.milliseconds(), 'Fetched', len(ohlcv), 'candles')
         first = ohlcv[0][0]
@@ -45,7 +46,7 @@ while True:
         print('First candle epoch', first, exchange.iso8601(first))
         print('Last candle epoch', last, exchange.iso8601(last))
         # Calculate time to next candle and sleep for that many seconds
-        sleeptime = (exchange.round_timeframe(timeframe, last, 'up') - exchange.milliseconds()) / 1000
+        sleeptime = (exchange.round_timeframe(timeframe, last, ROUND_UP) - exchange.milliseconds()) / 1000
         print('sleeping for: ', sleeptime, 's', sleeptime // 60, 'min')
         time.sleep(sleeptime)
     except (ccxt.ExchangeError, ccxt.AuthenticationError, ccxt.ExchangeNotAvailable, ccxt.RequestTimeout) as error:

--- a/examples/py/fetch-ohlcv-on-new-candle.py
+++ b/examples/py/fetch-ohlcv-on-new-candle.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import time
+
+# -----------------------------------------------------------------------------
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+# -----------------------------------------------------------------------------
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+# common constants
+
+msec = 1000
+minute = 60 * msec
+hold = 30
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.binance({
+    'rateLimit': 1000,
+    'enableRateLimit': True,
+    # 'verbose': True,
+})
+
+limit = 500
+timeframe = "5m"
+interval = exchange.parse_timeframe(timeframe) * 1000
+
+while True:
+
+    try:
+
+        print(exchange.milliseconds(), 'Fetching candles')
+        since = exchange.round_timeframe(timeframe, exchange.milliseconds(), 'up') - (limit * interval)
+        ohlcv = exchange.fetch_ohlcv('ETH/BTC', timeframe, since=since, limit=limit)
+        print(exchange.milliseconds(), 'Fetched', len(ohlcv), 'candles')
+        first = ohlcv[0][0]
+        last = ohlcv[-1][0]
+        print('First candle epoch', first, exchange.iso8601(first))
+        print('Last candle epoch', last, exchange.iso8601(last))
+        # Calculate time to next candle and sleep for that many seconds
+        sleeptime = (exchange.round_timeframe(timeframe, last, 'up') - exchange.milliseconds()) / 1000
+        print('sleeping for: ', sleeptime, 's', sleeptime // 60, 'min')
+        time.sleep(sleeptime)
+    except (ccxt.ExchangeError, ccxt.AuthenticationError, ccxt.ExchangeNotAvailable, ccxt.RequestTimeout) as error:
+
+        print('Got an error', type(error).__name__, error.args, ', retrying in', hold, 'seconds...')
+        time.sleep(hold)

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const { ROUND_UP, ROUND_DOWN } = require ('./number')
+
 //-------------------------------------------------------------------------
 // converts timeframe to seconds
 const parseTimeframe = (timeframe) => {
 
-    let amount = timeframe.slice (0, -1)
-    let unit = timeframe.slice (-1)
+    const amount = timeframe.slice (0, -1)
+    const unit = timeframe.slice (-1)
     let scale = 60 // 1m by default
 
     if (unit === 'y') {
@@ -23,30 +25,26 @@ const parseTimeframe = (timeframe) => {
     return amount * scale
 }
 
-const roundTimeframe = (timeframe, timestamp, direction = 'down') => {
-    const ms = parseTimeframe(timeframe) * 1000
+const roundTimeframe = (timeframe, timestamp, direction = ROUND_DOWN) => {
+    const ms = parseTimeframe (timeframe) * 1000
     // Get offset based on timeframe in milliseconds
-    let offset = timestamp % ms
-    if (direction === 'up') {
-        return timestamp - offset + ms
-    } else {
-        return timestamp - offset
-    }
+    const offset = timestamp % ms
+    return timestamp - offset + (direction === ROUND_UP) ? ms : 0;
 }
 
 // given a sorted arrays of trades (recent last) and a timeframe builds an array of OHLCV candles
 const buildOHLCVC = (trades, timeframe = '1m', since = -Infinity, limit = Infinity) => {
-    let ms = parseTimeframe (timeframe) * 1000;
-    let ohlcvs = [];
+    const ms = parseTimeframe (timeframe) * 1000;
+    const ohlcvs = [];
     const [ timestamp, /* open */, high, low, close, volume, count ] = [ 0, 1, 2, 3, 4, 5, 6 ];
-    let oldest = Math.min (trades.length - 1, limit);
+    const oldest = Math.min (trades.length - 1, limit);
 
     for (let i = 0; i <= oldest; i++) {
-        let trade = trades[i];
+        const trade = trades[i];
         if (trade.timestamp < since)
             continue;
-        let openingTime = Math.floor (trade.timestamp / ms) * ms; // shift to the edge of m/h/d (but not M)
-        let candle = ohlcvs.length - 1;
+        const openingTime = Math.floor (trade.timestamp / ms) * ms; // shift to the edge of m/h/d (but not M)
+        const candle = ohlcvs.length - 1;
 
         if (candle === -1 || openingTime >= ohlcvs[candle][timestamp] + ms) {
             // moved to a new timeframe -> create a new candle from opening trade
@@ -77,18 +75,19 @@ module.exports = {
 
     aggregate (bidasks) {
 
-        let result = {}
+        const result = {}
 
-        for (const [price, volume] of bidasks) {
-            if (volume > 0)
+        for (let i = 0; i < bidasks.length; i++) {
+            const [ price, volume ] = bidasks[i];
+            if (volume > 0) {
                 result[price] = (result[price] || 0) + volume
+            }
         }
 
         return Object.keys (result).map (price => [parseFloat (price), parseFloat (result[price])])
     },
 
     parseTimeframe,
-    roundTimeframe,
     buildOHLCVC,
 }
 

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -23,7 +23,7 @@ const parseTimeframe = (timeframe) => {
     return amount * scale
 }
 
-const round_timeframe = (timeframe, timestamp, direction = 'down') => {
+const roundTimeframe = (timeframe, timestamp, direction = 'down') => {
     const ms = parseTimeframe(timeframe) * 1000
     // Get offset based on timeframe in milliseconds
     let offset = timestamp % ms
@@ -88,7 +88,7 @@ module.exports = {
     },
 
     parseTimeframe,
-    round_timeframe,
+    roundTimeframe,
     buildOHLCVC,
 }
 

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -29,7 +29,7 @@ const roundTimeframe = (timeframe, timestamp, direction = ROUND_DOWN) => {
     const ms = parseTimeframe (timeframe) * 1000
     // Get offset based on timeframe in milliseconds
     const offset = timestamp % ms
-    return timestamp - offset + (direction === ROUND_UP) ? ms : 0;
+    return timestamp - offset + ((direction === ROUND_UP) ? ms : 0);
 }
 
 // given a sorted arrays of trades (recent last) and a timeframe builds an array of OHLCV candles

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -89,6 +89,8 @@ module.exports = {
 
     parseTimeframe,
     buildOHLCVC,
+    ROUND_UP,
+    ROUND_DOWN
 }
 
 /*  ------------------------------------------------------------------------ */

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -23,6 +23,17 @@ const parseTimeframe = (timeframe) => {
     return amount * scale
 }
 
+const round_timeframe = (timeframe, timestamp, direction = 'down') => {
+    const ms = parseTimeframe(timeframe) * 1000
+    // Get offset based on timeframe in milliseconds
+    let offset = timestamp % ms
+    if (direction === 'up') {
+        return timestamp - offset + ms
+    } else {
+        return timestamp - offset
+    }
+}
+
 // given a sorted arrays of trades (recent last) and a timeframe builds an array of OHLCV candles
 const buildOHLCVC = (trades, timeframe = '1m', since = -Infinity, limit = Infinity) => {
     let ms = parseTimeframe (timeframe) * 1000;
@@ -77,6 +88,7 @@ module.exports = {
     },
 
     parseTimeframe,
+    round_timeframe,
     buildOHLCVC,
 }
 

--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -88,6 +88,7 @@ module.exports = {
     },
 
     parseTimeframe,
+    roundTimeframe,
     buildOHLCVC,
     ROUND_UP,
     ROUND_DOWN

--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { isString, isNumber } = require ('./type')
-const { max } = Math
+    , { max } = Math
 
 /*  ------------------------------------------------------------------------
 
@@ -16,8 +16,10 @@ const { max } = Math
 
             decimalToPrecision ('123.456', ROUND, 2, DECIMAL_PLACES)                     */
 
-const ROUND    = 0                  // rounding mode
-    , TRUNCATE = 1
+const ROUND      = 0                // rounding mode
+    , TRUNCATE   = 1
+    , ROUND_UP   = 2
+    , ROUND_DOWN = 3
 
 const DECIMAL_PLACES     = 0        // digits counting mode
     , SIGNIFICANT_DIGITS = 1
@@ -49,7 +51,7 @@ function numberToString (x) { // avoids scientific notation for too large and to
         const e = parseInt (s.split ('e-')[1])
         const neg = (s[0] === '-')
         if (e) {
-            x *= Math.pow (10, e-1)
+            x *= Math.pow (10, e - 1)
             x = (neg ? '-' : '') + '0.' + (new Array (e)).join ('0') + x.toString ().substring (neg ? 3 : 2)
         }
     } else {
@@ -57,7 +59,7 @@ function numberToString (x) { // avoids scientific notation for too large and to
         if (e > 20) {
             e -= 20
             x /= Math.pow (10, e)
-            x += (new Array (e+1)).join ('0')
+            x += (new Array (e + 1)).join ('0')
         }
     }
     return x.toString ()
@@ -70,8 +72,8 @@ const truncate_regExpCache = []
     , truncate_to_string = (num, precision = 0) => {
         num = numberToString (num)
         if (precision > 0) {
-            const re = truncate_regExpCache[precision] || (truncate_regExpCache[precision] = new RegExp("([-]*\\d+\\.\\d{" + precision + "})(\\d)"))
-            const [,result] = num.toString ().match (re) || [null, num]
+            const re = truncate_regExpCache[precision] || (truncate_regExpCache[precision] = new RegExp ("([-]*\\d+\\.\\d{" + precision + "})(\\d)"))
+            const [ , result] = num.toString ().match (re) || [null, num]
             return result.toString ()
         }
         return parseInt (num).toString ()
@@ -94,7 +96,7 @@ const decimalToPrecision = (x, roundingMode
         if (countingMode === TICK_SIZE) {
             throw new Error (`TICK_SIZE cant be used with negative numPrecisionDigits`)
         }
-        let toNearest = Math.pow (10, -numPrecisionDigits)
+        const toNearest = Math.pow (10, -numPrecisionDigits)
         if (roundingMode === ROUND) {
             return (toNearest * decimalToPrecision (x / toNearest, roundingMode, 0, countingMode, paddingMode)).toString ()
         }
@@ -107,7 +109,7 @@ const decimalToPrecision = (x, roundingMode
     if (countingMode === TICK_SIZE) {
         const missing = x % numPrecisionDigits
         const reminder = x / numPrecisionDigits
-        if (reminder !== Math.floor(reminder)) {
+        if (reminder !== Math.floor (reminder)) {
             if (roundingMode === ROUND) {
                 if (x > 0) {
                     if (missing >= numPrecisionDigits / 2) {
@@ -117,9 +119,9 @@ const decimalToPrecision = (x, roundingMode
                     }
                 } else {
                     if (missing >= numPrecisionDigits / 2) {
-                        x = Number(x) - missing
+                        x = Number (x) - missing
                     } else {
-                        x = Number(x) - missing - numPrecisionDigits
+                        x = Number (x) - missing - numPrecisionDigits
                     }
                 }
             } else if (roundingMode === TRUNCATE) {
@@ -166,7 +168,7 @@ const decimalToPrecision = (x, roundingMode
       , digitsStart = -1                // significant digits
       , digitsEnd   = -1
 
-    for (var i = 1, j = strStart; j < strEnd; j++, i++) {
+    for (let i = 1, j = strStart; j < strEnd; j++, i++) {
 
         const c = str.charCodeAt (j)
 
@@ -293,6 +295,8 @@ module.exports = {
     precisionConstants,
     ROUND,
     TRUNCATE,
+    ROUND_UP,
+    ROUND_DOWN,
     DECIMAL_PLACES,
     SIGNIFICANT_DIGITS,
     TICK_SIZE,

--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -168,7 +168,7 @@ const decimalToPrecision = (x, roundingMode
       , digitsStart = -1                // significant digits
       , digitsEnd   = -1
 
-    for (let i = 1, j = strStart; j < strEnd; j++, i++) {
+    for (var i = 1, j = strStart; j < strEnd; j++, i++) {
 
         const c = str.charCodeAt (j)
 

--- a/js/test/base/functions/test.datetime.js
+++ b/js/test/base/functions/test.datetime.js
@@ -2,6 +2,7 @@
 
 const ccxt = require ('../../../../ccxt');
 const assert = require ('assert');
+const { ROUND_UP, ROUND_DOWN } = require ('../../../base/functions/misc');
 
 const exchange = new ccxt.Exchange ({
     'id': 'regirock',
@@ -46,13 +47,13 @@ assert (exchange.parseDate ('1986-04-26T01:23:47.000Z') === 514862627000);
 assert (exchange.parseDate ('1986-13-13 00:00:00') === undefined);
 
 
-assert (exchange.roundTimeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
-assert (exchange.roundTimeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
-assert (exchange.roundTimeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:00:00'))
-assert (exchange.roundTimeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 00:00:00'))
+assert (exchange.roundTimeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), ROUND_DOWN) === exchange.parse8601('2019-08-12 13:20:00'));
+assert (exchange.roundTimeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), ROUND_DOWN) === exchange.parse8601('2019-08-12 13:20:00'));
+assert (exchange.roundTimeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), ROUND_DOWN) === exchange.parse8601('2019-08-12 13:00:00'));
+assert (exchange.roundTimeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), ROUND_DOWN) === exchange.parse8601('2019-08-12 00:00:00'));
 
-assert (exchange.roundTimeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:25:00'))
-assert (exchange.roundTimeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
-assert (exchange.roundTimeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
-assert (exchange.roundTimeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 14:00:00'))
-assert (exchange.roundTimeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-13 00:00:00'))
+assert (exchange.roundTimeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), ROUND_UP) === exchange.parse8601('2019-08-12 13:25:00'));
+assert (exchange.roundTimeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), ROUND_UP) === exchange.parse8601('2019-08-12 13:30:00'));
+assert (exchange.roundTimeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), ROUND_UP) === exchange.parse8601('2019-08-12 13:30:00'));
+assert (exchange.roundTimeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), ROUND_UP) === exchange.parse8601('2019-08-12 14:00:00'));
+assert (exchange.roundTimeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), ROUND_UP) === exchange.parse8601('2019-08-13 00:00:00'));

--- a/js/test/base/functions/test.datetime.js
+++ b/js/test/base/functions/test.datetime.js
@@ -46,13 +46,13 @@ assert (exchange.parseDate ('1986-04-26T01:23:47.000Z') === 514862627000);
 assert (exchange.parseDate ('1986-13-13 00:00:00') === undefined);
 
 
-assert (exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
-assert (exchange.round_timeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
-assert (exchange.round_timeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:00:00'))
-assert (exchange.round_timeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 00:00:00'))
+assert (exchange.roundTimeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
+assert (exchange.roundTimeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
+assert (exchange.roundTimeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:00:00'))
+assert (exchange.roundTimeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 00:00:00'))
 
-assert (exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:25:00'))
-assert (exchange.round_timeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
-assert (exchange.round_timeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
-assert (exchange.round_timeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 14:00:00'))
-assert (exchange.round_timeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-13 00:00:00'))
+assert (exchange.roundTimeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:25:00'))
+assert (exchange.roundTimeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.roundTimeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.roundTimeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 14:00:00'))
+assert (exchange.roundTimeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-13 00:00:00'))

--- a/js/test/base/functions/test.datetime.js
+++ b/js/test/base/functions/test.datetime.js
@@ -44,3 +44,15 @@ assert (exchange.parse8601 (33) === undefined);
 assert (exchange.parseDate ('1986-04-26 00:00:00') === 514857600000);
 assert (exchange.parseDate ('1986-04-26T01:23:47.000Z') === 514862627000);
 assert (exchange.parseDate ('1986-13-13 00:00:00') === undefined);
+
+
+assert (exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
+assert (exchange.round_timeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00'))
+assert (exchange.round_timeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:00:00'))
+assert (exchange.round_timeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 00:00:00'))
+
+assert (exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.round_timeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.round_timeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.round_timeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.round_timeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-13 00:00:00'))

--- a/js/test/base/functions/test.datetime.js
+++ b/js/test/base/functions/test.datetime.js
@@ -51,8 +51,8 @@ assert (exchange.round_timeframe('10m', exchange.parse8601('2019-08-12 13:22:08'
 assert (exchange.round_timeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:00:00'))
 assert (exchange.round_timeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 00:00:00'))
 
-assert (exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:25:00'))
 assert (exchange.round_timeframe('10m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
 assert (exchange.round_timeframe('30m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
-assert (exchange.round_timeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00'))
+assert (exchange.round_timeframe('1h', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 14:00:00'))
 assert (exchange.round_timeframe('1d', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-13 00:00:00'))

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -39,6 +39,8 @@ $version = '1.18.1063';
 // rounding mode
 const TRUNCATE = 0;
 const ROUND = 1;
+const ROUND_UP = 2;
+const ROUND_DOWN = 3;
 
 // digits counting mode
 const DECIMAL_PLACES = 0;
@@ -349,15 +351,11 @@ class Exchange {
         return $amount * $scale;
     }
 
-    public static function round_timeframe($timeframe, $timestamp, $direction='down') {
+    public static function round_timeframe($timeframe, $timestamp, $direction=ROUND_DOWN) {
         $ms = static::parse_timeframe($timeframe) * 1000;
         // Get offset based on timeframe in milliseconds
         $offset = $timestamp % $ms;
-        if ($direction === 'up') {
-            return $timestamp - $offset + $ms;
-        } else {
-            return $timestamp - $offset;
-        }
+        return $timestamp - $offset + (($direction === ROUND_UP) ? $ms : 0);
     }
 
     // given a sorted arrays of trades (recent first) and a timeframe builds an array of OHLCV candles

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -349,6 +349,17 @@ class Exchange {
         return $amount * $scale;
     }
 
+    public static function round_timeframe($timeframe, $timestamp, $direction='down') {
+        $ms = static::parse_timeframe($timeframe) * 1000;
+        // Get offset based on timeframe in milliseconds
+        $offset = $timestamp % $ms;
+        if ($direction === 'up') {
+            return $timestamp - $offset + $ms;
+        } else {
+            return $timestamp - $offset;
+        }
+    }
+
     // given a sorted arrays of trades (recent first) and a timeframe builds an array of OHLCV candles
     public static function build_ohlcv($trades, $timeframe = '1m', $since = PHP_INT_MIN, $limits = PHP_INT_MAX) {
         if (empty($trades) || !is_array($trades)) {

--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -6,6 +6,8 @@ import re
 __all__ = [
     'TRUNCATE',
     'ROUND',
+    'ROUND_UP',
+    'ROUND_DOWN',
     'DECIMAL_PLACES',
     'SIGNIFICANT_DIGITS',
     'TICK_SIZE',
@@ -18,6 +20,8 @@ __all__ = [
 # rounding mode
 TRUNCATE = 0
 ROUND = 1
+ROUND_UP = 2,
+ROUND_DOWN = 3
 
 # digits counting mode
 DECIMAL_PLACES = 2

--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -20,7 +20,7 @@ __all__ = [
 # rounding mode
 TRUNCATE = 0
 ROUND = 1
-ROUND_UP = 2,
+ROUND_UP = 2
 ROUND_DOWN = 3
 
 # digits counting mode

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1526,6 +1526,16 @@ class Exchange(object):
             scale = 60  # 1m by default
         return amount * scale
 
+    @staticmethod
+    def round_timeframe(timeframe, timestamp, direction='down'):
+        ms = Exchange.parse_timeframe(timeframe) * 1000
+        # Get offset based on timeframe in milliseconds
+        offset = timestamp % ms
+        if direction == 'up':
+            return timestamp - offset + ms
+        else:
+            return timestamp - offset
+
     def parse_trades(self, trades, market=None, since=None, limit=None, params={}):
         array = self.to_array(trades)
         array = [self.extend(self.parse_trade(trade, market), params) for trade in array]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1531,7 +1531,7 @@ class Exchange(object):
         ms = Exchange.parse_timeframe(timeframe) * 1000
         # Get offset based on timeframe in milliseconds
         offset = timestamp % ms
-        return timestamp - offset + ms if direction == ROUND_UP else 0
+        return timestamp - offset + (ms if direction == ROUND_UP else 0)
 
     def parse_trades(self, trades, market=None, since=None, limit=None, params={}):
         array = self.to_array(trades)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -21,7 +21,7 @@ from ccxt.base.errors import ArgumentsRequired
 # -----------------------------------------------------------------------------
 
 from ccxt.base.decimal_to_precision import decimal_to_precision
-from ccxt.base.decimal_to_precision import DECIMAL_PLACES, TRUNCATE, ROUND
+from ccxt.base.decimal_to_precision import DECIMAL_PLACES, TRUNCATE, ROUND, ROUND_UP, ROUND_DOWN
 from ccxt.base.decimal_to_precision import number_to_string
 
 # -----------------------------------------------------------------------------
@@ -1527,14 +1527,11 @@ class Exchange(object):
         return amount * scale
 
     @staticmethod
-    def round_timeframe(timeframe, timestamp, direction='down'):
+    def round_timeframe(timeframe, timestamp, direction=ROUND_DOWN):
         ms = Exchange.parse_timeframe(timeframe) * 1000
         # Get offset based on timeframe in milliseconds
         offset = timestamp % ms
-        if direction == 'up':
-            return timestamp - offset + ms
-        else:
-            return timestamp - offset
+        return timestamp - offset + ms if direction == ROUND_UP else 0
 
     def parse_trades(self, trades, market=None, since=None, limit=None, params={}):
         array = self.to_array(trades)


### PR DESCRIPTION
This will add the static method `round_timeframe()`to  base exchange class.

Please review especially the JS / php code very rigorously - it's been a long time i used these languages and i wouldn't want to introduce a bug because of that.

example usage:

```
exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'down') === exchange.parse8601('2019-08-12 13:20:00')
exchange.round_timeframe('5m', exchange.parse8601('2019-08-12 13:22:08'), 'up') === exchange.parse8601('2019-08-12 13:30:00')
```

Closes #5683 

## todo:
* ~~I did not add constants for ROUND_DOWN / ROUND_UP yet, since honestly, i'm not sure where to place them.
Most constants are defined in `decimal_to_precision.py` (and corresponding files for other languages) - but these constants don't really fit there since the function is in the exchange.~~ Based on feedback below this is not needed anymore.

