### PR TITLE
Update BTCTurk API URL

### DIFF
--- a/js/btcturk.js
+++ b/js/btcturk.js
@@ -31,7 +31,7 @@ module.exports = class btcturk extends Exchange {
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87153926-efbef500-c2c0-11ea-9842-05b63612c4b9.jpg',
-                'api': 'https://www.btcturk.com/api',
+                'api': 'https://api.btcturk.com/api/v2',
                 'www': 'https://www.btcturk.com',
                 'doc': 'https://github.com/BTCTrader/broker-api-docs',
             },

--- a/python/ccxt/btcturk.py
+++ b/python/ccxt/btcturk.py
@@ -34,7 +34,7 @@ class btcturk(Exchange):
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87153926-efbef500-c2c0-11ea-9842-05b63612c4b9.jpg',
-                'api': 'https://www.btcturk.com/api',
+                'api': 'https://api.btcturk.com/api/v2',
                 'www': 'https://www.btcturk.com',
                 'doc': 'https://github.com/BTCTrader/broker-api-docs',
             },


### PR DESCRIPTION
[According to the docs](https://docs.btcturk.com/#usage), API URL is "https://api.btcturk.com/api/v2/", not " https://www.btcturk.com/api/"

I remembered we only need to update JS code, if that's the case, you can ignore the change in py code.