### PR TITLE
Coinspot: add missing read-only endpoints

### DIFF
--- a/js/coinspot.js
+++ b/js/coinspot.js
@@ -54,6 +54,8 @@ module.exports = class coinspot extends Exchange {
                         'my/sell',
                         'my/buy/cancel',
                         'my/sell/cancel',
+                        'ro/my/balances',
+                        'ro/my/transactions',
                     ],
                 },
             },


### PR DESCRIPTION
Coinspot has a strange API, different endpoint for read-only tokens.