### PR TITLE
Python async SOCKS proxy remote DNS failed bug fix

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -308,7 +308,7 @@ Python aiohttp SOCKS proxy
 
    async def test():
 
-       connector = aiohttp_socks.SocksConnector.from_url('socks5://user:password@127.0.0.1:1080')
+       connector = aiohttp_socks.ProxyConnector.from_url('socks5://user:password@127.0.0.1:1080')
        session = aiohttp.ClientSession(connector=connector)
 
        exchange = ccxt.binance({

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -294,7 +294,7 @@ import aiohttp_socks
 
 async def test():
 
-    connector = aiohttp_socks.SocksConnector.from_url('socks5://user:password@127.0.0.1:1080')
+    connector = aiohttp_socks.ProxyConnector.from_url('socks5://user:password@127.0.0.1:1080')
     session = aiohttp.ClientSession(connector=connector)
 
     exchange = ccxt.binance({


### PR DESCRIPTION
Python async SOCKS proxy remote DNS failed.  According to aiohttp_socks==0.3.4 code, aiohttp_socks SocksConnector is deprecated.  Using ProxyConnector instead can solve the problem.
```
class SocksConnector(TCPConnector):  # pragma: no cover
    def __init__(self, socks_ver=SocksVer.SOCKS5,
                 host=None, port=None,
                 username=None, password=None,
                 rdns=False, family=socket.AF_INET, **kwargs):

        warnings.warn('SocksConnector is deprecated. '
                      'Use ProxyConnector instead.', DeprecationWarning,
                      stacklevel=2)
        if rdns:
            kwargs['resolver'] = NoResolver()

```
