### PR TITLE
Bithumb: limits and precision

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -4,6 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { ExchangeError, ExchangeNotAvailable, AuthenticationError, BadRequest, PermissionDenied, InvalidAddress, ArgumentsRequired, InvalidOrder } = require ('./base/errors');
+const { DECIMAL_PLACES, SIGNIFICANT_DIGITS, TRUNCATE } = require ('./base/functions/number');
 
 //  ---------------------------------------------------------------------------
 
@@ -70,6 +71,7 @@ module.exports = class bithumb extends Exchange {
                     'taker': 0.25 / 100,
                 },
             },
+            'precisionMode': SIGNIFICANT_DIGITS,
             'exceptions': {
                 'Bad Request(SSL)': BadRequest,
                 'Bad Request(Bad Method)': BadRequest,
@@ -86,6 +88,10 @@ module.exports = class bithumb extends Exchange {
                 'After May 23th, recent_transactions is no longer, hence users will not be able to connect to recent_transactions': ExchangeError, // {"status":"5100","message":"After May 23th, recent_transactions is no longer, hence users will not be able to connect to recent_transactions"}
             },
         });
+    }
+
+    amountToPrecision (symbol, amount) {
+        return this.decimalToPrecision (amount, TRUNCATE, this.markets[symbol].precision.amount, DECIMAL_PLACES)
     }
 
     async fetchMarkets (params = {}) {
@@ -117,8 +123,8 @@ module.exports = class bithumb extends Exchange {
                 'info': market,
                 'active': active,
                 'precision': {
-                    'amount': undefined,
-                    'price': undefined,
+                    'amount': 4,
+                    'price': 4,
                 },
                 'limits': {
                     'amount': {

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -130,7 +130,7 @@ module.exports = class bithumb extends Exchange {
                         'max': undefined,
                     },
                     'cost': {
-                        'min': undefined,
+                        'min': 500,
                         'max': undefined,
                     },
                 },

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -131,7 +131,7 @@ module.exports = class bithumb extends Exchange {
                     },
                     'cost': {
                         'min': 500,
-                        'max': undefined,
+                        'max': 5000000000,
                     },
                 },
                 'baseId': undefined,

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -91,7 +91,7 @@ module.exports = class bithumb extends Exchange {
     }
 
     amountToPrecision (symbol, amount) {
-        return this.decimalToPrecision (amount, TRUNCATE, this.markets[symbol].precision.amount, DECIMAL_PLACES)
+        return this.decimalToPrecision (amount, TRUNCATE, this.markets[symbol]['precision']['amount'], DECIMAL_PLACES);
     }
 
     async fetchMarkets (params = {}) {


### PR DESCRIPTION
Since I have not found a documentation for limits and precision, I did a little try and error.
Here are the useful error messages I found:
```
{"status":"5600","message":"\ucd5c\ub300 \uc8fc\ubb38\uae08\uc561\uc740 5000000000 KRW \uc785\ub2c8\ub2e4."}
{"status":"5600","message":"\ucd5c\uc18c \uc8fc\ubb38\uae08\uc561\uc740 500 KRW \uc785\ub2c8\ub2e4."}
{"status":"5600","message":"BTC \uc218\ub7c9\uc740 \uc18c\uc218\uc810 4\uc790\ub9ac\uae4c\uc9c0\ub9cc \uc720\ud6a8\ud569\ub2c8\ub2e4."}
```

I did not log all createOrder parameters which worked and which didnt. Next time I will do these, so you can verify it.
