### PR TITLE
async py tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 - tox -e doc
 - cd ..
 - npm run test-base
-- bash -c 'node run-tests --js --python 5' 2>&1
+- bash -c 'node run-tests --js --python-async 5' 2>&1
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then env COMMIT_MESSAGE=${NPM_VERSION:1} GITHUB_TOKEN=${GITHUB_TOKEN} ./build/push.sh; fi
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then cd python && env PYPI_PASSWORD=${PYPI_PASSWORD} ./deploy.sh && cd ..; fi
 after_failure:


### PR DESCRIPTION
the reason we were tested sync python was because of python2, nowadays we should test the async python since that uses most of the sync python code anyway 