### PR TITLE
Private API sentence & same-exchange examples

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1244,8 +1244,8 @@ To get a list of all available methods with an exchange instance, including impl
 
 ```text
 console.log (new ccxt.kraken ())   // JavaScript
-print(dir(ccxt.hitbtc()))           # Python
-var_dump (new \ccxt\okcoinusd ()); // PHP
+print(dir(ccxt.kraken()))           # Python
+var_dump (new \ccxt\kraken ()); // PHP
 ```
 
 ## Public/Private API
@@ -1264,9 +1264,7 @@ Public APIs include the following:
 - OHLCV series for charting
 - other public endpoints
 
-For trading with private API you need to obtain API keys from/to exchanges. It often means registering with exchanges and creating API keys with your account. Most exchanges require personal info or identification. Some kind of verification may be necessary as well.
-
-If you want to trade you need to register yourself, this library will not create accounts or API keys for you. Some exchange APIs expose interface methods for registering an account from within the code itself, but most of exchanges don't. You have to sign up and create API keys with their websites.
+A private API is mostly used to access account-specific, personal data and require authentication. To use private API you need to obtain API keys from/to exchanges. For that, in most cases, you will need to register with exchanges and create API keys with your account ( CCXT will not create accounts or API keys for you ). Most exchanges require personal info or identification, or sometimes even a verification.
 
 Private APIs allow the following:
 
@@ -1289,8 +1287,8 @@ To get a list of all available methods with an exchange instance, you can simply
 
 ```text
 console.log (new ccxt.kraken ())   // JavaScript
-print(dir(ccxt.hitbtc()))           # Python
-var_dump (new \ccxt\okcoinusd ()); // PHP
+print(dir(ccxt.kraken()))           # Python
+var_dump (new \ccxt\kraken ()); // PHP
 ```
 
 ## Synchronous vs Asynchronous Calls

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1264,8 +1264,7 @@ Public APIs include the following:
 - OHLCV series for charting
 - other public endpoints
 
-A private API is mostly used to access account-specific, personal data and require authentication. To use private API you need to obtain API keys from/to exchanges. For that, in most cases, you will need to register with exchanges and create API keys with your account ( CCXT will not create accounts or API keys for you ). Most exchanges require personal info or identification, or sometimes even a verification.
-
+The private API is mostly used for trading and for accessing account-specific private data, therefore it requires authentication. You have to get the private API keys from the exchanges. It often means registering with an exchange website and creating the API keys for your account. Most exchanges require personal information or identification. Some exchanges will only allow trading after completing the KYC verification.
 Private APIs allow the following:
 
 - manage personal account info


### PR DESCRIPTION
- trimmed the same idea into one paragraph.
- about examples with same exchange names - as the main purpose is to compare just programming languages, it's better for emphasize to be the same example-names (so, noone will think that different kind of initialization is written there because of different exchange names).
but that's just my thought.