### PR TITLE
equos.io has moved to eqonex.com

### DIFF
--- a/js/equos.js
+++ b/js/equos.js
@@ -11,7 +11,7 @@ module.exports = class equos extends Exchange {
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'equos',
-            'name': 'EQUOS',
+            'name': 'EQONEX',
             'countries': [ 'US', 'SG' ], // United States, Singapore
             'rateLimit': 10,
             'has': {
@@ -49,18 +49,18 @@ module.exports = class equos extends Exchange {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/107758499-05edd180-6d38-11eb-9e09-0b69602a7a15.jpg',
                 'test': {
-                    'public': 'https://testnet.equos.io/api',
-                    'private': 'https://testnet.equos.io/api',
+                    'public': 'https://testnet.eqonex.com/api',
+                    'private': 'https://testnet.eqonex.com/api',
                 },
                 'api': {
-                    'public': 'https://equos.io/api',
-                    'private': 'https://equos.io/api',
+                    'public': 'https://eqonex.com/api',
+                    'private': 'https://eqonex.com/api',
                 },
-                'www': 'https://equos.io',
+                'www': 'https://eqonex.com',
                 'doc': [
-                    'https://developer.equos.io',
+                    'https://developer.eqonex.com',
                 ],
-                'referral': 'https://equos.io?referredByCode=zpa8kij4ouvBFup3',
+                'referral': 'https://eqonex.com?referredByCode=zpa8kij4ouvBFup3',
             },
             'api': {
                 'public': {


### PR DESCRIPTION
The exchange equos.io has changed domain and name, and is now located at eqonex.com.

The existing domain and API currently redirects to the new name and API, but this might not last forever.

There is also a new logo, I've included a screen-grab of it here (but I don't think I have access to the images github storage space to update this myself)

![eqonex](https://user-images.githubusercontent.com/10614716/122644844-d6b5f980-d149-11eb-9685-d65a90347939.png)
