### PR TITLE
Fix TICK_SIZE floating point error

### DIFF
--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -106,9 +106,12 @@ const decimalToPrecision = (x, roundingMode
 
 /*  handle tick size */
     if (countingMode === TICK_SIZE) {
+        const precisionDigitsString = decimalToPrecision (numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING)
+        const newNumPrecisionDigits = precisionFromString (precisionDigitsString)
         const missing = x % numPrecisionDigits
-        const reminder = x / numPrecisionDigits
-        if (reminder !== Math.floor (reminder)) {
+        let reminder = x / numPrecisionDigits
+        const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, newNumPrecisionDigits + 2, DECIMAL_PLACES, NO_PADDING)
+        if (!('1' === fpError || '-1' === fpError)) {
             if (roundingMode === ROUND) {
                 if (x > 0) {
                     if (missing >= numPrecisionDigits / 2) {
@@ -127,8 +130,6 @@ const decimalToPrecision = (x, roundingMode
                 x = x - missing
             }
         }
-        const precisionDigitsString = decimalToPrecision (numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING)
-        const newNumPrecisionDigits = precisionFromString (precisionDigitsString)
         return decimalToPrecision (x, ROUND, newNumPrecisionDigits, DECIMAL_PLACES, paddingMode);
     }
 

--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -110,7 +110,7 @@ const decimalToPrecision = (x, roundingMode
         const newNumPrecisionDigits = precisionFromString (precisionDigitsString)
         const missing = x % numPrecisionDigits
         let reminder = x / numPrecisionDigits
-        const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, newNumPrecisionDigits + 2, DECIMAL_PLACES, NO_PADDING)
+        const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, Math.max (newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING)
         if (!('1' === fpError || '-1' === fpError)) {
             if (roundingMode === ROUND) {
                 if (x > 0) {

--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -111,7 +111,7 @@ const decimalToPrecision = (x, roundingMode
         const missing = x % numPrecisionDigits
         let reminder = x / numPrecisionDigits
         const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, Math.max (newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING)
-        if (!('1' === fpError || '-1' === fpError)) {
+        if (precisionFromString (fpError) !== 0) {
             if (roundingMode === ROUND) {
                 if (x > 0) {
                     if (missing >= numPrecisionDigits / 2) {

--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -109,7 +109,6 @@ const decimalToPrecision = (x, roundingMode
         const precisionDigitsString = decimalToPrecision (numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING)
         const newNumPrecisionDigits = precisionFromString (precisionDigitsString)
         const missing = x % numPrecisionDigits
-        let reminder = x / numPrecisionDigits
         // See: https://github.com/ccxt/ccxt/pull/6486
         const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, Math.max (newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING)
         if (precisionFromString (fpError) !== 0) {

--- a/js/base/functions/number.js
+++ b/js/base/functions/number.js
@@ -110,6 +110,7 @@ const decimalToPrecision = (x, roundingMode
         const newNumPrecisionDigits = precisionFromString (precisionDigitsString)
         const missing = x % numPrecisionDigits
         let reminder = x / numPrecisionDigits
+        // See: https://github.com/ccxt/ccxt/pull/6486
         const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, Math.max (newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING)
         if (precisionFromString (fpError) !== 0) {
             if (roundingMode === ROUND) {

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -166,6 +166,10 @@ assert (decimalToPrecision ('0.6', TRUNCATE, 0.2, TICK_SIZE) === '0.6');
 assert (decimalToPrecision ('-0.6', TRUNCATE, 0.2, TICK_SIZE) === '-0.6');
 assert (decimalToPrecision ('1.2', ROUND, 0.4, TICK_SIZE) === '1.2');
 assert (decimalToPrecision ('-1.2', ROUND, 0.4, TICK_SIZE) === '-1.2');
+assert (decimalToPrecision ('1.2', ROUND, 0.02, TICK_SIZE) === '1.2');
+assert (decimalToPrecision ('-1.2', ROUND, 0.02, TICK_SIZE) === '-1.2');
+assert (decimalToPrecision ('44', ROUND, 4.4, TICK_SIZE) === '44');
+assert (decimalToPrecision ('-44', ROUND, 4.4, TICK_SIZE) === '-44');
 
 // ----------------------------------------------------------------------------
 // testDecimalToPrecisionNegativeNumbers

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -157,6 +157,11 @@ assert (decimalToPrecision ('-0.000123456789', ROUND, 0.00000012, TICK_SIZE) ===
 assert (decimalToPrecision ('-0.000123456789', TRUNCATE, 0.00000012, TICK_SIZE) === '-0.00012336');
 assert (decimalToPrecision ('-165', TRUNCATE, 110, TICK_SIZE) === '-110');
 assert (decimalToPrecision ('-165', ROUND, 110, TICK_SIZE) === '-220');
+assert (decimalToPrecision ('-1650', TRUNCATE, 1100, TICK_SIZE) === '-1100');
+assert (decimalToPrecision ('-1650', ROUND, 1100, TICK_SIZE) === '-2200');
+
+assert (decimalToPrecision ('0.0006', TRUNCATE, 0.0001, TICK_SIZE) === '0.0006');
+assert (decimalToPrecision ('-0.0006', TRUNCATE, 0.0001, TICK_SIZE) === '-0.0006');
 
 // ----------------------------------------------------------------------------
 // testDecimalToPrecisionNegativeNumbers

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -162,6 +162,10 @@ assert (decimalToPrecision ('-1650', ROUND, 1100, TICK_SIZE) === '-2200');
 
 assert (decimalToPrecision ('0.0006', TRUNCATE, 0.0001, TICK_SIZE) === '0.0006');
 assert (decimalToPrecision ('-0.0006', TRUNCATE, 0.0001, TICK_SIZE) === '-0.0006');
+assert (decimalToPrecision ('0.6', TRUNCATE, 0.2, TICK_SIZE) === '0.6');
+assert (decimalToPrecision ('-0.6', TRUNCATE, 0.2, TICK_SIZE) === '-0.6');
+assert (decimalToPrecision ('1.2', ROUND, 0.4, TICK_SIZE) === '1.2');
+assert (decimalToPrecision ('-1.2', ROUND, 0.4, TICK_SIZE) === '-1.2');
 
 // ----------------------------------------------------------------------------
 // testDecimalToPrecisionNegativeNumbers

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -2470,6 +2470,7 @@ class Exchange {
             $newNumPrecisionDigits = static::precisionFromString ($precisionDigitsString);
             $missing = fmod($x, $numPrecisionDigits);
             $reminder = $x / $numPrecisionDigits;
+            // See: https://github.com/ccxt/ccxt/pull/6486
             $fpError = static::decimal_to_precision ($missing / $numPrecisionDigits, ROUND, max($newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING);
             if (static::precisionFromString ($fpError) !== 0) {
                 if ($roundingMode === ROUND) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -2423,6 +2423,15 @@ class Exchange {
         return static::decimal_to_precision($x, $roundingMode, $numPrecisionDigits, $countingMode, $paddingMode);
     }
 
+    public static function precisionFromString($x) {
+        $parts = explode ('.', preg_replace ('/0+$/', '', $x));
+        if (count ($parts) > 1) {
+            return strlen ($parts[1]);
+        } else {
+            return 0;
+        }
+    }
+
     public static function decimal_to_precision($x, $roundingMode = ROUND, $numPrecisionDigits = null, $countingMode = DECIMAL_PLACES, $paddingMode = NO_PADDING) {
         if ($countingMode === TICK_SIZE) {
             if (!(is_float ($numPrecisionDigits) || is_int($numPrecisionDigits)))
@@ -2458,16 +2467,11 @@ class Exchange {
 
         if ($countingMode === TICK_SIZE) {
             $precisionDigitsString = static::decimal_to_precision ($numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING);
-            $parts = explode ('.', preg_replace ('/0+$/', '', $precisionDigitsString));
-            if (count ($parts) > 1) {
-                $newNumPrecisionDigits = strlen ($parts[1]);
-            } else {
-                $newNumPrecisionDigits = strlen (preg_replace ('/0+$/', '', $parts[0]));
-            }
+            $newNumPrecisionDigits = static::precisionFromString ($precisionDigitsString);
             $missing = fmod($x, $numPrecisionDigits);
             $reminder = $x / $numPrecisionDigits;
             $fpError = static::decimal_to_precision ($missing / $numPrecisionDigits, ROUND, max($newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING);
-            if (!('1' === $fpError || '-1' === $fpError)) {
+            if (static::precisionFromString ($fpError) !== 0) {
                 if ($roundingMode === ROUND) {
                     if ($x > 0) {
                         if ($missing >= $numPrecisionDigits / 2) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -2457,9 +2457,17 @@ class Exchange {
         }
 
         if ($countingMode === TICK_SIZE) {
+            $precisionDigitsString = static::decimal_to_precision ($numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING);
+            $parts = explode ('.', preg_replace ('/0+$/', '', $precisionDigitsString));
+            if (count ($parts) > 1) {
+                $newNumPrecisionDigits = strlen ($parts[1]);
+            } else {
+                $newNumPrecisionDigits = strlen (preg_replace ('/0+$/', '', $parts[0]));
+            }
             $missing = fmod($x, $numPrecisionDigits);
             $reminder = $x / $numPrecisionDigits;
-            if ($reminder !== floor($reminder)) {
+            $fpError = static::decimal_to_precision ($missing / $numPrecisionDigits, ROUND, $newNumPrecisionDigits + 2, DECIMAL_PLACES, NO_PADDING);
+            if (!('1' === $fpError || '-1' === $fpError)) {
                 if ($roundingMode === ROUND) {
                     if ($x > 0) {
                         if ($missing >= $numPrecisionDigits / 2) {
@@ -2477,13 +2485,6 @@ class Exchange {
                 } else if (TRUNCATE === $roundingMode) {
                     $x = $x - $missing;
                 }
-            }
-            $precisionDigitsString = static::decimal_to_precision ($numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING);
-            $parts = explode ('.', preg_replace ('/0+$/', '', $precisionDigitsString));
-            if (count ($parts) > 1) {
-                $newNumPrecisionDigits = strlen ($parts[1]);
-            } else {
-                $newNumPrecisionDigits = strlen (preg_replace ('/0+$/', '', $parts[0]));
             }
             return static::decimal_to_precision ($x, ROUND, $newNumPrecisionDigits, DECIMAL_PLACES, $paddingMode);
         }

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -2466,7 +2466,7 @@ class Exchange {
             }
             $missing = fmod($x, $numPrecisionDigits);
             $reminder = $x / $numPrecisionDigits;
-            $fpError = static::decimal_to_precision ($missing / $numPrecisionDigits, ROUND, $newNumPrecisionDigits + 2, DECIMAL_PLACES, NO_PADDING);
+            $fpError = static::decimal_to_precision ($missing / $numPrecisionDigits, ROUND, max($newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING);
             if (!('1' === $fpError || '-1' === $fpError)) {
                 if ($roundingMode === ROUND) {
                     if ($x > 0) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -2469,7 +2469,6 @@ class Exchange {
             $precisionDigitsString = static::decimal_to_precision ($numPrecisionDigits, ROUND, 100, DECIMAL_PLACES, NO_PADDING);
             $newNumPrecisionDigits = static::precisionFromString ($precisionDigitsString);
             $missing = fmod($x, $numPrecisionDigits);
-            $reminder = $x / $numPrecisionDigits;
             // See: https://github.com/ccxt/ccxt/pull/6486
             $fpError = static::decimal_to_precision ($missing / $numPrecisionDigits, ROUND, max($newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING);
             if (static::precisionFromString ($fpError) !== 0) {


### PR DESCRIPTION
This PR fixes #6483
Please let me sleep over this before merging.

Edit:
A little explanation on my old version:
Since fps cannot represent some values (e.g. 0.1) I added a check if there is calculation needed, because otherwise this example failed:
```
assert (decimalToPrecision ('0.01', ROUND, 0.0001, TICK_SIZE, PAD_WITH_ZERO) === '0.0100');
```
In this case `0` is missing to go to the next TICK_SIZE, but since the modulo operator is even more imprecise (internally calculated as `a - (b * floor(a/b))`, we get a missing of `0.01 % 0.0001 = 0.00009999999999999973`
So the if clause was intended to check, if we don't need a computation. Those edge cases should only occur, when we don't need a computation (In fps: Our number is really, really close to a multiple of TICK_SIZE).
As it turned out, the check was not enough.
(In python this is not needed, since we use Decimal for precise computation).

These commits should improve the test.
To clarify, what is happening:
The test basically is: `a % b / b === c (c is a multiple of 1)`, while a is our number and b is our TICK_SIZE.

```
a % b / b === c
# Modulo is computed internally with a - (b * floor(a/b))
(a - (b * floor(a / b))) / b
a / b - floor(a / b)
# x = a / b 
x - floor(x) === c
```

So c can only be a multiple of 1, if x is something like `1.9999999`, in this case, I assume, there is a fp problem and we dont need computation. I am not completely sure, this is always correct, but I think it is way better than the current solution and probably there is no better solution without using a library which does not use fps (like Decimal in python).

As can be seen here, basically a is a multiple of 1 times b, so we don't need the computation, we already are at TICK_SIZE.
https://www.wolframalpha.com/input/?i=1.9999999+%3D+a+%2F+b
https://www.wolframalpha.com/input/?i=2.9999999+%3D+a+%2F+b

Edit2:
To clarify it a bit more:
We need to compute the reminder, so we know, how much is missing to go to the next TICK_SIZE.
`44 % 4.4 -> 4.399999999999997`
So this is obviously a floating point problem, to check, if we have one, we determine how close the reminder is to TICK_SIZE by using a division. (We could also use: `c = 0.0001; if (-c < x < c)`
`4.399999999999997 / 4.4 -> 0.9999999999999992`
If this rounds to `1` or `-1`, there is a fp error and we dont need to compute to the closest TICK_SIZE.

This should only be true for fp errors, example:
```
> 44.00000001 % 4.4
9.999997274690031e-9
> 44.00000001 % 4.4 / 4.4
2.2727266533386433e-9
```