### PR TITLE
safeOrder string and float number support

### DIFF
--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -97,6 +97,78 @@ class Precise {
         return new Precise (-this.integer, this.decimals)
     }
 
+    max (other) {
+        if (this.decimals === other.decimals) {
+            if (this.integer > other.integer) {
+                return this
+            } else {
+                return other
+            }
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = new BN (bigger.decimals - smaller.decimals)
+            const normalised = smaller.integer.mul (new BN (this.base).pow (exponent))
+            if (normalised > bigger.integer) {
+                return smaller
+            } else {
+                return bigger
+            }
+        }
+    }
+
+    gt (other) {
+        if (this.decimals === other.decimals) {
+            return this.integer > other.integer
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = new BN (bigger.decimals - smaller.decimals)
+            const normalised = smaller.integer.mul (new BN (this.base).pow (exponent))
+            if (this.decimals > other.decimals) {
+                return bigger.integer > normalised
+            } else {
+                return normalised > bigger.integer
+            }
+        }
+    }
+    
+    ge (other) {
+        if (this.decimals === other.decimals) {
+            return this.integer >= other.integer
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = new BN (bigger.decimals - smaller.decimals)
+            const normalised = smaller.integer.mul (new BN (this.base).pow (exponent))
+            if (this.decimals > other.decimals) {
+                return bigger.integer >= normalised
+            } else {
+                return normalised >= bigger.integer
+            }
+        }
+    }
+    
+    eq (other) {
+        if (this.decimals === other.decimals) {
+            return this.integer === other.integer
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = new BN (bigger.decimals - smaller.decimals)
+            const normalised = smaller.integer.mul (new BN (this.base).pow (exponent))
+            return normalised === bigger.integer
+        }
+    }
+    
+    lt (other) {
+    	return other.gt (this)
+    }
+
+    le (other) {
+    	return other.ge (this)
+    }
+
     reduce () {
         if (this.integer === zero) {
             this.decimals = 0
@@ -198,6 +270,48 @@ class Precise {
             return undefined
         }
         return (new Precise (string1)).pow (new Precise (string2)).toString ()
+    }
+
+    static stringMax (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).max (new Precise (string2)).toString ()
+    }
+
+    static stringGt (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).gt (new Precise (string2))
+    }
+
+    static stringGe (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).ge (new Precise (string2))
+    }
+
+    static stringLt (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).lt (new Precise (string2))
+    }
+
+    static stringLe (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).le (new Precise (string2))
+    }
+
+    static stringEq (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).eq (new Precise (string2))
     }
 }
 

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -100,6 +100,78 @@ class Precise {
         return new Precise($result, $this->decimals * $other->integer->bi->toBase($this->base));
     }
 
