### PR TITLE
make the fee rate configurable

### DIFF
--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -632,6 +632,8 @@ module.exports = class bytetrade extends Exchange {
         const defaultDappId = 'Sagittarius';
         const dappId = this.safeString (params, 'dappId', defaultDappId);
         const defaultFee = this.safeString (this.options, 'fee', '300000000000000');
+        const totalFeeRate = this.safeString (params, 'totalFeeRate', 8);
+        const chainFeeRate = this.safeString (params, 'chainFeeRate', 1);
         const fee = this.safeString (params, 'fee', defaultFee);
         const eightBytes = this.integerPow ('2', '64');
         const allByteStringArray = [
@@ -656,7 +658,10 @@ module.exports = class bytetrade extends Exchange {
             this.numberToLE (0, 2),
             this.numberToLE (Math.floor (now / 1000), 4),
             this.numberToLE (Math.floor (expiration / 1000), 4),
-            this.numberToLE (0, 2),
+            this.numberToLE (1, 1),
+            this.numberToLE (parseInt (chainFeeRate), 2),
+            this.numberToLE (1, 1),
+            this.numberToLE (parseInt (totalFeeRate), 2),
             this.numberToLE (parseInt (quoteId), 4),
             this.numberToLE (parseInt (baseId), 4),
             this.numberToLE (0, 1),
@@ -686,7 +691,10 @@ module.exports = class bytetrade extends Exchange {
             this.numberToLE (0, 2),
             this.numberToLE (Math.floor (now / 1000), 4),
             this.numberToLE (Math.floor (expiration / 1000), 4),
-            this.numberToLE (0, 2),
+            this.numberToLE (1, 1),
+            this.numberToLE (parseInt (chainFeeRate), 2),
+            this.numberToLE (1, 1),
+            this.numberToLE (parseInt (totalFeeRate), 2),
             this.numberToLE (parseInt (quoteId), 4),
             this.numberToLE (parseInt (baseId), 4),
             this.numberToLE (0, 1),
@@ -724,6 +732,8 @@ module.exports = class bytetrade extends Exchange {
             'use_btt_as_fee': false,
             'money_id': parseInt (quoteId),
             'stock_id': parseInt (baseId),
+            'custom_no_btt_fee_rate': parseInt (totalFeeRate),
+            'custom_btt_fee_rate': parseInt (chainFeeRate),
         };
         const fatty = {
             'timestamp': datetime,


### PR DESCRIPTION
The default fee rate is 0.0008, the one given to the chain is 0.0001, and the one given to dappId is 0.0007. This commit will make the above parameters configurable, If not configured, the default parameters will be used.