### PR TITLE
Poloniex editOrder trades fixup

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1035,6 +1035,7 @@ module.exports = class poloniex extends Exchange {
                 'id': newid,
                 'price': price,
                 'status': 'open',
+                'trades': [],
             });
             if (amount !== undefined) {
                 this.orders[newid]['amount'] = amount;


### PR DESCRIPTION
Hello, 

Very quick PR , just to remove trades from newly created order when using edit function.
We don't want to keep trades linked to another order, otherwise we are going to replicate this old trade on any future order.

Regards,