### PR TITLE
coinbasepro: fetchTime(): use epoch instead of iso property.

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -518,7 +518,7 @@ module.exports = class coinbasepro extends Exchange {
 
     async fetchTime (params = {}) {
         const response = await this.publicGetTime (params);
-        return this.parse8601 (this.safeString (response, 'iso'));
+        return 1000 * this.safeFloat (response, 'epoch');
     }
 
     parseOrderStatus (status) {

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -518,7 +518,13 @@ module.exports = class coinbasepro extends Exchange {
 
     async fetchTime (params = {}) {
         const response = await this.publicGetTime (params);
-        return 1000 * this.safeFloat (response, 'epoch');
+        //
+        //     {
+        //         "iso":"2020-05-12T08:00:51.504Z",
+        //         "epoch":1589270451.504
+        //     }
+        //
+        return this.safeTimestamp (response, 'epoch');
     }
 
     parseOrderStatus (status) {


### PR DESCRIPTION
Running `curl https://api.pro.coinbase.com/time` returns

```{"iso":"2020-05-12T05:28:33.740Z","epoch":1589261313.74}```

so use the `epoch` property instead of parsing the `iso` property.