### PR TITLE
kucoin VAI mapping

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -248,6 +248,7 @@ module.exports = class kucoin extends Exchange {
                 'EDGE': 'DADI', // https://github.com/ccxt/ccxt/issues/5756
                 'WAX': 'WAXP',
                 'TRY': 'Trias',
+                'VAI': 'VAIOT',
             },
             'options': {
                 'version': 'v1',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/vaiot/markets/
conflict with https://coinmarketcap.com/currencies/vai/markets/