### PR TITLE
[deribit] wrong fee field in trades

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -883,7 +883,7 @@ module.exports = class deribit extends Exchange {
             // M = maker, T = taker, MT = both
             takerOrMaker = (liquidity === 'M') ? 'maker' : 'taker';
         }
-        const feeCost = this.safeFloat (trade, 'feeCost');
+        const feeCost = this.safeFloat (trade, 'fee');
         let fee = undefined;
         if (feeCost !== undefined) {
             const feeCurrencyId = this.safeString (trade, 'fee_currency');


### PR DESCRIPTION
Hi,

There is wrong 'feeCost' field in trade output:
https://docs.deribit.com/#private-get_user_trades_by_order

Replaced by 'fee'.