### PR TITLE
[okex] Pass correct asset type in `fetchMyTrades()`

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -1939,6 +1939,11 @@ module.exports = class okex extends Exchange {
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        const defaultType = this.safeString (this.options, 'defaultType');
+        const options = this.safeValue (this.options, 'fetchMyTrades', {});
+        let type = this.safeString (options, 'type', defaultType);
+        params = this.omit (params, 'type');
+        await this.loadMarkets ();
         const request = {
             // 'instType': 'SPOT', // SPOT, MARGIN, SWAP, FUTURES, OPTION
             // 'uly': currency['id'],
@@ -1948,16 +1953,13 @@ module.exports = class okex extends Exchange {
             // 'before': billId,
             // 'limit': limit, // default 100, max 100
         };
-        let instrumentType = this.safeString (params, 'type', 'SPOT');
-        params = this.omit (params, 'type');
-        await this.loadMarkets ();
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['instId'] = market['id'];
-            instrumentType = market['type'];
+            type = market['type'];
         }
-        request['instType'] = instrumentType.toUpperCase ();
+        request['instType'] = type.toUpperCase ();
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 100
         }


### PR DESCRIPTION
OKEx client's `fetchMyTrades()` fails on assets that are not spot, because it passes an incorrect `instType=SPOT` parameter.

The exception raised is:
```
ccxt.base.errors.BadSymbol: okex {"code":"51015","data":[],"msg":"Instrument ID does not match instrument type."}
```

This PR fixes it this way:
- if a symbol is passed, the symbol type is used
- if no symbol is passed, use `params["type"]`; if no value was provided, default to `SPOT`

## How to reproduce

Example:
```python
import asyncio

from ccxt.async_support import okex


async def main() -> None:
    okex_client = okex({"apiKey": "PUT YOURS", "secret": "PUT YOURS", "password": "PUT YOURS"})

    try:
        spot_trades = await okex_client.fetch_my_trades("BTC/USDT")
        print(f"Fetched {len(spot_trades)} spot trades.")

        spot_trades = await okex_client.fetch_my_trades("BTC-USDT-SWAP")
        print(f"Fetched {len(spot_trades)} swap trades.")
    finally:
        await okex_client.close()

if __name__ == '__main__':
    asyncio.run(main())
```

Output:
```
Fetched 100 spot trades.
Traceback (most recent call last):
  File "/Users/pd/Library/Application Support/JetBrains/PyCharm2021.2/scratches/scratch.py", line 22, in <module>
    asyncio.run(main())
  File "/Users/pd/.pyenv/versions/3.9.7/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/pd/.pyenv/versions/3.9.7/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/pd/Library/Application Support/JetBrains/PyCharm2021.2/scratches/scratch.py", line 16, in main
    spot_trades = await okex_client.fetch_my_trades("BTC-USDT-SWAP")
  File ".venv/lib/python3.9/site-packages/ccxt/async_support/okex.py", line 1897, in fetch_my_trades
    response = await self.privateGetTradeFillsHistory(self.extend(request, params))
  File ".venv/lib/python3.9/site-packages/ccxt/async_support/base/exchange.py", line 97, in fetch2
    return await self.fetch(request['url'], request['method'], request['headers'], request['body'])
  File ".venv/lib/python3.9/site-packages/ccxt/async_support/base/exchange.py", line 162, in fetch
    self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
  File ".venv/lib/python3.9/site-packages/ccxt/async_support/okex.py", line 2981, in handle_errors
    self.throw_exactly_matched_exception(self.exceptions['exact'], code, feedback)
  File ".venv/lib/python3.9/site-packages/ccxt/base/exchange.py", line 520, in throw_exactly_matched_exception
    raise exact[string](message)
ccxt.base.errors.BadSymbol: okex {"code":"51015","data":[],"msg":"Instrument ID does not match instrument type."}
/Users/pd/.pyenv/versions/3.9.7/lib/python3.9/asyncio/selector_events.py:704: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=9>
  _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```