### PR TITLE
Document average in the order structure

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2487,7 +2487,8 @@ Most of methods returning orders within ccxt unified API will usually yield an o
     'symbol':     'ETH/BTC',      // symbol
     'type':       'limit',        // 'market', 'limit'
     'side':       'buy',          // 'buy', 'sell'
-    'price':       0.06917684,    // float price in quote currency
+    'price':       0.06917684,    // float price in quote currency. May be empty for market orders
+    'average':     0.06917684,    // float average filling price.
     'amount':      1.5,           // ordered amount of base currency
     'filled':      1.1,           // filled amount of base currency
     'remaining':   0.4,           // remaining amount to fill

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2487,8 +2487,8 @@ Most of methods returning orders within ccxt unified API will usually yield an o
     'symbol':     'ETH/BTC',      // symbol
     'type':       'limit',        // 'market', 'limit'
     'side':       'buy',          // 'buy', 'sell'
-    'price':       0.06917684,    // float price in quote currency. May be empty for market orders
-    'average':     0.06917684,    // float average filling price.
+    'price':       0.06917684,    // float price in quote currency (may be empty for market orders)
+    'average':     0.06917684,    // float average filling price
     'amount':      1.5,           // ordered amount of base currency
     'filled':      1.1,           // filled amount of base currency
     'remaining':   0.4,           // remaining amount to fill


### PR DESCRIPTION
Document the unified field 'average' for order return values.

This is based on the discussion in #7218 (assuming `'average'` is really unified).

Please also take note of https://github.com/ccxt/ccxt/issues/7218#issuecomment-660808233 first - as i'm not convinced yet that price handling this is 100% unified at the moment across all exchanges.

closes #7218