### PR TITLE
bitmex fetchTrades reversed fix

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1168,6 +1168,9 @@ module.exports = class bitmex extends Exchange {
         };
         if (since !== undefined) {
             request['startTime'] = this.iso8601 (since);
+        } else {
+            // by default reverse=false, i.e. trades are fetched since the time of market inception (year 2015 for XBTUSD)
+            request['reverse'] = true;
         }
         if (limit !== undefined) {
             request['count'] = limit;


### PR DESCRIPTION
By default trades are returned in _ascending_ order, i.e. since 2015 for BTC/USD (in fact one could scrape the whole history). This PR renews the expected mechanism (at least in the example of #4435) of fetching the latest trades by default. [fetchTrade docs](https://www.bitmex.com/api/explorer/#!/Trade/Trade_get)