### PR TITLE
Fill the withdraw id to withdraw return structure for Gateio

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -823,7 +823,7 @@ module.exports = class gateio extends Exchange {
         const response = await this.privatePostWithdraw (this.extend (request, params));
         return {
             'info': response,
-            'id': undefined,
+            'id': this.safeString (response, 'withdrawid'),
         };
     }
 

--- a/python/ccxt/gateio.py
+++ b/python/ccxt/gateio.py
@@ -783,7 +783,7 @@ class gateio(Exchange):
         response = self.privatePostWithdraw(self.extend(request, params))
         return {
             'info': response,
-            'id': None,
+            'id': self.safe_string(response, 'withdrawid'),
         }
 
     def fetch_transactions_by_type(self, type=None, code=None, since=None, limit=None, params={}):


### PR DESCRIPTION
Original withdraw structure do not process the withdraw response data, and return a None directly.