### PR TITLE
Making all the options optional for Exchange class in type definitions file

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -229,20 +229,6 @@ declare module 'ccxt' {
         };
         options: {
             [key: string]: any;
-            fetchTradesMethod?: 'publicGetAggTrades' | string;
-            fetchTickersMethod?: 'publicGetTicker24hr' | string;
-            defaultTimeInForce?: 'GTC' | string;
-            defaultLimitOrderType?: 'limit' | 'market' | string;
-            hasAlreadyAuthenticatedSuccessfully?: boolean;
-            warnOnFetchOpenOrdersWithoutSymbol?: boolean;
-            recvWindow?: number;
-            timeDifference?: number;
-            adjustForTimeDifference?: boolean;
-            parseOrderToPrecision?: boolean;
-            newOrderRespType?: {
-                market: 'FULL' | string;
-                limit: 'RESULT' | string;
-            };
         };
         urls: {
             logo: string;

--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -229,17 +229,17 @@ declare module 'ccxt' {
         };
         options: {
             [key: string]: any;
-            fetchTradesMethod: 'publicGetAggTrades' | string;
-            fetchTickersMethod: 'publicGetTicker24hr' | string;
-            defaultTimeInForce: 'GTC' | string;
-            defaultLimitOrderType: 'limit' | 'market' | string;
-            hasAlreadyAuthenticatedSuccessfully: boolean;
-            warnOnFetchOpenOrdersWithoutSymbol: boolean;
-            recvWindow: number;
-            timeDifference: number;
-            adjustForTimeDifference: boolean;
-            parseOrderToPrecision: boolean;
-            newOrderRespType: {
+            fetchTradesMethod?: 'publicGetAggTrades' | string;
+            fetchTickersMethod?: 'publicGetTicker24hr' | string;
+            defaultTimeInForce?: 'GTC' | string;
+            defaultLimitOrderType?: 'limit' | 'market' | string;
+            hasAlreadyAuthenticatedSuccessfully?: boolean;
+            warnOnFetchOpenOrdersWithoutSymbol?: boolean;
+            recvWindow?: number;
+            timeDifference?: number;
+            adjustForTimeDifference?: boolean;
+            parseOrderToPrecision?: boolean;
+            newOrderRespType?: {
                 market: 'FULL' | string;
                 limit: 'RESULT' | string;
             };


### PR DESCRIPTION
I am trying to import ccxt into a typescript project and I am forced to use all options where I don't need to override them.
This change will make those options optional.
Thanks.