### PR TITLE
Moving transfer functions inside parent class

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -5006,4 +5006,26 @@ module.exports = class binance extends Exchange {
         }
         return result;
     }
+
+    async transferIn (code, amount, params = {}) {
+        // transfer from spot wallet to coinm or usdm futures wallet
+        let num = undefined;
+        if (this.options['defaultType'] === 'delivery') {
+            num = 3;
+        } else if (this.options['defaultType'] === 'future') {
+            num = 1;
+        }
+        return await this.futuresTransfer (code, amount, num, params);
+    }
+
+    async transferOut (code, amount, params = {}) {
+        // transfer from coinm or usdm futures wallet to spot wallet
+        let num = undefined;
+        if (this.options['defaultType'] === 'delivery') {
+            num = 4;
+        } else if (this.options['defaultType'] === 'future') {
+            num = 2;
+        }
+        return await this.futuresTransfer (code, amount, num, params);
+    }
 };

--- a/js/binancecoinm.js
+++ b/js/binancecoinm.js
@@ -24,14 +24,4 @@ module.exports = class binancecoinm extends binance {
             },
         });
     }
-
-    async transferIn (code, amount, params = {}) {
-        // transfer from spot wallet to coinm futures wallet
-        return await this.futuresTransfer (code, amount, 3, params);
-    }
-
-    async transferOut (code, amount, params = {}) {
-        // transfer from coinm futures wallet to spot wallet
-        return await this.futuresTransfer (code, amount, 4, params);
-    }
 };

--- a/js/binanceusdm.js
+++ b/js/binanceusdm.js
@@ -27,14 +27,4 @@ module.exports = class binanceusdm extends binance {
             },
         });
     }
-
-    async transferIn (code, amount, params = {}) {
-        // transfer from spot wallet to usdm futures wallet
-        return await this.futuresTransfer (code, amount, 1, params);
-    }
-
-    async transferOut (code, amount, params = {}) {
-        // transfer from usdm futures wallet to spot wallet
-        return await this.futuresTransfer (code, amount, 2, params);
-    }
 };


### PR DESCRIPTION
Earlier in a discussion you mentioned that people use 'binance' class to trade all sorts of floors (types). To meet consistency of intended functionality, I think the functionality itself must be available in base exchange class (instead of derived).
But if I miss some background reasons, then close this PR.