### PR TITLE
Add sending client_oid in createOrder function for Okex

### DIFF
--- a/js/okex3.js
+++ b/js/okex3.js
@@ -1495,6 +1495,10 @@ module.exports = class okex3 extends Exchange {
             // 'client_oid': 'abcdef1234567890', // [a-z0-9]{1,32}
             // 'order_type': '0', // 0: Normal limit order (Unfilled and 0 represent normal limit order) 1: Post only 2: Fill Or Kill 3: Immediatel Or Cancel
         };
+        const clientOid = this.safeString (params, 'client_oid');
+        if (clientOid !== undefined) {
+            request['client_oid'] = clientOid;
+        }
         let method = undefined;
         if (market['futures'] || market['swap']) {
             const size = market['futures'] ? this.numberToString (amount) : this.amountToPrecision (symbol, amount);


### PR DESCRIPTION
Problem: There is no way to send client_oid while
placing order for Okex exchange.

Solution: Added this parameter from params in
sendOrder function.