### PR TITLE
Fix poloniex error to actually be OrderNotFound

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -202,7 +202,7 @@ module.exports = class poloniex extends Exchange {
                     'Nonce must be greater': InvalidNonce,
                     'You have already called cancelOrder or moveOrder on this order.': CancelPending,
                     'Amount must be at least': InvalidOrder, // {"error":"Amount must be at least 0.000001."}
-                    'is either completed or does not exist': InvalidOrder, // {"error":"Order 587957810791 is either completed or does not exist."}
+                    'is either completed or does not exist': OrderNotFound, // {"error":"Order 587957810791 is either completed or does not exist."}
                     'Error pulling ': ExchangeError, // {"error":"Error pulling order book"}
                 },
             },


### PR DESCRIPTION
According to https://github.com/ccxt/ccxt/wiki/Manual#exceptions-on-order-canceling, `OrderNotFound` is the appropriate exception if cancelling an order fails due to it already being filled / already cancelled / not found.
This makes the behaviour of the poloniex wrapper actually do this instead of inappropriately throwing `InvalidOrder`.