### PR TITLE
IDEX: fix sandbox URL

### DIFF
--- a/js/idex.js
+++ b/js/idex.js
@@ -52,8 +52,7 @@ module.exports = class idex extends Exchange {
             },
             'urls': {
                 'test': {
-                    'public': 'https://api-sandbox-matic.idex.io',
-                    'private': 'https://api-sandbox-matic.idex.io',
+                    'MATIC': 'https://api-sandbox-matic.idex.io',
                 },
                 'logo': 'https://user-images.githubusercontent.com/51840849/94481303-2f222100-01e0-11eb-97dd-bc14c5943a86.jpg',
                 'api': {


### PR DESCRIPTION
Sandbox URL fixed to match structure of `urls.api` entry. Without it, all calls to IDEX sandbox end up with error: `idex GET undefined/v1/assets  Only absolute URLs are supported`, because of how URL is constructed [here](https://github.com/ccxt/ccxt/blob/495de446fc08e8eba763e172c48eac6df974da54/js/idex.js#L1291).