### PR TITLE
Update kucoin fetch closed orders example

### DIFF
--- a/examples/py/kucoin-fetch-closed-orders-pagination.py
+++ b/examples/py/kucoin-fetch-closed-orders-pagination.py
@@ -23,7 +23,7 @@ limit = 20
 
 while since < now:
 
-    end = max(since + week, now)
+    end = min(since + week, now)
     params = {'endAt': end}
     orders = exchange.fetch_closed_orders(symbol, since, limit, params)
     print(exchange.iso8601(since), '-', exchange.iso8601(end), len(orders), 'orders')


### PR DESCRIPTION
As mentioned [here](https://github.com/ccxt/ccxt/issues/8457#issue-807960660) the example needs to be update to use `min` instead of max for the end date, since if the difference between `startAt` and `endAt` is greater than 1 week the kucoin server responds with an error.