### PR TITLE
Python: fix tick size problems due to modulo

### DIFF
--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -211,6 +211,8 @@ assert (decimalToPrecision ('1.2', ROUND, 0.02, TICK_SIZE) === '1.2');
 assert (decimalToPrecision ('-1.2', ROUND, 0.02, TICK_SIZE) === '-1.2');
 assert (decimalToPrecision ('44', ROUND, 4.4, TICK_SIZE) === '44');
 assert (decimalToPrecision ('-44', ROUND, 4.4, TICK_SIZE) === '-44');
+assert (decimalToPrecision ('44.00000001', ROUND, 4.4, TICK_SIZE) === '44');
+assert (decimalToPrecision ('-44.00000001', ROUND, 4.4, TICK_SIZE) === '-44');
 
 // ----------------------------------------------------------------------------
 // testDecimalToPrecisionNegativeNumbers

--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -70,7 +70,8 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
             return decimal_to_precision(dec - dec % to_nearest, rounding_mode, 0, DECIMAL_PLACES, padding_mode)
 
     if counting_mode == TICK_SIZE:
-        missing = dec % precision_dec
+        # python modulo with negative numbers behaves different than js/php, so use abs first
+        missing = abs(dec) % precision_dec
         if missing != 0:
             if rounding_mode == ROUND:
                 if dec > 0:
@@ -80,11 +81,14 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
                         dec = dec - missing
                 else:
                     if missing >= precision / 2:
-                        dec = dec - missing
+                        dec = dec + missing - precision_dec
                     else:
-                        dec = dec - missing - precision_dec
+                        dec = dec + missing
             elif rounding_mode == TRUNCATE:
-                dec = dec - missing
+                if dec < 0:
+                    dec = dec + missing
+                else:
+                    dec = dec - missing
         parts = re.sub(r'0+$', '', '{:f}'.format(precision_dec)).split('.')
         if len(parts) > 1:
             new_precision = len(parts[1])


### PR DESCRIPTION
decimal_to_precision seams to be a never ending story. :-/
js:
```js
> -5 % 13
-5
> 5 % 13
5
```
python:
```python
>>> -5 % 13
8
>>> 5 % 13
5
```