### PR TITLE
use expired status in binance order statuses

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1450,7 +1450,7 @@ module.exports = class binance extends Exchange {
             'CANCELED': 'canceled',
             'PENDING_CANCEL': 'canceling', // currently unused
             'REJECTED': 'rejected',
-            'EXPIRED': 'canceled',
+            'EXPIRED': 'expired',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
Not sure, but I see that other exchanges make use of expired status (like Bitmex) so it could make sense to use this expired status in Binance too?