### PR TITLE
fix[Gate.io]: wrong clientOrderId assignment

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2413,6 +2413,7 @@ module.exports = class gateio extends Exchange {
         //
         //
         const id = this.safeString (order, 'id');
+        const clientOrderId = this.safeString (order, 'text');
         const marketId = this.safeString2 (order, 'currency_pair', 'contract');
         const symbol = this.safeSymbol (marketId, market);
         let timestamp = this.safeTimestamp (order, 'create_time');
@@ -2481,7 +2482,7 @@ module.exports = class gateio extends Exchange {
         }
         return this.safeOrder ({
             'id': id,
-            'clientOrderId': id,
+            'clientOrderId': clientOrderId,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,


### PR DESCRIPTION
Taking a look at line 2147, we can see that Gate.io supports defining a custom ```clientOrderId``` in a ```createOrder``` request. This ID is then returned in the response so the user can perform request <-> response mapping.

This PR fixes a bug in ```parseOrder``` where the request <-> response mapping was not possible because the ```clientOrderId``` was overridden by the numeric id that is also returned in the response.