### PR TITLE
Precise edit

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -212,7 +212,7 @@ class Transpiler {
             [ /Precise\.stringAbs\s/g, 'Precise.string_abs' ],
             [ /Precise\.stringNeg\s/g, 'Precise.string_neg' ],
             [ /Precise\.stringMod\s/g, 'Precise.string_mod' ],
-            [ /Precise\.stringPow\s/g, 'Precise.string_pow' ],
+            [ /Precise\.stringEquals\s/g, 'Precise.string_equals' ],
 
         // insert common regexes in the middle (critical)
         ].concat (this.getCommonRegexes ()).concat ([
@@ -361,7 +361,7 @@ class Transpiler {
             [ /Precise\.stringAbs\s/g, 'Precise::string_abs' ],
             [ /Precise\.stringNeg\s/g, 'Precise::string_neg' ],
             [ /Precise\.stringMod\s/g, 'Precise::string_mod' ],
-            [ /Precise\.stringPow\s/g, 'Precise::string_pow' ],
+            [ /Precise\.stringEquals\s/g, 'Precise::string_equals' ],
 
         // insert common regexes in the middle (critical)
         ].concat (this.getCommonRegexes ()).concat ([

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -84,17 +84,26 @@ class Precise {
     }
 
     reduce () {
-        if (this.integer === zero) {
-            this.decimals = 0
+        const string = this.integer.toString ()
+        const start = string.length - 1
+        if (start === 0) {
+            if (string === '0') {
+                this.decimals = 0
+            }
             return this
         }
-        let mod = this.integer % base
-        while (mod === zero) {
-            this.integer = this.integer / base
-            mod = this.integer % base
-            this.decimals--
+        let i
+        for (i = start; i >= 0; i--) {
+            if (string.charAt (i) !== '0') {
+                break
+            }
         }
-        return this
+        const difference = start - i
+        if (difference === 0) {
+            return this
+        }
+        this.decimals -= difference
+        this.integer = BigInt (string.slice (0, i + 1))
     }
 
     equals (other) {

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -21,8 +21,8 @@ class Precise {
         } else {
             this.integer = number
             this.decimals = decimals
+            this.reduce ()
         }
-        this.reduce ()
     }
 
     mul (other) {

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -195,7 +195,7 @@ class Precise {
         if ((string1 === undefined) || (string2 === undefined)) {
             return undefined
         }
-        return (new Precise (string1)).equals (new Precise (string2)).toString ()
+        return (new Precise (string1)).equals (new Precise (string2))
     }
 }
 

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -107,6 +107,7 @@ class Precise {
     }
 
     equals (other) {
+        this.reduce ()
         return (this.decimals === other.decimals) && (this.integer === other.integer)
     }
 

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -70,11 +70,6 @@ class Precise {
         return new Precise (result, rationizerDenominator + other.decimals)
     }
 
-    pow (other) {
-        const result = this.integer ** other.integer
-        return new Precise (result, this.decimals * parseInt (other.integer))
-    }
-
     sub (other) {
         const negative = new Precise (-other.integer, other.decimals)
         return this.add (negative)
@@ -187,11 +182,11 @@ class Precise {
         return (new Precise (string1)).mod (new Precise (string2)).toString ()
     }
 
-    static stringPow (string1, string2) {
+    static stringEquals (string1, string2) {
         if ((string1 === undefined) || (string2 === undefined)) {
             return undefined
         }
-        return (new Precise (string1)).pow (new Precise (string2)).toString ()
+        return (new Precise (string1)).equals (new Precise (string2)).toString ()
     }
 }
 

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -21,7 +21,6 @@ class Precise {
         } else {
             this.integer = number
             this.decimals = decimals
-            this.reduce ()
         }
     }
 
@@ -113,6 +112,7 @@ class Precise {
     }
 
     toString () {
+        this.reduce ()
         let sign
         let abs
         if (this.integer < 0) {

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -108,6 +108,7 @@ class Precise {
 
     equals (other) {
         this.reduce ()
+        other.reduce ()
         return (this.decimals === other.decimals) && (this.integer === other.integer)
     }
 

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -315,8 +315,3 @@ assert (Precise.stringMod ('18', '6') === '0');
 assert (Precise.stringMod ('10.1', '0.5') === '0.1');
 assert (Precise.stringMod ('10000000', '5555') === '1000');
 assert (Precise.stringMod ('5550', '120') === '30');
-
-assert (Precise.stringPow ('10', '2') === '100');
-assert (Precise.stringPow ('4', '4') === '256');
-assert (Precise.stringPow ('10000', '3') === '1000000000000');
-assert (Precise.stringPow ('5', '0') === '1');

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -315,3 +315,7 @@ assert (Precise.stringMod ('18', '6') === '0');
 assert (Precise.stringMod ('10.1', '0.5') === '0.1');
 assert (Precise.stringMod ('10000000', '5555') === '1000');
 assert (Precise.stringMod ('5550', '120') === '30');
+
+assert (Precise.stringEquals ('1.0000', '1'));
+assert (Precise.stringEquals ('-0.0', '0'));
+assert (Precise.stringEquals ('5.534000', '5.5340'));

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -87,20 +87,25 @@ class Precise {
     }
 
     public function reduce() {
-        $zero = new BigInteger(0);
-        if ($this->integer->equals($zero)) {
-            $this->decimals = 0;
+        $string = $this->integer->toString();
+        $start = strlen($string) - 1;
+        if ($start === 0) {
+            if ($string === '0') {
+                $this->decimals = 0;
+            }
             return $this;
         }
-        $div = $this->integer->div($this->base);
-        $mod = $this->integer->mod($this->base);
-        while ($mod->equals($zero)) {
-            $this->integer = $div;
-            $this->decimals--;
-            $div = $this->integer->div($this->base);
-            $mod = $this->integer->mod($this->base);
+        for ($i = $start; $i >= 0; $i--) {
+            if ($string[$i] !== '0') {
+                break;
+            }
         }
-        return $this;
+        $difference = $start - $i;
+        if ($difference === 0) {
+            return $this;
+        }
+        $this->decimals -= $difference;
+        $this->integer = new BigInteger(mb_substr($string, 0, $i + 1));
     }
 
     public function equals ($other) {

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -190,6 +190,6 @@ class Precise {
         if (($string1 === null) || ($string2 === null)) {
             return null;
         }
-        return strval((new Precise($string1))->equals(new Precise($string2)));
+        return (new Precise($string1))->equals(new Precise($string2));
     }
 }

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -109,6 +109,7 @@ class Precise {
     }
 
     public function equals ($other) {
+        $this->reduce();
         return ($this->decimals === $other->decimals) && $this->integer->equals($other->integer);
     }
 

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -86,11 +86,6 @@ class Precise {
         return new Precise($result, $denominatorRationizer + $other->decimals);
     }
 
-    public function pow($other) {
-        $result = $this->integer->pow($other->integer);
-        return new Precise($result, $this->decimals * $other->integer->toBase(10));
-    }
-
     public function reduce() {
         $zero = new BigInteger(0);
         if ($this->integer->equals($zero)) {
@@ -184,10 +179,10 @@ class Precise {
         return strval((new Precise($string1))->mod(new Precise($string2)));
     }
 
-    public static function string_pow($string1, $string2) {
+    public static function string_equals($string1, $string2) {
         if (($string1 === null) || ($string2 === null)) {
             return null;
         }
-        return strval((new Precise($string1))->pow(new Precise($string2)));
+        return strval((new Precise($string1))->equals(new Precise($string2)));
     }
 }

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -25,7 +25,6 @@ class Precise {
         } else {
             $this->integer = $number;
             $this->decimals = $decimals;
-            $this->reduce();
         }
         $this->base = new BigInteger (10);
     }
@@ -115,6 +114,7 @@ class Precise {
     }
 
     public function __toString() {
+        $this->reduce();
         $sign = $this->integer->sign() === -1 ? '-' : '';
         $integerArray = str_split(str_pad($this->integer->abs()->toString(), $this->decimals, '0', STR_PAD_LEFT));
         $index = count($integerArray) - $this->decimals;

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -25,9 +25,9 @@ class Precise {
         } else {
             $this->integer = $number;
             $this->decimals = $decimals;
+            $this->reduce();
         }
         $this->base = new BigInteger (10);
-        $this->reduce();
     }
 
     public function mul($other) {

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -110,6 +110,7 @@ class Precise {
 
     public function equals ($other) {
         $this->reduce();
+        $other->reduce();
         return ($this->decimals === $other->decimals) && $this->integer->equals($other->integer);
     }
 

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -58,7 +58,7 @@ class Precise {
             list($smaller, $bigger) =
                 ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
             $exponent = new BigInteger($bigger->decimals - $smaller->decimals);
-            $normalised = $smaller->integer->mul(($this->base)->pow($exponent));
+            $normalised = $smaller->integer->mul($this->base->pow($exponent));
             $result = $normalised->add($bigger->integer);
             return new Precise($result, $bigger->decimals);
         }
@@ -78,11 +78,10 @@ class Precise {
     }
 
     public function mod($other) {
-        $base = $this->base;
         $rationizerNumerator = max(-$this->decimals + $other->decimals, 0);
-        $numerator = $this->integer->mul($base->pow(new BigInteger($rationizerNumerator)));
+        $numerator = $this->integer->mul($this->base->pow(new BigInteger($rationizerNumerator)));
         $denominatorRationizer = max(-$other->decimals + $this->decimals, 0);
-        $denominator = $other->integer->mul($base->pow(new BigInteger($denominatorRationizer)));
+        $denominator = $other->integer->mul($this->base->pow(new BigInteger($denominatorRationizer)));
         $result = $numerator->mod($denominator);
         return new Precise($result, $denominatorRationizer + $other->decimals);
     }
@@ -98,20 +97,19 @@ class Precise {
             $this->decimals = 0;
             return $this;
         }
-        $base = $this->base;
-        $div = $this->integer->div($base);
-        $mod = $this->integer->mod($base);
+        $div = $this->integer->div($this->base);
+        $mod = $this->integer->mod($this->base);
         while ($mod->equals($zero)) {
             $this->integer = $div;
             $this->decimals--;
-            $div = $this->integer->div($base);
-            $mod = $this->integer->mod($base);
+            $div = $this->integer->div($this->base);
+            $mod = $this->integer->mod($this->base);
         }
         return $this;
     }
 
     public function equals ($other) {
-        return $this->decimals === $other->decimals && $this->integer->equals($other->integer);
+        return ($this->decimals === $other->decimals) && $this->integer->equals($other->integer);
     }
 
     public function __toString() {

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -99,6 +99,7 @@ class Precise:
         self.integer = int(string[:i + 1])
 
     def equals(self, other):
+        self.reduce()
         return self.decimals == other.decimals and self.integer == other.integer
 
     def __str__(self):

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -82,10 +82,6 @@ class Precise:
         result = numerator % denominator
         return Precise(result, rationizerDenominator + other.decimals)
 
-    def pow(self, other):
-        result = self.integer ** other.integer
-        return Precise(result, self.decimals * other.integer)
-
     def reduce(self):
         if self.integer == 0:
             self.decimals = 0
@@ -162,7 +158,7 @@ class Precise:
         return str(Precise(string1).mod(Precise(string2)))
 
     @staticmethod
-    def string_pow(string1, string2):
+    def string_equals(string1, string2):
         if string1 is None or string2 is None:
             return None
-        return str(Precise(string1).pow(Precise(string2)))
+        return str(Precise(string1).equals(Precise(string2)))

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -98,7 +98,6 @@ class Precise:
         self.decimals -= difference
         self.integer = int(string[:i + 1])
 
-
     def equals(self, other):
         return self.decimals == other.decimals and self.integer == other.integer
 

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -100,6 +100,7 @@ class Precise:
 
     def equals(self, other):
         self.reduce()
+        other.reduce()
         return self.decimals == other.decimals and self.integer == other.integer
 
     def __str__(self):

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -12,27 +12,24 @@
 
 
 class Precise:
-    def __init__(self, number, decimals=0):
-        is_string = isinstance(number, str)
-        is_int = isinstance(number, int)
-        if not (is_string or is_int):
-            raise RuntimeError('Precise class initiated with something other than a string or int')
-        if is_int:
-            self.integer = number
-            self.decimals = decimals
-        else:
-            if decimals:
-                raise RuntimeError('Cannot set decimals when initializing with a string')
+    def __init__(self, number, decimals=None):
+        if decimals is None:
             modifier = 0
             number = number.lower()
             if 'e' in number:
                 number, modifier = number.split('e')
                 modifier = int(modifier)
             decimal_index = number.find('.')
-            self.decimals = len(number) - decimal_index - 1 if decimal_index > -1 else 0
-            integer_string = number.replace('.', '')
-            self.integer = int(integer_string)
+            if decimal_index > -1:
+                self.decimals = len(number) - decimal_index - 1
+                self.integer = int(number.replace('.', ''))
+            else:
+                self.decimals = 0
+                self.integer = int(number)
             self.decimals = self.decimals - modifier
+        else:
+            self.integer = number
+            self.decimals = decimals
         self.base = 10
         self.reduce()
 
@@ -99,6 +96,9 @@ class Precise:
             self.decimals -= 1
             div, mod = divmod(self.integer, self.base)
         return self
+
+    def equals(self, other):
+        return self.decimals == other.decimals and self.integer == other.integer
 
     def __str__(self):
         sign = '-' if self.integer < 0 else ''

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -30,7 +30,6 @@ class Precise:
         else:
             self.integer = number
             self.decimals = decimals
-            self.reduce()
         self.base = 10
 
     def mul(self, other):
@@ -104,6 +103,7 @@ class Precise:
         return self.decimals == other.decimals and self.integer == other.integer
 
     def __str__(self):
+        self.reduce()
         sign = '-' if self.integer < 0 else ''
         integer_array = list(str(abs(self.integer)).rjust(self.decimals, '0'))
         index = len(integer_array) - self.decimals

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -30,8 +30,8 @@ class Precise:
         else:
             self.integer = number
             self.decimals = decimals
+            self.reduce()
         self.base = 10
-        self.reduce()
 
     def mul(self, other):
         integer_result = self.integer * other.integer

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -168,4 +168,4 @@ class Precise:
     def string_equals(string1, string2):
         if string1 is None or string2 is None:
             return None
-        return str(Precise(string1).equals(Precise(string2)))
+        return Precise(string1).equals(Precise(string2))

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -83,15 +83,21 @@ class Precise:
         return Precise(result, rationizerDenominator + other.decimals)
 
     def reduce(self):
-        if self.integer == 0:
-            self.decimals = 0
+        string = str(self.integer)
+        start = len(string) - 1
+        if start == 0:
+            if string == "0":
+                self.decimals = 0
             return self
-        div, mod = divmod(self.integer, self.base)
-        while mod == 0:
-            self.integer = div
-            self.decimals -= 1
-            div, mod = divmod(self.integer, self.base)
-        return self
+        for i in range(start, -1, -1):
+            if string[i] != '0':
+                break
+        difference = start - i
+        if difference == 0:
+            return self
+        self.decimals -= difference
+        self.integer = int(string[:i + 1])
+
 
     def equals(self, other):
         return self.decimals == other.decimals and self.integer == other.integer


### PR DESCRIPTION
```
import time
start = time.perf_counter()

for i in range(10000):
    assert Precise.string_mul(x, y) == '1393.938'
    assert Precise.string_mul(y, x) == '1393.938'
    assert Precise.string_add(x, y) == '69696900000.00000002'
    assert Precise.string_add(y, x) == '69696900000.00000002'
    assert Precise.string_sub(x, y) == '-69696899999.99999998'
    assert Precise.string_sub(y, x) == '69696899999.99999998'
    assert Precise.string_div(x, y, 1) == '0'
    assert Precise.string_div(x, y) == '0'
    assert Precise.string_div(x, y, 19) == '0.0000000000000000002'
    assert Precise.string_div(x, y, 20) == '0.00000000000000000028'
    assert Precise.string_div(x, y, 21) == '0.000000000000000000286'
    assert Precise.string_div(x, y, 22) == '0.0000000000000000002869'
    assert Precise.string_div(y, x) == '3484845000000000000'
    ...
end = time.perf_counter()
print(end - start)
```

I've profiled the code using using this method, these are the results (mostly from the `reduce` function)

master (seconds) - precise-edit (seconds) - percentage reduction

- Javascript - 0.88 - 0.6 - 32%
- Python . . . .  2.2 - 1.7 - 22%
- Php  . . . . . . 39.0 - 11.2 - 71%
