### PR TITLE
Latoken fetchOrderBook fix

### DIFF
--- a/js/latoken.js
+++ b/js/latoken.js
@@ -61,6 +61,7 @@ module.exports = class latoken extends Exchange {
                         'MarketData/tickers',
                         'MarketData/ticker/{symbol}',
                         'MarketData/orderBook/{symbol}',
+                        'MarketData/orderBook/{symbol}/{limit}',
                         'MarketData/trades/{symbol}',
                         'MarketData/trades/{symbol}/{limit}',
                     ],
@@ -313,22 +314,26 @@ module.exports = class latoken extends Exchange {
         const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
+            'limit': 10,
         };
-        const response = await this.publicGetMarketDataOrderBookSymbol (this.extend (request, params));
+        if (limit !== undefined) {
+            request['limit'] = limit; // default 10, max 100
+        }
+        const response = await this.publicGetMarketDataOrderBookSymbolLimit (this.extend (request, params));
         //
         //     {
         //         "pairId": 502,
         //         "symbol": "LAETH",
         //         "spread": 0.07,
         //         "asks": [
-        //             { "price": 136.3, "amount": 7.024 }
+        //             { "price": 136.3, "quantity": 7.024 }
         //         ],
         //         "bids": [
-        //             { "price": 136.2, "amount": 6.554 }
+        //             { "price": 136.2, "quantity": 6.554 }
         //         ]
         //     }
         //
-        return this.parseOrderBook (response, undefined, 'bids', 'asks', 'price', 'amount');
+        return this.parseOrderBook (response, undefined, 'bids', 'asks', 'price', 'quantity');
     }
 
     parseTicker (ticker, market = undefined) {


### PR DESCRIPTION
They change response format (`quantity` instead of `amount`):

`{"pairId":"63b41092-f3f6-4ea4-9e7c-4525ed250dad","symbol":"ETHBTC","spread":0.4952,"asks":[{"price":0.021000,"quantity":0.133},{"price":0.021808,"quantity":0.004},{"price":0.021999,"quantity":0.047},{"price":0.022000,"quantity":0.442},{"price":0.022076,"quantity":0.377},{"price":0.022100,"quantity":0.130},{"price":0.022104,"quantity":0.020},{"price":0.022206,"quantity":0.020},{"price":0.022470,"quantity":0.355},{"price":0.026013,"quantity":0.250}],"bids":[{"price":0.020896,"quantity":2.587},{"price":0.020828,"quantity":0.007},{"price":0.020200,"quantity":2.036},{"price":0.019000,"quantity":0.100},{"price":0.018700,"quantity":2.683},{"price":0.018509,"quantity":0.052},{"price":0.017500,"quantity":2.530},{"price":0.017400,"quantity":1.700},{"price":0.016280,"quantity":2.000},{"price":0.015010,"quantity":0.750}]}`

Also we can use endpoint with `limit` , but it's mandatory
