### PR TITLE
Fix Timex createOrder function

### DIFF
--- a/js/timex.js
+++ b/js/timex.js
@@ -468,7 +468,7 @@ module.exports = class timex extends Exchange {
             const expireIn = this.safeValue (params, 'expireIn', defaultExpireIn);
             if (expireTime !== undefined) {
                 request['expireTime'] = expireTime;
-            } else if (expireIn === undefined) {
+            } else if (expireIn !== undefined) {
                 request['expireIn'] = expireIn;
             } else {
                 throw new InvalidOrder (this.id + ' createOrder method requires a expireTime or expireIn param for a ' + type + ' order, you can also set the expireIn exchange-wide option');


### PR DESCRIPTION
Problem: createOrder has typo in checking existance
of expireIn in params, and as a result the this funciton
throws exception.

Solution: changed strict equals to strict not equals.