### PR TITLE
adding ability use parameter for Rounding 

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -42,7 +42,7 @@ const { // eslint-disable-line object-curly-newline
     , ExchangeNotAvailable
     , RateLimitExceeded } = require ('./errors')
 
-const { TRUNCATE, ROUND, DECIMAL_PLACES, NO_PADDING } = functions.precisionConstants
+const precisionConstants = functions.precisionConstants
 
 const BN = require ('../static_dependencies/BN/bn')
 const Precise = require ('./Precise')
@@ -186,8 +186,8 @@ module.exports = class Exchange {
                 'BCHABC': 'BCH',
                 'BCHSV': 'BSV',
             },
-            'precisionMode': DECIMAL_PLACES,
-            'paddingMode': NO_PADDING,
+            'precisionMode': precisionConstants.DECIMAL_PLACES,
+            'paddingMode': precisionConstants.NO_PADDING,
             'limits': {
                 'amount': { 'min': undefined, 'max': undefined },
                 'price': { 'min': undefined, 'max': undefined },
@@ -1470,28 +1470,28 @@ module.exports = class Exchange {
         return this.createOrder (symbol, 'market', 'sell', amount, undefined, params)
     }
 
-    costToPrecision (symbol, cost) {
+    costToPrecision (symbol, cost, roundingMode = 'TRUNCATE') {
         const market = this.market (symbol)
-        return decimalToPrecision (cost, TRUNCATE, market.precision.price, this.precisionMode, this.paddingMode)
+        return decimalToPrecision (cost, precisionConstants[roundingMode], market.precision.price, this.precisionMode, this.paddingMode)
     }
 
-    priceToPrecision (symbol, price) {
+    priceToPrecision (symbol, price, roundingMode = 'ROUND') {
         const market = this.market (symbol)
-        return decimalToPrecision (price, ROUND, market.precision.price, this.precisionMode, this.paddingMode)
+        return decimalToPrecision (price, precisionConstants[roundingMode], market.precision.price, this.precisionMode, this.paddingMode)
     }
 
-    amountToPrecision (symbol, amount) {
+    amountToPrecision (symbol, amount, roundingMode = 'TRUNCATE') {
         const market = this.market (symbol)
-        return decimalToPrecision (amount, TRUNCATE, market.precision.amount, this.precisionMode, this.paddingMode)
+        return decimalToPrecision (amount, precisionConstants[roundingMode], market.precision.amount, this.precisionMode, this.paddingMode)
     }
 
-    feeToPrecision (symbol, fee) {
+    feeToPrecision (symbol, fee, roundingMode = 'ROUND') {
         const market = this.market (symbol)
-        return decimalToPrecision (fee, ROUND, market.precision.price, this.precisionMode, this.paddingMode)
+        return decimalToPrecision (fee, precisionConstants[roundingMode], market.precision.price, this.precisionMode, this.paddingMode)
     }
 
-    currencyToPrecision (currency, fee) {
-        return decimalToPrecision (fee, ROUND, this.currencies[currency]['precision'], this.precisionMode, this.paddingMode);
+    currencyToPrecision (currency, fee, roundingMode = 'ROUND') {
+        return decimalToPrecision (fee, precisionConstants[roundingMode], this.currencies[currency]['precision'], this.precisionMode, this.paddingMode);
     }
 
     calculateFee (symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2545,28 +2545,28 @@ class Exchange {
         return (count($parts) > 1) ? strlen($parts[1]) : 0;
     }
 
-    public function cost_to_precision($symbol, $cost) {
+    public function cost_to_precision($symbol, $cost, $roundingMode = 'TRUNCATE') {
         $market = $this->market($symbol);
-        return self::decimal_to_precision($cost, TRUNCATE, $market['precision']['price'], $this->precisionMode, $this->paddingMode);
+        return self::decimal_to_precision($cost, constant($roundingMode), $market['precision']['price'], $this->precisionMode, $this->paddingMode);
     }
 
-    public function price_to_precision($symbol, $price) {
+    public function price_to_precision($symbol, $price, $roundingMode = 'ROUND') {
         $market = $this->market($symbol);
-        return self::decimal_to_precision($price, ROUND, $market['precision']['price'], $this->precisionMode, $this->paddingMode);
+        return self::decimal_to_precision($price, constant($roundingMode), $market['precision']['price'], $this->precisionMode, $this->paddingMode);
     }
 
-    public function amount_to_precision($symbol, $amount) {
+    public function amount_to_precision($symbol, $amount, $roundingMode = 'TRUNCATE') {
         $market = $this->market($symbol);
-        return self::decimal_to_precision($amount, TRUNCATE, $market['precision']['amount'], $this->precisionMode, $this->paddingMode);
+        return self::decimal_to_precision($amount, constant($roundingMode), $market['precision']['amount'], $this->precisionMode, $this->paddingMode);
     }
 
-    public function fee_to_precision($symbol, $fee) {
+    public function fee_to_precision($symbol, $fee, $roundingMode = 'ROUND') {
         $market = $this->market($symbol);
-        return self::decimalToPrecision($fee, ROUND, $market['precision']['price'], $this->precisionMode, $this->paddingMode);
+        return self::decimalToPrecision($fee, constant($roundingMode), $market['precision']['price'], $this->precisionMode, $this->paddingMode);
     }
 
-    public function currency_to_precision($currency, $fee) {
-        return self::decimal_to_precision($fee, ROUND, $this->currencies[$currency]['precision'], $this->precisionMode, $this->paddingMode);
+    public function currency_to_precision($currency, $fee, $roundingMode = 'ROUND') {
+        return self::decimal_to_precision($fee, constant($roundingMode), $this->currencies[$currency]['precision'], $this->precisionMode, $this->paddingMode);
     }
 
     public function currency($code) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -107,6 +107,7 @@ except ImportError:
 
 # -----------------------------------------------------------------------------
 
+globalVars = globals()
 
 class Exchange(object):
     """Base exchange class"""
@@ -1353,24 +1354,24 @@ class Exchange(object):
         parts = re.sub(r'0+$', '', string).split('.')
         return len(parts[1]) if len(parts) > 1 else 0
 
-    def cost_to_precision(self, symbol, cost):
+    def cost_to_precision(self, symbol, cost, roundingMode='TRUNCATE'):
         market = self.market(symbol)
-        return self.decimal_to_precision(cost, TRUNCATE, market['precision']['price'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(cost, globalVars[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
 
-    def price_to_precision(self, symbol, price):
+    def price_to_precision(self, symbol, price, roundingMode='ROUND'):
         market = self.market(symbol)
-        return self.decimal_to_precision(price, ROUND, market['precision']['price'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(price, globalVars[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
 
-    def amount_to_precision(self, symbol, amount):
+    def amount_to_precision(self, symbol, amount, roundingMode='TRUNCATE'):
         market = self.market(symbol)
-        return self.decimal_to_precision(amount, TRUNCATE, market['precision']['amount'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(amount, globalVars[roundingMode], market['precision']['amount'], self.precisionMode, self.paddingMode)
 
-    def fee_to_precision(self, symbol, fee):
+    def fee_to_precision(self, symbol, fee, roundingMode='ROUND'):
         market = self.market(symbol)
-        return self.decimal_to_precision(fee, ROUND, market['precision']['price'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(fee, globalVars[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
 
-    def currency_to_precision(self, currency, fee):
-        return self.decimal_to_precision(fee, ROUND, self.currencies[currency]['precision'], self.precisionMode, self.paddingMode)
+    def currency_to_precision(self, currency, fee, roundingMode='ROUND'):
+        return self.decimal_to_precision(fee, globalVars[roundingMode], self.currencies[currency]['precision'], self.precisionMode, self.paddingMode)
 
     def set_markets(self, markets, currencies=None):
         values = list(markets.values()) if type(markets) is dict else markets

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -107,13 +107,11 @@ except ImportError:
 
 # -----------------------------------------------------------------------------
 
-try
-    globalVars = globals()
-except
-    globalVars = {
-        'TRUNCATE': TRUNCATE,
-        'ROUND': ROUND,
-    }
+rounding_modes = {
+    'TRUNCATE': TRUNCATE,
+    'ROUND': ROUND,
+}
+
 
 class Exchange(object):
     """Base exchange class"""
@@ -1362,22 +1360,22 @@ class Exchange(object):
 
     def cost_to_precision(self, symbol, cost, roundingMode='TRUNCATE'):
         market = self.market(symbol)
-        return self.decimal_to_precision(cost, globalVars[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(cost, rounding_modes[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
 
     def price_to_precision(self, symbol, price, roundingMode='ROUND'):
         market = self.market(symbol)
-        return self.decimal_to_precision(price, globalVars[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(price, rounding_modes[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
 
     def amount_to_precision(self, symbol, amount, roundingMode='TRUNCATE'):
         market = self.market(symbol)
-        return self.decimal_to_precision(amount, globalVars[roundingMode], market['precision']['amount'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(amount, rounding_modes[roundingMode], market['precision']['amount'], self.precisionMode, self.paddingMode)
 
     def fee_to_precision(self, symbol, fee, roundingMode='ROUND'):
         market = self.market(symbol)
-        return self.decimal_to_precision(fee, globalVars[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(fee, rounding_modes[roundingMode], market['precision']['price'], self.precisionMode, self.paddingMode)
 
     def currency_to_precision(self, currency, fee, roundingMode='ROUND'):
-        return self.decimal_to_precision(fee, globalVars[roundingMode], self.currencies[currency]['precision'], self.precisionMode, self.paddingMode)
+        return self.decimal_to_precision(fee, rounding_modes[roundingMode], self.currencies[currency]['precision'], self.precisionMode, self.paddingMode)
 
     def set_markets(self, markets, currencies=None):
         values = list(markets.values()) if type(markets) is dict else markets

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -107,7 +107,13 @@ except ImportError:
 
 # -----------------------------------------------------------------------------
 
-globalVars = globals()
+try
+    globalVars = globals()
+except
+    globalVars = {
+        'TRUNCATE': TRUNCATE,
+        'ROUND': ROUND,
+    }
 
 class Exchange(object):
     """Base exchange class"""


### PR DESCRIPTION
I think there is no disadvantage to use additional argument for 'roundingMode' (this way might be better than the exchange-scope property, as roundings are done for different functions differently).

 [ fix #10065 ]