### PR TITLE
Add more parsing for transactions for HitBTC

### DIFF
--- a/js/hitbtc2.js
+++ b/js/hitbtc2.js
@@ -1019,8 +1019,10 @@ module.exports = class hitbtc2 extends hitbtc {
     parseTransactionType (type) {
         const types = {
             'payin': 'deposit',
+            'bankToExchange': 'deposit',
             'payout': 'withdrawal',
             'withdraw': 'withdrawal',
+            'exchangeToBank': 'withdrawal',
         };
         return this.safeString (types, type, type);
     }


### PR DESCRIPTION
HitBTC contains two extra transaction types, 'exchangeToBank' and
'bankToExchange', which can be considered as 'withdrawal' and 'deposit',
respectively.  It seems like this wasn't done earlier, so if there's a
reason for it, feel free to disregard this PR.