### PR TITLE
Accept operators for Novadax stop orders

### DIFF
--- a/js/novadax.js
+++ b/js/novadax.js
@@ -620,7 +620,8 @@ module.exports = class novadax extends Exchange {
             } else if (uppercaseType === 'MARKET') {
                 uppercaseType = 'STOP_MARKET';
             }
-            request['operator'] = (uppercaseSide === 'BUY') ? 'LTE' : 'GTE';
+            const defaultOperator = (uppercaseSide === 'BUY') ? 'LTE' : 'GTE';
+            request['operator'] = this.safeString (params, 'operator', defaultOperator);
             request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
             params = this.omit (params, 'stopPrice');
         }


### PR DESCRIPTION
Novadax API accepts parameter `operator` (“GTE” for >= and “LTE” for <=): https://doc.novadax.com/en-US/#order-introduction

Initially I have thought that it makes no sense and has ben arisen from bad API design. At least, native Novadax web UI does not accept any operators.
But then my colleague explained me the meaning. Turns out that existing logic calculates operator which is intended for "take-profit" orders creation. But this kind of stop orders isn't so useful since it can be achieved only by using limit orders with high price for selling and low price for buying (except that those orders are going to be visible in an orderbook).
The point is that passing the opposite operator ("GTE" for buying and "LTE" for selling) may be used for creating "stop-loss" orders. This kind of stop orders helps to minimize the loss if an instrument's price isn't behaving as expected. And its mechanic can not be achieved using non-stop orders.

So it would be useful to support both kinds of stop orders by accepting it from an user requests.
Existing logic for operator calculation is left as default behavior.
