### PR TITLE
ByteTrade BHT -> ByteHub

### DIFF
--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -93,6 +93,7 @@ module.exports = class bytetrade extends Exchange {
             },
             'commonCurrencies': {
                 '48': 'Blocktonic',
+                'BHT': 'ByteHub',
             },
             'exceptions': {
                 'vertify error': AuthenticationError, // typo on the exchange side, 'vertify'


### PR DESCRIPTION
https://bytetrade.zendesk.com/hc/en-gb/articles/360026047211-Dividend-Rules
```
What is BHT?
BHT is the token of ByteHub DAPP. It has various use cases such as stake and dividend or unlocking premium services.
```
Conflict with https://coinmarketcap.com/currencies/bhex-token/