### PR TITLE
Tidebit: fix error handling

### DIFF
--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -477,10 +477,13 @@ module.exports = class tidebit extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {
-        if (code === 400) {
+        if (code === 400 || !response) {
+            const feedback = this.id + ' ' + this.json (response);
+            if (!response) {
+                throw new ExchangeError (feedback);
+            }
             const error = this.safeValue (response, 'error');
             const errorCode = this.safeString (error, 'code');
-            const feedback = this.id + ' ' + this.json (response);
             const exceptions = this.exceptions;
             if (errorCode in exceptions) {
                 throw new exceptions[errorCode] (feedback);

--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -477,9 +477,9 @@ module.exports = class tidebit extends Exchange {
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {
-        if (code === 400 || !response) {
-            const feedback = this.id + ' ' + this.json (response);
-            if (!response) {
+        if ((code === 400) || (response === undefined)) {
+            const feedback = this.id + ' ' + body;
+            if (response === undefined) {
                 throw new ExchangeError (feedback);
             }
             const error = this.safeValue (response, 'error');


### PR DESCRIPTION
reproducible with:
`.venv/bin/python examples/py/cli.py tidebit fetch_ohlcv 'CNX/USX'`
