### PR TITLE
Fix  idna 3.1 is installed but idna<3,>=2.5 is required by {'requests…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
     && apt-get install -y nodejs \
 # Python 3
     && apt-get install -y --no-install-recommends python3 python3-pip \
+    && pip3 install 'idna==2.9' --force-reinstall \
     && pip3 install --upgrade setuptools \
     && pip3 install tox \
 # Installs as a local Node & Python module, so that `require ('ccxt')` and `import ccxt` should work after that


### PR DESCRIPTION
While running `docker-compose run --rm ccxt` I was hitting this error due to a version incompatibility ` idna 3.1 is installed but idna<3,>=2.5 is required by {'requests…}`. Adding this version specific installation of idna package solves the issue