### PR TITLE
onJsonResponse-fix

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -608,7 +608,7 @@ module.exports = class Exchange {
     }
 
     onJsonResponse (responseBody) {
-        return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+),/g, '":"$1",') : responseBody;
+        return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)[,}]/g, '":"$1",') : responseBody;
     }
 
     setMarkets (markets, currencies = undefined) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -608,7 +608,7 @@ module.exports = class Exchange {
     }
 
     onJsonResponse (responseBody) {
-        return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)[,}]/g, '":"$1",') : responseBody;
+        return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
     }
 
     setMarkets (markets, currencies = undefined) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1444,7 +1444,7 @@ class Exchange {
     }
 
     public function on_json_response($response_body) {
-        return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+),/', '":"$1",', $response_body) : $response_body;
+        return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)[,}]/', '":"$1",', $response_body) : $response_body;
     }
 
     public function fetch($url, $method = 'GET', $headers = null, $body = null) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1444,7 +1444,7 @@ class Exchange {
     }
 
     public function on_json_response($response_body) {
-        return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)[,}]/', '":"$1",', $response_body) : $response_body;
+        return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)([,}])/', '":"$1"$2', $response_body) : $response_body;
     }
 
     public function fetch($url, $method = 'GET', $headers = null, $body = null) {


### PR DESCRIPTION
output of binance fetchTicker

```
{
  "symbol": "BTC/USDT",
  "timestamp": 1618740633316,
  "datetime": "2021-04-18T10:10:33.316Z",
  "high": 61891.33,
  "low": 50931.3,
  "bid": 55085.62,
  "bidVolume": 1.181162,
  "ask": 55085.63,
  "askVolume": 0.105514,
  "vwap": 57453.40246687,
  "open": 61647.19,
  "close": 55085.63,
  "last": 55085.63,
  "previousClose": 61647.2,
  "change": -6561.56,
  "percentage": -10.644,
  "baseVolume": 109482.601067,
  "quoteVolume": 6290147942.222137,
  "info": {
    "symbol": "BTCUSDT",
    "priceChange": "-6561.56000000",
    "priceChangePercent": "-10.644",
    "weightedAvgPrice": "57453.40246687",
    "prevClosePrice": "61647.20000000",
    "lastPrice": "55085.63000000",
    "lastQty": "0.00259600",
    "bidPrice": "55085.62000000",
    "bidQty": "1.18116200",
    "askPrice": "55085.63000000",
    "askQty": "0.10551400",
    "openPrice": "61647.19000000",
    "highPrice": "61891.33000000",
    "lowPrice": "50931.30000000",
    "volume": "109482.60106700",
    "quoteVolume": "6290147942.22213701",
    "openTime": "1618654233316",
    "closeTime": "1618740633316",
    "firstId": "772096571",
    "lastId": "775368582",
    "count": 3272012
  }
}
```

the last number inside the {} does not have a comma to end it, instead it has a closing brace so it doesn't get parsed as a string