### PR TITLE
Fix php autload bug

### DIFF
--- a/php/errors.php
+++ b/php/errors.php
@@ -48,7 +48,7 @@ $error_hierarchy = array (
 if (!function_exists('ccxt\error_factory')) {
     function error_factory($array, $parent) {
         foreach ($array as $error => $subclasses) {
-            if (!class_exists($error)) {
+            if (!class_exists('ccxt\\'.$error, false)) {
                 eval("namespace ccxt; class $error extends $parent {};");
                 error_factory($subclasses, $error);
             }
@@ -56,7 +56,7 @@ if (!function_exists('ccxt\error_factory')) {
     }
 }
 
-if (!class_exists('ccxt\BaseError')) {
+if (!class_exists('ccxt\BaseError', false)) {
     class BaseError extends Exception {};
 }
 


### PR DESCRIPTION
The `class_exists` function called in `errors.php` actually declare everything in `ccxt\BaseError` before `error_factory` was executed in autoload environment. This can cause an error like this 
```
PHP Fatal error:  Cannot declare class ccxt\ExchangeError, because the name is already in use in /var/www/xxxxx/vendor/ccxt/ccxt/php/errors.php(56)
```
This can be fixed with passing `false` as the second parameter.  [doc](https://www.php.net/manual/en/function.class-exists.php)