### PR TITLE
Better exception handling for Coinbase Pro signature

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1299,7 +1299,7 @@ module.exports = class coinbasepro extends Exchange {
             try {
                 secret = this.base64ToBinary (this.secret);
             } catch (e) {
-                throw new AuthenticationError (this.id + ' sign() invalid secret');
+                throw new AuthenticationError (this.id + ' sign() invalid base64 secret');
             }
             const signature = this.hmac (this.encode (what), secret, 'sha256', 'base64');
             headers = {

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1295,15 +1295,19 @@ module.exports = class coinbasepro extends Exchange {
                 }
             }
             const what = nonce + method + request + payload;
-            const secret = this.base64ToBinary (this.secret);
-            const signature = this.hmac (this.encode (what), secret, 'sha256', 'base64');
-            headers = {
-                'CB-ACCESS-KEY': this.apiKey,
-                'CB-ACCESS-SIGN': signature,
-                'CB-ACCESS-TIMESTAMP': nonce,
-                'CB-ACCESS-PASSPHRASE': this.password,
-                'Content-Type': 'application/json',
-            };
+            try {
+                const secret = this.base64ToBinary (this.secret);
+                const signature = this.hmac (this.encode (what), secret, 'sha256', 'base64');
+                headers = {
+                    'CB-ACCESS-KEY': this.apiKey,
+                    'CB-ACCESS-SIGN': signature,
+                    'CB-ACCESS-TIMESTAMP': nonce,
+                    'CB-ACCESS-PASSPHRASE': this.password,
+                    'Content-Type': 'application/json',
+                };
+            } catch (e) {
+                throw new AuthenticationError ('Invalid secret');
+            }
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1295,19 +1295,20 @@ module.exports = class coinbasepro extends Exchange {
                 }
             }
             const what = nonce + method + request + payload;
+            let secret = undefined;
             try {
-                const secret = this.base64ToBinary (this.secret);
-                const signature = this.hmac (this.encode (what), secret, 'sha256', 'base64');
-                headers = {
-                    'CB-ACCESS-KEY': this.apiKey,
-                    'CB-ACCESS-SIGN': signature,
-                    'CB-ACCESS-TIMESTAMP': nonce,
-                    'CB-ACCESS-PASSPHRASE': this.password,
-                    'Content-Type': 'application/json',
-                };
+                secret = this.base64ToBinary (this.secret);
             } catch (e) {
-                throw new AuthenticationError ('Invalid secret');
+                throw new AuthenticationError (this.id + ' sign() invalid secret');
             }
+            const signature = this.hmac (this.encode (what), secret, 'sha256', 'base64');
+            headers = {
+                'CB-ACCESS-KEY': this.apiKey,
+                'CB-ACCESS-SIGN': signature,
+                'CB-ACCESS-TIMESTAMP': nonce,
+                'CB-ACCESS-PASSPHRASE': this.password,
+                'Content-Type': 'application/json',
+            };
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }


### PR DESCRIPTION
### What ###
This prevents the `sign()` method to raise a base64 exception when we use a malformed secret.

```
  File "/test/venv/lib/python3.9/site-packages/ccxt/async_support/base/exchange.py", line 96, in fetch2
    request = self.sign(path, api, method, params, headers, body)
  File "/test/venv/lib/python3.9/site-packages/ccxt/async_support/coinbasepro.py", line 1105, in sign
    what = nonce + method + request + payload
  File "/test/venv/lib/python3.9/site-packages/ccxt/base/exchange.py", line 1162, in base64_to_binary
    return base64.standard_b64decode(s)
  File "/usr/lib/python3.9/base64.py", line 105, in standard_b64decode
    return b64decode(s)
  File "/usr/lib/python3.9/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
``` 