### PR TITLE
Okex v5: No need to parse lastTradeTs

### DIFF
--- a/js/okex5.js
+++ b/js/okex5.js
@@ -1515,7 +1515,7 @@ module.exports = class okex5 extends Exchange {
             'clientOrderId': clientOrderId,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'lastTradeTimestamp': this.iso8601 (lastTradeTimestamp),
+            'lastTradeTimestamp': lastTradeTimestamp,
             'symbol': symbol,
             'type': type,
             'timeInForce': timeInForce,


### PR DESCRIPTION
At Okex v5 we are using `this.iso8601` to parse the `lastTradeTimestamp` field, which I believe is not necessary. None of the other exchanges are doing it, so we shouldn't do it here.