### PR TITLE
Add exception for disabled key on Bitmex

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -147,6 +147,7 @@ module.exports = class bitmex extends Exchange {
                     'Signature not valid': AuthenticationError,
                     'overloaded': ExchangeNotAvailable,
                     'Account has insufficient Available Balance': InsufficientFunds,
+                    'This key is disabled': PermissionDenied,
                 },
             },
             'precisionMode': TICK_SIZE,

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -137,6 +137,7 @@ module.exports = class bitmex extends Exchange {
             'exceptions': {
                 'exact': {
                     'Invalid API Key.': AuthenticationError,
+                    'This key is disabled.': PermissionDenied,
                     'Access Denied': PermissionDenied,
                     'Duplicate clOrdID': InvalidOrder,
                     'orderQty is invalid': InvalidOrder,
@@ -147,7 +148,6 @@ module.exports = class bitmex extends Exchange {
                     'Signature not valid': AuthenticationError,
                     'overloaded': ExchangeNotAvailable,
                     'Account has insufficient Available Balance': InsufficientFunds,
-                    'This key is disabled': PermissionDenied,
                 },
             },
             'precisionMode': TICK_SIZE,


### PR DESCRIPTION
When the key is disabled on Bitmex, private API responds with
```json
{
  "error": {
    "message": "This key is disabled.",
    "name": "HTTPError"
  }
}
```
This PR lets ccxt identify this error and throw `PermissionDenied`.