### PR TITLE
ccxt.d.ts: declare fetchOHLCV as a non-optional function/property.

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -315,7 +315,7 @@ declare module 'ccxt' {
         fetchTicker (symbol: string): Promise<Ticker>;
         fetchTickers (symbols?: string[]): Promise<Tickers>;
         fetchTrades (symbol: string, since?: number, limit?: number, params?: {}): Promise<Trade[]>;
-        fetchOHLCV? (symbol: string, timeframe?: string, since?: number, limit?: number, params?: {}): Promise<OHLCV[]>;
+        fetchOHLCV (symbol: string, timeframe?: string, since?: number, limit?: number, params?: {}): Promise<OHLCV[]>;
         fetchOrders (symbol?: string, since?: number, limit?: number, params?: {}): Promise<Order[]>;
         fetchOpenOrders (symbol?: string, since?: number, limit?: number, params?: {}): Promise<Order[]>;
         fetchCurrencies (params?: any): Promise<any>;


### PR DESCRIPTION
This removes the ? from fetchOHLCV()'s type declaration. This makes it consistent with all the other functions on Exchange. It appears that ccxt.d.ts declares other non-optional functions that may actually be optional on some exchanges.

Maybe the long-term proper approach is to add ? to all Exchange functions that may not exist on all exchanges, but that can be discussed separately.