### PR TITLE
[Placeholder PR] Create fetchBalance for all account/subaccount types at once

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4329,4 +4329,3 @@ In case you experience any difficulty connecting to a particular exchange, do th
 - As written above, some exchanges are not available in certain countries. You should use a proxy or get a server somewhere closer to the exchange.
 - If you are getting authentication errors or *'invalid keys'* errors, those are most likely due to a nonce issue.
 - Some exchanges do not state it clearly if they fail to authenticate your request. In those circumstances they might respond with an exotic error code, like HTTP 502 Bad Gateway Error or something that's even less related to the actual cause of the error.
-


### PR DESCRIPTION
There could be created `fetchBallanceAll` unified method, that will fetch balance from given exchange's all available `accountsByType` values. 
[This PR is not ready ATM and is just a placeholder for future commits; fixes #10165]