### PR TITLE
Bitfinex v2 fetchTransactions / movements endpoint issue fix

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1491,7 +1491,7 @@ module.exports = class bitfinex2 extends bitfinex {
         let method = 'privatePostAuthRMovementsHist';
         if (code !== undefined) {
             currency = this.currency (code);
-            request['currency'] = currency['code'];
+            request['currency'] = currency['code'].toUpper();
             method = 'privatePostAuthRMovementsCurrencyHist';
         }
         if (since !== undefined) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -361,7 +361,7 @@ module.exports = class bitfinex2 extends bitfinex {
     }
 
     async fetchMarkets (params = {}) {
-        // todo drop v1 in favor of v2 configs
+        // todo drop v1 in favor of v2 configs  ( temp-reference for v2update: https://pastebin.com/raw/S8CmqSHQ )
         // pub:list:pair:exchange,pub:list:pair:margin,pub:list:pair:futures,pub:info:pair
         const v2response = await this.publicGetConfPubListPairFutures (params);
         const v1response = await this.v1GetSymbolsDetails (params);
@@ -1491,7 +1491,7 @@ module.exports = class bitfinex2 extends bitfinex {
         let method = 'privatePostAuthRMovementsHist';
         if (code !== undefined) {
             currency = this.currency (code);
-            request['currency'] = currency['id'];
+            request['currency'] = currency['code'];
             method = 'privatePostAuthRMovementsCurrencyHist';
         }
         if (since !== undefined) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -554,6 +554,7 @@ module.exports = class bitfinex2 extends bitfinex {
             const fid = 'f' + id;
             result[code] = {
                 'id': fid,
+                'uppercaseId': id,
                 'code': code,
                 'info': [ id, label, pool, feeValues, undl ],
                 'type': type,
@@ -1491,7 +1492,7 @@ module.exports = class bitfinex2 extends bitfinex {
         let method = 'privatePostAuthRMovementsHist';
         if (code !== undefined) {
             currency = this.currency (code);
-            request['currency'] = currency['code'].toUpper ();
+            request['currency'] = currency['uppercaseId'];
             method = 'privatePostAuthRMovementsCurrencyHist';
         }
         if (since !== undefined) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1491,7 +1491,7 @@ module.exports = class bitfinex2 extends bitfinex {
         let method = 'privatePostAuthRMovementsHist';
         if (code !== undefined) {
             currency = this.currency (code);
-            request['currency'] = currency['code'].toUpper();
+            request['currency'] = currency['code'].toUpper ();
             method = 'privatePostAuthRMovementsCurrencyHist';
         }
         if (since !== undefined) {


### PR DESCRIPTION
This specific endpoint  ( https://docs.bitfinex.com/reference#rest-auth-movements ) requires the currency code without prepended chars.
( Also, I've added a temporary reference link to the partial code i've stared, but atm cant proceed with it, and will return to it later. )

[ fixes #10172 ]