### PR TITLE
Phemex - new private API end point

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -102,6 +102,7 @@ module.exports = class phemex extends Exchange {
                         'exchange/spot/order/trades', // ?symbol=<symbol>&start=<start>&end=<end>&limit=<limit>&offset=<offset>
                         // swap
                         'accounts/accountPositions', // ?currency=<currency>
+                        'accounts/positions', // ?currency=<currency>
                         'orders/activeList', // ?symbol=<symbol>
                         'exchange/order/list', // ?symbol=<symbol>&start=<start>&end=<end>&offset=<offset>&limit=<limit>&ordStatus=<ordStatus>&withCount=<withCount>
                         'exchange/order', // ?symbol=<symbol>&orderID=<orderID1,orderID2>


### PR DESCRIPTION
Phemex has new API end point 
/accounts/positions?currency=<currency>   
https://github.com/phemex/phemex-api-docs/blob/master/Public-Contract-API-en.md#query-trading-account-and-positions-with-unrealized-pnl

which allows to fetch unrealized PnL, which was not possible before and unPnL had to be calculated on the client side.