### PR TITLE
Add Bitzlato exchange

### DIFF
--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -23,14 +23,12 @@ module.exports = class bitzlato extends Exchange {
                 'CORS': true,
                 'createOrder': true,
                 // 'createDepositAddress': undefined,
+                // 'fetchDepositAddress': undefined,
                 // 'deposit': undefined,
                 'fetchBalance': true,
                 // 'fetchBidsAsks': undefined,
                 'fetchCurrencies': true,
-                // 'fetchDepositAddress': undefined,
-                // 'fetchDeposits': undefined,
                 // 'fetchFundingFees': undefined,
-                // 'fetchLedger': undefined,
                 'fetchMarkets': true,
                 // 'fetchOHLCV': 'emulated',
                 'fetchOrder': true,
@@ -47,7 +45,8 @@ module.exports = class bitzlato extends Exchange {
                 // 'fetchTradingFee': undefined,
                 // 'fetchTradingFees': undefined,
                 // 'fetchTradingLimits': undefined,
-                // 'fetchTransactions': undefined,
+                'fetchTransactions': true,
+                // 'fetchDeposits': true,
                 // 'fetchWithdrawals': undefined,
                 // 'withdraw': undefined,
             },
@@ -794,13 +793,65 @@ module.exports = class bitzlato extends Exchange {
     async fetchDepositAddress (code, params = {}) {
     }
 
+    async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
+    }
+
     parseTransactionStatus (status) {
     }
 
     parseTransaction (transaction, currency = undefined) {
+        const createdAt = this.safeString (transaction, 'created_at');
+        const updatedAt = this.safeString (transaction, 'updated_at');
+        if (currency === undefined) {
+            currency = this.safeString (transaction, 'currency');
+            currency = this.safeCurrencyCode (currency);
+        }
+        const timestamp = this.parse8601 (createdAt);
+        const updated = this.parse8601 (updatedAt);
+        const txid = this.safeString (transation, 'txid');
+        return {
+            'info': transaction,
+            'id': undefined,
+            'txid': txid,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'addressFrom': addressFrom,
+            'address': addressTo,
+            'addressTo': addressTo,
+            'tagFrom': undefined,
+            'tag': tag,
+            'tagTo': tag,
+            'type': type,
+            'amount': amount,
+            'currency': code,
+            'status': status,
+            'updated': updated,
+            'fee': {
+                'currency': code,
+                'cost': feeCost,
+                'rate': undefined,
+            },
+        };
     }
 
     async fetchTransactions (code = undefined, since = undefined, limit = undefined, params = {}) {
+        // [
+        //   {
+        //     address: '0x6fe5a2e4c137d7dc178bdaacfb8cda15b2181665',
+        //     currency: 'bnb',
+        //     amount: '1.000000000000000000',
+        //     fee: '0.000000000000000000',
+        //     txid: '0x6076decd3239e87cde86fd5de9366c08e489243eb976de29b424a27bfaa46032',
+        //     state: 'dispatched',
+        //     note: null,
+        //     confirmations: '39957',
+        //     created_at: '2021-10-09T08:08:46+03:00',
+        //     updated_at: '2021-10-09T08:09:07+03:00',
+        //     type: 'Deposit'
+        //   },
+        //   ...
+        // ]
+
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -222,7 +222,7 @@ module.exports = class bitzlato extends Exchange {
         //     "state": "enabled"
         //   },
         //   ...
-        if (!this.isArray (response)) {
+        if (!Array.isArray (response)) {
             return [];
         }
         const result = [];
@@ -281,7 +281,7 @@ module.exports = class bitzlato extends Exchange {
             'limit': limit,
         };
         const response = await this.publicGetCurrencies (this.extend (request, params));
-        if (!this.isArray (response)) {
+        if (!Array.isArray (response)) {
             return {};
         }
         const result = {};
@@ -358,7 +358,7 @@ module.exports = class bitzlato extends Exchange {
             'timestamp': undefined,
             'datetime': undefined,
         };
-        if (!this.isArray (response)) {
+        if (!Array.isArray (response)) {
             return result;
         }
         for (let i = 0; i < response.length; i++) {
@@ -604,7 +604,7 @@ module.exports = class bitzlato extends Exchange {
         //   },
         // ...
         // ]
-        if (!this.isArray (response)) {
+        if (!Array.isArray (response)) {
             return [];
         }
         const result = [];
@@ -966,7 +966,7 @@ module.exports = class bitzlato extends Exchange {
             method = 'privateGetAccountWithdraws';
         }
         const response = await this[method] (this.extend (request, params));
-        if (!this.isArray (response)) {
+        if (!Array.isArray (response)) {
             return [];
         }
         const result = [];
@@ -1108,7 +1108,7 @@ module.exports = class bitzlato extends Exchange {
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         const query = this.omit (params, this.extractParams (path));
-        const baseUrl = this.implodeHostname (this.urls.api[api]);
+        const baseUrl = this.implodeHostname (this.urls['api'][api]);
         let url = baseUrl + '/' + this.implodeParams (path, params);
         headers = {
             'Accept': 'application/json',

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -34,9 +34,8 @@ module.exports = class bitzlato extends Exchange {
                 'fetchMarkets': true,
                 // 'fetchMyTrades': undefined,
                 // 'fetchOHLCV': 'emulated',
-                // 'fetchOrder': undefined,
+                'fetchOrder': true,
                 'fetchOrderBook': true,
-                // 'fetchOrderBooks': undefined,
                 'fetchOrders': true,
                 'fetchOpenOrders': true,
                 'fetchClosedOrders': true,
@@ -405,10 +404,6 @@ module.exports = class bitzlato extends Exchange {
     async transfer (code, amount, fromAccount, toAccount, params = {}) {
     }
 
-    async fetchOrder (id, symbol = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchOrder is not implemented yet');
-    }
-
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
@@ -734,10 +729,12 @@ module.exports = class bitzlato extends Exchange {
         return order;
     }
 
-    async fetchOpenOrder (id, symbol = undefined, params = {}) {
-    }
-
-    async fetchClosedOrder (id, symbol = undefined, params = {}) {
+    async fetchOrder (id, symbol = undefined, params = {}) {
+        const request = {
+            'id': id,
+        };
+        const response = await this.privateGetMarketOrdersId (this.extend (request, params));
+        return this.parseOrder (response);
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -1,0 +1,303 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+
+const Exchange = require ('./base/Exchange');
+const { ExchangeError, InvalidAddress, ArgumentsRequired, InsufficientFunds, AuthenticationError, OrderNotFound, InvalidOrder, BadRequest, InvalidNonce, BadSymbol, OnMaintenance, NotSupported, PermissionDenied, ExchangeNotAvailable } = require ('./base/errors');
+const { SIGNIFICANT_DIGITS, DECIMAL_PLACES, TRUNCATE, ROUND } = require ('./base/functions/number');
+const Precise = require ('./base/Precise');
+
+// ---------------------------------------------------------------------------
+
+module.exports = class bitzlato extends Exchange {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'bitzlato',
+            'name': 'Bitzlato',
+            'countries': [ 'HK' ],
+            'version': 'v2',
+            'rateLimit': 1000,
+            'has': {
+                // 'cancelAllOrders': true,
+                // 'cancelOrder': true,
+                // 'cancelOrders': undefined,
+                // 'CORS': undefined,
+                // 'createOrder': true,
+                // 'createLimitOrder': true,
+                // 'createMarketOrder': true,
+                // 'createDepositAddress': undefined,
+                // 'deposit': undefined,
+                // 'editOrder': 'emulated',
+                // 'fetchBalance': true,
+                // 'fetchBidsAsks': undefined,
+                // 'fetchClosedOrders': undefined,
+                // 'fetchCurrencies': undefined,
+                // 'fetchDepositAddress': undefined,
+                // 'fetchDeposits': undefined,
+                // 'fetchFundingFees': undefined,
+                // 'fetchL2OrderBook': true,
+                // 'fetchLedger': undefined,
+                // 'fetchMarkets': true,
+                // 'fetchMyTrades': undefined,
+                // 'fetchOHLCV': 'emulated',
+                // 'fetchOpenOrders': undefined,
+                // 'fetchOrder': undefined,
+                // 'fetchOrderBook': true,
+                // 'fetchOrderBooks': undefined,
+                // 'fetchOrders': undefined,
+                // 'fetchOrderTrades': undefined,
+                // 'fetchStatus': 'emulated',
+                // 'fetchTicker': true,
+                // 'fetchTickers': undefined,
+                // 'fetchTime': undefined,
+                // 'fetchTrades': true,
+                // 'fetchTradingFee': undefined,
+                // 'fetchTradingFees': undefined,
+                // 'fetchTradingLimits': undefined,
+                // 'fetchTransactions': undefined,
+                // 'fetchWithdrawals': undefined,
+                // 'signIn': undefined,
+                // 'withdraw': undefined,
+            },
+            'timeframes': {
+                '1m': '1',
+                '5m': '5',
+                '15m': '15',
+                '30m': '30',
+                '1h': '60',
+                '2h': '120',
+                '4h': '240',
+                '6h': '360',
+                '12h': '720',
+                '1d': '1440',
+                '3d': '4320',
+                '1w': '10080',
+            },
+            'hostname': 'bitzlato.com',
+            'urls': {
+                'logo': '',
+                'test': 'https://market-sandbox.{hostname}/api',
+                'api': 'https://market.{hostname}/api',
+                'www': 'https://market.{hostname}/',
+                'doc': [
+                    'https://market.{hostname}/docs',
+                ],
+                'fees': '',
+            },
+            'api': {
+                'public': {
+                    'get': [
+                        'peatio/public/withdraw_limits',
+                        'peatio/public/trading_fees',
+                        'peatio/public/timestamp',
+                        'peatio/public/member-levels',
+                        'peatio/public/markets/{market}/tickers',
+                        'peatio/public/markets/tickers',
+                        'peatio/public/markets/{market}/k-line',
+                        'peatio/public/markets/{market}/depth',
+                        'peatio/public/markets/{market}/trades',
+                        'peatio/public/markets/{market}/order-book',
+                        'peatio/public/markets',
+                        'peatio/public/currencies',
+                        'peatio/public/currencies/{id}',
+                    ],
+                },
+                'private': {
+                    'get': [
+                        'peatio/account/internal_transfers',
+                        'peatio/account/transactions',
+                        'peatio/account/stats/pnl',
+                        'peatio/account/withdraws',
+                        'peatio/account/withdraws/sums',
+                        'peatio/account/beneficiaries/{id}',
+                        'peatio/account/beneficiaries',
+                        'peatio/account/deposit_address/{currency}',
+                        'peatio/account/deposits/{txid}',
+                        'peatio/account/deposits',
+                        'peatio/account/balances/{currency}',
+                        'peatio/account/balances',
+                        'peatio/account/trades',
+                        'peatio/market/orders',
+                        'peatio/market/orders/{id}',
+                        'peatio/coinmarketcap/orderbook/{market_pair}',
+                        'peatio/coinmarketcap/trades/{market_pair}',
+                        'peatio/coinmarketcap/ticker',
+                        'peatio/coinmarketcap/assets',
+                        'peatio/coinmarketcap/summary',
+                        'peatio/coingecko/historical_trades',
+                        'peatio/coingecko/orderbook',
+                        'peatio/coingecko/tickers',
+                        'peatio/coingecko/pairs',
+                    ],
+                    'post': [
+                        'peatio/account/internal_transfers',
+                        'peatio/account/withdraws',
+                        'peatio/account/beneficiaries',
+                        'peatio/account/deposits/intention',
+                        'peatio/market/orders/cancel',
+                        'peatio/market/orders/{id}/cancel',
+                        'peatio/market/orders',
+                    ],
+                    'patch': [
+                        'peatio/account/beneficiaries/{id}/activate',
+                        'peatio/account/beneficiaries/{id}/resend_pin',
+                    ],
+                    'delete': [
+                        'peatio/account/beneficiaries/{id}',
+                    ],
+                },
+            },
+            'fees': {
+                'trading': {
+                    'feeSide': 'get',
+                    'percentage': true,
+                    'tierBased': true,
+                    'maker': this.parseNumber ('0.002'),
+                    'taker': this.parseNumber ('0.002'),
+                    'tiers': {
+                        'taker': [
+                            [this.parseNumber ('1'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('2'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('3'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('4'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('5'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('6'), this.parseNumber ('0.002')],
+                        ],
+                        'maker': [
+                            [this.parseNumber ('1'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('2'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('3'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('4'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('5'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('6'), this.parseNumber ('0.002')],
+                        ],
+                    },
+                },
+                'funding': {
+                    'withdraw': {},
+                },
+            },
+            'options': {
+            },
+            'exceptions': {
+                'exact': {
+                },
+                'broad': {
+                },
+            },
+        });
+    }
+
+    isFiat (code) {
+    }
+
+    getCurrencyId (code) {
+    }
+
+    async fetchStatus (params = {}) {
+    }
+
+    async fetchMarkets (params = {}) {
+    }
+
+    async fetchCurrencies (params = {}) {
+    }
+
+    async fetchBalance (params = {}) {
+    }
+
+    async transfer (code, amount, fromAccount, toAccount, params = {}) {
+    }
+
+    async fetchOrder (id, symbol = undefined, params = {}) {
+        throw new NotSupported (this.id + ' fetchOrder is not implemented yet');
+    }
+
+    async fetchOrderBook (symbol, limit = undefined, params = {}) {
+    }
+
+    parseTicker (ticker, market = undefined) {
+    }
+
+    async fetchTickers (symbols = undefined, params = {}) {
+    }
+
+    async fetchTicker (symbol, params = {}) {
+    }
+
+    parseSymbol (marketId) {
+    }
+
+    parseTrade (trade, market = undefined) {
+    }
+
+    async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {
+    }
+
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = 100, params = {}) {
+    }
+
+    parseOrderStatus (status) {
+    }
+
+    parseOrder (order, market = undefined) {
+    }
+
+    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
+    }
+
+    async cancelAllOrders (symbol = undefined, params = {}) {
+    }
+
+    async cancelOrder (id, symbol = undefined, params = {}) {
+    }
+
+    async fetchOpenOrder (id, symbol = undefined, params = {}) {
+    }
+
+    async fetchClosedOrder (id, symbol = undefined, params = {}) {
+    }
+
+    async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+    }
+
+    async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+    }
+
+    async fetchOrderTrades (id, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+    }
+
+    async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+    }
+
+    async createDepositAddress (code, params = {}) {
+    }
+
+    async fetchDepositAddress (code, params = {}) {
+    }
+
+    parseTransactionStatus (status) {
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+    }
+
+    async fetchTransactions (code = undefined, since = undefined, limit = undefined, params = {}) {
+    }
+
+    async withdraw (code, amount, address, tag = undefined, params = {}) {
+    }
+
+    async fetchPositions (symbols = undefined, params = {}) {
+    }
+
+    nonce () {
+        return this.milliseconds ();
+    }
+
+    sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+    }
+
+    handleErrors (statusCode, statusText, url, method, responseHeaders, responseBody, response, requestHeaders, requestBody) {
+    }
+};

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -534,9 +534,6 @@ module.exports = class bitzlato extends Exchange {
         return this.parseTicker (response, market);
     }
 
-    parseSymbol (marketId) {
-    }
-
     parseTrade (trade, market = undefined) {
         const id = this.safeString (trade, 'id');
         const price = this.safeNumber (trade, 'price');
@@ -1111,8 +1108,8 @@ module.exports = class bitzlato extends Exchange {
         }
         if (api === 'private') {
             this.checkRequiredCredentials ();
-            const nonce = this.nonce ();
-            const message = this.encode (nonce.toString ()) + this.encode (this.apiKey);
+            const nonce = this.nonce ().toString ();
+            const message = this.encode (nonce) + this.encode (this.apiKey);
             const signature = this.hmac (message, this.encode (this.secret), 'sha256', 'hex');
             headers['X-Auth-ApiKey'] = this.apiKey;
             headers['X-Auth-Nonce'] = nonce;

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -49,7 +49,7 @@ module.exports = class bitzlato extends Exchange {
                 // 'fetchStatus': 'emulated',
                 // 'fetchTicker': true,
                 // 'fetchTickers': undefined,
-                // 'fetchTime': undefined,
+                'fetchTime': true,
                 // 'fetchTrades': true,
                 // 'fetchTradingFee': undefined,
                 // 'fetchTradingFees': undefined,
@@ -76,74 +76,80 @@ module.exports = class bitzlato extends Exchange {
             'hostname': 'bitzlato.com',
             'urls': {
                 'logo': '',
-                'test': 'https://market-sandbox.{hostname}/api',
-                'api': 'https://market.{hostname}/api',
-                'www': 'https://market.{hostname}/',
+                'test': {
+                    'public': 'https://market-sandbox.{hostname}/api/v2/peatio/public',
+                    'private': 'https://market-sandbox.{hostname}/api/v2/peatio',
+                },
+                'api': {
+                    'public': 'https://market.{hostname}/api/v2/peatio/public',
+                    'private': 'https://market.{hostname}/api/v2/peatio',
+                },
+                'www': 'https://market.bitzlato.com/',
                 'doc': [
-                    'https://market.{hostname}/docs',
+                    'https://market.bitzlato.com/docs',
                 ],
                 'fees': '',
             },
             'api': {
                 'public': {
                     'get': [
-                        'peatio/public/withdraw_limits',
-                        'peatio/public/trading_fees',
-                        'peatio/public/timestamp',
-                        'peatio/public/member-levels',
-                        'peatio/public/markets/{market}/tickers',
-                        'peatio/public/markets/tickers',
-                        'peatio/public/markets/{market}/k-line',
-                        'peatio/public/markets/{market}/depth',
-                        'peatio/public/markets/{market}/trades',
-                        'peatio/public/markets/{market}/order-book',
-                        'peatio/public/markets',
-                        'peatio/public/currencies',
-                        'peatio/public/currencies/{id}',
+                        'withdraw_limits',
+                        'trading_fees',
+                        'timestamp',
+                        'member-levels',
+                        'markets/{market}/tickers',
+                        'markets/tickers',
+                        'markets/{market}/k-line',
+                        'markets/{market}/depth',
+                        'markets/{market}/trades',
+                        'markets/{market}/order-book',
+                        'markets',
+                        'currencies',
+                        'currencies/{id}',
                     ],
                 },
                 'private': {
                     'get': [
-                        'peatio/account/internal_transfers',
-                        'peatio/account/transactions',
-                        'peatio/account/stats/pnl',
-                        'peatio/account/withdraws',
-                        'peatio/account/withdraws/sums',
-                        'peatio/account/beneficiaries/{id}',
-                        'peatio/account/beneficiaries',
-                        'peatio/account/deposit_address/{currency}',
-                        'peatio/account/deposits/{txid}',
-                        'peatio/account/deposits',
-                        'peatio/account/balances/{currency}',
-                        'peatio/account/balances',
-                        'peatio/account/trades',
-                        'peatio/market/orders',
-                        'peatio/market/orders/{id}',
-                        'peatio/coinmarketcap/orderbook/{market_pair}',
-                        'peatio/coinmarketcap/trades/{market_pair}',
-                        'peatio/coinmarketcap/ticker',
-                        'peatio/coinmarketcap/assets',
-                        'peatio/coinmarketcap/summary',
-                        'peatio/coingecko/historical_trades',
-                        'peatio/coingecko/orderbook',
-                        'peatio/coingecko/tickers',
-                        'peatio/coingecko/pairs',
+                        'account/internal_transfers',
+                        'account/transactions',
+                        'account/stats/pnl',
+                        'account/withdraws',
+                        'account/withdraws/sums',
+                        'account/beneficiaries/{id}',
+                        'account/beneficiaries',
+                        'account/deposit_address/{currency}',
+                        'account/deposits/{txid}',
+                        'account/deposits',
+                        'account/balances/{currency}',
+                        'account/balances',
+                        'account/trades',
+                        'market/orders',
+                        'market/orders/{id}',
+                        'coinmarketcap/orderbook/{market_pair}',
+                        'coinmarketcap/trades/{market_pair}',
+                        'coinmarketcap/ticker',
+                        'coinmarketcap/assets',
+                        'coinmarketcap/summary',
+                        'coingecko/historical_trades',
+                        'coingecko/orderbook',
+                        'coingecko/tickers',
+                        'coingecko/pairs',
                     ],
                     'post': [
-                        'peatio/account/internal_transfers',
-                        'peatio/account/withdraws',
-                        'peatio/account/beneficiaries',
-                        'peatio/account/deposits/intention',
-                        'peatio/market/orders/cancel',
-                        'peatio/market/orders/{id}/cancel',
-                        'peatio/market/orders',
+                        'account/internal_transfers',
+                        'account/withdraws',
+                        'account/beneficiaries',
+                        'account/deposits/intention',
+                        'market/orders/cancel',
+                        'market/orders/{id}/cancel',
+                        'market/orders',
                     ],
                     'patch': [
-                        'peatio/account/beneficiaries/{id}/activate',
-                        'peatio/account/beneficiaries/{id}/resend_pin',
+                        'account/beneficiaries/{id}/activate',
+                        'account/beneficiaries/{id}/resend_pin',
                     ],
                     'delete': [
-                        'peatio/account/beneficiaries/{id}',
+                        'account/beneficiaries/{id}',
                     ],
                 },
             },
@@ -158,18 +164,18 @@ module.exports = class bitzlato extends Exchange {
                         'taker': [
                             [this.parseNumber ('1'), this.parseNumber ('0.002')],
                             [this.parseNumber ('2'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('3'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('4'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('3'), this.parseNumber ('0.0018')],
+                            [this.parseNumber ('4'), this.parseNumber ('0.0016')],
                             [this.parseNumber ('5'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('6'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('6'), this.parseNumber ('0.0')],
                         ],
                         'maker': [
                             [this.parseNumber ('1'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('2'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('3'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('4'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('2'), this.parseNumber ('0.001')],
+                            [this.parseNumber ('3'), this.parseNumber ('0.0008')],
+                            [this.parseNumber ('4'), this.parseNumber ('0.0006')],
                             [this.parseNumber ('5'), this.parseNumber ('0.002')],
-                            [this.parseNumber ('6'), this.parseNumber ('0.002')],
+                            [this.parseNumber ('6'), this.parseNumber ('0.0')],
                         ],
                     },
                 },
@@ -178,6 +184,8 @@ module.exports = class bitzlato extends Exchange {
                 },
             },
             'options': {
+              'defaultType': 'spot',
+              'timeDifference': 0,
             },
             'exceptions': {
                 'exact': {
@@ -186,6 +194,13 @@ module.exports = class bitzlato extends Exchange {
                 },
             },
         });
+    }
+
+    async fetchTime (params = {}) {
+      const response = await this.publicGetTimestamp (params);
+      //  "\"2021-10-05T12:34:56+00:00\""
+      const parsed = JSON.parse (response);
+      return this.parse8601 (parsed);
     }
 
     isFiat (code) {
@@ -296,6 +311,25 @@ module.exports = class bitzlato extends Exchange {
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+        const query = this.omit (params, this.extractParams (path));
+        const baseUrl = this.implodeHostname (this.urls.api[api]);
+        let url = baseUrl + '/' + this.implodeParams (path, params);
+        headers = {
+          'Accept': 'application/json'
+        }
+        if (method === 'GET') {
+            if (Object.keys (query).length) {
+                url += '?' + this.urlencode (query);
+            }
+        } else if (method === 'POST') {
+            headers['Content-type'] = 'application/json'
+        }
+        if (api === 'private') {
+            this.checkRequiredCredentials ();
+            // TODO: implement authorization headers
+            headers['Authorization'] = 'Bearer ' + this.apiKey;
+        }
+        return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 
     handleErrors (statusCode, statusText, url, method, responseHeaders, responseBody, response, requestHeaders, requestBody) {

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -28,7 +28,7 @@ module.exports = class bitzlato extends Exchange {
                 // 'createDepositAddress': undefined,
                 // 'deposit': undefined,
                 // 'editOrder': 'emulated',
-                // 'fetchBalance': true,
+                'fetchBalance': true,
                 // 'fetchBidsAsks': undefined,
                 // 'fetchClosedOrders': undefined,
                 'fetchCurrencies': true,
@@ -42,7 +42,7 @@ module.exports = class bitzlato extends Exchange {
                 // 'fetchOHLCV': 'emulated',
                 // 'fetchOpenOrders': undefined,
                 // 'fetchOrder': undefined,
-                // 'fetchOrderBook': true,
+                'fetchOrderBook': true,
                 // 'fetchOrderBooks': undefined,
                 // 'fetchOrders': undefined,
                 // 'fetchOrderTrades': undefined,
@@ -200,6 +200,7 @@ module.exports = class bitzlato extends Exchange {
             },
             'options': {
                 'fetchMarkets': 'spot',
+                'orderBookLimit': 100,
                 'currencyType': [
                     'fiat',
                     'coin',
@@ -418,6 +419,22 @@ module.exports = class bitzlato extends Exchange {
     }
 
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'market': market['id'],
+        };
+        if (limit !== undefined) {
+            request['bids_limit'] = limit;
+            request['asks_limit'] = limit;
+        } else {
+            const defaultLimit = this.options['orderBookLimit'];
+            request['bids_limit'] = defaultLimit;
+            request['asks_limit'] = defaultLimit;
+        }
+        const response = await this.publicGetMarketsMarketOrderBook (this.extend (request, params));
+        const timestamp = undefined;
+        return this.parseOrderBook (response, symbol, timestamp, 'bids', 'asks', 'price', 'remaining_volume');
     }
 
     parseTicker (ticker, market = undefined) {

--- a/js/bitzlato.js
+++ b/js/bitzlato.js
@@ -533,6 +533,18 @@ module.exports = class bitzlato extends Exchange {
     }
 
     async fetchTickers (symbols = undefined, params = {}) {
+        await this.loadMarkets ();
+        const response = await this.publicGetMarketsTickers (params);
+        const ids = Object.keys (response);
+        const result = {};
+        for (let i = 0; i < ids.length; i++) {
+            const id = ids[i];
+            const market = this.safeMarket (id);
+            const symbol = market['symbol'];
+            const ticker = response[id];
+            result[symbol] = this.parseTicker (ticker, market);
+        }
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     async fetchTicker (symbol, params = {}) {


### PR DESCRIPTION
This PR adds support for [bitzlato.com](https://market.bitzlato.com) exchange.

Methods implemented so far:

- [x] `cancelAllOrders`
- [x] `cancelOrder`
- [ ] `cancelOrders`
- [ ] `createDepositAddress`
- [x] `createLimitOrder`
- [x] `createMarketOrder`
- [x] `createOrder`
- [ ] `deposit`
- [ ] `editOrder`
- [x] `fetchBalance`
- [ ] `fetchBidsAsks`
- [x] `fetchClosedOrders`
- [x] `fetchCurrencies`
- [x] `fetchDepositAddress`
- [x] `fetchDeposits`
- [ ] `fetchFundingFees`
- [ ] `fetchL2OrderBook`
- [ ] `fetchLedger`
- [x] `fetchMarkets`
- [x] `fetchMyTrades`
- [x] `fetchOHLCV`
- [x] `fetchOpenOrders`
- [x] `fetchOrder`
- [x] `fetchOrderBook`
- [ ] `fetchOrderBooks`
- [x] `fetchOrders`
- [ ] `fetchOrderTrades`
- [x] `fetchStatus`
- [x] `fetchTicker`
- [x] `fetchTickers`
- [x] `fetchTime`
- [x] `fetchTrades`
- [ ] `fetchTradingFee`
- [ ] `fetchTradingFees`
- [ ] `fetchTradingLimits`
- [x] `fetchTransactions`
- [x] `fetchWithdrawals`
- [x] `signIn`
- [x] `withdraw`