### PR TITLE
 parse_timeframe: dont allow wrong unit 

### DIFF
--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ROUND_UP, ROUND_DOWN } = require ('./number')
+const { NotSupported } = require ('./../errors')
 
 //-------------------------------------------------------------------------
 // converts timeframe to seconds
@@ -8,7 +9,7 @@ const parseTimeframe = (timeframe) => {
 
     const amount = timeframe.slice (0, -1)
     const unit = timeframe.slice (-1)
-    let scale = 60 // 1m by default
+    let scale = undefined;
 
     if (unit === 'y') {
         scale = 60 * 60 * 24 * 365
@@ -20,6 +21,10 @@ const parseTimeframe = (timeframe) => {
         scale = 60 * 60 * 24
     } else if (unit === 'h') {
         scale = 60 * 60
+    } else if (unit === 'm') {
+        scale = 60
+    } else {
+        throw new NotSupported ('timeframe unit ' + unit + ' is not supported')
     }
 
     return amount * scale

--- a/js/test/base/functions/test.generic.js
+++ b/js/test/base/functions/test.generic.js
@@ -132,7 +132,7 @@ it ('sortBy works', () => {
 
     const arr = [{ x: 5 }, { x: 2 }, { x: 4 }, { x: 0 },{ x: 1 },{ x: 3 }]
     sortBy (arr, 'x')
-    
+
     deepEqual (arr
         [ { x: 0 },
         { x: 1 },

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -352,7 +352,7 @@ class Exchange {
         } elseif ($unit === 'm') {
             $scale = 60;
         } else {
-            throw new NotSupported('timeframe unit ' + $unit + ' is not supported');
+            throw new NotSupported('timeframe unit ' . $unit . ' is not supported');
         }
         return $amount * $scale;
     }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -349,8 +349,10 @@ class Exchange {
             $scale = 60 * 60 * 24;
         } elseif ($unit === 'h') {
             $scale = 60 * 60;
-        } else {
+        } elseif ($unit === 'm') {
             $scale = 60;
+        } else {
+            throw new NotSupported('timeframe unit ' + $unit + ' is not supported');
         }
         return $amount * $scale;
     }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1533,15 +1533,15 @@ class Exchange(object):
     def parse_timeframe(timeframe):
         amount = int(timeframe[0:-1])
         unit = timeframe[-1]
-        if 'y' in unit:
+        if 'y' == unit:
             scale = 60 * 60 * 24 * 365
-        elif 'M' in unit:
+        elif 'M' == unit:
             scale = 60 * 60 * 24 * 30
-        elif 'w' in unit:
+        elif 'w' == unit:
             scale = 60 * 60 * 24 * 7
-        elif 'd' in unit:
+        elif 'd' == unit:
             scale = 60 * 60 * 24
-        elif 'h' in unit:
+        elif 'h' == unit:
             scale = 60 * 60
         else:
             scale = 60  # 1m by default

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1543,8 +1543,10 @@ class Exchange(object):
             scale = 60 * 60 * 24
         elif 'h' == unit:
             scale = 60 * 60
+        elif 'm' == unit:
+            scale = 60
         else:
-            scale = 60  # 1m by default
+            raise NotSupported('timeframe unit {} is not supported'.format(unit))
         return amount * scale
 
     @staticmethod


### PR DESCRIPTION
I dont think, we should accept wrong values and just assume minutes are meant.