### PR TITLE
KuCoin - Replace 'sequence' with 'time' in fetch_order_book

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -585,7 +585,9 @@ module.exports = class kucoin extends Exchange {
         const levelString = this.safeString (request, 'level');
         const levelParts = levelString.split ('_');
         const level = parseInt (levelParts[0]);
-        return this.parseOrderBook (data, timestamp, 'bids', 'asks', level - 2, level - 1);
+        const orderbook = this.parseOrderBook (data, timestamp, 'bids', 'asks', level - 2, level - 1);
+        orderbook['nonce'] = this.safeInteger (data, 'sequence');
+        return orderbook;
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -580,7 +580,7 @@ module.exports = class kucoin extends Exchange {
         //   bids: [ [ '5c419328ef83c75456bd615c', '0.9', '0.09' ], ... ], }
         //
         const data = response['data'];
-        const timestamp = this.safeInteger (data, 'sequence');
+        const timestamp = this.safeInteger (data, 'time');
         // level can be a string such as 2_20 or 2_100
         const levelString = this.safeString (request, 'level');
         const levelParts = levelString.split ('_');

--- a/php/kucoin.php
+++ b/php/kucoin.php
@@ -581,7 +581,7 @@ class kucoin extends Exchange {
         //   bids => array ( array ( '5c419328ef83c75456bd615c', '0.9', '0.09' ), ... ), }
         //
         $data = $response['data'];
-        $timestamp = $this->safe_integer($data, 'sequence');
+        $timestamp = $this->safe_integer($data, 'time');
         // $level can be a string such as 2_20 or 2_100
         $levelString = $this->safe_string($request, 'level');
         $levelParts = explode('_', $levelString);

--- a/python/ccxt/kucoin.py
+++ b/python/ccxt/kucoin.py
@@ -567,7 +567,7 @@ class kucoin(Exchange):
         #   bids: [['5c419328ef83c75456bd615c', '0.9', '0.09'], ...],}
         #
         data = response['data']
-        timestamp = self.safe_integer(data, 'sequence')
+        timestamp = self.safe_integer(data, 'time')
         # level can be a string such as 2_20 or 2_100
         levelString = self.safe_string(request, 'level')
         levelParts = levelString.split('_')


### PR DESCRIPTION
Currently the sequence of the KuCoin response is used as timestamp, but KuCoin does send the timestamp in an extra field.

## Response (from KuCoin)

```
{
    "sequence": "3262786978",
    "time": 1550653727731,
    "bids": [["6500.12", "0.45054140"],
             ["6500.11", "0.45054140"]],  //[price，size]
    "asks": [["6500.16", "0.57753524"],
             ["6500.15", "0.57753524"]]  
}
``` 