### PR TITLE
[#5843] Coinbase Pro - fetch_deposit_address() should POST, not GET

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -948,7 +948,7 @@ module.exports = class coinbasepro extends Exchange {
         const request = {
             'id': account['id'],
         };
-        const response = await this.privateGetCoinbaseAccountsIdAddresses (this.extend (request, params));
+        const response = await this.privatePostCoinbaseAccountsIdAddresses (this.extend (request, params));
         const address = this.safeString (response, 'address');
         const tag = this.safeString (response, 'destination_tag');
         return {

--- a/php/coinbasepro.php
+++ b/php/coinbasepro.php
@@ -953,7 +953,7 @@ class coinbasepro extends Exchange {
         $request = array(
             'id' => $account['id'],
         );
-        $response = $this->privateGetCoinbaseAccountsIdAddresses (array_merge($request, $params));
+        $response = $this->privatePostCoinbaseAccountsIdAddresses (array_merge($request, $params));
         $address = $this->safe_string($response, 'address');
         $tag = $this->safe_string($response, 'destination_tag');
         return array(

--- a/python/ccxt/coinbasepro.py
+++ b/python/ccxt/coinbasepro.py
@@ -893,7 +893,7 @@ class coinbasepro(Exchange):
         request = {
             'id': account['id'],
         }
-        response = self.privateGetCoinbaseAccountsIdAddresses(self.extend(request, params))
+        response = self.privatePostCoinbaseAccountsIdAddresses(self.extend(request, params))
         address = self.safe_string(response, 'address')
         tag = self.safe_string(response, 'destination_tag')
         return {


### PR DESCRIPTION
#5843

As per the documentation on Coinbase Pro API, fetch_deposit_address() should POST instead of GET. 

https://docs.pro.coinbase.com/#generate-a-crypto-deposit-address

Tested in Python, but since it was such an easy one I updated PHP and JS as well.