### PR TITLE
BitMax fetchClosedOrders limit fix

### DIFF
--- a/js/bitmax.js
+++ b/js/bitmax.js
@@ -943,7 +943,7 @@ module.exports = class bitmax extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
-            request['pageSize'] = limit;
+            request['n'] = limit; // default 15, max 50
         }
         const response = await this.privateGetOrderHistory (this.extend (request, params));
         //


### PR DESCRIPTION
We use v1 API so it will work with `n` not `pageSize`
v1: https://github.com/bitmax-exchange/api-doc/blob/master/archive/bitmax-api-doc-v1.1.md#list-historical-orders-api_pathorderhistory

v2: https://github.com/bitmax-exchange/api-doc/blob/master/bitmax-api-doc-v1.2.md#list-historical-orders-api_pathorderhistory