### PR TITLE
bitforex TON -> To The Moon

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -93,17 +93,12 @@ module.exports = class bitforex extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'ACE': 'ACE Entertainment',
-                'BDP': 'BidiPass',
                 'CAPP': 'Crypto Application Token',
                 'CREDIT': 'TerraCredit',
                 'CTC': 'Culture Ticket Chain',
-                'GOT': 'GoNetwork',
-                'HBC': 'Hybrid Bank Cash',
                 'IQ': 'IQ.Cash',
                 'MIR': 'MIR COIN',
                 'TON': 'To The Moon',
-                'UOS': 'UOS Network',
             },
             'exceptions': {
                 '1003': BadSymbol, // {"success":false,"code":"1003","message":"Param Invalid:param invalid -symbol:symbol error"}


### PR DESCRIPTION
https://support.bitforex.com/hc/en-us/articles/4407069593753-BitForex-Launches-To-The-Moon-TON-at-15-00-on-October-8th-2021-GMT-8-
conflict with https://www.coingecko.com/en/coins/tokamak-network#markets