### PR TITLE
Add public, private and web URLs for Gemini's test API

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -45,7 +45,11 @@ module.exports = class gemini extends Exchange {
                     'https://docs.gemini.com/rest-api',
                     'https://docs.sandbox.gemini.com',
                 ],
-                'test': 'https://api.sandbox.gemini.com',
+                'test': {
+                    'public': 'https://api.sandbox.gemini.com',
+                    'private': 'https://api.sandbox.gemini.com',
+                    'web': 'https://docs.sandbox.gemini.com',
+                },
                 'fees': [
                     'https://gemini.com/api-fee-schedule',
                     'https://gemini.com/trading-fees',


### PR DESCRIPTION
Steps to reproduce the issue this PR fixes:

```python
>>> gem = ccxt.gemini()
>>> gem.set_sandbox_mode(True)
>>> gem.fetch_balance()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/gemini.py", line 401, in fetch_balance
    self.load_markets()
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/base/exchange.py", line 1249, in load_markets
    markets = self.fetch_markets(params)
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/gemini.py", line 183, in fetch_markets
    return getattr(self, method)(params)
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/gemini.py", line 186, in fetch_markets_from_web
    response = self.webGetRestApi(params)
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/base/exchange.py", line 435, in inner
    return entry(_self, **inner_kwargs)
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/base/exchange.py", line 458, in request
    return self.fetch2(path, api, method, params, headers, body)
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/base/exchange.py", line 453, in fetch2
    request = self.sign(path, api, method, params, headers, body)
  File "/Users/marco/src/interchange/back-end/.venv/lib/python3.7/site-packages/ccxt/gemini.py", line 607, in sign
    url = self.urls['api'][api] + url
TypeError: string indices must be integers
```