### PR TITLE
Huobi fetch funding rate

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -736,7 +736,7 @@ module.exports = class huobi extends Exchange {
             },
             'precisionMode': TICK_SIZE,
             'options': {
-                'defaultType': 'swap', // spot, future, swap
+                'defaultType': 'spot', // spot, future, swap
                 'defaultSubType': 'inverse', // inverse, linear
                 'defaultNetwork': 'ERC20',
                 'networks': {
@@ -3022,21 +3022,20 @@ module.exports = class huobi extends Exchange {
     async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         //
         // Gets a history of funding rates with their timestamps
-        //  (param) symbol: Future currency pair (e.g. "BTC-PERP")
-        //  (param) limit: Not used by ftx
-        //  (param) since: Unix timestamp in miliseconds for the time of the earliest requested funding rate
+        //  (param) symbol: Future currency pair
+        //  (param) limit: not used by huobi
+        //  (param) since: not used by huobi
         //  (param) params: Object containing more params for the request
-        //             - until: Unix timestamp in miliseconds for the time of the earliest requested funding rate
-        //  return: [{symbol, fundingRate, timestamp}]
+        //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
         await this.loadMarkets ();
         const request = {};
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol parameter');
         } else {
-            // const market = this.market (symbol);
-            // request['contract_code'] = market['id'];
-            request['contract_code'] = symbol;
+            const market = this.market (symbol);
+            request['contract_code'] = market['id'];
+            // request['contract_code'] = symbol;
         }
         const response = await this.contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate (this.extend (request, params));
         //

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3031,7 +3031,7 @@ module.exports = class huobi extends Exchange {
         await this.loadMarkets ();
         const request = {};
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol parameter');
+            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
         } else {
             const market = this.market (symbol);
             request['contract_code'] = market['id'];

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3031,13 +3031,17 @@ module.exports = class huobi extends Exchange {
         //
         await this.loadMarkets ();
         const request = {};
+        const market = this.market (symbol);
+        let method = 'contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate';
+        if (market['inverse']) {
+            method = 'contractPublicGetSwapApiV1SwapHistoricalFundingRate';
+        }
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
         } else {
-            const market = this.market (symbol);
             request['contract_code'] = market['id'];
         }
-        const response = await this.contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate (this.extend (request, params));
+        const response = await this[method] (this.extend (request, params));
         //
         // {
         //     "status": "ok",

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -36,6 +36,7 @@ module.exports = class huobi extends Exchange {
                 'fetchDepositAddress': true,
                 'fetchDepositAddressesByNetwork': true,
                 'fetchDeposits': true,
+                'fetchFundingRateHistory': true,
                 'fetchIndexOHLCV': true,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': true,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3029,17 +3029,17 @@ module.exports = class huobi extends Exchange {
         //  (param) params: Object containing more params for the request
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
+        }
         await this.loadMarkets ();
-        const request = {};
         const market = this.market (symbol);
+        const request = {
+            'contract_code': market['id'],
+        };
         let method = 'contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate';
         if (market['inverse']) {
             method = 'contractPublicGetSwapApiV1SwapHistoricalFundingRate';
-        }
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
-        } else {
-            request['contract_code'] = market['id'];
         }
         const response = await this[method] (this.extend (request, params));
         //

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3040,28 +3040,39 @@ module.exports = class huobi extends Exchange {
         }
         const response = await this.contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate (this.extend (request, params));
         //
-        //     {
-        //        "success": true,
-        //        "result": [
-        //          {
-        //            "future": "BTC-PERP",
-        //            "rate": 0.0025,
-        //            "time": "2019-06-02T08:00:00+00:00"
-        //          }
-        //        ]
-        //      }
+        // {
+        //     "status": "ok",
+        //     "data": {
+        //         "total_page": 62,
+        //         "current_page": 1,
+        //         "total_size": 1237,
+        //         "data": [
+        //             {
+        //                 "avg_premium_index": "-0.000208064395065541",
+        //                 "funding_rate": "0.000100000000000000",
+        //                 "realized_rate": "0.000100000000000000",
+        //                 "funding_time": "1638921600000",
+        //                 "contract_code": "BTC-USDT",
+        //                 "symbol": "BTC",
+        //                 "fee_asset": "USDT"
+        //             },
+        //         ]
+        //     },
+        //     "ts": 1638939294277
+        // }
         //
-        const result = this.safeValue (response, 'result');
+        const data = this.safeValue (response, 'data');
+        const result = this.safeValue (data, 'data');
         const rates = [];
         for (let i = 0; i < result.length; i++) {
             const entry = result[i];
-            const marketId = this.safeString (entry, 'future');
+            const marketId = this.safeString (entry, 'contract_code');
             const symbol = this.safeSymbol (marketId);
-            const timestamp = this.parse8601 (this.safeString (result[i], 'time'));
+            const timestamp = this.safeString (entry, 'funding_time');
             rates.push ({
                 'info': entry,
                 'symbol': symbol,
-                'fundingRate': this.safeNumber (entry, 'rate'),
+                'fundingRate': this.safeNumber (entry, 'funding_rate'),
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
             });

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3035,7 +3035,6 @@ module.exports = class huobi extends Exchange {
         } else {
             const market = this.market (symbol);
             request['contract_code'] = market['id'];
-            // request['contract_code'] = symbol;
         }
         const response = await this.contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate (this.extend (request, params));
         //

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3030,13 +3030,16 @@ module.exports = class huobi extends Exchange {
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
         await this.loadMarkets ();
+        const request = {};
         const market = this.market (symbol);
-        const request = {
-            'contract_code': market['id'],
-        };
         let method = 'contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate';
         if (market['inverse']) {
             method = 'contractPublicGetSwapApiV1SwapHistoricalFundingRate';
+        }
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
+        } else {
+            request['contract_code'] = market['id'];
         }
         const response = await this[method] (this.extend (request, params));
         //

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3034,8 +3034,9 @@ module.exports = class huobi extends Exchange {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol parameter');
         } else {
-            const market = this.market (symbol);
-            request['contract_code'] = market['id'];
+            // const market = this.market (symbol);
+            // request['contract_code'] = market['id'];
+            request['contract_code'] = symbol;
         }
         const response = await this.contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate (this.extend (request, params));
         //

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ArgumentsRequired, AuthenticationError, ExchangeError, PermissionDenied, ExchangeNotAvailable, OnMaintenance, InvalidOrder, OrderNotFound, InsufficientFunds, BadSymbol, BadRequest, RequestTimeout, NetworkError, InvalidAddress } = require ('./base/errors');
+const { ArgumentsRequired, AuthenticationError, ExchangeError, PermissionDenied, ExchangeNotAvailable, OnMaintenance, InvalidOrder, OrderNotFound, InsufficientFunds, BadSymbol, BadRequest, RequestTimeout, NetworkError, InvalidAddress, NotSupported } = require ('./base/errors');
 const { TICK_SIZE, TRUNCATE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -3037,9 +3037,13 @@ module.exports = class huobi extends Exchange {
         const request = {
             'contract_code': market['id'],
         };
-        let method = 'contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate';
+        let method = undefined;
         if (market['inverse']) {
             method = 'contractPublicGetSwapApiV1SwapHistoricalFundingRate';
+        } else if (market['linear']) {
+            method = 'contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate';
+        } else {
+            throw new NotSupported (this.id + ' fetchFundingRateHistory() supports inverse and linear swaps only');
         }
         const response = await this[method] (this.extend (request, params));
         //

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3030,16 +3030,13 @@ module.exports = class huobi extends Exchange {
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
         await this.loadMarkets ();
-        const request = {};
         const market = this.market (symbol);
+        const request = {
+            'contract_code': market['id'],
+        };
         let method = 'contractPublicGetLinearSwapApiV1SwapHistoricalFundingRate';
         if (market['inverse']) {
             method = 'contractPublicGetSwapApiV1SwapHistoricalFundingRate';
-        }
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
-        } else {
-            request['contract_code'] = market['id'];
         }
         const response = await this[method] (this.extend (request, params));
         //


### PR DESCRIPTION
Added the method fetch funding rate history to huobi.js
```$ node examples/js/cli huobi fetchFundingRateHistory BTC-USDT
2021-12-08T05:10:59.208Z
Node.js: v16.9.1
CCXT v1.63.17
huobi.fetchFundingRateHistory (BTC-USDT)
2313 ms
  symbol |          fundingRate |     timestamp |                 datetime
--------------------------------------------------------------------------
BTC-USDT | 0.000239718617550076 | 1638374400000 | 2021-12-01T16:00:00.000Z
BTC-USDT |               0.0001 | 1638403200000 | 2021-12-02T00:00:00.000Z
BTC-USDT |  0.00022272728808391 | 1638432000000 | 2021-12-02T08:00:00.000Z
BTC-USDT |               0.0001 | 1638460800000 | 2021-12-02T16:00:00.000Z
BTC-USDT |               0.0001 | 1638489600000 | 2021-12-03T00:00:00.000Z
BTC-USDT |               0.0001 | 1638518400000 | 2021-12-03T08:00:00.000Z
BTC-USDT |               0.0001 | 1638547200000 | 2021-12-03T16:00:00.000Z
BTC-USDT | 0.000144546667406611 | 1638576000000 | 2021-12-04T00:00:00.000Z
BTC-USDT |               0.0001 | 1638604800000 | 2021-12-04T08:00:00.000Z
BTC-USDT |               0.0001 | 1638633600000 | 2021-12-04T16:00:00.000Z
BTC-USDT |               0.0001 | 1638662400000 | 2021-12-05T00:00:00.000Z
BTC-USDT | 0.000070406200835852 | 1638691200000 | 2021-12-05T08:00:00.000Z
BTC-USDT |               0.0001 | 1638720000000 | 2021-12-05T16:00:00.000Z
BTC-USDT |               0.0001 | 1638748800000 | 2021-12-06T00:00:00.000Z
BTC-USDT |               0.0001 | 1638777600000 | 2021-12-06T08:00:00.000Z
BTC-USDT |               0.0001 | 1638806400000 | 2021-12-06T16:00:00.000Z
BTC-USDT |               0.0001 | 1638835200000 | 2021-12-07T00:00:00.000Z
BTC-USDT |               0.0001 | 1638864000000 | 2021-12-07T08:00:00.000Z
BTC-USDT |               0.0001 | 1638892800000 | 2021-12-07T16:00:00.000Z
BTC-USDT |               0.0001 | 1638921600000 | 2021-12-08T00:00:00.000Z
20 objects
```