### PR TITLE
Bump aiohttp version to aiohttp>=3.8

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -87,7 +87,7 @@ setup(
 
     extras_require={
         ':python_version>="3.5.2"': [
-            'aiohttp>=3.7.4,<3.8',
+            'aiohttp>=3.8',
             'aiodns>=1.1.1',
             'yarl==1.6.3',
         ],


### PR DESCRIPTION
Fix conflicts with libraries that use newer versions of aiohttp. For example aiohttp==3.8.0 in https://github.com/Drakkar-Software/OctoBot-Trading/commit/fac394378fb84eb97269099f5069c19569f251bb/checks#step:4:99