### PR TITLE
Added gateio options endpoints

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -121,6 +121,22 @@ module.exports = class gateio extends Exchange {
                             '{settle}/insurance': 1.5,
                         },
                     },
+                    'options': {
+                        'get': {
+                            'underlyings': 1.5,
+                            'expirations': 1.5,
+                            'contracts': 1.5,
+                            'contracts/{contract}': 1.5,
+                            'settlements': 1.5,
+                            'settlements/{contract}': 1.5,
+                            'order_book': 1.5,
+                            'tickers': 1.5,
+                            'underlying/tickers/{underlying}': 1.5,
+                            'candlesticks': 1.5,
+                            'underlying/candlesticks': 1.5,
+                            'trades': 1.5,
+                        },
+                    },
                 },
                 'private': {
                     'withdrawals': {
@@ -263,6 +279,25 @@ module.exports = class gateio extends Exchange {
                             '{settle}/orders/{order_id}': 1.5,
                             '{settle}/price_orders': 1.5,
                             '{settle}/price_orders/{order_id}': 1.5,
+                        },
+                    },
+                    'options': {
+                        'get': {
+                            'accounts': 1.5,
+                            'account_book': 1.5,
+                            'positions': 1.5,
+                            'positions/{contract}': 1.5,
+                            'position_close': 1.5,
+                            'orders': 1.5,
+                            'orders/{order_id}': 1.5,
+                            'my_trades': 1.5,
+                        },
+                        'post': {
+                            'orders': 1.5,
+                        },
+                        'delete': {
+                            'orders': 1.5,
+                            'orders/{order_id}': 1.5,
                         },
                     },
                 },


### PR DESCRIPTION
I'm trying to call a method and getting this currently

```
% gateio publicOptionsGetUnderlyings --verbose
2021-12-31T08:02:39.975Z
Node.js: v14.17.0
CCXT v1.65.80
gateio.publicOptionsGetUnderlyings: no such property
```