### PR TITLE
liquid withdraw fix

### DIFF
--- a/js/liquid.js
+++ b/js/liquid.js
@@ -1015,30 +1015,30 @@ module.exports = class liquid extends Exchange {
             currency = this.currency (code);
         }
         const response = await this.privateGetCryptoWithdrawals (this.extend (request, params));
-            //
-            //     {
-            //         models: [
-            //             {
-            //                 id: '2',
-            //                 address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
-            //                 amount: '0.01',
-            //                 state: 'processed',
-            //                 currency: 'BTC',
-            //                 withdrawal_fee: '0.0005',
-            //                 created_at: '1614718276',
-            //                 updated_at: '1614720926',
-            //                 payment_id: null,
-            //                 transaction_hash: 'xxxxxxxx...',
-            //                 broadcasted_at: '1614720762',
-            //                 wallet_label: 'btc',
-            //                 chain_name: 'Bitcoin',
-            //                 network: null
-            //             },
-            //         ],
-            //         current_page: '1',
-            //         total_pages: '1'
-            //     }
-            //
+        //
+        //     {
+        //         models: [
+        //             {
+        //                 id: '2',
+        //                 address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+        //                 amount: '0.01',
+        //                 state: 'processed',
+        //                 currency: 'BTC',
+        //                 withdrawal_fee: '0.0005',
+        //                 created_at: '1614718276',
+        //                 updated_at: '1614720926',
+        //                 payment_id: null,
+        //                 transaction_hash: 'xxxxxxxx...',
+        //                 broadcasted_at: '1614720762',
+        //                 wallet_label: 'btc',
+        //                 chain_name: 'Bitcoin',
+        //                 network: null
+        //             },
+        //         ],
+        //         current_page: '1',
+        //         total_pages: '1'
+        //     }
+        //
         const transactions = this.safeValue (response, 'models', []);
         return this.parseTransactions (transactions, currency, since, limit);
     }
