### PR TITLE
Fix Okex cost/amount in market buy orders

### DIFF
--- a/js/okex5.js
+++ b/js/okex5.js
@@ -1488,12 +1488,18 @@ module.exports = class okex5 extends Exchange {
         }
         const marketId = this.safeString (order, 'instId');
         const symbol = this.safeSymbol (marketId, market, '-');
-        const amount = this.safeNumber (order, 'sz');
         const filled = this.safeNumber (order, 'accFillSz');
         const price = this.safeNumber2 (order, 'px', 'slOrdPx');
         const average = this.safeNumber (order, 'avgPx');
         const status = this.parseOrderStatus (this.safeString (order, 'state'));
         const feeCostString = this.safeString (order, 'fee');
+        let amount = undefined;
+        let cost = undefined;
+        if (side === 'buy' && type === 'market') {
+            cost = this.safeNumber (order, 'sz');
+        } else {
+            amount = this.safeNumber (order, 'sz');
+        }
         let fee = undefined;
         if (feeCostString !== undefined) {
             const feeCostSigned = Precise.stringNeg (feeCostString);
@@ -1524,7 +1530,7 @@ module.exports = class okex5 extends Exchange {
             'price': price,
             'stopPrice': stopPrice,
             'average': average,
-            'cost': undefined,
+            'cost': cost,
             'amount': amount,
             'filled': filled,
             'remaining': undefined,


### PR DESCRIPTION
Sell market order:
```json
{
      "accFillSz": "0.00033684",
      "avgPx": "31798.1",
      "category": "normal",
      "ccy": "",
      "feeCcy": "USDT",
      "fillPx": "31798.1",
      "fillSz": "0.00033684",
      "fillTime": "1626360349091",
      "instId": "BTC-USDT",
      "instType": "SPOT",
      "ordType": "market",
      "pnl": "0",
      "posSide": "net",
      "px": "",
      "rebate": "0",
      "rebateCcy": "BTC",
      "side": "sell",
      "slOrdPx": "",
      "slTriggerPx": "",
      "state": "filled",
      "sz": "0.00033684",
      "tdMode": "cash"
    }
```
Buy market order
```json
{
      "accFillSz": "0.00034622",
      "avgPx": "31771.3",
      "category": "normal",
      "ccy": "",
      "feeCcy": "BTC",
      "fillPx": "31771.3",
      "fillSz": "0.00032408",
      "instId": "BTC-USDT",
      "instType": "SPOT",
      "ordType": "market",
      "pnl": "0",
      "posSide": "net",
      "px": "",
      "rebate": "0",
      "rebateCcy": "USDT",
      "side": "buy",
      "slOrdPx": "",
      "slTriggerPx": "",
      "state": "filled",
      "sz": "11",
      "tdMode": "cash"
    }
```

The `sz` field means different things in buy/sell market orders, for buy orders it is the `cost` field, while in sell orders it is the `amount` field.