### PR TITLE
Correctly parse and map limit_stop_price would trigger immediately

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -465,6 +465,7 @@ module.exports = class binance extends Exchange {
             'exceptions': {
                 'API key does not exist': AuthenticationError,
                 'Order would trigger immediately.': OrderImmediatelyFillable,
+                'Stop price would trigger immediately.': OrderImmediatelyFillable, // {"code":-2010,"msg":"Stop price would trigger immediately."}
                 'Order would immediately match and take.': OrderImmediatelyFillable, // {"code":-2010,"msg":"Order would immediately match and take."}
                 'Account has insufficient balance for requested action.': InsufficientFunds,
                 'Rest API trading is not enabled.': ExchangeNotAvailable,


### PR DESCRIPTION
Correctly parse and map `limit_stop_price` immediate trigger.

This exception is raised by the exchange when creating a "stop_loss_limit" order with a price that's above the current trading price.

This should be mapped to the appropriate exception - currently it's mapped to `ExchangeException` - which is as unspecific as it get's ...

i think binance renamed the error message from `Order would trigger immediately.` to `Stop price would trigger immediately.` sometime in the recent months, as i know this used to work in the past but stopped working a few weeks (or months?) ago.

(*edit:* it's not closing any issue as it was quicker to fix this than to open an issue explaining the problem ... hope that's ok... ) 
