### PR TITLE
zb change hostname

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -89,8 +89,8 @@ module.exports = class zb extends Exchange {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/32859187-cd5214f0-ca5e-11e7-967d-96568e2e2bd1.jpg',
                 'api': {
-                    'public': 'http://api.zb.cn/data', // no https for public API
-                    'private': 'https://trade.zb.cn/api',
+                    'public': 'https://api.zb.today/data',
+                    'private': 'https://trade.zb.today/api',
                 },
                 'www': 'https://www.zb.com',
                 'doc': 'https://www.zb.com/i/developer',


### PR DESCRIPTION
`ExchangeNotAvailable zb GET https://trade.zb.cn/api/getUnfinishedOrdersIgnoreTradeType?accesskey=xxx&currency=btc_usdt&method=getUnfinishedOrdersIgnoreTradeType&pageIndex=1&pageSize=10&sign=xxx&reqTime=1617363026971 system request to https://trade.zb.cn/api/getUnfinishedOrdersIgnoreTradeType?accesskey=xxx&currency=btc_usdt&method=getUnfinishedOrdersIgnoreTradeType&pageIndex=1&pageSize=10&sign=xxx&reqTime=1617363026971 failed, reason: Hostname/IP does not match certificate's altnames: Host: trade.zb.cn. is not in the cert's altnames: DNS:*.bitkk.com, DNS:bitkk.com`

https://www.zb.com/en/api

Also it now works with https
