### PR TITLE
exmo parseTransaction fixes

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -1260,7 +1260,7 @@ module.exports = class exmo extends Exchange {
         //             "error": ""
         //          },
         //
-        const id = this.safeString (transaction, 'operation_id');
+        const id = this.safeString (transaction, 'order_id');
         const timestamp = this.safeTimestamp2 (transaction, 'dt', 'created');
         const updated = this.safeTimestamp (transaction, 'updated');
         let amount = this.safeNumber (transaction, 'amount');
@@ -1269,9 +1269,12 @@ module.exports = class exmo extends Exchange {
         }
         const status = this.parseTransactionStatus (this.safeStringLower (transaction, 'status'));
         let txid = this.safeString (transaction, 'txid');
-        const extra = this.safeValue (transaction, 'extra', {});
         if (txid === undefined) {
-            txid = this.safeString (extra, 'txid');
+            const extra = this.safeValue (transaction, 'extra', {});
+            const extraTxid = this.safeString (extra, 'txid');
+            if (txid !== '') {
+                txid = this.safeString (extra, 'txid');
+            }
         }
         const type = this.safeString (transaction, 'type');
         const currencyId = this.safeString2 (transaction, 'curr', 'currency');

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -1272,8 +1272,8 @@ module.exports = class exmo extends Exchange {
         if (txid === undefined) {
             const extra = this.safeValue (transaction, 'extra', {});
             const extraTxid = this.safeString (extra, 'txid');
-            if (txid !== '') {
-                txid = this.safeString (extra, 'txid');
+            if (extraTxid !== '') {
+                txid = extraTxid;
             }
         }
         const type = this.safeString (transaction, 'type');


### PR DESCRIPTION
`withdraw`:
```
{
  info: { result: true, error: '', task_id: '11073320' },
  id: '11073320'
} 
```

`fetchWithdrawals`:
```
{
    info: {
      operation_id: '473293756968468577',
      created: '1629041647',
      updated: '1629041647',
      type: 'withdrawal',
      currency: 'USDT',
      status: 'Paid',
      amount: '11',
      provider: 'USDT (TRC20)',
      commission: '1',
      account: 'USDTTRC20: T*****',
      order_id: '11073320',
      provider_type: 'crypto',
      crypto_address: 'T*****',
      card_number: '',
      wallet_address: '',
      email: '',
      phone: '',
      extra: { txid: '', confirmations: null, excode: '', invoice: '' },
      error: ''
    },
    id: '473293756968468577',
    timestamp: 1629041647000,
    datetime: '2021-08-15T15:34:07.000Z',
    currency: 'USDT',
    amount: 10,
    address: 'T*****',
    addressTo: 'T*****',
    addressFrom: undefined,
    tag: undefined,
    tagTo: undefined,
    tagFrom: undefined,
    status: 'ok',
    type: 'withdrawal',
    updated: 1629041647000,
    comment: undefined,
    txid: '',
    fee: { cost: 1, currency: 'USDT', rate: undefined }
  }
```

So we can track withdraw `id` if using `order_id` and `operation_id` looks useless.

Also for some reasons exmo gives empty string for `txid` in `extra` of new withdrawals (for old withdrawals in 2020 it still gives correct `txid`), so better to keep it `undefined`