### PR TITLE
add optional partnerId/signature to authenticated kucoin requests

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1801,9 +1801,10 @@ module.exports = class kucoin extends Exchange {
             const payload = timestamp + method + endpoint + endpart;
             const signature = this.hmac (this.encode (payload), this.encode (this.secret), 'sha256', 'base64');
             headers['KC-API-SIGN'] = this.decode (signature);
-            const partnerId = this.safeString (this.options, 'partnerId');
-            const partnerSecret = this.safeString (this.options, 'partnerSecret');
-            if (partnerId && partnerSecret) {
+            const partner = this.safeValue (this.options, 'partner', {});
+            const partnerId = this.safeString (partner, 'id');
+            const partnerSecret = this.safeString (partner, 'secret');
+            if ((partnerId !== undefined) && (partnerSecret !== undefined)) {
                 const partnerPayload = timestamp + partnerId + this.apiKey;
                 const partnerSignature = this.hmac (this.encode (partnerPayload), this.encode (partnerSecret), 'sha256', 'base64');
                 headers['KC-API-PARTNER-SIGN'] = this.decode (partnerSignature);

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1801,8 +1801,8 @@ module.exports = class kucoin extends Exchange {
             const payload = timestamp + method + endpoint + endpart;
             const signature = this.hmac (this.encode (payload), this.encode (this.secret), 'sha256', 'base64');
             headers['KC-API-SIGN'] = this.decode (signature);
-            const partnerId = this.options['partnerId'];
-            if (partnerId) {
+            if ('partnerId' in this.options && 'partnerSecret' in this.options) {
+                const partnerId = this.options['partnerId'];
                 const partnerSecret = this.options['partnerSecret'];
                 const partnerPayload = timestamp + partnerId + this.apiKey;
                 const partnerSignature = this.hmac (this.encode (partnerPayload), this.encode (partnerSecret), 'sha256', 'base64');

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1801,6 +1801,14 @@ module.exports = class kucoin extends Exchange {
             const payload = timestamp + method + endpoint + endpart;
             const signature = this.hmac (this.encode (payload), this.encode (this.secret), 'sha256', 'base64');
             headers['KC-API-SIGN'] = this.decode (signature);
+            const partnerId = this.options['partnerId'];
+            if (partnerId) {
+                const partnerSecret = this.options['partnerSecret'];
+                const partnerPayload = timestamp + partnerId + this.apiKey;
+                const partnerSignature = this.hmac (this.encode (partnerPayload), this.encode (partnerSecret), 'sha256', 'base64');
+                headers['KC-API-PARTNER-SIGN'] = this.decode (partnerSignature);
+                headers['KC-API-PARTNER'] = partnerId;
+            }
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1801,9 +1801,9 @@ module.exports = class kucoin extends Exchange {
             const payload = timestamp + method + endpoint + endpart;
             const signature = this.hmac (this.encode (payload), this.encode (this.secret), 'sha256', 'base64');
             headers['KC-API-SIGN'] = this.decode (signature);
-            if ('partnerId' in this.options && 'partnerSecret' in this.options) {
-                const partnerId = this.options['partnerId'];
-                const partnerSecret = this.options['partnerSecret'];
+            const partnerId = this.safeString (this.options, 'partnerId');
+            const partnerSecret = this.safeString (this.options, 'partnerSecret');
+            if (partnerId && partnerSecret) {
                 const partnerPayload = timestamp + partnerId + this.apiKey;
                 const partnerSignature = this.hmac (this.encode (partnerPayload), this.encode (partnerSecret), 'sha256', 'base64');
                 headers['KC-API-PARTNER-SIGN'] = this.decode (partnerSignature);


### PR DESCRIPTION
KuCoin has a partnership program that requires the partnered company to identify themselves via HTTP headers when sending an authenticated request.