### PR TITLE
XTZ (Tezos) description in bitfinex.js updated

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -411,7 +411,7 @@ module.exports = class bitfinex extends Exchange {
                     'YOYOW': 'yoyow',
                     'ZEC': 'zcash',
                     'ZRX': 'zrx',
-                    'XTZ': 'tezos',
+                    'XTZ': 'xtz',
                 },
                 'orderTypes': {
                     'limit': 'exchange limit',


### PR DESCRIPTION
Hi @kroitor,

Please, consider this pull request.
I've noticed I was not able to withdraw tezos from my Bitfinex wallet while using the 1.22.48 ccxt version. I've made some tests and this change seems to work it out. I've not tested this change against the other functions but withdraw, but I think it's all ok, as the only function at v1 Bitfinex documentation which uses the "xtz" name is the withdraw function.