### PR TITLE
idex parseTicker fix

### DIFF
--- a/js/idex.js
+++ b/js/idex.js
@@ -202,8 +202,8 @@ module.exports = class idex extends Exchange {
             'change': undefined,
             'percentage': percentage,
             'average': undefined,
-            'baseVolume': baseVolume,
-            'quoteVolume': quoteVolume,
+            'baseVolume': quoteVolume,
+            'quoteVolume': baseVolume,
             'info': ticker,
         };
     }


### PR DESCRIPTION
```
{ last: '0.0000178977',
     high: '0.0000178977',
     low: '0.0000178977',
     percentChange: '0',
     baseVolume: '0.157499759999999999',
     quoteVolume: '8799.999999999999951791',
     lowestAsk: '0.0000178977',
     highestBid: '0.00001557887887326' }
```