### PR TITLE
fix FTX endpoint latency stats

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -117,7 +117,6 @@ module.exports = class ftx extends Exchange {
                         'nft/collections',
                         // ftx pay
                         'ftxpay/apps/{user_specific_id}/details',
-                        'stats/latency_stats',
                     ],
                     'post': [
                         'ftxpay/apps/{user_specific_id}/orders',
@@ -185,6 +184,8 @@ module.exports = class ftx extends Exchange {
                         'nft/fills',
                         'nft/gallery/{gallery_id}',
                         'nft/gallery_settings',
+                        // latency statistics
+                        'stats/latency_stats',
                     ],
                     'post': [
                         // subaccounts


### PR DESCRIPTION
FTX endpoint latency stats is a private endpoint rather than a public endpoint.
I tested that the endpoint should work after moving to be under 'private'.
I updated ftx.js. Is there tests in this repo that I need to update as well?
Also I suppose other versions including ftx.py will be updated by CI bot.

See below error message for reference:

HTTPError: 401 Client Error: UNAUTHORIZED for url: https://ftx.com/api/stats/latency_stats
AuthenticationError: ftx {"success":false,"error":"Not logged in"}