### PR TITLE
gateio BYN remapping

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -270,7 +270,7 @@ module.exports = class gateio extends Exchange {
                 'BOX': 'DefiBox',
                 'BTCBEAR': 'BEAR',
                 'BTCBULL': 'BULL',
-                'BYN': 'Beyond Finance',
+                'BYN': 'BeyondFi',
                 'EGG': 'Goose Finance',
                 'GTC': 'Game.com', // conflict with Gitcoin and Gastrocoin
                 'GTC_HT': 'Game.com HT',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/beyondfi#markets
Beyond Finance has rebranded to BeyondFi