### PR TITLE
ftx: fix fetch trades

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -634,7 +634,7 @@ module.exports = class ftx extends Exchange {
             'market_name': market['id'],
         };
         if (since !== undefined) {
-            request['start_time'] = since;
+            request['start_time'] = parseInt (since / 1000);
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -635,6 +635,8 @@ module.exports = class ftx extends Exchange {
         };
         if (since !== undefined) {
             request['start_time'] = parseInt (since / 1000);
+            // start_time doesn't work without end_time
+            request['end_time'] = this.seconds ();
         }
         if (limit !== undefined) {
             request['limit'] = limit;


### PR DESCRIPTION
They use `since / 1000` everywhere (`fetchMyTrades`, `fetchOHLCV`, `fetchOrders`), but only for `fetchTrades` they support both `since` and `since / 1000`.
I changed it for `fetchTrades` to be consistent with the rest of the code, but my investigations resulted in: the result is equivalent with and without this code change. Please double check!