### PR TITLE
Gateio futures order methods

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2061,11 +2061,14 @@ module.exports = class gateio extends Exchange {
         timestamp = this.safeInteger (order, 'create_time_ms', timestamp);
         let lastTradeTimestamp = this.safeTimestamp (order, 'update_time');
         lastTradeTimestamp = this.safeInteger (order, 'update_time_ms', lastTradeTimestamp);
-        const amount = this.safeString (order, 'amount', 'size');
+        const amount = this.safeString2 (order, 'amount', 'size');
         const price = this.safeString (order, 'price');
         const remaining = this.safeString (order, 'left');
-        const cost = this.safeString (order, 'filled_total'); // same as filled_price
-        const side = this.safeString (order, 'side');
+        const cost = this.safeString2 (order, 'filled_total'); // same as filled_price
+        let side = this.safeString (order, 'side');
+        if (market['swap'] || market['delivery']) {
+            side = amount > 0 ? 'buy' : 'sell';
+        }
         const type = this.safeString (order, 'type');
         // open, closed, cancelled - almost already ccxt unified!
         const finishAs = this.safeString (order, 'finish_as'); // Perpetual Swap/Delivery Futures

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2000,7 +2000,7 @@ module.exports = class gateio extends Exchange {
         };
     }
 
-    async createOrder (symbol, type = 'limit', side, amount, price = undefined, params = {}) {
+    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         //
         // :param (str) symbol: base/quote currency pair
         // :param (str) type: Order type (limit, market, ...)

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -305,7 +305,7 @@ module.exports = class gateio extends Exchange {
                     'futures': 'futures',
                     'delivery': 'delivery',
                 },
-                'defaultType': 'swap',
+                'defaultType': 'spot',
                 'swap': {
                     'fetchMarkets': {
                         'settlementCurrencies': [ 'usdt', 'btc' ],
@@ -2244,36 +2244,19 @@ module.exports = class gateio extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        const defaultType = this.safeString2 (this.options, 'cancelOrder', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, 'type');
-        const spot = type === 'spot';
-        const swap = type === 'swap';
-        const futures = type === 'future';
-        let market = {};
-        if (symbol === undefined && spot) {
-            throw new ArgumentsRequired (this.id + ' spot and margin cancelOrders requires a symbol parameter');
-        } else if (symbol) {
-            market = this.market (symbol);
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' cancelOrders requires a symbol parameter');
         }
+        const market = this.market (symbol);
         const request = {
             'order_id': id,
         };
-        if ((swap || futures) && symbol) {
+        if ((market['swap'] || market['futures'])) {
             request['settle'] = market['settleId'];
-        } else if (swap || futures) {
-            if (!('settle' in params)) {
-                throw new ArgumentsRequired (this.id + ' requires either a symbol or settle parameter');
-            }
-            const settle = params['settle'];
-            request['settle'] = settle;
-            market = {
-                'settleId': settle,
-            };
         } else {
             request['currency_pair'] = market['id'];
         }
-        const method = this.getSupportedMapping (type, {
+        const method = this.getSupportedMapping (market['type'], {
             'spot': 'privateSpotDeleteOrdersOrderId',
             'margin': 'privateSpotDeleteOrdersOrderId',
             'swap': 'privateFuturesDeleteSettleOrdersOrderId',

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2116,7 +2116,7 @@ module.exports = class gateio extends Exchange {
         if (status === 'cancelled' || finishAs === 'cancelled') {
             status = 'canceled';
         }
-        const timeInForce = this.safeStringUpper (order, 'time_in_force', 'tif');
+        const timeInForce = this.safeStringUpper2 (order, 'time_in_force', 'tif');
         const fees = [];
         const gtFee = this.safeNumber (order, 'gt_fee');
         if (gtFee) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -788,12 +788,6 @@ module.exports = class gateio extends Exchange {
         return this.safeValue (fetchMarketsContractOptions, 'settlementCurrencies', defaultSettle);
     }
 
-    getType (params) {
-        const defaultType = this.safeString2 (this.options, 'fetchMarkets', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
-        return type;
-    }
-
     async fetchCurrencies (params = {}) {
         const response = await this.publicSpotGetCurrencies (params);
         //

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2023,7 +2023,7 @@ module.exports = class gateio extends Exchange {
 
     parseOrder (order, market = undefined) {
         //
-        // createOrder
+        // createOrder, spot
         //
         //     {
         //       "id": "62364648575",
@@ -2055,38 +2055,61 @@ module.exports = class gateio extends Exchange {
         //
         //
         const id = this.safeString (order, 'id');
-        const marketId = this.safeString (order, 'currency_pair');
+        const marketId = this.safeString2 (order, 'currency_pair', 'contract');
         const symbol = this.safeSymbol (marketId, market);
         let timestamp = this.safeTimestamp (order, 'create_time');
         timestamp = this.safeInteger (order, 'create_time_ms', timestamp);
         let lastTradeTimestamp = this.safeTimestamp (order, 'update_time');
         lastTradeTimestamp = this.safeInteger (order, 'update_time_ms', lastTradeTimestamp);
-        const amount = this.safeString (order, 'amount');
+        const amount = this.safeString (order, 'amount', 'size');
         const price = this.safeString (order, 'price');
         const remaining = this.safeString (order, 'left');
         const cost = this.safeString (order, 'filled_total'); // same as filled_price
         const side = this.safeString (order, 'side');
         const type = this.safeString (order, 'type');
         // open, closed, cancelled - almost already ccxt unified!
+        const finishAs = this.safeString (order, 'finish_as'); // Perpetual Swap/Delivery Futures
         let status = this.safeString (order, 'status');
-        if (status === 'cancelled') {
+        if (status === 'cancelled' || finishAs === 'cancelled') {
             status = 'canceled';
         }
-        const timeInForce = this.safeStringUpper (order, 'time_in_force');
+        const timeInForce = this.safeStringUpper (order, 'time_in_force', 'tif');
         const fees = [];
-        fees.push ({
-            'currency': 'GT',
-            'cost': this.safeNumber (order, 'gt_fee'),
-        });
-        fees.push ({
-            'currency': this.safeCurrencyCode (this.safeString (order, 'fee_currency')),
-            'cost': this.safeNumber (order, 'fee'),
-        });
+        const gtFee = this.safeNumber (order, 'gt_fee');
+        if (gtFee) {
+            fees.push ({
+                'currency': 'GT',
+                'cost': gtFee,
+            });
+        }
+        const fee = this.safeNumber (order, 'fee');
+        if (fee) {
+            fees.push ({
+                'currency': this.safeCurrencyCode (this.safeString (order, 'fee_currency')),
+                'cost': fee,
+            });
+        }
         const rebate = this.safeString (order, 'rebated_fee');
-        fees.push ({
-            'currency': this.safeCurrencyCode (this.safeString (order, 'rebated_fee_currency')),
-            'cost': this.parseNumber (Precise.stringNeg (rebate)),
-        });
+        if (rebate) {
+            fees.push ({
+                'currency': this.safeCurrencyCode (this.safeString (order, 'rebated_fee_currency')),
+                'cost': this.parseNumber (Precise.stringNeg (rebate)),
+            });
+        }
+        const mkfr = this.safeNumber (order, 'mkfr');
+        const tkfr = this.safeNumber (order, 'tkfr');
+        if (mkfr) {
+            fees.push ({
+                'currency': this.safeCurrencyCode (this.safeString (order, 'settleId')),
+                'cost': mkfr,
+            });
+        }
+        if (tkfr) {
+            fees.push ({
+                'currency': this.safeCurrencyCode (this.safeString (market, 'settleId')),
+                'cost': tkfr,
+            });
+        }
         return this.safeOrder2 ({
             'id': id,
             'clientOrderId': id,
@@ -2221,16 +2244,67 @@ module.exports = class gateio extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' cancelOrders requires a symbol parameter');
+        const defaultType = this.safeString2 (this.options, 'cancelOrder', 'defaultType', 'spot');
+        const type = this.safeString (params, 'type', defaultType);
+        params = this.omit (params, 'type');
+        const spot = type === 'spot';
+        const swap = type === 'swap';
+        const futures = type === 'future';
+        let market = {};
+        if (symbol === undefined && spot) {
+            throw new ArgumentsRequired (this.id + ' spot and margin cancelOrders requires a symbol parameter');
+        } else if (symbol) {
+            market = this.market (symbol);
         }
-        const market = this.market (symbol);
         const request = {
             'order_id': id,
-            'currency_pair': market['id'],
         };
-        const response = await this.privateSpotDeleteOrdersOrderId (this.extend (request, params));
-        return this.parseOrder (response);
+        if ((swap || futures) && symbol) {
+            request['settle'] = market['settleId'];
+        } else if (swap || futures) {
+            if (!('settle' in params)) {
+                throw new ArgumentsRequired (this.id + ' requires either a symbol or settle parameter');
+            }
+            const settle = params['settle'];
+            request['settle'] = settle;
+            market = {
+                'settleId': settle,
+            };
+        } else {
+            request['currency_pair'] = market['id'];
+        }
+        const method = this.getSupportedMapping (type, {
+            'spot': 'privateSpotDeleteOrdersOrderId',
+            'margin': 'privateSpotDeleteOrdersOrderId',
+            'swap': 'privateFuturesDeleteSettleOrdersOrderId',
+            'futures': 'privateDeliveryDeleteSettleOrdersOrderId',
+        });
+        const response = await this[method] (this.extend (request, params));
+        // Perpetual swap
+        // {
+        //     id: "82241928192",
+        //     contract: "BTC_USDT",
+        //     mkfr: "0",
+        //     tkfr: "0.0005",
+        //     tif: "gtc",
+        //     is_reduce_only: false,
+        //     create_time: "1635196145.06",
+        //     finish_time: "1635196233.396",
+        //     price: "61000",
+        //     size: "4",
+        //     refr: "0",
+        //     left: "4",
+        //     text: "web",
+        //     fill_price: "0",
+        //     user: "6693577",
+        //     finish_as: "cancelled",
+        //     status: "finished",
+        //     is_liq: false,
+        //     refu: "0",
+        //     is_close: false,
+        //     iceberg: "0",
+        // }
+        return this.parseOrder (response, market);
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {


### PR DESCRIPTION
All the order methods use the same parseOrder so I just combinded them

- fetchOrder
- cancelOrder
- createOrder
- fetchOrderByStatus
- fetchOpenOrders
- fetchClosedOrders