### PR TITLE
Fixing `expires` config for Bitmex API calls.

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1270,7 +1270,7 @@ module.exports = class bitmex extends Exchange {
                 'Content-Type': 'application/json',
                 'api-key': this.apiKey,
             };
-            expires = this.sum (this.seconds (), expires);
+            expires = this.sum (this.milliseconds (), expires);
             expires = expires.toString ();
             auth += expires;
             headers['api-expires'] = expires;


### PR DESCRIPTION
I was getting the error below and got it working by changing it from `seconds` to `milliseconds`.

```
bitmex {
  "error": {
    "message": "This request has expired - `expires` is in the past. Current time: 1574621316",
    "name": "HTTPError"
  }
}'
```