### PR TITLE
Add BCH into the linear asset list in bybit python file.

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -285,6 +285,7 @@ module.exports = class bybit extends Exchange {
             'options': {
                 'marketTypes': {
                     'BTC/USDT': 'linear',
+                    'BCH/USDT': 'linear',
                     'ETH/USDT': 'linear',
                     'LTC/USDT': 'linear',
                     'XTZ/USDT': 'linear',

--- a/python/ccxt/bybit.py
+++ b/python/ccxt/bybit.py
@@ -296,6 +296,7 @@ class bybit(Exchange):
                 'marketTypes': {
                     'BTC/USDT': 'linear',
                     'ETH/USDT': 'linear',
+                    'BCH/USDT': 'linear',
                     'LTC/USDT': 'linear',
                     'XTZ/USDT': 'linear',
                     'LINK/USDT': 'linear',


### PR DESCRIPTION
BCHUSDT is a relatively newly added linear asset pair on Bybit. 