### PR TITLE
Update ftx-fetch-all-my-trades.py to avoid potential incomplete results

### DIFF
--- a/examples/py/ftx-fetch-all-my-trades.py
+++ b/examples/py/ftx-fetch-all-my-trades.py
@@ -38,15 +38,14 @@ while True:
         first_trade = trades[0]
         last_trade = trades[len(trades) - 1]
         end_time = first_trade['timestamp'] + 1000
+        print('Fetched', len(trades), 'trades from', first_trade['datetime'], 'till', last_trade['datetime'])
         fetched_new_trades = False
         for trade in trades:
             trade_id = trade['id']
             if trade_id not in all_trades:
                 fetched_new_trades = True
                 all_trades[trade_id] = trade
-        if fetched_new_trades:
-            print('Fetched', len(trades), 'trades from', first_trade['datetime'], 'till', last_trade['datetime'])
-        else:
+        if not fetched_new_trades:
             print('Done')
             break
     else:

--- a/examples/py/ftx-fetch-all-my-trades.py
+++ b/examples/py/ftx-fetch-all-my-trades.py
@@ -22,7 +22,7 @@ markets = exchange.load_markets ()
 
 # exchange.verbose = True  # uncomment for debugging
 
-all_trades = []
+all_trades = {}
 symbol = None
 since = None
 limit = 200
@@ -36,25 +36,25 @@ while True:
     trades = exchange.fetch_my_trades(symbol, since, limit, params)
     if len(trades):
         first_trade = trades[0]
-        if(end_time == first_trade['timestamp'] + 1000): break
         last_trade = trades[len(trades) - 1]
         end_time = first_trade['timestamp'] + 1000
-        all_trades = trades + all_trades
-        print('Fetched', len(trades), 'trades from', first_trade['datetime'], 'till', last_trade['datetime'])
+        fetched_new_trades = False
+        for trade in trades:
+            trade_id = trade['id']
+            if trade_id not in all_trades:
+                fetched_new_trades = True
+                all_trades[trade_id] = trade
+        if fetched_new_trades:
+            print('Fetched', len(trades), 'trades from', first_trade['datetime'], 'till', last_trade['datetime'])
+        else:
+            print('Done')
+            break
     else:
         print('Done')
         break
 
         
-ret_list = []
-dup_ids = set()
-for trade in all_trades:
-    if trade['id'] in dup_ids: continue
-    dup_ids.add(trade['id'])
-    ret_list = [trade] + ret_list
-all_trades = ret_list
-
-   
+all_trades = list(all_trades.values())
 
 print('Fetched', len(all_trades), 'trades')
 for i in range(0, len(all_trades)):

--- a/examples/py/ftx-fetch-all-my-trades.py
+++ b/examples/py/ftx-fetch-all-my-trades.py
@@ -36,14 +36,25 @@ while True:
     trades = exchange.fetch_my_trades(symbol, since, limit, params)
     if len(trades):
         first_trade = trades[0]
+        if(end_time == first_trade['timestamp'] + 1000): break
         last_trade = trades[len(trades) - 1]
-        end_time = first_trade['timestamp']
+        end_time = first_trade['timestamp'] + 1000
         all_trades = trades + all_trades
         print('Fetched', len(trades), 'trades from', first_trade['datetime'], 'till', last_trade['datetime'])
     else:
         print('Done')
         break
 
+        
+ret_list = []
+dup_ids = set()
+for trade in all_trades:
+    if trade['id'] in dup_ids: continue
+    dup_ids.add(trade['id'])
+    ret_list = [trade] + ret_list
+all_trades = ret_list
+
+   
 
 print('Fetched', len(all_trades), 'trades')
 for i in range(0, len(all_trades)):


### PR DESCRIPTION
just found that when multiple trades happened in the exact same time, it might get skipped. take the following trades as example:
            2601438152  2021-06-13T17:43:46.315639+00:00
            2601438154  2021-06-13T17:43:46.315639+00:00
            2601438156  2021-06-13T17:43:46.315639+00:00
            2601438158  2021-06-13T17:43:46.315639+00:00

if first_trade == 2601438158, then the others 3 trades will be skipped while querying for the next page since the end_time would be "2021-06-13T17:43:46.315639".
since there is no way to query page by trade id, I used a quick and dirty fix to add 1000 milliseconds to make sure the results overlap, and remove the duplicate records in the end.