### PR TITLE
added trigger check to gateio stop order

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2213,7 +2213,7 @@ module.exports = class gateio extends Exchange {
                 const rule = (side === 'sell') ? '>=' : '<=';
                 request = {
                     'trigger': {
-                        'price': this.priceToPrecision (symbol, stopPrice),
+                        'price': stopPrice ? this.priceToPrecision (symbol, stopPrice) : '',
                         'rule': rule, // >= triggered when market price larger than or equal to price field, <= triggered when market price less than or equal to price field
                         'expiration': expiration, // required, how long (in seconds) to wait for the condition to be triggered before cancelling the order
                     },

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2211,9 +2211,10 @@ module.exports = class gateio extends Exchange {
                 const defaultExpiration = this.safeInteger (options, 'expiration');
                 const expiration = this.safeInteger (params, 'expiration', defaultExpiration);
                 const rule = (side === 'sell') ? '>=' : '<=';
+                const triggerPrice = this.safeValue (trigger, 'price', stopPrice);
                 request = {
                     'trigger': {
-                        'price': stopPrice ? this.priceToPrecision (symbol, stopPrice) : '',
+                        'price': this.priceToPrecision (symbol, triggerPrice),
                         'rule': rule, // >= triggered when market price larger than or equal to price field, <= triggered when market price less than or equal to price field
                         'expiration': expiration, // required, how long (in seconds) to wait for the condition to be triggered before cancelling the order
                     },

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2108,7 +2108,8 @@ module.exports = class gateio extends Exchange {
             throw new InvalidOrder (this.id + ' createOrder() does not support ' + type + ' orders for ' + market['type'] + ' markets');
         }
         let request = undefined;
-        if (stopPrice === undefined) {
+        const trigger = this.safeValue (params, 'trigger');
+        if (stopPrice === undefined && trigger === undefined) {
             if (contract) {
                 // contract order
                 request = {


### PR DESCRIPTION
This is needed so orders with the format in #9968 work properly. 

This doesn't currently work though, when I try an order like

```
const exchange_name = "gateio";
const exchange = new ccxt[exchange_name](config[exchange_name]);

exchange
  .createLimitSellOrder("ALGO/USDT", "limit", "sell", 2, 4, {
    trigger: {
      price: "100",
      rule: ">=",
      expiration: 3600,
    },
    put: {
      type: "limit",
      side: "sell",
      price: "2.15",
      amount: "2.00000000",
      account: "normal",
      time_in_force: "gtc",
    },
    market: "ALGO_USDT",
  })
  .then((res) => console.log(res))
  .catch((err) => console.log(err));
```

trigger is always undefined, and params is always an empty object

when I comment this line `        params = this.omit (params, [ 'stopPrice', 'reduce_only', 'reduceOnly', 'tif', 'time_in_force', 'timeInForce' ]);`

Then params is equal to `2`