### PR TITLE
Fix timeOut  MAX INTEGER issue

### DIFF
--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -2,7 +2,7 @@
 
 /*  ------------------------------------------------------------------------ */
 
-const { now } = require ('./time')
+const { now, sleep } = require ('./time')
 
 /*  ------------------------------------------------------------------------ */
 
@@ -35,7 +35,7 @@ class Throttle {
                     this.running = false
                 }
             } else {
-                await new Promise (x => setTimeout (x, this.config['delay'] * 1000));
+                await sleep(this.config['delay'] * 1000);
                 const current = now ()
                 const elapsed = current - lastTimestamp
                 lastTimestamp = current

--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -35,7 +35,7 @@ class Throttle {
                     this.running = false
                 }
             } else {
-                await sleep(this.config['delay'] * 1000);
+                await sleep (this.config['delay'] * 1000);
                 const current = now ()
                 const elapsed = current - lastTimestamp
                 lastTimestamp = current

--- a/js/base/functions/time.js
+++ b/js/base/functions/time.js
@@ -23,12 +23,16 @@ const uuidv1 = () => {
 const setTimeout_original = setTimeout
 const setTimeout_safe = (done, ms, setTimeout = setTimeout_original /* overrideable for mocking purposes */, targetTime = now () + ms) => {
 
+    // avoid MAX_INT issue ( https://stackoverflow.com/questions/60474110/ )
+    //if ( ms >= 2147483647 )
+    //   ... return setTimeout_safe
+    
     // The built-in setTimeout function can fire its callback earlier than specified, so we
     // need to ensure that it does not happen: sleep recursively until `targetTime` is reached...
 
     let clearInnerTimeout = () => {}
     let active = true
-
+    
     const id = setTimeout (() => {
         active = true
         const rest = targetTime - now ()

--- a/js/base/functions/time.js
+++ b/js/base/functions/time.js
@@ -32,7 +32,7 @@ const setTimeout_safe = (done, ms, setTimeout = setTimeout_original /* overridea
 
     let clearInnerTimeout = () => {}
     let active = true
-    
+
     const id = setTimeout (() => {
         active = true
         const rest = targetTime - now ()

--- a/js/base/functions/time.js
+++ b/js/base/functions/time.js
@@ -24,8 +24,8 @@ const setTimeout_original = setTimeout
 const setTimeout_safe = (done, ms, setTimeout = setTimeout_original /* overrideable for mocking purposes */, targetTime = now () + ms) => {
 
     // avoid MAX_INT issue ( https://stackoverflow.com/questions/60474110/ )
-    //if ( ms >= 2147483647 )
-    //   ... return setTimeout_safe
+    if ( ms >= 2147483647 )
+        throw new Exception(`setTimeout function was called with unrealistic value of ${ms}`);
     
     // The built-in setTimeout function can fire its callback earlier than specified, so we
     // need to ensure that it does not happen: sleep recursively until `targetTime` is reached...

--- a/js/base/functions/time.js
+++ b/js/base/functions/time.js
@@ -23,9 +23,10 @@ const uuidv1 = () => {
 const setTimeout_original = setTimeout
 const setTimeout_safe = (done, ms, setTimeout = setTimeout_original /* overrideable for mocking purposes */, targetTime = now () + ms) => {
 
-    // avoid MAX_INT issue ( https://stackoverflow.com/questions/60474110/ )
-    if ( ms >= 2147483647 )
-        throw new Exception(`setTimeout function was called with unrealistic value of ${ms}`);
+    // avoid MAX_INT issue https://stackoverflow.com/questions/60474110
+    if (ms >= 2147483647) {
+        throw new Exception('setTimeout() function was called with unrealistic value of ' + ms.toString ())
+    }
     
     // The built-in setTimeout function can fire its callback earlier than specified, so we
     // need to ensure that it does not happen: sleep recursively until `targetTime` is reached...


### PR DESCRIPTION
Actually, this PR is incomplete due to my lack of time and in-deep knowledge of ccxt internals. However, as I've noted in https://github.com/ccxt/ccxt/issues/10761 ,  and many similar issues out there in internet (i.e. [this](https://stackoverflow.com/questions/60474110/) ) suggest that it needs fix.

the ccxt's core function `setTimeout_safe` needs fix to accommodate that workaround.  plus. all of "setTimeout" functions in ccxt.pro might also need to be replaced by 'setTimeout_safe`, so CCXT will have one base fixed `setTimeout` function.


Even though, such high number setTimeout calls shouldn't be happening in realworld (who needs to fire callback after 2147483647 MS ? )  this is still happening in the wild (due to some unknown issues) and should be addressed. Maybe instead of workaround,  you can just leave throwing an exception from setTimeout_safe if it is called with such unrealistic delay. 

Also, this might be also needed to all 'setInternal' functions mentioned across ccxt/ccxt-pro.