### PR TITLE
binance: Fix code 1104: Do not send 'created' parameter

### DIFF
--- a/python/ccxt/binance.py
+++ b/python/ccxt/binance.py
@@ -1818,7 +1818,7 @@ class binance(Exchange):
         defaultType = self.safe_string_2(self.options, 'createOrder', 'defaultType', market['type'])
         orderType = self.safe_string(params, 'type', defaultType)
         clientOrderId = self.safe_string_2(params, 'newClientOrderId', 'clientOrderId')
-        params = self.omit(params, ['type', 'newClientOrderId', 'clientOrderId'])
+        params = self.omit(params, ['type', 'newClientOrderId', 'clientOrderId', 'created'])
         method = 'privatePostOrder'
         if orderType == 'future':
             method = 'fapiPrivatePostOrder'


### PR DESCRIPTION
It seems Binance is a bit strict, discarding order-requests
if they transmit unknown parameters.

The 'created' parameter is outside Binance's v3 API,
hence all trading orders were met with the following error:

"code":-1104,"msg":"Not all sent parameters were read;
read '9' parameter(s) but was sent '10'