### PR TITLE
Deribit fetchMarkets redo with new symbols

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -478,7 +478,7 @@ module.exports = class deribit extends Exchange {
                         type = 'option';
                         strike = this.safeNumber (market, 'strike');
                         optionType = this.safeString (market, 'option_type');
-                        symbol = symbol + ':' + strike.toString () + ':' + optionType;
+                        symbol = symbol + ':' + this.numberToString (strike) + ':' + optionType;
                     } else {
                         type = 'future';
                     }

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -472,12 +472,12 @@ module.exports = class deribit extends Exchange {
                 let strike = undefined;
                 let optionType = undefined;
                 if (option || future) {
-                    expiry = this.yyyymmdd (this.iso8601 (this.safeInteger (market, 'expiration_timestamp')), '');
+                    expiry = this.yyyymmdd (this.safeInteger (market, 'expiration_timestamp'), '');
                     symbol = symbol + '-' + expiry;
                     if (option) {
                         strike = this.safeNumber (market, 'strike');
                         optionType = this.safeString (market, 'option_type');
-                        symbol = symbol + ':' + strike + ':' + optionType;
+                        symbol = symbol + ':' + strike.toString () + ':' + optionType;
                     }
                 }
                 const minTradeAmount = this.safeNumber (market, 'min_trade_amount');

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -508,7 +508,6 @@ module.exports = class deribit extends Exchange {
                     'expiryDatetime': this.iso8601 (expiry),
                     'strike': strike,
                     'optionType': optionType,
-                    'fees': this.safeValue (this.fees, 'trading'),
                     'precision': {
                         'amount': minTradeAmount,
                         'price': tickSize,

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -468,12 +468,11 @@ module.exports = class deribit extends Exchange {
                 const future = !swap && (type === 'future');
                 const option = (type === 'option');
                 let symbol = quote + '/' + base + ':' + settle;
-                let expiry = undefined;
+                const expiry = this.safeInteger (market, 'expiration_timestamp');
                 let strike = undefined;
                 let optionType = undefined;
                 if (option || future) {
-                    expiry = this.yyyymmdd (this.safeInteger (market, 'expiration_timestamp'), '');
-                    symbol = symbol + '-' + expiry;
+                    symbol = symbol + '-' + this.yymmdd (expiry, '');
                     if (option) {
                         strike = this.safeNumber (market, 'strike');
                         optionType = this.safeString (market, 'option_type');
@@ -506,6 +505,7 @@ module.exports = class deribit extends Exchange {
                     'contractSize': this.safeString (market, 'contract_size'),
                     'active': this.safeValue (market, 'is_active'),
                     'expiry': expiry,
+                    'expiryDatetime': this.iso8601 (expiry),
                     'strike': strike,
                     'optionType': optionType,
                     'fees': this.safeValue (this.fees, 'trading'),

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -462,11 +462,11 @@ module.exports = class deribit extends Exchange {
                 const base = this.safeCurrencyCode (baseId);
                 const quote = this.safeCurrencyCode (quoteId);
                 const settle = this.safeCurrencyCode (settleId);
-                const deribitType = this.safeString (market, 'kind');
+                const kind = this.safeString (market, 'kind');
                 const settlementPeriod = this.safeValue (market, 'settlement_period');
                 const swap = (settlementPeriod === 'perpetual');
-                const future = !swap && (deribitType === 'future');
-                const option = (deribitType === 'option');
+                const future = !swap && (kind === 'future');
+                const option = (kind === 'option');
                 let symbol = quote + '/' + base + ':' + settle;
                 const expiry = this.safeInteger (market, 'expiration_timestamp');
                 let strike = undefined;

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -462,21 +462,25 @@ module.exports = class deribit extends Exchange {
                 const base = this.safeCurrencyCode (baseId);
                 const quote = this.safeCurrencyCode (quoteId);
                 const settle = this.safeCurrencyCode (settleId);
-                const type = this.safeString (market, 'kind');
+                const deribitType = this.safeString (market, 'kind');
                 const settlementPeriod = this.safeValue (market, 'settlement_period');
                 const swap = (settlementPeriod === 'perpetual');
-                const future = !swap && (type === 'future');
-                const option = (type === 'option');
+                const future = !swap && (deribitType === 'future');
+                const option = (deribitType === 'option');
                 let symbol = quote + '/' + base + ':' + settle;
                 const expiry = this.safeInteger (market, 'expiration_timestamp');
                 let strike = undefined;
                 let optionType = undefined;
+                let type = 'swap';
                 if (option || future) {
                     symbol = symbol + '-' + this.yymmdd (expiry, '');
                     if (option) {
+                        type = 'option';
                         strike = this.safeNumber (market, 'strike');
                         optionType = this.safeString (market, 'option_type');
                         symbol = symbol + ':' + strike.toString () + ':' + optionType;
+                    } else {
+                        type = 'future';
                     }
                 }
                 const minTradeAmount = this.safeNumber (market, 'min_trade_amount');


### PR DESCRIPTION
Properties added to Deribit.markets so the markets match other exchanges.
Unified symbols

```
deribit.fetchMarkets ()
1984 ms
                  id |                           symbol | base | quote | settle | baseId | quoteId | settleId |   type |  spot | margin | swap | future | option | derivative | contract | linear | inverse |  taker |   maker | contractSize | active |   expiry | strike | optionType | fees |                     precision |                                                                limits
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  ETH-17DEC21-3000-P |    ETH/ETH:ETH-20211217:3000:put |  ETH |   ETH |    ETH |    ETH |     ETH |      ETH | option | false |  false | true |  false |   true |       true |     true |  false |    true | 0.0003 |  0.0003 |          1.0 |   true | 20211217 |   3000 |        put |   {} |   {"amount":1,"price":0.0005} |   {"leverage":{},"amount":{"min":1},"price":{"min":0.0005},"cost":{}}
...
 BTC-24DEC21-40000-C |  BTC/BTC:BTC-20211224:40000:call |  BTC |   BTC |    BTC |    BTC |     BTC |      BTC | option | false |  false | true |  false |   true |       true |     true |  false |    true | 0.0003 |  0.0003 |          1.0 |   true | 20211224 |  40000 |       call |   {} | {"amount":0.1,"price":0.0005} | {"leverage":{},"amount":{"min":0.1},"price":{"min":0.0005},"cost":{}}
 BTC-25MAR22-22000-P |   BTC/BTC:BTC-20220325:22000:put |  BTC |   BTC |    BTC |    BTC |     BTC |      BTC | option | false |  false | true |  false |   true |       true |     true |  false |    true | 0.0003 |  0.0003 |          1.0 |   true | 20220325 |  22000 |        put |   {} | {"amount":0.1,"price":0.0005} | {"leverage":{},"amount":{"min":0.1},"price":{"min":0.0005},"cost":{}}
922 objects
```

--------------

We should probably add these properties to the markets of other exchange classes

```
'expiry': undefined,
'strike': undefined,
```