### PR TITLE
gateio safeInteger

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -215,9 +215,9 @@ module.exports = class gateio extends Exchange {
                 const currency = coin[id];
                 const code = this.safeCurrencyCode (id);
                 const delisted = this.safeValue (currency, 'delisted', 0);
-                const withdrawDisabled = this.safeValue (currency, 'withdraw_disabled', 0);
-                const depositDisabled = this.safeValue (currency, 'deposit_disabled', 0);
-                const tradeDisabled = this.safeValue (currency, 'trade_disabled', 0);
+                const withdrawDisabled = this.safeInteger2 (currency, 'withdraw_disabled', 0);
+                const depositDisabled = this.safeInteger2 (currency, 'deposit_disabled', 0);
+                const tradeDisabled = this.safeInteger2 (currency, 'trade_disabled', 0);
                 const listed = (delisted === 0);
                 const withdrawEnabled = (withdrawDisabled === 0);
                 const depositEnabled = (depositDisabled === 0);
@@ -324,7 +324,7 @@ module.exports = class gateio extends Exchange {
                 'price': priceLimits,
                 'cost': costLimits,
             };
-            const disabled = this.safeValue (details, 'trade_disabled');
+            const disabled = this.safeInteger (details, 'trade_disabled');
             const active = !disabled;
             const uppercaseId = id.toUpperCase ();
             const fee = this.safeFloat (details, 'fee');


### PR DESCRIPTION
Now after `loadMarkets` we get:


```
{
  limits: {
    amount: { min: 0.0001, max: undefined },
    price: { min: 1e-8, max: undefined },
    cost: { min: 0.001, max: undefined }
  },
  precision: { amount: 2, price: 8 },
  tierBased: true,
  percentage: true,
  taker: 0.002,
  maker: 0.002,
  id: 'mxc_eth',
  uppercaseId: 'MXC_ETH',
  symbol: 'MXC/ETH',
  base: 'MXC',
  quote: 'ETH',
  baseId: 'mxc',
  quoteId: 'eth',
  info: {
    mxc_eth: {
      decimal_places: '8',
      amount_decimal_places: '2',
      min_amount: '0.0001',
      min_amount_a: '0.0001',
      min_amount_b: '0.001',
      fee: '0.2',
      trade_disabled: '0',
      buy_disabled: '0',
      sell_disabled: 0
    }
  },
  active: false
}
```

so `active: false`. Maybe gate.io change their responce