### PR TITLE
Fix bmex stop order issue.

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1323,14 +1323,19 @@ module.exports = class bitmex extends Exchange {
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const orderType = this.capitalize (type);
         const request = {
             'symbol': market['id'],
             'side': this.capitalize (side),
             'orderQty': amount,
-            'ordType': this.capitalize (type),
+            'ordType': orderType,
         };
         if (price !== undefined) {
-            request['price'] = price;
+            if (orderType === 'Stop') {
+                request['stopPx'] = price;
+            } else {
+                request['price'] = price;
+            }
         }
         const clientOrderId = this.safeString2 (params, 'clOrdID', 'clientOrderId');
         if (clientOrderId !== undefined) {

--- a/python/ccxt/async_support/bitmex.py
+++ b/python/ccxt/async_support/bitmex.py
@@ -1256,7 +1256,10 @@ class bitmex(Exchange):
             'ordType': self.capitalize(type),
         }
         if price is not None:
-            request['price'] = price
+            if type.lower() == 'stop':
+                request['stopPx'] = price
+            else:
+                request['price'] = price
         clientOrderId = self.safe_string_2(params, 'clOrdID', 'clientOrderId')
         if clientOrderId is not None:
             request['clOrdID'] = clientOrderId

--- a/python/ccxt/bitmex.py
+++ b/python/ccxt/bitmex.py
@@ -1256,7 +1256,10 @@ class bitmex(Exchange):
             'ordType': self.capitalize(type),
         }
         if price is not None:
-            request['price'] = price
+            if type.lower() == 'stop':
+                request['stopPx'] = price
+            else:
+                request['price'] = price
         clientOrderId = self.safe_string_2(params, 'clOrdID', 'clientOrderId')
         if clientOrderId is not None:
             request['clOrdID'] = clientOrderId


### PR DESCRIPTION
Bmex "Stop" order requires "stopPx" instead of "price" as request params. O.w. it responds with error message and order failed.