### PR TITLE
BitMax parseOrder fix

### DIFF
--- a/js/bitmax.js
+++ b/js/bitmax.js
@@ -995,7 +995,7 @@ module.exports = class bitmax extends Exchange {
         if ((symbol === undefined) && (market !== undefined)) {
             symbol = market['symbol'];
         }
-        let timestamp = this.safeInteger (order, 'timestamp');
+        let timestamp = this.safeInteger2 (order, 'timestamp', 'sendingTime');
         let lastTradeTimestamp = this.safeInteger (order, 'lastExecTime');
         const price = this.safeFloat (order, 'price');
         const amount = this.safeFloat (order, 'orderQty');


### PR DESCRIPTION
Spot market response:
```
{
        ac: 'CASH',
        accountId: 'csh**********4ObD',
        avgPx: '0',
        cumFee: '0',
        cumQty: '0',
        errorCode: '',
        feeAsset: 'USDT',
        lastExecTime: 1591954830300,
        orderId: 'a172a7e6c024U7986675741sbtcutjek',
        orderQty: '0.01',
        orderType: 'Limit',
        price: '9500',
        sendingTime: 1591954817599,
        seqNum: 15668357292,
        side: 'Sell',
        status: 'Canceled',
        stopPrice: '',
        symbol: 'BTC/USDT',
        execInst: 'NULL_VAL'
}
```