### PR TITLE
Whitebit: Fix error handling and add BadSymbol

### DIFF
--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -617,7 +617,7 @@ module.exports = class whitebit extends Exchange {
             const success = this.safeValue (response, 'success');
             if (!success) {
                 const feedback = this.id + ' ' + body;
-                let message = this.safeValue (response, 'message');
+                const message = this.safeValue (response, 'message');
                 if (typeof message === 'string') {
                     const exact = this.safeValue (this.exceptions, 'exact', {});
                     if (message in exact) {

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -618,15 +618,14 @@ module.exports = class whitebit extends Exchange {
             if (!success) {
                 const feedback = this.id + ' ' + body;
                 let message = this.safeValue (response, 'message');
-                if (typeof message !== 'string') {
-                    message = this.json (message);
-                }
-                const exact = this.safeValue (this.exceptions, 'exact', {});
-                if (message in exact) {
-                    throw new exact[message] (feedback);
+                if (typeof message === 'string') {
+                    const exact = this.safeValue (this.exceptions, 'exact', {});
+                    if (message in exact) {
+                        throw new exact[message] (feedback);
+                    }
                 }
                 const broad = this.safeValue (this.exceptions, 'broad', {});
-                const broadKey = this.findBroadlyMatchedKey (broad, message);
+                const broadKey = this.findBroadlyMatchedKey (broad, body);
                 if (broadKey !== undefined) {
                     throw new broad[broadKey] (feedback);
                 }

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -610,17 +610,18 @@ module.exports = class whitebit extends Exchange {
             const success = this.safeValue (response, 'success');
             if (!success) {
                 const feedback = this.id + ' ' + body;
-                const message = this.safeValue (response, 'message');
-                if (typeof message === 'string') {
-                    const exact = this.safeValue (this.exceptions, 'exact', {});
-                    if (message in exact) {
-                        throw new exact[message] (feedback);
-                    }
-                    const broad = this.safeValue (this.exceptions, 'broad', {});
-                    const broadKey = this.findBroadlyMatchedKey (broad, message);
-                    if (broadKey !== undefined) {
-                        throw new broad[broadKey] (feedback);
-                    }
+                let message = this.safeValue (response, 'message');
+                if (typeof message !== 'string') {
+                    message = this.json (message);
+                }
+                const exact = this.safeValue (this.exceptions, 'exact', {});
+                if (message in exact) {
+                    throw new exact[message] (feedback);
+                }
+                const broad = this.safeValue (this.exceptions, 'broad', {});
+                const broadKey = this.findBroadlyMatchedKey (broad, message);
+                if (broadKey !== undefined) {
+                    throw new broad[broadKey] (feedback);
                 }
                 throw new ExchangeError (feedback);
             }

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, DDoSProtection } = require ('./base/errors');
+const { ExchangeError, DDoSProtection, BadSymbol } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -104,6 +104,13 @@ module.exports = class whitebit extends Exchange {
             },
             'options': {
                 'fetchTradesMethod': 'fetchTradesV1',
+            },
+            'exceptions': {
+                'exact': {
+                },
+                'broad': {
+                    'Market is not available': BadSymbol, // {"success":false,"message":{"market":["Market is not available"]},"result":[]}
+                },
             },
         });
     }


### PR DESCRIPTION
They have a weird error reporting:
`{"success":false,"message":{"market":["Market is not available"]},"result":[]}`
I think, in the message dict there can be anything (market, price, amount) as a key, so converting it to a json-string is a way to catch all of it.
Any ideas on improving this?