### PR TITLE
Binance fetchBorrowRateHistory

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4894,4 +4894,44 @@ module.exports = class binance extends Exchange {
     async addMargin (symbol, amount, params = {}) {
         return await this.modifyMarginHelper (symbol, amount, 1, params);
     }
+
+    async getMarginInterestRate (currency, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        if (limit > 100) {
+            throw new BadRequest (this.id + ' getMarginInterestRate limit parameter cannot exceed 100');
+        } else if (!limit) {
+            limit = 20;
+        }
+        const request = {
+            'asset': this.safeCurrencyCode (currency),
+            'limit': limit,
+        };
+        if (since) {
+            const sinceDate = new Date (since);
+            const threeMonthsAgo = new Date ();
+            threeMonthsAgo.setMonth (threeMonthsAgo.getMonth () - 3);
+            threeMonthsAgo.setDate (threeMonthsAgo.getDate ());
+            threeMonthsAgo.setHours (0, 0, 0);
+            if (sinceDate <= threeMonthsAgo) {
+                throw new BadRequest (this.id + ' getMarginInterestRate since parameter cannot pre-date today - 3 months');
+            }
+            request['startTime'] = since;
+            const endTime = this.sum (since, limit * 86400000);
+            request['endTime'] = Math.min (endTime, this.milliseconds ());
+        }
+        const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
+        const result = [];
+        for (let i = 0; i < response.length; i++) {
+            const rate = response[i];
+            const timestamp = this.safeNumber (rate, 'timestamp');
+            result.push ({
+                'currency': this.safeCurrencyCode (this.safeString (rate, 'asset')),
+                'rate': this.safeNumber (rate, 'dailyInterestRate'),
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+                'tier': this.safeNumber (rate, 'vipLevel'),
+            });
+        }
+        return result;
+    }
 };

--- a/js/binance.js
+++ b/js/binance.js
@@ -4895,7 +4895,7 @@ module.exports = class binance extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 1, params);
     }
 
-    async getMarginInterestRate (currency, since = undefined, limit = undefined, tier = undefined, params = {}) {
+    async fetchMarginInterestRate (currency, since = undefined, limit = undefined, tier = undefined, params = {}) {
         await this.loadMarkets ();
         if (limit > 100) {
             throw new BadRequest (this.id + ' getMarginInterestRate limit parameter cannot exceed 100');
@@ -4919,8 +4919,11 @@ module.exports = class binance extends Exchange {
                 throw new BadRequest (this.id + ' getMarginInterestRate since parameter cannot pre-date today - 3 months');
             }
             request['startTime'] = since;
-            const endTime = this.sum (since, limit * 86400000);
-            request['endTime'] = Math.min (endTime, this.milliseconds ());
+            const timeSinceStart = Precise.stringMul (limit.toString (), '86400000');
+            const endTime = Precise.stringAdd (since.toString (), timeSinceStart);
+            const now = new Date ();
+            now.setHours (0, 0, 0); // Binance gives an error if passed this
+            request['endTime'] = parseInt (Precise.stringMin (endTime, now.getTime ().toString ()));
         }
         const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
         const result = [];

--- a/js/binance.js
+++ b/js/binance.js
@@ -4895,7 +4895,7 @@ module.exports = class binance extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 1, params);
     }
 
