### PR TITLE
[binance] fix makerOrTaker in parseTrade

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1393,6 +1393,9 @@ module.exports = class binance extends Exchange {
             };
         }
         let takerOrMaker = undefined;
+        f ('isMaker' in trade) {
+            takerOrMaker = trade['isMaker'] ? 'maker' : 'taker';
+        }
         if ('maker' in trade) {
             takerOrMaker = trade['maker'] ? 'maker' : 'taker';
         }

--- a/js/binance.js
+++ b/js/binance.js
@@ -1350,6 +1350,23 @@ module.exports = class binance extends Exchange {
         //       "symbol": "BTCUSDT",
         //       "time": 1569514978020
         //     }
+        //     {
+        //       "symbol": "BTCUSDT",
+        //       "id": 477128891,
+        //       "orderId": 13809777875,
+        //       "side": "SELL",
+        //       "price": "38479.55",
+        //       "qty": "0.001",
+        //       "realizedPnl": "-0.00009534",
+        //       "marginAsset": "USDT",
+        //       "quoteQty": "38.47955",
+        //       "commission": "-0.00076959",
+        //       "commissionAsset": "USDT",
+        //       "time": 1612733566708,
+        //       "positionSide": "BOTH",
+        //       "maker": true,
+        //       "buyer": false
+        //     }
         //
         const timestamp = this.safeInteger2 (trade, 'T', 'time');
         const price = this.safeFloat2 (trade, 'p', 'price');
@@ -1376,8 +1393,8 @@ module.exports = class binance extends Exchange {
             };
         }
         let takerOrMaker = undefined;
-        if ('isMaker' in trade) {
-            takerOrMaker = trade['isMaker'] ? 'maker' : 'taker';
+        if ('maker' in trade) {
+            takerOrMaker = trade['maker'] ? 'maker' : 'taker';
         }
         const marketId = this.safeString (trade, 'symbol');
         const symbol = this.safeSymbol (marketId, market);

--- a/js/binance.js
+++ b/js/binance.js
@@ -1393,7 +1393,7 @@ module.exports = class binance extends Exchange {
             };
         }
         let takerOrMaker = undefined;
-        f ('isMaker' in trade) {
+        if ('isMaker' in trade) {
             takerOrMaker = trade['isMaker'] ? 'maker' : 'taker';
         }
         if ('maker' in trade) {


### PR DESCRIPTION
and replaced the futures example (actual data does not include 'accountId' or 'counterPartyId' fields)