### PR TITLE
rewrite parseOhlcvs and fix #8445

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1364,7 +1364,7 @@ module.exports = class Exchange {
         // still takes the input as a hex string
         // same as above but returns a string instead of an object
         const signature = this.signMessage (message, privateKey)
-        return signature['r'] + this.remove0xPrefix (signature['s']) + this.binaryToBase16 (this.numberToBE (signature['v']));
+        return signature['r'] + this.remove0xPrefix (signature['s']) + this.binaryToBase16 (this.numberToBE (signature['v']))
     }
 
     oath () {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1226,19 +1226,9 @@ module.exports = class Exchange {
         // if (!this.isArray (ohlcvs)) {
         //     throw new ExchangeError (this.id + ' parseOHLCVs expected an array in the ohlcvs argument, but got ' + typeof ohlcvs);
         // }
-        ohlcvs = Object.values (ohlcvs || [])
-        const result = []
-        for (let i = 0; i < ohlcvs.length; i++) {
-            if (limit && (result.length >= limit)) {
-                break;
-            }
-            const ohlcv = this.parseOHLCV (ohlcvs[i], market)
-            if (since && (ohlcv[0] < since)) {
-                continue
-            }
-            result.push (ohlcv)
-        }
-        return this.sortBy (result, 0)
+        const parsed = ohlcvs.map (ohlcv => this.parseOHLCV (ohlcv, market))
+        const tail = since === undefined
+        return this.filterBySinceLimit (parsed, since, limit, 0, tail)
     }
 
     editLimitBuyOrder (id, symbol, ...args) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1227,8 +1227,9 @@ module.exports = class Exchange {
         //     throw new ExchangeError (this.id + ' parseOHLCVs expected an array in the ohlcvs argument, but got ' + typeof ohlcvs);
         // }
         const parsed = ohlcvs.map (ohlcv => this.parseOHLCV (ohlcv, market))
+        const sorted = this.sortBy (parsed, 0)
         const tail = since === undefined
-        return this.filterBySinceLimit (parsed, since, limit, 0, tail)
+        return this.filterBySinceLimit (sorted, since, limit, 0, tail)
     }
 
     editLimitBuyOrder (id, symbol, ...args) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1728,8 +1728,9 @@ class Exchange {
         foreach ($ohlcvs as $ohlcv) {
             $parsed[] = $this->parse_ohlcv($ohlcv, $market);
         }
+        $sorted = $this->sort_by($parsed, 0);
         $tail = $since === null;
-        return $this->filter_by_since_limit($parsed, $since, $limit, 0, $tail);
+        return $this->filter_by_since_limit($sorted, $since, $limit, 0, $tail);
     }
 
     public function parse_bid_ask($bidask, $price_key = 0, $amount_key = 1) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1724,19 +1724,12 @@ class Exchange {
 
     public function parse_ohlcvs($ohlcvs, $market = null, $timeframe = 60, $since = null, $limit = null) {
         $ohlcvs = is_array($ohlcvs) ? array_values($ohlcvs) : array();
-        $result = array();
-        $num_ohlcvs = count($ohlcvs);
-        for ($i = 0; $i < $num_ohlcvs; $i++) {
-            if ($limit && (count($result) >= $limit)) {
-                break;
-            }
-            $ohlcv = $this->parse_ohlcv($ohlcvs[$i], $market);
-            if ($since && ($ohlcv[0] < $since)) {
-                continue;
-            }
-            $result[] = $ohlcv;
+        $parsed = array();
+        foreach ($ohlcvs as $ohlcv) {
+            $parsed[] = $this->parse_ohlcv($ohlcv, $market);
         }
-        return $this->sort_by($result, 0);
+        $tail = $since === null;
+        return $this->filter_by_since_limit($parsed, $since, $limit, 0, $tail);
     }
 
     public function parse_bid_ask($bidask, $price_key = 0, $amount_key = 1) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1462,8 +1462,9 @@ class Exchange(object):
 
     def parse_ohlcvs(self, ohlcvs, market=None, timeframe='1m', since=None, limit=None):
         parsed = [self.parse_ohlcv(ohlcv, market) for ohlcv in ohlcvs]
+        sorted = self.sort_by(parsed, 0)
         tail = since is None
-        return self.filter_by_since_limit(parsed, since, limit, 0, tail)
+        return self.filter_by_since_limit(sorted, since, limit, 0, tail)
 
     def parse_bid_ask(self, bidask, price_key=0, amount_key=0):
         return [float(bidask[price_key]), float(bidask[amount_key])]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1461,19 +1461,9 @@ class Exchange(object):
         return ohlcv[0:6] if isinstance(ohlcv, list) else ohlcv
 
     def parse_ohlcvs(self, ohlcvs, market=None, timeframe='1m', since=None, limit=None):
-        ohlcvs = self.to_array(ohlcvs)
-        num_ohlcvs = len(ohlcvs)
-        result = []
-        i = 0
-        while i < num_ohlcvs:
-            if limit and (len(result) >= limit):
-                break
-            ohlcv = self.parse_ohlcv(ohlcvs[i], market)
-            i = i + 1
-            if since and (ohlcv[0] < since):
-                continue
-            result.append(ohlcv)
-        return self.sort_by(result, 0)
+        parsed = [self.parse_ohlcv(ohlcv, market) for ohlcv in ohlcvs]
+        tail = since is None
+        return self.filter_by_since_limit(parsed, since, limit, 0, tail)
 
     def parse_bid_ask(self, bidask, price_key=0, amount_key=0):
         return [float(bidask[price_key]), float(bidask[amount_key])]


### PR DESCRIPTION
should fix all the exchanges that have this same problem

In particular we should have a different behaviour with and without the since argument. Without it we should limit from the end (and hence the tail argument), when it is present we should limit starting from the since timestamp. This mimics the API responses of binance when since and limit are present.