### PR TITLE
Exchange.indexBy : accept elements that are array in Python

### DIFF
--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -2,7 +2,7 @@
 
 /*  ------------------------------------------------------------------------ */
 
-const { isObject, isNumber, isDictionary, isArray } = require ('./type')
+const { isObject, isNumber, isInteger, isDictionary, isArray } = require ('./type')
 
 /*  ------------------------------------------------------------------------ */
 
@@ -77,12 +77,26 @@ module.exports =
           value2: { someKey: 'value2', anotherKey: 'anotherValue2' },
           value3: { someKey: 'value3', anotherKey: 'anotherValue3' },
       }
+      
+       Array objects itself can be array too:
+       array = [
+          [7900.0, 10.0],
+          [7901.0, 8.8],
+       ]
+       key = 0
+       
+       Returns:
+      {
+          7900.0: [7900.0, 10.0],
+          7901.0: [7901.0, 8.8],
+      }
     */
 
     , indexBy (x, k, out = {}) {
-
+        const isIntKey = isInteger(k)
         for (const v of values (x))
-            if (k in v)
+            if (((!isArray(v) && (k in v)) || (isArray(v) && isIntKey && k < v.length))
+                    && v[k] !== undefined)
                 out[v[k]] = v
 
         return out

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -2,7 +2,7 @@
 
 /*  ------------------------------------------------------------------------ */
 
-const { isObject, isNumber, isInteger, isDictionary, isArray } = require ('./type')
+const { isObject, isNumber, isDictionary, isArray } = require ('./type')
 
 /*  ------------------------------------------------------------------------ */
 
@@ -77,28 +77,14 @@ module.exports =
           value2: { someKey: 'value2', anotherKey: 'anotherValue2' },
           value3: { someKey: 'value3', anotherKey: 'anotherValue3' },
       }
-
-       Array objects itself can be array too:
-       array = [
-          [7900.0, 10.0],
-          [7901.0, 8.8],
-       ]
-       key = 0
-
-       Returns:
-      {
-          7900.0: [7900.0, 10.0],
-          7901.0: [7901.0, 8.8],
-      }
     */
 
     , indexBy (x, k, out = {}) {
-        const isIntKey = isInteger (k)
-        for (const v of values (x)) {
-            if ((isIntKey && (k < v.length)) || (k in v)) {
+
+        for (const v of values (x))
+            if (k in v)
                 out[v[k]] = v
-            }
-        }
+
         return out
     }
 

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -94,11 +94,11 @@ module.exports =
 
     , indexBy (x, k, out = {}) {
         const isIntKey = isInteger (k)
-        for (const v of values (x))
-            if (((!isArray (v) && (k in v)) || (isArray (v) && isIntKey && k < v.length))
-                    && (v[k] !== undefined))
+        for (const v of values (x)) {
+            if ((isIntKey && (k < v.length))) || (k in v)) {
                 out[v[k]] = v
-
+            }
+        }
         return out
     }
 

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -77,14 +77,14 @@ module.exports =
           value2: { someKey: 'value2', anotherKey: 'anotherValue2' },
           value3: { someKey: 'value3', anotherKey: 'anotherValue3' },
       }
-      
+
        Array objects itself can be array too:
        array = [
           [7900.0, 10.0],
           [7901.0, 8.8],
        ]
        key = 0
-       
+
        Returns:
       {
           7900.0: [7900.0, 10.0],
@@ -93,10 +93,10 @@ module.exports =
     */
 
     , indexBy (x, k, out = {}) {
-        const isIntKey = isInteger(k)
+        const isIntKey = isInteger (k)
         for (const v of values (x))
-            if (((!isArray(v) && (k in v)) || (isArray(v) && isIntKey && k < v.length))
-                    && v[k] !== undefined)
+            if (((!isArray (v) && (k in v)) || (isArray (v) && isIntKey && k < v.length))
+                    && (v[k] !== undefined))
                 out[v[k]] = v
 
         return out

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -95,7 +95,7 @@ module.exports =
     , indexBy (x, k, out = {}) {
         const isIntKey = isInteger (k)
         for (const v of values (x)) {
-            if ((isIntKey && (k < v.length))) || (k in v)) {
+            if ((isIntKey && (k < v.length)) || (k in v)) {
                 out[v[k]] = v
             }
         }

--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -3,6 +3,7 @@
 /*  ------------------------------------------------------------------------ */
 
 const isNumber          = Number.isFinite
+    , isInteger         = Number.isInteger
     , isArray           = Array.isArray
     , hasProps          = o => ((o !== undefined) && (o !== null))
     , isString          = s =>                 (typeof s === 'string')
@@ -25,6 +26,7 @@ const asFloat   = x => ((isNumber (x) || isString (x)) ? parseFloat (x)     : Na
 module.exports = {
 
     isNumber
+    , isInteger
     , isArray
     , isObject
     , isString

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -813,8 +813,11 @@ class Exchange(object):
         result = {}
         if type(array) is dict:
             array = Exchange.keysort(array).values()
+        is_int_key = isinstance(key, int)
         for element in array:
-            if (key in element) and (element[key] is not None):
+            is_dict = isinstance(element, dict)
+            if (((is_dict and key in element) or (not is_dict and is_int_key and key < len(element)))
+                 and (element[key] is not None)):
                 k = element[key]
                 result[k] = element
         return result

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -816,8 +816,9 @@ class Exchange(object):
         is_int_key = isinstance(key, int)
         for element in array:
             is_dict = isinstance(element, dict)
-            if (((is_dict and key in element) or (not is_dict and is_int_key and key < len(element)))
-                 and (element[key] is not None)):
+            dict_check = is_dict and (key in element)
+            list_check = not is_dict and is_int_key and (key < len(element))
+            if (dict_check or list_check) and (element[key] is not None):
                 k = element[key]
                 result[k] = element
         return result

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -815,7 +815,7 @@ class Exchange(object):
             array = Exchange.keysort(array).values()
         is_int_key = isinstance(key, int)
         for element in array:
-            if ((is_int_key and (key < len(element)) or (key in element)) and (element[key] is not None):
+            if ((is_int_key and (key < len(element))) or (key in element)) and (element[key] is not None):
                 k = element[key]
                 result[k] = element
         return result

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -815,10 +815,7 @@ class Exchange(object):
             array = Exchange.keysort(array).values()
         is_int_key = isinstance(key, int)
         for element in array:
-            is_dict = isinstance(element, dict)
-            dict_check = is_dict and (key in element)
-            list_check = not is_dict and is_int_key and (key < len(element))
-            if (dict_check or list_check) and (element[key] is not None):
+            if ((is_int_key and (key < len(element)) or (key in element)) and (element[key] is not None):
                 k = element[key]
                 result[k] = element
         return result


### PR DESCRIPTION
This will be useful for dropping duplicate prices in order book:
```
  Exchange.toArray (Exchange.indexBy ([ [ 7910, 10 ], [ 7910, 10 ] ], 0))
  -> [ [ 7910, 10 ] ]
```

I didn't modify the php version, since that wasn't key safe in any case:
```
public static function index_by($array, $key) {
    $result = array();
    foreach ($array as $element) {
        if (isset($element[$key])) {
            $result[$element[$key]] = $element;
        }
    }
    return $result;
}
```
and should satisfy the new requirements.