### PR TITLE
python base exchange: expose lists of base and quote currencies

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -633,7 +633,7 @@ module.exports = class Exchange {
         if (currencies) {
             this.currencies = deepExtend (currencies, this.currencies)
         } else {
-            const baseCurrencies =
+            let baseCurrencies =
                 values.filter (market => 'base' in market)
                     .map (market => ({
                         id: market.baseId || market.base,
@@ -641,7 +641,7 @@ module.exports = class Exchange {
                         code: market.base,
                         precision: market.precision ? (market.precision.base || market.precision.amount) : 8,
                     }))
-            const quoteCurrencies =
+            let quoteCurrencies =
                 values.filter (market => 'quote' in market)
                     .map (market => ({
                         id: market.quoteId || market.quote,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -649,6 +649,10 @@ module.exports = class Exchange {
                         code: market.quote,
                         precision: market.precision ? (market.precision.quote || market.precision.price) : 8,
                     }))
+            baseCurrencies = sortBy (baseCurrencies, 'code')
+            quoteCurrencies = sortBy (quoteCurrencies, 'code')
+            this.baseCurrencies = indexBy (baseCurrencies, 'code')
+            this.quoteCurrencies = indexBy (quoteCurrencies, 'code')
             const allCurrencies = baseCurrencies.concat (quoteCurrencies)
             const groupedCurrencies = groupBy (allCurrencies, 'code')
             const currencies = Object.keys (groupedCurrencies).map (code =>

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -815,6 +815,8 @@ class Exchange {
         $this->symbols = null;
         $this->ids = null;
         $this->currencies = array();
+        $this->base_currencies = null;
+        $this->quote_currencies = null;
         $this->balance = array();
         $this->orderbooks = array();
         $this->tickers = array();
@@ -1480,7 +1482,9 @@ class Exchange {
             }, array_filter($values, function ($market) {
                 return array_key_exists('quote', $market);
             }));
-            $currencies = static::index_by(array_merge($base_currencies, $quote_currencies), 'code');
+            $this->base_currencies = static::index_by($base_currencies, 'code');
+            $this->quote_currencies = static::index_by($quote_currencies, 'code');
+            $currencies = array_merge($this->base_currencies, $this->quote_currencies);
             $this->currencies = array_replace_recursive($currencies, $this->currencies);
         }
         $this->currencies_by_id = static::index_by(array_values($this->currencies), 'id');

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1482,6 +1482,8 @@ class Exchange {
             }, array_filter($values, function ($market) {
                 return array_key_exists('quote', $market);
             }));
+            $base_currencies = static::sort_by($base_currencies, 'code');
+            $quote_currencies = static::sort_by($quote_currencies, 'code');
             $this->base_currencies = static::index_by($base_currencies, 'code');
             $this->quote_currencies = static::index_by($quote_currencies, 'code');
             $currencies = array_merge($this->base_currencies, $this->quote_currencies);

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1297,14 +1297,6 @@ class Exchange(object):
         # and may be changed for consistency later
         return self.to_array(self.markets)
 
-    def fetch_base_currencies(self, params={}):
-        # returned as a list
-        return self.base_currencies
-
-    def fetch_quote_currencies(self, params={}):
-        # returned as a list
-        return self.quote_currencies
-
     def fetch_currencies(self, params={}):
         # markets are returned as a list
         # currencies are returned as a dict

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -214,6 +214,8 @@ class Exchange(object):
     transactions = None
     ohlcvs = None
     tickers = None
+    base_currencies = None
+    quote_currencies = None
     currencies = None
     options = None  # Python does not allow to define properties in run-time with setattr
     accounts = None
@@ -1233,7 +1235,7 @@ class Exchange(object):
         if currencies:
             self.currencies = self.deep_extend(currencies, self.currencies)
         else:
-            base_currencies = [{
+            self.base_currencies = [{
                 'id': market['baseId'] if 'baseId' in market else market['base'],
                 'numericId': market['baseNumericId'] if 'baseNumericId' in market else None,
                 'code': market['base'],
@@ -1243,7 +1245,7 @@ class Exchange(object):
                     )
                 ) if 'precision' in market else 8,
             } for market in values if 'base' in market]
-            quote_currencies = [{
+            self.quote_currencies = [{
                 'id': market['quoteId'] if 'quoteId' in market else market['quote'],
                 'numericId': market['quoteNumericId'] if 'quoteNumericId' in market else None,
                 'code': market['quote'],
@@ -1253,7 +1255,7 @@ class Exchange(object):
                     )
                 ) if 'precision' in market else 8,
             } for market in values if 'quote' in market]
-            currencies = self.sort_by(base_currencies + quote_currencies, 'code')
+            currencies = self.sort_by(self.base_currencies + self.quote_currencies, 'code')
             self.currencies = self.deep_extend(self.index_by(currencies, 'code'), self.currencies)
         self.currencies_by_id = self.index_by(list(self.currencies.values()), 'id')
         return self.markets
@@ -1294,6 +1296,14 @@ class Exchange(object):
         # this is for historical reasons
         # and may be changed for consistency later
         return self.to_array(self.markets)
+
+    def fetch_base_currencies(self, params={}):
+        # returned as a list
+        return self.base_currencies
+
+    def fetch_quote_currencies(self, params={}):
+        # returned as a list
+        return self.quote_currencies
 
     def fetch_currencies(self, params={}):
         # markets are returned as a list

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1235,7 +1235,7 @@ class Exchange(object):
         if currencies:
             self.currencies = self.deep_extend(currencies, self.currencies)
         else:
-            self.base_currencies = [{
+            base_currencies = [{
                 'id': market['baseId'] if 'baseId' in market else market['base'],
                 'numericId': market['baseNumericId'] if 'baseNumericId' in market else None,
                 'code': market['base'],
@@ -1245,7 +1245,7 @@ class Exchange(object):
                     )
                 ) if 'precision' in market else 8,
             } for market in values if 'base' in market]
-            self.quote_currencies = [{
+            quote_currencies = [{
                 'id': market['quoteId'] if 'quoteId' in market else market['quote'],
                 'numericId': market['quoteNumericId'] if 'quoteNumericId' in market else None,
                 'code': market['quote'],
@@ -1255,7 +1255,11 @@ class Exchange(object):
                     )
                 ) if 'precision' in market else 8,
             } for market in values if 'quote' in market]
-            currencies = self.sort_by(self.base_currencies + self.quote_currencies, 'code')
+            base_currencies = self.sort_by(base_currencies, 'code')
+            quote_currencies = self.sort_by(quote_currencies, 'code')
+            self.base_currencies = self.index_by(base_currencies, 'code')
+            self.quote_currencies = self.index_by(quote_currencies, 'code')
+            currencies = self.sort_by(base_currencies + quote_currencies, 'code')
             self.currencies = self.deep_extend(self.index_by(currencies, 'code'), self.currencies)
         self.currencies_by_id = self.index_by(list(self.currencies.values()), 'id')
         return self.markets


### PR DESCRIPTION
the lists are already created in the code, but not kept

* the new methods can be called `base_currencies()` and `quote_currencies()` (instead of `fetch_base_currencies()` and `fetch_quote_currencies()`)
* the lists returned can be simply lists of string currency codes (or ids), now the list of currency dicts are returned, I do not think it makes really sense, since dicts are available in the 'self.currencies' (with a call to `fetch_currencies()`)
