### PR TITLE
[okex] Parse expiry date in market info for futures

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -694,6 +694,10 @@ module.exports = class okex extends Exchange {
         const fees = this.safeValue2 (this.fees, type, 'trading', {});
         const contractSize = this.safeString (market, 'ctVal');
         const leverage = this.safeNumber (market, 'lever', 1);
+        let expiry = undefined;
+        if (futures || option) {
+            expiry = this.safeNumber (market, 'expTime');
+        }
         return this.extend (fees, {
             'id': id,
             'symbol': symbol,
@@ -712,6 +716,8 @@ module.exports = class okex extends Exchange {
             'active': active,
             'contractSize': contractSize,
             'precision': precision,
+            'expiry': expiry,
+            'expiryDatetime': this.iso8601 (expiry),
             'limits': {
                 'amount': {
                     'min': minAmount,


### PR DESCRIPTION
The OKEx [`GET /api/v5/public/instruments`](https://www.okex.com/docs-v5/en/#rest-api-public-data-get-instruments) API, used in `loadMarkets()`, gives us an `expTime` field in milliseconds, that we can use to expose the expiration time of futures and options to final users.

The `expiry` field is not standardized in the CCXT documentation yet. I followed the same format used in the `binance` client.