### PR TITLE
fixed nonce error on every private api call

### DIFF
--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -377,10 +377,10 @@ module.exports = class coincheck extends Exchange {
         return await this.privateDeleteExchangeOrdersId (this.extend (request, params));
     }
 
-    nonce(){
-        return this.milliseconds();
+    nonce () {
+        return this.milliseconds ();
     }
-    
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = this.urls['api'] + '/' + this.implodeParams (path, params);
         const query = this.omit (params, this.extractParams (path));

--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -377,6 +377,10 @@ module.exports = class coincheck extends Exchange {
         return await this.privateDeleteExchangeOrdersId (this.extend (request, params));
     }
 
+    nonce(){
+        return this.milliseconds();
+    }
+    
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = this.urls['api'] + '/' + this.implodeParams (path, params);
         const query = this.omit (params, this.extractParams (path));


### PR DESCRIPTION
added nonce() function for exchange coincheck.  The function returns milliseconds value instead of seconds (by exchange.nonce()), to fix error "Nonce must be incremented" when calling any private api.