@@ -1105,7 +1105,7 @@ module.exports = class liquid extends Exchange {
         const id = this.safeString (transaction, 'id');
         const address = this.safeString (transaction, 'address');
         const tag = this.safeString2 (transaction, 'payment_id', 'memo_value');
-        const txid = this.safeString (transaction, 'transaction_hash');;
+        const txid = this.safeString (transaction, 'transaction_hash');
         const currencyId = this.safeString2 (transaction, 'currency', 'asset');
         const code = this.safeCurrencyCode (currencyId, currency);
         const timestamp = this.safeTimestamp (transaction, 'created_at');

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -34,6 +34,7 @@ module.exports = class liquid extends Exchange {
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,
+                'fetchWithdrawals': true,
                 'withdraw': true,
             },
             'urls': {
@@ -66,7 +67,7 @@ module.exports = class liquid extends Exchange {
                         'accounts/{id}',
                         'accounts/{currency}/reserved_balance_details',
                         'crypto_accounts', // add fetchAccounts
-                        'crypto_withdrawals', // add fetchWithdrawals
+                        'crypto_withdrawals',
                         'executions/me',
                         'fiat_accounts', // add fetchAccounts
                         'fund_infos', // add fetchDeposits
@@ -1004,11 +1005,55 @@ module.exports = class liquid extends Exchange {
         return this.parseTransaction (response, currency);
     }
 
+    async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        const request = {
+            // state: 'processed', // optional: pending, filed, cancelled, processing, processed, reverted to_be_reviewed, declined, broadcasted
+        };
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
+        const response = await this.privateGetCryptoWithdrawals (this.extend (request, params));
+            //
+            //     {
+            //         models: [
+            //             {
+            //                 id: '2',
+            //                 address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+            //                 amount: '0.01',
+            //                 state: 'processed',
+            //                 currency: 'BTC',
+            //                 withdrawal_fee: '0.0005',
+            //                 created_at: '1614718276',
+            //                 updated_at: '1614720926',
+            //                 payment_id: null,
+            //                 transaction_hash: 'xxxxxxxx...',
+            //                 broadcasted_at: '1614720762',
+            //                 wallet_label: 'btc',
+            //                 chain_name: 'Bitcoin',
+            //                 network: null
+            //             },
+            //         ],
+            //         current_page: '1',
+            //         total_pages: '1'
+            //     }
+            //
+        const transactions = this.safeValue (response, 'models', []);
+        return this.parseTransactions (transactions, currency, since, limit);
+    }
+
     parseTransactionStatus (status) {
         const statuses = {
             'pending': 'pending',
             'cancelled': 'canceled',
             'approved': 'ok',
+            'processing': 'pending',
+            'processed': 'ok',
+            'reverted': 'failed',
+            'to_be_reviewed': 'pending',
+            'declined': 'failed',
+            'broadcasted': 'ok',
         };
         return this.safeString (statuses, status, status);
     }
@@ -1018,32 +1063,57 @@ module.exports = class liquid extends Exchange {
         // withdraw
         //
         //     {
-        //         "id": 1353,
-        //         "address": "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2",
-        //         "amount": 1.0,
-        //         "state": "pending",
-        //         "currency": "BTC",
-        //         "withdrawal_fee": 0.0,
-        //         "created_at": 1568016450,
-        //         "updated_at": 1568016450,
-        //         "payment_id": null
-        //     }
+        //         id: '1',
+        //         address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+        //         amount: '0.01',
+        //         state: 'pending',
+        //         currency: 'BTC',
+        //         withdrawal_fee: '0.0007',
+        //         created_at: '1626000533',
+        //         updated_at: '1626000533',
+        //         payment_id: null,
+        //         transaction_hash: null,
+        //         broadcasted_at: null,
+        //         wallet_label: null,
+        //         chain_name: 'Bitcoin',
+        //         network: null
+        //     },
         //
-        // fetchDeposits, fetchWithdrawals
+        // fetchWithdrawals
+        //
+        //     {
+        //         id: '2',
+        //         address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+        //         amount: '0.01',
+        //         state: 'processed',
+        //         currency: 'BTC',
+        //         withdrawal_fee: '0.0005',
+        //         created_at: '1614718276',
+        //         updated_at: '1614720926',
+        //         payment_id: '',
+        //         transaction_hash: 'xxxxxxxx...',
+        //         broadcasted_at: '1614720762',
+        //         wallet_label: 'btc',
+        //         chain_name: 'Bitcoin',
+        //         network: null
+        //     },
+        //
+        // fetchDeposits
         //
         //     ...
         //
         const id = this.safeString (transaction, 'id');
         const address = this.safeString (transaction, 'address');
         const tag = this.safeString2 (transaction, 'payment_id', 'memo_value');
-        const txid = undefined;
-        const currencyId = this.safeString (transaction, 'asset');
+        const txid = this.safeString (transaction, 'transaction_hash');;
+        const currencyId = this.safeString2 (transaction, 'currency', 'asset');
         const code = this.safeCurrencyCode (currencyId, currency);
         const timestamp = this.safeTimestamp (transaction, 'created_at');
         const updated = this.safeTimestamp (transaction, 'updated_at');
         const type = 'withdrawal';
         const status = this.parseTransactionStatus (this.safeString (transaction, 'state'));
         const amount = this.safeNumber (transaction, 'amount');
+        const feeCost = this.safeNumber (transaction, 'withdrawal_fee');
         return {
             'info': transaction,
             'id': id,
@@ -1057,7 +1127,10 @@ module.exports = class liquid extends Exchange {
             'currency': code,
             'status': status,
             'updated': updated,
-            'fee': undefined,
+            'fee': {
+                'currency': code,
+                'cost': feeCost,
+            },
         };
     }
 

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -972,7 +972,7 @@ module.exports = class liquid extends Exchange {
             // 'auth_code': '', // optional 2fa code
             'currency': currency['id'],
             'address': address,
-            'amount': this.currencyToPrecision (code, amount),
+            'amount': amount,
             // 'payment_id': tag, // for XRP only
             // 'memo_type': 'text', // 'text', 'id' or 'hash', for XLM only
             // 'memo_value': tag, // for XLM only


### PR DESCRIPTION
in other cases I get 
`422 Unprocessable Entity {"message":"Submitted withdrawal amount is invalid","code":"valid_amount","additional_data":[]}
`

Because in `currencyToPrecision` makes `{"currency":"ETH","address":"0xxxx","amount":"0"}` in verbose, when I set amount 1