### PR TITLE
hitbtc BIT -> BitRewards

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -198,6 +198,7 @@ module.exports = class hitbtc extends Exchange {
                 'BCC': 'BCC', // initial symbol for Bitcoin Cash, now inactive
                 'BDP': 'BidiPass',
                 'BET': 'DAO.Casino',
+                'BIT': 'BitRewards',
                 'BOX': 'BOX Token',
                 'CPT': 'Cryptaur', // conflict with CPT = Contents Protocol https://github.com/ccxt/ccxt/issues/4920 and https://github.com/ccxt/ccxt/issues/6081
                 'GET': 'Themis',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/bitrewards/markets/
conflict with https://coinmarketcap.com/currencies/bitdao/markets/