### PR TITLE
fetchBorrowRate, fetchBorrowRates

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -52,6 +52,8 @@ console.log ('CCXT v' + ccxt.version)
             'editOrder',
             'fetchAccounts',
             'fetchBalance',
+            'fetchBorrowRate',
+            'fetchBorrowRates',
             'fetchCanceledOrders',
             'fetchClosedOrder',
             'fetchClosedOrders',

--- a/examples/js/library-capabilities.js
+++ b/examples/js/library-capabilities.js
@@ -64,6 +64,8 @@ console.log ('CCXT v' + ccxt.version)
             'deposit',
             'editOrder',
             'fetchBalance',
+            'fetchBorrowRate',
+            'fetchBorrowRates',
             'fetchCanceledOrders',
             'fetchClosedOrder',
             'fetchClosedOrders',

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2061,4 +2061,17 @@ module.exports = class Exchange {
             throw new NotSupported (this.id + ' ' + key + ' does not have a value in mapping')
         }
     }
+
+    async fetchBorrowRate (code, params = {}) {
+        await this.loadMarkets ();
+        if (!this.has['fetchBorrowRates']) {
+            throw new NotSupported (this.id + 'fetchBorrowRate() is not supported yet')
+        }
+        const borrowRates = await this.fetchBorrowRates (params);
+        const rate = this.safeValue (borrowRates, code);
+        if (rate === undefined) {
+            throw new ExchangeError (this.id + 'fetchBorrowRate() could not find the borrow rate for currency code ' + code);
+        }
+        return rate;
+    }
 }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -22,6 +22,8 @@ module.exports = class bibox extends Exchange {
                 'createMarketOrder': undefined, // or they will return https://github.com/ccxt/ccxt/issues/2338
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/binance.js
+++ b/js/binance.js
@@ -25,6 +25,8 @@ module.exports = class binance extends Exchange {
                 'CORS': undefined,
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': true,
+                'fetchBorrowRates': false,
                 'fetchBidsAsks': true,
                 'fetchClosedOrders': 'emulated',
                 'fetchCurrencies': true,

--- a/js/binance.js
+++ b/js/binance.js
@@ -4900,17 +4900,18 @@ module.exports = class binance extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 1, params);
     }
 
