### PR TITLE
Update bitstamp.js

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -572,7 +572,7 @@ module.exports = class bitstamp extends Exchange {
         const market = this.market (symbol);
         const request = {
             'pair': market['id'],
-            'interval': this.timeframes[timeframe],
+            'step': this.timeframes[timeframe],
         };
         const duration = this.parseTimeframe (timeframe);
         if (limit === undefined) {


### PR DESCRIPTION
Fix to request parameter for bitstamp on fetchOHLCV method. Bitstamp uses 'step' instead of 'interval' as a parameter to define the candle length.