### PR TITLE
bibox fetchMarkets with right precisions

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -146,36 +146,23 @@ module.exports = class bibox extends Exchange {
 
     async fetchMarkets (params = {}) {
         const request = {
-            'cmd': 'marketAll',
+            'cmd': 'pairList',
         };
         const response = await this.publicGetMdata (this.extend (request, params));
         //
         //     {
         //         "result": [
         //             {
-        //                 "is_hide":0,
-        //                 "high_cny":"1.9478",
-        //                 "amount":"272.41",
-        //                 "coin_symbol":"BIX",
-        //                 "last":"0.00002487",
-        //                 "currency_symbol":"BTC",
-        //                 "change":"+0.00000073",
-        //                 "low_cny":"1.7408",
-        //                 "base_last_cny":"1.84538041",
-        //                 "area_id":7,
-        //                 "percent":"+3.02%",
-        //                 "last_cny":"1.8454",
-        //                 "high":"0.00002625",
-        //                 "low":"0.00002346",
-        //                 "pair_type":0,
-        //                 "last_usd":"0.2686",
-        //                 "vol24H":"10940613",
         //                 "id":1,
-        //                 "high_usd":"0.2835",
-        //                 "low_usd":"0.2534"
+        //                 "pair":"BIX_BTC",
+        //                 "pair_type":0,
+        //                 "area_id":7,
+        //                 "is_hide":0,
+        //                 "decimal":8,
+        //                 "amount_scale":4
         //             }
         //         ],
-        //         "cmd":"marketAll",
+        //         "cmd":"pairList",
         //         "ver":"1.1"
         //     }
         //
@@ -184,15 +171,20 @@ module.exports = class bibox extends Exchange {
         for (let i = 0; i < markets.length; i++) {
             const market = markets[i];
             const numericId = this.safeInteger (market, 'id');
-            const baseId = this.safeString (market, 'coin_symbol');
-            const quoteId = this.safeString (market, 'currency_symbol');
+            const id = this.safeString (market, 'pair');
+            let baseId = undefined;
+            let quoteId = undefined;
+            if (id !== undefined) {
+                const parts = id.split ('_');
+                baseId = this.safeString (parts, 0);
+                quoteId = this.safeString (parts, 1);
+            }
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
-            const id = baseId + '_' + quoteId;
             const precision = {
-                'amount': 4,
-                'price': 8,
+                'amount': this.safeNumber (market, 'amount_scale'),
+                'price': this.safeNumber (market, 'decimal'),
             };
             result.push ({
                 'id': id,


### PR DESCRIPTION
https://api.bibox.com/v1/mdata?cmd=pairList
`is_hide` looks like delisted on unavailable for API trading but on practice I can create order on this pairs using API, so all pairs `active: true`