### PR TITLE
Add strip to exchange base

### DIFF
--- a/js/base/functions/string.js
+++ b/js/base/functions/string.js
@@ -15,6 +15,7 @@ module.exports =
     , capitalize: s => s.length
                             ? (s.charAt (0).toUpperCase () + s.slice (1))
                             : s
+    , strip: s => s.replace(/^\s+|\s+$/g, '')
     }
 
 /*  ------------------------------------------------------------------------ */

--- a/js/btcbox.js
+++ b/js/btcbox.js
@@ -396,11 +396,9 @@ module.exports = class btcbox extends Exchange {
 
     async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let response = await this.fetch2 (path, api, method, params, headers, body);
-        // sometimes the exchange returns whitespace prepended to json
-        // the code below removes excessive spaces
         if (typeof response === 'string') {
-            response = response.split (' ');
-            response = response.join ('');
+            // sometimes the exchange returns whitespace prepended to json
+            response = this.strip (response);
             if (!this.isJsonEncodedObject (response)) {
                 throw new ExchangeError (this.id + ' ' + response);
             }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -215,6 +215,10 @@ class Exchange {
         return explode($delimiters[0], str_replace($delimiters, $delimiters[0], $string));
     }
 
+    public static function strip($string) {
+        return trim($string);
+    }
+
     public static function decimal($number) {
         return '' + $number;
     }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -731,6 +731,10 @@ class Exchange(object):
         return string.upper()
 
     @staticmethod
+    def strip(string):
+        return string.strip()
+
+    @staticmethod
     def keysort(dictionary):
         return collections.OrderedDict(sorted(dictionary.items(), key=lambda t: t[0]))
 


### PR DESCRIPTION
I think the split/join approach is problematic, because it also removes whitespaces in the middle of the response (error messages, order ids, dates, order status).
