### PR TITLE
btcmarkets: fetchTrades: Fix timestamp undefined

### DIFF
--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -415,7 +415,7 @@ module.exports = class btcmarkets extends Exchange {
     }
 
     parseTrade (trade, market = undefined) {
-        const timestamp = this.safeTimestamp (trade, 'timestamp');
+        const timestamp = this.safeTimestamp (trade, 'date');
         let symbol = undefined;
         if (market !== undefined) {
             symbol = market['symbol'];


### PR DESCRIPTION
In the response object of [both v1 and v2 endpoints](https://github.com/BTCMarkets/API/wiki/Market-data-API#trades) the timestamp comes in a property named `date`.