### PR TITLE
Adds a simple BUILD.md file (confirmed working)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,22 @@
+# Building
+
+## Prerequisites
+
+To build CCXT you will need:
+- git (from a command prompt: `git --version`)
+- node (from a command prompt: `node --version`)
+    - v14.3.0 is known to work
+- [Homebrew](https://brew.sh/) (macOS)
+- tox
+    - macOS: brew install tox
+    - linux: apt-get install tox
+    - windows: __________________
+
+## Build Steps
+
+1. Open a command prompt and cd to the root directory
+2. If you want to only build specific exchanges, edit `exchanges.cfg` (by default it will build them all)
+3. Run `npm install`
+4. Run `npm run build`
+    - If you get the error " let rstExchangeTableLines = match[2].split ("\n") then instead run `npm run build-without-docs`
+

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,18 +5,23 @@
 To build CCXT you will need:
 - git (from a command prompt: `git --version`)
 - node (from a command prompt: `node --version`)
-    - v14.3.0 is known to work
-- [Homebrew](https://brew.sh/) (macOS)
+    - v14.3.0 confirmed working
 - tox
-    - macOS: brew install tox
-    - linux: apt-get install tox
-    - windows: __________________
+    - via pip: `pip install tox` (confirmed works)
+    - [macOS](https://brew.sh): `brew install tox` (confirmed works)
+    - linux: `apt-get install tox`
+    - windows: 
 
 ## Build Steps
 
-1. Open a command prompt and cd to the root directory
+1. Checkout code:
+    > git clone https://github.com/ccxt/ccxt.git
+2. cd into to the root directory
 2. If you want to only build specific exchanges, edit `exchanges.cfg` (by default it will build them all)
-3. Run `npm install`
-4. Run `npm run build`
-    - If you get the error " let rstExchangeTableLines = match[2].split ("\n") then instead run `npm run build-without-docs`
+3. Run `npm install`. This will fetch packages and should end with a message saying "Thank you!"
+4. Run `npm run build`. If you get [the error](https://github.com/ccxt/ccxt/issues/4195):
+
+    > let rstExchangeTableLines = match[2].split ("\n") 
+   
+   then instead run `npm run build-without-docs`
 


### PR DESCRIPTION
Building out of the box on macOS failed for me. 
It took a couple hours searching for documentation and installing dependencies to get it working, and I was not able to find any documentation for building from source [in the wiki](https://github.com/ccxt/ccxt/wiki/Install).
This adds a simple BUILD.md file to get people going.

- Adds a BUILD.md file to main code
- Includes previously undocumented steps of installing tox (build fails without it) and the work around for https://github.com/ccxt/ccxt/issues/4195 
- Confirmed working on macOS with node v14.3.0
