### PR TITLE
Enhance coinone exchange market/ticker/orderbook/trades

### DIFF
--- a/examples/js/coinone-fetch-tickers.js
+++ b/examples/js/coinone-fetch-tickers.js
@@ -1,58 +1,49 @@
 "use strict"
 
-const asTable = require ('as-table')
-const ansi      = require ('ansicolor').nice
-const log = require('ololog').noLocate
-const ccxt = require('../../ccxt.js')
-const exchange = new ccxt.coinone({
-    "enableRateLimit": true,
-    'verbose': process.argv.includes('-v'),
+const ansi = require ('ansicolor').nice
+    , log = require ('ololog').noLocate
+    , asTable = require ('as-table').configure ({
+        delimiter: ' | '.dim,
+        right: true,
+    })
+    , ccxt = require ('../../ccxt.js')
+
+const exchange = new ccxt.coinone ({
+    'enableRateLimit': true,
+    'verbose': process.argv.includes ('--verbose'),
 })
 
 let printTickersAsTable = function (exchange, tickers) {
     log (exchange.id.green, exchange.iso8601 (exchange.milliseconds ()))
     log ('Fetched', Object.values (tickers).length.toString ().green, 'tickers:')
-    log (asTable.configure ({ delimiter: ' | '.dim, right: true }) (
-            ccxt.sortBy (Object.values (tickers), 'symbol', false)
-                                .map (ticker => ({
-                                    timestamp: ticker['timestamp'],
-                                    symbol: ticker['symbol'],
-                                    high: ticker['high'].toFixed (4),
-                                    low: ticker['low'].toFixed (4),
-                                    prevClose: ticker['previousClose'].toFixed (4),
-                                    price: ticker['close'].toFixed (4),
-                                    baseVolume: ticker['baseVolume'],
-                                    change: ticker['change'].toFixed(4),
-                                    percentage: ticker['percentage'].toFixed(2),
-                                    average: ticker['average'].toFixed(4),
-                                }))))
+    log (asTable (ccxt.sortBy (Object.values (tickers), 'symbol', false)))
 }
 
-async function fetchAllAndPrint() {
-    const tickers = await exchange.fetchTickers()
-    log ('---------------------------------------- (fetchAll) ----------------------------------------')
-    printTickersAsTable(exchange, tickers)
+async function fetchAllAndPrint () {
+    const tickers = await exchange.fetchTickers ()
+    log ('---------------------------------------- fetchTickers ----------------------------------------')
+    printTickersAsTable (exchange, tickers)
 }
 
-async function fetchOneByOneAndPrint() {
-    const markets = await exchange.loadMarkets()
-    const symbols = Object.keys(markets)
+async function fetchOneByOneAndPrint () {
+    const markets = await exchange.loadMarkets ()
+    const symbols = Object.keys (markets)
     const tickers = []
 
-    log ('---------------------------------------- (fetchEachByEach) ----------------------------------------')
+    log ('---------------------------------------- fetchTicker (one by one) ----------------------------------------')
 
     for (let i = 0; i < symbols.length; i++) {
-        const ticker = await exchange.fetchTicker(symbols[i])
-        tickers.push(ticker)
-        log(`${i+1} / ${symbols.length}`)
-        log('\u001b[1A'.repeat(2))  // cursor up
+        const ticker = await exchange.fetchTicker (symbols[i])
+        tickers.push (ticker)
+        log (`${i+1} / ${symbols.length}`)
+        log ('\u001b[1A'.repeat (2))  // cursor up
     }
     
-    printTickersAsTable(exchange, tickers)
+    printTickersAsTable (exchange, tickers)
 }
 
 ;(async () => {
-    await fetchAllAndPrint()
-    log('\n')
-    await fetchOneByOneAndPrint()
+    await fetchAllAndPrint ()
+    log ('\n')
+    await fetchOneByOneAndPrint ()
 }) ()

--- a/examples/js/coinone-fetch-tickers.js
+++ b/examples/js/coinone-fetch-tickers.js
@@ -1,0 +1,32 @@
+"use strict"
+
+const asTable = require ('as-table')
+const ansi      = require ('ansicolor').nice
+const log = require('ololog').noLocate
+const ccxt = require('../../ccxt.js')
+const exchange = new ccxt.coinone({
+    'verbose': process.argv.includes('-v'),
+})
+
+async function main() {
+    const tickers = await exchange.fetchTickers()
+    log(tickers)
+    log ('--------------------------------------------------------')
+    log (exchange.id.green, exchange.iso8601 (exchange.milliseconds ()))
+    log ('Fetched', Object.values (tickers).length.toString ().green, 'tickers:')
+    log (asTable.configure ({ delimiter: ' | '.dim, right: true }) (
+            ccxt.sortBy (Object.values (tickers), 'symbol', false)
+                                .map (ticker => ({
+                                    symbol: ticker['symbol'],
+                                    high: ticker['high'].toFixed (4),
+                                    low: ticker['low'].toFixed (4),
+                                    prevClose: ticker['previousClose'].toFixed (4),
+                                    price: ticker['close'].toFixed (4),
+                                    baseVolume: ticker['baseVolume'],
+                                    change: ticker['change'].toFixed(4),
+                                    percentage: ticker['percentage'].toFixed(2),
+                                    average: ticker['average'].toFixed(4),
+                                }))))
+}
+
+main()

--- a/examples/js/coinone-fetch-tickers.js
+++ b/examples/js/coinone-fetch-tickers.js
@@ -5,18 +5,17 @@ const ansi      = require ('ansicolor').nice
 const log = require('ololog').noLocate
 const ccxt = require('../../ccxt.js')
 const exchange = new ccxt.coinone({
+    "enableRateLimit": true,
     'verbose': process.argv.includes('-v'),
 })
 
-async function main() {
-    const tickers = await exchange.fetchTickers()
-    log(tickers)
-    log ('--------------------------------------------------------')
+let printTickersAsTable = function (exchange, tickers) {
     log (exchange.id.green, exchange.iso8601 (exchange.milliseconds ()))
     log ('Fetched', Object.values (tickers).length.toString ().green, 'tickers:')
     log (asTable.configure ({ delimiter: ' | '.dim, right: true }) (
             ccxt.sortBy (Object.values (tickers), 'symbol', false)
                                 .map (ticker => ({
+                                    timestamp: ticker['timestamp'],
                                     symbol: ticker['symbol'],
                                     high: ticker['high'].toFixed (4),
                                     low: ticker['low'].toFixed (4),
@@ -29,4 +28,31 @@ async function main() {
                                 }))))
 }
 
-main()
+async function fetchAllAndPrint() {
+    const tickers = await exchange.fetchTickers()
+    log ('---------------------------------------- (fetchAll) ----------------------------------------')
+    printTickersAsTable(exchange, tickers)
+}
+
+async function fetchOneByOneAndPrint() {
+    const markets = await exchange.loadMarkets()
+    const symbols = Object.keys(markets)
+    const tickers = []
+
+    log ('---------------------------------------- (fetchEachByEach) ----------------------------------------')
+
+    for (let i = 0; i < symbols.length; i++) {
+        const ticker = await exchange.fetchTicker(symbols[i])
+        tickers.push(ticker)
+        log(`${i+1} / ${symbols.length}`)
+        log('\u001b[1A'.repeat(2))  // cursor up
+    }
+    
+    printTickersAsTable(exchange, tickers)
+}
+
+;(async () => {
+    await fetchAllAndPrint()
+    log('\n')
+    await fetchOneByOneAndPrint()
+}) ()

--- a/examples/js/coinone-markets.js
+++ b/examples/js/coinone-markets.js
@@ -1,0 +1,16 @@
+"use strict"
+
+const log = require('ololog')
+const ccxt = require('../../ccxt.js')
+const exchange = new ccxt.coinone({
+    'verbose': process.argv.includes('-v'),
+})
+
+
+async function main () {
+    const markets = await exchange.load_markets()
+    log(markets)
+    log('\n' + exchange['name'] + ' supports ' + Object.keys(markets).length + ' pairs')
+}
+
+main()

--- a/examples/js/coinone-markets.js
+++ b/examples/js/coinone-markets.js
@@ -1,16 +1,17 @@
 "use strict"
 
-const log = require('ololog')
-const ccxt = require('../../ccxt.js')
-const exchange = new ccxt.coinone({
-    'verbose': process.argv.includes('-v'),
+const log = require ('ololog')
+    , ccxt = require ('../../ccxt.js')
+
+const exchange = new ccxt.coinone ({
+    'enableRateLimit': true,
+    'verbose': process.argv.includes ('--verbose'),
 })
 
+;(async function main () {
 
-async function main() {
-    const markets = await exchange.loadMarkets()
-    log(markets)
-    log('\n' + exchange['name'] + ' supports ' + Object.keys(markets).length + ' pairs')
-}
+    const markets = await exchange.loadMarkets ()
+    log (markets)
+    log ('\n' + exchange['name'] + ' supports ' + Object.keys (markets).length + ' pairs')
 
-main()
+}) ()

--- a/examples/js/coinone-markets.js
+++ b/examples/js/coinone-markets.js
@@ -7,8 +7,8 @@ const exchange = new ccxt.coinone({
 })
 
 
-async function main () {
-    const markets = await exchange.load_markets()
+async function main() {
+    const markets = await exchange.loadMarkets()
     log(markets)
     log('\n' + exchange['name'] + ' supports ' + Object.keys(markets).length + ' pairs')
 }

--- a/examples/php/coinone-fetch-tickers.php
+++ b/examples/php/coinone-fetch-tickers.php
@@ -6,7 +6,7 @@ include $root . '/ccxt.php';
 
 $exchange = new \ccxt\coinone (array (
     'enableRateLimit' => true,
-    'verbose' => false,
+    // 'verbose' => true, // uncomment for verbose output
 ));
 
 // fetch all

--- a/examples/php/coinone-fetch-tickers.php
+++ b/examples/php/coinone-fetch-tickers.php
@@ -1,0 +1,15 @@
+<?php
+
+$root = dirname (dirname (dirname (__FILE__)));
+
+include $root . '/ccxt.php';
+
+$exchange = new \ccxt\coinone (array (
+    'verbose' => true,
+));
+
+$tickers = $exchange->fetch_tickers();
+
+var_dump ($tickers);
+
+?>

--- a/examples/php/coinone-fetch-tickers.php
+++ b/examples/php/coinone-fetch-tickers.php
@@ -5,11 +5,20 @@ $root = dirname (dirname (dirname (__FILE__)));
 include $root . '/ccxt.php';
 
 $exchange = new \ccxt\coinone (array (
-    'verbose' => true,
+    'enableRateLimit' => true,
+    'verbose' => false,
 ));
 
+// fetch all
 $tickers = $exchange->fetch_tickers();
-
 var_dump ($tickers);
+
+echo "\n";
+
+// fetch one by one
+$markets = $exchange->load_markets();
+foreach ($markets as $symbol => $m) {
+    var_dump($exchange->fetch_ticker($symbol));
+}
 
 ?>

--- a/examples/php/coinone-markets.php
+++ b/examples/php/coinone-markets.php
@@ -5,7 +5,8 @@ $root = dirname (dirname (dirname (__FILE__)));
 include $root . '/ccxt.php';
 
 $exchange = new \ccxt\coinone (array (
-    'verbose' => true,
+    'enableRateLimit' => true,
+    // 'verbose' => true, // uncomment for verbose output
 ));
 
 $markets = $exchange->load_markets();

--- a/examples/php/coinone-markets.php
+++ b/examples/php/coinone-markets.php
@@ -1,0 +1,16 @@
+<?php
+
+$root = dirname (dirname (dirname (__FILE__)));
+
+include $root . '/ccxt.php';
+
+$exchange = new \ccxt\coinone (array (
+    'verbose' => true,
+));
+
+$markets = $exchange->load_markets();
+
+var_dump ($markets);
+echo "\n" . $exchange->name . " supports " . count($markets) . " pairs\n";
+
+?>

--- a/examples/py/coinone-fetch-tickers.py
+++ b/examples/py/coinone-fetch-tickers.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+exchange = ccxt.coinone({
+    'verbose': True,  # switch it to False if you don't want the HTTP log
+})
+
+tickers = exchange.fetch_tickers()
+for symbol, ticker in tickers.items():
+    print(
+        symbol,
+        'high:', str(ticker['high']),
+        'low:', str(ticker['low']),
+        'prevClose:', str(ticker['previousClose']),
+        'price:', str(ticker['close']),
+        'baseVolume:', str(ticker['baseVolume']),
+        'change:', str(ticker['change']),
+        'percentage:', str(ticker['percentage']),
+        'average:', str(ticker['average'])
+    )

--- a/examples/py/coinone-fetch-tickers.py
+++ b/examples/py/coinone-fetch-tickers.py
@@ -10,12 +10,13 @@ sys.path.append(root + '/python')
 import ccxt  # noqa: E402
 
 exchange = ccxt.coinone({
-    'verbose': True,  # switch it to False if you don't want the HTTP log
+    'enableRateLimit': True,
+    'verbose': False,  # switch it to False if you don't want the HTTP log
 })
 
-tickers = exchange.fetch_tickers()
-for symbol, ticker in tickers.items():
+def printTicker(symbol, ticker):
     print(
+        str(ticker['timestamp']),
         symbol,
         'high:', str(ticker['high']),
         'low:', str(ticker['low']),
@@ -26,3 +27,15 @@ for symbol, ticker in tickers.items():
         'percentage:', str(ticker['percentage']),
         'average:', str(ticker['average'])
     )
+
+# fetch all
+tickers = exchange.fetch_tickers()
+for symbol, ticker in tickers.items():
+    printTicker(symbol, ticker)
+
+print()
+
+# fetch one by one
+markets = exchange.load_markets()
+for symbol in markets.keys():
+    printTicker(symbol, exchange.fetch_ticker(symbol))

--- a/examples/py/coinone-fetch-tickers.py
+++ b/examples/py/coinone-fetch-tickers.py
@@ -11,31 +11,18 @@ import ccxt  # noqa: E402
 
 exchange = ccxt.coinone({
     'enableRateLimit': True,
-    'verbose': False,  # switch it to False if you don't want the HTTP log
+    # 'verbose': True,  # uncomment for verbose output
 })
-
-def printTicker(symbol, ticker):
-    print(
-        str(ticker['timestamp']),
-        symbol,
-        'high:', str(ticker['high']),
-        'low:', str(ticker['low']),
-        'prevClose:', str(ticker['previousClose']),
-        'price:', str(ticker['close']),
-        'baseVolume:', str(ticker['baseVolume']),
-        'change:', str(ticker['change']),
-        'percentage:', str(ticker['percentage']),
-        'average:', str(ticker['average'])
-    )
 
 # fetch all
 tickers = exchange.fetch_tickers()
 for symbol, ticker in tickers.items():
-    printTicker(symbol, ticker)
+    print(ticker)
 
-print()
+print("\n")
 
 # fetch one by one
 markets = exchange.load_markets()
 for symbol in markets.keys():
-    printTicker(symbol, exchange.fetch_ticker(symbol))
+    ticker = exchange.fetch_ticker(symbol)
+    print(ticker)

--- a/examples/py/coinone-markets.py
+++ b/examples/py/coinone-markets.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+exchange = ccxt.coinone({
+    'verbose': True,  # switch it to False if you don't want the HTTP log
+})
+
+markets = exchange.load_markets()
+pprint(markets)
+print('\n', exchange.name, 'supports', len(markets), 'pairs')

--- a/examples/py/coinone-markets.py
+++ b/examples/py/coinone-markets.py
@@ -10,7 +10,8 @@ sys.path.append(root + '/python')
 import ccxt  # noqa: E402
 
 exchange = ccxt.coinone({
-    'verbose': True,  # switch it to False if you don't want the HTTP log
+    'enableRateLimit': true,
+    # 'verbose': True,  # uncomment for verbose output
 })
 
 markets = exchange.load_markets()

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -13,13 +13,52 @@ module.exports = class coinone extends Exchange {
             'id': 'coinone',
             'name': 'CoinOne',
             'countries': [ 'KR' ], // Korea
+            // 'enableRateLimit': false,
             'rateLimit': 667,
             'version': 'v2',
             'has': {
+                // 'loadMarkets': true,         // true
+                // 'cancelAllOrders': false,
+                // 'cancelOrder': true,         // true
+                // 'cancelOrders': false,
                 'CORS': false,
+                // 'createDepositAddress': false,
+                // 'createLimitOrder': true,    // true
                 'createMarketOrder': false,
-                'fetchTickers': true,
+                // 'createOrder': true,         // true
+                // 'deposit': false,
+                // 'editOrder': 'emulated',
+                // 'fetchBalance': true,        // true
+                // 'fetchBidsAsks': false,
+                // 'fetchClosedOrders': false,  // good to be true
+                // 'fetchCurrencies': false,
+                // 'fetchDepositAddress': false,
+                // 'fetchDeposits': false,
+                // 'fetchFundingFees': false,
+                // 'fetchL2OrderBook': true,    // true
+                // 'fetchLedger': false,
+                // 'fetchMarkets': true,        // true
+                // 'fetchMyTrades': false,      // good to be true
+                // 'fetchOHLCV': 'emulated',
+                // 'fetchOpenOrders': false,    // good to be true
                 'fetchOrder': true,
+                // 'fetchOrderBook': true,      // true
+                // 'fetchOrderBooks': false,
+                // 'fetchOrders': false,        // good to be true
+                // 'fetchOrderTrades': false,
+                // 'fetchStatus': 'emulated',
+                // 'fetchTicker': true,         // true
+                'fetchTickers': true,
+                // 'fetchTime': false,
+                // 'fetchTrades': true,         // true
+                // 'fetchTradingFee': false,
+                // 'fetchTradingFees': false,
+                // 'fetchTradingLimits': false,
+                // 'fetchTransactions': false,
+                // 'fetchWithdrawals': false,
+                // 'privateAPI': true,
+                // 'publicAPI': true,
+                // 'withdraw': false,
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/38003300-adc12fba-323f-11e8-8525-725f53c4a659.jpg',
@@ -61,56 +100,12 @@ module.exports = class coinone extends Exchange {
                     ],
                 },
             },
-            'markets': {
-                'BCH/KRW': { 'id': 'bch', 'symbol': 'BCH/KRW', 'base': 'BCH', 'quote': 'KRW', 'baseId': 'bch', 'quoteId': 'krw' },
-                'BTC/KRW': { 'id': 'btc', 'symbol': 'BTC/KRW', 'base': 'BTC', 'quote': 'KRW', 'baseId': 'btc', 'quoteId': 'krw' },
-                'BTG/KRW': { 'id': 'btg', 'symbol': 'BTG/KRW', 'base': 'BTG', 'quote': 'KRW', 'baseId': 'btg', 'quoteId': 'krw' },
-                'ETC/KRW': { 'id': 'etc', 'symbol': 'ETC/KRW', 'base': 'ETC', 'quote': 'KRW', 'baseId': 'etc', 'quoteId': 'krw' },
-                'ETH/KRW': { 'id': 'eth', 'symbol': 'ETH/KRW', 'base': 'ETH', 'quote': 'KRW', 'baseId': 'eth', 'quoteId': 'krw' },
-                'IOTA/KRW': { 'id': 'iota', 'symbol': 'IOTA/KRW', 'base': 'IOTA', 'quote': 'KRW', 'baseId': 'iota', 'quoteId': 'krw' },
-                'LTC/KRW': { 'id': 'ltc', 'symbol': 'LTC/KRW', 'base': 'LTC', 'quote': 'KRW', 'baseId': 'ltc', 'quoteId': 'krw' },
-                'OMG/KRW': { 'id': 'omg', 'symbol': 'OMG/KRW', 'base': 'OMG', 'quote': 'KRW', 'baseId': 'omg', 'quoteId': 'krw' },
-                'QTUM/KRW': { 'id': 'qtum', 'symbol': 'QTUM/KRW', 'base': 'QTUM', 'quote': 'KRW', 'baseId': 'qtum', 'quoteId': 'krw' },
-                'XRP/KRW': { 'id': 'xrp', 'symbol': 'XRP/KRW', 'base': 'XRP', 'quote': 'KRW', 'baseId': 'xrp', 'quoteId': 'krw' },
-                'EOS/KRW': { 'id': 'eos', 'symbol': 'EOS/KRW', 'base': 'EOS', 'quote': 'KRW', 'baseId': 'eos', 'quoteId': 'krw' },
-                'DATA/KRW': { 'id': 'data', 'symbol': 'DATA/KRW', 'base': 'DATA', 'quote': 'KRW', 'baseId': 'data', 'quoteId': 'krw' },
-                'ZIL/KRW': { 'id': 'zil', 'symbol': 'ZIL/KRW', 'base': 'ZIL', 'quote': 'KRW', 'baseId': 'zil', 'quoteId': 'krw' },
-                'KNC/KRW': { 'id': 'knc', 'symbol': 'KNC/KRW', 'base': 'KNC', 'quote': 'KRW', 'baseId': 'knc', 'quoteId': 'krw' },
-                'ZRX/KRW': { 'id': 'zrx', 'symbol': 'ZRX/KRW', 'base': 'ZRX', 'quote': 'KRW', 'baseId': 'zrx', 'quoteId': 'krw' },
-                'LUNA/KRW': { 'id': 'luna', 'symbol': 'LUNA/KRW', 'base': 'LUNA', 'quote': 'KRW', 'baseId': 'luna', 'quoteId': 'krw' },
-                'ATOM/KRW': { 'id': 'atom', 'symbol': 'ATOM/KRW', 'base': 'ATOM', 'quote': 'KRW', 'baseId': 'atom', 'quoteId': 'krw' },
-                'VNT/KRW': { 'id': 'vnt', 'symbol': 'VNT/KRW', 'base': 'VNT', 'quote': 'KRW', 'baseId': 'vnt', 'quoteId': 'krw' },
-            },
             'fees': {
                 'trading': {
-                    'tierBased': true,
+                    'tierBased': false,
                     'percentage': true,
-                    'taker': 0.001,
-                    'maker': 0.001,
-                    'tiers': {
-                        'taker': [
-                            [0, 0.001],
-                            [100000000, 0.0009],
-                            [1000000000, 0.0008],
-                            [5000000000, 0.0007],
-                            [10000000000, 0.0006],
-                            [20000000000, 0.0005],
-                            [30000000000, 0.0004],
-                            [40000000000, 0.0003],
-                            [50000000000, 0.0002],
-                        ],
-                        'maker': [
-                            [0, 0.001],
-                            [100000000, 0.0008],
-                            [1000000000, 0.0006],
-                            [5000000000, 0.0004],
-                            [10000000000, 0.0002],
-                            [20000000000, 0],
-                            [30000000000, 0],
-                            [40000000000, 0],
-                            [50000000000, 0],
-                        ],
-                    },
+                    'taker': 0.002,
+                    'maker': 0.002,
                 },
             },
             'exceptions': {
@@ -120,6 +115,36 @@ module.exports = class coinone extends Exchange {
                 '107': BadRequest, // {"errorCode":"107","errorMsg":"Parameter error","result":"error"}
             },
         });
+    }
+
+    async fetchMarkets (params = {}) {
+        const request = {
+            'currency': 'all',
+        };
+        const response = await this.publicGetTicker (request);
+        const result = [];
+        const quoteId = 'krw';
+        const quote = quoteId.toUpperCase ();
+        const currencyIds = Object.keys (response);
+        for (let i = 0; i < currencyIds.length; i++) {
+            const ticker = response[currencyIds[i]];
+            let id = this.safeString (ticker, 'currency');
+            if (id === undefined) {
+                continue;
+            }
+            id = id.toLowerCase ();
+            const base = id.toUpperCase ();
+            result.push ({
+                'id': id,
+                'symbol': base + '/' + quote,
+                'base': base,
+                'quote': quote,
+                'baseId': id,
+                'quoteId': quoteId,
+                'active': true,
+            });
+        }
+        return result;
     }
 
     async fetchBalance (params = {}) {

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -235,10 +235,8 @@ module.exports = class coinone extends Exchange {
         let percentage = undefined;
         if (last !== undefined && previousClose !== undefined) {
             change = last - previousClose;
-            if (change !== 0) {
+            if (previousClose !== 0) {
                 percentage = change / previousClose * 100;
-            } else {
-                percentage = 0;
             }
         }
         const symbol = (market !== undefined) ? market['symbol'] : undefined;

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -216,13 +216,18 @@ module.exports = class coinone extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         const timestamp = this.milliseconds ();
+        const first = this.safeFloat (ticker, 'first');
         const last = this.safeFloat (ticker, 'last');
+        let average = undefined;
+        if (first !== undefined && last !== undefined) {
+            average = this.sum (first, last) / 2;
+        }
         const previousClose = this.safeFloat (ticker, 'yesterday_last');
         let change = undefined;
         let percentage = undefined;
         if (last !== undefined && previousClose !== undefined) {
             change = last - previousClose;
-            if (change != 0) {
+            if (change !== 0) {
                 percentage = change / previousClose * 100;
             } else {
                 percentage = 0;
@@ -240,13 +245,13 @@ module.exports = class coinone extends Exchange {
             'ask': undefined,
             'askVolume': undefined,
             'vwap': undefined,
-            'open': this.safeFloat (ticker, 'first'),
+            'open': first,
             'close': last,
             'last': last,
             'previousClose': previousClose,
             'change': change,
             'percentage': percentage,
-            'average': undefined,
+            'average': average,
             'baseVolume': this.safeFloat (ticker, 'volume'),
             'quoteVolume': undefined,
             'info': ticker,

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -31,7 +31,7 @@ module.exports = class coinone extends Exchange {
                 // 'fetchBalance': true,        // true
                 // 'fetchBidsAsks': false,
                 // 'fetchClosedOrders': false,  // good to be true
-                // 'fetchCurrencies': false,
+                'fetchCurrencies': false,
                 // 'fetchDepositAddress': false,
                 // 'fetchDeposits': false,
                 // 'fetchFundingFees': false,
@@ -182,7 +182,8 @@ module.exports = class coinone extends Exchange {
             'format': 'json',
         };
         const response = await this.publicGetOrderbook (this.extend (request, params));
-        return this.parseOrderBook (response, undefined, 'bid', 'ask', 'price', 'qty');
+        const timestamp = this.safeTimestamp (response, 'timestamp');
+        return this.parseOrderBook (response, timestamp, 'bid', 'ask', 'price', 'qty');
     }
 
     async fetchTickers (symbols = undefined, params = {}) {

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -219,8 +219,14 @@ module.exports = class coinone extends Exchange {
         const last = this.safeFloat (ticker, 'last');
         const previousClose = this.safeFloat (ticker, 'yesterday_last');
         let change = undefined;
+        let percentage = undefined;
         if (last !== undefined && previousClose !== undefined) {
-            change = previousClose - last;
+            change = last - previousClose;
+            if (change != 0) {
+                percentage = change / previousClose * 100;
+            } else {
+                percentage = 0;
+            }
         }
         const symbol = (market !== undefined) ? market['symbol'] : undefined;
         return {
@@ -239,7 +245,7 @@ module.exports = class coinone extends Exchange {
             'last': last,
             'previousClose': previousClose,
             'change': change,
-            'percentage': undefined,
+            'percentage': percentage,
             'average': undefined,
             'baseVolume': this.safeFloat (ticker, 'volume'),
             'quoteVolume': undefined,

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -133,10 +133,9 @@ module.exports = class coinone extends Exchange {
         const baseIds = Object.keys (response);
         for (let i = 0; i < baseIds.length; i++) {
             const baseId = baseIds[i];
-            const ticker = response[baseId];
             const base = this.safeCurrencyCode (baseId);
             result.push ({
-                'id': id,
+                'id': baseId,
                 'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -50,7 +50,7 @@ module.exports = class coinone extends Exchange {
                 // 'fetchTicker': true,         // true
                 'fetchTickers': true,
                 // 'fetchTime': false,
-                // 'fetchTrades': true,         // true
+                'fetchTrades': true,         // true
                 // 'fetchTradingFee': false,
                 // 'fetchTradingFees': false,
                 // 'fetchTradingLimits': false,
@@ -285,7 +285,7 @@ module.exports = class coinone extends Exchange {
             }
         }
         return {
-            'id': undefined,
+            'id': this.safeString (trade, 'id'),
             'info': trade,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -306,7 +306,6 @@ module.exports = class coinone extends Exchange {
         const market = this.market (symbol);
         const request = {
             'currency': market['id'],
-            'period': 'hour',
             'format': 'json',
         };
         const response = await this.publicGetTrades (this.extend (request, params));

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -43,7 +43,7 @@ module.exports = class coinone extends Exchange {
                 // 'fetchOpenOrders': false,    // good to be true
                 'fetchOrder': true,
                 // 'fetchOrderBook': true,      // true
-                // 'fetchOrderBooks': false,
+                'fetchOrderBooks': false,
                 // 'fetchOrders': false,        // good to be true
                 // 'fetchOrderTrades': false,
                 // 'fetchStatus': 'emulated',
@@ -107,6 +107,11 @@ module.exports = class coinone extends Exchange {
                     'taker': 0.002,
                     'maker': 0.002,
                 },
+            },
+            'precision': {
+                'price': 4,
+                'amount': 4,
+                'cost': 8,
             },
             'exceptions': {
                 '405': OnMaintenance, // {"errorCode":"405","status":"maintenance","result":"error"}
@@ -189,6 +194,7 @@ module.exports = class coinone extends Exchange {
         const response = await this.publicGetTicker (this.extend (request, params));
         const result = {};
         const ids = Object.keys (response);
+        const timestamp = this.safeTimestamp (response, 'timestamp');
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i];
             let symbol = id;
@@ -198,6 +204,7 @@ module.exports = class coinone extends Exchange {
                 symbol = market['symbol'];
                 const ticker = response[id];
                 result[symbol] = this.parseTicker (ticker, market);
+                result[symbol]['timestamp'] = timestamp;
             }
         }
         return result;
@@ -215,7 +222,7 @@ module.exports = class coinone extends Exchange {
     }
 
     parseTicker (ticker, market = undefined) {
-        const timestamp = this.milliseconds ();
+        const timestamp = this.safeTimestamp (ticker, 'timestamp');
         const first = this.safeFloat (ticker, 'first');
         const last = this.safeFloat (ticker, 'last');
         let average = undefined;

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -17,48 +17,20 @@ module.exports = class coinone extends Exchange {
             'rateLimit': 667,
             'version': 'v2',
             'has': {
-                // 'loadMarkets': true,         // true
-                // 'cancelAllOrders': false,
-                // 'cancelOrder': true,         // true
-                // 'cancelOrders': false,
                 'CORS': false,
-                // 'createDepositAddress': false,
-                // 'createLimitOrder': true,    // true
                 'createMarketOrder': false,
-                // 'createOrder': true,         // true
-                // 'deposit': false,
-                // 'editOrder': 'emulated',
-                // 'fetchBalance': true,        // true
-                // 'fetchBidsAsks': false,
-                // 'fetchClosedOrders': false,  // good to be true
+                // 'fetchClosedOrders': false, // not implemented yet
                 'fetchCurrencies': false,
-                // 'fetchDepositAddress': false,
-                // 'fetchDeposits': false,
-                // 'fetchFundingFees': false,
-                // 'fetchL2OrderBook': true,    // true
-                // 'fetchLedger': false,
-                // 'fetchMarkets': true,        // true
-                // 'fetchMyTrades': false,      // good to be true
-                // 'fetchOHLCV': 'emulated',
-                // 'fetchOpenOrders': false,    // good to be true
+                'fetchMarkets': true,
+                // 'fetchMyTrades': false, // not implemented yet
+                // 'fetchOpenOrders': false, // not implemented yet
                 'fetchOrder': true,
-                // 'fetchOrderBook': true,      // true
+                'fetchOrderBook': true,
                 'fetchOrderBooks': false,
-                // 'fetchOrders': false,        // good to be true
-                // 'fetchOrderTrades': false,
-                // 'fetchStatus': 'emulated',
-                // 'fetchTicker': true,         // true
+                // 'fetchOrders': false, // not implemented yet
+                'fetchTicker': true,
                 'fetchTickers': true,
-                // 'fetchTime': false,
-                'fetchTrades': true,         // true
-                // 'fetchTradingFee': false,
-                // 'fetchTradingFees': false,
-                // 'fetchTradingLimits': false,
-                // 'fetchTransactions': false,
-                // 'fetchWithdrawals': false,
-                // 'privateAPI': true,
-                // 'publicAPI': true,
-                // 'withdraw': false,
+                'fetchTrades': true,
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/38003300-adc12fba-323f-11e8-8525-725f53c4a659.jpg',

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -129,22 +129,18 @@ module.exports = class coinone extends Exchange {
         const response = await this.publicGetTicker (request);
         const result = [];
         const quoteId = 'krw';
-        const quote = quoteId.toUpperCase ();
-        const currencyIds = Object.keys (response);
-        for (let i = 0; i < currencyIds.length; i++) {
-            const ticker = response[currencyIds[i]];
-            let id = this.safeString (ticker, 'currency');
-            if (id === undefined) {
-                continue;
-            }
-            id = id.toLowerCase ();
-            const base = id.toUpperCase ();
+        const quote = this.safeCurrencyCode (quoteId);
+        const baseIds = Object.keys (response);
+        for (let i = 0; i < baseIds.length; i++) {
+            const baseId = baseIds[i];
+            const ticker = response[baseId];
+            const base = this.safeCurrencyCode (baseId);
             result.push ({
                 'id': id,
                 'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
-                'baseId': id,
+                'baseId': baseId,
                 'quoteId': quoteId,
                 'active': true,
             });


### PR DESCRIPTION
This PR is for enhancing market/ticker/orderbook/trades implementation for the exchange [Coinone](https://coinone.co.kr).

- Implemented fetchMarkets(): formerly the list of markets was hard-coded
- Add 'close', 'average' and 'change' into tickers
- Change 'timestamp' of tickers to the server data: formerly the client time
- Add 'timestamp' and 'datetime' into orderbooks
- Add 'id' into public trades
