### PR TITLE
bitmart fetchSpotMarkets precisions

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -435,7 +435,7 @@ module.exports = class bitmart extends Exchange {
             const pricePrecision = this.safeInteger (market, 'price_max_precision');
             const precision = {
                 'amount': this.safeNumber (market, 'base_min_size'),
-                'price': this.parseNumber (this.decimalToPrecision (Math.pow (10, -pricePrecision), ROUND, 12)),
+                'price': this.parseNumber (this.decimalToPrecision (Math.pow (10, -pricePrecision), ROUND, 14)),
             };
             const minBuyCost = this.safeNumber (market, 'min_buy_amount');
             const minSellCost = this.safeNumber (market, 'min_sell_amount');


### PR DESCRIPTION
Some pairs has 14 precision

```
{
  limits: {
    amount: { min: 1, max: 10000000 },
    price: { min: undefined, max: undefined },
    cost: { min: 0.001, max: undefined }
  },
  precision: { amount: 1, price: 0 },
  tierBased: true,
  percentage: true,
  taker: 0.0025,
  maker: 0.0025,
  tiers: {
    taker: [
      [Array], [Array],
      [Array], [Array],
      [Array], [Array],
      [Array], [Array]
    ],
    maker: [
      [Array], [Array],
      [Array], [Array],
      [Array], [Array],
      [Array], [Array]
    ]
  },
  id: 'NYN_ETH',
  numericId: 1149,
  symbol: 'NYN/ETH',
  base: 'NYN',
  quote: 'ETH',
  baseId: 'NYN',
  quoteId: 'ETH',
  type: 'spot',
  spot: true,
  future: false,
  swap: false,
  info: {
    symbol: 'NYN_ETH',
    symbol_id: '1149',
    base_currency: 'NYN',
    quote_currency: 'ETH',
    quote_increment: '1',
    base_min_size: '1',
    base_max_size: '10000000',
    price_min_precision: '11',
    price_max_precision: '14',
    expiration: 'NA',
    min_buy_amount: '0.001',
    min_sell_amount: '0.001'
  },
  active: true
}

```