### PR TITLE
ccxt.d.ts: more accurately define timeframes' type.

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -271,7 +271,7 @@ declare module 'ccxt' {
         verbose: boolean;
         twofa: boolean;// two-factor authentication
         substituteCommonCurrencyCodes: boolean;
-        timeframes: any;
+        timeframes: { [timeframe: string] : number | string };
         has: { [what: string]: any }; // https://github.com/ccxt/ccxt/pull/1984
         balance: object;
         orderbooks: object;


### PR DESCRIPTION
The new type accurately describes the timeframes in various exchanges. Some exchanges such as gdax.js have timeframe values that are numbers. Others, such as binance.js have values that are strings.

The Typescript definition for timeframe's type could be to have only strings for the values timeframe value were changed everywhere to strings, but some exchanges, e.g. polenix.js, use the value for math calculations to get the end of the time period for fetchOHLCV(), in which case they would use Number(), which seems wasteful.