### PR TITLE
Add MorCrypto Exchange

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+<html xmlns="http://www.w3.org/1999/xhtml">    
+  <head>      
+    <title>CryptoCurrency eXchange Trading Library</title>      
+    <meta http-equiv="refresh" content="0;URL='http://github.com/kroitor/ccxt'" />    
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
https://morcrypto-exchange.com/apikey 

We are MorCrypto Exchange, a crypto currency exchange form Africa/Nigeria registered as MorCrypto Ltd in Nigeria RC.1660409 we aim to contributei in driving the adaptation of crypto in Africa as this will bring a great opportunity for Africa and the Blockchain, we have successfully built our exchange and we will be honored to list on CCXT/GitHub, we would be grateful if our request is granted.

Thanks

MorCrypto Ltd 