### PR TITLE
[minor] Fix wrong error message in bittrex fetchorderbook

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -358,7 +358,7 @@ module.exports = class bittrex extends Exchange {
         };
         if (limit !== undefined) {
             if ((limit !== 1) && (limit !== 25) && (limit !== 500)) {
-                throw new BadRequest (this.id + ' fetchOrderBook() limit argument must be undefined, 1, 25 or 100, default is 25');
+                throw new BadRequest (this.id + ' fetchOrderBook() limit argument must be undefined, 1, 25 or 500, default is 25');
             }
             request['depth'] = limit;
         }


### PR DESCRIPTION

limit should be 1, 25 or 500 (correct in the if statement) - but the message was wrong.
