### PR TITLE
Add Binance margin interestRateHistory endpoint

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -137,6 +137,7 @@ module.exports = class binance extends Exchange {
                         'margin/isolated/account',
                         'margin/isolated/pair',
                         'margin/isolated/allPairs',
+                        'margin/interestRateHistory',
                         'fiatpayment/query/deposit/history',
                         'fiatpayment/query/withdraw/history',
                         'futures/transfer',


### PR DESCRIPTION
This endpoint was added on 2021-03-05.

https://binance-docs.github.io/apidocs/spot/en/#query-margin-interest-rate-history-user_data