### PR TITLE
bigone FXT -> FXTTOKEN

### DIFF
--- a/js/bigone.js
+++ b/js/bigone.js
@@ -149,6 +149,7 @@ module.exports = class bigone extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'FXT': 'FXTTOKEN',
                 'MBN': 'Mobilian Coin',
                 'ONE': 'BigONE Token',
             },


### PR DESCRIPTION
https://coinmarketcap.com/currencies/fxt-token/markets/ 
conflict with https://coinmarketcap.com/currencies/fuzex/markets/
naming like on probit