### PR TITLE
Phemex :: add setLeverage and example

### DIFF
--- a/examples/py/phemex-leverage-orders.py
+++ b/examples/py/phemex-leverage-orders.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+
+print('CCXT Version:', ccxt.__version__)
+
+exchange = ccxt.phemex({
+    'enableRateLimit': True,  # https://github.com/ccxt/ccxt/wiki/Manual#rate-limit
+    'apiKey': 'YOUR_API_KEY',  # testnet keys if using the testnet sandbox
+    'secret': 'YOUR_SECRET',  # testnet keys if using the testnet sandbox
+    'options': {
+        'defaultType': 'swap',
+    },
+})
+
+# exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
+
+markets = exchange.load_markets()
+
+amount = 5
+symbol = 'BTC/USD:USD'
+
+# Change leverage to the desired value
+leverageResponse = exchange.set_leverage(5, symbol)
+
+# Opening a pending contract (limit) order
+order = exchange.create_order(symbol, 'market', 'buy', amount)
+print(order)
+
+# Canceling pending contract 
+closingOrder = exchange.create_order(symbol, 'market', 'sell', amount)
+pprint(closingOrder)
+
+# Reset leverage to 1
+leverageResponse = exchange.set_leverage(1, symbol)
+print(leverageResponse)

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -46,6 +46,7 @@ module.exports = class phemex extends Exchange {
                 'fetchTicker': true,
                 'fetchTrades': true,
                 'fetchWithdrawals': true,
+                'setLeverage': true,
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/85225056-221eb600-b3d7-11ea-930d-564d2690e3f6.jpg',
@@ -2566,6 +2567,24 @@ module.exports = class phemex extends Exchange {
         }
         url = this.implodeHostname (this.urls['api'][api]) + url;
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
+    }
+
+    async setLeverage (leverage, symbol = undefined, params = {}) {
+        // WARNING: THIS WILL INCREASE LIQUIDATION PRICE FOR OPEN ISOLATED LONG POSITIONS
+        // AND DECREASE LIQUIDATION PRICE FOR OPEN ISOLATED SHORT POSITIONS
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
+        }
+        if ((leverage < 1) || (leverage > 100)) {
+            throw new BadRequest (this.id + ' leverage should be between 1 and 100');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+            'leverage': leverage,
+        };
+        return await this.privatePutPositionsLeverage (this.extend (request, params));
     }
 
     handleErrors (httpCode, reason, url, method, headers, body, response, requestHeaders, requestBody) {


### PR DESCRIPTION
I've noticed that the setLeverage method was not implemented although it's supported by Phemex. Also added an example to illustrate how to use leverage when trading contracts