### PR TITLE
add php error handling

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1672,7 +1672,8 @@ class Exchange {
         $this->handle_errors($http_status_code, $http_status_text, $url, $method, $response_headers, $result ? $result : null, $json_response, $headers, $body);
         $this->handle_http_status_code($http_status_code, $http_status_text, $url, $method, $result);
 
-        if ($curl_errno !== 0) {
+        // check if $curl_errno is not zero
+        if ($curl_errno) {
             throw new NetworkError($this->id . ' unknown error: ' . strval($curl_errno) . ' ' . $curl_error);
         }
 


### PR DESCRIPTION
we need to check if curl_errno is set to something other than 0 and throw.

this will help to reduce the number of errors such as this one that some users are reporting

```
php > count(null);
PHP Warning:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in php shell code:1
Stack trace:
#0 {main}
  thrown in php shell code on line 1

Warning: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in php shell code:1
Stack trace:
#0 {main}
  thrown in php shell code on line 1
```