### PR TITLE
Fixed 404

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -937,7 +937,7 @@ We also welcome financial contributions in full transparency on our [open collec
 
 Thank you to all the people who have already contributed to ccxt!
 
-<a href="graphs/contributors"><img src="https://opencollective.com/ccxt/contributors.svg?width=890" /></a>
+<a href="https://github.com/ccxt/ccxt/graphs/contributors"><img src="https://opencollective.com/ccxt/contributors.svg?width=890" /></a>
 
 ### Backers
 


### PR DESCRIPTION
Link [here](https://github.com/ccxt/ccxt/blob/master/CONTRIBUTING.md#financial-contributions
) is broken and gives a 404 error.
Corrected it to the correct path.