### PR TITLE
gateio.createOrder

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -296,7 +296,7 @@ module.exports = class gateio extends Exchange {
                     'futures': 'futures',
                     'delivery': 'delivery',
                 },
-                'defaultType': 'spot',
+                'defaultType': 'swap',
                 'swap': {
                     'fetchMarkets': {
                         'settlementCurrencies': [ 'usdt', 'btc' ],
@@ -1902,16 +1902,65 @@ module.exports = class gateio extends Exchange {
         };
     }
 
-    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
+    async createOrder (symbol, type = 'limit', side, amount, price = undefined, params = {}) {
+        //
+        // :param (str) symbol: base/quote currency pair
+        // :param (str) type: Order type (limit, market, ...)
+        // :param (str) side: buy or sell
+        // :param (number) amount: Amount of base currency ordered
+        // :param (number) price: Price of the base currency using quote currency
+        // :param (dict) params:
+        //          - type: market type (spot, futures, ...)
+        //          - reduceOnly
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const request = {
-            'currency_pair': market['id'],
-            'amount': this.amountToPrecision (symbol, amount),
-            'price': this.priceToPrecision (symbol, price),
-            'side': side,
-        };
-        const response = await this.privateSpotPostOrders (this.extend (request, params));
+        const defaultType = this.safeString2 (this.options, 'createOrder', 'defaultType', 'spot');
+        const marketType = this.safeString (params, 'type', defaultType);
+        const future = market['future'];
+        const swap = market['swap'];
+        const request = this.prepareRequest (market);
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        params = this.omit (params, 'reduceOnly');
+        if (reduceOnly !== undefined) {
+            if ((marketType !== 'future') && (marketType !== 'swap')) {
+                throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + marketType + ' orders, reduceOnly orders are supported for futures and perpetuals only');
+            }
+            request['reduce_only'] = reduceOnly;
+        }
+        if (future || swap) {
+            if (side === 'sell') {
+                amount = 0 - amount;
+            }
+            request['size'] = this.parseNumber (this.amountToPrecision (symbol, amount));
+            request['settle'] = market['settleId'];
+        } else {
+            request['side'] = side;
+            request['type'] = type;
+            request['amount'] = this.amountToPrecision (symbol, amount);
+            request['account'] = marketType;
+            // if (margin) {
+            //     if (entering trade) {
+            //         request['auto_borrow'] = true;
+            //     } else if (exiting trade) {
+            //         request['auto_repay'] = true;
+            //     }
+            // }
+        }
+        if (type === 'limit') {
+            if (!price) {
+                throw new ArgumentsRequired ('Argument price is required for ' + this.id + '.createOrder for limit orders');
+            }
+            request['price'] = this.priceToPrecision (symbol, price);
+        } else if (future || swap) {
+            request['price'] = 0;
+        }
+        const method = this.getSupportedMapping (market['type'], {
+            'spot': 'privateSpotPostOrders',
+            // 'margin': 'privateSpotPostOrders',
+            'swap': 'privateFuturesPostSettleOrders',
+            'future': 'privateDeliveryPostSettleOrders',
+        });
+        const response = await this[method] (this.extend (request, params));
         return this.parseOrder (response, market);
     }
 


### PR DESCRIPTION
I'm getting this response when I try to run it, I don't know why, [size is listed as a required param](https://www.gate.io/docs/developers/apiv4/en/#create-a-futures-order) in their docs. It also happens for buy orders

```
% gateio createOrder BTC/USDT:USDT market sell 0.0003 --verbose
2021-10-22T11:21:53.326Z
Node.js: v14.17.0
CCXT v1.58.76
gateio.createOrder (BTC/USDT:USDT, market, sell, 0.0003)
fetch:
 gateio POST https://api.gateio.ws/api/v4/futures/usdt/orders 
Request:
 {
  KEY: '...',
  Timestamp: '1634901716',
  SIGN: '...',
  'Content-Type': 'application/json'
} 
 {"contract":"BTC_USDT","size":-0.0003,"price":0} 

handleRestResponse:
 gateio POST https://api.gateio.ws/api/v4/futures/usdt/orders 400 Bad Request 
Response:
 {
  Connection: 'keep-alive',
  'Content-Type': 'application/json',
  Date: 'Fri, 22 Oct 2021 11:21:56 GMT',
  Server: 'openresty',
  'Transfer-Encoding': 'chunked'
} 
 {"label":"INVALID_PARAM_VALUE","detail":"Invalid request parameter `size` value: -0.0003"}
 

BadRequest gateio Invalid request parameter `size` value: -0.0003
---------------------------------------------------
[BadRequest] gateio Invalid request parameter `size` value: -0.0003

    at handleErrors               js/gateio.js:2258                   throw new Error (this.id + ' ' + message);                                      
    at                            js/base/Exchange.js:657             this.handleErrors (response.status, response.statusText, url, method, responseH…
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                  
    at async timeout              js/base/functions/time.js:195       return await Promise.race ([promise, expires.then (() => { throw new TimedOut (…
    at createOrder                js/gateio.js:1956                   const response = await this[method] (this.extend (request, params));            
    at async main                 examples/js/cli.js:243              const result = await exchange[methodName] (... args)                            

gateio Invalid request parameter `size` value: -0.0003
```