### PR TITLE
Bit-Z VTC -> VoteCoin

### DIFF
--- a/js/bitz.js
+++ b/js/bitz.js
@@ -161,6 +161,7 @@ module.exports = class bitz extends Exchange {
                 'BOX': 'BOX Token',
                 'XRB': 'NANO',
                 'PXC': 'Pixiecoin',
+                'VTC': 'VoteCoin',
             },
             'exceptions': {
                 // '200': Success


### PR DESCRIPTION
VTC is VertCoin (https://coinmarketcap.com/currencies/vertcoin/)
On Bit-Z is VoteCoin (https://www.bit-z.com/project/detail?id=218), but not the same as https://coinmarketcap.com/currencies/votecoin/ because of different circulating and description