-    async fetchBorrowRate (currency, params = {}) {
+    async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
+        const currencyId = this.currency (code)['id'];
         const request = {
-            'asset': this.safeCurrencyCode (currency),
+            'asset': currencyId,
             // 'vipLevel': this.safeInteger (params, 'vipLevel'),
         };
         const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
         const rate = response[0];
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
-            'currency': this.safeCurrencyCode (this.safeString (rate, 'asset')),
+            'currency': currencyId,
             'rate': this.safeNumber (rate, 'dailyInterestRate'),
             'span': 86400000,
             'timestamp': timestamp,

--- a/js/binance.js
+++ b/js/binance.js
@@ -4897,4 +4897,27 @@ module.exports = class binance extends Exchange {
     async addMargin (symbol, amount, params = {}) {
         return await this.modifyMarginHelper (symbol, amount, 1, params);
     }
+
+    async fetchBorrowRate (currency, tier = undefined, params = {}) {
+        await this.loadMarkets ();
+        const request = {
+            'asset': this.safeCurrencyCode (currency),
+        };
+        if (tier) {
+            request['vipLevel'] = tier;
+        }
+        const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
+        const rate = response[0];
+        const timestamp = this.safeNumber (rate, 'timestamp');
+        return {
+            'currency': this.safeCurrencyCode (this.safeString (rate, 'asset')),
+            'previousRate': this.safeNumber (rate, 'dailyInterestRate'),
+            'nextRate': undefined,
+            'tier': this.safeNumber (rate, 'vipLevel'),
+            'increment': 'daily',
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': response,
+        };
+    }
 };

--- a/js/binance.js
+++ b/js/binance.js
@@ -4912,7 +4912,7 @@ module.exports = class binance extends Exchange {
         return {
             'currency': this.safeCurrencyCode (this.safeString (rate, 'asset')),
             'rate': this.safeNumber (rate, 'dailyInterestRate'),
-            'increment': 'daily',
+            'span': 86400000,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': response,

--- a/js/binance.js
+++ b/js/binance.js
@@ -4908,12 +4908,12 @@ module.exports = class binance extends Exchange {
             // 'vipLevel': this.safeInteger (params, 'vipLevel'),
         };
         const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
-        const rate = response[0];
+        const rate = this.safeValue (response, 0);
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
             'currency': currencyId,
             'rate': this.safeNumber (rate, 'dailyInterestRate'),
-            'span': 86400000,
+            'period': 86400000,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': response,

--- a/js/binance.js
+++ b/js/binance.js
@@ -4902,16 +4902,27 @@ module.exports = class binance extends Exchange {
 
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        const currencyId = this.currency (code)['id'];
+        const currency = this.currency (code);
         const request = {
-            'asset': currencyId,
+            'asset': currency['id'],
             // 'vipLevel': this.safeInteger (params, 'vipLevel'),
         };
         const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
+        //
+        // [
+        //     {
+        //         "asset": "USDT",
+        //         "timestamp": 1638230400000,
+        //         "dailyInterestRate": "0.0006",
+        //         "vipLevel": 0
+        //     },
+        //     ...
+        // ]
+        //
         const rate = this.safeValue (response, 0);
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
-            'currency': currencyId,
+            'currency': code,
             'rate': this.safeNumber (rate, 'dailyInterestRate'),
             'period': 86400000,
             'timestamp': timestamp,

--- a/js/binance.js
+++ b/js/binance.js
@@ -4900,22 +4900,18 @@ module.exports = class binance extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 1, params);
     }
 
-    async fetchBorrowRate (currency, tier = undefined, params = {}) {
+    async fetchBorrowRate (currency, params = {}) {
         await this.loadMarkets ();
         const request = {
             'asset': this.safeCurrencyCode (currency),
+            // 'vipLevel': this.safeInteger (params, 'vipLevel'),
         };
-        if (tier) {
-            request['vipLevel'] = tier;
-        }
         const response = await this.sapiGetMarginInterestRateHistory (this.extend (request, params));
         const rate = response[0];
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
             'currency': this.safeCurrencyCode (this.safeString (rate, 'asset')),
-            'previousRate': this.safeNumber (rate, 'dailyInterestRate'),
-            'nextRate': undefined,
-            'tier': this.safeNumber (rate, 'vipLevel'),
+            'rate': this.safeNumber (rate, 'dailyInterestRate'),
             'increment': 'daily',
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -24,6 +24,8 @@ module.exports = class bitstamp extends Exchange {
                 'CORS': true,
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchFees': true,

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -27,6 +27,8 @@ module.exports = class bittrex extends Exchange {
                 'createMarketOrder': true,
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -26,6 +26,8 @@ module.exports = class bybit extends Exchange {
                 'createOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchDeposits': true,
                 'fetchFundingRate': true,

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -27,6 +27,8 @@ module.exports = class coinbase extends Exchange {
                 'createOrder': undefined,
                 'deposit': undefined,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchBidsAsks': undefined,
                 'fetchClosedOrders': undefined,
                 'fetchCurrencies': true,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2286,7 +2286,7 @@ module.exports = class ftx extends Exchange {
         return this.parseFundingRate (result, market);
     }
 
-    async fetchBorrowRates (tier = undefined, params = {}) {
+    async fetchBorrowRates (params = {}) {
         await this.loadMarkets ();
         const response = await this.privateGetSpotMarginBorrowRates ();
         const timestamp = this.milliseconds ();
@@ -2296,9 +2296,7 @@ module.exports = class ftx extends Exchange {
             const rate = result[i];
             rates.push ({
                 'currency': this.safeCurrencyCode (this.safeString (rate, 'coin')),
-                'previousRate': this.safeNumber (rate, 'previous'),
-                'nextRate': this.safeNumber (rate, 'estimate'),
-                'tier': undefined,
+                'rate': this.safeNumber (rate, 'previous'),
                 'increment': 'hourly',
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
@@ -2308,7 +2306,7 @@ module.exports = class ftx extends Exchange {
         return rates;
     }
 
-    async fetchBorrowRate (currency, tier = undefined, params = {}) {
+    async fetchBorrowRate (currency, params = {}) {
         await this.loadMarkets ();
         const response = await this.privateGetSpotMarginBorrowRates ();
         const timestamp = this.milliseconds ();
@@ -2320,9 +2318,7 @@ module.exports = class ftx extends Exchange {
             if (coin === currency) {
                 return {
                     'currency': currency,
-                    'previousRate': this.safeNumber (rate, 'previous'),
-                    'nextRate': this.safeNumber (rate, 'estimate'),
-                    'tier': undefined,
+                    'rate': this.safeNumber (rate, 'previous'),
                     'increment': 'hourly',
                     'timestamp': timestamp,
                     'datetime': this.iso8601 (timestamp),

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2319,40 +2319,4 @@ module.exports = class ftx extends Exchange {
         }
         return rates;
     }
-
-    async fetchBorrowRate (code, params = {}) {
-        await this.loadMarkets ();
-        const response = await this.privateGetSpotMarginBorrowRates (params);
-        //
-        // {
-        //     "success":true,
-        //     "result":[
-        //         {
-        //             "coin": "1INCH",
-        //             "previous": 0.0000462375,
-        //             "estimate": 0.0000462375
-        //         }
-        //         ...
-        //     ]
-        // }
-        //
-        const timestamp = this.milliseconds ();
-        const currencyId = this.currency (code)['id'];
-        const result = this.safeValue (response, 'result');
-        for (let i = 0; i < result.length; i++) {
-            const rate = result[i];
-            const coin = this.safeCurrencyCode (this.safeString (rate, 'coin'));
-            if (code === coin) {
-                return {
-                    'currency': coin,
-                    'rate': this.safeNumber (rate, 'previous'),
-                    'period': 3600000,
-                    'timestamp': timestamp,
-                    'datetime': this.iso8601 (timestamp),
-                    'info': rate,
-                };
-            }
-        }
-        throw new BadRequest ('Could not find rate for ' + currencyId);
-    }
 };

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2297,7 +2297,7 @@ module.exports = class ftx extends Exchange {
             rates.push ({
                 'currency': this.safeCurrencyCode (this.safeString (rate, 'coin')),
                 'rate': this.safeNumber (rate, 'previous'),
-                'increment': 'hourly',
+                'span': 3600000,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'info': rate,
@@ -2319,7 +2319,7 @@ module.exports = class ftx extends Exchange {
                 return {
                     'currency': currency,
                     'rate': this.safeNumber (rate, 'previous'),
-                    'increment': 'hourly',
+                    'span': 3600000,
                     'timestamp': timestamp,
                     'datetime': this.iso8601 (timestamp),
                     'info': rate,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2289,14 +2289,27 @@ module.exports = class ftx extends Exchange {
     async fetchBorrowRates (params = {}) {
         await this.loadMarkets ();
         const response = await this.privateGetSpotMarginBorrowRates ();
+        //
+        // {
+        //     "success":true,
+        //     "result":[
+        //         {
+        //             "coin": "1INCH",
+        //             "previous": 0.0000462375,
+        //             "estimate": 0.0000462375
+        //         }
+        //         ...
+        //     ]
+        // }
+        //
         const timestamp = this.milliseconds ();
         const result = this.safeValue (response, 'result');
-        const rates = [];
+        const rates = {};
         for (let i = 0; i < result.length; i++) {
             const rate = result[i];
-            const currency = this.safeCurrencyCode (this.safeString (rate, 'coin'));
-            rates[currency] = {
-                'currency': currency,
+            const code = this.safeCurrencyCode (this.safeString (rate, 'coin'));
+            rates[code] = {
+                'currency': code,
                 'rate': this.safeNumber (rate, 'previous'),
                 'period': 3600000,
                 'timestamp': timestamp,
@@ -2310,15 +2323,28 @@ module.exports = class ftx extends Exchange {
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
         const response = await this.privateGetSpotMarginBorrowRates (params);
+        //
+        // {
+        //     "success":true,
+        //     "result":[
+        //         {
+        //             "coin": "1INCH",
+        //             "previous": 0.0000462375,
+        //             "estimate": 0.0000462375
+        //         }
+        //         ...
+        //     ]
+        // }
+        //
         const timestamp = this.milliseconds ();
         const currencyId = this.currency (code)['id'];
         const result = this.safeValue (response, 'result');
         for (let i = 0; i < result.length; i++) {
             const rate = result[i];
             const coin = this.safeCurrencyCode (this.safeString (rate, 'coin'));
-            if (coin === currencyId) {
+            if (code === coin) {
                 return {
-                    'currency': currencyId,
+                    'currency': code,
                     'rate': this.safeNumber (rate, 'previous'),
                     'period': 3600000,
                     'timestamp': timestamp,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2344,7 +2344,7 @@ module.exports = class ftx extends Exchange {
             const coin = this.safeCurrencyCode (this.safeString (rate, 'coin'));
             if (code === coin) {
                 return {
-                    'currency': code,
+                    'currency': coin,
                     'rate': this.safeNumber (rate, 'previous'),
                     'period': 3600000,
                     'timestamp': timestamp,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -39,6 +39,8 @@ module.exports = class ftx extends Exchange {
                 'createOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': true,
+                'fetchBorrowRates': true,
                 'fetchClosedOrders': undefined,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2294,14 +2294,15 @@ module.exports = class ftx extends Exchange {
         const rates = [];
         for (let i = 0; i < result.length; i++) {
             const rate = result[i];
-            rates.push ({
-                'currency': this.safeCurrencyCode (this.safeString (rate, 'coin')),
+            const currency = this.safeCurrencyCode (this.safeString (rate, 'coin'));
+            rates[currency] = {
+                'currency': currency,
                 'rate': this.safeNumber (rate, 'previous'),
                 'span': 3600000,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'info': rate,
-            });
+            };
         }
         return rates;
     }

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2307,18 +2307,18 @@ module.exports = class ftx extends Exchange {
         return rates;
     }
 
-    async fetchBorrowRate (currency, params = {}) {
+    async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        const response = await this.privateGetSpotMarginBorrowRates ();
+        const response = await this.privateGetSpotMarginBorrowRates (params);
         const timestamp = this.milliseconds ();
-        currency = this.safeCurrencyCode (currency);
+        const currencyId = this.currency (code)['id'];
         const result = this.safeValue (response, 'result');
         for (let i = 0; i < result.length; i++) {
             const rate = result[i];
             const coin = rate['coin'];
-            if (coin === currency) {
+            if (coin === currencyId) {
                 return {
-                    'currency': currency,
+                    'currency': currencyId,
                     'rate': this.safeNumber (rate, 'previous'),
                     'span': 3600000,
                     'timestamp': timestamp,
@@ -2327,6 +2327,6 @@ module.exports = class ftx extends Exchange {
                 };
             }
         }
-        throw new BadRequest ('Could not find rate for ' + currency);
+        throw new BadRequest ('Could not find rate for ' + currencyId);
     }
 };

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2298,7 +2298,7 @@ module.exports = class ftx extends Exchange {
             rates[currency] = {
                 'currency': currency,
                 'rate': this.safeNumber (rate, 'previous'),
-                'span': 3600000,
+                'period': 3600000,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'info': rate,
@@ -2315,12 +2315,12 @@ module.exports = class ftx extends Exchange {
         const result = this.safeValue (response, 'result');
         for (let i = 0; i < result.length; i++) {
             const rate = result[i];
-            const coin = rate['coin'];
+            const coin = this.safeCurrencyCode (this.safeString (rate, 'coin'));
             if (coin === currencyId) {
                 return {
                     'currency': currencyId,
                     'rate': this.safeNumber (rate, 'previous'),
-                    'span': 3600000,
+                    'period': 3600000,
                     'timestamp': timestamp,
                     'datetime': this.iso8601 (timestamp),
                     'info': rate,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -36,7 +36,7 @@ module.exports = class gateio extends Exchange {
                 'createMarketOrder': false,
                 'createOrder': true,
                 'fetchBalance': true,
-                'fetchBorrowRate': true,
+                'fetchBorrowRate': false,
                 'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
@@ -2822,35 +2822,6 @@ module.exports = class gateio extends Exchange {
         //     }
         //
         return response;
-    }
-
-    async fetchBorrowRate (code, params = {}) {
-        await this.loadMarkets ();
-        const currency = this.currency (code);
-        const request = {
-            'currency': currency['id'],
-        };
-        const response = await this.publicMarginGetFundingBook (this.extend (request, params));
-        //
-        // [
-        //     {
-        //          "rate":"0.0003",
-        //          "amount":"6249098.618783217966",
-        //          "days":10
-        //     }
-        //     ...
-        // ]
-        //
-        const rate = this.safeValue (response, 0);
-        const timestamp = this.safeNumber (rate, 'timestamp');
-        return {
-            'currency': code,
-            'rate': this.safeNumber (rate, 'rate'),
-            'period': 86400000,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
-            'info': rate,
-        };
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2826,15 +2826,25 @@ module.exports = class gateio extends Exchange {
 
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        const currencyId = this.currency (code)['id'];
+        const currency = this.currency (code);
         const request = {
-            'currency': currencyId,
+            'currency': currency['id'],
         };
         const response = await this.publicMarginGetFundingBook (this.extend (request, params));
+        //
+        // [
+        //     {
+        //          "rate":"0.0003",
+        //          "amount":"6249098.618783217966",
+        //          "days":10
+        //     }
+        //     ...
+        // ]
+        //
         const rate = this.safeValue (response, 0);
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
-            'currency': currencyId,
+            'currency': code,
             'rate': this.safeNumber (rate, 'rate'),
             'period': 86400000,
             'timestamp': timestamp,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2824,17 +2824,17 @@ module.exports = class gateio extends Exchange {
         return response;
     }
 
-    async fetchBorrowRate (currency, params = {}) {
+    async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        currency = this.safeCurrencyCode (currency);
+        const currencyId = this.currency (code)['id'];
         const request = {
-            'currency': currency,
+            'currency': currencyId,
         };
         const response = await this.publicMarginGetFundingBook (this.extend (request, params));
         const rate = response[0];
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
-            'currency': currency,
+            'currency': currencyId,
             'rate': this.safeNumber (rate, 'rate'),
             'span': 86400000,
             'timestamp': timestamp,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -79,6 +79,7 @@ module.exports = class gateio extends Exchange {
                             'currency_pairs/{currency_pair}': 1,
                             'cross/currencies': 1,
                             'cross/currencies/{currency}': 1,
+                            'funding_book': 1,
                         },
                     },
                     'futures': {
@@ -2819,6 +2820,27 @@ module.exports = class gateio extends Exchange {
         //     }
         //
         return response;
+    }
+
+    async fetchBorrowRate (currency, tier = undefined, params = {}) {
+        await this.loadMarkets ();
+        currency = this.safeCurrencyCode (currency);
+        const request = {
+            'currency': currency,
+        };
+        const response = await this.publicMarginGetFundingBook (this.extend (request, params));
+        const rate = response[0];
+        const timestamp = this.safeNumber (rate, 'timestamp');
+        return {
+            'currency': currency,
+            'previousRate': this.safeNumber (rate, 'rate'),
+            'nextRate': undefined,
+            'tier': undefined,
+            'increment': 'daily',
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': rate,
+        };
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2836,7 +2836,7 @@ module.exports = class gateio extends Exchange {
         return {
             'currency': currency,
             'rate': this.safeNumber (rate, 'rate'),
-            'increment': 'daily',
+            'span': 86400000,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': rate,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2824,7 +2824,7 @@ module.exports = class gateio extends Exchange {
         return response;
     }
 
-    async fetchBorrowRate (currency, tier = undefined, params = {}) {
+    async fetchBorrowRate (currency, params = {}) {
         await this.loadMarkets ();
         currency = this.safeCurrencyCode (currency);
         const request = {
@@ -2835,9 +2835,7 @@ module.exports = class gateio extends Exchange {
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
             'currency': currency,
-            'previousRate': this.safeNumber (rate, 'rate'),
-            'nextRate': undefined,
-            'tier': undefined,
+            'rate': this.safeNumber (rate, 'rate'),
             'increment': 'daily',
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -36,6 +36,8 @@ module.exports = class gateio extends Exchange {
                 'createMarketOrder': false,
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': true,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2831,12 +2831,12 @@ module.exports = class gateio extends Exchange {
             'currency': currencyId,
         };
         const response = await this.publicMarginGetFundingBook (this.extend (request, params));
-        const rate = response[0];
+        const rate = this.safeValue (response, 0);
         const timestamp = this.safeNumber (rate, 'timestamp');
         return {
             'currency': currencyId,
             'rate': this.safeNumber (rate, 'rate'),
-            'span': 86400000,
+            'period': 86400000,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': rate,

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -25,6 +25,8 @@ module.exports = class hitbtc extends Exchange {
                 'createOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -25,6 +25,8 @@ module.exports = class kraken extends Exchange {
                 'createDepositAddress': true,
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -28,6 +28,8 @@ module.exports = class kucoin extends Exchange {
                 'createOrder': true,
                 'fetchAccounts': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/okex.js
+++ b/js/okex.js
@@ -3554,14 +3554,15 @@ module.exports = class okex extends Exchange {
         const rates = [];
         for (let i = 0; i < data.length; i++) {
             const rate = data[i];
-            rates.push ({
-                'currency': this.safeString (rate, 'ccy'),
+            const currency = this.safeCurrencyCode (this.safeString (rate, 'ccy'));
+            rates[currency] = {
+                'currency': currency,
                 'rate': this.safeNumber (rate, 'interestRate'),
                 'span': 86400000,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'info': rate,
-            });
+            };
         }
         return rates;
     }

--- a/js/okex.js
+++ b/js/okex.js
@@ -3567,18 +3567,18 @@ module.exports = class okex extends Exchange {
         return rates;
     }
 
-    async fetchBorrowRate (currency, params = {}) {
+    async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        currency = this.safeCurrencyCode (currency);
+        const currencyId = this.currency (code)['id'];
         const request = {
-            'ccy': currency,
+            'ccy': currencyId,
         };
         const response = await this.privateGetAccountInterestRate (this.extend (request, params));
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
         const rate = data[0];
         return {
-            'currency': currency,
+            'currency': currencyId,
             'rate': this.safeNumber (rate, 'interestRate'),
             'span': 86400000,
             'timestamp': timestamp,

--- a/js/okex.js
+++ b/js/okex.js
@@ -3557,7 +3557,7 @@ module.exports = class okex extends Exchange {
             rates.push ({
                 'currency': this.safeString (rate, 'ccy'),
                 'rate': this.safeNumber (rate, 'interestRate'),
-                'increment': 'daily',
+                'span': 86400000,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'info': rate,
@@ -3579,7 +3579,7 @@ module.exports = class okex extends Exchange {
         return {
             'currency': currency,
             'rate': this.safeNumber (rate, 'interestRate'),
-            'increment': 'daily',
+            'span': 86400000,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': rate,

--- a/js/okex.js
+++ b/js/okex.js
@@ -3546,7 +3546,7 @@ module.exports = class okex extends Exchange {
         };
     }
 
-    async fetchBorrowRates (tier = undefined, params = {}) {
+    async fetchBorrowRates (params = {}) {
         await this.loadMarkets ();
         const response = await this.privateGetAccountInterestRate (params);
         const timestamp = this.milliseconds ();
@@ -3556,9 +3556,7 @@ module.exports = class okex extends Exchange {
             const rate = data[i];
             rates.push ({
                 'currency': this.safeString (rate, 'ccy'),
-                'previousRate': this.safeNumber (rate, 'interestRate'),
-                'nextRate': undefined,
-                'tier': undefined,
+                'rate': this.safeNumber (rate, 'interestRate'),
                 'increment': 'daily',
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
@@ -3568,7 +3566,7 @@ module.exports = class okex extends Exchange {
         return rates;
     }
 
-    async fetchBorrowRate (currency, tier = undefined, params = {}) {
+    async fetchBorrowRate (currency, params = {}) {
         await this.loadMarkets ();
         currency = this.safeCurrencyCode (currency);
         const request = {
@@ -3580,9 +3578,7 @@ module.exports = class okex extends Exchange {
         const rate = data[0];
         return {
             'currency': currency,
-            'previousRate': this.safeNumber (rate, 'interestRate'),
-            'nextRate': undefined,
-            'tier': undefined,
+            'rate': this.safeNumber (rate, 'interestRate'),
             'increment': 'daily',
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),

--- a/js/okex.js
+++ b/js/okex.js
@@ -3549,14 +3549,24 @@ module.exports = class okex extends Exchange {
     async fetchBorrowRates (params = {}) {
         await this.loadMarkets ();
         const response = await this.privateGetAccountInterestRate (params);
+        // {
+        //     "code": "0",
+        //     "data": [
+        //         {
+        //             "ccy":"BTC",
+        //             "interestRate":"0.00000833"
+        //         }
+        //         ...
+        //     ],
+        // }
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
-        const rates = [];
+        const rates = {};
         for (let i = 0; i < data.length; i++) {
             const rate = data[i];
-            const currency = this.safeCurrencyCode (this.safeString (rate, 'ccy'));
-            rates[currency] = {
-                'currency': currency,
+            const code = this.safeCurrencyCode (this.safeString (rate, 'ccy'));
+            rates[code] = {
+                'currency': code,
                 'rate': this.safeNumber (rate, 'interestRate'),
                 'period': 86400000,
                 'timestamp': timestamp,
@@ -3569,16 +3579,27 @@ module.exports = class okex extends Exchange {
 
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        const currencyId = this.currency (code)['id'];
+        const currency = this.currency (code);
         const request = {
-            'ccy': currencyId,
+            'ccy': currency['id'],
         };
         const response = await this.privateGetAccountInterestRate (this.extend (request, params));
+        // {
+        //     "code": "0",
+        //     "data":[
+        //          {
+        //             "ccy":"USDT",
+        //             "interestRate":"0.00002065"
+        //          }
+        //          ...
+        //     ],
+        //     "msg":""
+        // }
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
         const rate = this.safeValue (data, 0);
         return {
-            'currency': currencyId,
+            'currency': code,
             'rate': this.safeNumber (rate, 'interestRate'),
             'period': 86400000,
             'timestamp': timestamp,

--- a/js/okex.js
+++ b/js/okex.js
@@ -3558,7 +3558,7 @@ module.exports = class okex extends Exchange {
             rates[currency] = {
                 'currency': currency,
                 'rate': this.safeNumber (rate, 'interestRate'),
-                'span': 86400000,
+                'period': 86400000,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'info': rate,
@@ -3576,11 +3576,11 @@ module.exports = class okex extends Exchange {
         const response = await this.privateGetAccountInterestRate (this.extend (request, params));
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
-        const rate = data[0];
+        const rate = this.safeValue (data, 0);
         return {
             'currency': currencyId,
             'rate': this.safeNumber (rate, 'interestRate'),
-            'span': 86400000,
+            'period': 86400000,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': rate,

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -25,6 +25,8 @@ module.exports = class phemex extends Exchange {
                 'cancelOrder': true,
                 'createOrder': true,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,

--- a/js/test/Exchange/test.borrowRate.js
+++ b/js/test/Exchange/test.borrowRate.js
@@ -1,0 +1,37 @@
+'use strict'
+
+// ----------------------------------------------------------------------------
+
+const log       = require ('ololog')
+    , ansi      = require ('ansicolor').nice
+    , chai      = require ('chai')
+    , expect    = chai.expect
+    , assert    = chai.assert
+
+/*  ------------------------------------------------------------------------ */
+
+module.exports = (exchange, borrowRate, method, code) => {
+
+    const format = {
+        'currency':      'USDT',
+        'info':          {},    // Or []
+        'timestamp':     1638230400000,
+        'datetime':      '2021-11-30T00:00:00.000Z',
+        'rate':          0.0006,    // Interest rate
+        'period':        86400000,  // Amount of time the interest rate is based on in milliseconds
+    }
+
+    expect (borrowRate).to.have.all.keys (format)
+
+    const keys = [ 'currency', 'info', 'timestamp', 'datetime', 'rate', 'period' ]
+    log (borrowRate['datetime'], exchange.id, method, borrowRate['currency'], borrowRate['rate'])
+    keys.forEach ((key) => assert (key in borrowRate))
+
+    const { currency, info, timestamp, datetime, rate, period } = borrowRate
+
+    assert (borrowRate['period'] === 86400000 || borrowRate['period'] === 3600000)   // Milliseconds in an hour or a day
+    assert (borrowRate['rate'] > 0)
+    assert (borrowRate['currency'] === code)
+
+    return borrowRate
+}

--- a/js/test/Exchange/test.borrowRate.js
+++ b/js/test/Exchange/test.borrowRate.js
@@ -31,7 +31,6 @@ module.exports = (exchange, borrowRate, method, code) => {
 
     assert (borrowRate['period'] === 86400000 || borrowRate['period'] === 3600000)   // Milliseconds in an hour or a day
     assert (borrowRate['rate'] > 0)
-    assert (borrowRate['currency'] === code)
 
     return borrowRate
 }

--- a/js/test/Exchange/test.fetchBorrowRate.js
+++ b/js/test/Exchange/test.fetchBorrowRate.js
@@ -1,0 +1,46 @@
+'use strict'
+
+// ----------------------------------------------------------------------------
+
+const log       = require ('ololog')
+    , ansi      = require ('ansicolor').nice
+    , chai      = require ('chai')
+    , expect    = chai.expect
+    , assert    = chai.assert
+    , testBorrowRate = require ('./test.borrowRate.js')
+
+// ----------------------------------------------------------------------------
+
+const printBorrowRateOneLiner = (borrowRate, method, code) => {
+
+    log (code.toString ().green,
+        method,
+        borrowRate['datetime'],
+        'rate: '       + (borrowRate['rate']),
+        'period: '     + (borrowRate['period']))
+}
+
+// ----------------------------------------------------------------------------
+
+module.exports = async (exchange, code) => {
+
+    const method = 'fetchborrowRate'
+
+    if (exchange.has[method]) {
+
+        // log (symbol.green, 'fetching borrowRate...')
+
+        const borrowRate = await exchange.fetchBorrowRate (code)
+
+        testBorrowRate (exchange, borrowRate, method, code)
+
+        printBorrowRateOneLiner (borrowRate, method, code)
+
+        return borrowRate
+
+    } else {
+
+        log (code.green, 'fetchborrowRate () not supported')
+    }
+}
+

--- a/js/test/Exchange/test.fetchBorrowRate.js
+++ b/js/test/Exchange/test.fetchBorrowRate.js
@@ -24,7 +24,7 @@ const printBorrowRateOneLiner = (borrowRate, method, code) => {
 
 module.exports = async (exchange, code) => {
 
-    const method = 'fetchborrowRate'
+    const method = 'fetchBorrowRate'
 
     if (exchange.has[method]) {
 
@@ -36,11 +36,14 @@ module.exports = async (exchange, code) => {
 
         printBorrowRateOneLiner (borrowRate, method, code)
 
+        if (code) {
+            assert (borrowRate['currency'] === code)
+        }
+
         return borrowRate
 
     } else {
 
-        log (code.green, 'fetchborrowRate () not supported')
+        log (code.green, 'fetchBorrowRate () not supported')
     }
 }
-

--- a/js/test/Exchange/test.fetchBorrowRates.js
+++ b/js/test/Exchange/test.fetchBorrowRates.js
@@ -11,7 +11,7 @@ const log       = require ('ololog')
 
 /*  ------------------------------------------------------------------------ */
 
-module.exports = async (exchange, code) => {
+module.exports = async (exchange) => {
 
     if (exchange.has.fetchBorrowRates) {
 
@@ -28,11 +28,11 @@ module.exports = async (exchange, code) => {
         } catch (e) {
 
             log ('failed to fetch all borrow rates, fetching multiple borrow rates at once...')
-            borrowRates = await exchange[method] ([ code ])
+            borrowRates = await exchange[method] ()
             log ('fetched', Object.keys (borrowRates).length.toString ().green, 'borrow rates')
         }
 
-        Object.values (borrowRates).forEach ((borrowRate) => testBorrowRate (exchange, borrowRate, method, code))
+        Object.values (borrowRates).forEach ((borrowRate) => testBorrowRate (exchange, borrowRate, method))
         return borrowRates
 
     } else {

--- a/js/test/Exchange/test.fetchBorrowRates.js
+++ b/js/test/Exchange/test.fetchBorrowRates.js
@@ -1,0 +1,43 @@
+'use strict'
+
+// ----------------------------------------------------------------------------
+
+const log       = require ('ololog')
+    , ansi      = require ('ansicolor').nice
+    , chai      = require ('chai')
+    , expect    = chai.expect
+    , assert    = chai.assert
+    , testBorrowRate = require ('./test.borrowRate.js')
+
+/*  ------------------------------------------------------------------------ */
+
+module.exports = async (exchange, code) => {
+
+    if (exchange.has.fetchBorrowRates) {
+
+        // log ('fetching all BorrowRates at once...')
+
+        const method = 'fetchBorrowRates'
+        let borrowRates = undefined
+
+        try {
+
+            borrowRates = await exchange[method] ()
+            log ('fetched all', Object.keys (borrowRates).length.toString ().green, 'borrow rates')
+
+        } catch (e) {
+
+            log ('failed to fetch all borrow rates, fetching multiple borrow rates at once...')
+            borrowRates = await exchange[method] ([ code ])
+            log ('fetched', Object.keys (borrowRates).length.toString ().green, 'borrow rates')
+        }
+
+        Object.values (borrowRates).forEach ((borrowRate) => testBorrowRate (exchange, borrowRate, method, code))
+        return borrowRates
+
+    } else {
+
+        log ('fetching all borrow rates at once not supported')
+    }
+}
+

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -304,6 +304,8 @@ async function testExchange (exchange) {
     await tests['fetchTransactions'] (exchange, code)
     await tests['fetchDeposits']     (exchange, code)
     await tests['fetchWithdrawals']  (exchange, code)
+    await tests['fetchBorrowRate']   (exchange, code)
+    await tests['fetchBorrowRates']  (exchange, code)
 
     if (exchange.extendedTest) {
 

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -305,7 +305,7 @@ async function testExchange (exchange) {
     await tests['fetchDeposits']     (exchange, code)
     await tests['fetchWithdrawals']  (exchange, code)
     await tests['fetchBorrowRate']   (exchange, code)
-    await tests['fetchBorrowRates']  (exchange, code)
+    await tests['fetchBorrowRates']  (exchange)
 
     if (exchange.extendedTest) {
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -365,6 +365,7 @@ class Exchange {
         'parsePrecision' => 'parse_precision',
         'handleWithdrawTagAndParams' => 'handle_withdraw_tag_and_params',
         'getSupportedMapping' => 'get_supported_mapping',
+        'fetchBorrowRate' => 'fetch_borrow_rate',
     );
 
     public static function split($string, $delimiters = array(' ')) {
@@ -3492,5 +3493,18 @@ class Exchange {
         } else {
             throw new NotSupported ($this->id . ' ' . $key . ' does not have a value in mapping');
         }
+    }
+
+    public function fetch_borrow_rate($code, $params = array()) {
+        $this->load_markets();
+        if (!$this->has['fetchBorrowRates']) {
+            throw new NotSupported($this->id + 'fetchBorrowRate() is not supported yet');
+        }
+        $borrow_rates = $this->fetch_borrow_rates($params);
+        $rate = $this->safe_value($borrow_rates, $code);
+        if ($rate == null) {
+            throw new ExchangeError($this->id + 'fetchBorrowRate() could not find the borrow rate for currency code ' + $code);
+        }
+        return $rate;
     }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2635,3 +2635,13 @@ class Exchange(object):
             return mapping[key]
         else:
             raise NotSupported(self.id + ' ' + key + ' does not have a value in mapping')
+
+    def fetch_borrow_rate(self, code, params={}):
+        self.load_markets()
+        if not self.has['fetchBorrowRates']:
+            raise NotSupported(self.id + 'fetchBorrowRate() is not supported yet')
+        borrow_rates = self.fetch_borrow_rates(params)
+        rate = self.safe_value(borrow_rates, code)
+        if rate is None:
+            raise ExchangeError(self.id + 'fetchBorrowRate() could not find the borrow rate for currency code ' + code)
+        return rate


### PR DESCRIPTION
Get's the interest rate for currrencies borrowed when using margin trading

- binance (public)
- ftx (private)
- okex (private)

@kroitor If you like, I can remove the `span` variable, and just convert ftx's interest rate to daily instead of hourly so that it matches the others, you will still be able to see the hourly interest rate inside `info`

-------------------------

21/11/18 05:16:57 +0000
Node.js: v14.17.0
CCXT v1.61.46

## exchange=binance, method=fetchBorrowRate currency=usdt,  
```
binance.fetchBorrowRate (usdt)
{  currency:   "USDT",
       rate:    0.0006,
  increment:   "daily",
  timestamp:    1637193600000,
   datetime:   "2021-11-18T00:00:00.000Z",
       info: [ {             asset: "USDT",
                         timestamp: "1637193600000",
                 dailyInterestRate: "0.0006",
                          vipLevel: "0"              },
               ...
               {             asset: "USDT",
                         timestamp: "1636588800000",
                 dailyInterestRate: "0.0006",
                          vipLevel: "0"              }  ] }
697 ms
```

## exchange=ftx, method=fetchBorrowRate currency=usdt,  
```
ftx.fetchBorrowRate (usdt)
{  currency:   "USDT",
       rate:    0.0000123255,
  increment:   "hourly",
  timestamp:    1637212620053,
   datetime:   "2021-11-18T05:17:00.053Z",
       info: {     coin: "USDT",
               previous: "0.0000123255",
               estimate: "0.0000123255"  } }
605 ms
```

## exchange=ftx, method=fetchBorrowRates currency=usdt,  
```
ftx.fetchBorrowRates (usdt)
currency |         rate | increment |     timestamp |                 datetime
------------------------------------------------------------------------------
   1INCH |      0.00027 |    hourly | 1637212621196 | 2021-11-18T05:17:01.196Z
      ...
      ZM |   0.00000135 |    hourly | 1637212621196 | 2021-11-18T05:17:01.196Z
97 objects
518 ms
```

## exchange=okex, method=fetchBorrowRate currency=usdt,  
```
okex.fetchBorrowRate (usdt)
{  currency:   "USDT",
       rate:    0.00001666,
  increment:   "daily",
  timestamp:    1637212625974,
   datetime:   "2021-11-18T05:17:05.974Z",
       info: { ccy: "USDT", interestRate: "0.00001666" } }
333 ms
```

## exchange=okex, method=fetchBorrowRates currency=usdt,  
```
okex.fetchBorrowRates (usdt)
currency |                   rate | increment |     timestamp |                 datetime
----------------------------------------------------------------------------------------
     BTC |             0.00000833 |     daily | 1637212628173 | 2021-11-18T05:17:08.173Z
    ...
     ZRX |             0.00000937 |     daily | 1637212628173 | 2021-11-18T05:17:08.173Z
133 objects
336 ms
```

