### PR TITLE
bitmart: use milliseconds for expires calculation

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -180,7 +180,7 @@ module.exports = class bitmart extends Exchange {
             throw new AuthenticationError (this.id + ' signIn() failed to authenticate. Access token missing from response.');
         }
         const expiresIn = this.safeInteger (response, 'expires_in');
-        this.options['expires'] = this.sum (this.nonce (), expiresIn * 1000);
+        this.options['expires'] = this.sum (this.milliseconds (), expiresIn * 1000);
         this.options['accessToken'] = accessToken;
         return response;
     }


### PR DESCRIPTION
I think, we should use milliseconds, if somebody overrides the nonce function.