### PR TITLE
Fix: py3 unicode error at braziliex sign method

### DIFF
--- a/js/braziliex.js
+++ b/js/braziliex.js
@@ -590,7 +590,7 @@ module.exports = class braziliex extends Exchange {
             headers = {
                 'Content-type': 'application/x-www-form-urlencoded',
                 'Key': this.apiKey,
-                'Sign': this.decode (signature),
+                'Sign': signature,
             };
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };


### PR DESCRIPTION
When using python3, the sign method in the braziliex exchange code is throwing the following error:

```
Traceback (most recent call last):
  File "braziliex_test.py", line 16, in <module>
    print(braziliex.fetch_open_orders('BTC/USDT'))
  File "/home/mauricio/projects/ccxt/python/ccxt/braziliex.py", line 523, in fetch_open_orders
    response = self.privatePostOpenOrders(self.extend(request, params))
  File "/home/mauricio/projects/ccxt/python/ccxt/base/exchange.py", line 444, in inner
    return entry(_self, **inner_kwargs)
  File "/home/mauricio/projects/ccxt/python/ccxt/braziliex.py", line 575, in request
    response = self.fetch2(path, api, method, params, headers, body)
  File "/home/mauricio/projects/ccxt/python/ccxt/base/exchange.py", line 462, in fetch2
    request = self.sign(path, api, method, params, headers, body)
  File "/home/mauricio/projects/ccxt/python/ccxt/braziliex.py", line 570, in sign
    'Sign': self.decode(signature),
  File "/home/mauricio/projects/ccxt/python/ccxt/base/exchange.py", line 1157, in decode
    return string.decode()
AttributeError: 'str' object has no attribute 'decode'
```

This fix is compatible with python2.
