### PR TITLE
SouthXChange new endpoint

### DIFF
--- a/js/southxchange.js
+++ b/js/southxchange.js
@@ -40,6 +40,7 @@ module.exports = class southxchange extends Exchange {
                     'post': [
                         'cancelMarketOrders',
                         'cancelOrder',
+                        'getOrder',
                         'generatenewaddress',
                         'listOrders',
                         'listBalances',


### PR DESCRIPTION
There is an undocumented endpoint called GetOrder that retrieves an order details. Can be useful it to get the details of some order returned by ListTransactions.

Request:
```
{
  Code: '7EWU3I7A' // OrderCode
}
```

Response:
```
{ 
  Code: '7EWU3I7A',
  Type: 'sell',
  Amount: 16916.05059405,
  LimitPrice: 0.00000117,
  ListingCurrency: 'OMEGA',
  ReferenceCurrency: 'BTC',
  Status: 'canceledpartiallyexecuted',
  DateAdded: '2018-04-10T19:03:33.5' 
}
```
