### PR TITLE
Sort kraken orders by timestamp

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -1143,6 +1143,7 @@ module.exports = class kraken extends Exchange {
             const order = this.extend ({ 'id': id }, orders[id]);
             result.push (this.extend (this.parseOrder (order, market), params));
         }
+        result = sortBy (result, 'timestamp')
         return this.filterBySymbolSinceLimit (result, symbol, since, limit);
     }
 

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -1132,7 +1132,7 @@ module.exports = class kraken extends Exchange {
     }
 
     parseOrders (orders, market = undefined, since = undefined, limit = undefined, params = {}) {
-        const result = [];
+        let result = [];
         const ids = Object.keys (orders);
         let symbol = undefined;
         if (market !== undefined) {
@@ -1143,7 +1143,7 @@ module.exports = class kraken extends Exchange {
             const order = this.extend ({ 'id': id }, orders[id]);
             result.push (this.extend (this.parseOrder (order, market), params));
         }
-        result = sortBy (result, 'timestamp')
+        result = this.sortBy (result, 'timestamp');
         return this.filterBySymbolSinceLimit (result, symbol, since, limit);
     }
 


### PR DESCRIPTION
base `Exchange` class is sorting orders by timestamp. But in kraken the method `parseOrders` is overrided without a call to `super.parseOrders`. So we are missing the sorting here