### PR TITLE
Fix OKEX USDT swap base error

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -774,7 +774,6 @@ module.exports = class okex extends Exchange {
                 marketType = 'swap';
                 spot = false;
                 swap = true;
-                baseId = this.safeString (market, 'coin');
                 const futuresAlias = this.safeString (market, 'alias');
                 if (futuresAlias !== undefined) {
                     swap = false;

--- a/python/ccxt/okex.py
+++ b/python/ccxt/okex.py
@@ -795,7 +795,6 @@ class okex(Exchange):
                 marketType = 'swap'
                 spot = False
                 swap = True
-                baseId = self.safe_string(market, 'coin')
                 futuresAlias = self.safe_string(market, 'alias')
                 if futuresAlias is not None:
                     swap = False


### PR DESCRIPTION
In current master brunch, CCXT parses OKEX swap in a wrong way

![a](https://user-images.githubusercontent.com/1466256/77746682-4547fc80-7058-11ea-949e-081314f8a869.jpeg)

Here,`base` and `baseId` should be 'BTC' rather than 'USDT'

According to OKEX's [official doc](https://www.okex.com/docs/en/#swap-swap---contract_information), the base is stored in the field 'base_currency'

However, CCXT uses the 'coin' field which has no meaning

In fact, the base is exactly parsed previously at https://github.com/ccxt/ccxt/blob/master/python/ccxt/okex.py#L782

So, the correct base valued is set by just delete this line of code