### PR TITLE
Handle additional python requests library errors

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -600,7 +600,7 @@ class Exchange(object):
 
         except RequestException as e:  # base exception class
             error_string = str(e)
-            if ('ECONNRESET' in error_string) or ('Connection aborted.' in error_string):
+            if any(x in error_string for x in ['ECONNRESET', 'Connection aborted.']):
                 raise NetworkError(method + ' ' + url + ' ' + error_string)
             else:
                 raise ExchangeError(method + ' ' + url + ' ' + error_string)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -600,7 +600,7 @@ class Exchange(object):
 
         except RequestException as e:  # base exception class
             error_string = str(e)
-            if any(x in error_string for x in ['ECONNRESET', 'Connection aborted.']):
+            if any(x in error_string for x in ['ECONNRESET', 'Connection aborted.', 'Connection broken:']):
                 raise NetworkError(method + ' ' + url + ' ' + error_string)
             else:
                 raise ExchangeError(method + ' ' + url + ' ' + error_string)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -71,7 +71,7 @@ from numbers import Number
 import re
 from requests import Session
 from requests.utils import default_user_agent
-from requests.exceptions import HTTPError, Timeout, TooManyRedirects, RequestException
+from requests.exceptions import HTTPError, Timeout, TooManyRedirects, RequestException, ConnectionError as requestsConnectionError
 # import socket
 from ssl import SSLError
 # import sys
@@ -597,6 +597,9 @@ class Exchange(object):
             self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
             self.handle_rest_errors(http_status_code, http_status_text, http_response, url, method)
             raise ExchangeError(method + ' ' + url)
+
+        except requestsConnectionError as e:
+            raise NetworkError(method + ' ' + url + ' ' + str(e))
 
         except RequestException as e:  # base exception class
             error_string = str(e)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -599,7 +599,11 @@ class Exchange(object):
             raise ExchangeError(method + ' ' + url)
 
         except requestsConnectionError as e:
-            raise NetworkError(method + ' ' + url + ' ' + str(e))
+            error_string = str(e)
+            if 'Read timed out' in error_string:
+                raise RequestTimeout(method + ' ' + url + ' ' + error_string)
+            else:
+                raise NetworkError(method + ' ' + url + ' ' + error_string)
 
         except RequestException as e:  # base exception class
             error_string = str(e)


### PR DESCRIPTION
A number of transient errors from the `requests` library are being translated to `ExchangeError`s.

1. There are `RequestTimeout` errors being missed due to a bug in requests, which requires either a breaking change to `requests` to fix or a change such as that in this PR.
2. The remaining `ConnectionError` errors should probably be translated to `NetworkError`s as they correspond to transient error conditions.
3. There is an example of a `ChunkedEncodingError` (with message `Connection broken`) which could be handled as a `ChunkedEncodingError` but I'm not sure whether every `ChunkedEncodingError` (derived from `ProtocolError` in urllib3) is indeed a transient error.