### PR TITLE
latoken TPAY -> Tetra Pay

### DIFF
--- a/js/latoken.js
+++ b/js/latoken.js
@@ -94,6 +94,7 @@ module.exports = class latoken extends Exchange {
             },
             'commonCurrencies': {
                 'MT': 'Monarch',
+                'TPAY': 'Tetra Pay',
                 'TSL': 'Treasure SL',
             },
             'options': {


### PR DESCRIPTION
https://www.coingecko.com/en/coins/tetra-pay#markets
conflict with https://www.coingecko.com/en/coins/tokenpay#markets