### PR TITLE
Exmo add BCH fees

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -318,6 +318,7 @@ module.exports = class exmo extends Exchange {
                                     { 'prov': 'XMR', 'dep': '0%', 'wd': '0.001 XMR' },
                                     { 'prov': 'XRP', 'dep': '0%', 'wd': '0.02 XRP' },
                                     { 'prov': 'ETC', 'dep': '0%', 'wd': '0.01 ETC' },
+                                    { 'prov': 'BCH', 'dep': '0%', 'wd': '0.001 BCH' },
                                     { 'prov': 'BTG', 'dep': '0%', 'wd': '0.001 BTG' },
                                     { 'prov': 'EOS', 'dep': '0%', 'wd': '0.05 EOS' },
                                     { 'prov': 'XLM', 'dep': '0%', 'wd': '0.01 XLM' },


### PR DESCRIPTION
https://exmo.com/en/docs/fees

Possibly, you make last changes during this event (https://exmo.com/en/news_view?id=3183) so BCH was temporary removed from EXMO fees table at that moment