### PR TITLE
Bybit: extend exceptions: Invalid API-key, IP, or permissions for action.

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -277,6 +277,7 @@ module.exports = class bybit extends Exchange {
                     '10002': InvalidNonce, // request expired, check your timestamp and recv_window
                     '10003': AuthenticationError, // Invalid apikey
                     '10004': AuthenticationError, // invalid sign
+                    '-2015': AuthenticationError, // Invalid API-key, IP, or permissions for action.
                     '10005': PermissionDenied, // permission denied for current apikey
                     '10006': RateLimitExceeded, // too many requests
                     '10007': AuthenticationError, // api_key not found in your request parameters

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -273,11 +273,11 @@ module.exports = class bybit extends Exchange {
             },
             'exceptions': {
                 'exact': {
+                    '-2015': AuthenticationError, // Invalid API-key, IP, or permissions for action.
                     '10001': BadRequest, // parameter error
                     '10002': InvalidNonce, // request expired, check your timestamp and recv_window
                     '10003': AuthenticationError, // Invalid apikey
                     '10004': AuthenticationError, // invalid sign
-                    '-2015': AuthenticationError, // Invalid API-key, IP, or permissions for action.
                     '10005': PermissionDenied, // permission denied for current apikey
                     '10006': RateLimitExceeded, // too many requests
                     '10007': AuthenticationError, // api_key not found in your request parameters


### PR DESCRIPTION
response: `{"ret_code":"-2015","ret_msg":"Invalid API-key, IP, or permissions for action.","ext_code":null,"ext_info":null,"result":null}`