### PR TITLE
#6404 Fix cached markets (Proposal 2)

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -637,7 +637,7 @@ module.exports = class Exchange {
             'limits': this.limits,
             'precision': this.precision,
         }, this.fees['trading'], market))
-        this.markets = deepExtend (this.markets, indexBy (values, 'symbol'))
+        this.markets = indexBy (values, 'symbol')
         this.marketsById = indexBy (markets, 'id')
         this.markets_by_id = this.marketsById
         this.symbols = Object.keys (this.markets).sort ()


### PR DESCRIPTION
I'm highly concered why we should deeply extend previously fetched markets with a new one. So I've removed this deepExtend function.

As we can see, below the buggy line we are setting marketsById without deeply extending the data from previously fetched ones. 