### PR TITLE
Fix gateIO fetchOHLCV

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -801,11 +801,14 @@ module.exports = class gateio extends Exchange {
             'currency_pair': market['id'],
             'interval': this.timeframes[timeframe],
         };
-        if (limit !== undefined) {
+        if (limit !== undefined && since === undefined) {
             request['limit'] = limit;
         }
         if (since !== undefined) {
-            request['start'] = Math.floor (since / 1000);
+            request['from'] = Math.floor (since / 1000);
+            if (limit !== undefined) {
+                request['to'] = this.sum (request['from'], limit * this.parseTimeframe (timeframe) - 1);
+            }
         }
         const response = await this.publicSpotGetCandlesticks (this.extend (request, params));
         return this.parseOHLCVs (response, market, timeframe, since, limit);

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -801,10 +801,11 @@ module.exports = class gateio extends Exchange {
             'currency_pair': market['id'],
             'interval': this.timeframes[timeframe],
         };
-        if (limit !== undefined && since === undefined) {
-            request['limit'] = limit;
-        }
-        if (since !== undefined) {
+        if (since === undefined) {
+            if (limit !== undefined) {
+                request['limit'] = limit;
+            }
+        } else {
             request['from'] = Math.floor (since / 1000);
             if (limit !== undefined) {
                 request['to'] = this.sum (request['from'], limit * this.parseTimeframe (timeframe) - 1);


### PR DESCRIPTION
Fix gateIO fetchOHLCV

Based on the [gateIO API documentation](https://www.gate.io/docs/apiv4/en/#market-candlesticks), the proper parameters are "from" and "to".
"limit" is not supported with "from" (at least not when specifying a limit earlier than 1000 candles ago) - therefore we must change this to sending "from" and "to" to allow proper iteration over historic data. 

Similar things are done for FTX (although here the from/to are inclusive, therefore we must subtract 1 to not fail when trying with limit 1000.

