### PR TITLE
aofex parseOrder, parseTrade, foWithMethod fixes

### DIFF
--- a/js/aofex.js
+++ b/js/aofex.js
@@ -560,7 +560,7 @@ module.exports = class aofex extends Exchange {
         //
         const id = this.safeString (trade, 'id');
         const ctime = this.parse8601 (this.safeString (trade, 'ctime'));
-        const timestamp = this.safeTimestamp (trade, 'ts', ctime);
+        const timestamp = this.safeTimestamp (trade, 'ts', ctime) - 28800000; // 8 hours, adjust to UTC;
         let symbol = undefined;
         if ((symbol === undefined) && (market !== undefined)) {
             symbol = market['symbol'];
@@ -726,7 +726,7 @@ module.exports = class aofex extends Exchange {
             base = market['base'];
             quote = market['quote'];
         }
-        const timestamp = this.parse8601 (this.safeString (order, 'ctime'));
+        const timestamp = this.parse8601 (this.safeString (order, 'ctime')) - 28800000; // 8 hours, adjust to UTC
         const orderType = this.safeString (order, 'type');
         const type = (orderType === '2') ? 'limit' : 'market';
         const side = this.safeString (order, 'side');
@@ -893,7 +893,7 @@ module.exports = class aofex extends Exchange {
         await this.loadMarkets ();
         const request = {
             // 'from': 'BM7442641584965237751ZMAKJ5', // query start order_sn
-            // 'direct': 'prev', // next
+            'direct': 'prev', // next
         };
         let market = undefined;
         if (symbol !== undefined) {


### PR DESCRIPTION
AOFEX return chinese time (UTC+8), need to be adjusted.

https://aofex.zendesk.com/hc/en-us/articles/360035736674-Order-History
https://aofex.zendesk.com/hc/en-us/articles/360035736274-Open-Orders
This examples are not clear, now we get the oldest orders if make request without `'direct': 'prev'`