### PR TITLE
Prevent exchange.symbols mutation

### DIFF
--- a/js/test/Exchange/test.fetchOrderBooks.js
+++ b/js/test/Exchange/test.fetchOrderBooks.js
@@ -13,7 +13,7 @@ const log       = require ('ololog')
 
 module.exports = async (exchange) => {
 
-    const randomSymbols = exchange.symbols.sort (() => 0.5 - Math.random ()).slice (0, 2)
+    const randomSymbols = exchange.symbols.slice ().sort (() => 0.5 - Math.random ()).slice (0, 2)
     const customExchangeParams = ([
         'yobit',
         'tidex',


### PR DESCRIPTION
exchange.symbols was getting shuffled here not only for this test but also affecting subsequent ones.