### PR TITLE
Add more specific exceptions for FTX

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -4,7 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { TICK_SIZE } = require ('./base/functions/number');
-const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol } = require ('./base/errors');
+const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId } = require ('./base/errors');
 const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------
@@ -237,6 +237,9 @@ module.exports = class ftx extends Exchange {
                     'Trigger price too high': InvalidOrder, // {"error":"Trigger price too high","success":false}
                     'Trigger price too low': InvalidOrder, // {"error":"Trigger price too low","success":false}
                     'Order already queued for cancellation': CancelPending, // {"error":"Order already queued for cancellation","success":false}
+                    'Duplicate client order ID': DuplicateOrderId, // {"error":"Duplicate client order ID","success":false}
+                    'Spot orders cannot be reduce-only': InvalidOrder, // {"error":"Spot orders cannot be reduce-only","success":false}
+                    'Invalid reduce-only order': InvalidOrder, // {"error":"Invalid reduce-only order","success":false}
                 },
                 'broad': {
                     'Account does not have enough margin for order': InsufficientFunds,


### PR DESCRIPTION
The following exceptions in FTX are raised as `ExchangeError` but could be more specific:

- Duplicate client order ID
- Spot orders can't be reducee-only
- Invalid reduce-only order

It's my first PR, I hope everything is ok 🤞 

To test the exception raising logic before and after, I created the following Python script:
```python
import asyncio
import uuid

from ccxt import ExchangeError
from ccxt.async_support import ftx

FTX_API_KEY = "provide yours"
FTX_API_SECRET = "provide yours"
FTX_SUBACCOUNT = "provide yours"


async def main() -> None:
    client = ftx(
        {
            "apiKey": FTX_API_KEY,
            "secret": FTX_API_SECRET,
            "headers": {"FTX-SUBACCOUNT": FTX_SUBACCOUNT},
        }
    )

    try:
        await duplicate_client_order_id(client)
        await invalid_reduce_only_order(client, "FTT/USD")
        await invalid_reduce_only_order(client, "FTT-PERP")
    finally:
        await client.close()

async def duplicate_client_order_id(client: ftx) -> None:
    print("\nPlacing 2 order with the same client_order_id.")

    order_id = uuid.uuid4().hex
    await client.create_limit_order(
        symbol="FTT/USD", side="buy", amount=1, price=20, params={"clientId": order_id}
    )
    try:
        await client.create_limit_order(
            symbol="FTT/USD", side="buy", amount=1, price=20, params={"clientId": order_id}
        )
    except ExchangeError as e:
        print(repr(e))
    finally:
        await client.cancel_order(id=None, params={"clientOrderId": order_id})


async def invalid_reduce_only_order(client: ftx, symbol: str) -> None:
    print(f"\nPlacing an invalid reduce-only order on {symbol}.")
    try:
        await client.create_limit_order(
            symbol=symbol, side="buy", amount=1, price=20, params={"reduceOnly": True}
        )
    except ExchangeError as e:
        print(repr(e))


if __name__ == '__main__':
    asyncio.run(main())
```