### PR TITLE
parse8601 incorrect parse milliseconds

### DIFF
--- a/js/test/base/functions/test.datetime.js
+++ b/js/test/base/functions/test.datetime.js
@@ -29,6 +29,9 @@ assert (exchange.parse8601 ('1986-04-26T01:23:47.000Z') === 514862627000);
 assert (exchange.parse8601 ('1986-04-26T01:23:47.559Z') === 514862627559);
 assert (exchange.parse8601 ('1986-04-26T01:23:47.062Z') === 514862627062);
 
+assert (exchange.parse8601 ('1986-04-26T01:23:47.06Z') === 514862627060);
+assert (exchange.parse8601 ('1986-04-26T01:23:47.6Z') === 514862627600);
+
 assert (exchange.parse8601 ('1977-13-13T00:00:00.000Z') === undefined);
 assert (exchange.parse8601 ('1986-04-26T25:71:47.000Z') === undefined);
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1002,6 +1002,7 @@ class Exchange(object):
                 return None
             yyyy, mm, dd, h, m, s, ms, sign, hours, minutes = match.groups()
             ms = ms or '.000'
+            ms = (ms + '00')[0:4]
             msint = int(ms[1:])
             sign = sign or ''
             sign = int(sign + '1') * -1


### PR DESCRIPTION
Some exchanges return dates with trimmed milliseconds part

By example:
https://github.com/ccxt/ccxt/blob/2bfe58a010083af2aa4be6a4e6364b5bd36e547d/js/bittrex.js#L931-L933

The Python base class implementation parse ms part `.19` as `0.019`, that is incorrect.

P.s. The JS and PHP is fine, but i found PHP assertions is suppressed 😯