### PR TITLE
Add Binance dust log and sub-account SAPI endpoints

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -128,6 +128,7 @@ module.exports = class binance extends Exchange {
                         'margin/priceIndex',
                         // these endpoints require this.apiKey + this.secret
                         'asset/assetDividend',
+                        'asset/dribblet',
                         'asset/transfer',
                         'asset/assetDetail',
                         'asset/tradeFee',
@@ -172,10 +173,12 @@ module.exports = class binance extends Exchange {
                         'sub-account/futures/accountSummary',
                         'sub-account/futures/positionRisk',
                         'sub-account/futures/internalTransfer',
+                        'sub-account/list',
                         'sub-account/margin/account',
                         'sub-account/margin/accountSummary',
                         'sub-account/spotSummary',
                         'sub-account/status',
+                        'sub-account/sub/transfer/history',
                         'sub-account/transfer/subUserHistory',
                         'sub-account/universalTransfer',
                         // lending endpoints


### PR DESCRIPTION
### Description
Add additional Binance SAPI endpoints. These replace their WAPI equivalents since the latter will be discontinued on 2021-08-01 2pm UTC.

### References
1. [DustLog](https://binance-docs.github.io/apidocs/spot/en/#dustlog-user_data)
2. [Query Sub-account List](https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-list-for-master-account)
3. [Query Sub-account Spot Asset Transfer History](https://binance-docs.github.io/apidocs/spot/en/#query-sub-account-spot-asset-transfer-history-for-master-account)
4. [Delisting WAPI endpoints](https://www.binance.com/en/support/announcement/f45dde7da58b473aa885349946bed269)