### PR TITLE
Kucoin: fix context parse

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -2156,7 +2156,7 @@ module.exports = class kucoin extends Exchange {
         //     "{\"symbol\":\"ETH-USDT\",\"orderId\":\"617adcd1eb3fa20001dd29a1\",\"tradeId\":\"617adcd12e113d2b91222ff9\"}"
         //
         let referenceId = undefined;
-        if (context !== undefined) {
+        if (context !== undefined && context !== '') {
             const parsed = JSON.parse (context);
             const orderId = this.safeString (parsed, 'orderId');
             const tradeId = this.safeString (parsed, 'tradeId');


### PR DESCRIPTION
This works:
```
{
"id":"5f818927a7cdcb0006be3850","currency":"POL",
"amount":"4.53108209","fee":"0","balance":"0",
"accountType":"POOL","bizType":"Staking Profits",
"direction":"in","createdAt":1602324775490,
"context":null <<<<<<<<< ✅
}
```

But this doesnt:
```
{
"id":"5f3e4dbfc354640006546e41","currency":"POL",
"amount":"1.20432072","fee":"0","balance":"0",
"accountType":"POOL","bizType":"Staking Profits",
"direction":"in","createdAt":1597918655000,
"context":"" <<<<<<<<< ❌
}
```
(empty string)

Not sure when Kucoin broke this. 
This happens on the ledgers endpoint.

My current workaround:

```
	parseLedgerEntry(item, currency = undefined) {
		if (item.context === '') {
			item.context = undefined;
		}
		const ledger = super.parseLedgerEntry(item, currency);
		return ledger;
	}
```