### PR TITLE
hbtc MIS mapping

### DIFF
--- a/js/hbtc.js
+++ b/js/hbtc.js
@@ -259,6 +259,9 @@ module.exports = class hbtc extends Exchange {
                     'method': 'quoteGetTicker24hr',
                 },
             },
+            'commonCurrencies': {
+                'MIS': 'Themis Protocol',
+            },
         });
     }
 


### PR DESCRIPTION
https://www.coingecko.com/en/coins/themis#markets conflict with https://www.coingecko.com/en/coins/mithril-share#markets
Also we already have renamed Themis https://www.coingecko.com/en/coins/themis-network, so I suggest 'Themis Protocol'