### PR TITLE
Mexc fetchFundingRateHistory

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2113,6 +2113,9 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
+        if (limit !== undefined) {
+            request['page_size'] = limit;
+        }
         const response = await this.contractPublicGetFundingRateHistory (this.extend (request, params));
         //
         // {

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2105,9 +2105,6 @@ module.exports = class mexc extends Exchange {
         //  (param) params: Object containing more params for the request
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
-        if (limit === undefined) {
-            limit = 20;  // page_size default is 20
-        }
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
         }

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2100,7 +2100,7 @@ module.exports = class mexc extends Exchange {
         //
         // Gets a history of funding rates with their timestamps
         //  (param) symbol: Future currency pair
-        //  (param) limit: mexc limit is default
+        //  (param) limit: mexc limit is page_size default 20
         //  (param) since: not used by mexc
         //  (param) params: Object containing more params for the request
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
@@ -2112,6 +2112,8 @@ module.exports = class mexc extends Exchange {
         const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
+            // 'page_size': limit, // optional
+            // 'page_num': 1, // optional
         };
         if (limit !== undefined) {
             request['page_size'] = limit;

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2106,7 +2106,7 @@ module.exports = class mexc extends Exchange {
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
         if (limit === undefined) {
-            limit = mexc.default;  // page_size default is 20
+            limit = 20;  // page_size default is 20
         }
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2100,7 +2100,7 @@ module.exports = class mexc extends Exchange {
         //
         // Gets a history of funding rates with their timestamps
         //  (param) symbol: Future currency pair
-        //  (param) limit: mexc limit is page_size default 20
+        //  (param) limit: mexc limit is page_size default 20, maximum is 100
         //  (param) since: not used by mexc
         //  (param) params: Object containing more params for the request
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
@@ -2113,7 +2113,7 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
             // 'page_size': limit, // optional
-            // 'page_num': 1, // optional
+            // 'page_num': 1, // optional, current page number, default is 1
         };
         if (limit !== undefined) {
             request['page_size'] = limit;

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2100,11 +2100,14 @@ module.exports = class mexc extends Exchange {
         //
         // Gets a history of funding rates with their timestamps
         //  (param) symbol: Future currency pair
-        //  (param) limit: not used by mexc
+        //  (param) limit: mexc limit is default
         //  (param) since: not used by mexc
         //  (param) params: Object containing more params for the request
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
+        if (limit === undefined) {
+            limit = 20;  // page_size default is 20
+        }
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
         }

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -30,6 +30,7 @@ module.exports = class mexc extends Exchange {
                 'fetchDepositAddress': true,
                 'fetchDepositAddressByNetwork': true,
                 'fetchDeposits': true,
+                'fetchFundingRateHistory': true,
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
@@ -2093,5 +2094,67 @@ module.exports = class mexc extends Exchange {
             this.throwExactlyMatchedException (this.exceptions['exact'], responseCode, feedback);
             throw new ExchangeError (feedback);
         }
+    }
+
+    async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        //
+        // Gets a history of funding rates with their timestamps
+        //  (param) symbol: Future currency pair
+        //  (param) limit: not used by mexc
+        //  (param) since: not used by mexc
+        //  (param) params: Object containing more params for the request
+        //  return: [{symbol, fundingRate, timestamp, dateTime}]
+        //
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.contractPublicGetFundingRateHistory (this.extend (request, params));
+        //
+        // {
+        //     "success": true,
+        //     "code": 0,
+        //     "data": {
+        //         "pageSize": 2,
+        //         "totalCount": 21,
+        //         "totalPage": 11,
+        //         "currentPage": 1,
+        //         "resultList": [
+        //             {
+        //                 "symbol": "BTC_USDT",
+        //                 "fundingRate": 0.000266,
+        //                 "settleTime": 1609804800000
+        //             },
+        //             {
+        //                 "symbol": "BTC_USDT",
+        //                 "fundingRate": 0.00029,
+        //                 "settleTime": 1609776000000
+        //             }
+        //         ]
+        //     }
+        // }
+        //
+        const data = this.safeValue (response, 'data');
+        const result = this.safeValue (data, 'resultList');
+        const rates = [];
+        for (let i = 0; i < result.length; i++) {
+            const entry = result[i];
+            const marketId = this.safeString (entry, 'symbol');
+            const symbol = this.safeSymbol (marketId);
+            const timestamp = this.safeString (entry, 'settleTime');
+            rates.push ({
+                'info': entry,
+                'symbol': symbol,
+                'fundingRate': this.safeNumber (entry, 'fundingRate'),
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+            });
+        }
+        const sorted = this.sortBy (rates, 'timestamp');
+        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
     }
 };

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2106,7 +2106,7 @@ module.exports = class mexc extends Exchange {
         //  return: [{symbol, fundingRate, timestamp, dateTime}]
         //
         if (limit === undefined) {
-            limit = 20;  // page_size default is 20
+            limit = mexc.default;  // page_size default is 20
         }
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');


### PR DESCRIPTION
Created the fetchFundingRateHistory method for mexc.js
``` 
node examples/js/cli mexc fetchFundingRateHistory BTC_USDT
2021-12-11T00:44:40.804Z
Node.js: v16.9.1
CCXT v1.63.19
mexc.fetchFundingRateHistory (BTC_USDT)
486 ms
  symbol | fundingRate |     timestamp |                 datetime
-----------------------------------------------------------------
BTC_USDT |    0.000079 | 1638633600000 | 2021-12-04T16:00:00.000Z
BTC_USDT |    0.000132 | 1638662400000 | 2021-12-05T00:00:00.000Z
BTC_USDT |     0.00014 | 1638691200000 | 2021-12-05T08:00:00.000Z
BTC_USDT |     0.00015 | 1638720000000 | 2021-12-05T16:00:00.000Z
BTC_USDT |     0.00015 | 1638748800000 | 2021-12-06T00:00:00.000Z
BTC_USDT |     0.00015 | 1638777600000 | 2021-12-06T08:00:00.000Z
BTC_USDT |     0.00005 | 1638806400000 | 2021-12-06T16:00:00.000Z
BTC_USDT |     0.00015 | 1638835200000 | 2021-12-07T00:00:00.000Z
BTC_USDT |   -0.000011 | 1638864000000 | 2021-12-07T08:00:00.000Z
BTC_USDT |     0.00005 | 1638892800000 | 2021-12-07T16:00:00.000Z
BTC_USDT |     0.00015 | 1638921600000 | 2021-12-08T00:00:00.000Z
BTC_USDT |     0.00015 | 1638950400000 | 2021-12-08T08:00:00.000Z
BTC_USDT |     0.00005 | 1638979200000 | 2021-12-08T16:00:00.000Z
BTC_USDT |     0.00015 | 1639008000000 | 2021-12-09T00:00:00.000Z
BTC_USDT |     0.00005 | 1639036800000 | 2021-12-09T08:00:00.000Z
BTC_USDT |     0.00015 | 1639065600000 | 2021-12-09T16:00:00.000Z
BTC_USDT |     0.00015 | 1639094400000 | 2021-12-10T00:00:00.000Z
BTC_USDT |     0.00015 | 1639123200000 | 2021-12-10T08:00:00.000Z
BTC_USDT |     0.00015 | 1639152000000 | 2021-12-10T16:00:00.000Z
BTC_USDT |     0.00015 | 1639180800000 | 2021-12-11T00:00:00.000Z
20 objects
```