### PR TITLE
FTX: map "No such future" error to BadSymbol exception

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -249,6 +249,7 @@ module.exports = class ftx extends Exchange {
                     'Invalid parameter': BadRequest, // {"error":"Invalid parameter start_time","success":false}
                     'The requested URL was not found on the server': BadRequest,
                     'No such coin': BadRequest,
+                    'No such future': BadSymbol,
                     'No such market': BadSymbol,
                     'Do not send more than': RateLimitExceeded,
                     'An unexpected error occurred': ExchangeNotAvailable, // {"error":"An unexpected error occurred, please try again later (58BC21C795).","success":false}


### PR DESCRIPTION
When calling `ftx.publicGetFundingRates(params={"symbol": "xyz-whatever"})` ([docs](https://docs.ftx.com/#get-funding-rates)), FTX raises an `ExchangeError` with this message:

```
ftx {"success":false,"error":"No such future: xyz-whatever "}
```

We can re-raise it more properly as a `BadSymbol` exception.