### PR TITLE
Typescript add urls test

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -268,6 +268,7 @@ declare module 'ccxt' {
         urls: {
             logo: string;
             api: string | Dictionary<string>;
+            test: string | Dictionary<string>;
             www: string;
             doc: string[];
             api_management?: string;

--- a/js/lykke.js
+++ b/js/lykke.js
@@ -33,11 +33,11 @@ module.exports = class lykke extends Exchange {
                     'mobile': 'https://public-api.lykke.com/api',
                     'public': 'https://hft-api.lykke.com/api',
                     'private': 'https://hft-api.lykke.com/api',
-                    'test': {
-                        'mobile': 'https://public-api.lykke.com/api',
-                        'public': 'https://hft-service-dev.lykkex.net/api',
-                        'private': 'https://hft-service-dev.lykkex.net/api',
-                    },
+                },
+                'test': {
+                    'mobile': 'https://public-api.lykke.com/api',
+                    'public': 'https://hft-service-dev.lykkex.net/api',
+                    'private': 'https://hft-service-dev.lykkex.net/api',
                 },
                 'www': 'https://www.lykke.com',
                 'doc': [


### PR DESCRIPTION
Add a missing urls.test property to the recent ccxt.d.ts improvements and then make the lykke exchange consistent with it.
