### PR TITLE
Simplify OKEx spot market buy logic and fix it for futures

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -1457,12 +1457,11 @@ module.exports = class okex extends Exchange {
             if (market['type'] === 'spot' && side === 'buy') {
                 // spot market buy: "sz" can refer either to base currency units or to quote currency units
                 // see documentation: https://www.okex.com/docs-v5/en/#rest-api-trade-place-order
-
-                const tgtCcy = this.safeString (params, 'tgtCcy', 'base_ccy');
+                const defaultTgtCcy = this.safeString (this.options, 'tgtCcy', 'base_ccy');
+                const tgtCcy = this.safeString (params, 'tgtCcy', defaultTgtCcy);
                 if (tgtCcy === 'quote_ccy') {
                     // quote_ccy: sz refers to units of quote currency
                     request['tgtCcy'] = 'quote_ccy';
-
                     let notional = this.safeNumber (params, 'sz');
                     const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
                     if (createMarketBuyOrderRequiresPrice) {


### PR DESCRIPTION
## Background on OKEx spot market orders
Some exchanges, including OKEx, interpret the `sz` parameters for spot market buy orders in a peculiar way: it is not the amount of trading currency / coins to buy, but the maximum amount in USD that should be spend.

This behaviour is documented in the [CCXT manual](https://ccxt.readthedocs.io/en/latest/manual.html#market-buys).

For example, if a BUY ETH/USDT with `sz=0.1` is sent, OKEx buys up to 0.1 USDT worth of ETH, *not* 0.1 ETH as one would expect.
This is the default behaviour for BUY market orders for spot and margin in OKEx. Remind that this happens only for the **BUY MARKET ORDERS ON THE SPOT**, indeed:
- It does not happen with limit orders.
- It does not happen with futures.
- It does not happen with sell orders on the spot.

## The problem
CCXT works around this issue by requiring that the user manually specifies the `sz` parameter in the `param` dictionary and gives an error if the user does not do so.

CCXT does this for all the market buy orders, even those of swaps and futures. This is unneeded (and probably incorrect), as in OKEx the `sz` parameter is always interpreted as the "number of contracts" when trading futures ([documentation](https://www.okex.com/docs-v5/en/#rest-api-trade-place-order)).

## The solution
It turns out that CCXT's workaround is not needed, even for spot market buy orders.
Indeed, the behaviour of OKEx can be "normalized" by setting the parameter `tgtCcy="base_ccy"`.

What it does is to tell OKEx that "sz" must be interpreted as units of the base currency (ETH), not of the quote currency (USDT). This way, spot buy market orders work exactly as the sell orders.

## How to try it
**I published [this script](https://gist.github.com/pietrodn/8a44ff329229b54dc311a5895762bbc6)** that buys and sell a small quantity of ETH/USDT with and without `tgtCcy`, to show the solution clearly.

Sorry for the long post but I tried to explain this as thoroughly as possible. 🙂 