### PR TITLE
bitfinex BCHN, BCHABC mapping

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -305,6 +305,7 @@ module.exports = class bitfinex extends Exchange {
                 'IQX': 'IQ',
                 'MNA': 'MANA',
                 'ORS': 'ORS Group', // conflict with Origin Sport #3230
+                'PAS': 'PASS',
                 'QSH': 'QASH',
                 'QTM': 'QTUM',
                 'RBT': 'RBTC',

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -294,6 +294,7 @@ module.exports = class bitfinex extends Exchange {
                 'BCHABC': 'BCHA',
                 'BCHN': 'BCH',
                 'DAT': 'DATA',
+                'DOG': 'MDOGE',
                 'DSH': 'DASH',
                 // https://github.com/ccxt/ccxt/issues/7399
                 // https://coinmarketcap.com/currencies/pnetwork/

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -294,7 +294,8 @@ module.exports = class bitfinex extends Exchange {
                 'AMP': 'AMPL',
                 'ATM': 'ATMI',
                 'ATO': 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
-                'BAB': 'BCH',
+                'BCHABC': 'BCHA',
+                'BCHN': 'BCH',
                 'CTX': 'CTXC',
                 'DAD': 'DADI',
                 'DAT': 'DATA',

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -299,6 +299,8 @@ module.exports = class bitfinex extends Exchange {
                 // https://coinmarketcap.com/currencies/pnetwork/
                 // https://en.cryptonomist.ch/blog/eidoo/the-edo-to-pnt-upgrade-what-you-need-to-know-updated/
                 'EDO': 'PNT',
+                'EUS': 'EURS',
+                'EUT': 'EURT',
                 'IOT': 'IOTA',
                 'IQX': 'IQ',
                 'MNA': 'MANA',

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -288,46 +288,30 @@ module.exports = class bitfinex extends Exchange {
             },
             // todo rewrite for https://api-pub.bitfinex.com//v2/conf/pub:map:tx:method
             'commonCurrencies': {
-                'ABS': 'ABYSS',
-                'AIO': 'AION',
                 'ALG': 'ALGO', // https://github.com/ccxt/ccxt/issues/6034
                 'AMP': 'AMPL',
-                'ATM': 'ATMI',
                 'ATO': 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
                 'BCHABC': 'BCHA',
                 'BCHN': 'BCH',
-                'CTX': 'CTXC',
-                'DAD': 'DADI',
                 'DAT': 'DATA',
                 'DSH': 'DASH',
-                'DRK': 'DRK',
                 // https://github.com/ccxt/ccxt/issues/7399
                 // https://coinmarketcap.com/currencies/pnetwork/
                 // https://en.cryptonomist.ch/blog/eidoo/the-edo-to-pnt-upgrade-what-you-need-to-know-updated/
                 'EDO': 'PNT',
-                'GSD': 'GUSD',
-                'HOT': 'Hydro Protocol',
-                'IOS': 'IOST',
                 'IOT': 'IOTA',
                 'IQX': 'IQ',
-                'MIT': 'MITH',
                 'MNA': 'MANA',
-                'NCA': 'NCASH',
                 'ORS': 'ORS Group', // conflict with Origin Sport #3230
-                'POY': 'POLY',
                 'QSH': 'QASH',
                 'QTM': 'QTUM',
                 'RBT': 'RBTC',
-                'SEE': 'SEER',
                 'SNG': 'SNGLS',
-                'SPK': 'SPANK',
                 'STJ': 'STORJ',
-                'TRI': 'TRIO',
                 'TSD': 'TUSD',
                 'YYW': 'YOYOW',
                 'UDC': 'USDC',
                 'UST': 'USDT',
-                'UTN': 'UTNP',
                 'VSY': 'VSYS',
                 'WAX': 'WAXP',
                 'XCH': 'XCHF',


### PR DESCRIPTION
Strange but after november 2020 hard fork bitfinex messed up BCHABC and BCH

BCH:
https://trading.bitfinex.com/t/BCHN:USD?demo=true
https://www.coingecko.com/en/coins/bitcoin-cash#markets

BCHA:
https://trading.bitfinex.com/t/BCHABC:USD?demo=true
https://www.coingecko.com/en/coins/bitcoin-cash-abc#markets