### PR TITLE
binance-safeOrder

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1768,7 +1768,7 @@ module.exports = class binance extends Exchange {
         //         "updateTime": 1499827319559
         //     }
         //
-        // market orders with { result: "FULL" }
+        // market orders with { "newOrderRespType": "FULL" }
         //
         //     {
         //       "symbol": "BTCUSDT",

--- a/js/binance.js
+++ b/js/binance.js
@@ -1768,7 +1768,7 @@ module.exports = class binance extends Exchange {
         //         "updateTime": 1499827319559
         //     }
         //
-        // market orders with { "newOrderRespType": "FULL" }
+        //  createOrder with { "newOrderRespType": "FULL" }
         //
         //     {
         //       "symbol": "BTCUSDT",

--- a/js/binance.js
+++ b/js/binance.js
@@ -1729,7 +1729,7 @@ module.exports = class binance extends Exchange {
 
     parseOrder (order, market = undefined) {
         //
-        //  spot
+        // spot
         //
         //     {
         //         "symbol": "LTCBTC",
@@ -1750,7 +1750,7 @@ module.exports = class binance extends Exchange {
         //         "isWorking": true
         //     }
         //
-        //  futures
+        // futures
         //
         //     {
         //         "symbol": "BTCUSDT",
@@ -1768,7 +1768,7 @@ module.exports = class binance extends Exchange {
         //         "updateTime": 1499827319559
         //     }
         //
-        //  createOrder with { "newOrderRespType": "FULL" }
+        // createOrder with { "newOrderRespType": "FULL" }
         //
         //     {
         //       "symbol": "BTCUSDT",

--- a/js/binance.js
+++ b/js/binance.js
@@ -1892,8 +1892,11 @@ module.exports = class binance extends Exchange {
         } else {
             request['newClientOrderId'] = clientOrderId;
         }
-        if (market['spot']) {
+        if ((orderType === 'spot') || (orderType === 'margin')) {
             request['newOrderRespType'] = this.safeValue (this.options['newOrderRespType'], type, 'RESULT'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
+        } else {
+            // delivery and future
+            request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
         }
         // additional required fields depending on the order type
         let timeInForceIsRequired = false;


### PR DESCRIPTION
also change `newOrderRespType` to FULL for limit orders (useful if people set limit orders above market price since they get more info, time difference is negligible)