### PR TITLE
Add Trigger price too high/low to FTX exceptions

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -229,6 +229,8 @@ module.exports = class ftx extends Exchange {
                     'Missing parameter price': InvalidOrder, // {"error":"Missing parameter price","success":false}
                     'Order not found': OrderNotFound, // {"error":"Order not found","success":false}
                     'Order already closed': InvalidOrder, // {"error":"Order already closed","success":false}
+                    'Trigger price too high': InvalidOrder, // {"error":"Trigger price too high","success":false}
+                    'Trigger price too low': InvalidOrder, // {"error":"Trigger price too low","success":false}
                     'Order already queued for cancellation': CancelPending, // {"error":"Order already queued for cancellation","success":false}
                 },
                 'broad': {


### PR DESCRIPTION
This exception can happen with stop sell orders which are placed with a stop-price higher than the current rate, 
or with stop buy orders with a stop-price below current rate.

Example:

``` python
import ccxt
exchange = ccxt.ftx({'apiKey': '<yourApiKey>', 'secret': '<yoursecret>' })
# Note: current price of FTT/USD is around 35$. 
# This will change over time, so this example may not be valid in the distant future.
pair = 'FTT/USD'
order = ct.create_order(pair, 'stop', 'buy', amount=1, price=4.230, params={'orderPrice': 4.230})


> ExchangeError: ftx {"error":"Trigger price too low","success":false}
```
The ExchangeError should be a InvalidOrder error, which will align this behaviour with other exchanges like binance.
