### PR TITLE
added client order id option to hitbtc

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -762,7 +762,7 @@ module.exports = class hitbtc extends Exchange {
         if (Math.abs (difference) > market['step']) {
             throw new ExchangeError (this.id + ' order amount should be evenly divisible by lot unit size of ' + market['lot'].toString ());
         }
-        const clientOrderId = this.milliseconds ();
+        const clientOrderId = params['clientOrderId'] || this.milliseconds ();
         const request = {
             'clientOrderId': clientOrderId.toString (),
             'symbol': market['id'],


### PR DESCRIPTION
To be able to track our HitBTC orders, we can set our custom clientOrderId.
If you don't supply a clientOrderId it falls back to the normal milliseconds.