### PR TITLE
parse "triggered" order status as "closed" in FTX

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -846,6 +846,7 @@ module.exports = class ftx extends Exchange {
             'new': 'open',
             'open': 'open',
             'closed': 'closed', // filled or canceled
+            'triggered': 'closed',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
fetchOrders for conditional orders return with status as 'triggered',
expected status as 'closed'

[docs](https://docs.ftx.com/?javascript#get-trigger-order-history)