### PR TITLE
Add binance futures listenKey endpoints

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -160,6 +160,9 @@ module.exports = class binance extends Exchange {
                         'ticker/bookTicker',
                         'income',
                     ],
+                    'put': [ 'listenKey' ],
+                    'post': [ 'listenKey' ],
+                    'delete': [ 'listenKey' ],
                 },
                 'fapiPrivate': {
                     'get': [
@@ -1605,7 +1608,7 @@ module.exports = class binance extends Exchange {
         if (api === 'wapi') {
             url += '.html';
         }
-        const userDataStream = (path === 'userDataStream');
+        const userDataStream = ((path === 'userDataStream') || (path === 'listenKey'));
         if (path === 'historicalTrades') {
             headers = {
                 'X-MBX-APIKEY': this.apiKey,


### PR DESCRIPTION
This /fapi/v1/listenKey is the exact equivalent of /api/v3/userDataStream, which is already defined.