### PR TITLE
fix sign method to use urlencodeWithArrayRepeat in sapiPostAssetDust

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1749,10 +1749,18 @@ module.exports = class binance extends Exchange {
         }
         if ((api === 'private') || (api === 'sapi') || (api === 'wapi' && path !== 'systemStatus') || (api === 'fapiPrivate')) {
             this.checkRequiredCredentials ();
-            let query = this.urlencode (this.extend ({
-                'timestamp': this.nonce (),
-                'recvWindow': this.options['recvWindow'],
-            }, params));
+            let query = undefined;
+            if (($api === 'sapi' && $path === 'asset/dust')){
+                query = this.urlencodeWithArrayRepeat (this.extend ({
+                    'timestamp': this.nonce (),
+                    'recvWindow': this.options['recvWindow'],
+                }, params));
+            } else {
+                query = this.urlencode (this.extend ({
+                    'timestamp': this.nonce (),
+                    'recvWindow': this.options['recvWindow'],
+                }, params));
+            }
             const signature = this.hmac (this.encode (query), this.encode (this.secret));
             query += '&' + 'signature=' + signature;
             headers = {

--- a/js/binance.js
+++ b/js/binance.js
@@ -1750,7 +1750,7 @@ module.exports = class binance extends Exchange {
         if ((api === 'private') || (api === 'sapi') || (api === 'wapi' && path !== 'systemStatus') || (api === 'fapiPrivate')) {
             this.checkRequiredCredentials ();
             let query = undefined;
-            if (($api === 'sapi' && $path === 'asset/dust')){
+            if ((api === 'sapi') && (path === 'asset/dust')) {
                 query = this.urlencodeWithArrayRepeat (this.extend ({
                     'timestamp': this.nonce (),
                     'recvWindow': this.options['recvWindow'],


### PR DESCRIPTION
When invoking sapiPostAssetDust with 

```javascript
 params = {
  'asset': ['ETH','BTC']
}
```

This method receives and array of assets that must be encoded like this: `asset=BTC&asset=USDT`, but using urlencode method Binance returns this error:  {"code":-1022,"msg":"Signature for this request is not valid."}

Using urlencodeWithArrayRepeat fix this issue.

[https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#dust-transfer-user_data](https://github.com/binance-exchange/binance-official-api-docs/blob/9dbe0e961b80557bb19708a707c7fad08842b28e/wapi-api.md#dust-transfer-user_data)


