### PR TITLE
okex fundingRate fixes

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -3120,6 +3120,8 @@ module.exports = class okex extends Exchange {
         //       "nextFundingTime": "1634284800000"
         //     }
         //
+        // in the response above nextFundingRate is actually two funding rates from now
+        //
         const nextFundingRateTimestamp = this.safeInteger (fundingRate, 'fundingTime');
         let previousFundingTimestamp = undefined;
         if (nextFundingRateTimestamp !== undefined) {

--- a/js/okex.js
+++ b/js/okex.js
@@ -3120,12 +3120,15 @@ module.exports = class okex extends Exchange {
         //       "nextFundingTime": "1634284800000"
         //     }
         //
-        const previousFundingRate = this.safeNumber (fundingRate, 'fundingRate');
-        const previousFundingTimestamp = this.safeInteger (fundingRate, 'fundingTime');
+        const nextFundingRateTimestamp = this.safeInteger (fundingRate, 'fundingTime');
+        let previousFundingTimestamp = undefined;
+        if (nextFundingRateTimestamp !== undefined) {
+            // eight hours
+            previousFundingTimestamp = nextFundingRateTimestamp - 28800000;
+        }
         const marketId = this.safeString (fundingRate, 'instId');
         const symbol = this.safeSymbol (marketId, market);
-        const nextFundingRate = this.safeNumber (fundingRate, 'nextFundingRate');
-        const nextFundingRateTimestamp = this.safeInteger (fundingRate, 'nextFundingTime');
+        const nextFundingRate = this.safeNumber (fundingRate, 'fundingRate');
         // https://www.okex.com/support/hc/en-us/articles/360053909272-Ⅸ-Introduction-to-perpetual-swap-funding-fee
         // > The current interest is 0.
         return {
@@ -3137,7 +3140,7 @@ module.exports = class okex extends Exchange {
             'estimatedSettlePrice': undefined,
             'timestamp': undefined,
             'datetime': undefined,
-            'previousFundingRate': previousFundingRate,
+            'previousFundingRate': undefined,
             'nextFundingRate': nextFundingRate,
             'previousFundingTimestamp': previousFundingTimestamp, // subtract 8 hours
             'nextFundingTimestamp': nextFundingRateTimestamp,


### PR DESCRIPTION
fundingRate = current funding rate not previous funding rate

this should fix it so it is in line with other exchanges