### PR TITLE
Sandbox Mode for okex

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -3678,7 +3678,7 @@ module.exports = class okex extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 'add', params);
     }
 
-    setDemo (enable) {
+    isDemoAccount (enable) {
         if (enable) {
             this.headers['x-simulated-trading'] = 1;
         } else {

--- a/js/okex.js
+++ b/js/okex.js
@@ -3678,7 +3678,7 @@ module.exports = class okex extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 'add', params);
     }
 
-    isDemoAccount (enable) {
+    setSandboxMode (enable) {
         if (enable) {
             this.headers['x-simulated-trading'] = 1;
         } else {

--- a/js/okex.js
+++ b/js/okex.js
@@ -3678,6 +3678,14 @@ module.exports = class okex extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 'add', params);
     }
 
+    setDemo (enable) {
+        if (enable) {
+            this.headers['x-simulated-trading'] = 1;
+        } else {
+            this.headers['x-simulated-trading'] = null;
+        }
+    }
+
     handleErrors (httpCode, reason, url, method, headers, body, response, requestHeaders, requestBody) {
         if (!response) {
             return; // fallback to default error handler


### PR DESCRIPTION
I think in future we might unify this (together with 'setSandboxMode') as exchanges have different ways of 'set flag for sandbox mode'. at this moment, user has a 'hard-to-find' way to enable sandbox ( fixes  #7088 ) and I think CCXT might facilitate things. Maybe we can implement a unified param like:
```
const exch = new ccxt.xyz({
    ...
    'sandbox/demo': true
});

```

However, at this moment, for okex users might use this one too.