### PR TITLE
properly parse cost in safeOrder with contractSize

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1846,7 +1846,8 @@ module.exports = class Exchange {
             // futures trading )
             if (this.safeString (market, 'contractSize') !== undefined) {
                 if (market['inverse']) {
-                    cost = Precise.stringDiv ('1', cost);
+                    // todo: remove constants
+                    cost = Precise.stringDiv ('1', cost, 8);
                 }
                 cost = Precise.stringMul (cost, market['contractSize']);
             }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1846,7 +1846,8 @@ module.exports = class Exchange {
             // contract trading
             const contractSize = this.safeString (market, 'contractSize');
             if (contractSize !== undefined) {
-                if (market['inverse']) {
+                const inverse = this.safeValue (market, 'inverse', false);
+                if (inverse) {
                     // todo: remove constants
                     cost = Precise.stringDiv ('1', cost, 8);
                 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1844,6 +1844,13 @@ module.exports = class Exchange {
                 cost = Precise.stringMul (average, filled);
             }
         }
+        // futures trading )
+        if (this.safeString (market, 'contractSize') !== undefined) {
+            if (market['inverse']) {
+                cost = Precise.stringDiv ('1', cost);
+            }
+            cost = Precise.stringMul (cost, market['contractSize']);
+        }
         // support for market orders
         const orderType = this.safeValue (order, 'type');
         const emptyPrice = (price === undefined) || Precise.stringEquals (price, '0');

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1843,13 +1843,13 @@ module.exports = class Exchange {
             } else {
                 cost = Precise.stringMul (average, filled);
             }
-        }
-        // futures trading )
-        if (this.safeString (market, 'contractSize') !== undefined) {
-            if (market['inverse']) {
-                cost = Precise.stringDiv ('1', cost);
+            // futures trading )
+            if (this.safeString (market, 'contractSize') !== undefined) {
+                if (market['inverse']) {
+                    cost = Precise.stringDiv ('1', cost);
+                }
+                cost = Precise.stringMul (cost, market['contractSize']);
             }
-            cost = Precise.stringMul (cost, market['contractSize']);
         }
         // support for market orders
         const orderType = this.safeValue (order, 'type');

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1843,13 +1843,14 @@ module.exports = class Exchange {
             } else {
                 cost = Precise.stringMul (average, filled);
             }
-            // futures trading )
-            if (this.safeString (market, 'contractSize') !== undefined) {
+            // contract trading
+            const contractSize = this.safeString (market, 'contractSize');
+            if (contractSize !== undefined) {
                 if (market['inverse']) {
                     // todo: remove constants
                     cost = Precise.stringDiv ('1', cost, 8);
                 }
-                cost = Precise.stringMul (cost, market['contractSize']);
+                cost = Precise.stringMul (cost, contractSize);
             }
         }
         // support for market orders

--- a/js/binance.js
+++ b/js/binance.js
@@ -2265,6 +2265,33 @@ module.exports = class binance extends Exchange {
         //       ]
         //     }
         //
+        // delivery
+        //
+        //     {
+        //       "orderId": "18742727411",
+        //       "symbol": "ETHUSD_PERP",
+        //       "pair": "ETHUSD",
+        //       "status": "FILLED",
+        //       "clientOrderId": "x-xcKtGhcu3e2d1503fdd543b3b02419",
+        //       "price": "0",
+        //       "avgPrice": "4522.14",
+        //       "origQty": "1",
+        //       "executedQty": "1",
+        //       "cumBase": "0.00221134",
+        //       "timeInForce": "GTC",
+        //       "type": "MARKET",
+        //       "reduceOnly": false,
+        //       "closePosition": false,
+        //       "side": "SELL",
+        //       "positionSide": "BOTH",
+        //       "stopPrice": "0",
+        //       "workingType": "CONTRACT_PRICE",
+        //       "priceProtect": false,
+        //       "origType": "MARKET",
+        //       "time": "1636061952660",
+        //       "updateTime": "1636061952660"
+        //     }
+        //
         const status = this.parseOrderStatus (this.safeString (order, 'status'));
         const marketId = this.safeString (order, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
@@ -2290,7 +2317,8 @@ module.exports = class binance extends Exchange {
         // - Spot/Margin market: cummulativeQuoteQty
         // - Futures market: cumQuote.
         //   Note this is not the actual cost, since Binance futures uses leverage to calculate margins.
-        const cost = this.safeString2 (order, 'cummulativeQuoteQty', 'cumQuote');
+        let cost = this.safeString2 (order, 'cummulativeQuoteQty', 'cumQuote');
+        cost = this.safeString2 (order, 'cumBase', cost);
         const id = this.safeString (order, 'orderId');
         let type = this.safeStringLower (order, 'type');
         const side = this.safeStringLower (order, 'side');

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3254,13 +3254,13 @@ class Exchange {
             } else {
                 $cost = Precise::string_mul($average, $filled);
             }
-        }
-        // futures trading )
-        if ($this->safe_string($market, 'contractSize') !== null) {
-            if ($market['inverse']) {
-                $cost = Precise::string_div('1', $cost);
+            // futures trading )
+            if ($this->safe_string($market, 'contractSize') !== null) {
+                if ($market['inverse']) {
+                    $cost = Precise::string_div('1', $cost);
+                }
+                $cost = Precise::string_mul($cost, $market['contractSize']);
             }
-            $cost = Precise::string_mul($cost, $market['contractSize']);
         }
         // support for $market orders
         $orderType = $this->safe_value($order, 'type');

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3257,7 +3257,8 @@ class Exchange {
             // contract trading
             $contractSize = $this->safe_string($market, 'contractSize');
             if ($contractSize !== null) {
-                if ($market['inverse']) {
+                $inverse = $this->safe_value($market, 'inverse', false);
+                if ($inverse) {
                     $cost = Precise::string_div('1', $cost, 8);
                 }
                 $cost = Precise::string_mul($cost, $contractSize);

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3257,7 +3257,7 @@ class Exchange {
             // futures trading )
             if ($this->safe_string($market, 'contractSize') !== null) {
                 if ($market['inverse']) {
-                    $cost = Precise::string_div('1', $cost);
+                    $cost = Precise::string_div('1', $cost, 8);
                 }
                 $cost = Precise::string_mul($cost, $market['contractSize']);
             }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3254,12 +3254,13 @@ class Exchange {
             } else {
                 $cost = Precise::string_mul($average, $filled);
             }
-            // futures trading )
-            if ($this->safe_string($market, 'contractSize') !== null) {
+            // contract trading
+            $contractSize = $this->safe_string($market, 'contractSize');
+            if ($contractSize !== null) {
                 if ($market['inverse']) {
                     $cost = Precise::string_div('1', $cost, 8);
                 }
-                $cost = Precise::string_mul($cost, $market['contractSize']);
+                $cost = Precise::string_mul($cost, $contractSize);
             }
         }
         // support for $market orders

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3255,6 +3255,13 @@ class Exchange {
                 $cost = Precise::string_mul($average, $filled);
             }
         }
+        // futures trading )
+        if ($this->safe_string($market, 'contractSize') !== null) {
+            if ($market['inverse']) {
+                $cost = Precise::string_div('1', $cost);
+            }
+            $cost = Precise::string_mul($cost, $market['contractSize']);
+        }
         // support for $market orders
         $orderType = $this->safe_value($order, 'type');
         $emptyPrice = ($price === null) || Precise::string_equals($price, '0');

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2436,11 +2436,12 @@ class Exchange(object):
                 cost = Precise.string_mul(price, filled)
             else:
                 cost = Precise.string_mul(average, filled)
-            # futures trading )
-            if self.safe_string(market, 'contractSize') is not None:
+            # contract trading )
+            contractSize = self.safe_string(market, 'contractSize')
+            if contractSize is not None:
                 if market['inverse']:
                     cost = Precise.string_div('1', cost, 8)
-                cost = Precise.string_mul(cost, market['contractSize'])
+                cost = Precise.string_mul(cost, contractSize)
         # support for market orders
         orderType = self.safe_value(order, 'type')
         emptyPrice = (price is None) or Precise.string_equals(price, '0')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2436,6 +2436,11 @@ class Exchange(object):
                 cost = Precise.string_mul(price, filled)
             else:
                 cost = Precise.string_mul(average, filled)
+        # futures trading )
+        if self.safe_string(market, 'contractSize') is not None:
+            if market['inverse']:
+                cost = Precise.string_div('1', cost)
+            cost = Precise.string_mul(cost, market['contractSize'])
         # support for market orders
         orderType = self.safe_value(order, 'type')
         emptyPrice = (price is None) or Precise.string_equals(price, '0')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2439,7 +2439,7 @@ class Exchange(object):
             # futures trading )
             if self.safe_string(market, 'contractSize') is not None:
                 if market['inverse']:
-                    cost = Precise.string_div('1', cost)
+                    cost = Precise.string_div('1', cost, 8)
                 cost = Precise.string_mul(cost, market['contractSize'])
         # support for market orders
         orderType = self.safe_value(order, 'type')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2436,11 +2436,11 @@ class Exchange(object):
                 cost = Precise.string_mul(price, filled)
             else:
                 cost = Precise.string_mul(average, filled)
-        # futures trading )
-        if self.safe_string(market, 'contractSize') is not None:
-            if market['inverse']:
-                cost = Precise.string_div('1', cost)
-            cost = Precise.string_mul(cost, market['contractSize'])
+            # futures trading )
+            if self.safe_string(market, 'contractSize') is not None:
+                if market['inverse']:
+                    cost = Precise.string_div('1', cost)
+                cost = Precise.string_mul(cost, market['contractSize'])
         # support for market orders
         orderType = self.safe_value(order, 'type')
         emptyPrice = (price is None) or Precise.string_equals(price, '0')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2439,7 +2439,8 @@ class Exchange(object):
             # contract trading )
             contractSize = self.safe_string(market, 'contractSize')
             if contractSize is not None:
-                if market['inverse']:
+                inverse = self.safe_string(market, 'inverse', False)
+                if inverse:
                     cost = Precise.string_div('1', cost, 8)
                 cost = Precise.string_mul(cost, contractSize)
         # support for market orders


### PR DESCRIPTION
currently the cost for inverse contracts and futures trading is bugged, this fixes it