### PR TITLE
package.json change npm test-base to use python3 instead of python

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fast-test": "node run-tests --js",
     "test-base": "npm run test-js-base && npm run test-python-base && npm run test-php-base",
     "test-js-base": "mocha js/test/base/test.base.js --reporter ololog/reporter",
-    "test-python-base": "python python/ccxt/test/test_decimal_to_precision.py && python python/ccxt/test/test_crypto.py",
+    "test-python-base": "python3 python/ccxt/test/test_decimal_to_precision.py && python3 python/ccxt/test/test_crypto.py",
     "test-php-base": "php -f php/test/decimal_to_precision.php && php -f php/test/test_crypto.php",
     "export-exchanges": "node build/export-exchanges",
     "export-docs": "python3 build/export-docs.py",


### PR DESCRIPTION
This allows tests
python/ccxt/test/test_decimal_to_precision.py and
python/ccxt/test/test_crypto.py
to pass.
When running with python (2), the following failure occurs:
root@af63df9e2453:/ccxt# python python/ccxt/test/test_decimal_to_precision.py
Traceback (most recent call last):
  File "python/ccxt/test/test_decimal_to_precision.py", line 14, in <module>
    from ccxt.base.decimal_to_precision import decimal_to_precision  # noqa F401
  File "/ccxt/python/ccxt/__init__.py", line 29, in <module>
    from ccxt.base.exchange import Exchange                     # noqa: F401
  File "/ccxt/python/ccxt/base/__init__.py", line 24, in <module>
    from ccxt.base import exchange
  File "/ccxt/python/ccxt/base/exchange.py", line 530
    def print(self, *args):
            ^
SyntaxError: invalid syntax
root@af63df9e2453:/ccxt# python3 python/ccxt/test/test_decimal_to_precision.py
root@af63df9e2453:/ccxt#
