### PR TITLE
kuna emulated fetchOHLCV

### DIFF
--- a/js/kuna.js
+++ b/js/kuna.js
@@ -18,11 +18,12 @@ module.exports = class kuna extends acx {
             'has': {
                 'CORS': false,
                 'fetchTickers': true,
-                'fetchOHLCV': false,
+                'fetchOHLCV': 'emulated',
                 'fetchOpenOrders': true,
                 'fetchMyTrades': true,
                 'withdraw': false,
             },
+            'timeframes': undefined,
             'urls': {
                 'referral': 'https://kuna.io?r=kunaid-gvfihe8az7o4',
                 'logo': 'https://user-images.githubusercontent.com/1294454/31697638-912824fa-b3c1-11e7-8c36-cf9606eb94ac.jpg',
@@ -190,5 +191,12 @@ module.exports = class kuna extends acx {
         };
         const response = await this.privateGetTradesMy (this.extend (request, params));
         return this.parseTrades (response, market, since, limit);
+    }
+
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limits = undefined, params = {}) {
+        await this.loadMarkets ();
+        const trades = await this.fetchTrades (symbol, since, limits, params);
+        const ohlcvc = this.buildOHLCVC (trades, timeframe, since, limits);
+        return ohlcvc.map (c => c.slice (0, -1));
     }
 };

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -197,6 +197,18 @@ module.exports = class kuna extends acx {
         await this.loadMarkets ();
         const trades = await this.fetchTrades (symbol, since, limits, params);
         const ohlcvc = this.buildOHLCVC (trades, timeframe, since, limits);
-        return ohlcvc.map (c => c.slice (0, -1));
+        const result = [];
+        for (let i = 0; i < ohlcvc.length; i++) {
+            const ohlcv = ohlcvc[i];
+            result.push ([
+                ohlcv[0],
+                ohlcv[1],
+                ohlcv[2],
+                ohlcv[3],
+                ohlcv[4],
+                ohlcv[5],
+            ])
+        }
+        return result;
     }
 };

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -207,7 +207,7 @@ module.exports = class kuna extends acx {
                 ohlcv[3],
                 ohlcv[4],
                 ohlcv[5],
-            ])
+            ]);
         }
         return result;
     }


### PR DESCRIPTION
We can use emulated method if they don't have original. But Kuna inherits `fetchOHLCV` from ACX so we need to override it