### PR TITLE
bittrex: createOrderV3: fix market ceiling order

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -707,6 +707,7 @@ module.exports = class bittrex extends Exchange {
                 request['limit'] = this.priceToPrecision (symbol, price);
                 request['timeInForce'] = 'GOOD_TIL_CANCELLED';
             } else {
+                // bittrex does not allow GOOD_TIL_CANCELLED for ceiling limit order
                 request['timeInForce'] = 'IMMEDIATE_OR_CANCEL';
             }
         }


### PR DESCRIPTION
I have not tested this, but I think the code was wrong before:
a limit ceiling order got 'IMMEDIATE_OR_CANCEL' set, because it went into the first branch.
Please let me know to improve my knowledge.