### PR TITLE
adds "futures/data" endpoint to the Binance futures API

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -80,6 +80,7 @@ module.exports = class binance extends Exchange {
                     'sapi': 'https://api.binance.com/sapi/v1',
                     'fapiPublic': 'https://fapi.binance.com/fapi/v1',
                     'fapiPrivate': 'https://fapi.binance.com/fapi/v1',
+                    'fapiPublicFuturesData': 'https://fapi.binance.com/futures/data',
                     'fapiPrivateV2': 'https://fapi.binance.com/fapi/v2',
                     'public': 'https://api.binance.com/api/v3',
                     'private': 'https://api.binance.com/api/v3',
@@ -228,6 +229,15 @@ module.exports = class binance extends Exchange {
                         'allForceOrders',
                         'openInterest',
                         'leverageBracket',
+                    ],
+                },
+                'fapiPublicFuturesData': {
+                    'get': [
+                        'openInterestHist',
+                        'topLongShortAccountRatio',
+                        'topLongShortPositionRatio',
+                        'globalLongShortAccountRatio',
+                        'takerlongshortRatio',
                     ],
                 },
                 'fapiPrivate': {

--- a/js/binance.js
+++ b/js/binance.js
@@ -80,7 +80,7 @@ module.exports = class binance extends Exchange {
                     'sapi': 'https://api.binance.com/sapi/v1',
                     'fapiPublic': 'https://fapi.binance.com/fapi/v1',
                     'fapiPrivate': 'https://fapi.binance.com/fapi/v1',
-                    'fapiPublicFuturesData': 'https://fapi.binance.com/futures/data',
+                    'fapiData': 'https://fapi.binance.com/futures/data',
                     'fapiPrivateV2': 'https://fapi.binance.com/fapi/v2',
                     'public': 'https://api.binance.com/api/v3',
                     'private': 'https://api.binance.com/api/v3',
@@ -231,7 +231,7 @@ module.exports = class binance extends Exchange {
                         'leverageBracket',
                     ],
                 },
-                'fapiPublicFuturesData': {
+                'fapiData': {
                     'get': [
                         'openInterestHist',
                         'topLongShortAccountRatio',


### PR DESCRIPTION
adds 'https://fapi.binance.com/futures/data' endpoint and requests: 'openInterestHist', 'topLongShortAccountRatio', 'topLongShortPositionRatio', 'globalLongShortAccountRatio', 'takerlongshortRatio'.
example: ccxtBinance.fapiPublicFuturesData_get_openinteresthist({'symbol':'BTCUSDT', 'period':'1h',  'limit': 100})