### PR TITLE
bitforex NOAI -> METANOIA

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -98,6 +98,7 @@ module.exports = class bitforex extends Exchange {
                 'CTC': 'Culture Ticket Chain',
                 'IQ': 'IQ.Cash',
                 'MIR': 'MIR COIN',
+                'NOIA': 'METANOIA',
                 'TON': 'To The Moon',
             },
             'exceptions': {


### PR DESCRIPTION
https://support.bitforex.com/hc/en-us/articles/360024526771-BitForex-Launches-METANOIA-NOIA-at-14-00-on-February-27-GMT-8-
conflict with https://www.coingecko.com/en/coins/syntropy#markets