### PR TITLE
Huobi Pro fetchMarkets max amount

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -263,6 +263,7 @@ module.exports = class huobipro extends Exchange {
             const maker = (base === 'OMG') ? 0 : 0.2 / 100;
             const taker = (base === 'OMG') ? 0 : 0.2 / 100;
             const minAmount = this.safeFloat (market, 'min-order-amt', Math.pow (10, -precision['amount']));
+            const maxAmount = this.safeFloat (market, 'max-order-amt');
             const minCost = this.safeFloat (market, 'min-order-value', 0);
             const state = this.safeString (market, 'state');
             const active = (state === 'online');
@@ -280,7 +281,7 @@ module.exports = class huobipro extends Exchange {
                 'limits': {
                     'amount': {
                         'min': minAmount,
-                        'max': undefined,
+                        'max': maxAmount,
                     },
                     'price': {
                         'min': Math.pow (10, -precision['price']),


### PR DESCRIPTION
```
info:
   { 'base-currency': 'eth',
     'quote-currency': 'btc',
     'price-precision': 6,
     'amount-precision': 4,
     'symbol-partition': 'main',
     symbol: 'ethbtc',
     state: 'online',
     'value-precision': 4,
     'min-order-amt': 0.001,
     'max-order-amt': 10000,
     'min-order-value': 0.0001,
     'leverage-ratio': 5,
     'super-margin-leverage-ratio': 3 }
```