### PR TITLE
Added properties marginAPI, swapAPI, and futureAPI to has

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -28,9 +28,9 @@ const isWindows = process.platform == 'win32' // fix for windows, as it doesn't 
         [
             'publicAPI',
             'privateAPI',
-            'marginAPI',
-            'swapAPI',
-            'futureAPI',
+            'margin',
+            'swap',
+            'future',
             'CORS',
             'fetchCurrencies',
             'fetchFundingFees',

--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -28,6 +28,9 @@ const isWindows = process.platform == 'win32' // fix for windows, as it doesn't 
         [
             'publicAPI',
             'privateAPI',
+            'marginAPI',
+            'swapAPI',
+            'futureAPI',
             'CORS',
             'fetchCurrencies',
             'fetchFundingFees',

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -63,9 +63,9 @@ module.exports = class Exchange {
             'has': {
                 'privateAPI': true,
                 'publicAPI': true,
-                'marginAPI': undefined,
-                'swapAPI': undefined,
-                'futureAPI': undefined,
+                'margin': undefined,
+                'swap': undefined,
+                'future': undefined,
                 'cancelAllOrders': undefined,
                 'cancelOrder': true,
                 'cancelOrders': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -61,7 +61,11 @@ module.exports = class Exchange {
             'pro': false, // if it is integrated with CCXT Pro for WebSocket support
             'alias': false, // whether this exchange is an alias to another exchange
             'has': {
-                'loadMarkets': true,
+                'privateAPI': true,
+                'publicAPI': true,
+                'marginAPI': undefined,
+                'swapAPI': undefined,
+                'futureAPI': undefined,
                 'cancelAllOrders': undefined,
                 'cancelOrder': true,
                 'cancelOrders': undefined,
@@ -102,8 +106,7 @@ module.exports = class Exchange {
                 'fetchTradingLimits': undefined,
                 'fetchTransactions': undefined,
                 'fetchWithdrawals': undefined,
-                'privateAPI': true,
-                'publicAPI': true,
+                'loadMarkets': true,
                 'signIn': undefined,
                 'withdraw': undefined,
             },

--- a/js/binance.js
+++ b/js/binance.js
@@ -20,6 +20,9 @@ module.exports = class binance extends Exchange {
             'pro': true,
             // new metainfo interface
             'has': {
+                'marginAPI': true,
+                'swapAPI': true,
+                'futureAPI': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/binance.js
+++ b/js/binance.js
@@ -20,9 +20,9 @@ module.exports = class binance extends Exchange {
             'pro': true,
             // new metainfo interface
             'has': {
-                'marginAPI': true,
-                'swapAPI': true,
-                'futureAPI': true,
+                'margin': true,
+                'swap': true,
+                'future': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -20,9 +20,9 @@ module.exports = class bittrex extends Exchange {
             'pro': true,
             // new metainfo interface
             'has': {
-                'marginAPI': false,
-                'swapAPI': false,
-                'futureAPI': false,
+                'margin': false,
+                'swap': false,
+                'future': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -20,6 +20,9 @@ module.exports = class bittrex extends Exchange {
             'pro': true,
             // new metainfo interface
             'has': {
+                'marginAPI': false,
+                'swapAPI': false,
+                'futureAPI': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -20,6 +20,9 @@ module.exports = class bybit extends Exchange {
             'rateLimit': 100,
             'hostname': 'bybit.com', // bybit.com, bytick.com
             'has': {
+                'marginAPI': false,
+                'swapAPI': true,
+                'futureAPI': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': true,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -20,9 +20,9 @@ module.exports = class bybit extends Exchange {
             'rateLimit': 100,
             'hostname': 'bybit.com', // bybit.com, bytick.com
             'has': {
-                'marginAPI': false,
-                'swapAPI': true,
-                'futureAPI': true,
+                'margin': false,
+                'swap': true,
+                'future': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': true,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -34,9 +34,9 @@ module.exports = class ftx extends Exchange {
                 },
             },
             'has': {
-                'marginAPI': true,
-                'swapAPI': true,
-                'futureAPI': true,
+                'margin': true,
+                'swap': true,
+                'future': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -34,6 +34,9 @@ module.exports = class ftx extends Exchange {
                 },
             },
             'has': {
+                'marginAPI': true,
+                'swapAPI': true,
+                'futureAPI': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -31,6 +31,9 @@ module.exports = class gateio extends Exchange {
                 },
             },
             'has': {
+                'margin': true,
+                'swap': true,
+                'future': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createMarketOrder': false,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -24,9 +24,9 @@ module.exports = class huobi extends Exchange {
             'hostname': 'api.huobi.pro', // api.testnet.huobi.pro
             'pro': true,
             'has': {
-                // 'marginAPI': true,
-                'swapAPI': true,
-                'futureAPI': true,
+                // 'margin': true,
+                'swap': true,
+                'future': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': true,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -24,6 +24,9 @@ module.exports = class huobi extends Exchange {
             'hostname': 'api.huobi.pro', // api.testnet.huobi.pro
             'pro': true,
             'has': {
+                // 'marginAPI': true,
+                'swapAPI': true,
+                'futureAPI': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': true,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -19,7 +19,7 @@ module.exports = class kraken extends Exchange {
             'certified': false,
             'pro': true,
             'has': {
-                'marginAPI': true,
+                'margin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -19,6 +19,7 @@ module.exports = class kraken extends Exchange {
             'certified': false,
             'pro': true,
             'has': {
+                'marginAPI': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -21,8 +21,8 @@ module.exports = class kucoin extends Exchange {
             'comment': 'Platform 2.0',
             'quoteJsonNumbers': false,
             'has': {
-                'swapAPI': false,
-                'futureAPI': false,
+                'swap': false,
+                'future': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -21,6 +21,8 @@ module.exports = class kucoin extends Exchange {
             'comment': 'Platform 2.0',
             'quoteJsonNumbers': false,
             'has': {
+                'swapAPI': false,
+                'futureAPI': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'CORS': undefined,

--- a/js/okex.js
+++ b/js/okex.js
@@ -20,9 +20,9 @@ module.exports = class okex extends Exchange {
             'pro': true,
             'certified': true,
             'has': {
-                'marginAPI': true,
-                'swapAPI': true,
-                'futureAPI': true,
+                'margin': true,
+                'swap': true,
+                'future': true,
                 'cancelOrder': true,
                 'CORS': undefined,
                 'createOrder': true,

--- a/js/okex.js
+++ b/js/okex.js
@@ -20,6 +20,9 @@ module.exports = class okex extends Exchange {
             'pro': true,
             'certified': true,
             'has': {
+                'marginAPI': true,
+                'swapAPI': true,
+                'futureAPI': true,
                 'cancelOrder': true,
                 'CORS': undefined,
                 'createOrder': true,


### PR DESCRIPTION
If  a unified implementation to these api endpoints has been written, then these go in has

----------------

We need to decide whether to use `future` or `futures`