### PR TITLE
bitforex GOT mapping

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -226,6 +226,7 @@ module.exports = class bitforex extends Exchange {
                 'ACE': 'ACE Entertainment',
                 'CREDIT': 'TerraCredit',
                 'CTC': 'Culture Ticket Chain',
+                'GOT': 'GoNetwork',
                 'HBC': 'Hybrid Bank Cash',
                 'IQ': 'IQ.Cash',
                 'UOS': 'UOS Network',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/gonetwork/markets/
conflict with https://coinmarketcap.com/currencies/parkingo/markets/