### PR TITLE
Easier subaccount management for FTX, just by using a parameter in methods |  fix #8215 | fix #10794 | fix #9805 | fix #10794

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2101,6 +2101,10 @@ module.exports = class ftx extends Exchange {
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let request = '/api/' + this.implodeParams (path, params);
+        const chosenSubaccount = this.safeString (params, 'FTX-SUBACCOUNT', undefined);
+        if (chosenSubaccount !== undefined) {
+            params = this.omit (params, 'FTX-SUBACCOUNT');
+        }
         const query = this.omit (params, this.extractParams (path));
         const baseUrl = this.implodeHostname (this.urls['api'][api]);
         let url = baseUrl + request;
@@ -2130,6 +2134,9 @@ module.exports = class ftx extends Exchange {
             headers[keyField] = this.apiKey;
             headers[tsField] = timestamp;
             headers[signField] = signature;
+            if (chosenSubaccount !== undefined) {
+                headers['FTX-SUBACCOUNT'] = chosenSubaccount;
+            }
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -987,31 +987,34 @@ module.exports = class liquid extends Exchange {
         const currency = this.currency (code);
         const request = {
             // 'auth_code': '', // optional 2fa code
-            'currency': currency['id'],
-            'address': address,
-            'amount': amount,
-            // 'payment_id': tag, // for XRP only
-            // 'memo_type': 'text', // 'text', 'id' or 'hash', for XLM only
-            // 'memo_value': tag, // for XLM only
+            'crypto_withdrawal': {
+                'currency': currency['id'],
+                'address': address,
+                'amount': amount,
+                // 'payment_id': tag, // for XRP only
+                // 'memo_type': 'text', // 'text', 'id' or 'hash', for XLM only
+                // 'memo_value': tag, // for XLM only
+            },
         };
         if (tag !== undefined) {
             if (code === 'XRP') {
-                request['payment_id'] = tag;
+                request['crypto_withdrawal']['payment_id'] = tag;
             } else if (code === 'XLM') {
-                request['memo_type'] = 'text'; // overrideable via params
-                request['memo_value'] = tag;
+                request['crypto_withdrawal']['memo_type'] = 'text'; // overrideable via params
+                request['crypto_withdrawal']['memo_value'] = tag;
             } else {
                 throw new NotSupported (this.id + ' withdraw() only supports a tag along the address for XRP or XLM');
             }
         }
         const networks = this.safeValue (this.options, 'networks', {});
-        let network = this.safeStringUpper (params, 'network'); // this line allows the user to specify either ERC20 or ETH
+        const paramsCwArray = this.safeValue (params, 'crypto_withdrawal', {});
+        let network = this.safeStringUpper (paramsCwArray, 'network'); // this line allows the user to specify either ERC20 or ETH
         network = this.safeString (networks, network, network); // handle ERC20>ETH alias
         if (network !== undefined) {
-            request['network'] = network;
-            params = this.omit (params, 'network');
+            request['crypto_withdrawal']['network'] = network;
+            params['crypto_withdrawal'] = this.omit (params['crypto_withdrawal'], 'network');
         }
-        const response = await this.privatePostCryptoWithdrawals (this.extend (request, params));
+        const response = await this.privatePostCryptoWithdrawals (this.deepExtend (request, params));
         //
         //     {
         //         "id": 1353,


### PR DESCRIPTION
I think CCXT should follow the route of being easy to do typical exchange actions. Subaccounts on FTX are quite popular, and that is just another internal functionality. However, at this moment, using subaccounts for FTX is (in my opinion) a bit complicated. User needs to set a non-regular syntax `headers: { 'FTX-SUBACCOUNT': 'testname' }` and user shouldn't be forced to "set headers manually in a very custom way" (like user doesn't need to set headers or whatever while needs to make actions on spot or margin, and the 'method parameters' do the whole thing.

Like that way,  (even thought the FTX API itself works that way) user shouldnt be needed to care at all about "what headers to set to trade on FTX", instead a single parameter (like in other exchange methods 'spot/margin' params do the job) should facilitate trading on FTX from multiple sub-accounts. This will have further benefit, users won't be needed to "initialize" several FTX exchange objects (saving much of resources and userland code handling) and from a single exchange object, users will do everything they want. 

This suggested implementation relies on a property named 'FTX-SUBACCOUNT' passed in 'params' object, like:

```
  const ex = new ccxt.ftx  ({ 
      'apiKey': '......', 
      'secret': '...'
  })
  await ex.loadMarkets();
  console.log(await ex.fetchBalance({'FTX-SUBACCOUNT':'mySubAccountName'}));
  console.log(await ex.fetchBalance());
// 
  console.log(await ex.createorder(.....));
  console.log(await ex.createorder(....., ...,  params: {'FTX-SUBACCOUNT':'mySubAccountName'}));

```


| fix #8215 | fix #10794 | fix #9805 | fix #10794 |