### PR TITLE
Add checkRequiredCredentials Override for Exchanges that Support HTTP Authentication

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -336,6 +336,7 @@ module.exports = class Exchange {
     }
 
     checkRequiredCredentials (error = true) {
+        if (this.token) return true;
         const keys = Object.keys (this.requiredCredentials)
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i]

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -1138,22 +1138,29 @@ module.exports = class coinbase extends Exchange {
         const url = this.urls['api'] + fullPath;
         if (api === 'private') {
             this.checkRequiredCredentials ();
-            const nonce = this.nonce ().toString ();
-            let payload = '';
-            if (method !== 'GET') {
-                if (Object.keys (query).length) {
-                    body = this.json (query);
-                    payload = body;
+            if (this.token) {
+                headers = {
+                    'Authorization': `Bearer ${this.token}`,
+                    'Content-Type': 'application/json',
+                };
+            } else {
+                const nonce = this.nonce ().toString ();
+                let payload = '';
+                if (method !== 'GET') {
+                    if (Object.keys (query).length) {
+                        body = this.json (query);
+                        payload = body;
+                    }
                 }
+                const auth = nonce + method + fullPath + payload;
+                const signature = this.hmac (this.encode (auth), this.encode (this.secret));
+                headers = {
+                    'CB-ACCESS-KEY': this.apiKey,
+                    'CB-ACCESS-SIGN': signature,
+                    'CB-ACCESS-TIMESTAMP': nonce,
+                    'Content-Type': 'application/json',
+                };
             }
-            const auth = nonce + method + fullPath + payload;
-            const signature = this.hmac (this.encode (auth), this.encode (this.secret));
-            headers = {
-                'CB-ACCESS-KEY': this.apiKey,
-                'CB-ACCESS-SIGN': signature,
-                'CB-ACCESS-TIMESTAMP': nonce,
-                'Content-Type': 'application/json',
-            };
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
@@ -1205,4 +1212,3 @@ module.exports = class coinbase extends Exchange {
         }
     }
 };
-

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -1140,7 +1140,7 @@ module.exports = class coinbase extends Exchange {
             this.checkRequiredCredentials ();
             if (this.token) {
                 headers = {
-                    'Authorization': `Bearer ${this.token}`,
+                    'Authorization': 'Bearer ' + this.token,
                     'Content-Type': 'application/json',
                 };
             } else {


### PR DESCRIPTION
Our use-case required adding Oauth 2.0 support for a number of exchanges, so we added a sample implementation for `coinbase`.

Coinbase reads API digest headers before reading Authorization Bearer tokens, so the check for required credentials must be overridden. The changes do not affect operation of any exchanges unless the user adds a `token` key to their exchange config.

We tried to follow the requests and advice of @kroitor in this issue, #4425.