### PR TITLE
Fix dockerfile to prevent "Call to undefined function ccxt\gmp_init() in Precise.php"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
 # Miscellaneous deps
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git ca-certificates
 # PHP
+
 RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath php-gmp
+
+RUN bash -c "source ${HOME}/.bashrc" 
 # Node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y nodejs
@@ -21,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 python3
 RUN pip3 install 'idna==2.9' --force-reinstall
 RUN pip3 install --upgrade setuptools
 RUN pip3 install tox
+RUN pip3 install aiohttp
 # Installs as a local Node & Python module, so that `require ('ccxt')` and `import ccxt` should work after that
 RUN npm install
 RUN ln -s /ccxt /usr/lib/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git ca-certificates
 # PHP
 RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath php-gmp
-
 # Node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
 # Miscellaneous deps
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git ca-certificates
 # PHP
-
 RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath php-gmp
 
-RUN bash -c "source ${HOME}/.bashrc" 
 # Node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y nodejs


### PR DESCRIPTION
After some digging, I found that `RUN cd python && python3 setup.py develop  && cd .. `command was failing, when installing dependencies, due to a missing package and was apparently interfering with the installation of other packages. Adding the missing package seems to solve the problem.

Error mentioned:
![image](https://user-images.githubusercontent.com/43336371/145543066-f948543e-11a7-451d-8e9f-74d518b42ab2.png)

Result:
![DockerFixPhp](https://user-images.githubusercontent.com/43336371/145543143-77cd1555-e188-4e7a-a899-546a350b7a58.gif)