+    public function max($other) {
+        if ($this->decimals === $other->decimals) {
+            if ($this->integer > $other->integer) {
+                return $this;
+            } else {
+                return $other;
+            }
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = new BN($bigger->decimals - $smaller->decimals);
+            $normalised = $smaller->integer->mul((new BN($this->base))->pow($exponent));
+            if ($normalised > $bigger->integer) {
+                return $smaller;
+            } else {
+                return $bigger;
+            }
+        }
+    }
+    
+    public function gt($other) {
+        if ($this->decimals === $other->decimals) {
+            return $this->integer > $other->integer;
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = new BN($bigger->decimals - $smaller->decimals);
+            $normalised = $smaller->integer->mul((new BN($this->base))->pow($exponent));
+            if ($this->decimals > $other->decimals) {
+                return $bigger->integer > $normalised;
+            } else {
+                return $normalised > $bigger->integer;
+            }
+        }
+    }
+    
+    public function ge($other) {
+        if ($this->decimals === $other->decimals) {
+            return $this->integer >= $other->integer;
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = new BN($bigger->decimals - $smaller->decimals);
+            $normalised = $smaller->integer->mul((new BN($this->base))->pow($exponent));
+            if ($this->decimals > $other->decimals) {
+                return $bigger->integer >= $normalised;
+            } else {
+                return $normalised >= $bigger->integer;
+            }
+        }
+    }
+    
+    public function eq($other) {
+        if ($this->decimals === $other->decimals) {
+            return $this->integer === $other->integer;
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = new BN($bigger->decimals - $smaller->decimals);
+            $normalised = $smaller->integer->mul((new BN($this->base))->pow($exponent));
+            return $normalised === $bigger->integer;
+        }
+    }
+    
+    public function lt($other) {
+        return $other->gt($this);
+    }
+    
+    public function le($other) {
+        return $other->ge($this);
+    }
+    
     public function reduce() {
         $zero = new BN(0);
         if ($this->integer->eq($zero)) {
@@ -195,5 +267,47 @@ class Precise {
             return null;
         }
         return strval((new Precise($string1))->pow(new Precise($string2)));
+    }
+    
+    public static function string_max($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return strval((new Precise($string1))->max(new Precise($string2)));
+    }
+    
+    public static function string_gt($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->gt(new Precise($string2));
+    }
+    
+    public static function string_ge($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->ge(new Precise($string2));
+    }
+    
+    public static function string_lt($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->lt(new Precise($string2));
+    }
+    
+    public static function string_le($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->le(new Precise($string2));
+    }
+    
+    public static function string_eq($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->eq(new Precise($string2));
     }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2185,12 +2185,12 @@ class Exchange(object):
         # Filled
         #
         # first we try to calculate the order fields from the trades
-        amount = self.safe_value(order, 'amount')
-        remaining = self.safe_value(order, 'remaining')
-        filled = self.safe_value(order, 'filled')
-        cost = self.safe_value(order, 'cost')
-        average = self.safe_value(order, 'average')
-        price = self.safe_value(order, 'price')
+        amount = self.safe_string(order, 'amount')
+        remaining = self.safe_string(order, 'remaining')
+        filled = self.safe_string(order, 'filled')
+        cost = self.safe_string(order, 'cost')
+        average = self.safe_string(order, 'average')
+        price = self.safe_string(order, 'price')
         lastTradeTimeTimestamp = self.safe_integer(order, 'lastTradeTimestamp')
         parseFilled = (filled is None)
         parseCost = (cost is None)
@@ -2199,21 +2199,22 @@ class Exchange(object):
         parseFees = self.safe_value(order, 'fees') is None
         shouldParseFees = parseFee or parseFees
         fees = self.safe_value(order, 'fees', [])
+        symbol = self.safe_value(order, 'symbol')
         if parseFilled or parseCost or shouldParseFees:
             trades = self.safe_value(order, 'trades')
             if isinstance(trades, list):
                 if parseFilled:
-                    filled = 0
+                    filled = '0'
                 if parseCost:
-                    cost = 0
+                    cost = '0'
                 for i in range(0, len(trades)):
                     trade = trades[i]
-                    tradeAmount = self.safe_value(trade, 'amount')
+                    tradeAmount = self.safe_string(trade, 'amount')
                     if parseFilled and (tradeAmount is not None):
-                        filled = self.sum(filled, tradeAmount)
-                    tradeCost = self.safe_value(trade, 'cost')
+                        filled = Precise.string_add(filled, tradeAmount)
+                    tradeCost = self.safe_string(trade, 'cost')
                     if parseCost and (tradeCost is not None):
-                        cost = self.sum(cost, tradeCost)
+                        cost = Precise.string_add(cost, tradeCost)
                     tradeTimestamp = self.safe_value(trade, 'timestamp')
                     if parseLastTradeTimeTimestamp and (tradeTimestamp is not None):
                         if lastTradeTimeTimestamp is None:
@@ -2242,36 +2243,36 @@ class Exchange(object):
         if amount is None:
             # ensure amount = filled + remaining
             if filled is not None and remaining is not None:
-                amount = self.sum(filled, remaining)
+                amount = Precise.string_add(filled, remaining)
             elif self.safe_string(order, 'status') == 'closed':
                 amount = filled
         if filled is None:
             if amount is not None and remaining is not None:
-                filled = max(self.sum(amount, -remaining), 0)
+                filled = Precise.string_max(Precise.string_sub(amount, remaining), '0')
         if remaining is None:
             if amount is not None and filled is not None:
-                remaining = max(self.sum(amount, -filled), 0)
+                remaining = Precise.string_max(Precise.string_sub(amount, filled), '0')
         # ensure that the average field is calculated correctly
         if average is None:
-            if (filled is not None) and (cost is not None) and (filled > 0):
-                average = cost / filled
+            if (filled is not None) and (cost is not None) and Precise.string_gt(filled, '0'):
+                average = self.price_to_precision(symbol, Precise.string_div(cost, filled))
         # also ensure the cost field is calculated correctly
         costPriceExists = (average is not None) or (price is not None)
         if parseCost and (filled is not None) and costPriceExists:
-            cost = (price * filled) if (average is None) else (average * filled)
+            cost = self.cost_to_precision(symbol, Precise.string_mul(price, filled) if (average is None) else Precise.string_mul(average, filled))
         # support for market orders
         orderType = self.safe_value(order, 'type')
-        emptyPrice = price is None or price == 0.0
+        emptyPrice = price is None or Precise.string_eq(price, '0')
         if emptyPrice and (orderType == 'market'):
             price = average
         return self.extend(order, {
             'lastTradeTimestamp': lastTradeTimeTimestamp,
-            'price': price,
-            'amount': amount,
-            'cost': cost,
-            'average': average,
-            'filled': filled,
-            'remaining': remaining,
+            'price': self.parse_number(price),
+            'amount': self.parse_number(amount),
+            'cost': self.parse_number(cost),
+            'average': self.parse_number(average),
+            'filled': self.parse_number(filled),
+            'remaining': self.parse_number(remaining),
         })
 
     def parse_number(self, value, default=None):

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -89,6 +89,60 @@ class Precise:
         result = self.integer ** other.integer
         return Precise(result, self.decimals * other.integer)
 
+    def max(self, other):
+        if self.decimals == other.decimals:
+            if self.integer > other.integer:
+                return self
+            else:
+                return other
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if normalised > bigger.integer:
+                return smaller
+            else:
+                return bigger
+
+    def gt(self, other):
+        if self.decimals == other.decimals:
+            return self.integer > other.integer
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if self.decimals > other.decimals:
+                return bigger.integer > normalised
+            else:
+                return normalised > bigger.integer
+
+    def ge(self, other):
+        if self.decimals == other.decimals:
+            return self.integer >= other.integer
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if self.decimals > other.decimals:
+                return bigger.integer >= normalised
+            else:
+                return normalised >= bigger.integer
+
+    def eq(self, other):
+        if self.decimals == other.decimals:
+            return self.integer == other.integer
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            return normalised == bigger.integer
+
+    def lt(self, other):
+        return other.gt(self)
+
+    def le(self, other):
+        return other.ge(self)
+
     def reduce(self):
         if self.integer == 0:
             self.decimals = 0
@@ -166,3 +220,39 @@ class Precise:
         if string1 is None or string2 is None:
             return None
         return str(Precise(string1).pow(Precise(string2)))
+
+    @staticmethod
+    def string_max(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return str(Precise(string1).max(Precise(string2)))
+
+    @staticmethod
+    def string_gt(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).gt(Precise(string2))
+
+    @staticmethod
+    def string_ge(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).ge(Precise(string2))
+
+    @staticmethod
+    def string_lt(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).lt(Precise(string2))
+
+    @staticmethod
+    def string_le(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).le(Precise(string2))
+
+    @staticmethod
+    def string_eq(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).eq(Precise(string2))


### PR DESCRIPTION
After experimentally changing parseNumber to return numbers as strings, I found that safeOrder failed because it performed float math exclusively.
I have now changed safeOrder according to the following strategy:
1) Change safeNumber calls to safeString calls. This returns string numbers for both string and float input.
2) Convert from float math to string math using Precise (NOTE new max and comparison operators for Precise)
3) Convert results from string numbers using safeNumber at the end. This will provide results in whatever numeric type safeNumber is configured to provide, whether that be floating point or string numbers.

This patch does NOT alter parseNumber. At this time it continues to return numbers as float.

It may be possible to optimise the math by using Precise objects instead of string numbers. The code currency converts strings to Precise objects to strings for every element of every math operation.

This patch also adds the following methods and static functions to Precise:
max, string_max (returns number or string number result)
gt, string_gt (returns boolean result of >)
ge, string_ge (returns boolean result of >=)
lt, string_lt (returns boolean result of <)
le, string_lt (returns boolean result of <=)
eq, string_eq (returns boolean result of ==)

This patch has been MINIMALLY tested at this point.
It has passed node run-tests.