### PR TITLE
Fix coinone markets

### DIFF
--- a/examples/py/coinone-markets.py
+++ b/examples/py/coinone-markets.py
@@ -10,7 +10,7 @@ sys.path.append(root + '/python')
 import ccxt  # noqa: E402
 
 exchange = ccxt.coinone({
-    'enableRateLimit': true,
+    'enableRateLimit': True,
     # 'verbose': True,  # uncomment for verbose output
 })
 

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -105,8 +105,9 @@ module.exports = class coinone extends Exchange {
         const baseIds = Object.keys (response);
         for (let i = 0; i < baseIds.length; i++) {
             const baseId = baseIds[i];
-            const ticker = this.safeValue (response, baseId);
-            if (ticker === undefined || this.safeValue (ticker, 'currency') === undefined) {
+            const ticker = this.safeValue (response, baseId, {});
+            const currency = this.safeValue (ticker, 'currency');
+            if (currency === undefined) {
                 continue;
             }
             const base = this.safeCurrencyCode (baseId);

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -105,6 +105,10 @@ module.exports = class coinone extends Exchange {
         const baseIds = Object.keys (response);
         for (let i = 0; i < baseIds.length; i++) {
             const baseId = baseIds[i];
+            const ticker = this.safeValue (response, baseId);
+            if (ticker === undefined || this.safeValue (ticker, 'currency') === undefined) {
+                continue;
+            }
             const base = this.safeCurrencyCode (baseId);
             result.push ({
                 'id': baseId,


### PR DESCRIPTION
Coinone Open-API doesn't provide dedicated endpoint for listing markets.
So I used all-tickers api alternatively, which returns a map of currencies vs tickers.

By the way, because the response includes non-currency fields (e.g. result, error),
without this fix the markets list must be corrupted.
