### PR TITLE
Mark index candles rest

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -28,8 +28,10 @@ module.exports = class bybit extends Exchange {
                 'fetchBalance': true,
                 'fetchClosedOrders': true,
                 'fetchDeposits': true,
+                'fetchIndexOHLCV': true,
                 'fetchLedger': true,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
@@ -771,6 +773,8 @@ module.exports = class bybit extends Exchange {
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const price = this.safeString (params, 'price');
+        params = this.omit (params, 'price');
         const request = {
             'symbol': market['id'],
             'interval': this.timeframes[timeframe],
@@ -789,7 +793,14 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // max 200, default 200
         }
-        const method = market['linear'] ? 'publicLinearGetKline' : 'v2PublicGetKlineList';
+        let method = 'v2PublicGetKlineList';
+        if (price === 'mark') {
+            method = 'v2PublicGetMarkPriceKline';
+        } else if (price === 'index') {
+            method = 'v2PublicGetIndexPriceKline';
+        } else if (market['linear']) {
+            method = 'publicLinearGetKline';
+        }
         const response = await this[method] (this.extend (request, params));
         //
         // inverse perpetual BTC/USD
@@ -840,6 +851,20 @@ module.exports = class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         return this.parseOHLCVs (result, market, timeframe, since, limit);
+    }
+
+    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'index',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+    }
+
+    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'mark',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     parseTrade (trade, market = undefined) {

--- a/js/okex.js
+++ b/js/okex.js
@@ -28,8 +28,10 @@ module.exports = class okex extends Exchange {
                 'fetchCurrencies': false, // see below
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
+                'fetchIndexOHLCV': true,
                 'fetchLedger': true,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
@@ -1138,6 +1140,8 @@ module.exports = class okex extends Exchange {
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const price = this.safeString (params, 'price');
+        params = this.omit (params, 'price');
         const request = {
             'instId': market['id'],
             'bar': this.timeframes[timeframe],
@@ -1149,7 +1153,12 @@ module.exports = class okex extends Exchange {
         const defaultType = this.safeString (options, 'type', 'Candles'); // Candles or HistoryCandles
         const type = this.safeString (params, 'type', defaultType);
         params = this.omit (params, 'type');
-        const method = 'publicGetMarket' + type;
+        let method = 'publicGetMarket' + type;
+        if (price === 'mark') {
+            method = 'publicGetMarketMarkPriceCandles';
+        } else if (price === 'index') {
+            method = 'publicGetMarketIndexCandles';
+        }
         if (since !== undefined) {
             request['before'] = since - 1;
         }
@@ -1167,6 +1176,20 @@ module.exports = class okex extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         return this.parseOHLCVs (data, market, timeframe, since, limit);
+    }
+
+    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'index',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+    }
+
+    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'mark',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     parseBalanceByType (type, response) {


### PR DESCRIPTION
Added methods `fetchMarkOHLCV` and `fetchIndexOHLCV` index price and mark price candle options to `fetchOHLCV` for exchanges **okex** and **bybit**

