### PR TITLE
Add BadSymbol to manual error hierarchy

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3663,6 +3663,8 @@ Below is an outline of exception inheritance hierarchy:
 |   +---+ ArgumentsRequired
 |   |
 |   +---+ BadRequest
+|   |   |
+|   |   +---+ BadSymbol
 |   |
 |   +---+ BadResponse
 |   |   |


### PR DESCRIPTION
I noticed this was missing from the wiki.

Also a question: I have found a number of cases across multiple exchanges where errors are not yet being categorized (e.g. `BadSymbol` or `RateLimitExceeded` errors not being identified, and therefore being raised as `ExchangeError`s). Each fix is one or two lines (adding the missing case and possible an import). Would it be ok to put them all into a single PR?