### PR TITLE
qTrade fetchMyTrades fix

### DIFF
--- a/js/qtrade.js
+++ b/js/qtrade.js
@@ -563,6 +563,7 @@ module.exports = class qtrade extends Exchange {
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {
+            'desc': true, // Returns newest trades first when true
             // 'older_than': 123, // returns trades with id < older_than
             // 'newer_than': 123, // returns trades with id > newer_than
         };


### PR DESCRIPTION
https://qtrade-exchange.github.io/qtrade-docs/#get-trades
Now it returns first 200 old trades