### PR TITLE
Add new Phemex API private endpoint

### DIFF
--- a/python/ccxt/phemex.py
+++ b/python/ccxt/phemex.py
@@ -128,6 +128,7 @@ class phemex(Exchange):
                         'exchange/wallets/confirm/withdraw',  # ?code=<withdrawConfirmCode>
                         'exchange/wallets/withdrawList',  # ?currency=<currency>&limit=<limit>&offset=<offset>&withCount=<withCount>
                         'exchange/wallets/depositList',  # ?currency=<currency>&offset=<offset>&limit=<limit>
+                        'exchange/wallets/v2/depositAddress',  # ?currency=<currency>
                     ],
                     'post': [
                         # spot


### PR DESCRIPTION
New Phemex API private endpoint added to query deposit address

GET /exchange/wallets/v2/depositAddress?currency=<currency>

https://github.com/phemex/phemex-api-docs/blob/master/Public-Spot-API-en.md#depositAddr