### PR TITLE
whitebit: fix handle_error error

### DIFF
--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -609,7 +609,7 @@ module.exports = class whitebit extends Exchange {
         if (response !== undefined) {
             const success = this.safeValue (response, 'success');
             if (!success) {
-                const message = response['message'];
+                const message = this.safeValue (response, 'message');
                 if (message) {
                     throw new ExchangeError (message);
                 } else {

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -610,7 +610,7 @@ module.exports = class whitebit extends Exchange {
             const success = this.safeValue (response, 'success');
             if (!success) {
                 const feedback = this.id + ' ' + body;
-                let message = this.safeValue (response, 'message');
+                const message = this.safeValue (response, 'message');
                 if (typeof message === 'string') {
                     const exact = this.safeValue (this.exceptions, 'exact', {});
                     if (message in exact) {

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -609,13 +609,20 @@ module.exports = class whitebit extends Exchange {
         if (response !== undefined) {
             const success = this.safeValue (response, 'success');
             if (!success) {
-                const message = this.safeValue (response, 'message');
-                if (message) {
-                    throw new ExchangeError (message);
-                } else {
-                    const feedback = this.id + ' ' + this.json (response);
-                    throw new ExchangeError (feedback);
+                const feedback = this.id + ' ' + body;
+                let message = this.safeValue (response, 'message');
+                if (typeof message === 'string') {
+                    const exact = this.safeValue (this.exceptions, 'exact', {});
+                    if (message in exact) {
+                        throw new exact[message] (feedback);
+                    }
+                    const broad = this.safeValue (this.exceptions, 'broad', {});
+                    const broadKey = this.findBroadlyMatchedKey (broad, message);
+                    if (broadKey !== undefined) {
+                        throw new broad[broadKey] (feedback);
+                    }
                 }
+                throw new ExchangeError (feedback);
             }
         }
     }


### PR DESCRIPTION
status 500 has no message, all other properties are null, besides:
`"errors": {"message": ["Server Error"]}`
