### PR TITLE
Define precisions based on dictionary instead of inferring from API

### DIFF
--- a/js/bitso.js
+++ b/js/bitso.js
@@ -31,11 +31,11 @@ module.exports = class bitso extends Exchange {
             },
             'options': {
                 'precision': {
-                    'default': 8,
                     'XRP': 6,
                     'MXN': 2,
                     'TUSD': 2,
                 },
+                'defaultPrecision': 8,
             },
             'api': {
                 'public': {
@@ -126,8 +126,8 @@ module.exports = class bitso extends Exchange {
                 },
             };
             const precision = {
-                'amount': this.options.precision[base] ? this.options.precision[base] : this.options.precision.default,
-                'price': this.options.precision[quote] ? this.options.precision[quote] : this.options.precision.default,
+                'amount': this.safeInteger (this.options['precision'], base, this.options['defaultPrecision']),
+                'price': this.safeInteger (this.options['precision'], quote, this.options['defaultPrecision']),
             };
             result.push ({
                 'id': id,

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -34,8 +34,8 @@ module.exports = class bitso extends Exchange {
                     'default': 8,
                     'XRP': 6,
                     'MXN': 2,
-                    'TUSD': 2
-                }
+                    'TUSD': 2,
+                },
             },
             'api': {
                 'public': {

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -29,6 +29,14 @@ module.exports = class bitso extends Exchange {
                 'fees': 'https://bitso.com/fees?l=es',
                 'referral': 'https://bitso.com/?ref=itej',
             },
+            'options': {
+                'precision': {
+                    'default': 8,
+                    'XRP': 6,
+                    'MXN': 2,
+                    'TUSD': 2
+                }
+            },
             'api': {
                 'public': {
                     'get': [
@@ -118,8 +126,8 @@ module.exports = class bitso extends Exchange {
                 },
             };
             const precision = {
-                'amount': this.precisionFromString (market['minimum_amount']),
-                'price': this.precisionFromString (market['minimum_price']),
+                'amount': this.options.precision[base] ? this.options.precision[base] : this.options.precision.default,
+                'price': this.options.precision[quote] ? this.options.precision[quote] : this.options.precision.default,
             };
             result.push ({
                 'id': id,

--- a/php/bitso.php
+++ b/php/bitso.php
@@ -30,6 +30,14 @@ class bitso extends Exchange {
                 'fees' => 'https://bitso.com/fees?l=es',
                 'referral' => 'https://bitso.com/?ref=itej',
             ),
+            'options' => array(
+                'precision' => array(
+                    'default' => 8,
+                    'XRP' => 6,
+                    'MXN' => 2,
+                    'TUSD' => 2
+                )
+            ),
             'api' => array (
                 'public' => array (
                     'get' => array (
@@ -119,8 +127,8 @@ class bitso extends Exchange {
                 ),
             );
             $precision = array (
-                'amount' => $this->precision_from_string($market['minimum_amount']),
-                'price' => $this->precision_from_string($market['minimum_price']),
+                'amount' => $this->options['precision'][$base] ? $this->options['precision'][$base] : $this->options['precision']['default'],
+                'price' => $this->options['precision'][$quote] ? $this->options['precision'][$quote] : $this->options['precision']['default'],
             );
             $result[] = array (
                 'id' => $id,

--- a/python/ccxt/bitso.py
+++ b/python/ccxt/bitso.py
@@ -40,6 +40,14 @@ class bitso (Exchange):
                 'fees': 'https://bitso.com/fees?l=es',
                 'referral': 'https://bitso.com/?ref=itej',
             },
+            'options': {
+                'precision': {
+                    'default': 8,
+                    'XRP': 6,
+                    'MXN': 2,
+                    'TUSD': 2
+                }
+            },
             'api': {
                 'public': {
                     'get': [
@@ -128,8 +136,8 @@ class bitso (Exchange):
                 },
             }
             precision = {
-                'amount': self.precision_from_string(market['minimum_amount']),
-                'price': self.precision_from_string(market['minimum_price']),
+                'amount': base in self.options['precision'] ? self.options['precision'][base] : self.options['precision']['default'],
+                'price': quote in self.options['precision'] ? self.options['precision'][quote] : self.options['precision']['default'],
             }
             result.append({
                 'id': id,


### PR DESCRIPTION
As discussed with @kroitor on #5960, the way that the markets' precision is inferred from the API is unreliable in Bitso. This PR proposes using a dictionary to define the default precision (8) with some overrides for the known symbols that have a smaller precision (XRP 6, MXN 2, tUSD 2).

It's been quite some years since I quit PHP in favor of JS and I have some basic Python knowledge, so please go easy on me with the inclusion of changes on these 2 languages 😄 