### PR TITLE
Digifinex change urls

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -44,7 +44,7 @@ module.exports = class digifinex extends Exchange {
                     'https://docs.digifinex.com',
                 ],
                 'fees': 'https://digifinex.zendesk.com/hc/en-us/articles/360000328422-Fee-Structure-on-DigiFinex',
-                'referral': 'https://www.digifinex.vip/en-ww/from/DhOzBg/3798****5114',
+                'referral': 'https://www.digifinex.com/en-ww/from/DhOzBg/3798****5114',
             },
             'api': {
                 'v2': {

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -38,10 +38,10 @@ module.exports = class digifinex extends Exchange {
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/62184319-304e8880-b366-11e9-99fe-8011d6929195.jpg',
-                'api': 'https://openapi.digifinex.vip',
-                'www': 'https://www.digifinex.vip',
+                'api': 'https://openapi.digifinex.com',
+                'www': 'https://www.digifinex.com',
                 'doc': [
-                    'https://docs.digifinex.vip',
+                    'https://docs.digifinex.com',
                 ],
                 'fees': 'https://digifinex.zendesk.com/hc/en-us/articles/360000328422-Fee-Structure-on-DigiFinex',
                 'referral': 'https://www.digifinex.vip/en-ww/from/DhOzBg/3798****5114',


### PR DESCRIPTION
Some problems with certificate on https://openapi.digifinex.vip

`ExchangeNotAvailable: digifinex GET https://openapi.digifinex.vip/v3/markets system request to https://openapi.digifinex.vip/v3/markets failed, reason: Hostname/IP does not match certificate's altnames: Host: openapi.digifinex.vip. is not in the cert's altnames: DNS:ssl421194.cloudflaressl.com`