### PR TITLE
bibox revert max amount, market type

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -211,7 +211,7 @@ module.exports = class bibox extends Exchange {
             const symbol = base + '/' + quote;
             let type = 'spot';
             let spot = true;
-            let areaId = this.safeInteger (market, 'area_id');
+            const areaId = this.safeInteger (market, 'area_id');
             if (areaId === 16) {
                 type = undefined;
                 spot = false;

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -209,6 +209,13 @@ module.exports = class bibox extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
+            let type = 'spot';
+            let spot = true;
+            let areaId = this.safeInteger (market, 'area_id');
+            if (areaId === 16) {
+                type = undefined;
+                spot = false;
+            }
             const precision = {
                 'amount': this.safeNumber (market, 'amount_scale'),
                 'price': this.safeNumber (market, 'decimal'),
@@ -227,7 +234,7 @@ module.exports = class bibox extends Exchange {
                 'limits': {
                     'amount': {
                         'min': Math.pow (10, -precision['amount']),
-                        'max': 1000000,
+                        'max': undefined,
                     },
                     'price': {
                         'min': Math.pow (10, -precision['price']),

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -228,6 +228,8 @@ module.exports = class bibox extends Exchange {
                 'quote': quote,
                 'baseId': baseId,
                 'quoteId': quoteId,
+                'type': type,
+                'spot': spot,
                 'active': true,
                 'info': market,
                 'precision': precision,


### PR DESCRIPTION
![2021-10-02_13h01_49](https://user-images.githubusercontent.com/38309641/135712628-427ef505-6411-40c7-9ccb-3149157ad211.png)
I found pair with max amount more than 1000000

Also I don't know what kind of pair is that, but this type of pairs has no orderbook, link https://www.bibox.com/en/exchange/basic/4BTC_USDT don't work and there is no other information about them. They all have `area_id: 16`.
`{"id":304,"pair":"4BTC_USDT","pair_type":4,"area_id":16,"is_hide":0,"decimal":4,"amount_scale":4}`
https://api.bibox.com/v1/mdata?cmd=pairList