### PR TITLE
Allow never versions of aiodns

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -80,7 +80,7 @@ setup(
     extras_require={
         ':python_version>="3.5.2"': [
             'aiohttp>=3.7.2,<3.8',
-            'aiodns==1.1.1',
+            'aiodns>=1.1.1,<2.1',
             'yarl==1.1.0',
         ],
         'qa': [


### PR DESCRIPTION
I think aiodns is only needed by aiohttp and they specify it with `>=1.1`
https://github.com/aio-libs/aiohttp/blob/master/setup.py