### PR TITLE
Install composer during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,27 +7,33 @@ ADD ./ /ccxt
 WORKDIR /ccxt
 
 # Update packages (use us.archive.ubuntu.com instead of archive.ubuntu.com — solves the painfully slow apt-get update)
-RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.list \
-    && apt-get update \
+RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.list
+
 # Miscellaneous deps
-    && apt-get install -y --no-install-recommends curl gnupg git ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git ca-certificates
 # PHP
-    && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath \
+RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath
 # Node
-    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-    && apt-get install -y nodejs \
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update && apt-get install -y nodejs
 # Python 3
-    && apt-get install -y --no-install-recommends python3 python3-pip \
-    && pip3 install 'idna==2.9' --force-reinstall \
-    && pip3 install --upgrade setuptools \
-    && pip3 install tox \
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip
+RUN pip3 install 'idna==2.9' --force-reinstall
+RUN pip3 install --upgrade setuptools
+RUN pip3 install tox
 # Installs as a local Node & Python module, so that `require ('ccxt')` and `import ccxt` should work after that
-    && npm install \
-    && ln -s /ccxt /usr/lib/node_modules/ \
-    && echo "export NODE_PATH=/usr/lib/node_modules" >> $HOME/.bashrc \
-    && cd python \
+RUN npm install
+RUN ln -s /ccxt /usr/lib/node_modules/
+RUN echo "export NODE_PATH=/usr/lib/node_modules" >> $HOME/.bashrc
+RUN cd python \
     && python3 setup.py develop \
-    && cd .. \
+    && cd ..
+## Install composer and everything else that it needs and manages
+RUN /ccxt/composer-install.sh
+RUN apt-get update && apt-get install -y --no-install-recommends zip unzip php-zip
+RUN mv /ccxt/composer.phar /usr/local/bin/composer
+RUN composer install
 ## Remove apt sources
-    && apt-get -y autoremove && apt-get clean && apt-get autoclean \
+RUN apt-get -y autoremove && apt-get clean && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+

--- a/composer-install.sh
+++ b/composer-install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This script taken from the composer installation instructions at
+# http://getcomposer.org/doc/faqs/how-to-install-composer-programatically.md
+
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT
+

--- a/composer.json
+++ b/composer.json
@@ -239,7 +239,9 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "symfony/polyfill-mbstring": "^1.7",
-        "pear/console_table": "1.3.1"
+        "pear/console_table": "1.3.1",
+        "react/http": "^1.3",
+        "recoil/react": "^1.0"
     },
     "suggest": {
         "recoil/recoil": "Required for asynchronous API calls to exchanges with PHP",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,7 @@
     "postinstall": "node postinstall"
   },
   "types": "./ccxt.d.ts",
-  "dependencies": {
-    "react": "^17.0.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "ansicolor": "1.1.81",
     "as-table": "1.0.37",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "postinstall": "node postinstall"
   },
   "types": "./ccxt.d.ts",
-  "dependencies": {},
+  "dependencies": {
+    "react": "^17.0.2"
+  },
   "devDependencies": {
     "ansicolor": "1.1.81",
     "as-table": "1.0.37",


### PR DESCRIPTION
For existing containers, it is necessary to run
docker-compose build ccxt
before these changes will take effect on the next
docker-compose run --rm ccxt
