### PR TITLE
Exchange capabilities - rewrite for better visibility

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -1,9 +1,10 @@
 "use strict";
 
-/*  ------------------------------------------------------------------------ */
-// node ./examples/js/exchange-capabilities.js --csv
+// example:   
+//      node ./examples/js/exchange-capabilities.js --csv --combined
 
 const isCsvStyle  = process.argv.includes ('--csv')
+const separationFlag = process.argv.includes ('--combined')
 const delimiter   = isCsvStyle ? ',' : '|'
 const ccxt        = require ('../../ccxt.js')
     , asTable     = require ('as-table').configure ({ delimiter: ' '+delimiter+' ', /* print: require ('string.ify').noPretty  */ })
@@ -20,109 +21,137 @@ const isWindows = process.platform == 'win32' // fix for windows, as it doesn't 
     let inexistentApi = 0
     let implemented = 0
     let emulated = 0
+    let __DIVISOR__ = "__DIVISOR__:"
 
-    const table = asTable (ccxt.exchanges.map (id => new ccxt[id]()).map (exchange => {
+    let commonEndpoints = { 'common': [
+        'publicAPI',
+        'privateAPI',
+        'CORS',
+        __DIVISOR__+'EXCHANGE-RELATED',
+        'fetchCurrencies',
+        'fetchMarkets',
+        'fetchOHLCV',
+        'fetchOrderBook',
+        'fetchStatus',
+        'fetchTicker',
+        'fetchTickers',
+        'fetchTime',
+        'fetchTrades',
+        __DIVISOR__+'TRADING-RELATED',
+        'fetchTradingFees',
+        'fetchTransactions',
+        'setLeverage',
+        'setMarginMode',
+        __DIVISOR__+'WALET-RELATED',
+        'createDepositAddress',
+        'fetchDeposits',
+        'fetchDepositAddress',
+        'fetchWithdrawals',
+        'fetchBalance',
+        'transfer',
+        'withdraw',
+        __DIVISOR__+'ORDER-RELATED',
+        'createOrder',
+        'editOrder',
+        'cancelOrder',
+        'fetchOrder',
+        'fetchOrders',
+        'fetchOpenOrders',
+        'fetchClosedOrders',
+        'fetchOrderTrades',
+        'fetchMyTrades',
+        'cancelAllOrders',
+        'fetchPositions',
+    ]};
+    let uncommonEndpoints = { 'uncommon': [
+        __DIVISOR__+'EXCHANGE-RELATED',
+        'fetchIndexOHLCV',
+        'fetchPremiumIndexOHLCV',
+        'fetchMarkOHLCV',
+        'fetchOrderBooks',
+        __DIVISOR__+'TRADING-RELATED',
+        'fetchTradingFee',
+        'fetchTradingLimits',
+        'fetchFundingRate',
+        'fetchFundingRates',
+        'fetchFundingFee',
+        'fetchFundingFees',
+        'fetchFundingHistory',
+        'fetchFundingRateHistory',
+        'fetchBorrowRate',
+        'fetchBorrowRates',
+        __DIVISOR__+'ORDER-RELATED',
+        'fetchOpenOrder',
+        'fetchClosedOrder',
+        'cancelOrders',
+        'fetchCanceledOrders',
+        'fetchPosition',
+        'fetchIsolatedPositions',
+        __DIVISOR__+'WALLET-RELATED',
+        'fetchAccounts',
+        'fetchDeposit',
+        'fetchDepositAddresses',
+        'fetchWithdrawal',
+        'fetchTransfers',
+        'fetchLedger',
+        'fetchLedgerEntry',
+        'signIn',
+        'deposit',
+    ]};
+    
+    let finalEndpoints = separationFlag ? [ {"all": commonEndpoints['common'].concat(uncommonEndpoints['uncommon']) } ] : [ commonEndpoints , uncommonEndpoints ]; 
 
-        let result = {};
+    for (const endpointGroup of finalEndpoints)
+    {
+        let title = Object.keys(endpointGroup)[0];
+        let values = endpointGroup[ title];
+        log ("\n"+'* Printing Table: '+title+ "\n")
 
-        [
-            'publicAPI',
-            'privateAPI',
-            'CORS',
-            'fetchCurrencies',
-            'fetchFundingFees',
-            'fetchFundingRate',
-            'fetchFundingRates',
-            'fetchFundingRateHistory',
-            'fetchIndexOHLCV',
-            'fetchMarkOHLCV',
-            'fetchMarkets',
-            'fetchOHLCV',
-            'fetchOrderBook',
-            'fetchOrderBooks',
-            'fetchStatus',
-            'fetchTicker',
-            'fetchTickers',
-            'fetchTime',
-            'fetchTrades',
-            'fetchTradingLimits',
-            'cancelAllOrders',
-            'cancelOrder',
-            'cancelOrders',
-            'createDepositAddress',
-            'createOrder',
-            'deposit',
-            'editOrder',
-            'fetchAccounts',
-            'fetchBalance',
-            'fetchBorrowRate',
-            'fetchBorrowRates',
-            'fetchCanceledOrders',
-            'fetchClosedOrder',
-            'fetchClosedOrders',
-            'fetchDeposit',
-            'fetchDepositAddress',
-            'fetchDepositAddresses',
-            'fetchDeposits',
-            'fetchFees',
-            'fetchFundingFee',
-            'fetchFundingHistory',
-            'fetchIsolatedPositions',
-            'fetchLedger',
-            'fetchLedgerEntry',
-            'fetchMyTrades',
-            'fetchOpenOrder',
-            'fetchOpenOrders',
-            'fetchOrder',
-            'fetchOrderTrades',
-            'fetchOrders',
-            'fetchPosition',
-            'fetchPositions',
-            'fetchPremiumIndexOHLCV',
-            'fetchTradingFee',
-            'fetchTradingFees',
-            'fetchTransactions',
-            'fetchTransfers',
-            'fetchWithdrawal',
-            'fetchWithdrawals',
-            'setLeverage',
-            'setMarginMode',
-            'signIn',
-            'transfer',
-            'withdraw',
-        ].forEach (key => {
+        const table = asTable (ccxt.exchanges.map (id => new ccxt[id]()).map (exchange => {
 
-            total += 1
+            let result = {};
+            values.forEach (key => {
+                
+                //skip headers
+                if (key.includes (__DIVISOR__)){
+                    key =  (key.replace(__DIVISOR__,'')+'>>>').darkGray;
+                    result[key] = ''
+                    return;
+                }
 
-            let capability = exchange.has[key]
+                total += 1
+    
+                let capability = exchange.has[key]
+    
+                if (capability === undefined) {
+                    capability = isWindows ? exchange.id.red : exchange.id.red.dim
+                    notImplemented += 1
+                } else if (capability === false) {
+                    capability = isWindows ? exchange.id.lightMagenta : exchange.id.red 
+                    inexistentApi += 1
+                } else if (capability.toString () === 'emulated') {
+                    capability = exchange.id.yellow
+                    emulated += 1
+                } else {
+                    capability = exchange.id.green
+                    implemented += 1
+                }
+    
+                result[key] = capability
+            })
+    
+            return result
+        }))
 
-            if (capability === undefined) {
-                capability = isWindows ? exchange.id.red : exchange.id.red.dim
-                notImplemented += 1
-            } else if (capability === false) {
-                capability = isWindows ? exchange.id.lightMagenta : exchange.id.red 
-                inexistentApi += 1
-            } else if (capability.toString () === 'emulated') {
-                capability = exchange.id.yellow
-                emulated += 1
-            } else {
-                capability = exchange.id.green
-                implemented += 1
-            }
+        if (isCsvStyle) {
+            let lines = table.split ("\n")	
+            lines = lines.slice (0, 1).concat (lines.slice (2))	
+            log (lines.join ("\n"))
+        } else {
+            log(table)
+        }
+    } 
 
-            result[key] = capability
-        })
-
-        return result
-    }))
-
-    if (isCsvStyle) {
-        let lines = table.split ("\n")	
-        lines = lines.slice (0, 1).concat (lines.slice (2))	
-        log (lines.join ("\n"))
-    } else {
-        log(table)
-    }
 
     log ('Summary: ',
         ccxt.exchanges.length.toString (), 'exchanges; ',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "check-js-syntax": "node -e \"console.log(process.cwd())\" && eslint --version && eslint \"js/*.js\"",
     "check-python-syntax": "cd python && tox -e qa && cd ..",
     "check-php-syntax": "php -f php/test/syntax.php",
+    "capabilities": "node ./examples/js/exchange-capabilities.js",
     "browserify": "browserify ./ccxt.browser.js > ./dist/ccxt.browser.js",
     "copy-python-files": "npm run copy-python-package && npm run copy-python-license && npm run copy-python-keys && npm run copy-python-readme",
     "copy-python-package": "node build/copy package.json python/package.json",


### PR DESCRIPTION
I've been trying to still make the capabilities functionality more clear and sorted by priorities & common unification order.

Also, as most npm commands are for devs mostly, the exchange-capabilities (to help devs & see most of CCXT functionalities in one output) command is a handy one for either core-devs and non-core-devs to see ccxt capabilities easily.  So, I think it's helpful to be in package.json shorthands too.

Please check it's output and let me know if you like that way, or if you suggest any edition.