### PR TITLE
Fix bittrex OHLCV endpoint

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -668,12 +668,11 @@ module.exports = class bittrex extends Exchange {
         if (since !== undefined) {
             const now = this.milliseconds ();
             const difference = Math.abs (now - since);
-            // const duration = this.parseTimeframe (timeframe);
             const sinceDate = this.ymd (since);
-            const sinceParts = sinceDate.split ('-');
-            const sinceYear = this.safeInteger (sinceParts, 0);
-            const sinceMonth = this.safeInteger (sinceParts, 1);
-            const sinceDay = this.safeInteger (sinceParts, 2);
+            const parts = sinceDate.split ('-');
+            const sinceYear = this.safeInteger (parts, 0);
+            const sinceMonth = this.safeInteger (parts, 1);
+            const sinceDay = this.safeInteger (parts, 2);
             if (timeframe === '1d') {
                 // if the since argument is beyond one year into the past
                 if (difference > 31622400000) {


### PR DESCRIPTION
As described in #7317 - bittrex logic for historic endpoints did change recently, to not accept month / day arguments for the daily history endpoint.

If needed, i also have a sample (copy from `binance-fetch-ohlcv.js`) which can serve as a testing example for this behaviour (by modifying times / years).

I hope the way the logic is done is kind of compatible with the way ccxt does this normally (it transpiles fine ...) - if you need changes done let me know (or adjust as needed).

closes #7317