### PR TITLE
python: async throttle: cancel all futures if an exception occurs

### DIFF
--- a/python/ccxt/async_support/base/throttle.py
+++ b/python/ccxt/async_support/base/throttle.py
@@ -26,20 +26,31 @@ def throttle(config=None):
 
     async def run():
         if not cfg['running']:
-            cfg['running'] = True
-            while not cfg['queue'].empty():
-                now = time()
-                elapsed = (now - cfg['lastTimestamp'])
-                cfg['lastTimestamp'] = now
-                cfg['numTokens'] = min(cfg['capacity'], cfg['numTokens'] + elapsed * cfg['refillRate'] * 1000)
-                if cfg['numTokens'] > 0:
-                    if not cfg['queue'].empty():
-                        cost, future = cfg['queue'].get_nowait()
-                        cfg['numTokens'] -= (cost if cost else cfg['defaultCost'])
-                        if not future.done():
-                            future.set_result(None)
-                await sleep(cfg['delay'])
-            cfg['running'] = False
+            future = None
+            try:
+                cfg['running'] = True
+                while not cfg['queue'].empty():
+                    now = time()
+                    elapsed = (now - cfg['lastTimestamp'])
+                    cfg['lastTimestamp'] = now
+                    cfg['numTokens'] = min(cfg['capacity'], cfg['numTokens'] + elapsed * cfg['refillRate'] * 1000)
+                    if cfg['numTokens'] > 0:
+                        if not cfg['queue'].empty():
+                            cost, future = cfg['queue'].get_nowait()
+                            cfg['numTokens'] -= (cost if cost else cfg['defaultCost'])
+                            if not future.done():
+                                future.set_result(None)
+                    await sleep(cfg['delay'])
+            except BaseException as excp:
+                if future is not None:
+                    if not future.done():
+                        future.set_exception(excp)
+                while not cfg['queue'].empty():
+                    _, future = cfg['queue'].get_nowait()
+                    if not future.done():
+                        future.set_exception(excp)
+            finally:
+                cfg['running'] = False
 
     def throttle(rate_limit, cost=None):
         future = Future()


### PR DESCRIPTION
My asyncio loop has an signal handler for KeyBoardInterrupt/SystemExit and stuff. These will cancel tasks in the running loop and invoke a cleanup method. The ccxt futures will be in an unresolved state, because the run loop will be killed due to CancelledError without cleaning up the remaining futures.