### PR TITLE
ftx: add fetchOrderTrades

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -63,6 +63,7 @@ module.exports = class ftx extends Exchange {
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchOrderTrades': true,
                 'fetchPositions': true,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
@@ -1694,6 +1695,13 @@ module.exports = class ftx extends Exchange {
         //
         const result = this.safeValue (response, 'result', []);
         return this.parseOrders (result, market, since, limit);
+    }
+
+    async fetchOrderTrades (id, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'orderId': id,
+        };
+        return await this.fetchMyTrades (symbol, since, limit, this.extend (request, params));
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Same as #10925 

I implement new method `fetchOrderTrades` for `ftx`.
Just add `orderId` to parameter.

Ref: https://docs.ftx.com/#fills