### PR TITLE
ByteTrade fix fetchMarkets

### DIFF
--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -217,6 +217,9 @@ module.exports = class bytetrade extends Exchange {
             const id = this.safeString (market, 'symbol');
             let base = this.safeString (market, 'baseName');
             let quote = this.safeString (market, 'quoteName');
+            const normalBase = base.split ('@')[0];
+            const normalQuote = quote.split ('@')[0];
+            const normalSymbol = normalBase + '/' + normalQuote;
             const baseId = this.safeString (market, 'base');
             const quoteId = this.safeString (market, 'quote');
             if (baseId in this.commonCurrencies) {
@@ -231,9 +234,6 @@ module.exports = class bytetrade extends Exchange {
             const price = this.safeValue (limits, 'price', {});
             const precision = this.safeValue (market, 'precision', {});
             const active = this.safeString (market, 'active');
-            const normalBase = base.split ('@')[0];
-            const normalQuote = quote.split ('@')[0];
-            const normalSymbol = normalBase + '/' + normalQuote;
             const entry = {
                 'id': id,
                 'symbol': symbol,


### PR DESCRIPTION
For `commonCurrencies` `base` and `quote` already changed in the code above and `normalSymbol` not normal so some request don't work