### PR TITLE
FTX - fix precision, ticker

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -508,6 +508,19 @@ module.exports = class ftx extends Exchange {
         }
         const last = this.safeNumber (ticker, 'last');
         const timestamp = this.safeTimestamp (ticker, 'time', this.milliseconds ());
+        let percentage = this.safeNumber (ticker, 'change24h');
+        if (percentage !== undefined) {
+            percentage *= 100;
+        }
+        let change = undefined;
+        let average = undefined;
+        let open = undefined;
+        if ((last !== undefined) && (percentage !== undefined)) {
+            const percentageNumberChange = percentage / 100;
+            change = percentageNumberChange * last;
+            open = last - change;
+            average = this.sum (open, last) / 2;
+        }
         return {
             'symbol': symbol,
             'timestamp': timestamp,
@@ -519,13 +532,13 @@ module.exports = class ftx extends Exchange {
             'ask': this.safeNumber (ticker, 'ask'),
             'askVolume': this.safeNumber (ticker, 'askSize'),
             'vwap': undefined,
-            'open': undefined,
+            'open': open,
             'close': last,
             'last': last,
             'previousClose': undefined,
-            'change': undefined,
-            'percentage': this.safeNumber (ticker, 'change24h'),
-            'average': undefined,
+            'change': change,
+            'percentage': percentage,
+            'average': average,
             'baseVolume': undefined,
             'quoteVolume': this.safeNumber (ticker, 'quoteVolume24h'),
             'info': ticker,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -430,8 +430,8 @@ module.exports = class ftx extends Exchange {
             const sizeIncrement = this.safeNumber (market, 'sizeIncrement');
             const priceIncrement = this.safeNumber (market, 'priceIncrement');
             const precision = {
-                'amount': sizeIncrement,
-                'price': priceIncrement,
+                'amount': createPrecisionFromLimit(sizeIncrement),
+                'price': createPrecisionFromLimit(priceIncrement),
             };
             result.push ({
                 'id': id,
@@ -2029,5 +2029,15 @@ module.exports = class ftx extends Exchange {
         }
         const response = await this[method] (this.extend (request, params));
         return this.parseIncomes (response, market, since, limit);
+    }
+
+    createPrecisionFromLimit (limit = undefined) {
+        if (limit >= 1) {
+            return 0;
+        }
+        if (limit > 0) {
+            return limit.toString().split(".")[1].length;
+        }
+        return limit;
     }
 };

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -367,6 +367,17 @@ module.exports = class ftx extends Exchange {
         return result;
     }
 
+    createPrecisionFromLimit (limit = undefined) {
+        if (limit >= 1) {
+            return 0;
+        }
+        if (limit > 0) {
+            const notScientificValueInString = limit.toFixed(8).replace(/0+$/, '');
+            return notScientificValueInString.toString().split('.')[1].length;
+        }
+        return limit;
+    }
+
     async fetchMarkets (params = {}) {
         const response = await this.publicGetMarkets (params);
         //
@@ -430,8 +441,8 @@ module.exports = class ftx extends Exchange {
             const sizeIncrement = this.safeNumber (market, 'sizeIncrement');
             const priceIncrement = this.safeNumber (market, 'priceIncrement');
             const precision = {
-                'amount': createPrecisionFromLimit(sizeIncrement),
-                'price': createPrecisionFromLimit(priceIncrement),
+                'amount': this.createPrecisionFromLimit(sizeIncrement),
+                'price': this.createPrecisionFromLimit(priceIncrement),
             };
             result.push ({
                 'id': id,
@@ -2042,15 +2053,5 @@ module.exports = class ftx extends Exchange {
         }
         const response = await this[method] (this.extend (request, params));
         return this.parseIncomes (response, market, since, limit);
-    }
-
-    createPrecisionFromLimit (limit = undefined) {
-        if (limit >= 1) {
-            return 0;
-        }
-        if (limit > 0) {
-            return limit.toString().split(".")[1].length;
-        }
-        return limit;
     }
 };


### PR DESCRIPTION
- FTX precision was actually coded as limits.
- FTX does not provide precision, I have created a function that converts the limits and outputs precision. Please check the function if the style is in alignment of the ccxt coding style
- Percentage was 100 times lower (not being a percentage but number)
- Adding calculation for open, change, average

Note: FTX currently does not provide high, low in ticker. I have asked for adding the values to their markets ticker.