### PR TITLE
Bitforex UOS -> UOS Network

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -220,6 +220,9 @@ module.exports = class bitforex extends Exchange {
                     },
                 },
             },
+            'commonCurrencies': {
+                'UOS': 'UOS Network',
+            },
             'exceptions': {
                 '4004': OrderNotFound,
                 '1013': AuthenticationError,


### PR DESCRIPTION
Conflict between 
https://coinmarketcap.com/currencies/ultra/markets/
and
https://coinmarketcap.com/currencies/uos-network/markets/