### PR TITLE
[ByteTrade] fetchBalance and createOrder update

### DIFF
--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -282,12 +282,9 @@ module.exports = class bytetrade extends Exchange {
             throw new ArgumentsRequired (this.id + ' fetchDeposits requires this.apiKey or userid argument');
         }
         await this.loadMarkets ();
-        const request = {};
-        if ('userid' in params) {
-            request['userid'] = params['userid'];
-        } else {
-            request['userid'] = this.apiKey;
-        }
+        const request = {
+            'userid': this.apiKey,
+        };
         const balances = await this.publicGetBalance (this.extend (request, params));
         const result = { 'info': balances };
         for (let i = 0; i < balances.length; i++) {
@@ -532,7 +529,37 @@ module.exports = class bytetrade extends Exchange {
         const defaultFee = this.safeString (this.options, 'fee', '300000000000000');
         const fee = this.safeString (params, 'fee', defaultFee);
         const eightBytes = this.integerPow ('2', '64');
-        const chainidByteStringArray = [this.numberToBE (1, 32)];
+        const allByteStringArray = [
+            this.numberToBE (1, 32),
+            this.numberToLE (Math.floor (now / 1000), 4),
+            this.numberToLE (1, 1),
+            this.numberToLE (Math.floor (expiration / 1000), 4),
+            this.numberToLE (1, 1),
+            this.numberToLE (32, 1),
+            this.numberToLE (0, 8),
+            this.numberToLE (fee, 8),  // string for 32 bit php
+            this.numberToLE (this.apiKey.length, 1),
+            this.stringToBinary (this.encode (this.apiKey)),
+            this.numberToLE (sideNum, 1),
+            this.numberToLE (typeNum, 1),
+            this.numberToLE (normalSymbol.length, 1),
+            this.stringToBinary (this.encode (normalSymbol)),
+            this.numberToLE (this.integerDivide (amountChain, eightBytes), 8),
+            this.numberToLE (this.integerModulo (amountChain, eightBytes), 8),
+            this.numberToLE (this.integerDivide (priceChain, eightBytes), 8),
+            this.numberToLE (this.integerModulo (priceChain, eightBytes), 8),
+            this.numberToLE (0, 2),
+            this.numberToLE (Math.floor (now / 1000), 4),
+            this.numberToLE (Math.floor (expiration / 1000), 4),
+            this.numberToLE (0, 2),
+            this.numberToLE (parseInt (quoteId), 4),
+            this.numberToLE (parseInt (baseId), 4),
+            this.numberToLE (0, 1),
+            this.numberToLE (1, 1),
+            this.numberToLE (chainName.length, 1),
+            this.stringToBinary (this.encode (chainName)),
+            this.numberToLE (0, 1),
+        ];
         const txByteStringArray = [
             this.numberToLE (Math.floor (now / 1000), 4),
             this.numberToLE (1, 1),
@@ -563,25 +590,18 @@ module.exports = class bytetrade extends Exchange {
             this.stringToBinary (this.encode (chainName)),
             this.numberToLE (0, 1),
         ];
-        const opid0ByteStringArray = [this.numberToBE (0, 4)];
-        const opid1ByteStringArray = [this.numberToBE (1, 4)];
         const txbytestring = this.binaryConcatArray (txByteStringArray);
         const txidhash = this.hash (txbytestring, 'sha256', 'hex');
         const txid = txidhash.slice (0, 40);
-        const txidByteStringArray = [
+        const orderidByteStringArray = [
             this.numberToLE (txid.length, 1),
             this.stringToBinary (this.encode (txid)),
+            this.numberToBE (0, 4),
         ];
-        const orderid0byteStringArray = this.arrayConcat (txidByteStringArray, opid0ByteStringArray);
-        const orderid0bytestring = this.binaryConcatArray (orderid0byteStringArray);
-        const orderid0hash = this.hash (orderid0bytestring, 'sha256', 'hex');
-        const orderid0 = orderid0hash.slice (0, 40);
-        const orderid1byteStringArray = this.arrayConcat (txidByteStringArray, opid1ByteStringArray);
-        const orderid1bytestring = this.binaryConcatArray (orderid1byteStringArray);
-        const orderid1hash = this.hash (orderid1bytestring, 'sha256', 'hex');
-        const orderid1 = orderid1hash.slice (0, 40);
-        const byteStringArray = this.arrayConcat (chainidByteStringArray, txByteStringArray);
-        const bytestring = this.binaryConcatArray (byteStringArray);
+        const orderidbytestring = this.binaryConcatArray (orderidByteStringArray);
+        const orderidhash = this.hash (orderidbytestring, 'sha256', 'hex');
+        const orderid = orderidhash.slice (0, 40);
+        const bytestring = this.binaryConcatArray (allByteStringArray);
         const hash = this.hash (bytestring, 'sha256', 'hex');
         const signature = this.ecdsa (hash, this.secret, 'secp256k1', undefined, true);
         const recoveryParam = this.decode (this.binaryToBase16 (this.numberToLE (this.sum (signature['v'], 31), 1)));
@@ -624,9 +644,7 @@ module.exports = class bytetrade extends Exchange {
         const status = (statusCode === '0') ? 'open' : 'failed';
         return {
             'info': response,
-            'id': orderid0,
-            'id1': orderid1,
-            'txid': txid,
+            'id': orderid,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': undefined,


### PR DESCRIPTION
the create_order operate index in transaction is always 0 becasue the transaction only include this operation, so the order_id is clearly and unique, so we can return the id  that can be used to fetch the order later with the fetchOrder method