### PR TITLE
Leverage Docker Layer Caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM ubuntu:18.04
 # Supresses unwanted user interaction (like "Please select the geographic area" when installing tzdata)
 ENV DEBIAN_FRONTEND=noninteractive
 
-ADD . /ccxt
 WORKDIR /ccxt
 
-# Update packages (use us.archive.ubuntu.com instead of archive.ubuntu.com — solves the painfully slow apt-get update)
+# Install system dependencies & Update packages (use us.archive.ubuntu.com instead of archive.ubuntu.com — solves the painfully slow apt-get update)
 RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.list \
     && apt-get update \
 # Miscellaneous deps
@@ -16,6 +15,8 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
 # Node
     && curl -sL https://deb.nodesource.com/setup_11.x | bash - \
     && apt-get -y install nodejs \
+    && ln -s /ccxt /usr/lib/node_modules \
+    && echo "export NODE_PATH=/usr/lib/node_modules" >> $HOME/.bashrc \
 # Python 2
     && apt-get install -y python-pip \
     && pip2 install --upgrade setuptools \
@@ -24,17 +25,15 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
     && apt-get install -y python3 python3-pip \
     && pip3 install --upgrade setuptools \
     && pip3 install tox \
-# Copy files to workdir to && install scripts against it (will be replaced with a live-mounted volume at startup)
-    && mkdir -p /ccxt \
-    && rm -rf /ccxt/node_modules \
-# Installs as a local Node & Python module, so that `require ('ccxt')` and `import ccxt` should work after that
-    && npm install \
-    && ln -s /ccxt /usr/lib/node_modules/ \
-    && echo "export NODE_PATH=/usr/lib/node_modules" >> $HOME/.bashrc \
-    && cd python \
-    && python3 setup.py develop \
-    && python setup.py develop \
-    && cd .. \
 ## Remove apt sources
     && apt-get -y autoremove && apt-get clean && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY . .
+
+# Installs as a local Node & Python module, so that `require ('ccxt')` and `import ccxt` should work after that
+RUN npm install \
+    && cd python \
+    && python3 setup.py develop \
+    && python setup.py develop \
+    && cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,13 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
     && apt-get -y autoremove && apt-get clean && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY . .
+COPY ["package.json", "package-lock.json", "/ccxt/"]
+RUN npm install
 
-# Installs as a local Node & Python module, so that `require ('ccxt')` and `import ccxt` should work after that
-RUN npm install \
-    && cd python \
+COPY ["python/setup.py", "python/setup.cfg", "python/README.rst", "/ccxt/python/"]
+RUN cd python \
     && python3 setup.py develop \
     && python setup.py develop \
     && cd ..
+
+COPY . .


### PR DESCRIPTION
* This separates out the system dependencies from the library
dependencies, allowing subsequent builds to use the cached system
dependency layer when only application code has changed.

* Install the library dependencies in their own layers so a rebuild is only necessary on library dependency changes.

To test:

* On master:
  * `docker build .`
  * change a file (even inserting a blank line)
  * run `docker build .` again.
* On this branch:
  * `docker build .`
  * change a file
  * and run `docker build .` again.
  * change a dependency
  * run `docker build .` again

On this branch you should see the initial long build, then no real build (only the last layer), then a build that re-installs all higher layers than the dependency changed (if node: node + python, if python: just python).