### PR TITLE
Kraken: added more exceptions

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { BadSymbol, ExchangeNotAvailable, ArgumentsRequired, PermissionDenied, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress, RateLimitExceeded } = require ('./base/errors');
+const { BadSymbol, BadRequest, ExchangeNotAvailable, ArgumentsRequired, PermissionDenied, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress, RateLimitExceeded } = require ('./base/errors');
 const { TRUNCATE, DECIMAL_PLACES } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -237,6 +237,9 @@ module.exports = class kraken extends Exchange {
                 'EGeneral:Permission denied': PermissionDenied,
                 'EOrder:Unknown order': InvalidOrder,
                 'EOrder:Order minimum not met': InvalidOrder,
+                'EGeneral:Temporary lockout': RateLimitExceeded,
+                'EGeneral:Invalid arguments': BadRequest,
+                'ESession:Invalid session': AuthenticationError,
             },
         });
     }

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -237,7 +237,6 @@ module.exports = class kraken extends Exchange {
                 'EGeneral:Permission denied': PermissionDenied,
                 'EOrder:Unknown order': InvalidOrder,
                 'EOrder:Order minimum not met': InvalidOrder,
-                'EGeneral:Temporary lockout': RateLimitExceeded,
                 'EGeneral:Invalid arguments': BadRequest,
                 'ESession:Invalid session': AuthenticationError,
             },


### PR DESCRIPTION
We are not sure about the `ESession:Invalid session`.

The docs saying: 

> Invalid signature errors occurs if either your API key or API secret are written incorrectly in your program or because the POST data used in the authentication and the POST data sent to the API do not match.

https://support.kraken.com/hc/en-us/articles/360001491786-API-error-messages

Is this a bug in ccxt, or do we have wrong api credentials? I can provide api credentials that are failing. Other api keys are working properly.