### PR TITLE
Easier subaccount management for FTX, just by using a parameter in methods | fix #8215 | fix #10794 | fix #9805 | fix #10794 | fix #8383 | fix #6985

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2104,9 +2104,9 @@ module.exports = class ftx extends Exchange {
         const signOptions = this.safeValue (this.options, 'sign', {});
         const headerPrefix = this.safeString (signOptions, this.hostname, 'FTX');
         const subaccountField = headerPrefix + '-SUBACCOUNT';
-        const chosenSubaccount = this.safeString (params, subaccountField);
+        const chosenSubaccount = this.safeString2 (params, subaccountField, 'subaccount');
         if (chosenSubaccount !== undefined) {
-            params = this.omit (params, subaccountField);
+            params = this.omit (params, [ subaccountField, 'subaccount' ]);
         }
         const query = this.omit (params, this.extractParams (path));
         const baseUrl = this.implodeHostname (this.urls['api'][api]);

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2104,7 +2104,7 @@ module.exports = class ftx extends Exchange {
         const signOptions = this.safeValue (this.options, 'sign', {});
         const headerPrefix = this.safeString (signOptions, this.hostname, 'FTX');
         const subaccountField = headerPrefix + '-SUBACCOUNT';
-        const chosenSubaccount = this.safeString (params, subaccountField, undefined);
+        const chosenSubaccount = this.safeString (params, subaccountField);
         if (chosenSubaccount !== undefined) {
             params = this.omit (params, subaccountField);
         }


### PR DESCRIPTION
Re-citing from previous PR:

I think CCXT should follow the route of being easy to do typical exchange actions. Subaccounts on FTX are quite popular, and that is just another internal functionality. However, at this moment, using subaccounts for FTX is (in my opinion) a bit complicated. User needs to set a non-regular syntax `headers: { 'FTX-SUBACCOUNT': 'testname' }` and user shouldn't be forced to "set headers manually in a very custom way" (like user doesn't need to set headers or whatever while needs to make actions on spot or margin, and the 'method parameters' do the whole thing.

Like that way,  (even thought the FTX API itself works that way) user shouldnt be needed to care at all about "what headers to set to trade on FTX", instead a single parameter (like in other exchange methods 'spot/margin' params do the job) should facilitate trading on FTX from multiple sub-accounts. This will have further benefit, users won't be needed to "initialize" several FTX exchange objects (saving much of resources and userland code handling) and from a single exchange object, users will do everything they want. 

This suggested implementation relies on a property named 'FTX-SUBACCOUNT' passed in 'params' object, like:

```
  const ex = new ccxt.ftx  ({ 
      'apiKey': '......', 
      'secret': '...'
  })
  await ex.loadMarkets();
  console.log(await ex.fetchBalance({'FTX-SUBACCOUNT':'mySubAccountName'}));
  console.log(await ex.fetchBalance());
// 
  console.log(await ex.createorder(.....));
  console.log(await ex.createorder(....., ...,  params: {'FTX-SUBACCOUNT':'mySubAccountName'}));

```


| fix #8215 | fix #10794 | fix #9805 | fix #10794 |  fix #8383 | fix #6985 |