### PR TITLE
Kraken: Use cost from response instead of calculating it

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -1000,7 +1000,7 @@ module.exports = class kraken extends Exchange {
         }
         const price = this.parseNumber (priceString);
         const amount = this.parseNumber (amountString);
-        const cost = this.parseNumber (Precise.stringMul (priceString, amountString));
+        const cost = this.safeNumber (trade, 'cost') || this.parseNumber (Precise.stringMul (priceString, amountString));
         return {
             'id': id,
             'order': orderId,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -998,10 +998,8 @@ module.exports = class kraken extends Exchange {
         if (market !== undefined) {
             symbol = market['symbol'];
         }
-        const price = this.parseNumber (priceString);
-        const amount = this.parseNumber (amountString);
-        const cost = this.safeNumber (trade, 'cost') || this.parseNumber (Precise.stringMul (priceString, amountString));
-        return {
+        const cost = this.safeString (trade, 'cost');
+        return this.safeTrade ({
             'id': id,
             'order': orderId,
             'info': trade,
@@ -1015,7 +1013,7 @@ module.exports = class kraken extends Exchange {
             'amount': amount,
             'cost': cost,
             'fee': fee,
-        };
+        }, market);
     }
 
     async fetchTrades (symbol, since = undefined, limit = undefined, params = {}) {

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -5,7 +5,6 @@
 const Exchange = require ('./base/Exchange');
 const { BadSymbol, BadRequest, ExchangeNotAvailable, ArgumentsRequired, PermissionDenied, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress, RateLimitExceeded } = require ('./base/errors');
 const { TRUNCATE, DECIMAL_PLACES } = require ('./base/functions/number');
-const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------
 
@@ -950,8 +949,8 @@ module.exports = class kraken extends Exchange {
         let timestamp = undefined;
         let side = undefined;
         let type = undefined;
-        let priceString = undefined;
-        let amountString = undefined;
+        let price = undefined;
+        let amount = undefined;
         let id = undefined;
         let orderId = undefined;
         let fee = undefined;
@@ -960,8 +959,8 @@ module.exports = class kraken extends Exchange {
             timestamp = this.safeTimestamp (trade, 2);
             side = (trade[3] === 's') ? 'sell' : 'buy';
             type = (trade[4] === 'l') ? 'limit' : 'market';
-            priceString = this.safeString (trade, 0);
-            amountString = this.safeString (trade, 1);
+            price = this.safeString (trade, 0);
+            amount = this.safeString (trade, 1);
             const tradeLength = trade.length;
             if (tradeLength > 6) {
                 id = this.safeString (trade, 6); // artificially added as per #1794
@@ -982,15 +981,15 @@ module.exports = class kraken extends Exchange {
             timestamp = this.safeTimestamp (trade, 'time');
             side = this.safeString (trade, 'type');
             type = this.safeString (trade, 'ordertype');
-            priceString = this.safeString (trade, 'price');
-            amountString = this.safeString (trade, 'vol');
+            price = this.safeString (trade, 'price');
+            amount = this.safeString (trade, 'vol');
             if ('fee' in trade) {
                 let currency = undefined;
                 if (market !== undefined) {
                     currency = market['quote'];
                 }
                 fee = {
-                    'cost': this.safeNumber (trade, 'fee'),
+                    'cost': this.safeString (trade, 'fee'),
                     'currency': currency,
                 };
             }


### PR DESCRIPTION
The cost is off a bit from the real value user see on the exchange frontend, because of the calculation of price x vol.

![image](https://user-images.githubusercontent.com/3694800/143284439-54cf59c1-4f91-4eab-84e0-688579612478.png)

0.01166049*20 = 0.2332098 this is wrong.
**correct is 0.23320971**

This PR fixes this, but fallbacks to the calculation if there is no cost in the response. Maybe this value was not there when this got implemented? I am not sure.
Maybe @kroitor can answer this.
