### PR TITLE
improve withdraw params handling

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -224,6 +224,7 @@ class Transpiler {
             // [ /this\.urlencode\s/g, '_urlencode.urlencode ' ], // use self.urlencode instead
             [ /this\./g, 'self.' ],
             [ /([^a-zA-Z\'])this([^a-zA-Z])/g, '$1self$2' ],
+            [ /\[\s*([^\]]+)\s\]\s=/g, '$1 =' ],
             [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s\[\s*([^\]]+)\s\]/g, '$1$2' ],
             [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s\{\s*([^\}]+)\s\}\s\=\s([^\;]+)/g, '$1$2 = (lambda $2: ($2))(**$3)' ],
             [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s/g, '$1' ],
@@ -384,7 +385,7 @@ class Transpiler {
 
         // add {}-array syntax conversions up to 20 levels deep in the same line
         ]).concat ([ ... Array (20) ].map (x => [ /\{([^\n\}]+)\}/g, 'array($1)' ] )).concat ([
-
+            [ /\[\s*([^\]]+)\s\]\s=/g, 'list($1) =' ],
             [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s\[\s*([^\]]+)\s\]/g, '$1list($2)' ],
             [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s\{\s*([^\}]+)\s\}/g, '$1array_values(list($2))' ],
             [ /(^|[^a-zA-Z0-9_])(?:let|const|var)\s/g, '$1' ],

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1723,4 +1723,14 @@ module.exports = class Exchange {
         }
         return '1e' + Precise.stringNeg (precision)
     }
+
+    handleTagAndParams (tag, params) {
+        if (typeof tag === 'object') {
+            params = this.extend (tag, params)
+        }
+        if (tag === undefined) {
+            tag = this.safeString (params, 'tag')
+        }
+        return [ tag, params ]
+    }
 }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -994,7 +994,7 @@ module.exports = class bibox extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
