### PR TITLE
Phemex :: Add example and small fix

### DIFF
--- a/examples/py/phemex-open-cancel-close-positions.py
+++ b/examples/py/phemex-open-cancel-close-positions.py
@@ -25,21 +25,21 @@ exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
 
 markets = exchange.load_markets()
 
-amount = 10
+amount = 20
 symbol = 'BTC/USD:USD'
 
-# Opening and Canceling a pending contract (limit) order (unrealistic price)
+# Opening and Canceling a pending contract (limit) order
 order = exchange.create_order(symbol, 'limit', 'buy', amount, '20000')
 response = exchange.cancel_order(order['id'], symbol)
 pprint(response)
 
-# Opening and Canceling a pending contract (stop-market) order (unrealistic price)
-stopMarketOrder = exchange.create_order(symbol, 'MarketIfTouched', 'buy', amount, None, {'stopPx': 20000})
+# Opening and Canceling a pending contract (stop-market) order 
+stopMarketOrder = exchange.create_order(symbol, 'Stop', 'buy', amount, None, {'stopPx': 70000, "triggerType": "ByLastPrice"})
 stopMarketResponse = exchange.cancel_order(stopMarketOrder['id'], symbol)
 pprint(stopMarketResponse)
 
-# Opening and Canceling a pending contract (stop-limit) order (unrealistic price)
-stopLimitOrder = exchange.create_order(symbol, 'LimitIfTouched', 'buy', amount, 20000, {'stopPx': 20000})
+# Opening and Canceling a pending contract (stop-limit) order 
+stopLimitOrder = exchange.create_order(symbol, 'StopLimit', 'buy', amount, 20000, {'stopPx': 70000, "triggerType": "ByLastPrice"})
 stopLimitResponse = exchange.cancel_order(stopLimitOrder['id'], symbol)
 pprint(stopLimitResponse)
 

--- a/examples/py/phemex-open-cancel-close-positions.py
+++ b/examples/py/phemex-open-cancel-close-positions.py
@@ -21,22 +21,30 @@ exchange = ccxt.phemex({
     },
 })
 
-# exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
+exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
 
 markets = exchange.load_markets()
 
 amount = 10
 symbol = 'BTC/USD:USD'
 
-# Opening and Canceling a pending contract order (unrealistic price)
+# Opening and Canceling a pending contract (limit) order (unrealistic price)
 order = exchange.create_order(symbol, 'limit', 'buy', amount, '20000')
-exchange.cancel_order(order['id'], symbol)
+response = exchange.cancel_order(order['id'], symbol)
+pprint(response)
+
+# Opening and Canceling a pending contract (stop-market) order (unrealistic price)
+stopMarketOrder = exchange.create_order(symbol, 'MarketIfTouched', 'buy', amount, None, {'stopPx': 20000})
+stopMarketResponse = exchange.cancel_order(stopMarketOrder['id'], symbol)
+pprint(stopMarketResponse)
+
+# Opening and Canceling a pending contract (stop-limit) order (unrealistic price)
+stopLimitOrder = exchange.create_order(symbol, 'LimitIfTouched', 'buy', amount, 20000, {'stopPx': 20000})
+stopLimitResponse = exchange.cancel_order(stopLimitOrder['id'], symbol)
+pprint(stopLimitResponse)
 
 # Opening and exiting a filled contract position by issuing the exact same order but in the opposite direction
-
-# Opening a long position
 order = exchange.create_order(symbol, 'market', 'buy', amount)
-
 # closing the previous position by issuing the exact same order but in the opposite direction
 # with reduceOnly option to prevent an unwanted exposure increase
 orderClose = exchange.create_order(symbol, 'market', 'sell', amount, None, {'reduceOnly': True})

--- a/examples/py/phemex-open-cancel-close-positions.py
+++ b/examples/py/phemex-open-cancel-close-positions.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+
+print('CCXT Version:', ccxt.__version__)
+
+exchange = ccxt.phemex({
+    'enableRateLimit': True,  # https://github.com/ccxt/ccxt/wiki/Manual#rate-limit
+    'apiKey': 'YOUR_API_KEY',  # testnet keys if using the testnet sandbox
+    'secret': 'YOUR_SECRET',  # testnet keys if using the testnet sandbox
+    'options': {
+        'defaultType': 'swap',
+    },
+})
+
+# exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
+
+markets = exchange.load_markets()
+
+amount = 10
+symbol = 'BTC/USD:USD'
+
+# Opening and Canceling a pending contract order (unrealistic price)
+order = exchange.create_order(symbol, 'limit', 'buy', amount, '20000')
+exchange.cancel_order(order['id'], symbol)
+
+# Opening and exiting a filled contract position by issuing the exact same order but in the opposite direction
+
+# Opening a long position
+order = exchange.create_order(symbol, 'market', 'buy', amount)
+
+# closing the previous position by issuing the exact same order but in the opposite direction
+# with reduceOnly option to prevent an unwanted exposure increase
+orderClose = exchange.create_order(symbol, 'market', 'sell', amount, None, {'reduceOnly': True})

--- a/examples/py/phemex-open-cancel-close-positions.py
+++ b/examples/py/phemex-open-cancel-close-positions.py
@@ -21,7 +21,7 @@ exchange = ccxt.phemex({
     },
 })
 
-exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
+# exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
 
 markets = exchange.load_markets()
 

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1833,7 +1833,7 @@ module.exports = class phemex extends Exchange {
         } else if (market['swap']) {
             request['orderQty'] = parseInt (amount);
         }
-        if ((type === 'Limit') || (type === 'LimitIfTouched')) {
+        if ((type === 'Limit') || (type === 'StopLimit') || (type === 'LimitIfTouched')) {
             const priceString = price.toString ();
             request['priceEp'] = this.toEp (priceString, market);
         }

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1833,7 +1833,7 @@ module.exports = class phemex extends Exchange {
         } else if (market['swap']) {
             request['orderQty'] = parseInt (amount);
         }
-        if (type === 'Limit') {
+        if ((type === 'Limit') || (type === 'LimitIfTouched')) {
             const priceString = price.toString ();
             request['priceEp'] = this.toEp (priceString, market);
         }


### PR DESCRIPTION
As suggested, I'm adding some examples of how to create, cancel and close different contract orders. 
While creating the examples I've also noticed that the createOrder was not adding the price to limit-based orders such as stopLimit and LimitIfTouched so I fixed it.
