### PR TITLE
modify getBaseMethods

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -21,6 +21,7 @@ const fs = require ('fs')
         replaceInFile,
         overwriteFile,
     } = require ('./fs.js')
+    , Exchange = require ('../js/base/Exchange.js')
 
 class Transpiler {
 
@@ -389,12 +390,27 @@ class Transpiler {
         ])
     }
 
+    getBaseClass () {
+        return new Exchange ()
+    }
+
+    getBaseMethods () {
+        const baseExchange = this.getBaseClass ()
+        let object = baseExchange
+        let properties = []
+        while (object !== Object.prototype) {
+            properties = properties.concat (Object.getOwnPropertyNames (object))
+            object = Object.getPrototypeOf (object)
+        }
+        return properties.filter (x => typeof baseExchange[x] === 'function')
+    }
+
     getPythonBaseMethods () {
-        return []
+        return this.getBaseMethods ()
     }
 
     getPHPBaseMethods () {
-        return []
+        return this.getBaseMethods ()
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
the effects of this change are twofold:

1.  it removes the extraneous space before method calls in php and converts php and python method calls to underscore notation in the source code
2. it allows arbitrary closures to be passed in ccxt pro without having to statically define them

( ͡° ͜ʖ ͡°)