### PR TITLE
FairGame/FairCoin confusion

### DIFF
--- a/js/coinexchange.js
+++ b/js/coinexchange.js
@@ -546,6 +546,7 @@ module.exports = class coinexchange extends Exchange {
                 'BONPAY': 'BON',
                 'eNAU': 'ENAU',
                 'ETN': 'Ethernex',
+                'FAIR': 'FairCoin',
                 'FRC': 'FireRoosterCoin',
                 'GET': 'GreenEnergyToken',
                 'GDC': 'GoldenCryptoCoin',

--- a/js/nova.js
+++ b/js/nova.js
@@ -72,6 +72,9 @@ module.exports = class nova extends Exchange {
                     'taker': 0.2 / 100,
                 },
             },
+            'commonCurrencies': {
+                'FAIR': 'FairCoin',
+            },
         });
     }
 

--- a/js/okex.js
+++ b/js/okex.js
@@ -53,7 +53,6 @@ module.exports = class okex extends okcoinusd {
             'commonCurrencies': {
                 // OKEX refers to ERC20 version of Aeternity (AEToken)
                 'AE': 'AET', // https://github.com/ccxt/ccxt/issues/4981
-                'FAIR': 'FairGame',
                 'HOT': 'Hydro Protocol',
                 'HSR': 'HC',
                 'MAG': 'Maggie',

--- a/js/okex3.js
+++ b/js/okex3.js
@@ -452,7 +452,6 @@ module.exports = class okex3 extends Exchange {
             'commonCurrencies': {
                 // OKEX refers to ERC20 version of Aeternity (AEToken)
                 'AE': 'AET', // https://github.com/ccxt/ccxt/issues/4981
-                'FAIR': 'FairGame',
                 'HOT': 'Hydro Protocol',
                 'HSR': 'HC',
                 'MAG': 'Maggie',


### PR DESCRIPTION
Now on Okex we have FairGame, on Huobi and Digifinex FAIR means FairGame, on Nova and Coinexchange FAIR means FairCoin. Looks like FairGame is more popular then FairCoin (bigger exchanges and much bigger volume) so I suggest to link FairGame as 'FAIR' and FairCoin as 'FairCoin'

https://coinmarketcap.com/currencies/fairgame/#markets
https://coinmarketcap.com/currencies/faircoin/#markets