### PR TITLE
Ascendex cancelAllOrders() Swap Functionality

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1432,7 +1432,7 @@ module.exports = class ascendex extends Exchange {
     async cancelAllOrders (symbol = undefined, params = {}) {
         await this.loadMarkets ();
         await this.loadAccounts ();
-        const defaultAccountCategory = this.safeString (this.options, 'account-category', this.defaultType);
+        const defaultAccountCategory = this.safeString (this.options, 'account-category');
         const options = this.safeValue (this.options, 'cancelAllOrders', {});
         let accountCategory = this.safeString (options, 'account-category', defaultAccountCategory);
         accountCategory = this.safeString (params, 'account-category', accountCategory);

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1448,7 +1448,13 @@ module.exports = class ascendex extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const response = await this.v1PrivateAccountCategoryDeleteOrderAll (this.extend (request, params));
+        let method = 'v1PrivateAccountCategoryDeleteOrderAll';
+        if (market['swap']) {
+            method = 'v2PrivateAccountGroupDeleteFuturesOrderAll';
+        }
+        const response = await this[method] (this.extend (request, params));
+        //
+        // AccountCategoryDeleteOrderAll
         //
         //     {
         //         "code": 0,
@@ -1464,6 +1470,20 @@ module.exports = class ascendex extends Exchange {
         //                 "timestamp": 1574118495462
         //             },
         //             "status": "Ack"
+        //         }
+        //     }
+        //
+        // AccountGroupDeleteFuturesOrderAll
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "ac": "FUTURES",
+        //             "accountId": "fut2ODPhGiY71Pl4vtXnOZ00ssgD7QGn",
+        //             "action": "cancel-all",
+        //             "info": {
+        //                 "symbol":"BTC-PERP"
+        //             }
         //         }
         //     }
         //


### PR DESCRIPTION
Added swap functionality for cancelAllOrders() method
```
ascendex.cancelAllOrders (BTC/USDT:USDT)
1414 ms
{ code:   "0",
  data: {        ac:   "FUTURES",
          accountId:   "fut2ODPhGiY71Pl4vtXnOZ00ssgD7QGn",
             action:   "cancel-all",
               info: { symbol: "BTC-PERP" }                } }
```