### PR TITLE
WIP: [Binance] defaultType in Exchange constructor

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -243,6 +243,7 @@ declare module 'ccxt' {
                 market: 'FULL' | string;
                 limit: 'RESULT' | string;
             };
+            defaultType: 'spot' | string;
         };
         urls: {
             logo: string;


### PR DESCRIPTION
Want to use this change https://github.com/ccxt/ccxt/pull/5907 in typescript but the current type definition for Exchange constructor does not include the new field defaultType.