### PR TITLE
[kraken] removed bogus fields from createOrder response

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -971,23 +971,7 @@ module.exports = class kraken extends Exchange {
         }
         return {
             'id': id,
-            'clientOrderId': clientOrderId,
             'info': response,
-            'timestamp': undefined,
-            'datetime': undefined,
-            'lastTradeTimestamp': undefined,
-            'symbol': symbol,
-            'type': type,
-            'side': side,
-            'price': price,
-            'amount': amount,
-            'cost': undefined,
-            'average': undefined,
-            'filled': undefined,
-            'remaining': undefined,
-            'status': undefined,
-            'fee': undefined,
-            'trades': undefined,
         };
     }
 

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -222,6 +222,8 @@ module.exports = class kraken extends Exchange {
                 'EGeneral:Internal error': ExchangeNotAvailable,
                 'EGeneral:Temporary lockout': DDoSProtection,
                 'EGeneral:Permission denied': PermissionDenied,
+                'EOrder:Unknown order': InvalidOrder,
+                'EOrder:Order minimum not met': InvalidOrder,
             },
         });
     }
@@ -971,7 +973,23 @@ module.exports = class kraken extends Exchange {
         }
         return {
             'id': id,
+            'clientOrderId': clientOrderId,
             'info': response,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'lastTradeTimestamp': undefined,
+            'symbol': symbol,
+            'type': type,
+            'side': side,
+            'price': undefined,
+            'amount': undefined,
+            'cost': undefined,
+            'average': undefined,
+            'filled': undefined,
+            'remaining': undefined,
+            'status': undefined,
+            'fee': undefined,
+            'trades': undefined,
         };
     }
 


### PR DESCRIPTION
The fields have the wrong type because they are simply the input parameters echo'd back out again.  Additionally, if the exchange modifies the order price or amount in some way (as some exchanges do) they would be incorrect.