### PR TITLE
[coinfloor] implementing some error handling around placing orders

### DIFF
--- a/js/coinfloor.js
+++ b/js/coinfloor.js
@@ -470,17 +470,19 @@ module.exports = class coinfloor extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {
-        if (code >= 400) {
-            if (body[0] === '{') {
-                const message = response['error_msg'];
-                const feedback = this.id + ' ' + body;
-                const exact = this.exceptions['exact'];
-                if (message in exact) {
-                    throw new exact[message] (feedback);
-                }
-            }
-            throw new ExchangeError (this.id + ' ' + body);
+        if (code < 400) {
+            return;
         }
+        if (response === undefined) {
+            return;
+        }
+        const message = this.safeString (response, 'error_msg');
+        const feedback = this.id + ' ' + body;
+        const exact = this.exceptions['exact'];
+        if (message in exact) {
+            throw new exact[message] (feedback);
+        }
+        throw new ExchangeError (feedback);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
Error now looks like this:

```
     InsufficientFunds: coinfloor {"error_code":4,"error_msg":"You have insufficient funds."}
      at coinfloor.handleErrors (node_modules/ccxt/js/coinfloor.js:479:27)
      at response.text.then (node_modules/ccxt/js/base/Exchange.js:628:18)

```
