### PR TITLE
Add bitz transactions

### DIFF
--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1014,11 +1014,11 @@ module.exports = class bitz extends Exchange {
 
     parseTransactionStatus (status) {
         const statuses = {
-            1: 'pending',
-            2: 'pending',
-            3: 'pending',
-            4: 'ok',
-            5: 'canceled',
+            '1': 'pending',
+            '2': 'pending',
+            '3': 'pending',
+            '4': 'ok',
+            '5': 'canceled',
         };
         return this.safeString (statuses, status, status);
     }

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1076,7 +1076,7 @@ module.exports = class bitz extends Exchange {
         }
         const currencyId = this.safeString (transaction, 'coin');
         const code = this.safeCurrencyCode (currencyId, currency);
-        const type = this.safeStringLower (transaction, 'type'); // DEPOSIT or WITHDRAWAL
+        const type = this.safeStringLower (transaction, 'type');
         const status = this.parseTransactionStatus (this.safeString (transaction, 'status'));
 
         return {
@@ -1085,7 +1085,7 @@ module.exports = class bitz extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'address': this.safeString (transaction, 'wallet'),
-            'tag': this.safeString (transaction, 'memo'), // refix it properly for the tag from description
+            'tag': this.safeString (transaction, 'memo'),
             'type': type,
             'amount': this.safeFloat (transaction, 'number'),
             'currency': code,

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -24,6 +24,9 @@ module.exports = class bitz extends Exchange {
                 'fetchOrders': true,
                 'fetchOrder': true,
                 'createMarketOrder': false,
+                'fetchDeposits': true,
+                'fetchWithdrawals': true,
+                'fetchTransactions': false,
             },
             'timeframes': {
                 '1m': '1min',
@@ -71,6 +74,7 @@ module.exports = class bitz extends Exchange {
                         'getUserHistoryEntrustSheet', // closed orders
                         'getUserNowEntrustSheet', // open orders
                         'getEntrustSheetInfo', // order
+                        'depositOrWithdraw', // transactions
                     ],
                 },
                 'assets': {
@@ -1006,6 +1010,140 @@ module.exports = class bitz extends Exchange {
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         return await this.fetchOrdersWithMethod ('tradePostGetUserHistoryEntrustSheet', symbol, since, limit, params);
+    }
+
+    parseTransactionStatus (status) {
+        const statuses = {
+            1: 'pending',
+            2: 'pending',
+            3: 'pending',
+            4: 'ok',
+            5: 'canceled',
+        };
+        return this.safeString (statuses, status, status);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        // { 
+        //   "id": '96275',
+        //   "uid": '2109073',
+        //   "wallet": '0xf4c4141c0127bc37b1d0c409a091920eba13ada7',
+        //   "txid": '0xb7adfa52aa566f9ac112e3c01f77bd91179b19eab12092a9a5a8b33d5086e31d',
+        //   "confirm": '12',
+        //   "number": '0.50000000',
+        //   "status": 4,
+        //   "updated": '1534944168605',
+        //   "addressUrl": 'https://etherscan.io/address/',
+        //   "txidUrl": 'https://etherscan.io/tx/',
+        //   "description": 'Ethereum',
+        //   "coin": 'eth',
+        //   "memo": ''
+        // }
+        // {
+        //   "id":"397574",
+        //   "uid":"2033056",
+        //   "wallet":"1AG1gZvQAYu3WBvgg7p4BMMghQD2gE693k",
+        //   "txid":"",
+        //   "confirm":"0",
+        //   "number":"1000.00000000",
+        //   "status":1,
+        //   "updated":"0",
+        //   "addressUrl":"http://omniexplorer.info/lookupadd.aspx?address=",
+        //   "txidUrl":"http://omniexplorer.info/lookuptx.aspx?txid=",
+        //   "description":"Tether",
+        //   "coin":"usdt",
+        //   "memo":""
+        // }
+        // {
+        //   "id":"153606",
+        //   "uid":"2033056",
+        //   "wallet":"1AG1gZvQAYu3WBvgg7p4BMMghQD2gE693k",
+        //   "txid":"aa2b179f84cd6dedafd41845e0fbf7f01e14c0d71ea3140d03d6f5a9ccd93199",
+        //   "confirm":"0",
+        //   "number":"761.11110000",
+        //   "status":4,
+        //   "updated":"1536726133579",
+        //   "addressUrl":"http://omniexplorer.info/lookupadd.aspx?address=",
+        //   "txidUrl":"http://omniexplorer.info/lookuptx.aspx?txid=",
+        //   "description":"Tether",
+        //   "coin":"usdt",
+        //   "memo":""
+        // }
+
+        let timestamp = this.safeInteger (transaction, 'updated');
+        if (timestamp === 0) {
+            timestamp = undefined;
+        }
+        const currencyId = this.safeString (transaction, 'coin');
+        const code = this.safeCurrencyCode (currencyId, currency);
+        const type = this.safeStringLower (transaction, 'type'); // DEPOSIT or WITHDRAWAL
+        const status = this.parseTransactionStatus (this.safeString (transaction, 'status'));
+
+        return {
+            'id': this.safeString (transaction, 'id'),
+            'txid': this.safeString (transaction, 'txid'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'address': this.safeString (transaction, 'wallet'),
+            'tag': this.safeString (transaction, 'memo'), // refix it properly for the tag from description
+            'type': type,
+            'amount': this.safeFloat (transaction, 'number'),
+            'currency': code,
+            'status': status,
+            'updated': timestamp,
+            'fee': undefined,
+            'info': transaction
+        }
+    }
+
+    parseTransactionsByType (type, transactions, code = undefined, since = undefined, limit = undefined) {
+        const result = [];
+        for (let i = 0; i < transactions.length; i++) {
+            const transaction = this.parseTransaction (this.extend ({
+                'type': type,
+            }, transactions[i]));
+            result.push (transaction);
+        }
+        console.error(result);
+        return this.filterByCurrencySinceLimit (result, code, since, limit);
+    }
+
+    parseTransactionType (type) {
+        const types = {
+            'deposit': 1,
+            'withdrawal': 2,
+        };
+        return this.safeInteger (types, type, type);
+    }
+
+    async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
+        return await this.fetchTransactionsForType ('deposit', code, since, limit, params);
+    }
+
+    async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
+        return await this.fetchTransactionsForType ('withdrawal', code, since, limit, params);
+    }
+
+    async fetchTransactionsForType (type, code = undefined, since = undefined, limit = undefined, params = {}) {
+        if (code === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchTransactions() requires a currency `code` argument');
+        }
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'coin': currency['id'],
+            'type': this.parseTransactionType (type),
+        };
+        if (since !== undefined) {
+            request['startTime'] = parseInt (since / 1000).toString ();
+        }
+        if (limit !== undefined) {
+            request['page'] = 1;
+            request['pageSize'] = limit;
+        }
+        const response = await this.tradePostDepositOrWithdraw (this.extend (request, params));
+        const transactions = this.safeValue (response['data'], 'data', []);
+        return this.parseTransactionsByType (type, transactions, code, since, limit);
     }
 
     nonce () {

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1069,7 +1069,6 @@ module.exports = class bitz extends Exchange {
         //   "coin":"usdt",
         //   "memo":""
         // }
-
         let timestamp = this.safeInteger (transaction, 'updated');
         if (timestamp === 0) {
             timestamp = undefined;
@@ -1078,7 +1077,6 @@ module.exports = class bitz extends Exchange {
         const code = this.safeCurrencyCode (currencyId, currency);
         const type = this.safeStringLower (transaction, 'type');
         const status = this.parseTransactionStatus (this.safeString (transaction, 'status'));
-
         return {
             'id': this.safeString (transaction, 'id'),
             'txid': this.safeString (transaction, 'txid'),

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1090,8 +1090,8 @@ module.exports = class bitz extends Exchange {
             'status': status,
             'updated': timestamp,
             'fee': undefined,
-            'info': transaction
-        }
+            'info': transaction,
+        };
     }
 
     parseTransactionsByType (type, transactions, code = undefined, since = undefined, limit = undefined) {

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1025,7 +1025,7 @@ module.exports = class bitz extends Exchange {
 
     parseTransaction (transaction, currency = undefined) {
         //
-        //     { 
+        //     {
         //         "id": '96275',
         //         "uid": '2109073',
         //         "wallet": '0xf4c4141c0127bc37b1d0c409a091920eba13ada7',

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1024,51 +1024,55 @@ module.exports = class bitz extends Exchange {
     }
 
     parseTransaction (transaction, currency = undefined) {
-        // { 
-        //   "id": '96275',
-        //   "uid": '2109073',
-        //   "wallet": '0xf4c4141c0127bc37b1d0c409a091920eba13ada7',
-        //   "txid": '0xb7adfa52aa566f9ac112e3c01f77bd91179b19eab12092a9a5a8b33d5086e31d',
-        //   "confirm": '12',
-        //   "number": '0.50000000',
-        //   "status": 4,
-        //   "updated": '1534944168605',
-        //   "addressUrl": 'https://etherscan.io/address/',
-        //   "txidUrl": 'https://etherscan.io/tx/',
-        //   "description": 'Ethereum',
-        //   "coin": 'eth',
-        //   "memo": ''
-        // }
-        // {
-        //   "id":"397574",
-        //   "uid":"2033056",
-        //   "wallet":"1AG1gZvQAYu3WBvgg7p4BMMghQD2gE693k",
-        //   "txid":"",
-        //   "confirm":"0",
-        //   "number":"1000.00000000",
-        //   "status":1,
-        //   "updated":"0",
-        //   "addressUrl":"http://omniexplorer.info/lookupadd.aspx?address=",
-        //   "txidUrl":"http://omniexplorer.info/lookuptx.aspx?txid=",
-        //   "description":"Tether",
-        //   "coin":"usdt",
-        //   "memo":""
-        // }
-        // {
-        //   "id":"153606",
-        //   "uid":"2033056",
-        //   "wallet":"1AG1gZvQAYu3WBvgg7p4BMMghQD2gE693k",
-        //   "txid":"aa2b179f84cd6dedafd41845e0fbf7f01e14c0d71ea3140d03d6f5a9ccd93199",
-        //   "confirm":"0",
-        //   "number":"761.11110000",
-        //   "status":4,
-        //   "updated":"1536726133579",
-        //   "addressUrl":"http://omniexplorer.info/lookupadd.aspx?address=",
-        //   "txidUrl":"http://omniexplorer.info/lookuptx.aspx?txid=",
-        //   "description":"Tether",
-        //   "coin":"usdt",
-        //   "memo":""
-        // }
+        //
+        //     { 
+        //         "id": '96275',
+        //         "uid": '2109073',
+        //         "wallet": '0xf4c4141c0127bc37b1d0c409a091920eba13ada7',
+        //         "txid": '0xb7adfa52aa566f9ac112e3c01f77bd91179b19eab12092a9a5a8b33d5086e31d',
+        //         "confirm": '12',
+        //         "number": '0.50000000',
+        //         "status": 4,
+        //         "updated": '1534944168605',
+        //         "addressUrl": 'https://etherscan.io/address/',
+        //         "txidUrl": 'https://etherscan.io/tx/',
+        //         "description": 'Ethereum',
+        //         "coin": 'eth',
+        //         "memo": ''
+        //     }
+        //
+        //     {
+        //         "id":"397574",
+        //         "uid":"2033056",
+        //         "wallet":"1AG1gZvQAYu3WBvgg7p4BMMghQD2gE693k",
+        //         "txid":"",
+        //         "confirm":"0",
+        //         "number":"1000.00000000",
+        //         "status":1,
+        //         "updated":"0",
+        //         "addressUrl":"http://omniexplorer.info/lookupadd.aspx?address=",
+        //         "txidUrl":"http://omniexplorer.info/lookuptx.aspx?txid=",
+        //         "description":"Tether",
+        //         "coin":"usdt",
+        //         "memo":""
+        //     }
+        //
+        //     {
+        //         "id":"153606",
+        //         "uid":"2033056",
+        //         "wallet":"1AG1gZvQAYu3WBvgg7p4BMMghQD2gE693k",
+        //         "txid":"aa2b179f84cd6dedafd41845e0fbf7f01e14c0d71ea3140d03d6f5a9ccd93199",
+        //         "confirm":"0",
+        //         "number":"761.11110000",
+        //         "status":4,
+        //         "updated":"1536726133579",
+        //         "addressUrl":"http://omniexplorer.info/lookupadd.aspx?address=",
+        //         "txidUrl":"http://omniexplorer.info/lookuptx.aspx?txid=",
+        //         "description":"Tether",
+        //         "coin":"usdt",
+        //         "memo":""
+        //     }
+        //
         let timestamp = this.safeInteger (transaction, 'updated');
         if (timestamp === 0) {
             timestamp = undefined;

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1102,7 +1102,6 @@ module.exports = class bitz extends Exchange {
             }, transactions[i]));
             result.push (transaction);
         }
-        console.error(result);
         return this.filterByCurrencySinceLimit (result, code, since, limit);
     }
 


### PR DESCRIPTION
The documentation on this is sketchy, and not even available in the English API pages, but the Japanese version contains examples of these endpoints, and they actually work! See https://apidoc.bit-z.pro/jp/recharge-interface/Deposit-Or-with-Draw.html for info.  This implementation follows the example of Kraken for the `parseTransactionsByType`.