### PR TITLE
default fetchCurrencies off

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -661,7 +661,7 @@ module.exports = class binance extends Exchange {
             },
             // exchange-specific options
             'options': {
-                'fetchCurrencies': true, // this is a private call and it requires API keys
+                'fetchCurrencies': false, // this is a private call and it requires API keys
                 // 'fetchTradesMethod': 'publicGetAggTrades', // publicGetTrades, publicGetHistoricalTrades
                 'defaultTimeInForce': 'GTC', // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
                 'defaultType': 'spot', // 'spot', 'future', 'margin', 'delivery'


### PR DESCRIPTION
this call makes short scripts take longer to run due to needing to get currency info which is not really critical for 99% of cases also it's not really a true fetchCurrencies endpoint since it is authenticated