### PR TITLE
New binance symbols for futures and delivery

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1446,6 +1446,7 @@ module.exports = class Exchange {
                     const quoteId = this.safeString (parts, 1);
                     const base = this.safeCurrencyCode (baseId)
                     const quote = this.safeCurrencyCode (quoteId)
+                    // TODO: What is this? Will this conflict with gateio, okex, and kucoin symbols?
                     const symbol = base + '/' + quote
                     return {
                         'id': marketId,

--- a/js/binance.js
+++ b/js/binance.js
@@ -1171,17 +1171,12 @@ module.exports = class binance extends Exchange {
         });
     }
 
-    costToPrecision (symbol, cost) {
-        return this.decimalToPrecision (cost, TRUNCATE, this.market (symbol)['precision']['quote'], this.precisionMode, this.paddingMode);
+    amountToPrecision (symbol, amount) {
+        return super.amountToPrecision (this.getCorrectSymbol (symbol), amount);
     }
 
-    currencyToPrecision (currency, fee) {
-        // info is available in currencies only if the user has configured his api keys
-        if (this.safeValue (this.currencies[currency], 'precision') !== undefined) {
-            return this.decimalToPrecision (fee, TRUNCATE, this.currencies[currency]['precision'], this.precisionMode, this.paddingMode);
-        } else {
-            return this.numberToString (fee);
-        }
+    costToPrecision (symbol, cost) {
+        return super.costToPrecision (this.getCorrectSymbol (symbol), cost);
     }
 
     nonce () {
@@ -1510,7 +1505,7 @@ module.exports = class binance extends Exchange {
         }
         const markets = this.safeValue (response, 'symbols', []);
         const result = [];
-        this.markets_by_deprecated_symbols = {};
+        this.oldSymbolMappings = {};
         for (let i = 0; i < markets.length; i++) {
             const market = markets[i];
             const spot = (type === 'spot');
@@ -1530,21 +1525,17 @@ module.exports = class binance extends Exchange {
             const idSymbol = contract && (contractType !== 'PERPETUAL');
             let symbol = undefined;
             let expiry = undefined;
-            let deprecatedSymbol = undefined;
             if (idSymbol) {
                 expiry = this.safeString (market, 'deliveryDate');
                 symbol = base + '/' + quote + ':' + settle + '-' + expiry;
-                deprecatedSymbol = id;
                 this.oldSymbolMappings[id] = symbol;
                 expiry = parseInt (expiry);
             } else if (contract) { // Already known that it's not delivery
                 symbol = base + '/' + quote + ':' + settle;
-                deprecatedSymbol = base + '/' + quote;
                 this.oldSymbolMappings[base + '/' + quote] = symbol;
             } else {
                 symbol = base + '/' + quote;
-                deprecatedSymbol = base + '/' + quote;
-                this.oldSymbolMappings[deprecatedSymbol] = symbol;
+                this.oldSymbolMappings[base + '/' + quote] = symbol;
             }
             const filters = this.safeValue (market, 'filters', []);
             const filtersByType = this.indexBy (filters, 'filterType');
@@ -1644,7 +1635,6 @@ module.exports = class binance extends Exchange {
                 entry['limits']['cost']['min'] = this.safeNumber2 (filter, 'minNotional', 'notional');
             }
             result.push (entry);
-            this.markets_by_deprecated_symbols[deprecatedSymbol] = entry;
         }
         return result;
     }
@@ -1712,22 +1702,6 @@ module.exports = class binance extends Exchange {
         return this.safeBalance (result);
     }
 
-    market (symbol) {
-        if (this.markets === undefined) {
-            throw new ExchangeError (this.id + ' markets not loaded')
-        }
-        if (typeof symbol === 'string') {
-            if (symbol in this.markets) {
-                return this.markets[symbol];
-            } else if (symbol in this.markets_by_id) {
-                return this.markets_by_id[symbol];
-            } else if (symbol in this.markets_by_id) {
-                return this.markets_by_deprecated_symbols[symbol];
-            }
-        }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
-    }
-
     getCorrectSymbol (symbol) {
         if (this.markets === undefined) {
             throw new ExchangeError (this.id + ' markets not loaded');
@@ -1755,8 +1729,17 @@ module.exports = class binance extends Exchange {
         return newSymbols;
     }
 
+    market (symbol) {
+        return super.market (this.getCorrectSymbol (symbol));
+    }
+
     async loadTradingLimits (symbols = undefined, reload = false, params = {}) {
         return super.loadTradingLimits (this.getCorrectSymbols (symbols), reload, params);
+    }
+
+    calculateFee (symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {
+        symbol = this.getCorrectSymbol (symbol);
+        return super.calculateFee (symbol, type, side, amount, price, takerOrMaker, params);
     }
 
     async fetchBalance (params = {}) {

--- a/js/binance.js
+++ b/js/binance.js
@@ -1520,16 +1520,14 @@ module.exports = class binance extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const settle = this.safeCurrencyCode (settleId);
-            const contract = future || delivery;
             const contractType = this.safeString (market, 'contractType');
             const idSymbol = contract && (contractType !== 'PERPETUAL');
             let symbol = undefined;
             let expiry = undefined;
             if (idSymbol) {
-                expiry = this.safeString (market, 'deliveryDate');
-                symbol = base + '/' + quote + ':' + settle + '-' + expiry;
+                expiry = this.safeInteger (market, 'deliveryDate');
+                symbol = base + '/' + quote + ':' + settle + '-' + this.yymmdd (expiry, '');
                 this.oldSymbolMappings[id] = symbol;
-                expiry = parseInt (expiry);
             } else if (contract) { // Already known that it's not delivery
                 symbol = base + '/' + quote + ':' + settle;
                 this.oldSymbolMappings[base + '/' + quote] = symbol;
@@ -1575,10 +1573,10 @@ module.exports = class binance extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'price': this.safeInteger (market, 'pricePrecision'),
-                    'amount': this.safeInteger (market, 'quantityPrecision'),
                     'base': this.safeInteger (market, 'baseAssetPrecision'),
                     'quote': this.safeInteger (market, 'quotePrecision'),
+                    'amount': this.safeInteger (market, 'quantityPrecision'),
+                    'price': this.safeInteger (market, 'pricePrecision'),
                 },
                 'limits': {
                     'leverage': {


### PR DESCRIPTION
This gives Binance symbols the new schema of `QUOTE/BASE:SETTLE` for perpetual swaps and `QUOTE/BASE:SETTLE-EXPIRY` for delivery futures while still accepting the old symbols. I haven't tested everything yet, but I can create orders with the old and new symbols.

```
% binanceusdm createOrder ETH/USDT market sell 0.1 
2021-11-27T06:59:57.212Z
Node.js: v14.17.0
CCXT v1.62.38
binanceusdm.createOrder (ETH/USDT, market, sell, 0.1)
{               info: {       orderId: "8389765511101523028",
                               symbol: "ETHUSDT",
                               status: "FILLED",
                        clientOrderId: "x-xcKtGhcub3e6484d35a046dba6c3e3",
                                price: "0",
                             avgPrice: "4096.20000",
                              origQty: "0.100",
                          executedQty: "0.100",
                               cumQty: "0.100",
                             cumQuote: "409.62000",
                          timeInForce: "GTC",
                                 type: "MARKET",
                           reduceOnly:  false,
                        closePosition:  false,
                                 side: "SELL",
                         positionSide: "BOTH",
                            stopPrice: "0",
                          workingType: "CONTRACT_PRICE",
                         priceProtect:  false,
                             origType: "MARKET",
                           updateTime: "1637996398143"                     },
                  id:   "8389765511101523028",
       clientOrderId:   "x-xcKtGhcub3e6484d35a046dba6c3e3",
           timestamp:    undefined,
            datetime:    undefined,
  lastTradeTimestamp:    undefined,
              symbol:   "ETH/USDT:USDT",
                type:   "market",
         timeInForce:   "GTC",
            postOnly:    false,
                side:   "sell",
               price:    4096.2,
           stopPrice:    undefined,
              amount:    0.1,
                cost:    409.62,
             average:    4096.2,
              filled:    0.1,
           remaining:    0,
              status:   "closed",
                 fee:    undefined,
              trades: [],
                fees: []                                                      }
228 ms
```
```
% binanceusdm createOrder ETH/USDT:USDT market sell 0.1 
2021-11-27T07:00:10.044Z
Node.js: v14.17.0
CCXT v1.62.38
binanceusdm.createOrder (ETH/USDT:USDT, market, sell, 0.1)
{               info: {       orderId: "8389765511101533544",
                               symbol: "ETHUSDT",
                               status: "FILLED",
                        clientOrderId: "x-xcKtGhcudbcaedc6e74c479785fe62",
                                price: "0",
                             avgPrice: "4099.65000",
                              origQty: "0.100",
                          executedQty: "0.100",
                               cumQty: "0.100",
                             cumQuote: "409.96500",
                          timeInForce: "GTC",
                                 type: "MARKET",
                           reduceOnly:  false,
                        closePosition:  false,
                                 side: "SELL",
                         positionSide: "BOTH",
                            stopPrice: "0",
                          workingType: "CONTRACT_PRICE",
                         priceProtect:  false,
                             origType: "MARKET",
                           updateTime: "1637996410789"                     },
                  id:   "8389765511101533544",
       clientOrderId:   "x-xcKtGhcudbcaedc6e74c479785fe62",
           timestamp:    undefined,
            datetime:    undefined,
  lastTradeTimestamp:    undefined,
              symbol:   "ETH/USDT:USDT",
                type:   "market",
         timeInForce:   "GTC",
            postOnly:    false,
                side:   "sell",
               price:    4099.65,
           stopPrice:    undefined,
              amount:    0.1,
                cost:    409.965,
             average:    4099.65,
              filled:    0.1,
           remaining:    0,
              status:   "closed",
                 fee:    undefined,
              trades: [],
                fees: []                                                      }
226 ms
```