### PR TITLE
Fix bitmax testnet url

### DIFF
--- a/js/bitmax.js
+++ b/js/bitmax.js
@@ -52,7 +52,7 @@ module.exports = class bitmax extends Exchange {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/66820319-19710880-ef49-11e9-8fbe-16be62a11992.jpg',
                 'api': 'https://bitmax.io',
-                'test': 'https://bitmax-test.io/api',
+                'test': 'https://bitmax-test.io',
                 'www': 'https://bitmax.io',
                 'doc': [
                     'https://github.com/bitmax-exchange/api-doc/blob/master/bitmax-api-doc-v1.2.md',

--- a/php/bitmax.php
+++ b/php/bitmax.php
@@ -54,7 +54,7 @@ class bitmax extends Exchange {
             'urls' => array(
                 'logo' => 'https://user-images.githubusercontent.com/1294454/66820319-19710880-ef49-11e9-8fbe-16be62a11992.jpg',
                 'api' => 'https://bitmax.io',
-                'test' => 'https://bitmax-test.io/api',
+                'test' => 'https://bitmax-test.io',
                 'www' => 'https://bitmax.io',
                 'doc' => array(
                     'https://github.com/bitmax-exchange/api-doc/blob/master/bitmax-api-doc-v1.2.md',

--- a/python/ccxt/async_support/bitmax.py
+++ b/python/ccxt/async_support/bitmax.py
@@ -60,7 +60,7 @@ class bitmax(Exchange):
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/66820319-19710880-ef49-11e9-8fbe-16be62a11992.jpg',
                 'api': 'https://bitmax.io',
-                'test': 'https://bitmax-test.io/api',
+                'test': 'https://bitmax-test.io',
                 'www': 'https://bitmax.io',
                 'doc': [
                     'https://github.com/bitmax-exchange/api-doc/blob/master/bitmax-api-doc-v1.2.md',

--- a/python/ccxt/bitmax.py
+++ b/python/ccxt/bitmax.py
@@ -60,7 +60,7 @@ class bitmax(Exchange):
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/66820319-19710880-ef49-11e9-8fbe-16be62a11992.jpg',
                 'api': 'https://bitmax.io',
-                'test': 'https://bitmax-test.io/api',
+                'test': 'https://bitmax-test.io',
                 'www': 'https://bitmax.io',
                 'doc': [
                     'https://github.com/bitmax-exchange/api-doc/blob/master/bitmax-api-doc-v1.2.md',


### PR DESCRIPTION
fix bitmax testnet url.
You can test it easily with old url that request https://bitmax-test.io/api/api/v1/assets that doesn't exist. And after the fix : https://bitmax-test.io/api/v1/assets.