### PR TITLE
updated wiki/Manual.md regarding Exchange Metadata 'has'

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -514,7 +514,7 @@ See this section on [Overriding exchange properties](#overriding-exchange-proper
 
     The meaning of each flag showing availability of this or that method is:
 
-    - a value of `undefined` / `None` / `null` means the method is not unified in the ccxt library yet
+    - a value of `undefined` / `None` / `null` means the method is not unified in the ccxt library yet or the method isn't natively available from the exchange API
     - boolean `false` means the method isn't natively available from the exchange API
     - boolean `true` means the method is natively available from the exchange API and unified in the ccxt library
     - an `'emulated'` string means the endpoint isn't natively available from the exchange API but reconstructed by the ccxt library from available true-methods


### PR DESCRIPTION
Updated

```
- a value of `undefined` / `None` / `null` means the method is not unified in the ccxt library yet
```

```
- a value of `undefined` / `None` / `null` means the method is not unified in the ccxt library yet or the method isn't natively available from the exchange API
```

Because methods are `undefined` by default, but are set to `false` when it is discovered that the method isn't natively available from the exchange API