### PR TITLE
bithumb: reset precision of BTC price (to 4), set BTC costs

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -112,11 +112,21 @@ module.exports = class bithumb extends Exchange {
             'options': {
                 'quoteCurrencies': {
                     'BTC': {
-                        'precision': {
-                            'price': 8,
+                        'limits': {
+                            'cost': {
+                                'min': 0.0002,
+                                'max': 100,
+                            },
                         },
                     },
-                    'KRW': {},
+                    'KRW': {
+                        'limits': {
+                            'cost': {
+                                'min': 500,
+                                'max': 5000000000,
+                            },
+                        },
+                    },
                 },
             },
         });
@@ -172,10 +182,7 @@ module.exports = class bithumb extends Exchange {
                             'min': undefined,
                             'max': undefined,
                         },
-                        'cost': {
-                            'min': 500,
-                            'max': 5000000000,
-                        },
+                        'cost': {}, // set via options
                     },
                     'baseId': undefined,
                     'quoteId': undefined,


### PR DESCRIPTION
These settings work for me. I found the 0.0002 via an error.
I deduced the cost of 100 BTC from the KRW pair.