### PR TITLE
mexc parseOrder fix

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1707,7 +1707,9 @@ module.exports = class mexc extends Exchange {
             clientOrderId = undefined;
         }
         let orderType = this.safeStringLower (order, 'order_type');
-        orderType = orderType.replace ('_order', '');
+        if (orderType !== undefined) {
+            orderType = orderType.replace ('_order', '');
+        }
         return this.safeOrder2 ({
             'id': id,
             'clientOrderId': clientOrderId,


### PR DESCRIPTION
```
fetch:
 mexc POST https://www.mexc.com/open/api/v2/order/place
Request:
 {
  ApiKey: '***',
  'Request-Time': '1634661644854',
  'Content-Type': 'application/json',
  Signature: 'xxx'
}
 {"symbol":"ETH_USDT","price":"3700","quantity":"0.01","trade_type":"BID","order_type":"LIMIT_ORDER"}

handleRestResponse:
 mexc POST https://www.mexc.com/open/api/v2/order/place 200 OK
Response:
 {
  Connection: 'keep-alive',
  'Content-Length': '54',
  'Content-Type': 'application/json;charset=UTF-8',
  Date: 'Tue, 19 Oct 2021 16:40:45 GMT',
  'Server-Timing': 'cdn-cache; desc=MISS, edge; dur=188, origin; dur=53'
}
 {"code":200,"data":"5ec2f0a560014c52822fc20054bd6214"}

TypeError: Cannot read property 'replace' of undefined
    at mexc.parseOrder (/var/***/test/node_modules/ccxt/js/mexc.js:1710:31)
    at mexc.createSpotOrder (/var/***/test/node_modules/ccxt/js/mexc.js:1541:21)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async mexc.createOrder (/var/***/node_modules/ccxt/js/mexc.js:1505:20)
    at async test (/var/***/test/test.js:256:24)
```
