### PR TITLE
Added funding fee exchange hours to describe.fees

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -144,6 +144,12 @@ module.exports = class aax extends Exchange {
                 },
             },
             'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
                 'trading': {
                     'tierBased': false,
                     'percentage': true,

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -183,6 +183,12 @@ module.exports = class ascendex extends Exchange {
                 },
             },
             'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
                 'trading': {
                     'feeSide': 'get',
                     'tierBased': true,

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -98,6 +98,11 @@ module.exports = class bibox extends Exchange {
                     'taker': this.parseNumber ('0.001'),
                     'maker': this.parseNumber ('0.0008'),
                 },
+                'future': {
+                    'fundingFee': {
+                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                    },
+                },
                 'funding': {
                     'tierBased': false,
                     'percentage': false,

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -100,7 +100,8 @@ module.exports = class bibox extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 8,
                     },
                 },
                 'funding': {

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -105,6 +105,12 @@ module.exports = class bigone extends Exchange {
                 'funding': {
                     'withdraw': {},
                 },
+                'swap': {
+                    'fundingFee': {
+                        'start': '06:00',
+                        'interval': 8,
+                    },
+                },
             },
             'exceptions': {
                 'exact': {

--- a/js/binance.js
+++ b/js/binance.js
@@ -581,7 +581,8 @@ module.exports = class binance extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 8,
                     },
                     'trading': {
                         'feeSide': 'quote',

--- a/js/binance.js
+++ b/js/binance.js
@@ -580,6 +580,9 @@ module.exports = class binance extends Exchange {
                     'maker': this.parseNumber ('0.001'),
                 },
                 'future': {
+                    'fundingFee': {
+                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                    },
                     'trading': {
                         'feeSide': 'quote',
                         'tierBased': true,

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -198,6 +198,12 @@ module.exports = class bitfinex extends Exchange {
                         ],
                     },
                 },
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
                 'funding': {
                     'tierBased': false, // true for tier-based/progressive
                     'percentage': false, // fixed commission

--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -91,6 +91,12 @@ module.exports = class bitforex extends Exchange {
                     'deposit': {},
                     'withdraw': {},
                 },
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
             },
             'commonCurrencies': {
                 'BKC': 'Bank Coin',

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -173,6 +173,12 @@ module.exports = class bitget extends Exchange {
                 'swap': {
                     'taker': this.parseNumber ('0.0006'),
                     'maker': this.parseNumber ('0.0004'),
+                    'swap': {
+                        'fundingFee': {
+                            'start': '00:00',
+                            'interval': 8,
+                        },
+                    },
                 },
             },
             'requiredCredentials': {

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -140,6 +140,12 @@ module.exports = class bitmart extends Exchange {
                 '1M': 43200,
             },
             'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
                 'trading': {
                     'tierBased': true,
                     'percentage': true,

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -155,6 +155,14 @@ module.exports = class bitmex extends Exchange {
                     ],
                 },
             },
+            'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
+            },
             'exceptions': {
                 'exact': {
                     'Invalid API Key.': AuthenticationError,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -412,6 +412,11 @@ module.exports = class bybit extends Exchange {
                     'taker': 0.00075,
                     'maker': -0.00025,
                 },
+                'future': {
+                    'fundingFee': {
+                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                    },
+                },
                 'funding': {
                     'tierBased': false,
                     'percentage': false,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -414,7 +414,8 @@ module.exports = class bybit extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 8,
                     },
                 },
                 'funding': {

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -331,7 +331,7 @@ module.exports = class deribit extends Exchange {
                         'interval': 8,
                     },
                 },
-            }
+            },
         });
     }
 

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -324,6 +324,14 @@ module.exports = class deribit extends Exchange {
                     'code': 'BTC',
                 },
             },
+            'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
+            }
         });
     }
 

--- a/js/eqonex.js
+++ b/js/eqonex.js
@@ -110,6 +110,14 @@ module.exports = class eqonex extends Exchange {
                     'symbol not found': BadSymbol,
                 },
             },
+            'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '04:00',
+                        'interval': 8,
+                    },
+                },
+            },
         });
     }
 

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -282,6 +282,11 @@ module.exports = class ftx extends Exchange {
                         ],
                     },
                 },
+                'future': {
+                    'fundingFee': {
+                        'exchangedAt': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],  // hours of the day in UTC
+                    },
+                },
                 'funding': {
                     'withdraw': {},
                 },

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -284,7 +284,8 @@ module.exports = class ftx extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],  // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 1,
                     },
                 },
                 'funding': {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -405,7 +405,8 @@ module.exports = class gateio extends Exchange {
                         ],
                     },
                     'fundingFee': {
-                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 8,
                     },
                 },
             },

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -404,6 +404,9 @@ module.exports = class gateio extends Exchange {
                             [ this.parseNumber ('75000'), this.parseNumber ('0.00030') ],
                         ],
                     },
