### PR TITLE
Phemex :: Add default TriggerType

### DIFF
--- a/examples/py/phemex-open-cancel-close-positions.py
+++ b/examples/py/phemex-open-cancel-close-positions.py
@@ -13,12 +13,12 @@ import ccxt  # noqa: E402
 print('CCXT Version:', ccxt.__version__)
 
 exchange = ccxt.phemex({
-    'enableRateLimit': True,  # https://github.com/ccxt/ccxt/wiki/Manual#rate-limit
-    'apiKey': 'YOUR_API_KEY',  # testnet keys if using the testnet sandbox
-    'secret': 'YOUR_SECRET',  # testnet keys if using the testnet sandbox
-    'options': {
-        'defaultType': 'swap',
-    },
+    'enableRateLimit': True,
+	'apiKey': 'YOUR_API_KEY',
+	'secret': 'YOUR_SECRET',
+	'options': {
+	'defaultType': 'swap',
+	},
 })
 
 # exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox
@@ -34,7 +34,7 @@ response = exchange.cancel_order(order['id'], symbol)
 pprint(response)
 
 # Opening and Canceling a pending contract (stop-market) order 
-stopMarketOrder = exchange.create_order(symbol, 'Stop', 'buy', amount, None, {'stopPx': 70000, "triggerType": "ByLastPrice"})
+stopMarketOrder = exchange.create_order(symbol, 'Stop', 'buy', amount, None, {'stopPx': 70000}) # default triggerType is ByMarkPrice
 stopMarketResponse = exchange.cancel_order(stopMarketOrder['id'], symbol)
 pprint(stopMarketResponse)
 
@@ -61,7 +61,6 @@ trailingOrder = exchange.create_order(symbol = ethSymbol, type = 'StopLimit', si
     'ordType': 'StopLimit',
     'pegPriceType': 'TrailingStopPeg',
     'pegOffsetValueEp': 10000, # needs to be scaled
-    'triggerType': 'ByMarkPrice'
-    }
+    } # default triggerType is ByMarkPrice
 )
 pprint(trailingOrder)

--- a/examples/py/phemex-open-cancel-close-positions.py
+++ b/examples/py/phemex-open-cancel-close-positions.py
@@ -13,12 +13,12 @@ import ccxt  # noqa: E402
 print('CCXT Version:', ccxt.__version__)
 
 exchange = ccxt.phemex({
-    'enableRateLimit': True,
-	'apiKey': 'YOUR_API_KEY',
-	'secret': 'YOUR_SECRET',
-	'options': {
-	'defaultType': 'swap',
-	},
+    'enableRateLimit': True,  # https://github.com/ccxt/ccxt/wiki/Manual#rate-limit
+    'apiKey': 'YOUR_API_KEY',  # testnet keys if using the testnet sandbox
+    'secret': 'YOUR_SECRET',  # testnet keys if using the testnet sandbox
+    'options': {
+        'defaultType': 'swap',
+    },
 })
 
 # exchange.set_sandbox_mode(True)  # uncomment to use the testnet sandbox

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1806,6 +1806,11 @@ module.exports = class phemex extends Exchange {
             // 'pegPriceType': 'TrailingStopPeg', // TrailingTakeProfitPeg
             // 'text': 'comment',
         };
+        const stopPrice = this.safeString2 (params, 'stopPx', 'stopPrice');
+        if (stopPrice !== undefined) {
+            request['stopPxEp'] = this.toEp (stopPrice, market);
+        }
+        params = this.omit (params, [ 'stopPx', 'stopPrice' ]);
         if (market['spot']) {
             let qtyType = this.safeValue (params, 'qtyType', 'ByBase');
             if ((type === 'Market') || (type === 'Stop') || (type === 'MarketIfTouched')) {
@@ -1833,16 +1838,16 @@ module.exports = class phemex extends Exchange {
             }
         } else if (market['swap']) {
             request['orderQty'] = parseInt (amount);
+            if (stopPrice !== undefined) {
+                const triggerType = this.safeString (params, 'triggerType', 'ByMarkPrice');
+                params = this.omit (params, 'triggerType');
+                request['triggerType'] = triggerType;
+            }
         }
         if ((type === 'Limit') || (type === 'StopLimit') || (type === 'LimitIfTouched')) {
             const priceString = price.toString ();
             request['priceEp'] = this.toEp (priceString, market);
         }
-        const stopPrice = this.safeString2 (params, 'stopPx', 'stopPrice');
-        if (stopPrice !== undefined) {
-            request['stopPxEp'] = this.toEp (stopPrice, market);
-        }
-        params = this.omit (params, [ 'stopPx', 'stopPrice' ]);
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
         if (takeProfitPrice !== undefined) {
             request['takeProfitEp'] = this.toEp (takeProfitPrice, market);


### PR DESCRIPTION
In Phemex, when specifying a stopPrice it's mandatory (contract only) to set the triggerType as well, so to avoid failing when no triggerType is passed, I'm adding it with a default value.