### PR TITLE
HitBTC Extra Transaction Types

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -683,6 +683,8 @@ module.exports = class hitbtc extends Exchange {
             'payin': 'deposit',
             'payout': 'withdrawal',
             'withdraw': 'withdrawal',
+			'exchangeToBank': 'withdrawal',
+			'bankToExchange': 'deposit'
         };
         return this.safeString (types, type, type);
     }

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -683,8 +683,8 @@ module.exports = class hitbtc extends Exchange {
             'payin': 'deposit',
             'payout': 'withdrawal',
             'withdraw': 'withdrawal',
-			'exchangeToBank': 'withdrawal',
-			'bankToExchange': 'deposit'
+	        'exchangeToBank': 'withdrawal',
+	        'bankToExchange': 'deposit'
         };
         return this.safeString (types, type, type);
     }

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -683,8 +683,8 @@ module.exports = class hitbtc extends Exchange {
             'payin': 'deposit',
             'payout': 'withdrawal',
             'withdraw': 'withdrawal',
-	        'exchangeToBank': 'withdrawal',
-	        'bankToExchange': 'deposit'
+            'exchangeToBank': 'withdrawal',
+            'bankToExchange': 'deposit',
         };
         return this.safeString (types, type, type);
     }


### PR DESCRIPTION
PR for ticket #7205. This addresses the two extra transaction types that come back from HitBTC, marking them as 'deposit' or 'withdrawal'.