### PR TITLE
Gate.io: Fix wrong naming order (date <-> settle)

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -638,7 +638,7 @@ module.exports = class gateio extends Exchange {
                     const quote = this.safeCurrencyCode (quoteId);
                     let symbol = '';
                     if (date !== undefined) {
-                        symbol = base + '/' + quote + '-' + date + ':' + this.safeCurrencyCode (settle);
+                        symbol = base + '/' + quote + ':' + this.safeCurrencyCode (settle) + '-' + date;
                     } else {
                         symbol = base + '/' + quote + ':' + this.safeCurrencyCode (settle);
                     }


### PR DESCRIPTION
The documentation states the following naming order, which I was able to observe in multiple exchange implementations.

```
//
// base asset or currency
// ↓
// ↓  quote asset or currency
// ↓  ↓
// ↓  ↓    settlement asset or currency
// ↓  ↓    ↓
// ↓  ↓    ↓     identifier (settlement date)
// ↓  ↓    ↓     ↓
// ↓  ↓    ↓     ↓
'BTC/USDT:BTC-211225'  // BTC/USDT futures contract settled in BTC (inverse) on 2021-12-25
'BTC/USDT:USDT-211225' // BTC/USDT futures contract settled in USDT (linear, vanilla) on 2021-12-25
'ETH/USDT:ETH-210625'  // ETH/USDT futures contract settled in ETH (inverse) on 2021-06-25
'ETH/USDT:USDT-210625' // ETH/USDT futures contract settled in USDT (linear, vanilla) on 2021-06-25
```

For Gate.io however, the date is set after the quote currency. I couldn't find any reason why doing so. If there is a reason forcing to first place the date, a comment explaining the reasoning might be helpful to other users in the future.