### PR TITLE
parseBalance edits for pro

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -945,7 +945,10 @@ module.exports = class Exchange {
         balance['used'] = {}
         balance['total'] = {}
 
-        currencies.forEach ((currency) => {
+        for (const currency of currencies) {
+            if (currency === 'free' || currency === 'used' || currency === 'total') {
+                continue
+            }
 
             if (balance[currency].total === undefined) {
                 if (balance[currency].free !== undefined && balance[currency].used !== undefined) {
@@ -964,10 +967,9 @@ module.exports = class Exchange {
             }
 
             [ 'free', 'used', 'total' ].forEach ((account) => {
-                balance[account] = balance[account] || {}
                 balance[account][currency] = balance[currency][account]
             })
-        })
+        }
 
         return balance
     }

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1637,30 +1637,29 @@ class Exchange {
         $balance['used'] = array();
         $balance['total'] = array();
 
+        $accounts = array('free', 'used', 'total');
+
         foreach ($currencies as $code => $value) {
+            if ($code === 'free' || $code === 'used' || $code === 'total') {
+                continue;
+            }
             if (!isset($value['total'])) {
                 if (isset($value['free']) && isset($value['used'])) {
-                    $currencies[$code]['total'] = static::sum($value['free'], $value['used']);
+                    $balance[$code]['total'] = static::sum($value['free'], $value['used']);
                 }
             }
             if (!isset($value['used'])) {
                 if (isset($value['total']) && isset($value['free'])) {
-                    $currencies[$code]['used'] = static::sum($value['total'], -$value['free']);
+                    $balance[$code]['used'] = static::sum($value['total'], -$value['free']);
                 }
             }
             if (!isset($value['free'])) {
                 if (isset($value['total']) && isset($value['used'])) {
-                    $currencies[$code]['free'] = static::sum($value['total'], -$value['used']);
+                    $balance[$code]['free'] = static::sum($value['total'], -$value['used']);
                 }
             }
-        }
-
-        $accounts = array('free', 'used', 'total');
-        foreach ($accounts as $account) {
-            $balance[$account] = array();
-            foreach ($currencies as $code => $value) {
-                $balance[$code] = isset($balance[$code]) ? $balance[$code] : array();
-                $balance[$code][$account] = $balance[$account][$code] = $value[$account];
+            foreach ($accounts as $account) {
+                $balance[$account][$code] = $balance[$code][$account];
             }
         }
         return $balance;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1419,6 +1419,9 @@ class Exchange(object):
         balance['total'] = {}
 
         for currency in currencies:
+            if currency == 'free' or currency == 'used' or currency == 'total':
+                continue
+
             if balance[currency].get('total') is None:
                 if balance[currency].get('free') is not None and balance[currency].get('used') is not None:
                     balance[currency]['total'] = self.sum(balance[currency].get('free'), balance[currency].get('used'))
@@ -1431,9 +1434,7 @@ class Exchange(object):
                 if balance[currency].get('total') is not None and balance[currency].get('free') is not None:
                     balance[currency]['used'] = self.sum(balance[currency]['total'], -balance[currency]['free'])
 
-        for account in ['free', 'used', 'total']:
-            balance[account] = {}
-            for currency in currencies:
+            for account in ['free', 'used', 'total']:
                 balance[account][currency] = balance[currency][account]
         return balance
 


### PR DESCRIPTION
makes all `parseBalance` code the same as the js code, with incremental balance structures the 'free' keys were getting parsed as currencies 