### PR TITLE
Huobi bad symbol errors

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -508,7 +508,7 @@ module.exports = class huobipro extends Exchange {
         //
         if ('tick' in response) {
             if (!response['tick']) {
-                throw new ExchangeError (this.id + ' fetchOrderBook() returned empty response: ' + this.json (response));
+                throw new BadSymbol (this.id + ' fetchOrderBook() returned empty response: ' + this.json (response));
             }
             const tick = this.safeValue (response, 'tick');
             const timestamp = this.safeInteger (tick, 'ts', this.safeInteger (response, 'ts'));

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -215,6 +215,7 @@ module.exports = class huobipro extends Exchange {
                     'api-signature-not-valid': AuthenticationError, // {"status":"error","err-code":"api-signature-not-valid","err-msg":"Signature not valid: Incorrect Access key [Access key错误]","data":null}
                     'base-record-invalid': OrderNotFound, // https://github.com/ccxt/ccxt/issues/5750
                     'base-symbol-trade-disabled': BadSymbol, // {"status":"error","err-code":"base-symbol-trade-disabled","err-msg":"Trading is disabled for this symbol","data":null}
+                    'base-symbol-error': BadSymbol, // {"status":"error","err-code":"base-symbol-error","err-msg":"The symbol is invalid","data":null}
                     'system-maintenance': OnMaintenance, // {"status": "error", "err-code": "system-maintenance", "err-msg": "System is in maintenance!", "data": null}
                     // err-msg
                     'invalid symbol': BadSymbol, // {"ts":1568813334794,"status":"error","err-code":"invalid-parameter","err-msg":"invalid symbol"}


### PR DESCRIPTION
I've a pair of `BadSymbol` errors to add, for huobipro.

The first gives a more precise error to an `ExchangeError`. This error corresponds to trading on the relevant market being (temporarily) suspended. Reloading `loadMarkets` at this point results in the relevant market being marked inactive. (I'm fairly confident this should be `BadSymbol` but there may be a better variant).

The second is an additional error.

`huobipro` tests (run in docker) pass.