### PR TITLE
digifinex is_allow

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -347,7 +347,7 @@ module.exports = class digifinex extends Exchange {
             // const status = this.safeString (market, 'status');
             // const active = (status === 'TRADING');
             //
-            const isAllowed = this.safeValue (market, 'is_allow', 1);
+            const isAllowed = this.safeInteger (market, 'is_allow', 1);
             const active = isAllowed ? true : false;
             const type = 'spot';
             const spot = (type === 'spot');


### PR DESCRIPTION
Now we have problems with string number
```
{
    order_types: [ 'LIMIT' ],
    quote_asset: 'ETH',
    minimum_value: '0.005',
    amount_precision: '2',
    status: 'TRADING',
    minimum_amount: '2',
    symbol: 'ABBC_ETH',
    is_allow: '0',
    zone: 'INNOVATE',
    base_asset: 'ABBC',
    price_precision: 8
  }
```