### PR TITLE
Fix to transpile.js for indexOf

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -405,6 +405,7 @@ class Transpiler {
             [ /([^\(\s]+)\s+%\s+([^\s\,\;\)]+)/g, 'fmod($1, $2)' ],
             [ /\(([^\s\(]+)\.indexOf\s*\(([^\)]+)\)\s*\>\=\s*0\)/g, '(mb_strpos($1, $2) !== false)' ],
             [ /([^\s\(]+)\.indexOf\s*\(([^\)]+)\)\s*\>\=\s*0/g, 'mb_strpos($1, $2) !== false' ],
+            [ /([^\s\(]+)\.indexOf\s*\(([^\)]+)\)\s*\<\s*0/g, 'mb_strpos($1, $2) === false' ],
             [ /([^\s\(]+)\.indexOf\s*\(([^\)]+)\)/g, 'mb_strpos($1, $2)' ],
             [ /\(([^\s\(]+)\sin\s([^\)]+)\)/g, '(is_array($2) && array_key_exists($1, $2))' ],
             [ /([^\s]+)\.join\s*\(\s*([^\)]+?)\s*\)/g, 'implode($2, $1)' ],


### PR DESCRIPTION
Fix to transpile.js for indexOf()->mb_strpos() for PHP transpile -- no match returns -1 in JS, but false in PHP.

Affects only bitstamp->get_currency_id_from_transaction() and delta->fetch_markets() PHP methods, fixing bugs in both.