### PR TITLE
Fix ftx's parseTrade function

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -570,7 +570,7 @@ module.exports = class ftx extends Exchange {
         let symbol = undefined;
         if (marketId !== undefined) {
             if (marketId in this.markets_by_id) {
-                market = this.markets_by_id;
+                market = this.markets_by_id[marketId];
                 symbol = market['symbol'];
             } else {
                 const base = this.safeCurrencyCode (this.safeString (trade, 'baseCurrency'));


### PR DESCRIPTION
Problem: in FTX's parseTrades function market object
conditionally overrode by the map of all markets, but
then it's treated as a just market object. Because of this
this function couldn't map symbol from market to trade
object, and then parseTrades filters out trades without
symbol and as a result ccxt returns an empty list of trades.

Solution: Fixed by setting a market variable as an element
of markets_by_id with id of marketId.