### PR TITLE
orderbook parse numbers with indirection

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -927,8 +927,8 @@ module.exports = class Exchange {
     }
 
     parseBidAsk (bidask, priceKey = 0, amountKey = 1) {
-        const price = parseFloat (bidask[priceKey])
-        const amount = parseFloat (bidask[amountKey])
+        const price = this.number (bidask[priceKey])
+        const amount = this.number (bidask[amountKey])
         return [ price, amount ]
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1570,7 +1570,11 @@ module.exports = class Exchange {
         if (value === undefined) {
             return d
         } else {
-            return this.number (value)
+            try {
+                return this.number (value)
+            } catch (e) {
+                return d
+            }
         }
     }
 
@@ -1579,7 +1583,11 @@ module.exports = class Exchange {
         if (value === undefined) {
             return d
         } else {
-            return this.number (value)
+            try {
+                return this.number (value)
+            } catch (e) {
+                return d
+            }
         }
     }
 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1564,4 +1564,22 @@ module.exports = class Exchange {
             'remaining': remaining,
         });
     }
+
+    safeNumber (object, key, d) {
+        const value = this.safeString (object, key)
+        if (value === undefined) {
+            return d
+        } else {
+            return this.number (value)
+        }
+    }
+
+    safeNumber2 (object, key1, key2, d) {
+        const value = this.safeString2 (object, key1, key2)
+        if (value === undefined) {
+            return d
+        } else {
+            return this.number (value)
+        }
+    }
 }

