### PR TITLE
fix: update fetchTickers for Gate.io to prevent python KeyError

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1432,7 +1432,7 @@ module.exports = class gateio extends Exchange {
         const request = {};
         const futures = type === 'futures';
         const swap = type === 'swap';
-        const settle = this.safeString (params, 'settle')
+        const settle = this.safeString (params, 'settle');
         if ((swap || futures) && !settle) {
             request['settle'] = swap ? 'usdt' : 'btc';
         }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1433,7 +1433,7 @@ module.exports = class gateio extends Exchange {
         const futures = type === 'futures';
         const swap = type === 'swap';
         const settle = this.safeString (params, 'settle');
-        if ((swap || futures) && !settle) {
+        if ((swap || futures) && (settle === undefined)) {
             request['settle'] = swap ? 'usdt' : 'btc';
         }
         const response = await this[method] (this.extend (request, params));

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1432,7 +1432,8 @@ module.exports = class gateio extends Exchange {
         const request = {};
         const futures = type === 'futures';
         const swap = type === 'swap';
-        if ((swap || futures) && !params['settle']) {
+        const settle = this.safeString (params, 'settle')
+        if ((swap || futures) && !settle) {
             request['settle'] = swap ? 'usdt' : 'btc';
         }
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
Without the proposed change, the JavaScript code ```fetchTickers``` for Gate.io results in the following python code:

```python
if (swap or futures) and not params['settle']:
    request['settle'] = 'usdt' if swap else 'btc'
```

This is problematic due to the possibility of a KeyError when ```params['settle']``` is not set. Below is my current workaround. However, I would prefer to not override the whole method for this small fix, so it would be great if my proposed change could be merged.

```python
# This line is problematic in base implementation due to: "and not params['settle']"
# leading to key errors, so we replace it with: "and 'settle' not in params"
if (swap or futures) and "settle" not in params:
```

