### PR TITLE
bitforex BKC -> Bank Coin

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -93,6 +93,7 @@ module.exports = class bitforex extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'BKC': 'Bank Coin',
                 'CAPP': 'Crypto Application Token',
                 'CREDIT': 'TerraCredit',
                 'CTC': 'Culture Ticket Chain',


### PR DESCRIPTION
https://support.bitforex.com/hc/en-us/articles/4402372580493-BitForex-Launches-Bank-Coin-BKC-at-16-00-on-June-10th-2021-GMT-8-
conflict with https://www.coingecko.com/en/coins/facts#markets