### PR TITLE
Bitstamp - Return withdrawal id as string

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -1550,7 +1550,7 @@ module.exports = class bitstamp extends Exchange {
         const response = await this[method] (this.extend (request, params));
         return {
             'info': response,
-            'id': response['id'],
+            'id': this.safeString (response, 'id'),
         };
     }
 


### PR DESCRIPTION
IDs are generally handled as strings, but Bitstamp uses integer IDs. These integers are coerced to strings in other functions e.g. parseTransactions, so I believe coercing this id to a string is desired.