--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -41,6 +41,7 @@ module.exports = {
     , asInteger
 
     , safeFloat:          (o, k,          $default, n =   asFloat (prop (o, k))) => (isNumber (n)          ? n                         : $default)
+    , safeNumber:         (o, k,          $default, n = this.number (prop (o, k))) => (isNumber (n)          ? n                         : $default)
     , safeInteger:        (o, k,          $default, n = asInteger (prop (o, k))) => (isNumber (n)          ? n                         : $default)
     , safeIntegerProduct: (o, k, $factor, $default, n = asInteger (prop (o, k))) => (isNumber (n)          ? parseInt (n * $factor)    : $default)
     , safeTimestamp:      (o, k,          $default, n =   asFloat (prop (o, k))) => (isNumber (n)          ? parseInt (n * 1000)       : $default)
@@ -53,6 +54,7 @@ module.exports = {
     // we're not using safeFloat3 either because those cases are too rare to deserve their own optimization
 
     , safeFloat2:          (o, k1, k2,          $default, n =   asFloat (prop2 (o, k1, k2))) => (isNumber (n)          ? n                         : $default)
+    , safeNumber2:         (o, k1, k2,          $default, n = this.number (prop2 (o, k1, k2))) => (isNumber (n)          ? n                         : $default)
     , safeInteger2:        (o, k1, k2,          $default, n = asInteger (prop2 (o, k1, k2))) => (isNumber (n)          ? n                         : $default)
     , safeIntegerProduct2: (o, k1, k2, $factor, $default, n = asInteger (prop2 (o, k1, k2))) => (isNumber (n)          ? parseInt (n * $factor)    : $default)
     , safeTimestamp2:      (o, k1, k2,          $default, n =   asFloat (prop2 (o, k1, k2))) => (isNumber (n)          ? parseInt (n * 1000)       : $default)

--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -41,7 +41,6 @@ module.exports = {
     , asInteger
 
     , safeFloat:          (o, k,          $default, n =   asFloat (prop (o, k))) => (isNumber (n)          ? n                         : $default)
-    , safeNumber:         (o, k,          $default, n = this.number (prop (o, k))) => (isNumber (n)          ? n                         : $default)
     , safeInteger:        (o, k,          $default, n = asInteger (prop (o, k))) => (isNumber (n)          ? n                         : $default)
     , safeIntegerProduct: (o, k, $factor, $default, n = asInteger (prop (o, k))) => (isNumber (n)          ? parseInt (n * $factor)    : $default)
     , safeTimestamp:      (o, k,          $default, n =   asFloat (prop (o, k))) => (isNumber (n)          ? parseInt (n * 1000)       : $default)
@@ -54,7 +53,6 @@ module.exports = {
     // we're not using safeFloat3 either because those cases are too rare to deserve their own optimization
 
     , safeFloat2:          (o, k1, k2,          $default, n =   asFloat (prop2 (o, k1, k2))) => (isNumber (n)          ? n                         : $default)
-    , safeNumber2:         (o, k1, k2,          $default, n = this.number (prop2 (o, k1, k2))) => (isNumber (n)          ? n                         : $default)
     , safeInteger2:        (o, k1, k2,          $default, n = asInteger (prop2 (o, k1, k2))) => (isNumber (n)          ? n                         : $default)
     , safeIntegerProduct2: (o, k1, k2, $factor, $default, n = asInteger (prop2 (o, k1, k2))) => (isNumber (n)          ? parseInt (n * $factor)    : $default)
     , safeTimestamp2:      (o, k1, k2,          $default, n =   asFloat (prop2 (o, k1, k2))) => (isNumber (n)          ? parseInt (n * 1000)       : $default)

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -385,10 +385,6 @@ class Exchange {
         return (isset($object[$key]) && is_numeric($object[$key])) ? floatval($object[$key]) : $default_value;
     }
 
-    public function safe_number($object, $key, $default_value = null) {
-        return (isset($object[$key]) && is_numeric($object[$key])) ? $this->number($object[$key]) : $default_value;
-    }
-
     public static function safe_string($object, $key, $default_value = null) {
         return (isset($object[$key]) && is_scalar($object[$key])) ? strval($object[$key]) : $default_value;
     }
@@ -423,11 +419,6 @@ class Exchange {
     public static function safe_float_2($object, $key1, $key2, $default_value = null) {
         $value = static::safe_float($object, $key1);
         return isset($value) ? $value : static::safe_float($object, $key2, $default_value);
-    }
-
-    public function safe_number_2($object, $key1, $key2, $default_value = null) {
-        $value = $this->safe_number($object, $key1);
-        return isset($value) ? $value : $this->safe_number($object, $key2, $default_value);
     }
 
     public static function safe_string_2($object, $key1, $key2, $default_value = null) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -35,6 +35,7 @@ use kornrunner\Solidity;
 use Elliptic\EC;
 use Elliptic\EdDSA;
 use BN\BN;
+use Exception;
 
 $version = '1.44.34';
 
@@ -2954,16 +2955,24 @@ class Exchange {
         if ($value === null) {
             return $default;
         } else {
-            return $this->number($value);
+            try {
+                return $this->number($value);
+            } catch (Exception $e) {
+                return $default;
+            }
         }
     }
 
     public function safe_number_2($object, $key1, $key2, $default) {
-        $value = $this->safe_string2($object, $key1, $key2);
+        $value = $this->safe_string_2($object, $key1, $key2);
         if ($value === null) {
             return $default;
         } else {
-            return $this->number($value);
+            try {
+                return $this->number($value);
+            } catch (Exception $e) {
+                return $default;
+            }
         }
     }
 }

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1158,7 +1158,7 @@ class Exchange {
 
         $this->precisionMode = DECIMAL_PLACES;
         $this->paddingMode = NO_PADDING;
-        $this->number ='floatval';
+        $this->number = 'floatval';
 
         $this->lastRestRequestTimestamp = 0;
         $this->lastRestPollTimestamp = 0;

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1747,9 +1747,8 @@ class Exchange {
         return $this->filter_by_since_limit($sorted, $since, $limit, 0, $tail);
     }
 
-    public function number($number) {
-        $number_function = $this->number;
-        return $number_function($number);
+    public function number($n) {
+        return call_user_func($this->number, $n);
     }
 
     public function parse_bid_ask($bidask, $price_key = 0, $amount_key = 1) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1747,9 +1747,14 @@ class Exchange {
         return $this->filter_by_since_limit($sorted, $since, $limit, 0, $tail);
     }
 
+    public function number($number) {
+        $number_function = $this->number;
+        return $number_function($number);
+    }
+
     public function parse_bid_ask($bidask, $price_key = 0, $amount_key = 1) {
-        $price = call_user_func($this->number, $bidask[$price_key]);
-        $amount = call_user_func($this->number, $bidask[$amount_key]);
+        $price = $this->number($bidask[$price_key]);
+        $amount = $this->number($bidask[$amount_key]);
         return array($price, $amount);
     }
 

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -385,6 +385,10 @@ class Exchange {
         return (isset($object[$key]) && is_numeric($object[$key])) ? floatval($object[$key]) : $default_value;
     }
 
+    public function safe_number($object, $key, $default_value = null) {
+        return (isset($object[$key]) && is_numeric($object[$key])) ? $this->number($object[$key]) : $default_value;
+    }
+
     public static function safe_string($object, $key, $default_value = null) {
         return (isset($object[$key]) && is_scalar($object[$key])) ? strval($object[$key]) : $default_value;
     }
@@ -419,6 +423,11 @@ class Exchange {
     public static function safe_float_2($object, $key1, $key2, $default_value = null) {
         $value = static::safe_float($object, $key1);
         return isset($value) ? $value : static::safe_float($object, $key2, $default_value);
+    }
+
+    public function safe_number_2($object, $key1, $key2, $default_value = null) {
+        $value = $this->safe_number($object, $key1);
+        return isset($value) ? $value : $this->safe_number($object, $key2, $default_value);
     }
 
     public static function safe_string_2($object, $key1, $key2, $default_value = null) {

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -2948,4 +2948,22 @@ class Exchange {
             'remaining' => $remaining,
         ));
     }
+
+    public function safe_number($object, $key, $default) {
+        $value = $this->safe_string($object, $key);
+        if ($value === null) {
+            return $default;
+        } else {
+            return $this->number($value);
+        }
+    }
+
+    public function safe_number_2($object, $key1, $key2, $default) {
+        $value = $this->safe_string2($object, $key1, $key2);
+        if ($value === null) {
+            return $default;
+        } else {
+            return $this->number($value);
+        }
+    }
 }

--- a/php/base/Exchange.php
+++ b/php/base/Exchange.php
@@ -1158,7 +1158,7 @@ class Exchange {
 
         $this->precisionMode = DECIMAL_PLACES;
         $this->paddingMode = NO_PADDING;
-        $this->number = \Closure::fromCallable('floatval');
+        $this->number ='floatval';
 
         $this->lastRestRequestTimestamp = 0;
         $this->lastRestPollTimestamp = 0;
@@ -1748,7 +1748,9 @@ class Exchange {
     }
 
     public function parse_bid_ask($bidask, $price_key = 0, $amount_key = 1) {
-        return array(floatval($bidask[$price_key]), floatval($bidask[$amount_key]));
+        $price = call_user_func($this->number, $bidask[$price_key]);
+        $amount = call_user_func($this->number, $bidask[$amount_key]);
+        return array($price, $amount);
     }
 
     public function parse_bids_asks($bidasks, $price_key = 0, $amount_key = 1) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -689,6 +689,15 @@ class Exchange(object):
             value = default_value
         return value
 
+    def safe_number(self, dictionary, key, default_value=None):
+        value = default_value
+        try:
+            if Exchange.key_exists(dictionary, key):
+                value = self.number(dictionary[key])
+        except ValueError as e:
+            value = default_value
+        return value
+
     @staticmethod
     def safe_string(dictionary, key, default_value=None):
         return str(dictionary[key]) if Exchange.key_exists(dictionary, key) else default_value
@@ -743,6 +752,9 @@ class Exchange(object):
     @staticmethod
     def safe_float_2(dictionary, key1, key2, default_value=None):
         return Exchange.safe_either(Exchange.safe_float, dictionary, key1, key2, default_value)
+
+    def safe_number_2(self, dictionary, key1, key2, default_value=None):
+        return Exchange.safe_either(self.safe_float, dictionary, key1, key2, default_value)
 
     @staticmethod
     def safe_string_2(dictionary, key1, key2, default_value=None):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2246,3 +2246,17 @@ class Exchange(object):
             'filled': filled,
             'remaining': remaining,
         })
+
+    def safe_number(self, dictionary, key, default):
+        value = self.safe_string(dictionary, key)
+        if value is None:
+            return default
+        else:
+            return self.number(value)
+
+    def safe_number_2(self, dictionary, key1, key2, default):
+        value = self.safe_string_2(dictionary, key1, key2)
+        if value is None:
+            return default
+        else:
+            return self.number(value)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -689,15 +689,6 @@ class Exchange(object):
             value = default_value
         return value
 
-    def safe_number(self, dictionary, key, default_value=None):
-        value = default_value
-        try:
-            if Exchange.key_exists(dictionary, key):
-                value = self.number(dictionary[key])
-        except ValueError as e:
-            value = default_value
-        return value
-
     @staticmethod
     def safe_string(dictionary, key, default_value=None):
         return str(dictionary[key]) if Exchange.key_exists(dictionary, key) else default_value
@@ -752,9 +743,6 @@ class Exchange(object):
     @staticmethod
     def safe_float_2(dictionary, key1, key2, default_value=None):
         return Exchange.safe_either(Exchange.safe_float, dictionary, key1, key2, default_value)
-
-    def safe_number_2(self, dictionary, key1, key2, default_value=None):
-        return Exchange.safe_either(self.safe_float, dictionary, key1, key2, default_value)
 
     @staticmethod
     def safe_string_2(dictionary, key1, key2, default_value=None):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1493,7 +1493,7 @@ class Exchange(object):
         return self.filter_by_since_limit(sorted, since, limit, 0, tail)
 
     def parse_bid_ask(self, bidask, price_key=0, amount_key=0):
-        return [float(bidask[price_key]), float(bidask[amount_key])]
+        return [self.number(bidask[price_key]), self.number(bidask[amount_key])]
 
     def parse_bids_asks(self, bidasks, price_key=0, amount_key=1):
         result = []

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2252,11 +2252,17 @@ class Exchange(object):
         if value is None:
             return default
         else:
-            return self.number(value)
+            try:
+                return self.number(value)
+            except Exception:
+                return default
 
     def safe_number_2(self, dictionary, key1, key2, default):
         value = self.safe_string_2(dictionary, key1, key2)
         if value is None:
             return default
         else:
-            return self.number(value)
+            try:
+                return self.number(value)
+            except Exception:
+                return default


### PR DESCRIPTION
**Usage:**

```Python
import ccxt
import decimal


b = ccxt.binance()
b.number = decimal.Decimal

book = b.fetch_order_book('BTC/USDT')

print(book)
```


```Javascript
const b = new ccxt.binance()
b.number = x => x

const response = await b.fetchOrderBook ('BTC/USDT')
console.log (response)
```

```php
<?php

namespace ccxt;

include 'ccxt.php';

$x = new binance();

$x->number = function ($n) { return $n; };

$y = $x->fetch_order_book('BTC/USDT');

var_dump($y['bids'][0][0]);
```