### PR TITLE
Bitmax update fees

### DIFF
--- a/js/bitmax.js
+++ b/js/bitmax.js
@@ -133,8 +133,8 @@ module.exports = class bitmax extends Exchange {
                 'trading': {
                     'tierBased': true,
                     'percentage': true,
-                    'taker': 0.001,
-                    'maker': 0.001,
+                    'taker': 0.002,
+                    'maker': 0.002,
                 },
             },
             'precisionMode': TICK_SIZE,


### PR DESCRIPTION
https://bitmaxhelp.zendesk.com/hc/en-us/articles/360059859114-BitMax-io-to-Implement-New-VIP-Fee-Rebate-Structure
For altcoin markets fee is max fee is 0.2 now.