### PR TITLE
gateio fetchOHLCV since edits

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1624,6 +1624,8 @@ module.exports = class gateio extends Exchange {
         request['interval'] = this.timeframes[timeframe];
         let method = 'publicSpotGetCandlesticks';
         if (market['contract']) {
+            const maxLimit = 1999;
+            limit = (limit === undefined) ? maxLimit : Math.min (limit, maxLimit);
             if (market['future']) {
                 method = 'publicDeliveryGetSettleCandlesticks';
             } else if (market['swap']) {
@@ -1635,17 +1637,15 @@ module.exports = class gateio extends Exchange {
                 request['contract'] = price + '_' + market['id'];
                 params = this.omit (params, 'price');
             }
-        }
-        if (since === undefined) {
-            if (limit !== undefined) {
-                request['limit'] = limit;
-            }
         } else {
-            const timeframeSeconds = this.parseTimeframe (timeframe);
+            const maxLimit = 1000;
+            limit = (limit === undefined) ? maxLimit : Math.min (limit, maxLimit);
+            request['limit'] = limit;
+        }
+        if (since !== undefined) {
+            const duration = this.parseTimeframe (timeframe);
             request['from'] = parseInt (since / 1000);
-            if (limit !== undefined) {
-                request['to'] = this.sum (request['from'], limit * timeframeSeconds - 1);
-            }
+            request['to'] = this.sum (request['from'], limit * duration - 1);
         }
         const response = await this[method] (this.extend (request, params));
         return this.parseOHLCVs (response, market, timeframe, since, limit);

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1642,9 +1642,6 @@ module.exports = class gateio extends Exchange {
             }
         } else {
             const timeframeSeconds = this.parseTimeframe (timeframe);
-            const timeframeMilliseconds = timeframeSeconds * 1000;
-            // align forward to the next timeframe alignment
-            since = this.sum (since - (since % timeframeMilliseconds), timeframeMilliseconds);
             request['from'] = parseInt (since / 1000);
             if (limit !== undefined) {
                 request['to'] = this.sum (request['from'], limit * timeframeSeconds - 1);


### PR DESCRIPTION
`await exchange.fetchOHLCV (pair, '30m', 1640437200000)`

```
fetch Request:
 gateio GET https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=30m&from=1640439000
RequestHeaders:
 {}
RequestBody:
 undefined

handleRestResponse:
 gateio GET https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=30m&from=1640439000 200 OK
ResponseHeaders:
 {
  'Access-Control-Allow-Headers': 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type',
  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,DELETE,PUT',
  'Access-Control-Max-Age': '1728000',
  Connection: 'keep-alive',
  'Content-Encoding': 'gzip',
  'Content-Type': 'application/json',
  Date: 'Sat, 25 Dec 2021 14:07:06 GMT',
  Server: 'openresty',
  'Transfer-Encoding': 'chunked',
  Vary: 'Origin',
  'X-Request-Id': '[xxxxxxxx]'
}
ResponseBody:
 [["1640439000","1745827.84925435115","50845.36","50893.85","50641.03","50756.57"],["1640440800","228954.090101569392","50830.09","50860.61","50798.97","50845.36"]]

[
  [
    1640439000000,
    50756.57,
    50893.85,
    50641.03,
    50845.36,
    1745827.849254351
  ],
  [
    1640440800000,
    50845.36,
    50860.61,
    50798.97,
    50830.09,
    228954.0901015694
  ]
]
```

So it ignores `1640437200000` candle. As I tested it's no need to align forward to work correctly. 