### PR TITLE
[OKEx] Fix sandbox header exception with python

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -3726,8 +3726,8 @@ module.exports = class okex extends Exchange {
     setSandboxMode (enable) {
         if (enable) {
             this.headers['x-simulated-trading'] = 1;
-        } else {
-            this.headers['x-simulated-trading'] = null;
+        } else if ('x-simulated-trading' in this.headers) {
+            delete this.headers['x-simulated-trading'];
         }
     }
 


### PR DESCRIPTION
Aiohttp can't serialize no-str `None` when setDemo has been called with False. 
Example here : https://github.com/Drakkar-Software/OctoBot-Trading/runs/4682784793?check_suite_focus=true#step:5:520
I think the best fix is to only add the header when using demo mode. There is no disable value in [OKEx API doc](https://www.okex.com/docs-v5/en/#overview-demo-trading-services), it only describes that `x-simulated-trading: 1` should be added when using demo trading.

Related to https://github.com/ccxt/ccxt/issues/7088 and https://github.com/ccxt/ccxt/pull/10912