### PR TITLE
Bittrex CPC mapping remove

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -267,7 +267,6 @@ module.exports = class bittrex extends Exchange {
             },
             'commonCurrencies': {
                 'BITS': 'SWIFT',
-                'CPC': 'Capricoin',
             },
         });
     }


### PR DESCRIPTION
https://coinmarketcap.com/currencies/capricoin/markets/
https://coinmarketcap.com/currencies/cpchain/markets/

There are mistake on CMC, because on Bittrex we can see, that CPC is CPChain

![image](https://user-images.githubusercontent.com/38309641/77640702-eefd8f80-6f6b-11ea-8b53-de3551ab2baf.png)
