### PR TITLE
python: filter_by: use python filter and dont group array

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -443,14 +443,11 @@ class Exchange {
     }
 
     public function filter_by($array, $key, $value = null) {
-        if ($value) {
-            $grouped = static::group_by($array, $key);
-            if (is_array($grouped) && array_key_exists($value, $grouped)) {
-                return $grouped[$value];
-            }
-            return array();
+        $grouped = static::group_by($array, $key);
+        if (is_array($grouped) && array_key_exists($value, $grouped)) {
+            return $grouped[$value];
         }
-        return $array;
+        return array();
     }
 
     public static function group_by($array, $key) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -767,9 +767,7 @@ class Exchange(object):
 
     @staticmethod
     def filter_by(array, key, value=None):
-        if value:
-            return list(filter(lambda x: x[key] == value, array))
-        return array
+        return list(filter(lambda x: x[key] == value, array))
 
     @staticmethod
     def filterBy(array, key, value=None):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -768,10 +768,7 @@ class Exchange(object):
     @staticmethod
     def filter_by(array, key, value=None):
         if value:
-            grouped = Exchange.group_by(array, key)
-            if value in grouped:
-                return grouped[value]
-            return []
+            return list(filter(lambda x: x[key] == value, array))
         return array
 
     @staticmethod


### PR DESCRIPTION
I think the python filter solution has a better performance and is more readable.

I dont know, if there is a language difference, but I think that the js function behaved differently than python/php. With python/php it was not possible to filter for values that evalutate to False, for example False, 0, ...