### PR TITLE
hbtc precisions fix

### DIFF
--- a/js/hbtc.js
+++ b/js/hbtc.js
@@ -310,16 +310,20 @@ module.exports = class hbtc extends Exchange {
         let priceMin = undefined;
         let priceMax = undefined;
         let costMin = undefined;
+        let pricePrecision = undefined;
+        let amountPrecision = undefined;
         for (let j = 0; j < filters.length; j++) {
             const filter = filters[j];
             const filterType = this.safeString (filter, 'filterType');
             if (filterType === 'LOT_SIZE') {
                 amountMin = this.safeNumber (filter, 'minQty');
                 amountMax = this.safeNumber (filter, 'maxQty');
+                amountPrecision = this.safeNumber (filter, 'stepSize');
             }
             if (filterType === 'PRICE_FILTER') {
                 priceMin = this.safeNumber (filter, 'minPrice');
                 priceMax = this.safeNumber (filter, 'maxPrice');
+                pricePrecision = this.safeNumber (filter, 'tickSize');
             }
             if (filterType === 'MIN_NOTIONAL') {
                 costMin = this.safeNumber (filter, 'minNotional');
@@ -329,8 +333,10 @@ module.exports = class hbtc extends Exchange {
             costMin = amountMin * priceMin;
         }
         const precision = {
-            'price': this.safeNumber2 (market, 'quotePrecision', 'quoteAssetPrecision'),
-            'amount': this.safeNumber (market, 'baseAssetPrecision'),
+            'price': pricePrecision,
+            'amount': amountPrecision,
+            'base': this.safeNumber (market, 'baseAssetPrecision'),
+            'quote': this.safeNumber2 (market, 'quotePrecision', 'quoteAssetPrecision'),
         };
         const limits = {
             'amount': {

--- a/js/hbtc.js
+++ b/js/hbtc.js
@@ -325,11 +325,8 @@ module.exports = class hbtc extends Exchange {
                 priceMax = this.safeNumber (filter, 'maxPrice');
                 pricePrecision = this.safeNumber (filter, 'tickSize');
             }
-            if (filterType === 'MIN_NOTIONAL') {
-                costMin = this.safeNumber (filter, 'minNotional');
-            }
         }
-        if ((costMin === undefined) && (amountMin !== undefined) && (priceMin !== undefined)) {
+        if ((amountMin !== undefined) && (priceMin !== undefined)) {
             costMin = amountMin * priceMin;
         }
         const precision = {


### PR DESCRIPTION
```
{"filters":
  [
    {"minPrice":"0.0001","maxPrice":"100000.00000000","tickSize":"0.0001","filterType":"PRICE_FILTER"},
    {"minQty":"1","maxQty":"100000.00000000","stepSize":"0.01","filterType":"LOT_SIZE"},
    {"minNotional":"10","filterType":"MIN_NOTIONAL"}
  ],
  "exchangeId":"301",
  "symbol":"ONGUSDT",
  "symbolName":"ONGUSDT",
  "status":"TRADING",
  "baseAsset":"ONG",
  "baseAssetName":"ONG",
  "baseAssetPrecision":"0.01",
  "quoteAsset":"USDT",
  "quoteAssetName":"USDT",
  "quotePrecision":"0.01",
  "icebergAllowed":false,
  "isAggregate":false,
  "allowMargin":false
},
```

https://www.hbtc.com/exchange/ONG/USDT

True price precision is 0.0001 and it's not equal to `quotePrecision`
