### PR TITLE
Add all error types from errorHierarchy.js

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -7,63 +7,39 @@ declare module 'ccxt' {
         [key: string]: T;
     }
 
-    // error.js -----------------------------------------
+    // errors.js -----------------------------------------
 
     export class BaseError extends Error {
         constructor(message: string);
     }
+    export class ExchangeError extends BaseError {}
+    export class AuthenticationError extends ExchangeError {}
+    export class PermissionDenied extends AuthenticationError {}
+    export class AccountSuspended extends AuthenticationError {}
+    export class ArgumentsRequired extends ExchangeError {}
+    export class BadRequest extends ExchangeError {}
+    export class BadSymbol extends BadRequest {}
+    export class BadResponse extends ExchangeError {}
+    export class NullResponse extends BadResponse {}
+    export class InsufficientFunds extends ExchangeError {}
+    export class InvalidAddress extends ExchangeError {}
+    export class AddressPending extends InvalidAddress {}
+    export class InvalidOrder extends ExchangeError {}
+    export class OrderNotFound extends InvalidOrder {}
+    export class OrderNotCached extends InvalidOrder {}
+    export class CancelPending extends InvalidOrder {}
+    export class OrderImmediatelyFillable extends InvalidOrder {}
+    export class OrderNotFillable extends InvalidOrder {}
+    export class DuplicateOrderId extends InvalidOrder {}
+    export class NotSupported extends ExchangeError {}
+    export class NetworkError extends BaseError {}
+    export class DDoSProtection extends NetworkError {}
+    export class RateLimitExceeded extends DDoSProtection {}
+    export class ExchangeNotAvailable extends NetworkError {}
+    export class OnMaintenance extends ExchangeNotAvailable {}
+    export class InvalidNonce extends NetworkError {}
+    export class RequestTimeout extends NetworkError {}
 
-    export class ExchangeError extends BaseError {
-        constructor(message: string);
-    }
-
-    export class NotSupported extends ExchangeError {
-        constructor(message: string);
-    }
-
-    export class AuthenticationError extends ExchangeError {
-        constructor(message: string);
-    }
-
-    export class InvalidNonce extends ExchangeError {
-        constructor(message: string);
-    }
-
-    export class InsufficientFunds extends ExchangeError {
-        constructor(message: string);
-    }
-
-    export class InvalidOrder extends ExchangeError {
-        constructor(message: string);
-    }
-
-    export class OrderNotFound extends InvalidOrder {
-        constructor(message: string);
-    }
-
-    export class OrderNotCached extends InvalidOrder {
-        constructor(message: string);
-    }
-
-    export class CancelPending extends InvalidOrder {
-        constructor(message: string);
-    }
-
-    export class NetworkError extends BaseError {
-        constructor(message: string);
-    }
-
-    export class DDoSProtection extends NetworkError {
-        constructor(message: string);
-    }
-
-    export class RequestTimeout extends NetworkError {
-        constructor(message: string);
-    }
-
-    export class ExchangeNotAvailable extends NetworkError {
-        constructor(message: string);
-    }
 
     // -----------------------------------------------
 


### PR DESCRIPTION
Also removed `constructor(message: string);` signature from derived classes because the signature is inherited and was not necessary to repeat.