### PR TITLE
Bibox parseTrade feeCost fix

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -321,7 +321,7 @@ module.exports = class bibox extends Exchange {
         }
         if (feeCost !== undefined) {
             fee = {
-                'cost': feeCost,
+                'cost': -feeCost,
                 'currency': feeCurrency,
                 'rate': feeRate,
             };


### PR DESCRIPTION
look like they change format of response

```
{
      id: '2251799823075909774',
      createdAt: 1598904430000,
      account_type: 0,
      coin_symbol: 'BIX',
      currency_symbol: 'BTC',
      order_side: 2,
      order_type: 2,
      price: '0.00000785',
      amount: '10150.7335',
      money: '0.07968325',
      pay_bix: 0,
      fee_symbol: 'BTC',
      fee: '-0.00007570',
      is_maker: 1,
      relay_id: '12814808028616619'
    },

```