### PR TITLE
Fix: transpile removed space between not and the following bracket

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -251,6 +251,7 @@ const pythonRegexes = [
     [ /([^:+=\/\*\s-]+) \(/g, '$1(' ], // PEP8 E225 remove whitespaces before left ( round bracket
     [ /\sand\(/g, ' and (' ],
     [ /\sor\(/g, ' or (' ],
+    [ /\snot\(/g, ' not (' ],
     [ /\[ /g, '[' ],              // PEP8 E201 remove whitespaces after left [ square bracket
     [ /\{ /g, '{' ],              // PEP8 E201 remove whitespaces after left { bracket
     [ /([^\s]+) \]/g, '$1]' ],    // PEP8 E202 remove whitespaces before right ] square bracket


### PR DESCRIPTION
I fixed the same for and/or in 04023db867879b6e2aac7e40f5c2ef22cf74fbbe