### PR TITLE
Novadax: fix changing order type to stop if stop price is set

### DIFF
--- a/js/novadax.js
+++ b/js/novadax.js
@@ -602,7 +602,6 @@ module.exports = class novadax extends Exchange {
         const uppercaseSide = side.toUpperCase ();
         const request = {
             'symbol': market['id'],
-            'type': uppercaseType, // LIMIT, MARKET
             'side': uppercaseSide, // or SELL
             // 'amount': this.amountToPrecision (symbol, amount),
             // "price": "1234.5678", // required for LIMIT and STOP orders
@@ -649,6 +648,7 @@ module.exports = class novadax extends Exchange {
                 request['value'] = this.decimalToPrecision (value, TRUNCATE, precision, this.precisionMode);
             }
         }
+        request['type'] = uppercaseType;
         const response = await this.privatePostOrdersCreate (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
There's a logic that updates the order type is the stop price is passed ("LIMIT" -> "STOP_LIMIT", "MARKET" -> "STOP_MARKET"): https://github.com/ccxt/ccxt/blob/master/js/novadax.js#L619

But the updated value isn't being passed to the exchange. The old, non-stop order type is passed instead and the exchange opens non-stop order ignoring a stop price.