### PR TITLE
binance.js remove currencyToPrecision

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -784,10 +784,6 @@ module.exports = class binance extends Exchange {
         });
     }
 
-    currencyToPrecision (currency, fee) {
-        return this.numberToString (fee);
-    }
-
     nonce () {
         return this.milliseconds () - this.options['timeDifference'];
     }


### PR DESCRIPTION
It overrides a robust base class implementation with an incorrect implementation.
Also mark currencyToPrecision for review in:
bitvavo.js
huobi.s
wavesexchange.js
I have not touched currencyToPrecision in those exchanges, but they should be reviewed.