### PR TITLE
qTrade fetchBalance fix

### DIFF
--- a/js/qtrade.js
+++ b/js/qtrade.js
@@ -733,6 +733,7 @@ module.exports = class qtrade extends Exchange {
             const code = this.safeCurrencyCode (currencyId);
             const account = (code in result) ? result[code] : this.account ();
             account['free'] = this.safeFloat (balance, 'balance');
+            account['used'] = 0;
             result[code] = account;
         }
         balances = this.safeValue (data, 'order_balances', []);


### PR DESCRIPTION
```
handleRestResponse:
 qtrade GET https://api.qtrade.io/v1/user/balances_all 200 OK
Response:
 {
  'Cf-Cache-Status': 'DYNAMIC',
...
}
 {"data":{"balances":[{"currency":"BTC","balance":"0.00557638"},{"currency":"ETH","balance":"0"}],"order_balances":[{"currency":"ETH","balance":"0.25"}],"limit_used":0,"limit_remaining":2000,"limit":2000}}

{
  info: {
    data: {
      balances: [Array],
      order_balances: [Array],
      limit_used: 0,
      limit_remaining: 2000,
      limit: 2000
    }
  },
  BTC: { free: 0.00557638, used: undefined, total: undefined },
  ETH: { free: 0, used: 0.25, total: 0.25 },
  free: { BTC: 0.00557638, ETH: 0 },
  used: { BTC: undefined, ETH: 0.25 },
  total: { BTC: undefined, ETH: 0.25 }
}
```

Now if we don't have order with some currency we have `used` and `total` `undefined` because exchange don't give `order_balances` for this currency. But even if all currency in order (ETH in my case) exchange gives his free balance like 0. So this code will give correct result