### PR TITLE
Binance: add error 'Verification failed'

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -927,6 +927,7 @@ module.exports = class binance extends Exchange {
                     '-5013': InsufficientFunds, // Asset transfer failed: insufficient balance"
                     '-11008': InsufficientFunds, // {"code":-11008,"msg":"Exceeding the account's maximum borrowable limit."}
                     '-4051': InsufficientFunds, // {"code":-4051,"msg":"Isolated balance insufficient."}
+                    '100001003': BadRequest, // {"code":100001003,"msg":"Verification failed"}
                 },
                 'broad': {
                     'has no operation privilege': PermissionDenied,


### PR DESCRIPTION
This error appears when you pass the wrong parameters to the endpoint `/sapi/v1/rebate/taxQuery`.

I talked to Binance already, and they will add better errors in the upcoming release.