### PR TITLE
bitstamp: remove false default value for safeTimestamp

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -228,7 +228,7 @@ module.exports = class bitstamp extends Exchange {
             'pair': this.marketId (symbol),
         };
         const response = await this.publicGetOrderBookPair (this.extend (request, params));
-        const timestamp = this.safeTimestamp (response, 'timestamp', 1000);
+        const timestamp = this.safeTimestamp (response, 'timestamp');
         return this.parseOrderBook (response, timestamp);
     }
 
@@ -238,7 +238,7 @@ module.exports = class bitstamp extends Exchange {
             'pair': this.marketId (symbol),
         };
         const ticker = await this.publicGetTickerPair (this.extend (request, params));
-        const timestamp = this.safeTimestamp (ticker, 'timestamp', 1000);
+        const timestamp = this.safeTimestamp (ticker, 'timestamp');
         const vwap = this.safeFloat (ticker, 'vwap');
         const baseVolume = this.safeFloat (ticker, 'volume');
         let quoteVolume = undefined;


### PR DESCRIPTION
This issue got introduced in 5a40c8aadaf46409934bf91d587f42e8dd860988 