### PR TITLE
Fix empty bids list in python for NDAX exchange https://github.com/ccxt/ccxt/issues/9019

### DIFF
--- a/js/ndax.js
+++ b/js/ndax.js
@@ -386,7 +386,7 @@ module.exports = class ndax extends Exchange {
                 nonce = Math.max (nonce, newNonce);
             }
             const bidask = this.parseBidAsk (level, priceKey, amountKey);
-            const levelSide = this.safeValue (level, 9);
+            const levelSide = this.safeInteger (level, 9);
             const side = levelSide ? asksKey : bidsKey;
             result[side].push (bidask);
         }

--- a/python/ccxt/ndax.py
+++ b/python/ccxt/ndax.py
@@ -386,7 +386,7 @@ class ndax(Exchange):
                 nonce = max(nonce, newNonce)
             bidask = self.parse_bid_ask(level, priceKey, amountKey)
             levelSide = self.safe_value(level, 9)
-            side = asksKey if levelSide else bidsKey
+            side = asksKey if int(levelSide) else bidsKey
             result[side].append(bidask)
         result['bids'] = self.sort_by(result['bids'], 0, True)
         result['asks'] = self.sort_by(result['asks'], 0)


### PR DESCRIPTION
if '0', if '1' both  return true, therefore every level appears on asks and bids list is empty.