### PR TITLE
hbtc parseMarket enhancement

### DIFF
--- a/js/hbtc.js
+++ b/js/hbtc.js
@@ -299,6 +299,12 @@ module.exports = class hbtc extends Exchange {
             spot = false;
             option = true;
         }
+        const margin = this.safeValue (market, 'allowMargin', undefined);
+        const isAggregate = this.safeValue (market, 'isAggregate', undefined);
+        let active = true;
+        if (isAggregate === true) {
+            active = false;
+        }
         let amountMin = undefined;
         let amountMax = undefined;
         let priceMin = undefined;
@@ -347,11 +353,12 @@ module.exports = class hbtc extends Exchange {
             'quote': quote,
             'baseId': baseId,
             'quoteId': quoteId,
-            'active': true,
+            'active': active,
             'type': type,
             'spot': spot,
             'future': future,
             'option': option,
+            'margin': margin,
             'inverse': inverse,
             'precision': precision,
             'limits': limits,
@@ -371,18 +378,22 @@ module.exports = class hbtc extends Exchange {
         //                 "filters":[
         //                     {"minPrice":"0.01","maxPrice":"100000.00000000","tickSize":"0.01","filterType":"PRICE_FILTER"},
         //                     {"minQty":"0.0005","maxQty":"100000.00000000","stepSize":"0.000001","filterType":"LOT_SIZE"},
-        //                     {"minNotional":"5","filterType":"MIN_NOTIONAL"}
+        //                     {"minNotional":"0.01","filterType":"MIN_NOTIONAL"}
         //                 ],
         //                 "exchangeId":"301",
         //                 "symbol":"BTCUSDT",
         //                 "symbolName":"BTCUSDT",
         //                 "status":"TRADING",
         //                 "baseAsset":"BTC",
+        //                 "baseAssetName":"BTC",
         //                 "baseAssetPrecision":"0.000001",
         //                 "quoteAsset":"USDT",
+        //                 "quoteAssetName":"USDT",
         //                 "quotePrecision":"0.01",
-        //                 "icebergAllowed":false
-        //             },
+        //                 "icebergAllowed":false,
+        //                 "isAggregate":false,
+        //                 "allowMargin":true
+        //            },
         //         ],
         //         "options":[
         //             {
@@ -396,10 +407,14 @@ module.exports = class hbtc extends Exchange {
         //                 "symbolName":"BTC0501CS8500",
         //                 "status":"TRADING",
         //                 "baseAsset":"BTC0501CS8500",
+        //                 "baseAssetName":"BTC0306CS3800",
         //                 "baseAssetPrecision":"0.001",
         //                 "quoteAsset":"BUSDT",
+        //                 "quoteAssetName":"BUSDT",
         //                 "quotePrecision":"0.01",
         //                 "icebergAllowed":false
+        //                 "isAggregate":false,
+        //                 "allowMargin":false
         //             },
         //         ],
         //         "contracts":[


### PR DESCRIPTION
> What is Aggregate Trading Pair?
> When a user buys and/or sells currencies on HBTC, our Aggregate trading system will automatically place the same buy and/or sell order on other exchanges. Therefore, our user is assured that the assets purchased through this process are all real assets in full reserves. Aggregate trading is commonly used in the trading industry. The purpose of HBTC aggregate trading is mainly to provide our users with access to new and popular assets. HBTC aggregate trading system uses a local and an external order matching mechanism with transaction speed and user experience that are similar to that of placing an order on other trading pairs on HBTC. HBTC will evaluate the holding amount of these aggregate trading tokens later and consider to dock with the project wallets for these projects with a large holding amount, to meet the deposit and withdrawal requirements of users.


As i found, API trading on this market is not allowed:
`ExchangeError hbtc {"code":-1157,"msg":"The trading pair is not available for api trading"}`

https://api.hbtc.com/openapi/v1/brokerInfo