### PR TITLE
A bug in loadMarkets() for Kuna Exchange fixed (GOL quote coin added)

### DIFF
--- a/js/kuna.js
+++ b/js/kuna.js
@@ -60,7 +60,7 @@ module.exports = class kuna extends acx {
     }
 
     async fetchMarkets (params = {}) {
-        const quotes = [ 'btc', 'eth', 'eurs', 'rub', 'uah', 'usd', 'usdt' ];
+        const quotes = [ 'btc', 'eth', 'eurs', 'rub', 'uah', 'usd', 'usdt', 'gol' ];
         const pricePrecisions = {
             'UAH': 0,
         };


### PR DESCRIPTION
One of the quote currencies was missed in the method. This is `GOL` coin.
So we couldn't interact with `CYBER/GOL` symbol.

I've tested it locally after adding `GOL` now it returns `CYBER/GOL` ticker.
However, I didn't run any unit tests. I hope this simple change will break nothing.