### PR TITLE
Bitvavo.fetchMarkets properties match unified structure

### DIFF
--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -321,8 +321,8 @@ module.exports = class bitvavo extends Exchange {
                 },
                 'limits': {
                     'leverage': {
-                        'min': this.parseNumber ('1'),
-                        'max': this.parseNumber ('1'),
+                        'min': undefined,
+                        'max': undefined,
                     },
                     'amount': {
                         'min': this.safeNumber (market, 'minOrderInBaseAsset'),

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -282,31 +282,48 @@ module.exports = class bitvavo extends Exchange {
             const quoteId = this.safeString (market, 'quote');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const symbol = base + '/' + quote;
             const status = this.safeString (market, 'status');
-            const active = (status === 'trading');
             const baseCurrency = this.safeValue (currenciesById, baseId);
             let amountPrecision = undefined;
             if (baseCurrency !== undefined) {
                 amountPrecision = this.safeInteger (baseCurrency, 'decimals', 8);
             }
-            const precision = {
-                'price': this.safeInteger (market, 'pricePrecision'),
-                'amount': amountPrecision,
-            };
             result.push ({
                 'id': id,
-                'symbol': symbol,
+                'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
+                'settle': undefined,
                 'baseId': baseId,
                 'quoteId': quoteId,
-                'info': market,
+                'settleId': undefined,
                 'type': 'spot',
                 'spot': true,
-                'active': active,
-                'precision': precision,
+                'margin': false,
+                'swap': false,
+                'future': false,
+                'option': false,
+                'derivative': false,
+                'contract': false,
+                'linear': undefined,
+                'inverse': undefined,
+                'taker': undefined,
+                'maker': undefined,
+                'contractSize': undefined,
+                'active': (status === 'trading'),
+                'expiry': undefined,
+                'expiryDatetime': undefined,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'price': this.safeInteger (market, 'pricePrecision'),
+                    'amount': amountPrecision,
+                },
                 'limits': {
+                    'leverage': {
+                        'min': this.parseNumber ('1'),
+                        'max': this.parseNumber ('1'),
+                    },
                     'amount': {
                         'min': this.safeNumber (market, 'minOrderInBaseAsset'),
                         'max': undefined,
@@ -320,6 +337,7 @@ module.exports = class bitvavo extends Exchange {
                         'max': undefined,
                     },
                 },
+                'info': market,
             });
         }
         return result;


### PR DESCRIPTION
```
% bitvavo fetchMarkets 
2021-12-20T11:43:05.878Z
Node.js: v14.17.0
CCXT v1.64.39
bitvavo.fetchMarkets ()
1452 ms
        id |     symbol |   base | quote | settle | baseId | quoteId | settleId | type | spot | margin |  swap | future | option | derivative | contract | linear | inverse | taker | maker | contractSize | active | expiry | expiryDatetime | strike | optionType |              precision |                                                                                limits
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1INCH-EUR |  1INCH/EUR |  1INCH |   EUR |        |  1INCH |     EUR |          | spot | true |  false | false |  false |  false |      false |    false |        |         |       |       |              |   true |        |                |        |            | {"price":5,"amount":8} |         {"leverage":{"min":1,"max":1},"amount":{"min":2},"price":{},"cost":{"min":5}}
...
   ZRX-BTC |    ZRX/BTC |    ZRX |   BTC |        |    ZRX |     BTC |          | spot | true |  false | false |  false |  false |      false |    false |        |         |       |       |              |  false |        |                |        |            | {"price":5,"amount":8} |     {"leverage":{"min":1,"max":1},"amount":{"min":7},"price":{},"cost":{"min":0.001}}
   ZRX-EUR |    ZRX/EUR |    ZRX |   EUR |        |    ZRX |     EUR |          | spot | true |  false | false |  false |  false |      false |    false |        |         |       |       |              |   true |        |                |        |            | {"price":5,"amount":8} |         {"leverage":{"min":1,"max":1},"amount":{"min":3},"price":{},"cost":{"min":5}}
221 objects
```