### PR TITLE
add fetchOrder method in typescript definition

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -311,6 +311,7 @@ declare module 'ccxt' {
         fetchTotalBalance (params?: any): Promise<PartialBalances>;
         fetchUsedBalance (params?: any): Promise<PartialBalances>;
         fetchFreeBalance (params?: any): Promise<PartialBalances>;
+        fetchOrder(id: string, symbol: string, params?: any): Promise<Order>;
         fetchOrderBook (symbol: string, limit?: number, params?: any): Promise<OrderBook>;
         fetchTicker (symbol: string): Promise<Ticker>;
         fetchTickers (symbols?: string[]): Promise<Tickers>;


### PR DESCRIPTION
it seems `fetchOrder` is a unified method (according to: https://github.com/ccxt/ccxt/wiki/Manual#overview) so it should be in the typescript definition