### PR TITLE
Add XRP/BTC pair to bitbank

### DIFF
--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -88,6 +88,7 @@ module.exports = class bitbank extends Exchange {
                 'BTC/JPY': { 'id': 'btc_jpy', 'symbol': 'BTC/JPY', 'base': 'BTC', 'quote': 'JPY', 'baseId': 'btc', 'quoteId': 'jpy' },
                 'ETH/JPY': { 'id': 'eth_jpy', 'symbol': 'ETH/JPY', 'base': 'ETH', 'quote': 'JPY', 'baseId': 'eth', 'quoteId': 'jpy' },
                 'LTC/JPY': { 'id': 'ltc_jpy', 'symbol': 'LTC/JPY', 'base': 'LTC', 'quote': 'JPY', 'baseId': 'ltc', 'quoteId': 'jpy' },
+                'XRP/BTC': { 'id': 'xrp_btc', 'symbol': 'XRP/BTC', 'base': 'XRP', 'quote': 'BTC', 'baseId': 'xrp', 'quoteId': 'btc' },
             },
             'fees': {
                 'trading': {


### PR DESCRIPTION
Hello,
XRP/BTC pair is listed on bitbank.
https://blog.bitbank.cc/20200524/
