### PR TITLE
Created isMarketType method

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1913,4 +1913,12 @@ module.exports = class Exchange {
             throw new NotSupported (this.id + ' ' + key + ' does not have a value in mapping')
         }
     }
+
+    isMarketType (market) {
+        const spot = market['spot'];
+        const margin = market['margin'];
+        const swap = market['swap'];
+        const futures = market['futures'];
+        return [spot, margin, swap, futures];
+    }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3338,4 +3338,13 @@ class Exchange {
             throw new NotSupported ($this->id + ' ' + $key + ' does not have a value in mapping');
         }
     }
+
+    public function is_market_type($market){
+        // Returns boolean values for each market type
+        $spot = $market['spot'];
+        $margin = $market['margin'];
+        $swap = $market['swap'];
+        $futures = $market['futures'];
+        return [$spot, $margin, $swap, $futures];
+    }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2506,3 +2506,11 @@ class Exchange(object):
             return mapping[key]
         else:
             raise NotSupported(self.id + ' ' + key + ' does not have a value in mapping')
+
+    def is_market_type(market):
+        # Returns boolean values for each market type
+        spot = market['spot']
+        margin = market['margin']
+        swap = market['swap']
+        futures = market['futures']
+        return [spot, margin, swap, futures]


### PR DESCRIPTION
Reduces this code

```
const spot = market['spot'];
const margin = market['margin'];
const swap = market['swap'];
const futures = market['futures'];
```

to 

```
const [spot, margin, swap, futures] = this.isMarketType (market);
```