### PR TITLE
[Hitbtc] Fix order avgPrice parsing

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -937,7 +937,7 @@ module.exports = class hitbtc extends Exchange {
         const side = this.safeString (order, 'side');
         let trades = this.safeValue (order, 'tradesReport');
         const fee = undefined;
-        const average = this.safeValue (order, 'avgPrice');
+        const average = this.safeNumber (order, 'avgPrice');
         if (trades !== undefined) {
             trades = this.parseTrades (trades, market);
         }


### PR DESCRIPTION
When parsing order with avgPrice, `average = '0'`, that's raising `can't multiply sequence by non-int of type 'float'` when calling `cost = (price * filled) if (average is None) else (average * filled)` from exchange.safe_order.