### PR TITLE
Fix error introduced by Issue #6749

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -922,7 +922,7 @@ class Exchange(object):
                 ordered[price] = (ordered[price] if price in ordered else 0) + volume
         result = []
         items = list(ordered.items())
-        for price, volume in items:
+        for price, volume, *_ in items:
             result.append([price, volume])
         return result
 


### PR DESCRIPTION
In fixing Issue #6749, aggregating on the L2 order books no longer works. To fix this, the 3rd element must be unpacked and disregarded.
The star operator should maintain compatibility with the existing exchanges