### PR TITLE
Exchange: FTX Correct fetchOrderBook definition; add limit

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -447,12 +447,15 @@ module.exports = class ftx extends Exchange {
         return this.parseTickers (tickers, symbols);
     }
 
-    async fetchOrderBook (symbol, params = {}) {
+    async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
             'market_name': market['id'],
         };
+        if (limit !== undefined) {
+            request['depth'] = limit; // max 100, default 20
+        }
         const response = await this.publicGetMarketsMarketNameOrderbook (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
The fetchOrderBook() function call had an inconsistent argument list compared to supported exchanges