### PR TITLE
[okex] Change exception type to CancelPending for error 51410

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ExchangeNotAvailable, OnMaintenance, ArgumentsRequired, BadRequest, AccountSuspended, InvalidAddress, PermissionDenied, InsufficientFunds, InvalidNonce, InvalidOrder, OrderNotFound, AuthenticationError, RequestTimeout, BadSymbol, RateLimitExceeded, NetworkError } = require ('./base/errors');
+const { ExchangeError, ExchangeNotAvailable, OnMaintenance, ArgumentsRequired, BadRequest, AccountSuspended, InvalidAddress, PermissionDenied, InsufficientFunds, InvalidNonce, InvalidOrder, OrderNotFound, AuthenticationError, RequestTimeout, BadSymbol, RateLimitExceeded, NetworkError, CancelPending } = require ('./base/errors');
 const { TICK_SIZE, TRUNCATE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -382,7 +382,7 @@ module.exports = class okex extends Exchange {
                     '51407': BadRequest, // Either order ID or client order ID is required
                     '51408': ExchangeError, // Pair ID or name does not match the order info
                     '51409': ExchangeError, // Either pair ID or pair name ID is required
-                    '51410': ExchangeError, // Cancellation failed as the order is already under cancelling status
+                    '51410': CancelPending, // Cancellation failed as the order is already under cancelling status
                     '51500': ExchangeError, // Either order price or amount is required
                     '51501': ExchangeError, // Maximum {0} orders can be modified
                     '51502': InsufficientFunds, // Order modification failed for insufficient margin


### PR DESCRIPTION
Error 51410 in OKEx is `Cancellation failed as the order is already under cancelling status` and it gets raised as `ExchangeError`.

This PR makes it raise the more specific `CancelPending` exception.