### PR TITLE
[cex] fix order status

### DIFF
--- a/js/cex.js
+++ b/js/cex.js
@@ -146,7 +146,7 @@ module.exports = class cex extends Exchange {
                     'status': {
                         'c': 'canceled',
                         'd': 'closed',
-                        'cd': 'closed',
+                        'cd': 'canceled',
                         'a': 'open',
                     },
                 },


### PR DESCRIPTION
'cd' means canceled-done according to the docs, ie a partially filled order that was cancelled.