### PR TITLE
FTX: added error "Not authorized for subaccount-specific access"

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -295,6 +295,7 @@ module.exports = class ftx extends Exchange {
                     'Spot orders cannot be reduce-only': InvalidOrder, // {"error":"Spot orders cannot be reduce-only","success":false}
                     'Invalid reduce-only order': InvalidOrder, // {"error":"Invalid reduce-only order","success":false}
                     'Account does not have enough balances': InsufficientFunds, // {"success":false,"error":"Account does not have enough balances"}
+                    'Not authorized for subaccount-specific access': PermissionDenied, // {"success":false,"error":"Not authorized for subaccount-specific access"}
                 },
                 'broad': {
                     'Account does not have enough margin for order': InsufficientFunds,


### PR DESCRIPTION
This happens when I execute `https://ftx.com/api/staking/staking_rewards?limit=200` with a subaccount API key.
Because sub accounts have no staking rewards.