### PR TITLE
Fix hitbtc createOrder  response parsing field feeCurrencyCode

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -862,9 +862,10 @@ module.exports = class hitbtc extends Exchange {
                 }
             }
             if (feeCost !== undefined) {
+                const feeCurrencyCode = market ? market['quote'] : undefined;
                 fee = {
                     'cost': feeCost,
-                    'currency': market['quote'],
+                    'currency': feeCurrencyCode,
                 };
             }
         }


### PR DESCRIPTION
The issue is about Hitbtc parsing error of the `createOrder` response, order successfully placed. I'm not confident about this fix, at least it avoids the unexpected error