### PR TITLE
liquid new endpoint

### DIFF
--- a/js/liquid.js
+++ b/js/liquid.js
@@ -442,7 +442,7 @@ module.exports = class liquid extends Exchange {
         //                 minimum_withdraw: null,
         //                 currency_type: 'crypto'
         //             },
-        //     ],
+        //         ],
         //         fiat_accounts: [
         //             {
         //                 id: 1112734,


### PR DESCRIPTION
Undocumented.
Return something like https://developers.liquid.com/#get-fiat-accounts + https://developers.liquid.com/#get-crypto-accounts

As I see, a good alternative for `fetchBalance`. Now it doesn't show `used` funds
```
{
  crypto_accounts: [
    {
      id: 2221179,
      currency: 'USDT',
      balance: '0.0',
      reserved_balance: '0.0',
      pusher_channel: 'user_xxxxx_account_usdt',
      lowest_offer_interest_rate: null,
      highest_offer_interest_rate: null,
      address: '0',
      currency_symbol: 'USDT',
      minimum_withdraw: null,
      currency_type: 'crypto'
    },
   .....
    {
      id: 2131443,
      currency: 'BTC',
      balance: '0.00293318',
      reserved_balance: '0.0',
      pusher_channel: 'user_xxxxx_account_btc',
      lowest_offer_interest_rate: '0.00001',
      highest_offer_interest_rate: '0.00200',
      address: '0',
      currency_symbol: '₿',
      minimum_withdraw: '0.02',
      currency_type: 'crypto'
    }
  ],
  fiat_accounts: [
    {
      id: 1112734,
      currency: 'USD',
      balance: '0.0',
      reserved_balance: '0.0',
      pusher_channel: 'user_xxxxx_account_usd',
      lowest_offer_interest_rate: null,
      highest_offer_interest_rate: null,
      currency_symbol: '$',
      send_to_btc_address: null,
      exchange_rate: '1.0',
      currency_type: 'fiat'
    }
  ]
}
```