-        [ tag, params ] = this.handleTagAndParams (tag, params);        
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -994,6 +994,7 @@ module.exports = class bibox extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);        
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -1204,6 +1204,7 @@ module.exports = class bigone extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {

--- a/js/binance.js
+++ b/js/binance.js
@@ -3410,6 +3410,7 @@ module.exports = class binance extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -564,6 +564,7 @@ module.exports = class bitbank extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         if (!('uuid' in params)) {
             throw new ExchangeError (this.id + ' uuid is required for withdrawal');
         }

--- a/js/bitbay.js
+++ b/js/bitbay.js
@@ -1130,6 +1130,7 @@ module.exports = class bitbay extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         let method = undefined;

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -1162,6 +1162,7 @@ module.exports = class bitfinex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         // todo rewrite for https://api-pub.bitfinex.com//v2/conf/pub:map:tx:method

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -826,6 +826,7 @@ module.exports = class bithumb extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2086,6 +2086,7 @@ module.exports = class bitmart extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1569,6 +1569,7 @@ module.exports = class bitmex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         // let currency = this.currency (code);

--- a/js/bitpanda.js
+++ b/js/bitpanda.js
@@ -1056,6 +1056,7 @@ module.exports = class bitpanda extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -553,6 +553,7 @@ module.exports = class bitso extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const methods = {

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -1499,6 +1499,7 @@ module.exports = class bitstamp extends Exchange {
     async withdraw (code, amount, address, tag = undefined, params = {}) {
         // For fiat withdrawals please provide all required additional parameters in the 'params'
         // Check https://www.bitstamp.net/api/ under 'Open bank withdrawal' for list and description.
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         this.checkAddress (address);
         const request = {

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -1249,6 +1249,7 @@ module.exports = class bittrex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -1246,6 +1246,7 @@ module.exports = class bitvavo extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/bitz.js
+++ b/js/bitz.js
@@ -1163,6 +1163,7 @@ module.exports = class bitz extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/buda.js
+++ b/js/buda.js
@@ -749,6 +749,7 @@ module.exports = class buda extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -977,6 +977,7 @@ module.exports = class coinbasepro extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -703,6 +703,7 @@ module.exports = class coinex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/crex24.js
+++ b/js/crex24.js
@@ -1316,6 +1316,7 @@ module.exports = class crex24 extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1702,6 +1702,7 @@ module.exports = class deribit extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1398,6 +1398,7 @@ module.exports = class digifinex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/eqonex.js
+++ b/js/eqonex.js
@@ -1147,6 +1147,7 @@ module.exports = class eqonex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -1186,6 +1186,7 @@ module.exports = class exmo extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1606,6 +1606,7 @@ module.exports = class ftx extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         this.checkAddress (address);
         const currency = this.currency (code);

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -991,6 +991,7 @@ module.exports = class gateio extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -719,6 +719,7 @@ module.exports = class gemini extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/hbtc.js
+++ b/js/hbtc.js
@@ -1343,6 +1343,7 @@ module.exports = class hbtc extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -1149,6 +1149,7 @@ module.exports = class hitbtc extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         this.checkAddress (address);
         const currency = this.currency (code);

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -1236,6 +1236,7 @@ module.exports = class hollaex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1498,6 +1498,7 @@ module.exports = class huobi extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         this.checkAddress (address);
         const currency = this.currency (code);

--- a/js/idex.js
+++ b/js/idex.js
@@ -1083,6 +1083,7 @@ module.exports = class idex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkRequiredCredentials ();
         await this.loadMarkets ();
         const nonce = this.uuidv1 ();

--- a/js/indodax.js
+++ b/js/indodax.js
@@ -556,6 +556,7 @@ module.exports = class indodax extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -1718,6 +1718,7 @@ module.exports = class kraken extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         if ('key' in params) {
             await this.loadMarkets ();

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1470,6 +1470,7 @@ module.exports = class kucoin extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         this.checkAddress (address);
         const currency = this.currency (code);

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -544,6 +544,7 @@ module.exports = class lbank extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         // mark and fee are optional params, mark is a note and must be less than 255 characters
         this.checkAddress (address);
         await this.loadMarkets ();

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -974,6 +974,7 @@ module.exports = class liquid extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -472,6 +472,7 @@ module.exports = class mercado extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/ndax.js
+++ b/js/ndax.js
@@ -2012,6 +2012,7 @@ module.exports = class ndax extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         // this method required login, password and twofa key
         const sessionToken = this.safeString (this.options, 'sessionToken');
         if (sessionToken === undefined) {

--- a/js/novadax.js
+++ b/js/novadax.js
@@ -905,6 +905,7 @@ module.exports = class novadax extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {

--- a/js/okex.js
+++ b/js/okex.js
@@ -2174,6 +2174,7 @@ module.exports = class okex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/okex3.js
+++ b/js/okex3.js
@@ -2500,6 +2500,7 @@ module.exports = class okex3 extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1282,6 +1282,7 @@ module.exports = class poloniex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/probit.js
+++ b/js/probit.js
@@ -1085,6 +1085,7 @@ module.exports = class probit extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         // In order to use this method
         // you need to allow API withdrawal from the API Settings Page, and
         // and register the list of withdrawal addresses and destination tags on the API Settings page

--- a/js/qtrade.js
+++ b/js/qtrade.js
@@ -1397,6 +1397,7 @@ module.exports = class qtrade extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {

--- a/js/stex.js
+++ b/js/stex.js
@@ -1665,6 +1665,7 @@ module.exports = class stex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -467,6 +467,7 @@ module.exports = class tidebit extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/tidex.js
+++ b/js/tidex.js
@@ -716,6 +716,7 @@ module.exports = class tidex extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/upbit.js
+++ b/js/upbit.js
@@ -1421,6 +1421,7 @@ module.exports = class upbit extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -1552,6 +1552,7 @@ module.exports = class wavesexchange extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         // currently only works for BTC and WAVES
         if (code !== 'WAVES') {
             const supportedCurrencies = await this.privateGetWithdrawCurrencies ();

--- a/js/xena.js
+++ b/js/xena.js
@@ -1492,6 +1492,7 @@ module.exports = class xena extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         await this.loadAccounts ();

--- a/js/yobit.js
+++ b/js/yobit.js
@@ -738,6 +738,7 @@ module.exports = class yobit extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/zaif.js
+++ b/js/zaif.js
@@ -424,6 +424,7 @@ module.exports = class zaif extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/zb.js
+++ b/js/zb.js
@@ -1012,6 +1012,7 @@ module.exports = class zb extends Exchange {
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
+        [ tag, params ] = this.handleTagAndParams (tag, params);
         const password = this.safeString (params, 'safePwd', this.password);
         if (password === undefined) {
             throw new ArgumentsRequired (this.id + ' withdraw() requires exchange.password or a safePwd parameter');

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -359,6 +359,7 @@ class Exchange {
         'safeNumber' => 'safe_number',
         'safeNumber2' => 'safe_number2',
         'parsePrecision' => 'parse_precision',
+        'handleTagAndParams' => 'handle_tag_and_params',
     );
 
     public static function split($string, $delimiters = array(' ')) {
@@ -3143,5 +3144,15 @@ class Exchange {
             return null;
         }
         return $string_number;
+    }
+
+    public function handle_tag_and_params($tag, $params) {
+        if (gettype($tag) === 'array') {
+            $params = $this->extend($tag, $params);
+        }
+        if ($tag === null) {
+            $tag = $this->safe_string($params, 'tag');
+        }
+        return array( $tag, $params );
     }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2357,3 +2357,10 @@ class Exchange(object):
         if float(string_number) == 0:
             return None
         return string_number
+
+    def handle_tag_and_params(self, tag, params):
+        if isinstance(tag, dict):
+            params = self.extend(tag, params)
+        if tag is None:
+            tag = self.safe_string(params, 'tag')
+        return [ tag, params ]

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3497,7 +3497,7 @@ In some cases you can also use the withdrawal id to check withdrawal status late
 
 #### Other supported withdraw signatures
 
-It is also possible to pass the parameters as the third argument with or without a specified tag
+It is also possible to pass the parameters as the fourth argument with or without a specified tag
 
 ```JavaScript
 // JavaScript

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3495,6 +3495,26 @@ Some exchanges require a manual approval of each withdrawal by means of 2FA (2-f
 
 In some cases you can also use the withdrawal id to check withdrawal status later (whether it succeeded or not) and to submit 2FA confirmation codes, where this is supported by the exchange. See [their docs](#exchanges) for details.
 
+#### Other supported withdraw signatures
+
+It is also possible to pass the parameters as the third argument with or without a specified tag
+
+```JavaScript
+// JavaScript
+exchange.withdraw (code, amount, address, { tag, network: 'ETH' })
+```
+
+```Python
+# Python
+exchange.withdraw(code, amount, address, { 'tag': tag, 'network': 'ETH' })
+```
+
+```PHP
+// PHP
+$exchange->withdraw ($code, $amount, $address, array( 'tag' => tag, 'network' -> 'ETH' ));
+```
+
+
 ## Transactions
 
 #### Transaction Structure


### PR DESCRIPTION
many currencies do not have tags so this will be able to support this signature:

```
exchange.withdraw (code, amount, address, params)
```

also it will be possible to send this:

```
exchange.withdraw (code, amount, address, { tag: '12345', 'network': 'btc' })
```

the existing signature of

```
exchange.withdraw (code, amount, address, tag, params)
```

will continue to be supported