### PR TITLE
php add solidity support

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2741,6 +2741,10 @@ class Exchange {
         }
     }
 
+    public function soliditySha3 ($array) {
+        return Solidity::sha3(...$array);
+    }
+
     public static function totp($key) {
         function base32_decode($s) {
             static $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';


### PR DESCRIPTION
beware there are differences to how it treats hex strings which aren't addresses:

```
var_dump($exchange->soliditySha3(['0x0ab991497116f7f5532a4c2f4f7b1784488628']));
```

gives different output to js and py