### PR TITLE
timex safeOrder2

### DIFF
--- a/js/timex.js
+++ b/js/timex.js
@@ -176,7 +176,7 @@ module.exports = class timex extends Exchange {
                 },
             },
             'options': {
-                'expireIn': '31536000', // 365 × 24 × 60 × 60
+                'expireIn': 31536000, // 365 × 24 × 60 × 60
                 'fetchTickers': {
                     'period': '1d',
                 },


### PR DESCRIPTION
it seems despite all our efforts to remove the floating point bugs in the lib it does matter cause timex uses floats internally 😵
<img width="855" alt="Screenshot 2021-12-22 at 23 55 20" src="https://user-images.githubusercontent.com/14319357/147207862-9c47de94-32cd-4e0f-96b0-95d005d8b196.png">
 