### PR TITLE
coinex: Wierd markets symbol

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -165,11 +165,15 @@ module.exports = class coinex extends Exchange {
             const key = keys[i];
             const market = markets[key];
             const id = this.safeString (market, 'name');
-            const baseId = this.safeString (market, 'trading_name');
+            const tradingName = this.safeString (market, 'trading_name');
+            const baseId = tradingName;
             const quoteId = this.safeString (market, 'pricing_name');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const symbol = base + '/' + quote;
+            let symbol = base + '/' + quote;
+            if (tradingName === id) {
+                symbol = id;
+            }
             const precision = {
                 'amount': this.safeInteger (market, 'trading_decimal'),
                 'price': this.safeInteger (market, 'pricing_decimal'),


### PR DESCRIPTION
Coinex has some wierd symbols, that dont work (for example with fetch_ohlcv), for example: 
`'BTCUSDT190930C12000/USDT', 'BTCUSDT190930C10500/USDT', 'BTCUSDT191130P2700/USDT`

To reproduce:
```
import ccxt
from pprint import pprint
exchange = ccxt.coinex()
exchange.load_markets()
exchange.fetch_markets()
pprint(exchange.markets['BTCUSDT190930C10500/USDT'])
exchange.fetch_ohlcv('BTCUSDT190930C10500/USDT', '1m')
```

Result:
```
{'active': None,
 'base': 'BTCUSDT190930C10500',
 'baseId': 'BTCUSDT190930C10500',
 'id': 'BTCUSDT190930C10500',
 'info': {'maker_fee_rate': '0.001',
          'min_amount': '0.0001',
          'name': 'BTCUSDT190930C10500',
          'pricing_decimal': 2,
          'pricing_name': 'USDT',
          'taker_fee_rate': '0.001',
          'trading_decimal': 8,
          'trading_name': 'BTCUSDT190930C10500'},
 'limits': {'amount': {'max': None, 'min': 0.0001},
            'price': {'max': None, 'min': 0.01}},
 'maker': 0.001,
 'percentage': True,
 'precision': {'amount': 8, 'price': 2},
 'quote': 'USDT',
 'quoteId': 'USDT',
 'symbol': 'BTCUSDT190930C10500/USDT',
 'taker': 0.001}
Traceback (most recent call last):
  File "coinex.py", line 7, in <module>
    exchange.fetch_ohlcv('BTCUSDT190930C10500/USDT', '1m')
  File "/home/work/ccxt/python/ccxt/coinex.py", line 352, in fetch_ohlcv
    response = self.publicGetMarketKline(self.extend(request, params))
  File "/home/work/ccxt/python/ccxt/base/exchange.py", line 436, in inner
    return entry(_self, **inner_kwargs)
  File "/home/work/ccxt/python/ccxt/coinex.py", line 848, in request
    raise ErrorClass(response['message'])
```

These symbols can be detected with `trading_name` === `name`.
I am not really sure if this is a good solution, now at least there is no error with fetch_ohlcv.
