### PR TITLE
Phemex - editOrder implementation

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -24,6 +24,7 @@ module.exports = class phemex extends Exchange {
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,
+                'editOrder': true,
                 'fetchBalance': true,
                 'fetchBorrowRate': false,
                 'fetchBorrowRates': false,

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1929,10 +1929,10 @@ module.exports = class phemex extends Exchange {
             throw new ArgumentsRequired (this.id + ' editOrder() requires a symbol argument');
         }
         if (type !== undefined) {
-            throw new ArgumentsRequired (this.id + ' editOrder() type changing is not implemented. Try to cancel & recreate order if you need to change type');
+            throw new ArgumentsRequired (this.id + ' editOrder() does not support changing the order type. Cancel and recreate the order if you need to change the order type');
         }
         if (side !== undefined) {
-            throw new ArgumentsRequired (this.id + ' editOrder() side changing is not implemented. Try to cancel & recreate order if you need to change side');
+            throw new ArgumentsRequired (this.id + ' editOrder() does not support changing the order side. Cancel and recreate order if you need to change the order side');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1945,18 +1945,14 @@ module.exports = class phemex extends Exchange {
         } else {
             request['orderID'] = id;
         }
-        const finalPrice = this.safeString (params, 'priceEp');
-        params = this.omit (params, [ 'priceEp' ]);
-        if (finalPrice !== undefined) {
-            request['priceEp'] = this.priceToPrecision (symbol, finalPrice);
-        } else if (price !== undefined) {
+        if (price !== undefined) {
             request['priceEp'] = this.toEp (price, market);
         }
-        const finalQty = this.safeString2 (params, 'baseQtyEv', 'baseQtyEV');
-        params = this.omit (params, [ 'baseQtyEv', 'baseQtyEV' ]);
-        // Note the uppercase 'V' in 'baseQtyEV' request. that is exchange's requirement at this moment.
+        // Note the uppercase 'V' in 'baseQtyEV' request. that is exchange's requirement at this moment. However, to avoid mistakes from user side, let's support lowercased 'baseQtyEv' too
+        const finalQty = this.safeString (params, 'baseQtyEv');
+        params = this.omit (params, [ 'baseQtyEv' ]);
         if (finalQty !== undefined) {
-            request['baseQtyEV'] = this.amountToPrecision (symbol, finalQty);
+            request['baseQtyEV'] = finalQty;
         } else if (amount !== undefined) {
             request['baseQtyEV'] = this.toEv (amount, market);
         }


### PR DESCRIPTION
Implemented editorder

(btw, might need revision whether my used `market['valueScale']` is the one that needs to be used there. Phemex had a bit complex structure & insufficient docs to find the explanation of all params, which I could used for creating editorder).

[ fixes #10073 ] 