### PR TITLE
bitmart parseTicker volume fix

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -692,8 +692,8 @@ module.exports = class bitmart extends Exchange {
             percentage *= 100;
         }
         // bitmart base/quote reversed
-        const baseVolume = this.safeFloat2 (ticker, 'quote_volume_24h', 'base_coin_volume');
-        const quoteVolume = this.safeFloat2 (ticker, 'base_volume_24h', 'quote_coin_volume');
+        const baseVolume = this.safeFloat2 (ticker, 'base_volume_24h', 'base_coin_volume');
+        const quoteVolume = this.safeFloat2 (ticker, 'quote_volume_24h', 'quote_coin_volume');
         let vwap = undefined;
         if ((quoteVolume !== undefined) && (baseVolume !== undefined) && (baseVolume !== 0)) {
             vwap = quoteVolume / baseVolume;


### PR DESCRIPTION
Need to be swapped

```
{
    symbol: 'ETH_BTC',
    last_price: '0.034789',
    quote_volume_24h: '527.5667730282',
    base_volume_24h: '15027.8630000000',
    high_24h: '0.035884',
    low_24h: '0.033731',
    open_24h: '0.035227',
    close_24h: '0.034789',
    best_ask: '0.034800',
    best_ask_size: '1.3561',
    best_bid: '0.034040',
    best_bid_size: '9.9500',
    fluctuation: '-0.0124',
    url: 'https://www.bitmart.com/trade?symbol=ETH_BTC'
  }

```