### PR TITLE
Huobi funding rate

### DIFF
--- a/examples/js/binance-universal-transfer.js
+++ b/examples/js/binance-universal-transfer.js
@@ -14,8 +14,8 @@ const ccxt = require ('../../ccxt.js')
     console.log (await binance.transfer ('USDT', 1, 'spot', 'margin'))
 
     // binance requires from and to in the params
-    console.log (await binance.fetchTransfers (undefined, undefined, { from: 'spot', to: 'margin' }))
+    console.log (await binance.fetchTransfers (undefined, undefined, undefined, { from: 'spot', to: 'margin' }))
 
     // alternatively the same effect as above
-    console.log (await binance.fetchTransfers (undefined, undefined, { type: 'MAIN_MARGIN' })) // defaults to MAIN_UMFUTURE
+    console.log (await binance.fetchTransfers (undefined, undefined, undefined, { type: 'MAIN_MARGIN' })) // defaults to MAIN_UMFUTURE
 }) ()

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3132,9 +3132,13 @@ module.exports = class huobi extends Exchange {
     async fetchFundingRate (symbol, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        let method = 'contractPublicGetLinearSwapApiV1SwapFundingRate';
+        let method = undefined;
         if (market['inverse']) {
             method = 'contractPublicGetSwapApiV1SwapFundingRate';
+        } else if (market['linear']) {
+            method = 'contractPublicGetLinearSwapApiV1SwapFundingRate';
+        } else {
+            throw new NotSupported (this.id + ' fetchFundingRateHistory() supports inverse and linear swaps only');
         }
         const request = {
             'contract_code': market['id'],

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -56,7 +56,6 @@ module.exports = class huobi extends Exchange {
                 'fetchTradingFee': true,
                 'fetchTradingLimits': true,
                 'fetchWithdrawals': true,
-                'parseFundingRate': true,
                 'transfer': true,
                 'withdraw': true,
             },
@@ -3107,20 +3106,21 @@ module.exports = class huobi extends Exchange {
         //     "ts": 1639085854775
         // }
         //
-        const previousFundingRate = this.safeNumber (fundingRate, 'funding_rate');
         const nextFundingRate = this.safeNumber (fundingRate, 'estimated_rate');
         const previousFundingTimestamp = this.safeInteger (fundingRate, 'funding_time');
         const nextFundingTimestamp = this.safeInteger (fundingRate, 'next_funding_time');
+        const marketId = this.safeString (fundingRate, 'contract_code');
+        const symbol = this.safeSymbol (marketId, market);
         return {
             'info': fundingRate,
-            'symbol': market['symbol'],
+            'symbol': symbol,
             'markPrice': undefined,
             'indexPrice': undefined,
             'interestRate': undefined,
             'estimatedSettlePrice': undefined,
             'timestamp': undefined,
             'datetime': undefined,
-            'previousFundingRate': previousFundingRate,
+            'previousFundingRate': this.safeNumber (fundingRate, 'funding_rate'),
             'nextFundingRate': nextFundingRate,
             'previousFundingTimestamp': previousFundingTimestamp,
             'nextFundingTimestamp': nextFundingTimestamp,


### PR DESCRIPTION
Huobi fetchFundingRate and parseFundingRate methods:
```node examples/js/cli huobi fetchFundingRate BCH/USD:BCH
2021-12-09T22:02:28.723Z
Node.js: v16.9.1
CCXT v1.63.36
huobi.fetchFundingRate (BCH/USD:BCH)
331 ms
{                     info: {    estimated_rate: "0.000100000000000000",
                                   funding_rate: "0.000100000000000000",
                                  contract_code: "BCH-USD",
                                         symbol: "BCH",
                                      fee_asset: "BCH",
                                   funding_time: "1639094400000",
                              next_funding_time: "1639123200000"         },
                    symbol:   "BCH/USD:BCH",
                 markPrice:    undefined,
                indexPrice:    undefined,
              interestRate:    undefined,
      estimatedSettlePrice:    undefined,
                 timestamp:    undefined,
                  datetime:    undefined,
       previousFundingRate:    0.0001,
           nextFundingRate:    0.0001,
  previousFundingTimestamp:    1639094400000,
      nextFundingTimestamp:    1639123200000,
   previousFundingDatetime:   "2021-12-10T00:00:00.000Z",
       nextFundingDatetime:   "2021-12-10T08:00:00.000Z"                    }
```