### PR TITLE
BigInt needs 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./ccxt.js",
   "unpkg": "dist/ccxt.browser.js",
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=10.4.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com"


### PR DESCRIPTION
ccxt is now using BigInt https://github.com/ccxt/ccxt/pull/9439
which have been included to nodejs 10.4.0
https://github.com/nodejs/node/pull/21167 check 4c48b69e90
https://github.com/nodejs/node/commit/4c48b69e90