### PR TITLE
add keepalive js

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -378,8 +378,8 @@ module.exports = class Exchange {
             const params = { method, headers, body, timeout: this.timeout }
 
             if (this.agent) {
-                params['agent'] = this.agent
                 this.agent.keepAlive = true
+                params['agent'] = this.agent
             } else if (this.httpAgent && url.indexOf ('http://') === 0) {
                 params['agent'] = this.httpAgent
             } else if (this.httpsAgent && url.indexOf ('https://') === 0) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -226,8 +226,6 @@ module.exports = class Exchange {
             'chrome': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36',
             'chrome39': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
         }
-        this.httpAgent = new http.Agent ({ 'keepAlive': true })
-        this.httpsAgent = new https.Agent ({ 'keepAlive': true })
 
         this.headers = {}
 
@@ -291,6 +289,14 @@ module.exports = class Exchange {
         // merge to this
         for (const [property, value] of Object.entries (config))
             this[property] = deepExtend (this[property], value)
+        
+        if (!this.httpAgent) {
+            this.httpAgent = new http.Agent ({ 'keepAlive': true })
+        }
+        
+        if (!this.httpsAgent) {
+            this.httpsAgent = new https.Agent ({ 'keepAlive': true })
+        }
 
         // generate old metainfo interface
         for (const k in this.has) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -227,7 +227,7 @@ module.exports = class Exchange {
             'chrome39': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
         }
         this.httpAgent = new http.Agent ({ 'keepAlive': true })
-        this.httpsAgent = new https.Agent({ 'keepAlive': true })
+        this.httpsAgent = new https.Agent ({ 'keepAlive': true })
 
         this.headers = {}
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -376,6 +376,10 @@ module.exports = class Exchange {
             } else if (this.httpsAgent && url.indexOf ('https://') === 0) {
                 params['agent'] = this.httpsAgent;
             }
+            if (this.agent) {
+                params['agent'] = this.agent
+                this.agent.keepAlive = true
+            }
 
             const promise =
                 fetchImplementation (url, this.extend (params, this.fetchOptions))

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2,6 +2,8 @@
 
 /*  ------------------------------------------------------------------------ */
 
+const http = require ('http')
+const https = require ('https')
 const functions = require ('./functions')
 
 const {
@@ -224,6 +226,8 @@ module.exports = class Exchange {
             'chrome': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36',
             'chrome39': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
         }
+        this.httpAgent = new http.Agent ({ 'keepAlive': true })
+        this.httpsAgent = new https.Agent({ 'keepAlive': true })
 
         this.headers = {}
 
@@ -371,8 +375,6 @@ module.exports = class Exchange {
                 params['agent'] = this.httpAgent;
             } else if (this.httpsAgent && url.indexOf ('https://') === 0) {
                 params['agent'] = this.httpsAgent;
-            } else if (this.agent) {
-                params['agent'] = this.agent;
             }
 
             const promise =

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -371,14 +371,13 @@ module.exports = class Exchange {
 
             const params = { method, headers, body, timeout: this.timeout }
 
-            if (this.httpAgent && url.indexOf ('http://') === 0) {
-                params['agent'] = this.httpAgent;
-            } else if (this.httpsAgent && url.indexOf ('https://') === 0) {
-                params['agent'] = this.httpsAgent;
-            }
             if (this.agent) {
                 params['agent'] = this.agent
                 this.agent.keepAlive = true
+            } else if (this.httpAgent && url.indexOf ('http://') === 0) {
+                params['agent'] = this.httpAgent
+            } else if (this.httpsAgent && url.indexOf ('https://') === 0) {
+                params['agent'] = this.httpsAgent
             }
 
             const promise =


### PR DESCRIPTION
i found kraken to be a particular good exchange to test this on because they have pretty lax ratelimits

```
// node fetch profiling

let ccxt = require ('./ccxt')

;(async () => {
    const start = process.hrtime ()
    const kraken = new ccxt.kraken ()
    for (let i = 0; i < 20; i++) {
        await kraken.fetchTicker ('ETH/BTC')
    }
    const end = process.hrtime (start)
    console.log (end[0] + end[1] / 1000000000)
}) ()
```