### PR TITLE
Precise string add behaviour

### DIFF
--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -115,8 +115,13 @@ class Precise {
     }
 
     static stringAdd (string1, string2) {
-        if ((string1 === undefined) || (string2 === undefined)) {
+        if ((string1 === undefined) && (string2 === undefined)) {
             return undefined
+        }
+        if (string1 === undefined) {
+            return string2
+        } else if (string2 === undefined) {
+            return string1
         }
         return (new Precise (string1)).add (new Precise (string2)).toString ()
     }

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -121,8 +121,13 @@ class Precise {
     }
 
     public static function string_add($string1, $string2) {
-        if (($string1 === null) || ($string2 === null)) {
+        if (($string1 === null) && ($string2 === null)) {
             return null;
+        }
+        if ($string1 === null) {
+            return $string2;
+        } elseif ($string2 === null) {
+            return $string1;
         }
         return strval((new Precise($string1))->add(new Precise($string2)));
     }

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -105,8 +105,12 @@ class Precise:
 
     @staticmethod
     def string_add(string1, string2):
-        if string1 is None or string2 is None:
+        if string1 is None and string2 is None:
             return None
+        if string1 is None:
+            return string2
+        elif string2 is None:
+            return string1
         return str(Precise(string1).add(Precise(string2)))
 
     @staticmethod


### PR DESCRIPTION
this mimics the current behaviour in `exchange.sum` more closely and allows us to chain `Precise.stringAdd` without worrying about undefined propagating 

like so

```
Precise.stringAdd (Precise.stringAdd (one, two), three);
```