### PR TITLE
Coinbase fix. When using stats api instead of tick

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -454,7 +454,7 @@ module.exports = class coinbasepro extends Exchange {
         const timestamp = this.parse8601 (this.safeValue (ticker, 'time'));
         const bid = this.safeNumber (ticker, 'bid');
         const ask = this.safeNumber (ticker, 'ask');
-        const last = this.safeNumber (ticker, 'price');
+        const last = (ticker['price'] !== undefined ) ? this.safeNumber (ticker, 'price') : this.safeNumber (ticker, 'last');
         const symbol = (market === undefined) ? undefined : market['symbol'];
         return {
             'symbol': symbol,

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -454,7 +454,7 @@ module.exports = class coinbasepro extends Exchange {
         const timestamp = this.parse8601 (this.safeValue (ticker, 'time'));
         const bid = this.safeNumber (ticker, 'bid');
         const ask = this.safeNumber (ticker, 'ask');
-        const last = (ticker['price'] !== undefined ) ? this.safeNumber (ticker, 'price') : this.safeNumber (ticker, 'last');
+        const last = (ticker['price'] === undefined ) ? this.safeNumber (ticker, 'last') : this.safeNumber (ticker, 'price');
         const symbol = (market === undefined) ? undefined : market['symbol'];
         return {
             'symbol': symbol,


### PR DESCRIPTION
When parsing ticker using stats API price attribute is not available but last attribute is available.