### PR TITLE
FTX: Not logged in: Invalid API key

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -291,6 +291,7 @@ module.exports = class ftx extends Exchange {
                     'Please slow down': RateLimitExceeded, // {"error":"Please slow down","success":false}
                     'Size too small for provide': InvalidOrder, // {"error":"Size too small for provide","success":false}
                     'Not logged in': AuthenticationError, // {"error":"Not logged in","success":false}
+                    'Not logged in: Invalid API key': AuthenticationError, // {"error":"Not logged in: Invalid API key","success":false}
                     'Not enough balances': InsufficientFunds, // {"error":"Not enough balances","success":false}
                     'InvalidPrice': InvalidOrder, // {"error":"Invalid price","success":false}
                     'Size too small': InvalidOrder, // {"error":"Size too small","success":false}

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -290,8 +290,6 @@ module.exports = class ftx extends Exchange {
                 'exact': {
                     'Please slow down': RateLimitExceeded, // {"error":"Please slow down","success":false}
                     'Size too small for provide': InvalidOrder, // {"error":"Size too small for provide","success":false}
-                    'Not logged in': AuthenticationError, // {"error":"Not logged in","success":false}
-                    'Not logged in: Invalid API key': AuthenticationError, // {"error":"Not logged in: Invalid API key","success":false}
                     'Not enough balances': InsufficientFunds, // {"error":"Not enough balances","success":false}
                     'InvalidPrice': InvalidOrder, // {"error":"Invalid price","success":false}
                     'Size too small': InvalidOrder, // {"error":"Size too small","success":false}
@@ -310,6 +308,9 @@ module.exports = class ftx extends Exchange {
                     'Not approved to trade this product': PermissionDenied, // {"success":false,"error":"Not approved to trade this product"}
                 },
                 'broad': {
+                    // {"error":"Not logged in","success":false}
+                    // {"error":"Not logged in: Invalid API key","success":false}
+                    'Not logged in': AuthenticationError,
                     'Account does not have enough margin for order': InsufficientFunds,
                     'Invalid parameter': BadRequest, // {"error":"Invalid parameter start_time","success":false}
                     'The requested URL was not found on the server': BadRequest,


### PR DESCRIPTION
Looks like they changed the error response:

`{"error":"Not logged in: Invalid API key","success":false}`

With this change we now have 2 **exact** exceptions:

```
'Not logged in': AuthenticationError, // {"error":"Not logged in","success":false}
'Not logged in: Invalid API key': AuthenticationError, // {"error":"Not logged in: Invalid API key","success":false}
```

Should we use one **broad** exception?