### PR TITLE
aax.fetchPositions and aax.fetchPosition

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -2640,8 +2640,8 @@ module.exports = class aax extends Exchange {
         if (symbols !== undefined) {
             let symbol = undefined;
             if (Array.isArray (symbols)) {
-                const symLen = symbols.length;
-                if (symLen > 1) {
+                const symbolsLength = symbols.length;
+                if (symbolsLength > 1) {
                     throw new BadRequest (this.id + ' fetchPositions symbols argument cannot contain more than 1 symbol');
                 }
                 symbol = symbols[0];

--- a/js/aax.js
+++ b/js/aax.js
@@ -2552,6 +2552,9 @@ module.exports = class aax extends Exchange {
         const marketPrice = this.safeString (position, 'marketPrice');
         const notional = Precise.stringMul (initialQuote, marketPrice);
         const timestamp = this.safeInteger (position, 'ts');
+        const liquidationPrice = this.safeString (position, 'liquidationPrice');
+        const bankruptPrice = this.safeString (position, 'bankruptPrice');
+        const maintenanceMargin = Precise.stringSub (liquidationPrice, bankruptPrice);
         return {
             'info': position,
             'symbol': this.safeString (market, 'symbol'),
@@ -2559,8 +2562,8 @@ module.exports = class aax extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'initialMargin': undefined,
             'initialMarginPercentage': undefined,
-            'maintenanceMargin': undefined,
-            'maintenanceMarginPercentage': undefined,
+            'maintenanceMargin': maintenanceMargin,
+            'maintenanceMarginPercentage': Precise.stringDiv (maintenanceMargin, notional),
             'entryPrice': this.safeNumber (position, 'avgEntryPrice'),
             'notional': this.parseNumber (notional),
             'leverage': this.parseNumber (leverage),
@@ -2568,7 +2571,7 @@ module.exports = class aax extends Exchange {
             'contracts': this.parseNumber (size),
             'contractSize': this.parseNumber (contractSize),
             'marginRatio': undefined,
-            'liquidationPrice': this.safeNumber (position, 'liquidationPrice'),
+            'liquidationPrice': liquidationPrice,
             'markPrice': this.safeNumber (position, 'marketPrice'),
             'collateral': this.safeNumber (position, 'posMargin'),
             'marginType': this.safeString (position, 'settleType'),

--- a/js/aax.js
+++ b/js/aax.js
@@ -2553,8 +2553,6 @@ module.exports = class aax extends Exchange {
         const notional = Precise.stringMul (initialQuote, marketPrice);
         const timestamp = this.safeInteger (position, 'ts');
         const liquidationPrice = this.safeString (position, 'liquidationPrice');
-        const bankruptPrice = this.safeString (position, 'bankruptPrice');
-        const maintenanceMargin = Precise.stringDiv (liquidationPrice, bankruptPrice);
         return {
             'info': position,
             'symbol': this.safeString (market, 'symbol'),
@@ -2562,8 +2560,8 @@ module.exports = class aax extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'initialMargin': undefined,
             'initialMarginPercentage': undefined,
-            'maintenanceMargin': maintenanceMargin,
-            'maintenanceMarginPercentage': Precise.stringDiv (maintenanceMargin, notional),
+            'maintenanceMargin': undefined,
+            'maintenanceMarginPercentage': undefined,
             'entryPrice': this.safeNumber (position, 'avgEntryPrice'),
             'notional': this.parseNumber (notional),
             'leverage': this.parseNumber (leverage),

--- a/js/aax.js
+++ b/js/aax.js
@@ -2554,7 +2554,7 @@ module.exports = class aax extends Exchange {
         const timestamp = this.safeInteger (position, 'ts');
         const liquidationPrice = this.safeString (position, 'liquidationPrice');
         const bankruptPrice = this.safeString (position, 'bankruptPrice');
-        const maintenanceMargin = Precise.stringSub (liquidationPrice, bankruptPrice);
+        const maintenanceMargin = Precise.stringDiv (liquidationPrice, bankruptPrice);
         return {
             'info': position,
             'symbol': this.safeString (market, 'symbol'),

--- a/js/aax.js
+++ b/js/aax.js
@@ -78,7 +78,6 @@ module.exports = class aax extends Exchange {
                 'fetchOrderBooks': undefined,
                 'fetchOrders': true,
                 'fetchOrderTrades': undefined,
-                'fetchPartiallyFilledOrders': undefined,
                 'fetchPosition': true,
                 'fetchPositions': true,
                 'fetchPositionsRisk': false,

--- a/js/aax.js
+++ b/js/aax.js
@@ -2548,25 +2548,25 @@ module.exports = class aax extends Exchange {
         // const notional = this.safeString (position, 'value');
         const leverage = this.safeString (position, 'leverage');
         const unrealisedPnl = this.safeString (position, 'unrealisedPnl');
-        const realisedPnl = this.safeString (position, 'realisedPnl');
+        // const realisedPnl = this.safeString (position, 'realisedPnl');
         // Initial Position Margin = ( Position Value / Leverage ) + Close Position Fee
-        const takerFee = this.fees.trading.taker;
+        // const takerFee = this.fees['trading']['taker'];
         // const feePaid = Precise.stringMul (takerFee, notional);
-        const initialMarginString = this.safeString (position, 'posMargin');
-        const percentage = Precise.stringMul (Precise.stringDiv (unrealisedPnl, initialMarginString), '100');
+        // const initialMarginString = this.safeString (position, 'posMargin');
+        // const percentage = Precise.stringMul (Precise.stringDiv (unrealisedPnl, initialMarginString), '100');
         const timestamp = this.safeInteger (position, 'ts');
         return {
             'info': position,
             'symbol': this.safeString (market, 'symbol'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'initialMargin': this.parseNumber (initialMarginString),
+            // 'initialMargin': this.parseNumber (initialMarginString),
             // 'initialMarginPercentage': this.parseNumber (Precise.stringDiv (initialMarginString, notional)),
             // 'maintenanceMargin': this.parseNumber (Precise.stringMul (maintenanceRate, notional)),
             // 'maintenanceMarginPercentage': this.parseNumber (maintenanceRate),
             'entryPrice': this.safeNumber (position, 'avgEntryPrice'),
             // 'notional': this.parseNumber (notional),
-            'leverage': parseInt (leverage),
+            'leverage': this.parseNumber (leverage),
             'unrealizedPnl': this.parseNumber (unrealisedPnl),
             'contracts': this.parseNumber (size),
             'contractSize': this.safeNumber (market, 'contractSize'),
@@ -2574,10 +2574,10 @@ module.exports = class aax extends Exchange {
             // 'marginRatio': undefined,
             'liquidationPrice': this.safeNumber (position, 'liquidationPrice'),
             'markPrice': this.safeNumber (position, 'marketPrice'),
-            // 'collateral': this.safeNumber (position, 'margin'),
+            'collateral': this.safeNumber (position, 'posMargin'),
             'marginType': this.safeString (position, 'settleType'),
             'side': side,
-            'percentage': this.parseNumber (percentage),
+            // 'percentage': this.parseNumber (percentage),
         };
     }
 

--- a/js/aax.js
+++ b/js/aax.js
@@ -2629,8 +2629,13 @@ module.exports = class aax extends Exchange {
         //    }
         //
         const positions = this.safeValue (response, 'data', []);
+        const timestamp = this.safeInteger (response, 'ts');
         const first = this.safeValue (positions, 0);
-        return this.parsePosition (first);
+        const position = this.parsePosition (first);
+        return this.extend (position, {
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+        })
     }
 
     async fetchPositions (symbols = undefined, params = {}) {
@@ -2693,8 +2698,13 @@ module.exports = class aax extends Exchange {
         //
         const result = [];
         const positions = this.safeValue (response, 'data', []);
+        const timestamp = this.safeInteger (response, 'ts');
         for (let i = 0; i < positions.length; i++) {
-            result.push (this.parsePosition (positions[i]));
+            const position = this.parsePosition (positions[i])
+            result.push (this.extend (position, {
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+            }));
         }
         return this.filterByArray (result, 'symbol', symbols, false);
     }


### PR DESCRIPTION
```
% aax fetchPosition ETH/USDT:USDT         
2022-01-13T04:26:07.994Z
Node.js: v14.17.0
CCXT v1.67.31
aax.fetchPosition (ETH/USDT:USDT)
887 ms
{
  info: {
    autoMarginCall: false,
    avgEntryPrice: '3343.91',
    bankruptPrice: '3512.4430640000',
    base: 'ETH',
    code: 'FP',
    commission: '0.06687820',
    currentQty: '-10',
    funding: '0',
    fundingStatus: null,
    id: '397221377228075008',
    leverage: '20',
    liquidationPrice: '3494.33',
    marketPrice: '3346.04',
    openTime: '2022-01-13T04:09:23.898Z',
    posLeverage: '19.85',
    posMargin: '16.85330640',
    quote: 'USDT',
    realisedPnl: '-0.06687820',
    riskLimit: '10000000',
    riskyPrice: '3434.16',
    settleType: 'VANILLA',
    stopLossPrice: '0',
    stopLossSource: '0',
    symbol: 'ETHUSDTFP',
    takeProfitPrice: '0',
    takeProfitSource: '1',
    unrealisedPnl: '-0.21300000',
    userID: '3204388'
  },
  symbol: 'ETH/USDT:USDT',
  timestamp: 1642047971218,
  datetime: '2022-01-13T04:26:11.218Z',
  initialMargin: -334.391,
  initialMarginPercentage: 0.9993634266177333,
  maintenanceMargin: undefined,
  maintenanceMarginPercentage: undefined,
  entryPrice: 3343.91,
  notional: -334.604,
  leverage: 20,
  unrealizedPnl: -0.213,
  contracts: -10,
  contractSize: 0.01,
  marginRatio: undefined,
  liquidationPrice: 3494.33,
  markPrice: 3346.04,
  collateral: 16.8533064,
  marginType: 'VANILLA',
  side: 'sell',
  percentage: 0.0636978866057997
}
```