### PR TITLE
gdax: use this.iso8601 () instead of this.ymdhms ().

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -408,12 +408,12 @@ module.exports = class gdax extends Exchange {
             'granularity': granularity,
         };
         if (since !== undefined) {
-            request['start'] = this.ymdhms (since);
+            request['start'] = this.iso8601 (since);
             if (limit === undefined) {
                 // https://docs.pro.coinbase.com/#get-historic-rates
                 limit = 300; // max = 300
             }
-            request['end'] = this.ymdhms (this.sum (limit * granularity * 1000, since));
+            request['end'] = this.iso8601 (this.sum (limit * granularity * 1000, since));
         }
         const response = await this.publicGetProductsIdCandles (this.extend (request, params));
         return this.parseOHLCVs (response, market, timeframe, since, limit);


### PR DESCRIPTION
This makes gdax.js consistent everywhere to use this.iso8601() instead of this.ymdhms(). This switches over to this.iso8601 () in fetchOHLCV ().

The API at https://docs.pro.coinbase.com/#get-historic-rates says that ISO 8601 is used.