### PR TITLE
fetchMyTrades, parseTrade fixes

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -496,7 +496,7 @@ module.exports = class bitmart extends Exchange {
         const request = {
             'symbol': market['id'],
             'offset': 0, // current page, starts from 0
-            'limit': 500, 
+            'limit': 500,
         };
         if (limit !== undefined) {
             request['limit'] = limit; // default 500, max 1000

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -392,20 +392,24 @@ module.exports = class bitmart extends Exchange {
         // fetchMyTrades (private)
         //
         //     {
-        //         "symbol": "BMX_ETH",
-        //         "amount": "1.0",
-        //         "fees": "0.0005000000",
-        //         "trade_id": 2734956,
-        //         "price": "0.00013737",
-        //         "active": true,
-        //         "entrust_id": 5576623,
-        //         "timestamp": 1545292334000
-        //     }
+        //         active: true,
+        //             amount: '0.2000',
+        //             entrustType: 1,
+        //             entrust_id: 979648824,
+        //             fees: '0.0000085532',
+        //             price: '0.021383',
+        //             symbol: 'ETH_BTC',
+        //             timestamp: 1574343514000,
+        //             trade_id: 329418828
+        //     },
         //
         const id = this.safeString (trade, 'trade_id');
         const timestamp = this.safeInteger2 (trade, 'timestamp', 'order_time');
         const type = undefined;
-        const side = this.safeStringLower (trade, 'type');
+        let side = this.safeStringLower (trade, 'type');
+        if (side === undefined && 'entrustType' in trade) {
+            side = trade['entrustType'] ? 'sell' : 'buy';
+        }
         const price = this.safeFloat (trade, 'price');
         const amount = this.safeFloat (trade, 'amount');
         let cost = undefined;
@@ -436,8 +440,10 @@ module.exports = class bitmart extends Exchange {
         const feeCost = this.safeFloat (trade, 'fees');
         let fee = undefined;
         if (feeCost !== undefined) {
-            // is it always quote, always base, or base-quote depending on the side?
-            const feeCurrencyCode = undefined;
+            let feeCurrencyCode = undefined;
+            if (market !== undefined) {
+                feeCurrencyCode = (side === 'buy') ? market['base'] : market['quote'];
+            }
             fee = {
                 'cost': feeCost,
                 'currency': feeCurrencyCode,
@@ -489,7 +495,8 @@ module.exports = class bitmart extends Exchange {
         const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
-            // 'offset': 0, // current page, starts from 0
+            'offset': 0, // current page, starts from 0
+            'limit': 500, 
         };
         if (limit !== undefined) {
             request['limit'] = limit; // default 500, max 1000

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -407,7 +407,7 @@ module.exports = class bitmart extends Exchange {
         const timestamp = this.safeInteger2 (trade, 'timestamp', 'order_time');
         const type = undefined;
         let side = this.safeStringLower (trade, 'type');
-        if (side === undefined && 'entrustType' in trade) {
+        if ((side === undefined) && ('entrustType' in trade)) {
             side = trade['entrustType'] ? 'sell' : 'buy';
         }
         const price = this.safeFloat (trade, 'price');


### PR DESCRIPTION
https://developer.bitmart.com/v2/en/#authenticated-endpoints-user-trade-history
They say: "`offset `and `limit `are optional." But I always got 
```
ExchangeError: bitmart {"message":"Internal Server Error"}
  constructor: [Function: ExchangeError],
  name: 'ExchangeError'
}
```
And it works fine, when I set `limit` and `offset`

About `feeCurrency`: they also have BMX token to pay currency but in API there are always `base/quote` sums. So unfortunately looks like it's not possible to mark fee in BMX correctly now.
```
{
      active: false,
      amount: '32216',
      entrustType: 1,
      entrust_id: 982193976,
      fees: '0.0001517373',
      price: '0.00000471',
      symbol: 'APL_ETH',
      timestamp: 1574375219000,
      trade_id: 330108197
    },
{
      active: false,
      amount: '31481',
      entrustType: 0,
      entrust_id: 984839061,
      fees: '31.4810000000',
      price: '0.00000482',
      symbol: 'APL_ETH',
      timestamp: 1574413580000,
      trade_id: 330821823
    }
```
![image](https://user-images.githubusercontent.com/38309641/69415222-4a511400-0d25-11ea-9ad9-cd17c79e28b5.png)
