### PR TITLE
fix: Okex parseFuturesAccount for free balance

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -1602,7 +1602,7 @@ module.exports = class okex extends Exchange {
                     free += this.safeFloat (cont, 'fixed_balance') + this.safeFloat (cont, 'realized_pnl') 
                             - this.safeFloat (cont, 'margin_frozen') - this.safeFloat (cont, 'margin_for_unfilled');
                 }
-                account['free'] = free
+                account['free'] = free;
             } else {
                 account['free'] = totalAvailBalance + this.safeFloat (balance, 'realized_pnl') 
                                   + this.safeFloat (balance, 'unrealized_pnl') 

--- a/js/okex.js
+++ b/js/okex.js
@@ -1599,13 +1599,20 @@ module.exports = class okex extends Exchange {
                 let free = totalAvailBalance;
                 for (let i = 0; i < contracts.length; i++) {
                     let cont = contracts[i];
-                    free += this.sum(this.safeFloat (cont, 'fixed_balance'), this.safeFloat (cont, 'realized_pnl'))
-                            - this.sum(this.safeFloat (cont, 'margin_frozen'), this.safeFloat (cont, 'margin_for_unfilled'));
+                    const fixedBalance = this.safeFloat (cont, 'fixed_balance');
+                    const realizedPnl = this.safeFloat (cont, 'realized_pnl');
+                    const marginFrozen = this.safeFloat (cont, 'margin_frozen');
+                    const marginForUnfilled = this.safeFloat (cont, 'margin_for_unfilled');
+                    const margin = this.sum (fixedBalance, realizedPnl) - marginFrozen - marginForUnfilled;
+                    free = this.sum (free, margin);
                 }
                 account['free'] = free;
             } else {
-                account['free'] = this.sum(totalAvailBalance, this.safeFloat (balance, 'realized_pnl'), this.safeFloat (balance, 'unrealized_pnl'))
-                                  - this.sum(this.safeFloat (balance, 'margin_frozen'), this.safeFloat (balance, 'margin_for_unfilled'));
+                const realizedPnl = this.safeFloat (balance, 'realized_pnl');
+                const unrealizedPnl = this.safeFloat (balance, 'unrealized_pnl');
+                const marginFrozen = this.safeFloat (balance, 'margin_frozen');
+                const marginForUnfilled = this.safeFloat (balance, 'margin_for_unfilled');
+                account['free'] = this.sum (totalAvailBalance, realizedPnl, unrealizedPnl) - marginFrozen - marginForUnfilled;
             }
             // it may be incorrect to use total, free and used for swap accounts
             account['total'] = this.safeFloat (balance, 'equity');

--- a/js/okex.js
+++ b/js/okex.js
@@ -1599,15 +1599,13 @@ module.exports = class okex extends Exchange {
                 let free = totalAvailBalance;
                 for (let i = 0; i < contracts.length; i++) {
                     let cont = contracts[i];
-                    free += this.safeFloat (cont, 'fixed_balance') + this.safeFloat (cont, 'realized_pnl') 
-                            - this.safeFloat (cont, 'margin_frozen') - this.safeFloat (cont, 'margin_for_unfilled');
+                    free += this.sum(this.safeFloat (cont, 'fixed_balance'), this.safeFloat (cont, 'realized_pnl'))
+                            - this.sum(this.safeFloat (cont, 'margin_frozen'), this.safeFloat (cont, 'margin_for_unfilled'));
                 }
                 account['free'] = free;
             } else {
-                account['free'] = totalAvailBalance + this.safeFloat (balance, 'realized_pnl') 
-                                  + this.safeFloat (balance, 'unrealized_pnl') 
-                                  - this.safeFloat (balance, 'margin_frozen') 
-                                  - this.safeFloat (balance, 'margin_for_unfilled');
+                account['free'] = this.sum(totalAvailBalance, this.safeFloat (balance, 'realized_pnl'), this.safeFloat (balance, 'unrealized_pnl'))
+                                  - this.sum(this.safeFloat (balance, 'margin_frozen'), this.safeFloat (balance, 'margin_for_unfilled'));
             }
             // it may be incorrect to use total, free and used for swap accounts
             account['total'] = this.safeFloat (balance, 'equity');

--- a/js/okex.js
+++ b/js/okex.js
@@ -1594,11 +1594,11 @@ module.exports = class okex extends Exchange {
             const balance = this.safeValue (info, id, {});
             const account = this.account ();
             const totalAvailBalance = this.safeFloat (balance, 'total_avail_balance');
-            if (this.safeString(balance, 'margin_mode') === 'fixed') {
-                const contracts = this.safeValue(balance, 'contracts', []);
+            if (this.safeString (balance, 'margin_mode') === 'fixed') {
+                const contracts = this.safeValue (balance, 'contracts', []);
                 let free = totalAvailBalance;
                 for (let i = 0; i < contracts.length; i++) {
-                    let cont = contracts[i];
+                    const cont = contracts[i];
                     const fixedBalance = this.safeFloat (cont, 'fixed_balance');
                     const realizedPnl = this.safeFloat (cont, 'realized_pnl');
                     const marginFrozen = this.safeFloat (cont, 'margin_frozen');

--- a/js/okex.js
+++ b/js/okex.js
@@ -1598,11 +1598,11 @@ module.exports = class okex extends Exchange {
                 const contracts = this.safeValue (balance, 'contracts', []);
                 let free = totalAvailBalance;
                 for (let i = 0; i < contracts.length; i++) {
-                    const cont = contracts[i];
-                    const fixedBalance = this.safeFloat (cont, 'fixed_balance');
-                    const realizedPnl = this.safeFloat (cont, 'realized_pnl');
-                    const marginFrozen = this.safeFloat (cont, 'margin_frozen');
-                    const marginForUnfilled = this.safeFloat (cont, 'margin_for_unfilled');
+                    const contract = contracts[i];
+                    const fixedBalance = this.safeFloat (contract, 'fixed_balance');
+                    const realizedPnl = this.safeFloat (contract, 'realized_pnl');
+                    const marginFrozen = this.safeFloat (contract, 'margin_frozen');
+                    const marginForUnfilled = this.safeFloat (contract, 'margin_for_unfilled');
                     const margin = this.sum (fixedBalance, realizedPnl) - marginFrozen - marginForUnfilled;
                     free = this.sum (free, margin);
                 }


### PR DESCRIPTION
Incorrect calculation for futures's free balance.  
Docs: https://www.okex.com/docs/en/#futures-singleness-single