-    async getMarginInterestRate (currency, since = undefined, limit = undefined, params = {}) {
+    async getMarginInterestRate (currency, since = undefined, limit = undefined, tier = undefined, params = {}) {
         await this.loadMarkets ();
         if (limit > 100) {
             throw new BadRequest (this.id + ' getMarginInterestRate limit parameter cannot exceed 100');
@@ -4906,6 +4906,9 @@ module.exports = class binance extends Exchange {
             'asset': this.safeCurrencyCode (currency),
             'limit': limit,
         };
+        if (tier) {
+            request['vipLevel'] = tier;
+        }
         if (since) {
             const sinceDate = new Date (since);
             const threeMonthsAgo = new Date ();


### PR DESCRIPTION
Get the interest rate for currencies borrowed when margin trading

The name `getMarginInterestRate` was chosen over `getInterestRate` because there is also a futures interest rate, which is something different

The limit parameter is almost completely useless in this, the endpoint doesn't let you query anything earlier than 3 months, so there will always be under 100 items returned, which is the max limit. Their api sets the limit at 20 by default, so I did too, but maybe just always setting it to 100 makes more sense? 

There's only one item per day, and if you set an end date late than midnight on today or midnight 3 months ago + 1 day, it returns

```
binance {"code":-1100,"msg":"Illegal characters found in a parameter."}
```

----------------

21/11/18 02:00:48 +0000
Node.js: v14.17.0
CCXT v1.61.26

## currency=usdt, since=, limit=, tier=
```
binance.fetchMarginInterestRate (usdt)
currency |   rate |     timestamp |                 datetime | tier
-------------------------------------------------------------------
    USDT | 0.0006 | 1637193600000 | 2021-11-18T00:00:00.000Z |    0
    ...
    USDT | 0.0006 | 1636588800000 | 2021-11-11T00:00:00.000Z |    0
8 objects
695 ms
```

## currency=usdt, since=undefined, limit=100, tier=
```
binance.fetchMarginInterestRate (usdt, , 100)
currency |   rate |     timestamp |                 datetime | tier
-------------------------------------------------------------------
    USDT | 0.0006 | 1637193600000 | 2021-11-18T00:00:00.000Z |    0
    ...
    USDT | 0.0006 | 1636588800000 | 2021-11-11T00:00:00.000Z |    0
8 objects
697 ms
```

## currency=usdt, since=undefined, limit=101, tier=
```
binance.fetchMarginInterestRate (usdt, , 101)
BadRequest binance getMarginInterestRate limit parameter cannot exceed 100
---------------------------------------------------
[BadRequest] binance getMarginInterestRate limit parameter cannot exceed 100
    at fetchMarginInterestRate    js/binance.js:4901                  throw new BadRequest (this.id + ' getMarginInterestRate limit parameter cannot …
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                  
    at async main                 examples/js/cli.js:246              const result = await exchange[methodName] (... args)                            
binance getMarginInterestRate limit parameter cannot exceed 100
```

## currency=usdt, since=undefined, limit=undefined, tier=0
```
binance.fetchMarginInterestRate (usdt, , , 0)
currency |   rate |     timestamp |                 datetime | tier
-------------------------------------------------------------------
    USDT | 0.0006 | 1637193600000 | 2021-11-18T00:00:00.000Z |    0
    ...
    USDT | 0.0006 | 1636588800000 | 2021-11-11T00:00:00.000Z |    0
8 objects
703 ms
```

## currency=usdt, since=1629176400000, limit=, tier=
```
binance.fetchMarginInterestRate (usdt, 1629176400000)
BadRequest binance getMarginInterestRate since parameter cannot pre-date today - 3 months
---------------------------------------------------
[BadRequest] binance getMarginInterestRate since parameter cannot pre-date today - 3 months
    at fetchMarginInterestRate    js/binance.js:4919                  throw new BadRequest (this.id + ' getMarginInterestRate since parameter cannot …
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                  
    at async main                 examples/js/cli.js:246              const result = await exchange[methodName] (... args)                            
binance getMarginInterestRate since parameter cannot pre-date today - 3 months
```

## currency=usdt, since=1629212400000, limit=, tier=
```
binance.fetchMarginInterestRate (usdt, 1629212400000)
currency |   rate |     timestamp |                 datetime | tier
-------------------------------------------------------------------
    USDT | 0.0007 | 1630886400000 | 2021-09-06T00:00:00.000Z |    0
    ...
    USDT | 0.0005 | 1629244800000 | 2021-08-18T00:00:00.000Z |    0
20 objects
716 ms
```

## currency=usdt, since=1629212400000, limit=20, tier=
```
binance.fetchMarginInterestRate (usdt, 1629212400000, 20)
currency |   rate |     timestamp |                 datetime | tier
-------------------------------------------------------------------
    USDT | 0.0007 | 1630886400000 | 2021-09-06T00:00:00.000Z |    0
    ...
    USDT | 0.0005 | 1629244800000 | 2021-08-18T00:00:00.000Z |    0
20 objects
705 ms
```

## currency=usdt, since=1629212400000, limit=100, tier=1
```
binance.fetchMarginInterestRate (usdt, 1629212400000, 100, 1)
currency |     rate |     timestamp |                 datetime | tier
---------------------------------------------------------------------
    USDT |  0.00057 | 1637107200000 | 2021-11-17T00:00:00.000Z |    1
    ...
    USDT | 0.000475 | 1629158400000 | 2021-08-17T00:00:00.000Z |    1
93 objects
704 ms
```

