### PR TITLE
ZB: Add limit to FetchOrderBook

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -262,12 +262,13 @@ module.exports = class zb extends Exchange {
         };
     }
 
-    async fetchOrderBook (symbol, limit = undefined, params = {}) {
+    async fetchOrderBook (symbol, limit = 50, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const marketFieldName = this.getMarketFieldName ();
         const request = {};
         request[marketFieldName] = market['id'];
+        request[size] = limit
         const response = await this.publicGetDepth (this.extend (request, params));
         return this.parseOrderBook (response);
     }

--- a/js/zb.js
+++ b/js/zb.js
@@ -262,13 +262,15 @@ module.exports = class zb extends Exchange {
         };
     }
 
-    async fetchOrderBook (symbol, limit = 50, params = {}) {
+    async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const marketFieldName = this.getMarketFieldName ();
         const request = {};
         request[marketFieldName] = market['id'];
-        request['size'] = limit;
+        if (limit !== undefined) {
+            request['size'] = limit;
+        }
         const response = await this.publicGetDepth (this.extend (request, params));
         return this.parseOrderBook (response);
     }

--- a/js/zb.js
+++ b/js/zb.js
@@ -268,7 +268,7 @@ module.exports = class zb extends Exchange {
         const marketFieldName = this.getMarketFieldName ();
         const request = {};
         request[marketFieldName] = market['id'];
-        request[size] = limit
+        request['size'] = limit
         const response = await this.publicGetDepth (this.extend (request, params));
         return this.parseOrderBook (response);
     }

--- a/js/zb.js
+++ b/js/zb.js
@@ -268,7 +268,7 @@ module.exports = class zb extends Exchange {
         const marketFieldName = this.getMarketFieldName ();
         const request = {};
         request[marketFieldName] = market['id'];
-        request['size'] = limit
+        request['size'] = limit;
         const response = await this.publicGetDepth (this.extend (request, params));
         return this.parseOrderBook (response);
     }


### PR DESCRIPTION
ZB supports ```size``` as the ```limit``` on FetchOrderBook. See https://www.zb.com/api#rkxgwlsqnlpypod