### PR TITLE
IndependentReserve - fix symbol in trade parse

### DIFF
--- a/js/independentreserve.js
+++ b/js/independentreserve.js
@@ -395,10 +395,9 @@ module.exports = class independentreserve extends Exchange {
                 cost = price * amount;
             }
         }
-        let symbol = undefined;
-        if (market !== undefined) {
-            symbol = market['symbol'];
-        }
+        const baseId = this.safeString (trade, 'PrimaryCurrencyCode');
+        const quoteId = this.safeString (trade, 'SecondaryCurrencyCode');
+        const symbol = this.safeCurrencyCode (baseId) + '/' + this.safeCurrencyCode (quoteId);
         let side = this.safeString (trade, 'OrderType');
         if (side !== undefined) {
             if (side.indexOf ('Bid') >= 0) {

--- a/js/independentreserve.js
+++ b/js/independentreserve.js
@@ -397,7 +397,11 @@ module.exports = class independentreserve extends Exchange {
         }
         const baseId = this.safeString (trade, 'PrimaryCurrencyCode');
         const quoteId = this.safeString (trade, 'SecondaryCurrencyCode');
-        const symbol = this.safeCurrencyCode (baseId) + '/' + this.safeCurrencyCode (quoteId);
+        let marketId = undefined;
+        if ((baseId !== undefined) && (quoteId !== undefined)) {
+            marketId = baseId + '/' + quoteId;
+        }
+        const symbol = this.safeSymbol (marketId, market, '/');
         let side = this.safeString (trade, 'OrderType');
         if (side !== undefined) {
             if (side.indexOf ('Bid') >= 0) {


### PR DESCRIPTION
fetchMyTrades() ( privatePostGetTrades() ) doesn't take market param. 

parseTrade was erroneously taking this param and returning it as the symbol for the parsed trade, rather than getting the symbol from the trade object