### PR TITLE
huobipro revert NFT mapping

### DIFF
--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -253,7 +253,6 @@ module.exports = class huobipro extends Exchange {
                 'GET': 'Themis', // conflict with GET (Guaranteed Entrance Token, GET Protocol)
                 'GTC': 'Game.com', // conflict with Gitcoin and Gastrocoin
                 'HOT': 'Hydro Protocol', // conflict with HOT (Holo) https://github.com/ccxt/ccxt/issues/4929
-                'NFT': 'APENFT',
                 // https://github.com/ccxt/ccxt/issues/7399
                 // https://coinmarketcap.com/currencies/pnetwork/
                 // https://coinmarketcap.com/currencies/penta/markets/


### PR DESCRIPTION
now I see that https://coinmarketcap.com/currencies/apenft/markets/ has more markets specially on ccxt exchange than https://coinmarketcap.com/currencies/nft/markets/