### PR TITLE
Check for availability of currency precision in Binance

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -806,7 +806,7 @@ module.exports = class binance extends Exchange {
 
     currencyToPrecision (currency, fee) {
         // info is available in currencies only if the user has configured his api keys
-        if ('info' in this.currencies[currency]) {
+        if (this.safeValue (this.currencies[currency], 'precision') !== undefined) {
             return this.decimalToPrecision (fee, TRUNCATE, this.currencies[currency]['precision'], this.precisionMode, this.paddingMode);
         } else {
             return this.numberToString (fee);


### PR DESCRIPTION
Issue: `watch_orders()` / `watch_my_trades()` fails on `assert precision is not None` in [`decimal_to_precision`](https://github.com/ccxt/ccxt/blob/master/python/ccxt/base/decimal_to_precision.py#L37) when partial order fills next to the first one for the same order are processed.

What happens:
1. In Binance, `fetch_currencies()` always sets `self.currency[curr]["precision"]` to `None`, for all currencies (see: [code](https://github.com/ccxt/ccxt/blob/master/python/ccxt/binance.py#L947-L972)).
2. The method [`currency_to_precision`](https://github.com/ccxt/ccxt/blob/master/python/ccxt/binance.py#L822-L827) calls `self.decimal_to_precision(fee, TRUNCATE, self.currencies[currency]['precision'], self.precisionMode, self.paddingMode)`, passing `self.currencies[currency]['precision']` as the `precision` parameter to the `decimal_to_precision` method. That value is always `None`.
3. The `decimal_to_precision` requires `precision` not to be None.

This PR changes `currency_to_precision` to actually check if the precision value is available before using it. Otherwise, it falls back on `self.number_to_string`.

## Software versions

- Python 3.9.6
- CCXT 1.56.35 
- CCXT Pro 0.8.56

## How to reproduce

In `ccxtpro.binance`, change the body of `def handle_order_update(self, client, message):`, inverting the order of the following operations:
```
        self.handle_my_trade(client, message)
        self.handle_order(client, message)
```

to:

```
        self.handle_order(client, message)
        self.handle_my_trade(client, message)
```

Then, execute a market order while listening for orders and/or trades with `watch_orders()` and `watch_trades()`.
The issue should happen also for total order fills, and it should not happen with this fix.

(Sorry but I don't have time to build a full repro script...)