### PR TITLE
removed manually calculated previousFundingRate timestamps from fetchFundingRate

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4072,7 +4072,6 @@ module.exports = class binance extends Exchange {
         const estimatedSettlePrice = this.safeNumber (premiumIndex, 'estimatedSettlePrice');
         const nextFundingRate = this.safeNumber (premiumIndex, 'lastFundingRate');
         const nextFundingTime = this.safeInteger (premiumIndex, 'nextFundingTime');
-        const previousFundingTime = nextFundingTime - (8 * 3600000);
         return {
             'info': premiumIndex,
             'symbol': symbol,
@@ -4084,9 +4083,9 @@ module.exports = class binance extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'previousFundingRate': undefined,
             'nextFundingRate': nextFundingRate,
-            'previousFundingTimestamp': previousFundingTime, // subtract 8 hours
+            'previousFundingTimestamp': undefined,
             'nextFundingTimestamp': nextFundingTime,
-            'previousFundingDatetime': this.iso8601 (previousFundingTime),
+            'previousFundingDatetime': undefined,
             'nextFundingDatetime': this.iso8601 (nextFundingTime),
         };
     }

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2255,10 +2255,6 @@ module.exports = class ftx extends Exchange {
         const nextFundingRate = this.safeNumber (fundingRate, 'nextFundingRate');
         const nextFundingRateDatetimeRaw = this.safeString (fundingRate, 'nextFundingTime');
         const nextFundingRateTimestamp = this.parse8601 (nextFundingRateDatetimeRaw);
-        let previousFundingTimestamp = undefined;
-        if (nextFundingRateTimestamp !== undefined) {
-            previousFundingTimestamp = nextFundingRateTimestamp - 3600000;
-        }
         const estimatedSettlePrice = this.safeNumber (fundingRate, 'predictedExpirationPrice');
         return {
             'info': fundingRate,
@@ -2271,9 +2267,9 @@ module.exports = class ftx extends Exchange {
             'datetime': undefined,
             'previousFundingRate': undefined,
             'nextFundingRate': nextFundingRate,
-            'previousFundingTimestamp': previousFundingTimestamp, // subtract 8 hours
+            'previousFundingTimestamp': undefined,
             'nextFundingTimestamp': nextFundingRateTimestamp,
-            'previousFundingDatetime': this.iso8601 (previousFundingTimestamp),
+            'previousFundingDatetime': undefined,
             'nextFundingDatetime': this.iso8601 (nextFundingRateTimestamp),
         };
     }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1032,11 +1032,8 @@ module.exports = class gateio extends Exchange {
         const indexPrice = this.safeNumber (contract, 'index_price');
         const interestRate = this.safeNumber (contract, 'interest_rate');
         const fundingRate = this.safeString (contract, 'funding_rate');
-        const fundingInterval = this.safeString (contract, 'funding_interval') * 1000;
         const nextFundingTime = this.safeInteger (contract, 'funding_next_apply') * 1000;
-        const previousFundingTime = (this.safeNumber (contract, 'funding_next_apply') * 1000) - fundingInterval;
         const fundingRateIndicative = this.safeNumber (contract, 'funding_rate_indicative');
-        const timestamp = this.milliseconds ();
         return {
             'info': contract,
             'symbol': symbol,
@@ -1044,13 +1041,13 @@ module.exports = class gateio extends Exchange {
             'indexPrice': indexPrice,
             'interestRate': interestRate,
             'estimatedSettlePrice': undefined,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'previousFundingRate': fundingRate,
             'nextFundingRate': fundingRateIndicative,
-            'previousFundingTimestamp': previousFundingTime,
+            'previousFundingTimestamp': undefined,
             'nextFundingTimestamp': nextFundingTime,
-            'previousFundingDatetime': this.iso8601 (previousFundingTime),
+            'previousFundingDatetime': undefined,
             'nextFundingDatetime': this.iso8601 (nextFundingTime),
         };
     }

--- a/js/okex.js
+++ b/js/okex.js
@@ -3279,11 +3279,6 @@ module.exports = class okex extends Exchange {
         // in the response above nextFundingRate is actually two funding rates from now
         //
         const nextFundingRateTimestamp = this.safeInteger (fundingRate, 'fundingTime');
-        let previousFundingTimestamp = undefined;
-        if (nextFundingRateTimestamp !== undefined) {
-            // eight hours
-            previousFundingTimestamp = nextFundingRateTimestamp - 28800000;
-        }
         const marketId = this.safeString (fundingRate, 'instId');
         const symbol = this.safeSymbol (marketId, market);
         const nextFundingRate = this.safeNumber (fundingRate, 'fundingRate');
@@ -3300,9 +3295,9 @@ module.exports = class okex extends Exchange {
             'datetime': undefined,
             'previousFundingRate': undefined,
             'nextFundingRate': nextFundingRate,
-            'previousFundingTimestamp': previousFundingTimestamp, // subtract 8 hours
+            'previousFundingTimestamp': undefined,
             'nextFundingTimestamp': nextFundingRateTimestamp,
-            'previousFundingDatetime': this.iso8601 (previousFundingTimestamp),
+            'previousFundingDatetime': undefined,
             'nextFundingDatetime': this.iso8601 (nextFundingRateTimestamp),
         };
     }


### PR DESCRIPTION
```
2021-12-21T14:18:45.037Z
Node.js: v14.17.0
CCXT v1.64.49

% gateio fetchFundingRate ETH/USDT:USDT
gateio.fetchFundingRate (ETH/USDT:USDT)
170 ms
{                     info: { funding_rate_indicative: "0.0001",
                                     mark_price_round: "0.01",
                                       funding_offset: "0",
                                         in_delisting:  false,
                                      risk_limit_base: "500000",
                                        interest_rate: "0.0003",
                                          index_price: "3994.05",
                                    order_price_round: "0.05",
                                       order_size_min: "1",
                                      ref_rebate_rate: "0.2",
                                                 name: "ETH_USDT",
                                    ref_discount_rate: "0",
                                  order_price_deviate: "0.5",
                                     maintenance_rate: "0.005",
                                            mark_type: "index",
                                     funding_interval: "28800",
                                                 type: "direct",
                                      risk_limit_step: "500000",
                                         enable_bonus:  true,
                                         leverage_min: "1",
                                         funding_rate: "0.0001",
                                           last_price: "3994.95",
                                           mark_price: "3994.13",
                                       order_size_max: "1000000",
                                   funding_next_apply: "1640102400",
                                          short_users: "2955",
                                   config_change_time: "1626945369",
                                           trade_size: "9974815589",
                                        position_size: "7856996",
                                           long_users: "2981",
                                    quanto_multiplier: "0.01",
                                 funding_impact_value: "20000",
                                         leverage_max: "100",
                                       risk_limit_max: "10000000",
                                       maker_fee_rate: "-0.00025",
                                       taker_fee_rate: "0.00075",
                                         orders_limit: "50",
                                             trade_id: "52429851",
                                         orderbook_id: "10296073371" },
                    symbol:   "ETH/USDT:USDT",
                 markPrice:    3994.13,
                indexPrice:    3994.05,
              interestRate:    0.0003,
      estimatedSettlePrice:    undefined,
                 timestamp:    1640096326281,
                  datetime:   "2021-12-21T14:18:46.281Z",
       previousFundingRate:   "0.0001",
           nextFundingRate:    0.0001,
  previousFundingTimestamp:    1640073600000,
      nextFundingTimestamp:    1640102400000,
   previousFundingDatetime:   "2021-12-21T08:00:00.000Z",
       nextFundingDatetime:   "2021-12-21T16:00:00.000Z"                }

% okex fetchFundingRate ETH/USDT:USDT  
okex.fetchFundingRate (ETH/USDT:USDT)
626 ms
{                     info: {     fundingRate: "0.00016065",
                                  fundingTime: "1640102400000",
                                       instId: "ETH-USDT-SWAP",
                                     instType: "SWAP",
                              nextFundingRate: "0.00015",
                              nextFundingTime: "1640131200000"  },
                    symbol:   "ETH/USDT:USDT",
                 markPrice:    undefined,
                indexPrice:    undefined,
              interestRate:    0,
      estimatedSettlePrice:    undefined,
                 timestamp:    undefined,
                  datetime:    undefined,
       previousFundingRate:    undefined,
           nextFundingRate:    0.00016065,
  previousFundingTimestamp:    1640073600000,
      nextFundingTimestamp:    1640102400000,
   previousFundingDatetime:   "2021-12-21T08:00:00.000Z",
       nextFundingDatetime:   "2021-12-21T16:00:00.000Z"           }

% binanceusdm fetchFundingRate ETH/USDT
binanceusdm.fetchFundingRate (ETH/USDT)
175 ms
{                     info: {               symbol: "ETHUSDT",
                                         markPrice: "3996.56872714",
                                        indexPrice: "3996.25692648",
                              estimatedSettlePrice: "4005.35953914",
                                   lastFundingRate: "0.00010000",
                                      interestRate: "0.00010000",
                                   nextFundingTime: "1640102400000",
                                              time: "1640096340005"  },
                    symbol:   "ETH/USDT",
                 markPrice:    3996.56872714,
                indexPrice:    3996.25692648,
              interestRate:    0.0001,
      estimatedSettlePrice:    4005.35953914,
                 timestamp:    1640096340005,
                  datetime:   "2021-12-21T14:19:00.005Z",
       previousFundingRate:    undefined,
           nextFundingRate:    0.0001,
  previousFundingTimestamp:    1640073600000,
      nextFundingTimestamp:    1640102400000,
   previousFundingDatetime:   "2021-12-21T08:00:00.000Z",
       nextFundingDatetime:   "2021-12-21T16:00:00.000Z"                }

% ftx fetchFundingRate ETH-PERP
ftx.fetchFundingRate (ETH-PERP)
139 ms
{                     info: {          volume: "734283.064",
                              nextFundingRate: "0.00001",
                              nextFundingTime: "2021-12-21T15:00:00+00:00",
                                 openInterest: "458535.687"                 },
                    symbol:   "ETH-PERP",
                 markPrice:    undefined,
                indexPrice:    undefined,
              interestRate:    0,
      estimatedSettlePrice:    undefined,
                 timestamp:    undefined,
                  datetime:    undefined,
       previousFundingRate:    undefined,
           nextFundingRate:    0.00001,
  previousFundingTimestamp:    1640095200000,
      nextFundingTimestamp:    1640098800000,
   previousFundingDatetime:   "2021-12-21T14:00:00.000Z",
       nextFundingDatetime:   "2021-12-21T15:00:00.000Z"                       }
       ```