### PR TITLE
Huobi fetchBorrowRates

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2776,7 +2776,7 @@ module.exports = class huobi extends Exchange {
 
     async fetchBorrowRates (params = {}) {
         await this.loadMarkets ();
-        const response = await this.privateGetMarginLoanInfo (params);
+        const response = await this.spotPrivateGetV1MarginLoanInfo (params);
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
         const rates = {};
@@ -2786,9 +2786,9 @@ module.exports = class huobi extends Exchange {
             for (let j = 0; j < currencies.length; j++) {
                 const currency = currencies[j];
                 const currencyId = this.safeString (currency, 'currency');
-                const upperCurrencyId = this.safeCurrencyCode (currencyId, 'currency');
-                rates[upperCurrencyId] = {
-                    'currency': upperCurrencyId,
+                const code = this.safeCurrencyCode (currencyId, 'currency');
+                rates[code] = {
+                    'currency': code,
                     'rate': this.safeNumber (currency, 'actual-rate'),
                     'span': 86400000,
                     'timestamp': timestamp,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2806,13 +2806,13 @@ module.exports = class huobi extends Exchange {
         // }
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
-        const rates = {};
+        const rates = {
+            'info': response,
+        };
         for (let i = 0; i < data.length; i++) {
             const rate = data[i];
             const currencies = this.safeValue (rate, 'currencies');
-            const symbolRates = {
-                'info': rate,
-            };
+            const symbolRates = {};
             for (let j = 0; j < currencies.length; j++) {
                 const currency = currencies[j];
                 const currencyId = this.safeString (currency, 'currency');

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2777,6 +2777,33 @@ module.exports = class huobi extends Exchange {
     async fetchBorrowRates (params = {}) {
         await this.loadMarkets ();
         const response = await this.spotPrivateGetV1MarginLoanInfo (params);
+        // {
+        //     "status": "ok",
+        //     "data": [
+        //         {
+        //             "symbol": "1inchusdt",
+        //             "currencies": [
+        //                 {
+        //                     "currency": "1inch",
+        //                     "interest-rate": "0.00098",
+        //                     "min-loan-amt": "90.000000000000000000",
+        //                     "max-loan-amt": "1000.000000000000000000",
+        //                     "loanable-amt": "0.0",
+        //                     "actual-rate": "0.00098"
+        //                 },
+        //                 {
+        //                     "currency": "usdt",
+        //                     "interest-rate": "0.00098",
+        //                     "min-loan-amt": "100.000000000000000000",
+        //                     "max-loan-amt": "1000.000000000000000000",
+        //                     "loanable-amt": "0.0",
+        //                     "actual-rate": "0.00098"
+        //                 }
+        //             ]
+        //         },
+        //         ...
+        //     ]
+        // }
         const timestamp = this.milliseconds ();
         const data = this.safeValue (response, 'data');
         const rates = {};


### PR DESCRIPTION
So huobi's api response is kind of weird, it returns something like

```
"data": [
    {
      "symbol": "1inchusdt",
      "currencies": [
        {
          "currency": "1inch",
          "interest-rate": "0.00098",
          "min-loan-amt": "90.000000000000000000",
          "max-loan-amt": "1000.000000000000000000",
          "loanable-amt": "0.0",
          "actual-rate": "0.00098"
        },
        {
          "currency": "usdt",
          "interest-rate": "0.00098",
          "min-loan-amt": "100.000000000000000000",
          "max-loan-amt": "1000.000000000000000000",
          "loanable-amt": "0.0",
          "actual-rate": "0.00098"
        }
      ]
    },
    {
      "symbol": "aaveusdt",
      "currencies": [
        {
          "currency": "aave",
          "interest-rate": "0.00098",
          "min-loan-amt": "1.500000000000000000",
          "max-loan-amt": "30.000000000000000000",
          "loanable-amt": "0.0",
          "actual-rate": "0.00098"
        },
        {
          "currency": "usdt",
          "interest-rate": "0.00098",
          "min-loan-amt": "100.000000000000000000",
          "max-loan-amt": "8000.000000000000000000",
          "loanable-amt": "0.0",
          "actual-rate": "0.00098"
        }
      ]
    },
 ```
 
 so I just assign a dictionary value to a response, and if it shows up again it's overwritten
 On my account the interest rate values are the same for every pair, and they're also the same for every coin, always 0.00098
 Before I write `fetchBorrowRate` I watch to know if this method is good
 
 --------------------------
 
# Response

```
   ...
            ZIL: {  currency: "ZIL",
                  rate:  0.00098,
                  span:  86400000,
             timestamp:  1637650709614,
              datetime: "2021-11-23T06:58:29.614Z" },
      ZRX: {  currency: "ZRX",
                  rate:  0.00098,
                  span:  86400000,
             timestamp:  1637650709614,
              datetime: "2021-11-23T06:58:29.614Z" }  }
```