### PR TITLE
fix timestamp type in huobipro fetch_ticker

### DIFF
--- a/python/ccxt/async_support/huobipro.py
+++ b/python/ccxt/async_support/huobipro.py
@@ -554,7 +554,7 @@ class huobipro(Exchange):
         #     }
         #
         ticker = self.parse_ticker(response['tick'], market)
-        timestamp = self.safe_value(response, 'ts')
+        timestamp = self.safe_integer(response, 'ts')
         ticker['timestamp'] = timestamp
         ticker['datetime'] = self.iso8601(timestamp)
         return ticker

--- a/python/ccxt/huobipro.py
+++ b/python/ccxt/huobipro.py
@@ -554,7 +554,7 @@ class huobipro(Exchange):
         #     }
         #
         ticker = self.parse_ticker(response['tick'], market)
-        timestamp = self.safe_value(response, 'ts')
+        timestamp = self.safe_integer(response, 'ts')
         ticker['timestamp'] = timestamp
         ticker['datetime'] = self.iso8601(timestamp)
         return ticker


### PR DESCRIPTION
Issue:
In fetch_ticker on huobipro, the timestamp result is a str instead of an integer