### PR TITLE
huobipro no longer have CNY pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ const ccxt = require ('ccxt');
 
     console.log (kraken.id,    await kraken.fetchOrderBook (kraken.symbols[0]))
     console.log (bitfinex.id,  await bitfinex.fetchTicker ('BTC/USD'))
-    console.log (huobipro.id,  await huobipro.fetchTrades ('ETH/CNY'))
+    console.log (huobipro.id,  await huobipro.fetchTrades ('ETH/USDT'))
 
     console.log (okcoinusd.id, await okcoinusd.fetchBalance ())
 
@@ -417,7 +417,7 @@ print(huobipro.id, huobipro.load_markets())
 
 print(hitbtc.fetch_order_book(hitbtc.symbols[0]))
 print(bitmex.fetch_ticker('BTC/USD'))
-print(huobipro.fetch_trades('LTC/CNY'))
+print(huobipro.fetch_trades('LTC/USDT'))
 
 print(exmo.fetch_balance())
 


### PR DESCRIPTION
This error is caused by the usage demo code in README.me and fixed in this PR

````
(node:15266) UnhandledPromiseRejectionWarning: BadSymbol: huobipro does not have market symbol ETH/CNY
    at huobipro.market (/home/a/Proyectos/arbitrage/node_modules/ccxt/js/base/Exchange.js:894:15)
    at huobipro.fetchTrades (/home/a/Proyectos/arbitrage/node_modules/ccxt/js/huobipro.js:686:29)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async /home/a/Proyectos/arbitrage/test_ccxt.js:21:32
(node:15266) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
````