### PR TITLE
bigone ANG -> Anagram

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -252,6 +252,7 @@ module.exports = class zb extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'ANG': 'Anagram',
                 'ENT': 'ENTCash',
             },
         });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38309641/122249510-964c4680-ced1-11eb-9bdf-61f721fb006d.png)
https://big.one/en/trade/ANG-USDT

conflict with https://coinmarketcap.com/currencies/aureus-nummus-gold/markets/