### PR TITLE
Fix python async load_markets

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -171,7 +171,7 @@ class Exchange(BaseExchange):
             self.reloading_markets = True
             coroutine = self.load_markets_helper(reload, params)
             # coroutines can only be awaited once so we wrap it in a task
-            self.markets_loading = asyncio.create_task(coroutine)
+            self.markets_loading = asyncio.ensure_future(coroutine)
         try:
             result = await self.markets_loading
         except Exception as e:


### PR DESCRIPTION
asyncio.create_task is only supported since python 3.7+