### PR TITLE
Bitstamp: add new exception for "Invalid offset."

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { AuthenticationError, ExchangeError, NotSupported, PermissionDenied, InvalidNonce, OrderNotFound, InsufficientFunds, InvalidAddress, InvalidOrder, ArgumentsRequired, OnMaintenance, ExchangeNotAvailable } = require ('./base/errors');
+const { AuthenticationError, BadRequest, ExchangeError, NotSupported, PermissionDenied, InvalidNonce, OrderNotFound, InsufficientFunds, InvalidAddress, InvalidOrder, ArgumentsRequired, OnMaintenance, ExchangeNotAvailable } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -255,6 +255,7 @@ module.exports = class bitstamp extends Exchange {
                     'Price is more than 20% below market price.': InvalidOrder,
                     'Bitstamp.net is under scheduled maintenance.': OnMaintenance, // { "error": "Bitstamp.net is under scheduled maintenance. We'll be back soon." }
                     'Order could not be placed.': ExchangeNotAvailable, // Order could not be placed (perhaps due to internal error or trade halt). Please retry placing order.
+                    'Invalid offset.': BadRequest,
                 },
                 'broad': {
                     'Minimum order size is': InvalidOrder, // Minimum order size is 5.0 EUR.


### PR DESCRIPTION
This happens when you send:

```
fetch:
 bitstamp POST https://www.bitstamp.net/api/v2/user_transactions/
body: "limit=1000&offset=" 
```

Maybe we also need to add a case in the code, when offset is given in the params, then replace it with "0" when its empty.

This PR gives at least a proper Error (BadRequest) instead of ExchangeError.