### PR TITLE
btcmarkets: createOrder occasionally fails with "incorrect number of decimal points"

### DIFF
--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -4,6 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { ExchangeError, OrderNotFound, ArgumentsRequired, InvalidOrder, DDoSProtection } = require ('./base/errors');
+const { ROUND } = require ('./base/functions/number');
 
 //  ---------------------------------------------------------------------------
 
@@ -467,8 +468,8 @@ module.exports = class btcmarkets extends Exchange {
         });
         request['currency'] = market['quote'];
         request['instrument'] = market['base'];
-        request['price'] = parseInt (price * multiplier);
-        request['volume'] = parseInt (amount * multiplier);
+        request['price'] = parseInt (this.decimalToPrecision (price * multiplier), ROUND, 0);
+        request['volume'] = parseInt (this.decimalToPrecision (amount * multiplier), ROUND, 0);
         request['orderSide'] = orderSide;
         request['ordertype'] = this.capitalize (type);
         request['clientRequestId'] = this.nonce ().toString ();

--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -468,8 +468,8 @@ module.exports = class btcmarkets extends Exchange {
         });
         request['currency'] = market['quote'];
         request['instrument'] = market['base'];
-        request['price'] = parseInt (this.decimalToPrecision (price * multiplier), ROUND, 0);
-        request['volume'] = parseInt (this.decimalToPrecision (amount * multiplier), ROUND, 0);
+        request['price'] = parseInt (this.decimalToPrecision (price * multiplier, ROUND, 0));
+        request['volume'] = parseInt (this.decimalToPrecision (amount * multiplier, ROUND, 0));
         request['orderSide'] = orderSide;
         request['ordertype'] = this.capitalize (type);
         request['clientRequestId'] = this.nonce ().toString ();


### PR DESCRIPTION
When creating an order with certain prices, the API returns "incorrect number of decimal points".

For example, in the market XRP/AUD, creating an order with price 0.2724 raises the error:

```
"btcmarkets {\"success\":false,\"errorCode\":3,\"errorMessage\":\"Invalid amount.\",\"errorDetail\":\"incorrect number of decimal points\",\"id\":0,\"clientRequestId\":\"1585226664431\"}",
```

Note: even if the error says "Invalid amount", I can confirm that the problem is with the price in this case, not the amount.

The root cause seems to be a multiplication by 100000000 that is being applied to both price and amount. In this case, `0.2724 * 100000000 = 27239999.999999996`; then, `parseInt(27239999.999999996) = 27239999`, and is 27239999 what is sent to the API in the price field.

BTC Markets API tries to recreate the original price, presumably doing `27239999 / 100000000` which returns 0.27239999 and (also presumably) some decimal position validation runs against that number and fails. 

The solution consists in using [`this.decimalToPrecision`](https://github.com/ccxt/ccxt/wiki/Manual#methods-for-formatting-decimals) after the multiplication to round the number. 

With this, instead of getting 27239999 we get 27240000, which seems more consistent.