### PR TITLE
fetchPremiumIndexOHLCV

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -73,6 +73,7 @@ console.log ('CCXT v' + ccxt.version)
             'fetchOrders',
             'fetchPosition',
             'fetchPositions',
+            'fetchPremiumIndexOHLCV',
             'fetchTradingFee',
             'fetchTradingFees',
             'fetchTransactions',

--- a/examples/js/library-capabilities.js
+++ b/examples/js/library-capabilities.js
@@ -60,6 +60,7 @@ console.log ('CCXT v' + ccxt.version)
             'createMarketOrder',
             'createMarketSellOrder',
             'createOrder',
+            'fetchPremiumIndexOHLCV',
             'deposit',
             'editOrder',
             'fetchBalance',

--- a/js/binance.js
+++ b/js/binance.js
@@ -46,6 +46,7 @@ module.exports = class binance extends Exchange {
                 'fetchOrderBook': true,
                 'fetchOrders': true,
                 'fetchPositions': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
                 'fetchTicker': true,
                 'fetchTickers': true,

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -40,6 +40,7 @@ module.exports = class bitfinex extends Exchange {
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -37,6 +37,7 @@ module.exports = class bitmex extends Exchange {
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -36,6 +36,7 @@ module.exports = class bitstamp extends Exchange {
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTrades': true,
                 'fetchTradingFee': true,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -900,6 +900,9 @@ module.exports = class bybit extends Exchange {
     }
 
     async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        if (since === undefined && limit === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchIndexOHLCV() requires a since argument or a limit argument');
+        }
         const request = {
             'price': 'index',
         };
@@ -907,6 +910,9 @@ module.exports = class bybit extends Exchange {
     }
 
     async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        if (since === undefined && limit === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchMarkOHLCV() requires a since argument or a limit argument');
+        }
         const request = {
             'price': 'mark',
         };
@@ -914,6 +920,9 @@ module.exports = class bybit extends Exchange {
     }
 
     async fetchPremiumIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        if (since === undefined && limit === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchPremiumIndexOHLCV() requires a since argument or a limit argument');
+        }
         const request = {
             'price': 'premiumIndex',
         };

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -800,7 +800,7 @@ module.exports = class bybit extends Exchange {
             method = 'v2PublicGetMarkPriceKline';
         } else if (price === 'index') {
             method = 'v2PublicGetIndexPriceKline';
-        } else if (price === 'premiumIndex' || price === 'premium_index' || price === 'premium-index') {
+        } else if (price === 'premiumIndex') {
             method = 'v2PublicGetPremiumIndexKline';
         } else if (market['linear']) {
             method = 'publicLinearGetKline';

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -41,6 +41,7 @@ module.exports = class bybit extends Exchange {
                 'fetchOrders': true,
                 'fetchOrderTrades': true,
                 'fetchPositions': true,
+                'fetchPremiumIndexOHLCV': true,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,
@@ -799,6 +800,8 @@ module.exports = class bybit extends Exchange {
             method = 'v2PublicGetMarkPriceKline';
         } else if (price === 'index') {
             method = 'v2PublicGetIndexPriceKline';
+        } else if (price === 'premiumIndex' || price === 'premium_index' || price === 'premium-index') {
+            method = 'v2PublicGetPremiumIndexKline';
         } else if (market['linear']) {
             method = 'publicLinearGetKline';
         }
@@ -906,6 +909,13 @@ module.exports = class bybit extends Exchange {
     async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         const request = {
             'price': 'mark',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+    }
+
+    async fetchPremiumIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'premiumIndex',
         };
         return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -45,6 +45,7 @@ module.exports = class coinbase extends Exchange {
                 'fetchOrder': undefined,
                 'fetchOrderBook': undefined,
                 'fetchOrders': undefined,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': undefined,
                 'fetchTime': true,

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -39,6 +39,7 @@ module.exports = class deribit extends Exchange {
                 'fetchOrderBook': true,
                 'fetchOrders': undefined,
                 'fetchOrderTrades': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
                 'fetchTicker': true,
                 'fetchTickers': true,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -57,6 +57,7 @@ module.exports = class ftx extends Exchange {
                 'fetchOrderBook': true,
                 'fetchOrders': true,
                 'fetchPositions': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -44,6 +44,7 @@ module.exports = class gateio extends Exchange {
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -42,6 +42,7 @@ module.exports = class huobi extends Exchange {
                 'fetchOrderBook': true,
                 'fetchOrders': true,
                 'fetchOrderTrades': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -30,6 +30,7 @@ module.exports = class kraken extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchLedger': true,
                 'fetchLedgerEntry': true,
                 'fetchMarkets': true,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -42,6 +42,7 @@ module.exports = class kucoin extends Exchange {
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
                 'fetchTicker': true,
                 'fetchTickers': true,

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -38,6 +38,7 @@ module.exports = class phemex extends Exchange {
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTrades': true,
                 'fetchWithdrawals': true,


### PR DESCRIPTION
Added unified fetchPremiumIndexOHLCV method
'premium_index', 'premiumIndex' or 'premium-index' can be used as the value for key `price` in `fetchOHLCV` params.

Currently only implemented on `Bybit`