### PR TITLE
FTX: raise ExchangeNotAvailable on "Try again"

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -251,6 +251,7 @@ module.exports = class ftx extends Exchange {
                     'An unexpected error occurred': ExchangeNotAvailable, // {"error":"An unexpected error occurred, please try again later (58BC21C795).","success":false}
                     'Please retry request': ExchangeNotAvailable, // {"error":"Please retry request","success":false}
                     'Please try again': ExchangeNotAvailable, // {"error":"Please try again","success":false}
+                    'Try again': ExchangeNotAvailable, // {"error":"Try again","success":false}
                     'Only have permissions for subaccount': PermissionDenied, // {"success":false,"error":"Only have permissions for subaccount *sub_name*"}
                 },
             },


### PR DESCRIPTION
While inserting a new order on FTX, I got the following exception:

```
ccxt.base.errors.ExchangeError: ftx {"success":false,"error":"Try again"}" 
```

I think it is worth raising it as a `NetworkError` rather than an `ExchangeError`, such that it can be retried together with all the other transient errors.

Unfortunately it is not reproducible (it's the first time I see such an exception in months), but I got the detailed logs of this response.