### PR TITLE
zb fetchMarkets number

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -225,10 +225,10 @@ module.exports = class zb extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
-            const amountPrecisionString = this.safeString (market, 'amountScale', false);
-            const pricePrecisionString = this.safeString (market, 'priceScale', false);
-            const amountPrecision = amountPrecisionString ? '1e-' + amountPrecisionString : undefined;
-            const pricePrecision = pricePrecisionString ? '1e-' + pricePrecisionString : undefined;
+            const amountPrecisionString = this.safeString (market, 'amountScale');
+            const pricePrecisionString = this.safeString (market, 'priceScale');
+            const amountLimit = (amountPrecisionString === undefined) ? undefined : '1e-' + amountPrecisionString;
+            const priceLimit = (pricePrecisionString === undefined) ? undefined : '1e-' + pricePrecisionString;
             const precision = {
                 'amount': parseInt (amountPrecisionString),
                 'price': parseInt (pricePrecisionString),
@@ -244,11 +244,11 @@ module.exports = class zb extends Exchange {
                 'precision': precision,
                 'limits': {
                     'amount': {
-                        'min': this.parseNumber (amountPrecision),
+                        'min': this.parseNumber (amountLimit),
                         'max': undefined,
                     },
                     'price': {
-                        'min': this.parseNumber (pricePrecision),
+                        'min': this.parseNumber (priceLimit),
                         'max': undefined,
                     },
                     'cost': {

--- a/js/zb.js
+++ b/js/zb.js
@@ -225,9 +225,13 @@ module.exports = class zb extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
+            const amountPrecisionString = this.safeString (market, 'amountScale', false);
+            const pricePrecisionString = this.safeString (market, 'priceScale', false);
+            const amountPrecision = amountPrecisionString ? '1e-' + amountPrecisionString : undefined;
+            const pricePrecision = pricePrecisionString ? '1e-' + pricePrecisionString : undefined;
             const precision = {
-                'amount': this.safeInteger (market, 'amountScale'),
-                'price': this.safeInteger (market, 'priceScale'),
+                'amount': parseInt (amountPrecisionString),
+                'price': parseInt (pricePrecisionString),
             };
             result.push ({
                 'id': id,
@@ -240,11 +244,11 @@ module.exports = class zb extends Exchange {
                 'precision': precision,
                 'limits': {
                     'amount': {
-                        'min': Math.pow (10, -precision['amount']),
+                        'min': this.parseNumber (amountPrecision),
                         'max': undefined,
                     },
                     'price': {
-                        'min': Math.pow (10, -precision['price']),
+                        'min': this.parseNumber (pricePrecision),
                         'max': undefined,
                     },
                     'cost': {


### PR DESCRIPTION
```
  {
    "id": "pond_qc",
    "symbol": "POND/QC",
    "baseId": "pond",
    "quoteId": "qc",
    "base": "POND",
    "quote": "QC",
    "active": true,
    "precision": {
      "amount": 2,
      "price": 4
    },
    "limits": {
      "amount": {
        "min": 0.01
      },
      "price": {
        "min": 0.00009999999999999999
      },
      "cost": {
        "min": 0
      }
    },
```

fixes the `Math.pow (10, -5)` bug