### PR TITLE
Added method get_type to exchange

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2077,10 +2077,13 @@ module.exports = class Exchange {
         return rate;
     }
 
-    getType (methodName, params = {}) {
+    getType (methodName, params = {}, market = undefined) {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
         const type = this.safeString (params, 'type', defaultType);
         this.omit (params, 'type');
+        if (market) {
+            return [market['type'], params];
+        }
         return [ type, params ];
     }
 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2077,13 +2077,11 @@ module.exports = class Exchange {
         return rate;
     }
 
-    getType (methodName, params = {}, market = undefined) {
+    handleDefaultTypeAndParams (methodName, params = {}, market = undefined) {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
+        const marketType = (market === undefined) ? defaultType : market['type'];
         const type = this.safeString (params, 'type', defaultType);
         this.omit (params, 'type');
-        if (market) {
-            return [market['type'], params];
-        }
         return [ type, params ];
     }
 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2079,6 +2079,8 @@ module.exports = class Exchange {
 
     getType (methodName, params = {}) {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
-        return this.safeString (params, 'type', defaultType);
+        const type = this.safeString (params, 'type', defaultType);
+        delete params['type'];
+        return type;
     }
 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2080,7 +2080,7 @@ module.exports = class Exchange {
     getType (methodName, params = {}) {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
         const type = this.safeString (params, 'type', defaultType);
-        delete params['type'];
-        return type;
+        this.omit (params, 'type');
+        return [ type, params ];
     }
 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2076,4 +2076,9 @@ module.exports = class Exchange {
         }
         return rate;
     }
+
+    getType (methodName, params = {}) {
+        const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
+        return this.safeString (params, 'type', defaultType);
+    }
 }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2080,7 +2080,7 @@ module.exports = class Exchange {
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
         const marketType = (market === undefined) ? defaultType : market['type'];
-        const type = this.safeString (params, 'type', defaultType);
+        const type = this.safeString (params, 'type', marketType);
         this.omit (params, 'type');
         return [ type, params ];
     }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2077,7 +2077,7 @@ module.exports = class Exchange {
         return rate;
     }
 
-    handleDefaultTypeAndParams (methodName, params = {}, market = undefined) {
+    handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
         const marketType = (market === undefined) ? defaultType : market['type'];
         const type = this.safeString (params, 'type', defaultType);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2081,7 +2081,7 @@ module.exports = class Exchange {
         const defaultType = this.safeString2 (this.options, methodName, 'defaultType', 'spot');
         const marketType = (market === undefined) ? defaultType : market['type'];
         const type = this.safeString (params, 'type', marketType);
-        this.omit (params, 'type');
+        params = this.omit (params, 'type');
         return [ type, params ];
     }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3512,10 +3512,13 @@ class Exchange {
         return $rate;
     }
 
-    public function get_type($method_name, $params = array()) {
+    public function get_type($method_name, $params = array(), $market=null) {
         $default_type = $this->safe_string_2($this->options, $method_name, 'defaultType', 'spot');
         $type = $this->safe_string($params, 'type', $default_type);
         $this->omit($params, $type);
+        if (isset($market)){
+            return array($market['type'], $params);
+        }
         return array($type, $params);
     }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3511,4 +3511,9 @@ class Exchange {
         }
         return $rate;
     }
+
+    public function get_type($method_name, $params = array()) {
+        $default_type = $this->safe_string_2($this->options, $method_name, 'defaultType', 'spot');
+        return $this->safe_string($params, 'type', $default_type);
+    }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3514,6 +3514,10 @@ class Exchange {
 
     public function get_type($method_name, $params = array()) {
         $default_type = $this->safe_string_2($this->options, $method_name, 'defaultType', 'spot');
-        return $this->safe_string($params, 'type', $default_type);
+        $type = $this->safe_string($params, 'type', $default_type);
+        if (in_array('type', $params)) {
+            unset($params['type']);
+        }
+        return $type;
     }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3515,9 +3515,7 @@ class Exchange {
     public function get_type($method_name, $params = array()) {
         $default_type = $this->safe_string_2($this->options, $method_name, 'defaultType', 'spot');
         $type = $this->safe_string($params, 'type', $default_type);
-        if (in_array('type', $params)) {
-            unset($params['type']);
-        }
-        return $type;
+        $this->omit($params, $type);
+        return array($type, $params);
     }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3512,13 +3512,11 @@ class Exchange {
         return $rate;
     }
 
-    public function get_type($method_name, $params = array(), $market=null) {
+    public function handle_market_type_and_params($method_name, $market=null, $params = array()) {
         $default_type = $this->safe_string_2($this->options, $method_name, 'defaultType', 'spot');
-        $type = $this->safe_string($params, 'type', $default_type);
+        $market_type = isset($market) ? market['type'] : $default_type;
+        $type = $this->safe_string($params, 'type', $market_type);
         $this->omit($params, $type);
-        if (isset($market)){
-            return array($market['type'], $params);
-        }
         return array($type, $params);
     }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3516,7 +3516,7 @@ class Exchange {
         $default_type = $this->safe_string_2($this->options, $method_name, 'defaultType', 'spot');
         $market_type = isset($market) ? market['type'] : $default_type;
         $type = $this->safe_string($params, 'type', $market_type);
-        $this->omit($params, $type);
+        $params = $this->omit($params, $type);
         return array($type, $params);
     }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2652,5 +2652,5 @@ class Exchange(object):
         default_type = self.safe_string_2(self.options, method_name, 'defaultType', 'spot')
         market_type = default_type if market is None else market['type']
         type = self.safe_string(params, 'type', market_type)
-        self.omit(params, 'type')
+        params = self.omit(params, 'type')
         return [type, params]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2650,4 +2650,7 @@ class Exchange(object):
 
     def get_type(self, method_name, params={}):
         default_type = self.safe_string_2(self.options, method_name, 'defaultType', 'spot')
-        return self.safe_string(params, 'type', default_type)
+        type = self.safe_string(params, 'type', default_type)
+        if 'type' in params:
+            del params['type']
+        return type

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2651,6 +2651,5 @@ class Exchange(object):
     def get_type(self, method_name, params={}):
         default_type = self.safe_string_2(self.options, method_name, 'defaultType', 'spot')
         type = self.safe_string(params, 'type', default_type)
-        if 'type' in params:
-            del params['type']
-        return type
+        self.omit(params, 'type')
+        return [type, params]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2648,10 +2648,9 @@ class Exchange(object):
             raise ExchangeError(self.id + 'fetchBorrowRate() could not find the borrow rate for currency code ' + code)
         return rate
 
-    def get_type(self, method_name, params={}, market=None):
+    def handle_market_type_and_params(self, method_name, market=None, params={}):
         default_type = self.safe_string_2(self.options, method_name, 'defaultType', 'spot')
-        type = self.safe_string(params, 'type', default_type)
+        market_type = default_type if market is None else market['type']
+        type = self.safe_string(params, 'type', market_type)
         self.omit(params, 'type')
-        if market:
-            return [market['type'], params]
         return [type, params]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2647,3 +2647,7 @@ class Exchange(object):
         if rate is None:
             raise ExchangeError(self.id + 'fetchBorrowRate() could not find the borrow rate for currency code ' + code)
         return rate
+
+    def get_type(self, method_name, params={}):
+        default_type = self.safe_string_2(self.options, method_name, 'defaultType', 'spot')
+        return self.safe_string(params, 'type', default_type)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2648,8 +2648,10 @@ class Exchange(object):
             raise ExchangeError(self.id + 'fetchBorrowRate() could not find the borrow rate for currency code ' + code)
         return rate
 
-    def get_type(self, method_name, params={}):
+    def get_type(self, method_name, params={}, market=None):
         default_type = self.safe_string_2(self.options, method_name, 'defaultType', 'spot')
         type = self.safe_string(params, 'type', default_type)
         self.omit(params, 'type')
+        if market:
+            return [market['type'], params]
         return [type, params]


### PR DESCRIPTION
Makes it so that code blocks which look like

```
const defaultType = this.safeString2 (this.options, 'fetchBalance', 'defaultType', 'spot');
const type = this.safeString (params, 'type', defaultType);
params = this.omit (params, 'type');
```

can now be written like

```
const type = this.getType ('fetchBalance', params);
params = this.omit (params, 'type');
```