### PR TITLE
hitbtc fetchMarkets precise

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -249,8 +249,10 @@ module.exports = class hitbtc extends Exchange {
             if (id.indexOf ('_') >= 0) {
                 symbol = id;
             }
-            const lot = this.safeNumber (market, 'quantityIncrement');
-            const step = this.safeNumber (market, 'tickSize');
+            const lotString = this.safeString (market, 'quantityIncrement');
+            const stepString = this.safeString (market, 'tickSize');
+            const lot = this.parseNumber (lotString);
+            const step = this.parseNumber (stepString);
             const precision = {
                 'price': step,
                 'amount': lot,
@@ -282,7 +284,7 @@ module.exports = class hitbtc extends Exchange {
                         'max': undefined,
                     },
                     'cost': {
-                        'min': lot * step,
+                        'min': this.parseNumber (Precise.stringMul (lotString, stepString)),
                         'max': undefined,
                     },
                 },


### PR DESCRIPTION
```
  {
    "tierBased": false,
    "percentage": true,
    "taker": "0.0025",
    "maker": "0.001",
    "info": {
      "id": "BTCUSD",
      "baseCurrency": "BTC",
      "quoteCurrency": "USD",
      "quantityIncrement": "0.00001",
      "tickSize": "0.01",
      "takeLiquidityRate": "0.0025",
      "provideLiquidityRate": "0.001",
      "feeCurrency": "USD",
      "marginTrading": true,
      "maxInitialLeverage": "12.00"
    },
    "id": "BTCUSD",
    "symbol": "BTC/USDT",
    "base": "BTC",
    "quote": "USDT",
    "baseId": "BTC",
    "quoteId": "USD",
    "active": true,
    "precision": {
      "price": "0.01",
      "amount": "0.00001"
    },
    "feeCurrency": "USDT",
    "limits": {
      "amount": {
        "min": "0.00001"
      },
      "price": {
        "min": "0.01"
      },
      "cost": {
        "min": 1.0000000000000001e-7
      }
    }
  },
  ```
  
  
  looks better now...