### PR TITLE
Gate.io fetchOHLCV fixes

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -683,7 +683,7 @@ module.exports = class ftx extends Exchange {
             this.safeNumber (ohlcv, 'high'),
             this.safeNumber (ohlcv, 'low'),
             this.safeNumber (ohlcv, 'close'),
-            this.safeNumber (ohlcv, 'volume'),
+            this.safeNumber (ohlcv, 'volume', 0),
         ];
     }
 

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -683,7 +683,7 @@ module.exports = class ftx extends Exchange {
             this.safeNumber (ohlcv, 'high'),
             this.safeNumber (ohlcv, 'low'),
             this.safeNumber (ohlcv, 'close'),
-            this.safeNumber (ohlcv, 'volume', 0),
+            this.safeNumber (ohlcv, 'volume'),
         ];
     }
 

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1510,15 +1510,14 @@ module.exports = class gateio extends Exchange {
         params = this.omit (params, 'price');
         const request = this.prepareRequest (market);
         request['interval'] = this.timeframes[timeframe];
-        const isMark = price === 'mark';
-        const isIndex = price === 'index';
+        const isMark = (price === 'mark');
+        const isIndex = (price === 'index');
         let method = 'publicSpotGetCandlesticks';
-        if (isMark || isIndex || market['swap'] || market['futures']) {
+        const isMarkOrIndex = (isMark || isIndex);
+        if (isMarkOrIndex || market['swap'] || market['futures']) {
             method = market['futures'] ? 'publicDeliveryGetSettleCandlesticks' : 'publicFuturesGetSettleCandlesticks';
-            if (isMark || isIndex) {
-                const prefix = isMark ? 'mark_' : 'index_';
-                request['contract'] = prefix + market['id'];
-            }
+            const prefix = isMarkOrIndex ? (price + '_') : '';
+            request['contract'] = prefix + market['id'];
         }
         if (since === undefined) {
             if (limit !== undefined) {


### PR DESCRIPTION
I think that you should be able to access the mark and index candlesticks even if your defaultType is `spot` or `margin` but right now if you try to with `spot` then you get an error than your signature is missing the timestamp

Previously the gateio method returned candlesticks, but they weren't the correct ones when the price was `mark` or `index` but the defaultType was `spot`