### PR TITLE
fix private spot api routes

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2501,11 +2501,7 @@ module.exports = class bybit extends Exchange {
         const type = this.safeString (api, 0);
         let section = this.safeString (api, 1);
         if (type === 'spot') {
-            if (section === 'public') {
-                section = 'v1';
-            } else {
-                section += '/v1';
-            }
+            section = 'v1';
         }
         let url = this.implodeHostname (this.urls['api'][type]);
         let request = '/' + type + '/' + section + '/' + path;


### PR DESCRIPTION
Private spot request had /private/v1 attached. Converted to /v1 only.