### PR TITLE
implement dynamic rate limit for huobi

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -15,7 +15,7 @@ module.exports = class huobi extends Exchange {
             'id': 'huobi',
             'name': 'Huobi',
             'countries': [ 'CN' ],
-            'rateLimit': 2000,
+            'rateLimit': 100,
             'userAgent': this.userAgents['chrome39'],
             'certified': true,
             'version': 'v1',
@@ -91,145 +91,145 @@ module.exports = class huobi extends Exchange {
             },
             'api': {
                 'v2Public': {
-                    'get': [
-                        'reference/currencies', // 币链参考信息
-                        'market-status', // 获取当前市场状态
-                    ],
+                    'get': {
+                        'reference/currencies': 1, // 币链参考信息
+                        'market-status': 1, // 获取当前市场状态
+                    },
                 },
                 'v2Private': {
-                    'get': [
-                        'account/ledger',
-                        'account/withdraw/quota',
-                        'account/withdraw/address', // 提币地址查询(限母用户可用)
-                        'account/deposit/address',
-                        'account/repayment', // 还币交易记录查询
-                        'reference/transact-fee-rate',
-                        'account/asset-valuation', // 获取账户资产估值
-                        'point/account', // 点卡余额查询
-                        'sub-user/user-list', // 获取子用户列表
-                        'sub-user/user-state', // 获取特定子用户的用户状态
-                        'sub-user/account-list', // 获取特定子用户的账户列表
-                        'sub-user/deposit-address', // 子用户充币地址查询
-                        'sub-user/query-deposit', // 子用户充币记录查询
-                        'user/api-key', // 母子用户API key信息查询
-                        'user/uid', // 母子用户获取用户UID
-                        'algo-orders/opening', // 查询未触发OPEN策略委托
-                        'algo-orders/history', // 查询策略委托历史
-                        'algo-orders/specific', // 查询特定策略委托
-                        'c2c/offers', // 查询借入借出订单
-                        'c2c/offer', // 查询特定借入借出订单及其交易记录
-                        'c2c/transactions', // 查询借入借出交易记录
-                        'c2c/repayment', // 查询还币交易记录
-                        'c2c/account', // 查询账户余额
-                        'etp/reference', // 基础参考信息
-                        'etp/transactions', // 获取杠杆ETP申赎记录
-                        'etp/transaction', // 获取特定杠杆ETP申赎记录
-                        'etp/rebalance', // 获取杠杆ETP调仓记录
-                        'etp/limit', // 获取ETP持仓限额
-                    ],
-                    'post': [
-                        'account/transfer',
-                        'account/repayment', // 归还借币（全仓逐仓通用）
-                        'point/transfer', // 点卡划转
-                        'sub-user/management', // 冻结/解冻子用户
-                        'sub-user/creation', // 子用户创建
-                        'sub-user/tradable-market', // 设置子用户交易权限
-                        'sub-user/transferability', // 设置子用户资产转出权限
-                        'sub-user/api-key-generation', // 子用户API key创建
-                        'sub-user/api-key-modification', // 修改子用户API key
-                        'sub-user/api-key-deletion', // 删除子用户API key
-                        'sub-user/deduct-mode', // 设置子用户手续费抵扣模式
-                        'algo-orders', // 策略委托下单
-                        'algo-orders/cancel-all-after', // 自动撤销订单
-                        'algo-orders/cancellation', // 策略委托（触发前）撤单
-                        'c2c/offer', // 借入借出下单
-                        'c2c/cancellation', // 借入借出撤单
-                        'c2c/cancel-all', // 撤销所有借入借出订单
-                        'c2c/repayment', // 还币
-                        'c2c/transfer', // 资产划转
-                        'etp/creation', // 杠杆ETP换入
-                        'etp/redemption', // 杠杆ETP换出
-                        'etp/{transactId}/cancel', // 杠杆ETP单个撤单
-                        'etp/batch-cancel', // 杠杆ETP批量撤单
-                    ],
+                    'get': {
+                        'account/ledger': 1,
+                        'account/withdraw/quota': 1,
+                        'account/withdraw/address': 1, // 提币地址查询(限母用户可用)
+                        'account/deposit/address': 1,
+                        'account/repayment': 5, // 还币交易记录查询
+                        'reference/transact-fee-rate': 1,
+                        'account/asset-valuation': 0.2, // 获取账户资产估值
+                        'point/account': 5, // 点卡余额查询
+                        'sub-user/user-list': 1, // 获取子用户列表
+                        'sub-user/user-state': 1, // 获取特定子用户的用户状态
+                        'sub-user/account-list': 1, // 获取特定子用户的账户列表
+                        'sub-user/deposit-address': 1, // 子用户充币地址查询
+                        'sub-user/query-deposit': 1, // 子用户充币记录查询
+                        'user/api-key': 1, // 母子用户API key信息查询
+                        'user/uid': 1, // 母子用户获取用户UID
+                        'algo-orders/opening': 1, // 查询未触发OPEN策略委托
+                        'algo-orders/history': 1, // 查询策略委托历史
+                        'algo-orders/specific': 1, // 查询特定策略委托
+                        'c2c/offers': 1, // 查询借入借出订单
+                        'c2c/offer': 1, // 查询特定借入借出订单及其交易记录
+                        'c2c/transactions': 1, // 查询借入借出交易记录
+                        'c2c/repayment': 1, // 查询还币交易记录
+                        'c2c/account': 1, // 查询账户余额
+                        'etp/reference': 1, // 基础参考信息
+                        'etp/transactions': 5, // 获取杠杆ETP申赎记录
+                        'etp/transaction': 5, // 获取特定杠杆ETP申赎记录
+                        'etp/rebalance': 1, // 获取杠杆ETP调仓记录
+                        'etp/limit': 1, // 获取ETP持仓限额
+                    },
+                    'post': {
+                        // 'account/transfer',
+                        'account/repayment': 5, // 归还借币（全仓逐仓通用）
+                        'point/transfer': 5, // 点卡划转
+                        'sub-user/management': 1, // 冻结/解冻子用户
+                        'sub-user/creation': 1, // 子用户创建
+                        'sub-user/tradable-market': 1, // 设置子用户交易权限
+                        'sub-user/transferability': 1, // 设置子用户资产转出权限
+                        'sub-user/api-key-generation': 1, // 子用户API key创建
+                        'sub-user/api-key-modification': 1, // 修改子用户API key
+                        'sub-user/api-key-deletion': 1, // 删除子用户API key
+                        'sub-user/deduct-mode': 1, // 设置子用户手续费抵扣模式
+                        'algo-orders': 1, // 策略委托下单
+                        'algo-orders/cancel-all-after': 1, // 自动撤销订单
+                        'algo-orders/cancellation': 1, // 策略委托（触发前）撤单
+                        'c2c/offer': 1, // 借入借出下单
+                        'c2c/cancellation': 1, // 借入借出撤单
+                        'c2c/cancel-all': 1, // 撤销所有借入借出订单
+                        'c2c/repayment': 1, // 还币
+                        'c2c/transfer': 1, // 资产划转
+                        'etp/creation': 5, // 杠杆ETP换入
+                        'etp/redemption': 5, // 杠杆ETP换出
+                        'etp/{transactId}/cancel': 10, // 杠杆ETP单个撤单
+                        'etp/batch-cancel': 50, // 杠杆ETP批量撤单
+                    },
                 },
                 'market': {
-                    'get': [
-                        'history/kline', // 获取K线数据
-                        'detail/merged', // 获取聚合行情(Ticker)
-                        'depth', // 获取 Market Depth 数据
-                        'trade', // 获取 Trade Detail 数据
-                        'history/trade', // 批量获取最近的交易记录
-                        'detail', // 获取 Market Detail 24小时成交量数据
-                        'tickers',
-                        'etp', // 获取杠杆ETP实时净值
-                    ],
+                    'get': {
+                        'history/kline': 1, // 获取K线数据
+                        'detail/merged': 1, // 获取聚合行情(Ticker)
+                        'depth': 1, // 获取 Market Depth 数据
+                        'trade': 1, // 获取 Trade Detail 数据
+                        'history/trade': 1, // 批量获取最近的交易记录
+                        'detail': 1, // 获取 Market Detail 24小时成交量数据
+                        'tickers': 1,
+                        'etp': 1, // 获取杠杆ETP实时净值
+                    },
                 },
                 'public': {
-                    'get': [
-                        'common/symbols', // 查询系统支持的所有交易对
-                        'common/currencys', // 查询系统支持的所有币种
-                        'common/timestamp', // 查询系统当前时间
-                        'common/exchange', // order limits
-                        'settings/currencys', // ?language=en-US
-                    ],
+                    'get': {
+                        'common/symbols': 1, // 查询系统支持的所有交易对
+                        'common/currencys': 1, // 查询系统支持的所有币种
+                        'common/timestamp': 1, // 查询系统当前时间
+                        'common/exchange': 1, // order limits
+                        'settings/currencys': 1, // ?language=en-US
+                    },
                 },
                 'private': {
-                    'get': [
-                        'account/accounts', // 查询当前用户的所有账户(即account-id)
-                        'account/accounts/{id}/balance', // 查询指定账户的余额
-                        'account/accounts/{sub-uid}',
-                        'account/history',
-                        'cross-margin/loan-info',
-                        'margin/loan-info', // 查询借币币息率及额度
-                        'fee/fee-rate/get',
-                        'order/openOrders',
-                        'order/orders',
-                        'order/orders/{id}', // 查询某个订单详情
-                        'order/orders/{id}/matchresults', // 查询某个订单的成交明细
-                        'order/orders/getClientOrder',
-                        'order/history', // 查询当前委托、历史委托
-                        'order/matchresults', // 查询当前成交、历史成交
-                        'dw/withdraw-virtual/addresses', // 查询虚拟币提现地址（Deprecated）
-                        'query/deposit-withdraw',
-                        'margin/loan-info',
-                        'margin/loan-orders', // 借贷订单
-                        'margin/accounts/balance', // 借贷账户详情
-                        'cross-margin/loan-orders', // 查询借币订单
-                        'cross-margin/accounts/balance', // 借币账户详情
-                        'points/actions',
-                        'points/orders',
-                        'subuser/aggregate-balance',
-                        'stable-coin/exchange_rate',
-                        'stable-coin/quote',
-                    ],
-                    'post': [
-                        'account/transfer', // 资产划转(该节点为母用户和子用户进行资产划转的通用接口。)
-                        'futures/transfer',
-                        'order/batch-orders',
-                        'order/orders/place', // 创建并执行一个新订单 (一步下单， 推荐使用)
-                        'order/orders/submitCancelClientOrder',
-                        'order/orders/batchCancelOpenOrders',
-                        'order/orders', // 创建一个新的订单请求 （仅创建订单，不执行下单）
-                        'order/orders/{id}/place', // 执行一个订单 （仅执行已创建的订单）
-                        'order/orders/{id}/submitcancel', // 申请撤销一个订单请求
-                        'order/orders/batchcancel', // 批量撤销订单
-                        'dw/balance/transfer', // 资产划转
-                        'dw/withdraw/api/create', // 申请提现虚拟币
-                        'dw/withdraw-virtual/create', // 申请提现虚拟币
-                        'dw/withdraw-virtual/{id}/place', // 确认申请虚拟币提现（Deprecated）
-                        'dw/withdraw-virtual/{id}/cancel', // 申请取消提现虚拟币
-                        'dw/transfer-in/margin', // 现货账户划入至借贷账户
-                        'dw/transfer-out/margin', // 借贷账户划出至现货账户
-                        'margin/orders', // 申请借贷
-                        'margin/orders/{id}/repay', // 归还借贷
-                        'cross-margin/transfer-in', // 资产划转
-                        'cross-margin/transfer-out', // 资产划转
-                        'cross-margin/orders', // 申请借币
-                        'cross-margin/orders/{id}/repay', // 归还借币
-                        'stable-coin/exchange',
-                        'subuser/transfer',
-                    ],
+                    'get': {
+                        'account/accounts': 0.2, // 查询当前用户的所有账户(即account-id)
+                        'account/accounts/{id}/balance': 0.2, // 查询指定账户的余额
+                        'account/accounts/{sub-uid}': 1,
+                        'account/history': 4,
+                        'cross-margin/loan-info': 1,
+                        'margin/loan-info': 1, // 查询借币币息率及额度
+                        'fee/fee-rate/get': 1,
+                        'order/openOrders': 0.4,
+                        'order/orders': 0.4,
+                        'order/orders/{id}': 0.4, // 查询某个订单详情
+                        'order/orders/{id}/matchresults': 0.4, // 查询某个订单的成交明细
+                        'order/orders/getClientOrder': 0.4,
+                        'order/history': 1, // 查询当前委托、历史委托
+                        'order/matchresults': 1, // 查询当前成交、历史成交
+                        // 'dw/withdraw-virtual/addresses', // 查询虚拟币提现地址（Deprecated）
+                        'query/deposit-withdraw': 1,
+                        // 'margin/loan-info', // duplicate
+                        'margin/loan-orders': 0.2, // 借贷订单
+                        'margin/accounts/balance': 0.2, // 借贷账户详情
+                        'cross-margin/loan-orders': 1, // 查询借币订单
+                        'cross-margin/accounts/balance': 1, // 借币账户详情
+                        'points/actions': 1,
+                        'points/orders': 1,
+                        'subuser/aggregate-balance': 10,
+                        'stable-coin/exchange_rate': 1,
+                        'stable-coin/quote': 1,
+                    },
+                    'post': {
+                        'account/transfer': 1, // 资产划转(该节点为母用户和子用户进行资产划转的通用接口。)
+                        'futures/transfer': 1,
+                        'order/batch-orders': 0.4,
+                        'order/orders/place': 0.2, // 创建并执行一个新订单 (一步下单， 推荐使用)
+                        'order/orders/submitCancelClientOrder': 0.2,
+                        'order/orders/batchCancelOpenOrders': 0.4,
+                        // 'order/orders', // 创建一个新的订单请求 （仅创建订单，不执行下单）
+                        // 'order/orders/{id}/place', // 执行一个订单 （仅执行已创建的订单）
+                        'order/orders/{id}/submitcancel': 0.2, // 申请撤销一个订单请求
+                        'order/orders/batchcancel': 0.4, // 批量撤销订单
+                        // 'dw/balance/transfer', // 资产划转
+                        'dw/withdraw/api/create': 1, // 申请提现虚拟币
+                        // 'dw/withdraw-virtual/create', // 申请提现虚拟币
+                        // 'dw/withdraw-virtual/{id}/place', // 确认申请虚拟币提现（Deprecated）
+                        'dw/withdraw-virtual/{id}/cancel': 1, // 申请取消提现虚拟币
+                        'dw/transfer-in/margin': 10, // 现货账户划入至借贷账户
+                        'dw/transfer-out/margin': 10, // 借贷账户划出至现货账户
+                        'margin/orders': 10, // 申请借贷
+                        'margin/orders/{id}/repay': 10, // 归还借贷
+                        'cross-margin/transfer-in': 1, // 资产划转
+                        'cross-margin/transfer-out': 1, // 资产划转
+                        'cross-margin/orders': 1, // 申请借币
+                        'cross-margin/orders/{id}/repay': 1, // 归还借币
+                        'stable-coin/exchange': 1,
+                        'subuser/transfer': 10,
+                    },
                 },
             },
             'fees': {
@@ -237,8 +237,8 @@ module.exports = class huobi extends Exchange {
                     'feeSide': 'get',
                     'tierBased': false,
                     'percentage': true,
-                    'maker': 0.002,
-                    'taker': 0.002,
+                    'maker': this.parseNumber ('0.002'),
+                    'taker': this.parseNumber ('0.002'),
                 },
             },
             'exceptions': {
@@ -1580,6 +1580,11 @@ module.exports = class huobi extends Exchange {
             'hostname': this.hostname,
         }) + url;
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
+    }
+
+    calculateRateLimiterCost (api, method, path, params, config = {}, context = {}) {
+        console.log (config)
+        return this.safeInteger (config, 'cost', 1);
     }
 
     handleErrors (httpCode, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1583,7 +1583,6 @@ module.exports = class huobi extends Exchange {
     }
 
     calculateRateLimiterCost (api, method, path, params, config = {}, context = {}) {
-        console.log (config)
         return this.safeInteger (config, 'cost', 1);
     }
 


### PR DESCRIPTION
a 20x smaller ratelimit

most requests create a window of 2 seconds in which either 100 or 50 or 10 requests can be made, after that the rate limit expires and starts again from 49 or 99 depending on the endpoint. interestingly it seems that most ratelimits are independent of each other so further optimisations can be made.