### PR TITLE
timex createOrder type

### DIFF
--- a/js/timex.js
+++ b/js/timex.js
@@ -466,7 +466,7 @@ module.exports = class timex extends Exchange {
             'symbol': market['id'],
             'quantity': this.amountToPrecision (symbol, amount),
             'side': uppercaseSide,
-            'type': uppercaseType,
+            'orderTypes': uppercaseType,
             // 'clientOrderId': '123',
             // 'expireIn': 1575523308, // in seconds
             // 'expireTime': 1575523308, // unix timestamp


### PR DESCRIPTION
If i trying create order with 'type' param, i have error: `{"error":{"timestamp":"09.03.2021T12:47:38.315+0000","status":"BAD_REQUEST","message":"Validation error","code":4000,"subErrors":[{"field":"type","problem":"must not be null"}]}}`

https://plasma-relay-backend.timex.io/swagger-ui.html?urls.primaryName=Relay#/Trading
timex api don't have 'type' param in create order request, have 'orderTypes'