### PR TITLE
hitbtc implement withdraw with multiple networks

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -1184,6 +1184,13 @@ module.exports = class hitbtc extends Exchange {
         if (tag) {
             request['paymentId'] = tag;
         }
+        const networks = this.safeValue (this.options, 'networks', {});
+        let network = this.safeString (params, 'network'); // this line allows the user to specify either ERC20 or ETH
+        network = this.safeString (networks, network, network); // handle ERC20>ETH alias
+        if (network !== undefined) {
+            request['currency'] += network; // when network the currency need to be changed to currency + network
+            params = this.omit (params, 'network');
+        }
         const response = await this.privatePostAccountCryptoWithdraw (this.extend (request, params));
         return {
             'info': response,


### PR DESCRIPTION
reference https://api.hitbtc.com/v2#withdraw-crypto
hitbtc has no documentation regarding multi-net withdrawals but understanding how the currency conversion works between networks was not difficult to use the same standard currency concatenated with the network.
Tested with USDT in ERC20 and TRC20