### PR TITLE
Fix incorrect exchangePairCode for southxchange SMT,MTC pairs

### DIFF
--- a/js/southxchange.js
+++ b/js/southxchange.js
@@ -75,7 +75,7 @@ module.exports = class southxchange extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
-            const id = symbol;
+            const id = baseId + '/' + quoteId;
             result.push ({
                 'id': id,
                 'symbol': symbol,


### PR DESCRIPTION
Using the `commonCurrencySymbol` for the id breaks any operation involving pairs with these assets.