### PR TITLE
bithumb createOrder parameter typo fix #8216

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -539,7 +539,7 @@ module.exports = class bithumb extends Exchange {
         const market = this.market (symbol);
         const request = {
             'order_currency': market['id'],
-            'Payment_currency': market['quote'],
+            'payment_currency': market['quote'],
             'units': amount,
         };
         let method = 'privatePostTradePlace';


### PR DESCRIPTION
It was giving me `BadRequest: bithumb {"status":"5500","message":"Invalid Parameter"}` Error

Because the first character of the parameter should've been in lowercase.
