### PR TITLE
binance.fetchOHLCV check interval safely

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1909,8 +1909,12 @@ module.exports = class binance extends Exchange {
         const price = this.safeString (params, 'price');
         params = this.omit (params, 'price');
         limit = (limit === undefined) ? defaultLimit : Math.min (limit, maxLimit);
+        const interval = this.safeString (this.timeframes, timeframe);
+        if (interval === undefined) {
+            throw new BadRequest (this.id + ' does not have timeframe ' + timeframe);
+        }
         const request = {
-            'interval': this.timeframes[timeframe],
+            'interval': interval,
             'limit': limit,
         };
         if (price === 'index') {


### PR DESCRIPTION
When timeframe is skipped as a parameter, the previous error message was

```
% binance fetchOHLCV BTC/USDT 1516792801000 1
2021-12-16T22:04:20.503Z
Node.js: v14.17.0
CCXT v1.63.97
binance.fetchOHLCV (BTC/USDT, 1516792801000, 1)
BadRequest binance {"code":-1102,"msg":"Mandatory parameter 'interval' was not sent, was empty/null, or malformed."}
---------------------------------------------------
[BadRequest] binance {"code":-1102,"msg":"Mandatory parameter 'interval' was not sent, was empty/null, or malformed."}

    at throwExactlyMatchedException  ../../ccxt/ccxt/js/base/Exchange.js:593        throw new exact[string] (message)                                               
    at handleErrors                  ../../ccxt/ccxt/js/binance.js:4814             this.throwExactlyMatchedException (this.exceptions['exact'], error, feedback);  
    at                               ../../ccxt/ccxt/js/base/Exchange.js:670        this.handleErrors (response.status, response.statusText, url, method, responseH…
    at processTicksAndRejections     internal/process/task_queues.js:95                                                                                             
    at async timeout                 ../../ccxt/ccxt/js/base/functions/time.js:203  return await Promise.race ([promise, expires.then (() => { throw new TimedOut (…
    at request                       ../../ccxt/ccxt/js/binance.js:4841             const response = await this.fetch2 (path, api, method, params, headers, body, c…
    at fetchOHLCV                    ../../ccxt/ccxt/js/binance.js:1952             const response = await this[method] (this.extend (request, params));            
    at async main                    ../../ccxt/ccxt/examples/js/cli.js:246         const result = await exchange[methodName] (... args)                            

binance {"code":-1102,"msg":"Mandatory parameter 'interval' was not sent, was empty/null, or malformed."}
```

The new error message is
```
2021-12-16T22:07:54.704Z
Node.js: v14.17.0
CCXT v1.63.97
binance.fetchOHLCV (BTC/USDT, 1516792801000, 1)
BadRequest binance does not have timeframe 1516792801000
---------------------------------------------------
[BadRequest] binance does not have timeframe 1516792801000

    at fetchOHLCV                 ../../ccxt/ccxt/js/binance.js:1914      throw new BadRequest (this.id + ' does not have timeframe ' + timeframe);
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                               
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:246  const result = await exchange[methodName] (... args)                     

binance does not have timeframe 1516792801000
```