### PR TITLE
A bug in parseTrade() for Kuna Exchange fixed (side is undefined)

### DIFF
--- a/js/kuna.js
+++ b/js/kuna.js
@@ -146,7 +146,7 @@ module.exports = class kuna extends acx {
                 'ask': 'sell',
                 'bid': 'buy',
             };
-            side = this.safeString (sideMap, side);
+            side = this.safeString (sideMap, side, side);
         }
         const price = this.safeFloat (trade, 'price');
         const amount = this.safeFloat (trade, 'volume');


### PR DESCRIPTION
- The bug was with 'side' field. It was always 'undefined'.
- The problem was in the values of 'trend' raw field. Kuna returns 'sell' or 'buy' values in the field.
- 'side' raw field always 'null'
- I don't know why are we waiting 'ask' | 'bid' values in this (trend|side) raw fields. May be 'side' field was containing such values some times ago. However, now 'side' is always null.

I've tested it locally. Now `fetchTrades()` returns `side` field correctly (`sell` | `buy`).
However, I didn't run any unit tests. I hope this little change will break nothing.