### PR TITLE
Add 'currencies' to fetchMarkets

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -922,7 +922,7 @@ module.exports = class Exchange {
         return new Promise ((resolve, reject) => resolve (this.currencies));
     }
 
-    fetchMarkets (params = {}, currencies) {
+    fetchMarkets (params = {}, currencies = undefined) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -738,7 +738,7 @@ module.exports = class Exchange {
         if (this.has.fetchCurrencies === true) {
             currencies = await this.fetchCurrencies ()
         }
-        const markets = await this.fetchMarkets (params)
+        const markets = await this.fetchMarkets (params, currencies)
         return this.setMarkets (markets, currencies)
     }
 
@@ -922,7 +922,7 @@ module.exports = class Exchange {
         return new Promise ((resolve, reject) => resolve (this.currencies));
     }
 
-    fetchMarkets (params = {}) {
+    fetchMarkets (params = {}, currencies) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1795,7 +1795,7 @@ class Exchange {
         if (array_key_exists('fetchCurrencies', $this->has) && $this->has['fetchCurrencies'] === true) {
             $currencies = $this->fetch_currencies();
         }
-        $markets = $this->fetch_markets($params);
+        $markets = $this->fetch_markets($params, $currencies);
         return $this->set_markets($markets, $currencies);
     }
 
@@ -2345,7 +2345,7 @@ class Exchange {
         }
     }
 
-    public function fetch_markets($params = array()) {
+    public function fetch_markets($params = array(), $currencies = null) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -201,7 +201,7 @@ class Exchange extends \ccxt\Exchange {
         if (array_key_exists('fetchCurrencies', $this->has) && $this->has['fetchCurrencies'] === true) {
             $currencies = yield $this->fetch_currencies ();
         }
-        $markets = yield $this->fetch_markets ($params);
+        $markets = yield $this->fetch_markets ($params, $currencies);
         return $this->set_markets ($markets, $currencies);
     }
 

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -182,7 +182,7 @@ class Exchange(BaseExchange):
         currencies = None
         if self.has['fetchCurrencies'] is True:
             currencies = await self.fetch_currencies()
-        markets = await self.fetch_markets(params)
+        markets = await self.fetch_markets(params, currencies)
         return self.set_markets(markets, currencies)
 
     async def load_markets(self, reload=False, params={}):
@@ -219,7 +219,7 @@ class Exchange(BaseExchange):
         self.loaded_fees = self.deep_extend(self.loaded_fees, await self.fetch_fees())
         return self.loaded_fees
 
-    async def fetch_markets(self, params={}):
+    async def fetch_markets(self, params={}, currencies=None):
         # markets are returned as a list
         # currencies are returned as a dict
         # this is for historical reasons

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1426,7 +1426,7 @@ class Exchange(object):
         currencies = None
         if self.has['fetchCurrencies'] is True:
             currencies = self.fetch_currencies()
-        markets = self.fetch_markets(params)
+        markets = self.fetch_markets(params, currencies)
         return self.set_markets(markets, currencies)
 
     def load_accounts(self, reload=False, params={}):
@@ -1447,7 +1447,7 @@ class Exchange(object):
         self.loaded_fees = self.deep_extend(self.loaded_fees, self.fetch_fees())
         return self.loaded_fees
 
-    def fetch_markets(self, params={}):
+    def fetch_markets(self, params={}, currencies=None):
         # markets are returned as a list
         # currencies are returned as a dict
         # this is for historical reasons


### PR DESCRIPTION
There seems to be cases, when inside `fetchMarkets` it's needed  to have access to currencies data (i.e. I'm working on bitfinex2 now and there is needed to know currencies names/list to correctly match markets base/quote ids), however, it's not available in fetchMarkets. I think it's non destructive way to add second parameter to `fetchMarkets` where we can pass `currencies`.