### PR TITLE
Reference PR for Exchange-Specific DOCS creation

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4313,3 +4313,4 @@ In case you experience any difficulty connecting to a particular exchange, do th
 - As written above, some exchanges are not available in certain countries. You should use a proxy or get a server somewhere closer to the exchange.
 - If you are getting authentication errors or *'invalid keys'* errors, those are most likely due to a nonce issue.
 - Some exchanges do not state it clearly if they fail to authenticate your request. In those circumstances they might respond with an exotic error code, like HTTP 502 Bad Gateway Error or something that's even less related to the actual cause of the error.
+


### PR DESCRIPTION
Many people ask what parameters can be passed here-or-there in CCXT methods. In future, CCXT might implement "exchange-specific" documentation where will be listed the nuances of each exchange methods. Till that, please read [CCXT PARAMETERS](https://github.com/ccxt/ccxt/blob/master/wiki/Manual.md#passing-parameters-to-api-methods) paragraph.


_[ Fixes #10505 | ... ]_