### PR TITLE
Ascendex fetchFundingRate()

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1721,10 +1721,7 @@ module.exports = class ascendex extends Exchange {
         const currentTime = this.safeInteger (fundingRate, 'time');
         const nextFundingRate = this.safeNumber (fundingRate, 'fundingRate');
         const nextFundingRateTimestamp = this.safeInteger (fundingRate, 'nextFundingTime');
-        let previousFundingTimestamp = undefined;
-        if (nextFundingRateTimestamp !== undefined) {
-            previousFundingTimestamp = nextFundingRateTimestamp - 28800000;
-        }
+        const previousFundingTimestamp = undefined;
         return {
             'info': fundingRate,
             'symbol': symbol,
@@ -1744,9 +1741,6 @@ module.exports = class ascendex extends Exchange {
     }
 
     async fetchFundingRate (symbol, params = {}) {
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchFundingRate() requires a symbol argument');
-        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
@@ -1768,22 +1762,7 @@ module.exports = class ascendex extends Exchange {
         //                      "nextFundingTime": 1640073600000
         //                  },
         //                  {
-        //                      "time": 1640061364633,
-        //                      "symbol": "AKT-PERP",
-        //                      "markPrice": "1.433190832",
-        //                      "indexPrice": "1.43317",
-        //                      "openInterest": "58154",
-        //                      "fundingRate": "0.000014439",
-        //                      "nextFundingTime": 1640073600000
-        //                  },
-        //                  {
-        //                      "time": 1640061364701,
-        //                      "symbol": "BNB-PERP",
-        //                      "markPrice": "531.437102256",
-        //                      "indexPrice": "531.1",
-        //                      "openInterest": "817.22",
-        //                      "fundingRate": "0.000634599",
-        //                      "nextFundingTime":1640073600000
+        //                              ...
         //                  }
         //              ],
         //              "collaterals": [
@@ -1792,12 +1771,7 @@ module.exports = class ascendex extends Exchange {
         //                      "referencePrice": "1"
         //                  },
         //                  {
-        //                      "asset": "KAVA-S",
-        //                      "referencePrice": "3.559"
-        //                  },
-        //                  {
-        //                      "asset": "SRM",
-        //                      "referencePrice": "3.456515"
+        //                              ...
         //                  }
         //              ]
         //          }

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -28,6 +28,7 @@ module.exports = class ascendex extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
+                'fetchFundingRate': true,
                 'fetchMarkets': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
@@ -1715,6 +1716,8 @@ module.exports = class ascendex extends Exchange {
         //     nextFundingTime: "1640102400000"
         // }
         //
+        const marketId = this.safeString (fundingRate, 'symbol');
+        const symbol = this.safeSymbol (marketId, market);
         const currentTime = this.safeInteger (fundingRate, 'time');
         const nextFundingRate = this.safeNumber (fundingRate, 'fundingRate');
         const nextFundingRateTimestamp = this.safeInteger (fundingRate, 'nextFundingTime');
@@ -1724,7 +1727,7 @@ module.exports = class ascendex extends Exchange {
         }
         return {
             'info': fundingRate,
-            'symbol': market['id'],
+            'symbol': symbol,
             'markPrice': this.safeNumber (fundingRate, 'markPrice'),
             'indexPrice': this.safeNumber (fundingRate, 'indexPrice'),
             'interestRate': this.parseNumber ('0'),

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1706,33 +1706,15 @@ module.exports = class ascendex extends Exchange {
 
     parseFundingRate (fundingRate, market = undefined) {
         //
-        // {
-        //     'EOS/USDT:USDT': {
-        //         info: {
-        //             time: "1640148724831",
-        //             symbol: "EOS-PERP",
-        //             markPrice: "3.358762969",
-        //             indexPrice: "3.3589",
-        //             openInterest: "14147",
-        //             fundingRate: "-0.000041038",
-        //             nextFundingTime: "1640160000000"
-        //         },
-        //             symbol:   "EOS/USDT:USDT",
-        //             markPrice:    3.358762969,
-        //             indexPrice:    3.3589,
-        //             interestRate:    0,
-        //             estimatedSettlePrice:    undefined,
-        //             timestamp:    1640148724831,
-        //             datetime:   "2021-12-22T04:52:04.831Z",
-        //             previousFundingRate:    undefined,
-        //             nextFundingRate:    -0.000041038,
-        //             previousFundingTimestamp:    undefined,
-        //             nextFundingTimestamp:    1640160000000,
-        //             previousFundingDatetime:    undefined,
-        //             nextFundingDatetime:   "2021-12-22T08:00:00.000Z"
-        //     },
-        //                      ...
-        // }
+        //      {
+        //          "time": 1640061364830,
+        //          "symbol": "EOS-PERP",
+        //          "markPrice": "3.353854865",
+        //          "indexPrice": "3.3542",
+        //          "openInterest": "14242",
+        //          "fundingRate": "-0.000073026",
+        //          "nextFundingTime": 1640073600000
+        //      }
         //
         const marketId = this.safeString (fundingRate, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
@@ -1775,18 +1757,12 @@ module.exports = class ascendex extends Exchange {
         //                      "fundingRate": "-0.000073026",
         //                      "nextFundingTime": 1640073600000
         //                  },
-        //                  {
-        //                              ...
-        //                  }
         //              ],
         //              "collaterals": [
         //                  {
         //                      "asset": "USDTR",
         //                      "referencePrice": "1"
         //                  },
-        //                  {
-        //                              ...
-        //                  }
         //              ]
         //          }
         //      }

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1760,10 +1760,7 @@ module.exports = class ascendex extends Exchange {
 
     async fetchFundingRates (symbols, params = {}) {
         await this.loadMarkets ();
-        const request = {
-            // 'symbol': market['id'],
-        };
-        const response = await this.v2PublicGetFuturesPricingData (this.extend (request, params));
+        const response = await this.v2PublicGetFuturesPricingData (params);
         //
         //     {
         //          "code": 0,

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -28,7 +28,7 @@ module.exports = class ascendex extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
-                'fetchFundingRate': true,
+                'fetchFundingRates': true,
                 'fetchMarkets': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
@@ -1707,13 +1707,31 @@ module.exports = class ascendex extends Exchange {
     parseFundingRate (fundingRate, market = undefined) {
         //
         // {
-        //     time: "1640078764560",
-        //     symbol: "BTC-PERP",
-        //     markPrice: "48499.644083351",
-        //     indexPrice: "48530.35",
-        //     openInterest: "252.1125",
-        //     fundingRate: "-0.000631045",
-        //     nextFundingTime: "1640102400000"
+        //     'EOS/USDT:USDT': {
+        //         info: {
+        //             time: "1640148724831",
+        //             symbol: "EOS-PERP",
+        //             markPrice: "3.358762969",
+        //             indexPrice: "3.3589",
+        //             openInterest: "14147",
+        //             fundingRate: "-0.000041038",
+        //             nextFundingTime: "1640160000000"
+        //         },
+        //             symbol:   "EOS/USDT:USDT",
+        //             markPrice:    3.358762969,
+        //             indexPrice:    3.3589,
+        //             interestRate:    0,
+        //             estimatedSettlePrice:    undefined,
+        //             timestamp:    1640148724831,
+        //             datetime:   "2021-12-22T04:52:04.831Z",
+        //             previousFundingRate:    undefined,
+        //             nextFundingRate:    -0.000041038,
+        //             previousFundingTimestamp:    undefined,
+        //             nextFundingTimestamp:    1640160000000,
+        //             previousFundingDatetime:    undefined,
+        //             nextFundingDatetime:   "2021-12-22T08:00:00.000Z"
+        //     },
+        //                      ...
         // }
         //
         const marketId = this.safeString (fundingRate, 'symbol');
@@ -1740,11 +1758,10 @@ module.exports = class ascendex extends Exchange {
         };
     }
 
-    async fetchFundingRate (symbol, params = {}) {
+    async fetchFundingRates (symbols, params = {}) {
         await this.loadMarkets ();
-        const market = this.market (symbol);
         const request = {
-            'symbol': market['id'],
+            // 'symbol': market['id'],
         };
         const response = await this.v2PublicGetFuturesPricingData (this.extend (request, params));
         //
@@ -1779,9 +1796,8 @@ module.exports = class ascendex extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const contracts = this.safeValue (data, 'contracts', []);
-        const contractsBySymbol = this.indexBy (contracts, 'symbol');
-        const contract = this.safeValue (contractsBySymbol, market['id'], {});
-        return this.parseFundingRate (contract, market);
+        const result = this.parseFundingRates (contracts);
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     async setLeverage (leverage, symbol = undefined, params = {}) {


### PR DESCRIPTION
Created the fetchFundingRate() and parseFundingRate() methods.
```
node examples/js/cli ascendex fetchFundingRate BTC/USDT:USDT
ascendex.fetchFundingRate (BTC/USDT:USDT)
689 ms
{                     info: {            time: "1640080684563",
                                       symbol: "BTC-PERP",
                                    markPrice: "48578.40161195",
                                   indexPrice: "48614.05181619",
                                 openInterest: "252.1558",
                                  fundingRate: "-0.000710933",
                              nextFundingTime: "1640102400000"   },
                    symbol:   "BTC/USDT:USDT",
                 markPrice:    48578.40161195,
                indexPrice:    48614.05181619,
              interestRate:    0,
      estimatedSettlePrice:    undefined,
                 timestamp:    1640080684563,
                  datetime:   "2021-12-21T09:58:04.563Z",
       previousFundingRate:    undefined,
           nextFundingRate:    -0.000710933,
  previousFundingTimestamp:    1640073600000,
      nextFundingTimestamp:    1640102400000,
   previousFundingDatetime:   "2021-12-21T08:00:00.000Z",
       nextFundingDatetime:   "2021-12-21T16:00:00.000Z"            }
```