### PR TITLE
[Python][Throttler] Reapply an old workaround

### DIFF
--- a/python/ccxt/async_support/base/throttler.py
+++ b/python/ccxt/async_support/base/throttler.py
@@ -28,7 +28,8 @@ class Throttler:
             cost = self.config['cost'] if cost is None else cost
             if self.config['tokens'] >= 0:
                 self.config['tokens'] -= cost
-                future.set_result(None)
+                if not future.done():
+                    future.set_result(None)
                 self.queue.popleft()
                 # context switch
                 await asyncio.sleep(0)


### PR DESCRIPTION
We have the same issue as https://github.com/ccxt/ccxt/issues/1094 at https://github.com/Drakkar-Software/OctoBot-Trading/runs/3256559480#step:7:199. Probably due to recent refactor of throttle https://github.com/ccxt/ccxt/commit/b22cbd358809ccf1ea31a85f4a0421cbab163179#diff-09eb2467423cc2d09a80d8d2270a998bbeeab7c57d1701e92d42138f040ec6fcR30 that didn't integrate the previous workaround.
