### PR TITLE
fix minPrice type in crex24 fetch_markets

### DIFF
--- a/js/crex24.js
+++ b/js/crex24.js
@@ -206,7 +206,7 @@ module.exports = class crex24 extends Exchange {
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
             const tickSize = this.safeValue (market, 'tickSize');
-            const minPrice = this.safeValue (market, 'minPrice');
+            const minPrice = this.safeNumber (market, 'minPrice');
             const minAmount = this.safeNumber (market, 'minVolume');
             const precision = {
                 'amount': this.precisionFromString (this.numberToString (minAmount)),


### PR DESCRIPTION
issue:
in crex24 market data, the limits["price"]["minPrice"] is a str instead of a float