### PR TITLE
fetchFundingRateHistory not available on bybit

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -29,6 +29,7 @@ module.exports = class bybit extends Exchange {
                 'fetchClosedOrders': true,
                 'fetchDeposits': true,
                 'fetchFundingRate': true,
+                'fetchFundingRateHistory': false,
                 'fetchIndexOHLCV': true,
                 'fetchLedger': true,
                 'fetchMarkets': true,


### PR DESCRIPTION
Historical funding rates aren't available through the api, but you can [get a csv of them here](https://www.bybit.com/data/basic/inverse/funding-history?symbol=BTCUSD)