### PR TITLE
bybit: add trade/closed-pnl/list url

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -90,6 +90,7 @@ module.exports = class bybit extends Exchange {
                         'position/list',
                         'wallet/balance',
                         'execution/list',
+                        'trade/closed-pnl/list',
                     ],
                     'post': [
                         'order/create',


### PR DESCRIPTION
It seemed to be missing. I did a quick scan of other ones that might be missing from the same section, but everything else was there. I didn't check any other sections.