### PR TITLE
qtrade fetchMarkets fix

### DIFF
--- a/js/qtrade.js
+++ b/js/qtrade.js
@@ -113,6 +113,7 @@ module.exports = class qtrade extends Exchange {
                     'invalid_auth': AuthenticationError,
                     'insuff_funds': InsufficientFunds,
                     'market_not_found': BadSymbol, // {"errors":[{"code":"market_not_found","title":"Requested market does not exist"}]}
+                    'too_small': InvalidOrder,
                 },
             },
         });
@@ -185,7 +186,7 @@ module.exports = class qtrade extends Exchange {
                 'maker': this.safeNumber (market, 'maker_fee'),
                 'limits': {
                     'amount': {
-                        'min': this.safeNumber (market, 'minimum_buy_value'),
+                        'min': this.safeNumber (market, 'minimum_sell_value'),
                         'max': undefined,
                     },
                     'price': {
@@ -193,7 +194,7 @@ module.exports = class qtrade extends Exchange {
                         'max': undefined,
                     },
                     'cost': {
-                        'min': undefined,
+                        'min': this.safeNumber (market, 'minimum_buy_value'),
                         'max': undefined,
                     },
                 },


### PR DESCRIPTION
`{"id":56,"market_currency":"BTC","base_currency":"USDT","maker_fee":"0","taker_fee":"0.005","metadata":{},"can_trade":true,"can_cancel":true,"can_view":true,"market_string":"BTC_USDT","minimum_sell_amount":"0.0001","minimum_buy_value":"0.1","market_precision":8,"base_precision":6},`

If we try to buy less than on 0.1 USDT, we get:
`{"errors":[{"code":"too_small","title":"Trade value (cost) is below minimum. Total value must be greater than 0.1 USDT, but amount * price = 0.09990000000333.","title_template":"Trade value (cost) is below minimum. Total value must be greater than {{minimum_value}} {{currency_code}}, but amount * price = {{order_value}}.","title_values":{"currency_code":"USDT","minimum_value":"0.1","order_value":"0.09990000000333"}}]}`

But we can create order with 0.1 USDT

If we try to sell less than 0.0001 BTC, we get:
`{"errors":[{"code":"too_small","title":"Trade amount is below minimum. Amount must be greater than 0.0001 BTC, but amount = 0.00005.","title_template":"Trade amount is below minimum. Amount must be greater than {{minimum_value}} {{currency_code}}, but amount = {{order_amount}}.","title_values":{"currency_code":"BTC","minimum_value":"0.0001","order_amount":"0.00005"}}]}`

So we can buy less than 0.0001 BTC but can't sell this amount. So i'm not sure is it right to set `min amount/cost` it this situation. But current `min amount` is 100% incorrect