### PR TITLE
binance implement withdraw with multiple networks

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3,7 +3,24 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ArgumentsRequired, ExchangeNotAvailable, InsufficientFunds, OrderNotFound, InvalidOrder, DDoSProtection, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, NotSupported, BadRequest, BadSymbol, AccountSuspended, OrderImmediatelyFillable } = require ('./base/errors');
+const {
+    ExchangeError,
+    ArgumentsRequired,
+    ExchangeNotAvailable,
+    InsufficientFunds,
+    OrderNotFound,
+    InvalidOrder,
+    DDoSProtection,
+    InvalidNonce,
+    AuthenticationError,
+    RateLimitExceeded,
+    PermissionDenied,
+    NotSupported,
+    BadRequest,
+    BadSymbol,
+    AccountSuspended,
+    OrderImmediatelyFillable,
+} = require ('./base/errors');
 const { TRUNCATE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -691,6 +708,14 @@ module.exports = class binance extends Exchange {
                     'CMFUTURE': 'delivery',
                     'MINING': 'mining',
                 },
+                'networks': {
+                    'ERC20': 'ETH',
+                    'TRC20': 'TRX',
+                    'BNB': 'BNB',
+                    'BSC': 'BSC',
+                    'OMNI': 'OMNI',
+                    'EOS': 'EOS',
+                },
                 'legalMoney': {
                     'MXN': true,
                     'UGX': true,
@@ -968,6 +993,7 @@ module.exports = class binance extends Exchange {
                 'precision': precision,
                 'info': entry,
                 'active': active,
+                'networkList': networkList,
                 'fee': fee,
                 'fees': fees,
                 'limits': this.limits,
@@ -3414,6 +3440,16 @@ module.exports = class binance extends Exchange {
         };
         if (tag !== undefined) {
             request['addressTag'] = tag;
+        }
+        const network = this.safeString (params, 'network');
+        if (network !== undefined) {
+            if (this.options.networks[network] !== undefined) {
+                request['network'] = network;
+            } else {
+                const networkEnabled = [];
+                for (let i = 0; i < currency.networkList.length; i++) networkEnabled.push (currency.networkList[i].network);
+                throw new ArgumentsRequired (this.id + ' does not have this network enabled, only this ' + networkEnabled.join (', '));
+            }
         }
         const response = await this.sapiPostCapitalWithdrawApply (this.extend (request, params));
         //     { id: '9a67628b16ba4988ae20d329333f16bc' }

--- a/js/binance.js
+++ b/js/binance.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ArgumentsRequired, ExchangeNotAvailable, InsufficientFunds, OrderNotFound, InvalidOrder, DDoSProtection, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, NotSupported, BadRequest, BadSymbol, AccountSuspended, OrderImmediatelyFillable} = require ('./base/errors');
+const { ExchangeError, ArgumentsRequired, ExchangeNotAvailable, InsufficientFunds, OrderNotFound, InvalidOrder, DDoSProtection, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, NotSupported, BadRequest, BadSymbol, AccountSuspended, OrderImmediatelyFillable } = require ('./base/errors');
 const { TRUNCATE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 

--- a/js/binance.js
+++ b/js/binance.js
@@ -3,24 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const {
-    ExchangeError,
-    ArgumentsRequired,
-    ExchangeNotAvailable,
-    InsufficientFunds,
-    OrderNotFound,
-    InvalidOrder,
-    DDoSProtection,
-    InvalidNonce,
-    AuthenticationError,
-    RateLimitExceeded,
-    PermissionDenied,
-    NotSupported,
-    BadRequest,
-    BadSymbol,
-    AccountSuspended,
-    OrderImmediatelyFillable,
-} = require ('./base/errors');
+const { ExchangeError, ArgumentsRequired, ExchangeNotAvailable, InsufficientFunds, OrderNotFound, InvalidOrder, DDoSProtection, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, NotSupported, BadRequest, BadSymbol, AccountSuspended, OrderImmediatelyFillable} = require ('./base/errors');
 const { TRUNCATE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -3441,15 +3424,12 @@ module.exports = class binance extends Exchange {
         if (tag !== undefined) {
             request['addressTag'] = tag;
         }
-        const network = this.safeString (params, 'network');
+        const networks = this.safeValue (this.options, 'networks', {});
+        let network = this.safeString (params, 'network'); // this line allows the user to specify either ERC20 or ETH
+        network = this.safeString (networks, network, network); // handle ERC20>ETH alias
         if (network !== undefined) {
-            if (this.options.networks[network] !== undefined) {
-                request['network'] = network;
-            } else {
-                const networkEnabled = [];
-                for (let i = 0; i < currency.networkList.length; i++) networkEnabled.push (currency.networkList[i].network);
-                throw new ArgumentsRequired (this.id + ' does not have this network enabled, only this ' + networkEnabled.join (', '));
-            }
+            request['network'] = network;
+            params = this.omit (params, 'network');
         }
         const response = await this.sapiPostCapitalWithdrawApply (this.extend (request, params));
         //     { id: '9a67628b16ba4988ae20d329333f16bc' }

--- a/js/binance.js
+++ b/js/binance.js
@@ -976,7 +976,7 @@ module.exports = class binance extends Exchange {
                 'precision': precision,
                 'info': entry,
                 'active': active,
-                'networkList': networkList,
+                'networks': networkList,
                 'fee': fee,
                 'fees': fees,
                 'limits': this.limits,


### PR DESCRIPTION
As I said in discord I implemented the withdrawal by multiple networks for binance.

I have inserted existing networks for multi-network withdrawals into the options object.

The network parameter is optional for the withdrawal. 
And if the user enters a non-existent network, I create the throw and alert the user about the enabled networks, recovering from the list of the currency itself