### PR TITLE
crex24 EGG -> NestEGG Coin

### DIFF
--- a/js/crex24.js
+++ b/js/crex24.js
@@ -137,6 +137,7 @@ module.exports = class crex24 extends Exchange {
                 'BULL': 'BuySell',
                 'CLC': 'CaluraCoin',
                 'CREDIT': 'TerraCredit',
+                'EGG': 'NestEGG Coin',
                 'EPS': 'Epanus',  // conflict with EPS Ellipsis https://github.com/ccxt/ccxt/issues/8909
                 'FUND': 'FUNDChains',
                 'GHOST': 'GHOSTPRISM',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/nestegg-coin/markets/
conflict with https://coinmarketcap.com/currencies/nestree/markets/