+                    'fundingFee': {
+                        'exchangedAt': [0, 8, 16],  // hours of the day in UTC
+                    },
                 },
             },
             // https://www.gate.io/docs/apiv4/en/index.html#label-list

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -170,6 +170,11 @@ module.exports = class hitbtc extends Exchange {
                     'maker': 0.1 / 100,
                     'taker': 0.2 / 100,
                 },
+                'future': {
+                    'fundingFee': {
+                        'exchangedAt': [0, 8, 16],    // hours of the day in UTC
+                    },
+                },
             },
             'options': {
                 'networks': {

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -172,7 +172,8 @@ module.exports = class hitbtc extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [0, 8, 16],    // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 8,
                     },
                 },
             },

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -236,6 +236,12 @@ module.exports = class huobi extends Exchange {
                 },
             },
             'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
                 'trading': {
                     'feeSide': 'get',
                     'tierBased': false,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -106,7 +106,8 @@ module.exports = class kraken extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [0, 4, 8, 12, 16, 20],     // hours of the day in UTC
+                        'start': '00:00',
+                        'interval': 4,
                     },
                 },
                 // this is a bad way of hardcoding fees that change on daily basis

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -104,6 +104,11 @@ module.exports = class kraken extends Exchange {
                         ],
                     },
                 },
+                'future': {
+                    'fundingFee': {
+                        'exchangedAt': [0, 4, 8, 12, 16, 20],     // hours of the day in UTC
+                    },
+                },
                 // this is a bad way of hardcoding fees that change on daily basis
                 // hardcoding is now considered obsolete, we will remove all of it eventually
                 'funding': {

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -300,6 +300,11 @@ module.exports = class kucoin extends Exchange {
                     'taker': 0.001,
                     'maker': 0.001,
                 },
+                'future': {
+                    'fundingFee': {
+                        'exchangedAt': [4, 12, 20],    // hours of the day in UTC
+                    },
+                },
                 'funding': {
                     'tierBased': false,
                     'percentage': false,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -302,7 +302,8 @@ module.exports = class kucoin extends Exchange {
                 },
                 'future': {
                     'fundingFee': {
-                        'exchangedAt': [4, 12, 20],    // hours of the day in UTC
+                        'start': '04:00',
+                        'interval': 8,
                     },
                 },
                 'funding': {

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -187,6 +187,12 @@ module.exports = class liquid extends Exchange {
                         },
                     },
                 },
+                'swap': {
+                    'fundingFee': {
+                        'start': '04:00',
+                        'interval': 8,
+                    },
+                },
             },
             'precisionMode': TICK_SIZE,
             'exceptions': {

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -178,6 +178,12 @@ module.exports = class mexc extends Exchange {
             },
             'precisionMode': TICK_SIZE,
             'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '04:00',
+                        'interval': 8,
+                    },
+                },
                 'trading': {
                     'tierBased': false,
                     'percentage': true,

--- a/js/okex.js
+++ b/js/okex.js
@@ -212,6 +212,10 @@ module.exports = class okex extends Exchange {
                 'swap': {
                     'taker': this.parseNumber ('0.00050'),
                     'maker': this.parseNumber ('0.00020'),
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
                 },
             },
             'requiredCredentials': {

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -159,6 +159,12 @@ module.exports = class phemex extends Exchange {
             },
             'precisionMode': TICK_SIZE,
             'fees': {
+                'swap': {
+                    'fundingFee': {
+                        'start': '00:00',
+                        'interval': 8,
+                    },
+                },
                 'trading': {
                     'tierBased': false,
                     'percentage': true,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -120,6 +120,12 @@ module.exports = class poloniex extends Exchange {
                     'maker': this.parseNumber ('0.0009'),
                     'taker': this.parseNumber ('0.0009'),
                 },
+                'swap': {
+                    'fundingFee': {
+                        'start': '04:00',
+                        'interval': 8,
+                    },
+                },
                 'funding': {},
             },
             'limits': {


### PR DESCRIPTION
Added the property fees.future.fundingFee.exchangedAt to the exchanges bibox, binance, bybit, ftx, gateio, hitbtc, kraken and kucoin

This property is a dictionary containing the properties
- **start** (string): the time of day that the first funding fee is exchanged with format `hh:mm`
- **interval** (number): The number of hours between funding fee exchanges
Example:

```
`fees`: {
          'fundingFee': {
                        'start': '00:00',
                        'interval': 8,
           },
}
```

This exchange would have funding fees exchanged between traders at times 00:00, 08:00, and 16:00