### PR TITLE
Poloniex: fix Permission denied error

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -195,6 +195,7 @@ module.exports = class poloniex extends Exchange {
                     'You may only place orders that reduce your position.': InvalidOrder,
                     'Invalid order number, or you are not the person who placed the order.': OrderNotFound,
                     'Permission denied': PermissionDenied,
+                    'Permission denied.': PermissionDenied,
                     'Connection timed out. Please try again.': RequestTimeout,
                     'Internal error. Please try again.': ExchangeNotAvailable,
                     'Currently in maintenance mode.': OnMaintenance,


### PR DESCRIPTION
The response of poloniex is:` {"error":"Permission denied."}`
And in the current code the error is without the dot. So not sure if it was without the dot in the past so I kept it in the code.

Not sure if thats correct this way. Or should I remove the error without the dot?