### PR TITLE
Fixed since= parameter for fetchMyTrades on huobi

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -736,8 +736,7 @@ module.exports = class huobi extends Exchange {
             request['size'] = limit; // 1-100 orders, default is 100
         }
         if (since !== undefined) {
-            request['start-date'] = this.ymd (since); // a date within 61 days from today
-            request['end-date'] = this.ymd (this.sum (since, 86400000));
+            request['start-time'] = Math.floor (since); // a date within 120 days from today
         }
         const response = await this.privateGetOrderMatchresults (this.extend (request, params));
         return this.parseTrades (response['data'], market, since, limit);


### PR DESCRIPTION
The since= parameter is using the wrong parameter names for huobi, see parameters for `GET /v1/order/matchresults` on https://huobiapi.github.io/docs/spot/v1/en

This expects a timestamp in milliseconds but was receiving a ymd string.

I have adjusted it to be a timestamp in milliseconds. It also was setting an end-date to 1 day from now unnecessarily, I have removed this to allow it to return the maximum number of results unless otherwise specified.