### PR TITLE
Coinbase Prime Deprecating old API URLs

### DIFF
--- a/js/coinbaseprime.js
+++ b/js/coinbaseprime.js
@@ -12,20 +12,19 @@ module.exports = class coinbaseprime extends coinbasepro {
             'id': 'coinbaseprime',
             'name': 'Coinbase Prime',
             'pro': true,
-            'hostname': 'prime.coinbase.com',
+            'hostname': 'exchange.coinbase.com',
             'urls': {
                 'test': {
-                    'public': 'https://api-public.sandbox.prime.coinbase.com',
-                    'private': 'https://api-public.sandbox.prime.coinbase.com',
+                    'public': 'https://public.sandbox.exchange.coinbase.com',
+                    'private': 'https://public.sandbox.exchange.coinbase.com',
                 },
                 'logo': 'https://user-images.githubusercontent.com/1294454/44539184-29f26e00-a70c-11e8-868f-e907fc236a7c.jpg',
                 'api': {
                     'public': 'https://api.{hostname}',
                     'private': 'https://api.{hostname}',
                 },
-                'www': 'https://prime.coinbase.com',
-                'doc': 'https://docs.prime.coinbase.com',
-                'fees': 'https://support.prime.coinbase.com/customer/en/portal/articles/2945629-fees?b_id=17475',
+                'www': 'https://exchange.coinbase.com',
+                'doc': 'https://docs.exchange.coinbase.com',
             },
         });
     }


### PR DESCRIPTION
Prime is deprecating current URLs on June 3rd. See notice below:
https://docs.exchange.coinbase.com/#introduction