### PR TITLE
Fix parsing side for Bitbay public trades

### DIFF
--- a/js/bitbay.js
+++ b/js/bitbay.js
@@ -922,8 +922,13 @@ module.exports = class bitbay extends Exchange {
         //     }
         //
         const timestamp = this.safeInteger2 (trade, 'time', 't');
-        const userAction = this.safeString (trade, 'userAction');
-        const side = (userAction === 'Buy') ? 'buy' : 'sell';
+        const sideRaw = this.safeString (trade, 'userAction') || this.safeString (trade, 'ty');
+        let side = undefined;
+        if (sideRaw === 'Buy') {
+            side = 'buy';
+        } else if (sideRaw === 'Sell') {
+            side = 'sell';
+        }
         const wasTaker = this.safeValue (trade, 'wasTaker');
         let takerOrMaker = undefined;
         if (wasTaker !== undefined) {

--- a/js/bitbay.js
+++ b/js/bitbay.js
@@ -922,13 +922,7 @@ module.exports = class bitbay extends Exchange {
         //     }
         //
         const timestamp = this.safeInteger2 (trade, 'time', 't');
-        const sideRaw = this.safeString (trade, 'userAction') || this.safeString (trade, 'ty');
-        let side = undefined;
-        if (sideRaw === 'Buy') {
-            side = 'buy';
-        } else if (sideRaw === 'Sell') {
-            side = 'sell';
-        }
+        const side = this.safeString2 (trade, 'userAction', 'ty');
         const wasTaker = this.safeValue (trade, 'wasTaker');
         let takerOrMaker = undefined;
         if (wasTaker !== undefined) {

--- a/js/bitbay.js
+++ b/js/bitbay.js
@@ -922,7 +922,7 @@ module.exports = class bitbay extends Exchange {
         //     }
         //
         const timestamp = this.safeInteger2 (trade, 'time', 't');
-        const side = this.safeString2 (trade, 'userAction', 'ty');
+        const side = this.safeStringLower2 (trade, 'userAction', 'ty');
         const wasTaker = this.safeValue (trade, 'wasTaker');
         let takerOrMaker = undefined;
         if (wasTaker !== undefined) {

--- a/php/bitbay.php
+++ b/php/bitbay.php
@@ -923,8 +923,13 @@ class bitbay extends Exchange {
         //     }
         //
         $timestamp = $this->safe_integer_2($trade, 'time', 't');
-        $userAction = $this->safe_string($trade, 'userAction');
-        $side = ($userAction === 'Buy') ? 'buy' : 'sell';
+        $sideRaw = $this->safe_string($trade, 'userAction') ?? $this->safe_string($trade, 'ty');
+        $side = null;
+        if ($sideRaw === 'Buy') {
+            $side = 'buy';
+        } else if ($sideRaw === 'Sell') {
+            $side = 'sell';
+        }
         $wasTaker = $this->safe_value($trade, 'wasTaker');
         $takerOrMaker = null;
         if ($wasTaker !== null) {

--- a/python/ccxt/bitbay.py
+++ b/python/ccxt/bitbay.py
@@ -909,8 +909,8 @@ class bitbay(Exchange):
         #     }
         #
         timestamp = self.safe_integer_2(trade, 'time', 't')
-        userAction = self.safe_string(trade, 'userAction')
-        side = 'buy' if (userAction == 'Buy') else 'sell'
+        sideRaw = self.safe_string(trade, 'userAction') or self.safe_string(trade, 'ty')
+        side = 'buy' if (sideRaw == 'Buy') else 'sell' if (sideRaw == 'Sell') else None
         wasTaker = self.safe_value(trade, 'wasTaker')
         takerOrMaker = None
         if wasTaker is not None:


### PR DESCRIPTION
A user trade history order sides are provided with attribute `userAction`: https://docs.bitbay.net/v1.0.1-en/reference#transactions-history.
A public trade history order sides are provided with attribute `ty`: https://docs.bitbay.net/v1.0.1-en/reference#last-transactions

The `parseTrade` method is used for parsing both private and public trades, but only the `userAction` parameter is being handled.
Due to that and the incorrect if-else clause, the `sell` side is returned for all public trades (including buy-trades).

Example where the bug is visible (look at the difference between "side" and "info.ty" attributes):
```
[
  {
    "id": "d3615f28-e93e-11eb-901d-0242ac110008",
    "timestamp": 1626774160855,
    "datetime": "2021-07-20T09:42:40.855Z",
    "symbol": "ATRI/USDT",
    "side": "sell",
    "price": 0.044278,
    "amount": 4,
    "cost": 0.177112,
    "info": {
      "id": "d3615f28-e93e-11eb-901d-0242ac110008",
      "t": "1626774160855",
      "a": "4",
      "r": "0.044278",
      "ty": "Buy"
    }
  },
  {
    "id": "d58d6682-e93e-11eb-901d-0242ac110008",
    "timestamp": 1626774164498,
    "datetime": "2021-07-20T09:42:44.498Z",
    "symbol": "ATRI/USDT",
    "side": "sell",
    "price": 0.044191,
    "amount": 5.5958,
    "cost": 0.2472839978,
    "info": {
      "id": "d58d6682-e93e-11eb-901d-0242ac110008",
      "t": "1626774164498",
      "a": "5.5958",
      "r": "0.044191",
      "ty": "Buy"
    }
  },
  {
    "id": "d5fa594f-e93e-11eb-901d-0242ac110008",
    "timestamp": 1626774165213,
    "datetime": "2021-07-20T09:42:45.213Z",
    "symbol": "ATRI/USDT",
    "side": "sell",
    "price": 0.044023,
    "amount": 7,
    "cost": 0.308161,
    "info": {
      "id": "d5fa594f-e93e-11eb-901d-0242ac110008",
      "t": "1626774165213",
      "a": "7",
      "r": "0.044023",
      "ty": "Sell"
    }
  },
  ...
]
```
 