### PR TITLE
binance future min cost field name bug fix

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -807,7 +807,7 @@ module.exports = class binance extends Exchange {
             }
             if ('MIN_NOTIONAL' in filtersByType) {
                 const filter = this.safeValue (filtersByType, 'MIN_NOTIONAL', {});
-                entry['limits']['cost']['min'] = this.safeFloat (filter, 'minNotional');
+                entry['limits']['cost']['min'] = this.safeFloat2 (filter, 'minNotional', 'notional');
             }
             result.push (entry);
         }


### PR DESCRIPTION
Recently, binance future add min cost restrict, its api returns `{'notional': '1', 'filterType': 'MIN_NOTIONAL'}`, the field name `notional` is different than the spot field name `minNotional`, thus causing minCost be None.
 ```'cost': {'min': None, 'max': None}```