### PR TITLE
Remove colors

### DIFF
--- a/js/test/Exchange/test.fetchBalance.js
+++ b/js/test/Exchange/test.fetchBalance.js
@@ -10,7 +10,7 @@ const log = require ('ololog')
 module.exports = async (exchange) => {
 
     if (!(exchange.has.fetchBalance)) {
-        log (exchange.id.green, ' does not have fetchBalance')
+        log (exchange.id, ' does not have fetchBalance')
         return
     }
 

--- a/js/test/Exchange/test.fetchBalance.js
+++ b/js/test/Exchange/test.fetchBalance.js
@@ -2,19 +2,18 @@
 
 // ----------------------------------------------------------------------------
 
-const log = require ('ololog')
-    , testBalance = require ('./test.balance.js')
+const testBalance = require ('./test.balance.js')
 
 // ----------------------------------------------------------------------------
 
 module.exports = async (exchange) => {
 
     if (!(exchange.has.fetchBalance)) {
-        log (exchange.id, ' does not have fetchBalance')
+        console.log (exchange.id, ' does not have fetchBalance')
         return
     }
 
-    log ('fetching balance...')
+    console.log ('fetching balance...')
 
     const response = await exchange.fetchBalance ()
 

--- a/js/test/Exchange/test.fetchOHLCV.js
+++ b/js/test/Exchange/test.fetchOHLCV.js
@@ -35,7 +35,7 @@ module.exports = async (exchange, symbol) => {
             testOHLCV (exchange, ohlcv, symbol, now)
         }
 
-        console.log (symbol.green, 'fetched', Object.keys (ohlcvs).length, 'OHLCVs')
+        console.log (symbol, 'fetched', Object.keys (ohlcvs).length, 'OHLCVs')
 
         return ohlcvs
 

--- a/js/test/Exchange/test.fetchTicker.js
+++ b/js/test/Exchange/test.fetchTicker.js
@@ -32,7 +32,7 @@ module.exports = async (exchange, symbol) => {
 
     } else {
 
-        console.log (symbol.green, 'fetchTicker () not supported')
+        console.log (symbol, 'fetchTicker () not supported')
     }
 }
 


### PR DESCRIPTION
When running tests, there are probably different cases (mostly in Windows, I can't say about Mac) when the console being used, doesn't support the colors (or might support colors, but not specific colors.) this can happen differently in `CMD` and `PowerShell` and at this moment, even in VScode I get this: https://i.imgur.com/EWuLzro.png  , when running tests.
I suggest that it was more compatible then feature-oriented in this case, as it is for mostly developers, who might bare the small inconvenience (of not having colored strings in 3 places) in benefit of larger compatibility.
