### PR TITLE
kucoin: switch to api v2 for orderbook

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -236,10 +236,10 @@ module.exports = class kucoin extends Exchange {
                     'public': {
                         'GET': {
                             'status': 'v1',
-                            'market/orderbook/level{level}': 'v1',
+                            'market/orderbook/level{level}': 'v2',
                             'market/orderbook/level2': 'v2',
-                            'market/orderbook/level2_20': 'v1',
-                            'market/orderbook/level2_100': 'v1',
+                            'market/orderbook/level2_20': 'v2',
+                            'market/orderbook/level2_100': 'v2',
                         },
                     },
                     'private': {


### PR DESCRIPTION
Kucoin changed tonight something and v1 is not working for me anymore for orderbooks.