### PR TITLE
Fix bithumb ticker volumes

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -193,7 +193,7 @@ module.exports = class bithumb extends Exchange {
         const quoteVolume = this.safeFloat (ticker, 'acc_trade_value_24H');
         let vwap = undefined;
         if (quoteVolume !== undefined && baseVolume !== undefined) {
-            vwap = quoteVolume / baseVolume
+            vwap = quoteVolume / baseVolume;
         }
         return {
             'symbol': symbol,

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -189,11 +189,11 @@ module.exports = class bithumb extends Exchange {
             }
             average = this.sum (open, close) / 2;
         }
-        const vwap = this.safeFloat (ticker, 'average_price');
-        const baseVolume = this.safeFloat (ticker, 'volume_1day');
-        let quoteVolume = undefined;
-        if (vwap !== undefined && baseVolume !== undefined) {
-            quoteVolume = baseVolume * vwap;
+        const baseVolume = this.safeFloat (ticker, 'units_traded_24H');
+        const quoteVolume = this.safeFloat (ticker, 'acc_trade_value_24H');
+        let vwap = undefined;
+        if (quoteVolume !== undefined && baseVolume !== undefined) {
+            vwap = quoteVolume / baseVolume
         }
         return {
             'symbol': symbol,


### PR DESCRIPTION
In response to undocumented API change. I'm currently getting the following response from `publicGetTickerAll()['data']['BTC']`:

```json
{
  "opening_price": "11782000",
  "closing_price": "11694000",
  "min_price": "11680000",
  "max_price": "11825000",
  "units_traded": "263.94",
  "acc_trade_value": "3098791559.33",
  "prev_closing_price": "11788000",
  "units_traded_24H": "4059.26",
  "acc_trade_value_24H": "47907105051.59",
  "fluctate_24H": "-160,000",
  "fluctate_rate_24H": "-1.35"
}
```