### PR TITLE
iso8601(): don't convert number to a string just to parse it again.

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -432,7 +432,7 @@ declare module 'ccxt' {
         getMarket (symbol: string): Market;
         handleResponse (url: string, method: string, headers?: any, body?: any): any;
         initRestRateLimiter (): void;
-        iso8601 (timestamp: string): string;
+        iso8601 (timestamp: number | string): string;
         loadMarkets (reload?: boolean): Promise<Dictionary<Market>>;
         market (symbol: string): Market;
         marketId (symbol: string): string;

--- a/js/base/functions/time.js
+++ b/js/base/functions/time.js
@@ -52,7 +52,12 @@ class TimedOut extends Error {
 /*  ------------------------------------------------------------------------ */
 
 const iso8601 = (timestamp) => {
-    const _timestampNumber = parseInt (timestamp, 10);
+    let _timestampNumber;
+    if (typeof timestamp === 'number') {
+        _timestampNumber = Math.floor (timestamp);
+    } else {
+        _timestampNumber = parseInt (timestamp, 10);
+    }
 
     // undefined, null and lots of nasty non-numeric values yield NaN
     if (Number.isNaN (_timestampNumber) || _timestampNumber < 0) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt :

> The value to parse. If this argument is not a string, then it is converted to one using the ToString abstract operation. Leading whitespace in this argument is ignored.

This is a micro-optimization, but it appears that a number is passed to iso8601() in a number of exchange files, so don't convert a number to a string back to a number again.