### PR TITLE
Fix for EQUOS's parseOrderBook

### DIFF
--- a/js/equos.js
+++ b/js/equos.js
@@ -379,7 +379,7 @@ module.exports = class equos extends Exchange {
         ];
     }
 
-    parseOrderBook (orderbook, timestamp = undefined, bidsKey = 'bids', asksKey = 'asks', priceKey = 0, amountKey = 1, market = undefined) {
+    parseOrderBook (orderbook, symbol, timestamp = undefined, bidsKey = 'bids', asksKey = 'asks', priceKey = 0, amountKey = 1, market = undefined) {
         const result = {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),


### PR DESCRIPTION
Since [1.48.46](https://github.com/ccxt/ccxt/commit/d1663db6adcd9599e3bae69cdf698d8be7ea67b0), the EQUOS fetch orderbook has been failing.

A minimal repro in python is:
```
import ccxt
equos = ccxt.equos()
equos.fetch_order_book('BTC/USDC')
```

which returns:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-461ad2b2c761> in <module>
      1 import ccxt
      2 equos = ccxt.equos()
----> 3 equos.fetch_order_book('BTC/USDC')

/usr/local/lib/python3.8/dist-packages/ccxt/equos.py in fetch_order_book(self, symbol, limit, params)
    417         #     }
    418         #
--> 419         return self.parse_order_book(response, symbol, None, 'bids', 'asks', 0, 1, market)
    420 
    421     def fetch_trades(self, symbol, since=None, limit=None, params={}):

TypeError: parse_order_book() takes from 2 to 8 positional arguments but 9 were given
```

This is because the [fetchOrderBook](https://github.com/ccxt/ccxt/blob/master/js/equos.js#L430) function was updated, but the corresponding [parseOrderBook](https://github.com/ccxt/ccxt/blob/master/js/equos.js#L382) signature was not.

After adding symbol to the parseOrderBook function in js, and transpiling the code using `npm`, I'm able to run this functionality successfully again.