### PR TITLE
bitforex ACE mapping

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -223,6 +223,7 @@ module.exports = class bitforex extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'ACE': 'ACE Entertainment',
                 'CREDIT': 'TerraCredit',
                 'CTC': 'Culture Ticket Chain',
                 'HBC': 'Hybrid Bank Cash',


### PR DESCRIPTION
https://aceentertainment.io/
conflict with https://www.acent.tech/ on KuCoin