### PR TITLE
hbtc maxAmount undefined

### DIFF
--- a/js/hbtc.js
+++ b/js/hbtc.js
@@ -306,7 +306,6 @@ module.exports = class hbtc extends Exchange {
             active = false;
         }
         let amountMin = undefined;
-        let amountMax = undefined;
         let priceMin = undefined;
         let priceMax = undefined;
         let costMin = undefined;
@@ -317,7 +316,6 @@ module.exports = class hbtc extends Exchange {
             const filterType = this.safeString (filter, 'filterType');
             if (filterType === 'LOT_SIZE') {
                 amountMin = this.safeNumber (filter, 'minQty');
-                amountMax = this.safeNumber (filter, 'maxQty');
                 amountPrecision = this.safeNumber (filter, 'stepSize');
             }
             if (filterType === 'PRICE_FILTER') {
@@ -338,7 +336,7 @@ module.exports = class hbtc extends Exchange {
         const limits = {
             'amount': {
                 'min': amountMin,
-                'max': amountMax,
+                'max': undefined,
             },
             'price': {
                 'min': priceMin,


### PR DESCRIPTION
https://api.hbtc.com/openapi/v1/brokerInfo
It specified that `maxQty` is 100000 for all pairs but it is possible to create order with amount over `maxQty`

`{"filters":[{"minPrice":"0.00000001","maxPrice":"100000.00000000","tickSize":"0.00000001","filterType":"PRICE_FILTER"},{"minQty":"1","maxQty":"100000.00000000","stepSize":"1","filterType":"LOT_SIZE"},{"minNotional":"1","filterType":"MIN_NOTIONAL"}],"exchangeId":"301","symbol":"AKITAUSDT","symbolName":"AKITAUSDT","status":"TRADING","baseAsset":"AKITA","baseAssetName":"AKITA","baseAssetPrecision":"1","quoteAsset":"USDT","quoteAssetName":"USDT","quotePrecision":"1","icebergAllowed":false,"isAggregate":false,"allowMargin":false}`

![2021-06-03_18h09_17](https://user-images.githubusercontent.com/38309641/120668746-6d6e8f00-c497-11eb-921c-265c1fa23002.png)
