### PR TITLE
Fix: transpile removed space between and/or and the following bracket

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -244,6 +244,8 @@ const pythonRegexes = [
     [ /console\.log\s/g, 'print' ],
     [ /process\.exit\s+/g, 'sys.exit' ],
     [ /([^:+=\/\*\s-]+) \(/g, '$1(' ], // PEP8 E225 remove whitespaces before left ( round bracket
+    [ /\sand\(/g, ' and (' ],
+    [ /\sor\(/g, ' or (' ],
     [ /\[ /g, '[' ],              // PEP8 E201 remove whitespaces after left [ square bracket
     [ /\{ /g, '{' ],              // PEP8 E201 remove whitespaces after left { bracket
     [ /([^\s]+) \]/g, '$1]' ],    // PEP8 E202 remove whitespaces before right ] square bracket


### PR DESCRIPTION
The regex `[ /([^:+=\/\*\s-]+) \(/g, '$1(' ]` transpiles `if ((cost !== undefined) && (filled !== undefined) && (filled > 0)) {` to `if (cost is not None) and (filled is not None) and (filled > 0):` in python.
The regex is not easy to fix to ignore and/or, so I added new ones to fix this behavior.