### PR TITLE
Fixes two breaking errors in coinbasepro fetchLedgerEntry method

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1055,7 +1055,7 @@ module.exports = class coinbasepro extends Exchange {
         let direction = undefined;
         const afterString = this.safeString (item, 'balance');
         const beforeString = Precise.stringSub (afterString, amountString);
-        if (Precise.lt (amountString, '0')) {
+        if (Precise.stringLt (amountString, '0')) {
             direction = 'out';
             amountString = Precise.stringAbs (amountString);
         } else {

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1053,7 +1053,7 @@ module.exports = class coinbasepro extends Exchange {
         const id = this.safeString (item, 'id');
         let amountString = this.safeString (item, 'amount');
         let direction = undefined;
-        const afterString = this.safeNumber (item, 'balance');
+        const afterString = this.safeString (item, 'balance');
         const beforeString = Precise.stringSub (afterString, amountString);
         if (Precise.lt (amountString, '0')) {
             direction = 'out';


### PR DESCRIPTION
Fixed a TypeError: number.toLowerCase is not a function by changing
```const afterString = this.safeNumber (item, 'balance');```
to
```const afterString = this.safeString (item, 'balance');```

Fixed a TypeError: Precise.lt is not a function by pointing to the static function of Precise.stringLt…
```if (Precise.lt (amountString, '0')) {```
to
```if (Precise.stringLt (amountString, '0')) {```

coinbasepro's fetchLedger method works perfectly after these two changes are made.
