### PR TITLE
ByteTrade commonCurrencies: use code instead of name

### DIFF
--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -93,7 +93,7 @@ module.exports = class bytetrade extends Exchange {
             },
             'commonCurrencies': {
                 '48': 'Blocktonic',
-                'BHT': 'ByteHub',
+                '57': 'ByteHub',
             },
             'exceptions': {
                 'vertify error': AuthenticationError, // typo on the exchange side, 'vertify'


### PR DESCRIPTION
According to the note:

>             // that is because bytetrade is a DEX, supports people create coin with the same name, but the id(code) of coin is unique, so we should use the id or name and id as the identity of coin.
>             // For coin name and symbol is same with CCXT, I use name@id as the key of commonCurrencies dict.
