### PR TITLE
Timex parseOHLCV fix

### DIFF
--- a/js/timex.js
+++ b/js/timex.js
@@ -1105,7 +1105,7 @@ module.exports = class timex extends Exchange {
             this.safeFloat (ohlcv, 'high'),
             this.safeFloat (ohlcv, 'low'),
             this.safeFloat (ohlcv, 'close'),
-            this.safeFloat (ohlcv, 'volume'),
+            this.safeFloat (ohlcv, 'volumeQuote'),
         ];
     }
 


### PR DESCRIPTION
ETH/BTC:
```
{
"timestamp":"2019-12-10T20:00:00",
"open":"0.02004298",
"high":"0.02004298",
"low":"0.02003553",
"close":"0.02003753",
"volume":"0.097582224670656",
"volumeQuote":"4.8696383"
}
```