### PR TITLE
gateio fetchTickers fix

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -763,8 +763,7 @@ module.exports = class gateio extends Exchange {
     async fetchTickers (symbols = undefined, params = {}) {
         await this.loadMarkets ();
         const response = await this.publicSpotGetTickers (params);
-        const ticker = this.safeValue (response, 0);
-        return this.parseTickers (ticker, symbols);
+        return this.parseTickers (response, symbols);
     }
 
     async fetchBalance (params = {}) {


### PR DESCRIPTION
for now response is array, no need to select 0 element
https://api.gateio.ws/api/v4/spot/tickers