### PR TITLE
coinbase: fetchTime(): use epoch instead of iso property.

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -156,8 +156,16 @@ module.exports = class coinbase extends Exchange {
 
     async fetchTime (params = {}) {
         const response = await this.publicGetTime (params);
+        //
+        //     {
+        //         "data": {
+        //             "epoch": 1589295679,
+        //             "iso": "2020-05-12T15:01:19Z"
+        //         }
+        //     }
+        //
         const data = this.safeValue (response, 'data', {});
-        return this.parse8601 (this.safeString (data, 'iso'));
+        return this.safeTimestamp (data, 'epoch');
     }
 
     async fetchAccounts (params = {}) {


### PR DESCRIPTION
`curl https://api.coinbase.com/v2/time` returns

```
{
    "data": {
        "iso": "2020-05-13T06:27:33Z",
        "epoch": 1589351253
    }
}
```