### PR TITLE
[binance] Return unified symbol name from fetchFundingRateHistory()

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3970,7 +3970,7 @@ module.exports = class binance extends Exchange {
             const timestamp = this.safeInteger (entry, 'fundingTime');
             rates.push ({
                 'info': entry,
-                'symbol': this.safeString (entry, 'symbol'),
+                'symbol': this.safeSymbol (this.safeString (entry, 'symbol')),
                 'fundingRate': this.safeNumber (entry, 'fundingRate'),
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),


### PR DESCRIPTION
The `fetchFundingRateHistory()` method in the Binance client returns dictionaries with the wrong `symbol` attribute.

Specifically, the value returned is the **market ID**, not the CCXT unified symbol as in other exchanges (see the OKEx implementation for example).