### PR TITLE
WAX/WAXP coin conflict

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -309,6 +309,7 @@ module.exports = class bitfinex extends Exchange {
                 'UST': 'USDT',
                 'UTN': 'UTNP',
                 'VSY': 'VSYS',
+                'WAX': 'WAXP',
                 'XCH': 'XCHF',
                 'ZBT': 'ZB',
             },

--- a/js/idex.js
+++ b/js/idex.js
@@ -100,6 +100,7 @@ module.exports = class idex extends Exchange {
                 'ONE': 'Menlo One',
                 'FT': 'Fabric Token',
                 'PLA': 'PlayChip',
+                'WAX': 'WAXP',
             },
         });
     }

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -183,6 +183,7 @@ module.exports = class kucoin extends Exchange {
             'commonCurrencies': {
                 'HOT': 'HOTNOW',
                 'EDGE': 'DADI', // https://github.com/ccxt/ccxt/issues/5756
+                'WAX': 'WAXP',
             },
             'options': {
                 'version': 'v1',

--- a/js/livecoin.js
+++ b/js/livecoin.js
@@ -104,6 +104,7 @@ module.exports = class livecoin extends Exchange {
                 'RUR': 'RUB',
                 'SCT': 'SpaceCoin',
                 'TPI': 'ThaneCoin',
+                'WAX': 'WAXP',
                 'wETT': 'WETT',
                 'XBT': 'Bricktox',
             },


### PR DESCRIPTION
On some exchanges it is WAXP, on some WAX:
https://coinmarketcap.com/currencies/wax/markets/

On Kucoin the link looks like https://www.kucoin.com/trade/WAX-ETH but it leads to WAXP/ETH, on ccxt `fetchBalance` we have `WAX` but after `loadMarkets` markets call `WAXP/ETH`, `WAXP/BTC`