### PR TITLE
YOBIT: AirCoin is renamed to Air Token

### DIFF
--- a/js/yobit.js
+++ b/js/yobit.js
@@ -80,7 +80,7 @@ module.exports = class yobit extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'AIR': 'AirCoin',
+                'AIR': 'Air Token',
                 'ANI': 'ANICoin',
                 'ANT': 'AntsCoin',  // what is this, a coin for ants?
                 'ATMCHA': 'ATM',


### PR DESCRIPTION
AirCoin is renamed to Air Token on the Yobit Exchange

<img width="278" alt="изображение" src="https://user-images.githubusercontent.com/35682654/128602442-521a900a-1f7d-43fa-a1ad-34e3b3ae7595.png">

<img width="857" alt="изображение" src="https://user-images.githubusercontent.com/35682654/128602527-e73272e5-d5e8-46de-ae58-e4c0b83177e7.png">

