### PR TITLE
kucoin NIM address error

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -682,7 +682,10 @@ module.exports = class kucoin extends Exchange {
             address = address.replace ('bitcoincash:', '');
         }
         const tag = this.safeString (data, 'memo');
-        this.checkAddress (address);
+        if (code !== 'NIM') {
+            // contains spaces
+            this.checkAddress (address);
+        }
         return {
             'info': response,
             'currency': code,
@@ -705,7 +708,10 @@ module.exports = class kucoin extends Exchange {
             address = address.replace ('bitcoincash:', '');
         }
         const tag = this.safeString (data, 'memo');
-        this.checkAddress (address);
+        if (code !== 'NIM') {
+            // contains spaces
+            this.checkAddress (address);
+        }
         return {
             'info': response,
             'currency': code,


### PR DESCRIPTION
> And the generated address by KuCoin for me is: "NQ39 AGBD UK1L M2UC 0AL1 88GN HU9X AN62 C5X0". So the problem is easy to solve i guess)


```
{ info: 
   { code: '200000',
     data: 
      { address: 'NQ83 U55G 6TA5 B62K 5850 5GBH AYR6 P8G7 EPNA',
        memo: '',
        chain: null } },
  currency: 'NIM',
  address: 'NQ83 U55G 6TA5 B62K 5850 5GBH AYR6 P8G7 EPNA',
  tag: '' }
```