### PR TITLE
Handle static_dependencies better

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -36,6 +36,10 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 # ecdsa signing
 try:
+    ModuleNotFoundError
+except NameError:
+    ModuleNotFoundError = ImportError
+try:
     import ecdsa
 except ModuleNotFoundError:
     from static_dependencies import ecdsa

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -35,7 +35,10 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 # -----------------------------------------------------------------------------
 
 # ecdsa signing
-from static_dependencies import ecdsa
+try:
+    import ecdsa
+except ModuleNotFoundError:
+    from static_dependencies import ecdsa
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
I understand, why you use static dependencies, but I dont think, this is the correct way to handle it.
There is no possibility for the user to have control over his dependencies (e.g. use another version.)
For example I use a package manager from my linux distribution, which has ecdsa and I'd rather use this version.