### PR TITLE
fix: ftx type should depend on whether there's a destinationName field

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1410,7 +1410,7 @@ module.exports = class ftx extends Exchange {
         const address = this.safeString (transaction, 'address');
         const tag = this.safeString (transaction, 'tag');
         const fee = this.safeFloat (transaction, 'fee');
-        const type = ('confirmations' in transaction) ? 'deposit' : 'withdrawal';
+        const type = ('destinationName' in transaction) ? 'deposit' : 'withdrawal';
         return {
             'info': transaction,
             'id': id,

--- a/python/ccxt/ftx.py
+++ b/python/ccxt/ftx.py
@@ -1347,7 +1347,7 @@ class ftx(Exchange):
         address = self.safe_string(transaction, 'address')
         tag = self.safe_string(transaction, 'tag')
         fee = self.safe_float(transaction, 'fee')
-        type = 'deposit' if ('confirmations' in transaction) else 'withdrawal'
+        type = 'withdrawal' if 'destinationName' in transaction else 'deposit'
         return {
             'info': transaction,
             'id': id,


### PR DESCRIPTION
Some transactions are incorrectly classified as `withdrawal` where they should be `deposit`. This particular transaction happened when FTX reimbursed us for trade error and is booked as a deopsit from their records.

![image](https://user-images.githubusercontent.com/92614/90356659-dad53e80-e082-11ea-8946-d88c605681b2.png)
