### PR TITLE
FTX: add status 'cancelled'

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1936,6 +1936,7 @@ module.exports = class ftx extends Exchange {
             // what are other statuses here?
             'confirmed': 'ok', // deposits
             'complete': 'ok', // withdrawals
+            'cancelled': 'canceled', // deposits
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
We got one FIAT deposit, that got cancelled:
...
"status": "cancelled",
"cancelReason": "One month passed and no matching deposit was received.",
...
I copy&pasted the canceled (with one L) from the other exchange file to keep it consistent.