### PR TITLE
Fix Binance Futures income history

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -158,7 +158,6 @@ module.exports = class binance extends Exchange {
                         'ticker/24hr',
                         'ticker/price',
                         'ticker/bookTicker',
-                        'income',
                     ],
                     'put': [ 'listenKey' ],
                     'post': [ 'listenKey' ],
@@ -173,6 +172,7 @@ module.exports = class binance extends Exchange {
                         'balance',
                         'positionRisk',
                         'userTrades',
+                        'income',
                     ],
                     'post': [
                         'order',


### PR DESCRIPTION
`/fapi/v1/income` is a private endpoint, not a public endpoint.