### PR TITLE
Add hold-balances endpoint for Coinbase Pro

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -122,8 +122,9 @@ module.exports = class coinbasepro extends Exchange {
                         'reports/{report_id}',
                         'transfers',
                         'transfers/{transfer_id}',
-                        'users/self/trailing-volume',
                         'users/self/exchange-limits',
+                        'users/self/hold-balances',
+                        'users/self/trailing-volume',
                         'withdrawals/fee-estimate',
                     ],
                     'post': [


### PR DESCRIPTION
I needed this to determine how much I can withdraw. Here's what it outputs:

```
{
    "total_hold_balance": {
        "amount": "0.00",
        "currency": "USD"
    },
    "pending_holds": [{
        "date": "2021-05-03T01:08:51Z",
        "amount": {
            "amount": "10.00",
            "currency": "USD"
        },
        "available_in": "4 days",
        "transfer": {
            "resource": "Deposit",
            "currency": "USD"
        },
        "exchange": true
    }, {
        "date": "2021-05-03T00:55:15Z",
        "amount": {
            "amount": "10.00",
            "currency": "USD"
        },
        "available_in": "4 days",
        "transfer": {
            "resource": "Deposit",
            "currency": "USD"
        },
        "exchange": true
    }, {
        "date": "2021-05-02T23:41:39Z",
        "amount": {
            "amount": "10.00",
            "currency": "USD"
        },
        "available_in": "4 days",
        "transfer": {
            "resource": "Deposit",
            "currency": "USD"
        },
        "exchange": true
    }],
    "completed_optional_textmatch": false,
    "available_balance": {
        "amount": "0.20",
        "currency": "USD"
    },
    "total_portfolio_balance": {
        "amount": "30.20",
        "currency": "USD"
    },
    "support_url": {
        "link": "https://help.coinbase.com/en/pro/trading-and-funding/depositing-or-withdrawing/available-balance",
        "text": "Learn more"
    },
    "description": "While we wait for your bank transfers you can instantly trade with your total balance. Your pending deposits will be available to send or withdraw in a few days.",
    "total_hold_balance_pro": {
        "amount": "30.00",
        "currency": "USD"
    }
}
```