### PR TITLE
updated fetchCurrencies for margin

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -789,7 +789,7 @@ module.exports = class gateio extends Exchange {
         params = this.omit (params, 'type');
         let method = 'publicSpotGetCurrencies';
         if (type === 'margin') {
-            method = 'publicMarginGetCurrencies';
+            method = 'publicMarginGetCurrencyPairs';
         }
         const response = await this[method] (params);
         //


### PR DESCRIPTION
There's no `/futures/currencies` or `/delivery/currencies` endpoint, so should we just leave this method like this?