### PR TITLE
Stex parseTicker fix

### DIFF
--- a/js/stex.js
+++ b/js/stex.js
@@ -516,8 +516,8 @@ module.exports = class stex extends Exchange {
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeFloat (ticker, 'volume'),
-            'quoteVolume': this.safeFloat (ticker, 'volumeQuote'),
+            'baseVolume': this.safeFloat (ticker, 'volumeQuote'),
+            'quoteVolume': this.safeFloat (ticker, 'volume'),
             'info': ticker,
         };
     }


### PR DESCRIPTION
```{
    id: 2,
    amount_multiplier: 1,
    currency_code: 'ETH',
    market_code: 'BTC',
    currency_name: 'Ethereum',
    market_name: 'Bitcoin',
    symbol: 'ETH_BTC',
    group_name: 'BTC',
    group_id: 1,
    ask: '0.02066300',
    bid: '0.02065704',
    last: '0.02066011',
    open: '0.02077524',
    low: '0.02040562',
    high: '0.02090000',
    volume: '458.12190698',
    volumeQuote: '22179.73021984',
    count: '6851',
    fiatsRate: {
      USD: 7061.82,
      EUR: 6359.5,
      UAH: 165419,
      AUD: 10247.02,
      IDR: 98262301,
      CNY: 48850,
      KRW: 8165345,
      JPY: 752858,
      VND: 159706147,
      INR: 491764,
      GBP: 5355.81,
      CAD: 9171.99,
      BRL: 29317,
      RUB: 444946
    }