### PR TITLE
Phemex: fix parsing numbers with multiple commas

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -327,7 +327,7 @@ module.exports = class phemex extends Exchange {
         if (value === undefined) {
             return value;
         }
-        value = value.replace (',', '');
+        value = value.replace (/,/g, '');
         const parts = value.split (' ');
         return this.safeNumber (parts, 0);
     }


### PR DESCRIPTION
Phemex is sending market data like this:

```
    "info": {
      "symbol": "sSHIBUSDT",
      "displaySymbol": "SHIB / USDT",
      "quoteCurrency": "USDT",
      "pricePrecision": "8",
      "type": "Spot",
      "baseCurrency": "SHIB",
      "baseTickSize": "1 SHIB",
      "baseTickSizeEv": "100",
      "quoteTickSize": "0.00000001 USDT",
      "quoteTickSizeEv": "1",
      "minOrderValue": "10 USDT",
      "minOrderValueEv": "1000000000",
      "maxBaseOrderSize": "5,000,000,000 SHIB",
      "maxBaseOrderSizeEv": "500000000000",
      "maxOrderValue": "5,000,000 USDT",
      "maxOrderValueEv": "500000000000000",
      "defaultTakerFee": "0.001",
      "defaultTakerFeeEr": "100000",
      "defaultMakerFee": "0.001",
      "defaultMakerFeeEr": "100000",
      "baseQtyPrecision": "0",
      "quoteQtyPrecision": "2",
      "status": "Listed",
      "tipOrderQty": "1500000000"
    },
```

but the current implementation of  `parseSafeNumber ` that is used to parse some keys (`maxBaseOrderSize`, `minOrderValue`, `maxOrderValue`, `baseTickSize`, `quoteTickSize`) replaces just first comma, not all of them, and as a result numbers with more than one comma are parsed as NaNs.