### PR TITLE
probit withdraw fix

### DIFF
--- a/js/probit.js
+++ b/js/probit.js
@@ -1103,7 +1103,7 @@ module.exports = class probit extends Exchange {
             // 'platform_id': 'ETH', // if omitted it will use the default platform for the currency
             'address': address,
             'destination_tag': tag,
-            'amount': this.currencyToPrecision (code, amount),
+            'amount': amount,
             // which currency to pay the withdrawal fees
             // only applicable for currencies that accepts multiple withdrawal fee options
             // 'fee_currency_id': 'ETH', // if omitted it will use the default fee policy for each currency


### PR DESCRIPTION
`currencyToPrecision` with TICK_SIZE gives incorrect results:
`currencyToPrecision ('USDT', 101) -> 102`