### PR TITLE
binance future fetchOpenOrders type bug fix (futures should be future)

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1388,7 +1388,7 @@ module.exports = class binance extends Exchange {
             query = this.omit (params, 'type');
         }
         let method = 'privateGetOpenOrders';
-        if (type === 'futures') {
+        if (type === 'future') {
             method = 'fapiPrivateGetOpenOrders';
         } else if (type === 'margin') {
             method = 'sapiGetMarginOpenOrders';


### PR DESCRIPTION
this is a bug import by 1.28.35, binance fetchOpenOrders future type has a typo, futures should be future.