### PR TITLE
gateio STX remove mapping

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -279,7 +279,6 @@ module.exports = class gateio extends Exchange {
                 'MPH': 'Morpher', // conflict with 88MPH
                 'RAI': 'Rai Reflex Index', // conflict with RAI Finance
                 'SBTC': 'Super Bitcoin',
-                'STX': 'Stox',
                 'TNC': 'Trinity Network Credit',
                 'TON': 'TONToken',
                 'VAI': 'VAIOT',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/stacks#markets was listed 
and old STX renamed to STOX https://www.coingecko.com/en/coins/stox#markets