### PR TITLE
Fix fees reporting as 20% on gate.io

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -445,7 +445,8 @@ module.exports = class gateio extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
-            const taker = this.safeNumber (entry, 'fee');
+            // Fee is in %, so divide by 100
+            const taker = this.safeNumber (entry, 'fee') / 100;
             const maker = taker;
             const tradeStatus = this.safeString (entry, 'trade_status');
             const active = tradeStatus === 'tradable';


### PR DESCRIPTION
currently gate.io returns a fee of 20% (instead of 0.2%).

this is because the [API used](https://www.gate.io/docs/apiv4/en/#list-all-currency-pairs-supported) returns 0.2 (representing 0.2%).
For ccxt, we'll therefore have to divide it by 100 to get fee reporting corrected.