### PR TITLE
Digifinex fetchTicker/fetchTickers fix, new v3 endpoint

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -74,6 +74,7 @@ module.exports = class digifinex extends Exchange {
                         'time',
                         'trades',
                         'trades/symbols',
+                        'ticker',
                     ],
                 },
                 'private': {
@@ -411,7 +412,7 @@ module.exports = class digifinex extends Exchange {
                 'date': date,
             }, tickers[reversedMarketId]);
             const [ quoteId, baseId ] = reversedMarketId.split ('_');
-            const marketId = baseId + '_' + quoteId;
+            const marketId = baseId.toUpperCase () + '_' + quoteId.toUpperCase ();
             let market = undefined;
             let symbol = undefined;
             if (marketId in this.markets_by_id) {
@@ -435,7 +436,7 @@ module.exports = class digifinex extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         // reversed base/quote in v2
-        const marketId = market['quoteId'] + '_' + market['baseId'];
+        const marketId = market['quoteId'].toLowerCase () + '_' + market['baseId'].toLowerCase ();
         const request = {
             'symbol': marketId,
             'apiKey': apiKey,


### PR DESCRIPTION
Now due ID conflict the answer for `fetchTickers` is:
```
{
  undefined: {
    symbol: undefined,
    timestamp: 1600783418000,
    datetime: '2020-09-22T14:03:38.000Z',
    high: 0.0000489,
    low: 0.0000465,
    bid: 0.0000452,
    bidVolume: undefined,
    ask: 0.0000471,
    askVolume: undefined,
    vwap: undefined,
    open: undefined,
    close: 0.0000468,
    last: 0.0000468,
    previousClose: undefined,
    change: undefined,
    percentage: -4.29,
    average: undefined,
    baseVolume: 692436.16,
    quoteVolume: 32.67064131,
    info: {
      date: 1600783418,
      last: 0.0000468,
      base_vol: 32.67064131,
      change: -4.29,
      vol: 692436.16,
      sell: 0.0000471,
      low: 0.0000465,
      buy: 0.0000452,
      high: 0.0000489
    }
  }
}
```

`fetchTicker` is also broken.

Also they now have v3 endpoint for this - https://docs.digifinex.com/en-ww/v3/#ticker-price