### PR TITLE
Hitbtc: handle errors

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -302,7 +302,9 @@ const phpRegexes = [
     [ /([^'])this_\./g, '$1$this_->' ],
     [ /\{\}/g, 'array()' ],
     [ /\[\]/g, 'array()' ],
-    [ /\{([^\n\}]+)\}/g, 'array($1)' ],
+
+// add {}-array syntax conversions up to 20 levels deep in the same line
+]).concat ([ ... Array (20) ].map (x => [ /\{([^\n\}]+)\}/g, 'array($1)' ] )).concat ([
     [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s\[\s*([^\]]+)\s\]/g, '$1list($2)' ],
     [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s\{\s*([^\}]+)\s\}/g, '$1array_values(list($2))' ],
     [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s/g, '$1' ],

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, InsufficientFunds, OrderNotFound, InvalidOrder } = require ('./base/errors');
+const { BadSymbol, ExchangeError, InsufficientFunds, OrderNotFound, InvalidOrder } = require ('./base/errors');
 
 // ---------------------------------------------------------------------------
 
@@ -497,6 +497,7 @@ module.exports = class hitbtc extends Exchange {
             },
             'exceptions': {
                 'exact': {
+                    '2001': BadSymbol, // {"error":{"code":2001,"message":"Symbol not found","description":"Try get /api/2/public/symbol, to get list of all available symbols."}}
                 },
                 'broad': {
                 },


### PR DESCRIPTION
The transpile modification was needed for the comment after BadSymbol. Nested objects in the same line werent supported in php.