### PR TITLE
binance fetchOrderTrades for spot markets

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -49,6 +49,7 @@ module.exports = class binance extends Exchange {
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchOrderTrades': true,
                 'fetchPositions': true,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
@@ -2753,6 +2754,17 @@ module.exports = class binance extends Exchange {
         } else {
             return response;
         }
+    }
+
+    async fetchOrderTrades (id, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+            'orderId': id,
+        };
+        const response = await this.privateGetMyTrades (this.extend (request, params));
+        return this.parseTrades (response, market);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/binance.js
+++ b/js/binance.js
@@ -2757,6 +2757,17 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchOrderTrades (id, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchOrderTrades() requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const type = this.safeString (params, 'type', market['type']);
+        params = this.omit (params, 'type');
+        let method = undefined;
+        if (type !== 'spot') {
+            throw new NotSupported (this.id + ' fetchOrderTrades() supports spot markets only');
+        }
         const request = {
             'orderId': id,
         };
@@ -2769,8 +2780,7 @@ module.exports = class binance extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const defaultType = this.safeString2 (this.options, 'fetchMyTrades', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
+        const type = this.safeString (params, 'type', market['type']);
         params = this.omit (params, 'type');
         let method = undefined;
         if (type === 'spot') {

--- a/js/binance.js
+++ b/js/binance.js
@@ -2764,7 +2764,6 @@ module.exports = class binance extends Exchange {
         const market = this.market (symbol);
         const type = this.safeString (params, 'type', market['type']);
         params = this.omit (params, 'type');
-        let method = undefined;
         if (type !== 'spot') {
             throw new NotSupported (this.id + ' fetchOrderTrades() supports spot markets only');
         }

--- a/js/binance.js
+++ b/js/binance.js
@@ -2757,14 +2757,10 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchOrderTrades (id, symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        await this.loadMarkets ();
-        const market = this.market (symbol);
         const request = {
-            'symbol': market['id'],
             'orderId': id,
         };
-        const response = await this.privateGetMyTrades (this.extend (request, params));
-        return this.parseTrades (response, market);
+        return await this.fetchMyTrades (symbol, since, limit, this.extend (request, params));
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Binance allow get trades list for order when input `orderId` to `myTrades` API

Ref: https://binance-docs.github.io/apidocs/spot/en/#account-trade-list-user_data