### PR TITLE
Assumption: REP always means REPv2 and then there is REPV1. Binance t…

### DIFF
--- a/examples/py/async-analyse-augur-v1-vs-v2-exchanges.py
+++ b/examples/py/async-analyse-augur-v1-vs-v2-exchanges.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import os
+import sys
+from typing import Optional
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt.async_support as ccxt
+
+
+unchecked_exchanges = []
+
+
+def is_symbol_match(
+    symbol: str,
+    allowed_infix: str,
+    disallowed_infix: Optional[str] = None
+) -> bool:
+    """This function is to keep everything that has allowed_infix=REP, but
+    excpude everything that has disallowed_infix=DREP, except for when you encounter something like: REPV2/DREP
+
+    Returns True if this symbol is allowed to be in the list.
+
+    Args:
+        symbol (str): the symbol to evaluate
+        allowed_infix (str): the allowed infix for both currencies in this symbol
+        disallowed_infix (Optional[str], optional): the disallowed infix for when the other currency is does not have the allowed infix. Defaults to None.
+
+    Returns:
+        bool:
+    """
+    parts = symbol.split('/')
+
+    if disallowed_infix:
+        for i, currency in enumerate(parts):
+            if disallowed_infix in currency:
+                # if one currency contains for instance disallowed_infix=DREP,
+                # then the other currency must contain allowed_infix=REP to be allowed, else disallow
+                return allowed_infix in parts[i + 1 % 2]
+
+    return any([allowed_infix in currency for currency in parts])
+
+
+async def check_symbol_infix(exchange, symbol_infix, exclude_infix=None):
+    try:
+        await exchange.load_markets()
+    except Exception as exc:
+        # exchange could not load_markets for some reason...
+        unchecked_exchanges.append(exchange.id)
+    else:
+        matching_symbols = [
+            symbol for symbol in exchange.symbols
+            if is_symbol_match(symbol, symbol_infix, exclude_infix)
+        ]
+        if matching_symbols:
+            print(
+                f'on exchange {exchange.id} these symbols contain {symbol_infix}:'
+            )
+            for symbol in matching_symbols:
+                print(f' - {symbol}:')
+                # print(f'   exchange specific market info: {exchange.markets[symbol]["info"]}')
+                if 'V1' in symbol:
+                    print('   - marked V1')
+                if 'V2' in symbol:
+                    print('   - marked V2')
+            print()
+
+    await exchange.close()
+
+
+async def main():
+    tasks = []
+    for exchange_id in ccxt.exchanges:
+        exchange = getattr(ccxt, exchange_id)()
+        tasks.append(
+            check_symbol_infix(
+                exchange, symbol_infix='REP', exclude_infix='DREP'
+            )
+        )
+    await asyncio.gather(*tasks)
+
+    print(f'errors for exchanges: {", ".join(unchecked_exchanges)}')
+
+
+asyncio.run(main())

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -207,6 +207,8 @@ module.exports = class kraken extends Exchange {
             'commonCurrencies': {
                 'XBT': 'BTC',
                 'XDG': 'DOGE',
+                'REPV2': 'REP',
+                'REP': 'REPV1',
             },
             'options': {
                 'cacheDepositMethodsOnFetchDepositAddress': true, // will issue up to two calls in fetchDepositAddress


### PR DESCRIPTION
Hi all,

I was working on my arbitrage bot when I noticed that REP(Augur) on one exchange is not the same as REP on another exchange. This was wrongly telling me there was a continuously big (>8%) artbitrage opportunity between REP on both exchanges.

For example:
- Binance has two currencies: `REP` (which is REPv2), and `REPV1`
- Kraken has two currencies: `REP` (which here is REPv1) and `REPV2`

This did not yet broke my brain, because you wrote some awesome guidelines on how to determine which one is winning (look at coinmarketcap which one uses most volume, etc...). But coinmarketcap only lists Augur as being one coin and within the listing you see both V1 and V2 variants. This exception I believe is not covered by the guidelines...

So I made a little scr1ptz0rs: ccxt/examples/py/async-analyse-augur-v1-vs-v2-exchanges.py
This script prints usage of REP or variants REPV1 or REPV2 on different exchanges:

<details><summary>Click here to expand output</summary>
<p>

```
on exchange bitbay these symbols contain REP:
 - REP/BTC:
 - REP/EUR:
 - REP/PLN:
 - REP/USD:

on exchange binanceus these symbols contain REP:
 - REP/BUSD:
 - REP/USD:

on exchange bitcoincom these symbols contain REP:
 - REP/ETH:

on exchange bittrex these symbols contain REP:
 - REPV2/BTC:
   - marked V2
 - REPV2/ETH:
   - marked V2

on exchange bithumb these symbols contain REP:
 - REP/KRW:

on exchange coinbasepro these symbols contain REP:
 - REP/BTC:
 - REP/USD:

on exchange coinbase these symbols contain REP:
 - REP/AED:
 - REP/AFN:
 - REP/ALL:
 - REP/AMD:
 - REP/ANG:
 - REP/AOA:
 - REP/ARS:
 - REP/AUD:
 - REP/AWG:
 - REP/AZN:
 - REP/BAM:
 - REP/BBD:
 - REP/BDT:
 - REP/BGN:
 - REP/BHD:
 - REP/BIF:
 - REP/BMD:
 - REP/BND:
 - REP/BOB:
 - REP/BRL:
 - REP/BSD:
 - REP/BTN:
 - REP/BWP:
 - REP/BYN:
 - REP/BYR:
 - REP/BZD:
 - REP/CAD:
 - REP/CDF:
 - REP/CHF:
 - REP/CLF:
 - REP/CLP:
 - REP/CNH:
 - REP/CNY:
 - REP/COP:
 - REP/CRC:
 - REP/CUC:
 - REP/CVE:
 - REP/CZK:
 - REP/DJF:
 - REP/DKK:
 - REP/DOP:
 - REP/DZD:
 - REP/EEK:
 - REP/EGP:
 - REP/ERN:
 - REP/ETB:
 - REP/EUR:
 - REP/FJD:
 - REP/FKP:
 - REP/GBP:
 - REP/GEL:
 - REP/GGP:
 - REP/GHS:
 - REP/GIP:
 - REP/GMD:
 - REP/GNF:
 - REP/GTQ:
 - REP/GYD:
 - REP/HKD:
 - REP/HNL:
 - REP/HRK:
 - REP/HTG:
 - REP/HUF:
 - REP/IDR:
 - REP/ILS:
 - REP/IMP:
 - REP/INR:
 - REP/IQD:
 - REP/ISK:
 - REP/JEP:
 - REP/JMD:
 - REP/JOD:
 - REP/JPY:
 - REP/KES:
 - REP/KGS:
 - REP/KHR:
 - REP/KMF:
 - REP/KRW:
 - REP/KWD:
 - REP/KYD:
 - REP/KZT:
 - REP/LAK:
 - REP/LBP:
 - REP/LKR:
 - REP/LRD:
 - REP/LSL:
 - REP/LTL:
 - REP/LVL:
 - REP/LYD:
 - REP/MAD:
 - REP/MDL:
 - REP/MGA:
 - REP/MKD:
 - REP/MMK:
 - REP/MNT:
 - REP/MOP:
 - REP/MRO:
 - REP/MTL:
 - REP/MUR:
 - REP/MVR:
 - REP/MWK:
 - REP/MXN:
 - REP/MYR:
 - REP/MZN:
 - REP/NAD:
 - REP/NGN:
 - REP/NIO:
 - REP/NOK:
 - REP/NPR:
 - REP/NZD:
 - REP/OMR:
 - REP/PAB:
 - REP/PEN:
 - REP/PGK:
 - REP/PHP:
 - REP/PKR:
 - REP/PLN:
 - REP/PYG:
 - REP/QAR:
 - REP/RON:
 - REP/RSD:
 - REP/RUB:
 - REP/RWF:
 - REP/SAR:
 - REP/SBD:
 - REP/SCR:
 - REP/SEK:
 - REP/SGD:
 - REP/SHP:
 - REP/SLL:
 - REP/SOS:
 - REP/SRD:
 - REP/SSP:
 - REP/STD:
 - REP/SVC:
 - REP/SZL:
 - REP/THB:
 - REP/TJS:
 - REP/TMT:
 - REP/TND:
 - REP/TOP:
 - REP/TRY:
 - REP/TTD:
 - REP/TWD:
 - REP/TZS:
 - REP/UAH:
 - REP/UGX:
 - REP/USD:
 - REP/UYU:
 - REP/UZS:
 - REP/VEF:
 - REP/VES:
 - REP/VND:
 - REP/VUV:
 - REP/WST:
 - REP/XAF:
 - REP/XAG:
 - REP/XAU:
 - REP/XCD:
 - REP/XDR:
 - REP/XOF:
 - REP/XPD:
 - REP/XPF:
 - REP/XPT:
 - REP/YER:
 - REP/ZAR:
 - REP/ZMK:
 - REP/ZMW:
 - REP/ZWL:

on exchange coinbaseprime these symbols contain REP:
 - REP/BTC:
 - REP/USD:

on exchange binance these symbols contain REP:
 - REP/BNB:
 - REP/BTC:
 - REP/BUSD:
 - REP/ETH:
 - REP/USDT:

on exchange crex24 these symbols contain REP:
 - AREPA/BTC:
 - BTC/EUREP:
 - CREP/BTC:
 - REP/BTC:
 - REP_OLD/BTC:
 - USDT/EUREP:

on exchange bitfinex these symbols contain REP:
 - REP/BTC:
 - REP/USD:

on exchange currencycom these symbols contain REP:
 - REP/EUR:

on exchange rightbtc these symbols contain REP:
 - REP/BTC:
 - REP/USDT:

on exchange bytetrade these symbols contain REP:
 - REP/ByteTrade:

on exchange lykke these symbols contain REP:
 - REP/BTC:
 - REP/ETH:

on exchange hitbtc these symbols contain REP:
 - REP/BTC:
 - REP/ETH:
 - REP/USDT:

on exchange bitfinex2 these symbols contain REP:
 - REP/BTC:
 - REP/USD:

on exchange upbit these symbols contain REP:
 - REP/BTC:
 - REP/KRW:

on exchange poloniex these symbols contain REP:
 - REPV2/BTC:
   - marked V2
 - REPV2/USDT:
   - marked V2

on exchange kraken these symbols contain REP:
 - REP/BTC:
 - REP/ETH:
 - REP/EUR:
 - REP/USD:
 - REPV2/BTC:
   - marked V2
 - REPV2/ETH:
   - marked V2
 - REPV2/EUR:
   - marked V2
 - REPV2/USD:
   - marked V2

on exchange coinex these symbols contain REP:
 - REP/BTC:
 - REP/ETH:
 - REP/USDT:

on exchange gateio these symbols contain REP:
 - REP/ETH:

on exchange bitmart these symbols contain REP:
 - REP/BTC:
 - REP/ETH:
 - REPO/BTC:
 - REPO/ETH:

on exchange aofex these symbols contain REP:
 - REP/AQ:
 - REP/USDT:

on exchange latoken these symbols contain REP:
 - REP/BTC:
 - REP/ETH:
 - REP/LA:

on exchange okex these symbols contain REP:
 - REP/ETH:
 - REP/USDT:

on exchange indodax these symbols contain REP:
 - REP/IDR:

on exchange probit these symbols contain REP:
 - REP/KRW:
 - REP/USDT:

errors for exchanges: bibox, xbtce, btcturk, coingi, vaultoro, flowbtc, buda, coinmarketcap, bcex, ripio, eterbase
```

</p>
</details>

I then attempted to fix the situation for Kraken by assuming Binance is doing it the right way...
But there are a lot more exchanges that use REP variants... so before continuing, what do you people (@kroitor) think about this?