### PR TITLE
[kraken] fix: change from webpage to zendesk api to fetch minOrderAmounts

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -234,7 +234,7 @@ module.exports = class kraken extends Exchange {
         return this.decimalToPrecision (fee, TRUNCATE, this.markets[symbol]['precision']['amount'], DECIMAL_PLACES);
     }
 
-    async fetchMinOrderAmounts (params) {
+    async fetchMinOrderAmounts (params = {}) {
         const response = await this.zendeskGet205893708 (params);
         const article = this.safeValue (response, 'article');
         const html = this.safeString (article, 'body');

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -54,7 +54,7 @@ module.exports = class kraken extends Exchange {
                 'api': {
                     'public': 'https://api.kraken.com',
                     'private': 'https://api.kraken.com',
-                    'zendesk': 'https://kraken.zendesk.com/api/v2/help_center/en-us/articles/', // use the public zendesk api to receive article bodies and bypass new anti-spam protections
+                    'zendesk': 'https://kraken.zendesk.com/api/v2/help_center/en-us/articles', // use the public zendesk api to receive article bodies and bypass new anti-spam protections
                 },
                 'www': 'https://www.kraken.com',
                 'doc': 'https://www.kraken.com/features/api',
@@ -206,7 +206,7 @@ module.exports = class kraken extends Exchange {
                 'delistedMarketsById': {},
                 // cannot withdraw/deposit these
                 'inactiveCurrencies': [ 'CAD', 'USD', 'JPY', 'GBP' ],
-                'fetchMinOrderAmounts': false,
+                'fetchMinOrderAmounts': true,
             },
             'exceptions': {
                 'EQuery:Invalid asset pair': BadSymbol, // {"error":["EQuery:Invalid asset pair"]}
@@ -235,8 +235,9 @@ module.exports = class kraken extends Exchange {
     }
 
     async fetchMinOrderAmounts (params) {
-        const data = await this.zendeskGet205893708 (params);
-        const html = data['article']['body'];
+        const response = await this.zendeskGet205893708 (params);
+        const article = this.safeValue (response, 'article');
+        const html = this.safeString (article, 'body');
         const parts = html.split ('<td class="wysiwyg-text-align-right">');
         const numParts = parts.length;
         if (numParts < 3) {

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -54,7 +54,7 @@ module.exports = class kraken extends Exchange {
                 'api': {
                     'public': 'https://api.kraken.com',
                     'private': 'https://api.kraken.com',
-                    'zendesk': 'https://support.kraken.com/hc/en-us/articles',
+                    'zendesk': 'https://kraken.zendesk.com/api/v2/help_center/en-us/articles/', // use the public zendesk api to receive article bodies and bypass new anti-spam protections
                 },
                 'www': 'https://www.kraken.com',
                 'doc': 'https://www.kraken.com/features/api',
@@ -149,9 +149,9 @@ module.exports = class kraken extends Exchange {
                     'get': [
                         // we should really refrain from putting fixed fee numbers and stop hardcoding
                         // we will be using their web APIs to scrape all numbers from these articles
-                        '205893708-What-is-the-minimum-order-size-',
-                        '201396777-What-are-the-deposit-fees-',
-                        '201893608-What-are-the-withdrawal-fees-',
+                        '205893708', // -What-is-the-minimum-order-size-
+                        '360000292886', // -What-are-the-deposit-fees-
+                        '201893608', // -What-are-the-withdrawal-fees-
                     ],
                 },
                 'public': {
@@ -235,7 +235,8 @@ module.exports = class kraken extends Exchange {
     }
 
     async fetchMinOrderAmounts (params) {
-        const html = await this.zendeskGet205893708WhatIsTheMinimumOrderSize (params);
+        const data = await this.zendeskGet205893708 (params);
+        const html = data['article']['body'];
         const parts = html.split ('<td class="wysiwyg-text-align-right">');
         const numParts = parts.length;
         if (numParts < 3) {


### PR DESCRIPTION
Issue: directly fetching zendesk article pages is now prevented by anti-spam protection. 

To reproduce issue use the following anonymous function 

```javascript
const ccxt = require('ccxt');

(async () => {
  const kraken = new ccxt.kraken ();
  const minOrderAmounts = await kraken.fetchMinOrderAmounts();
  console.log(minOrderAmounts);
})();
```
It should throw an error in the console with the current release. And render correctly when built on this branch.

However building with my quick fix implemented will result in the data as expected. Using the public zendesk api bypassed the spam protection on the main article link. The id of the article was found in the original url.

This is a quick fix for a fairly urgent issue as not having the minimum order amounts is quite disruptive to many workflows.