### PR TITLE
Precise new min, max and comparison functions try 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
 # Miscellaneous deps
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git ca-certificates
 # PHP
-RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath
+RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath php-gmp
 # Node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y nodejs

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -213,6 +213,12 @@ class Transpiler {
             [ /Precise\.stringNeg\s/g, 'Precise.string_neg' ],
             [ /Precise\.stringMod\s/g, 'Precise.string_mod' ],
             [ /Precise\.stringEquals\s/g, 'Precise.string_equals' ],
+            [ /Precise\.stringMin\s/g, 'Precise.string_min' ],
+            [ /Precise\.stringMax\s/g, 'Precise.string_max' ],
+            [ /Precise\.stringGt\s/g, 'Precise.string_gt' ],
+            [ /Precise\.stringGe\s/g, 'Precise.string_ge' ],
+            [ /Precise\.stringLt\s/g, 'Precise.string_lt' ],
+            [ /Precise\.stringLe\s/g, 'Precise.string_le' ],
 
         // insert common regexes in the middle (critical)
         ].concat (this.getCommonRegexes ()).concat ([
@@ -362,6 +368,12 @@ class Transpiler {
             [ /Precise\.stringNeg\s/g, 'Precise::string_neg' ],
             [ /Precise\.stringMod\s/g, 'Precise::string_mod' ],
             [ /Precise\.stringEquals\s/g, 'Precise::string_equals' ],
+            [ /Precise\.stringMin\s/g, 'Precise::string_min' ],
+            [ /Precise\.stringMax\s/g, 'Precise::string_max' ],
+            [ /Precise\.stringGt\s/g, 'Precise::string_gt' ],
+            [ /Precise\.stringGe\s/g, 'Precise::string_ge' ],
+            [ /Precise\.stringLt\s/g, 'Precise::string_lt' ],
+            [ /Precise\.stringLe\s/g, 'Precise::string_le' ],
 
         // insert common regexes in the middle (critical)
         ].concat (this.getCommonRegexes ()).concat ([

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -482,10 +482,18 @@ class Transpiler {
     //-------------------------------------------------------------------------
     // the following common headers are used for transpiled tests
 
-    getPythonPreamble () {
-        return [
+    getPythonPreamble (pythonBody) {
+        const libraries = [
             "import os",
             "import sys",
+        ]
+        
+        if (pythonBody.match (/[\s(]Precise/)) {
+            libraries.push ('from ccxt.base.precise import Precise')
+        }
+
+        return [
+            libraries.join('\n'),
             "",
             "root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))",
             "sys.path.append(root)",
@@ -561,6 +569,7 @@ class Transpiler {
 
         const baseClasses = {
             'Exchange': 'base.exchange',
+            'Precise': 'base.Precise',
         }
 
         async = (async ? '.async_support' : '')
@@ -1302,7 +1311,7 @@ class Transpiler {
             "",
         ].join ("\n")
 
-        const python = this.getPythonPreamble () + pythonHeader + python2Body
+        const python = this.getPythonPreamble (python2Body) + pythonHeader + python2Body
         const php = this.getPHPPreamble () + phpBody
 
         log.magenta ('→', pyFile.yellow)
@@ -1375,7 +1384,7 @@ class Transpiler {
             "",
         ].join ("\n")
 
-        const python = this.getPythonPreamble () + pythonHeader + python2Body
+        const python = this.getPythonPreamble (python2Body) + pythonHeader + python2Body
         const php = this.getPHPPreamble () + phpHeader + phpBody
 
         log.magenta ('→', pyFile.yellow)
@@ -1442,7 +1451,7 @@ class Transpiler {
             "}",
         ].join ("\n")
 
-        const python = this.getPythonPreamble () + pythonHeader + python2Body
+        const python = this.getPythonPreamble (python2Body) + pythonHeader + python2Body
         const php = this.getPHPPreamble () + phpHeader + phpBody
 
         log.magenta ('→', pyFile.yellow)
@@ -1505,7 +1514,7 @@ class Transpiler {
         ].join('\n')
 
         let { python3Body, python2Body, phpBody } = this.transpileJavaScriptToPythonAndPHP ({ js, removeEmptyLines: false })
-        const python = pythonHeader + python3Body;
+        const python = this.getPythonPreamble (python3Body) + pythonHeader + python3Body;
         const php = this.getPHPPreamble (false) + phpBody;
 
         log.magenta ('→', test.pyFile.yellow)

--- a/js/base/Precise.js
+++ b/js/base/Precise.js
@@ -82,6 +82,86 @@ class Precise {
         return new Precise (-this.integer, this.decimals)
     }
 
+    min (other) {
+        if (this.decimals === other.decimals) {
+            if (this.integer < other.integer) {
+                return this
+            } else {
+                return other
+            }
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = bigger.decimals - smaller.decimals
+            const normalised = smaller.integer * (base ** BigInt(exponent))
+            if (normalised < bigger.integer) {
+                return smaller
+            } else {
+                return bigger
+            }
+        }
+    }
+
+    max (other) {
+        if (this.decimals === other.decimals) {
+            if (this.integer > other.integer) {
+                return this
+            } else {
+                return other
+            }
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = bigger.decimals - smaller.decimals
+            const normalised = smaller.integer * (base ** BigInt(exponent))
+            if (normalised > bigger.integer) {
+                return smaller
+            } else {
+                return bigger
+            }
+        }
+    }
+
+    gt (other) {
+        if (this.decimals === other.decimals) {
+            return this.integer > other.integer
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = bigger.decimals - smaller.decimals
+            const normalised = smaller.integer * (base ** BigInt(exponent))
+            if (this.decimals > other.decimals) {
+                return bigger.integer > normalised
+            } else {
+                return normalised > bigger.integer
+            }
+        }
+    }
+    
+    ge (other) {
+        if (this.decimals === other.decimals) {
+            return this.integer >= other.integer
+        } else {
+            const [ smaller, bigger ] =
+                (this.decimals > other.decimals) ? [ other, this ] : [ this, other ]
+            const exponent = bigger.decimals - smaller.decimals
+            const normalised = smaller.integer * (base ** BigInt(exponent))
+            if (this.decimals > other.decimals) {
+                return bigger.integer >= normalised
+            } else {
+                return normalised >= bigger.integer
+            }
+        }
+    }
+    
+    lt (other) {
+    	return other.gt (this)
+    }
+
+    le (other) {
+    	return other.ge (this)
+    }
+
     reduce () {
         const string = this.integer.toString ()
         const start = string.length - 1
@@ -198,6 +278,48 @@ class Precise {
             return undefined
         }
         return (new Precise (string1)).equals (new Precise (string2))
+    }
+
+    static stringMin (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).min (new Precise (string2)).toString ()
+    }
+
+    static stringMax (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).max (new Precise (string2)).toString ()
+    }
+
+    static stringGt (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).gt (new Precise (string2))
+    }
+
+    static stringGe (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).ge (new Precise (string2))
+    }
+
+    static stringLt (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).lt (new Precise (string2))
+    }
+
+    static stringLe (string1, string2) {
+        if ((string1 === undefined) || (string2 === undefined)) {
+            return undefined
+        }
+        return (new Precise (string1)).le (new Precise (string2))
     }
 }
 

--- a/js/test/base/functions/test.number.js
+++ b/js/test/base/functions/test.number.js
@@ -318,4 +318,45 @@ assert (Precise.stringMod ('5550', '120') === '30');
 
 assert (Precise.stringEquals ('1.0000', '1'));
 assert (Precise.stringEquals ('-0.0', '0'));
+assert (Precise.stringEquals ('-0.0', '0.0'));
 assert (Precise.stringEquals ('5.534000', '5.5340'));
+
+assert (Precise.stringMin ('1.0000', '2') === '1');
+assert (Precise.stringMin ('2', '1.2345') === '1.2345');
+assert (Precise.stringMin ('3.1415', '-2') === '-2');
+assert (Precise.stringMin ('-3.1415', '-2') === '-3.1415');
+assert (Precise.stringMin ('0.000', '-0.0') === '0');
+
+assert (Precise.stringMax ('1.0000', '2') === '2');
+assert (Precise.stringMax ('2', '1.2345') === '2');
+assert (Precise.stringMax ('3.1415', '-2') === '3.1415');
+assert (Precise.stringMax ('-3.1415', '-2') === '-2');
+assert (Precise.stringMax ('0.000', '-0.0') === '0');
+
+assert (!Precise.stringGt ('1.0000', '2'));
+assert (Precise.stringGt ('2', '1.2345'));
+assert (Precise.stringGt ('3.1415', '-2'));
+assert (!Precise.stringGt ('-3.1415', '-2'));
+assert (!Precise.stringGt ('3.1415', '3.1415'));
+assert (Precise.stringGt ('3.14150000000000000000001', '3.1415'));
+
+assert (!Precise.stringGe ('1.0000', '2'));
+assert (Precise.stringGe ('2', '1.2345'));
+assert (Precise.stringGe ('3.1415', '-2'));
+assert (!Precise.stringGe ('-3.1415', '-2'));
+assert (Precise.stringGe ('3.1415', '3.1415'));
+assert (Precise.stringGe ('3.14150000000000000000001', '3.1415'));
+
+assert (Precise.stringLt ('1.0000', '2'));
+assert (!Precise.stringLt ('2', '1.2345'));
+assert (!Precise.stringLt ('3.1415', '-2'));
+assert (Precise.stringLt ('-3.1415', '-2'));
+assert (!Precise.stringLt ('3.1415', '3.1415'));
+assert (Precise.stringLt ('3.1415', '3.14150000000000000000001'));
+
+assert (Precise.stringLe ('1.0000', '2'));
+assert (!Precise.stringLe ('2', '1.2345'));
+assert (!Precise.stringLe ('3.1415', '-2'));
+assert (Precise.stringLe ('-3.1415', '-2'));
+assert (Precise.stringLe ('3.1415', '3.1415'));
+assert (Precise.stringLe ('3.1415', '3.14150000000000000000001'));

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -83,6 +83,86 @@ class Precise {
         return new Precise($result, $denominatorRationizer + $other->decimals);
     }
 
+    public function min($other) {
+        if ($this->decimals === $other->decimals) {
+            if (gmp_cmp($this->integer, $other->integer) < 0) {
+                return $this;
+            } else {
+                return $other;
+            }
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = $bigger->decimals - $smaller->decimals;
+            $normalised = gmp_mul($smaller->integer, gmp_pow($this->base, $exponent));
+            if (gmp_cmp($normalised, $bigger->integer) < 0) {
+                return $smaller;
+            } else {
+                return $bigger;
+            }
+        }
+    }
+    
+    public function max($other) {
+        if ($this->decimals === $other->decimals) {
+            if (gmp_cmp($this->integer, $other->integer) > 0) {
+                return $this;
+            } else {
+                return $other;
+            }
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = $bigger->decimals - $smaller->decimals;
+            $normalised = gmp_mul($smaller->integer, gmp_pow($this->base, $exponent));
+            if (gmp_cmp($normalised, $bigger->integer) > 0) {
+                return $smaller;
+            } else {
+                return $bigger;
+            }
+        }
+    }
+    
+    public function gt($other) {
+        if ($this->decimals === $other->decimals) {
+            return gmp_cmp($this->integer, $other->integer) > 0;
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = $bigger->decimals - $smaller->decimals;
+            $normalised = gmp_mul($smaller->integer, gmp_pow($this->base, $exponent));
+            if ($this->decimals > $other->decimals) {
+                return gmp_cmp($bigger->integer, $normalised) > 0;
+            } else {
+                return gmp_cmp($normalised, $bigger->integer) > 0;
+            }
+        }
+    }
+    
+    public function ge($other) {
+        if ($this->decimals === $other->decimals) {
+            return gmp_cmp($this->integer, $other->integer) >= 0;
+        } else {
+            list($smaller, $bigger) =
+            ($this->decimals > $other->decimals) ? array( $other, $this ) : array( $this, $other );
+            $exponent = $bigger->decimals - $smaller->decimals;
+            $normalised = gmp_mul($smaller->integer, gmp_pow($this->base, $exponent));
+            if ($this->decimals > $other->decimals) {
+                return gmp_cmp($bigger->integer, $normalised) >= 0;
+            } else {
+                return gmp_cmp($normalised, $bigger->integer) >= 0;
+            }
+        }
+    }
+    
+    public function lt($other) {
+        return $other->gt($this);
+    }
+    
+    public function le($other) {
+        return $other->ge($this);
+    }
+    
     public function reduce() {
         $string = strval($this->integer);
         $start = strlen($string) - 1;
@@ -189,5 +269,47 @@ class Precise {
             return null;
         }
         return (new Precise($string1))->equals(new Precise($string2));
+    }
+    
+    public static function string_min($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return strval((new Precise($string1))->min(new Precise($string2)));
+    }
+    
+    public static function string_max($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return strval((new Precise($string1))->max(new Precise($string2)));
+    }
+    
+    public static function string_gt($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->gt(new Precise($string2));
+    }
+    
+    public static function string_ge($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->ge(new Precise($string2));
+    }
+    
+    public static function string_lt($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->lt(new Precise($string2));
+    }
+    
+    public static function string_le($string1, $string2) {
+        if (($string1 === null) || ($string2 === null)) {
+            return null;
+        }
+        return (new Precise($string1))->le(new Precise($string2));
     }
 }

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -81,6 +81,66 @@ class Precise:
         result = numerator % denominator
         return Precise(result, rationizerDenominator + other.decimals)
 
+    def min(self, other):
+        if self.decimals == other.decimals:
+            if self.integer < other.integer:
+                return self
+            else:
+                return other
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if normalised < bigger.integer:
+                return smaller
+            else:
+                return bigger
+
+    def max(self, other):
+        if self.decimals == other.decimals:
+            if self.integer > other.integer:
+                return self
+            else:
+                return other
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if normalised > bigger.integer:
+                return smaller
+            else:
+                return bigger
+
+    def gt(self, other):
+        if self.decimals == other.decimals:
+            return self.integer > other.integer
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if self.decimals > other.decimals:
+                return bigger.integer > normalised
+            else:
+                return normalised > bigger.integer
+
+    def ge(self, other):
+        if self.decimals == other.decimals:
+            return self.integer >= other.integer
+        else:
+            smaller, bigger = [other, self] if self.decimals > other.decimals else [self, other]
+            exponent = bigger.decimals - smaller.decimals
+            normalised = smaller.integer * (self.base ** exponent)
+            if self.decimals > other.decimals:
+                return bigger.integer >= normalised
+            else:
+                return normalised >= bigger.integer
+
+    def lt(self, other):
+        return other.gt(self)
+
+    def le(self, other):
+        return other.ge(self)
+
     def reduce(self):
         string = str(self.integer)
         start = len(string) - 1
@@ -169,3 +229,39 @@ class Precise:
         if string1 is None or string2 is None:
             return None
         return Precise(string1).equals(Precise(string2))
+
+    @staticmethod
+    def string_min(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return str(Precise(string1).min(Precise(string2)))
+
+    @staticmethod
+    def string_max(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return str(Precise(string1).max(Precise(string2)))
+
+    @staticmethod
+    def string_gt(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).gt(Precise(string2))
+
+    @staticmethod
+    def string_ge(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).ge(Precise(string2))
+
+    @staticmethod
+    def string_lt(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).lt(Precise(string2))
+
+    @staticmethod
+    def string_le(string1, string2):
+        if string1 is None or string2 is None:
+            return None
+        return Precise(string1).le(Precise(string2))


### PR DESCRIPTION
This patch also adds the following methods and static functions to Precise:
min, string_min (returns number or string number result)
max, string_max (returns number or string number result)
gt, string_gt (returns boolean result of >)
ge, string_ge (returns boolean result of >=)
lt, string_lt (returns boolean result of <)
le, string_lt (returns boolean result of <=)

Also provides additional tests in test.number.js.
Adds php-gmp dependency to Dockerfile (required by Precise.php modifications before this PR).

I am able to pass node run test-base and npm run-tests in my docker environment.

These functions are required for later PRs.