### PR TITLE
poloniex BCHABC mapping

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -144,6 +144,7 @@ module.exports = class poloniex extends Exchange {
                 'AIR': 'AirCoin',
                 'APH': 'AphroditeCoin',
                 'BCC': 'BTCtalkcoin',
+                'BCHABC': 'BCHABC',
                 'BDG': 'Badgercoin',
                 'BTM': 'Bitmark',
                 'CON': 'Coino',


### PR DESCRIPTION
fetchBalance info from exchange:
```
"BCHABC":{"available":"0.00000000","onOrders":"0.00000000","btcValue":"0.00000000"},
"BCH":{"available":"0.28332629","onOrders":"0.00000000","btcValue":"0.00370042"},
```
But in ccxt `{ free: 0, used: 0, total: 0 }` because of mapping BCHABC to BCH
`BCH` is a true `BCH`, `BCHABC`  possibly inactive, there is no pairs with this coin https://poloniex.com/public?command=returnTicker