### PR TITLE
[bleutrade] [fetchMarkets] change in response

### DIFF
--- a/js/bleutrade.js
+++ b/js/bleutrade.js
@@ -192,8 +192,8 @@ module.exports = class bleutrade extends Exchange {
             //     MarketCurrencyLong: 'Litecoin',
             //     BaseCurrencyLong: 'Tether' }
             const id = this.safeString (market, 'MarketName');
-            const baseId = this.safeString (market, 'MarketCurrency');
-            const quoteId = this.safeString (market, 'BaseCurrency');
+            const baseId = this.safeString (market, 'MarketAsset');
+            const quoteId = this.safeString (market, 'BaseAsset');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;


### PR DESCRIPTION
this change in the API response is avoiding this exchange to work with ccxt.
Changed the api response for  fetchMarkets from 'MarketCurrency' and 'BaseCurrency' to 'MarketAsset' and 'BaseAsset'

Now [bleutrade] is working