### PR TITLE
[Crypto.com] Fix None symbol behaviour for fetch-[open-]orders

### DIFF
--- a/python/ccxt/async_support/cryptocom.py
+++ b/python/ccxt/async_support/cryptocom.py
@@ -513,13 +513,11 @@ class cryptocom(Exchange):
         return self.parse_ticker(data, market)
 
     async def fetch_orders(self, symbol=None, since=None, limit=None, params={}):
-        if symbol is None:
-            raise ArgumentsRequired(self.id + ' fetchClosedOrders() requires a symbol argument')
-        await self.load_markets()
-        market = self.market(symbol)
-        request = {
-            'instrument_name': market['id'],
-        }
+        request = {}
+        if symbol is not None:
+            await self.load_markets()
+            market = self.market(symbol)
+            request['instrument_name'] = market['id']
         if since is not None:
             # maximum date range is one day
             request['start_ts'] = since
@@ -945,9 +943,8 @@ class cryptocom(Exchange):
             request['page_size'] = limit
         marketType, query = self.handle_market_type_and_params('fetchOpenOrders', market, params)
         if marketType == 'spot':
-            if symbol is None:
-                raise ArgumentsRequired(self.id + ' fetchOpenOrders() requires a symbol argument for ' + marketType + ' orders')
-            request['instrument_name'] = market['id']
+            if symbol is not None:
+                request['instrument_name'] = market['id']
         method = self.get_supported_mapping(marketType, {
             'spot': 'spotPrivatePostPrivateGetOpenOrders',
             'future': 'derivativesPrivatePostPrivateGetOpenOrders',

--- a/python/ccxt/cryptocom.py
+++ b/python/ccxt/cryptocom.py
@@ -513,13 +513,11 @@ class cryptocom(Exchange):
         return self.parse_ticker(data, market)
 
     def fetch_orders(self, symbol=None, since=None, limit=None, params={}):
-        if symbol is None:
-            raise ArgumentsRequired(self.id + ' fetchClosedOrders() requires a symbol argument')
-        self.load_markets()
-        market = self.market(symbol)
-        request = {
-            'instrument_name': market['id'],
-        }
+        request = {}
+        if symbol is not None:    
+            self.load_markets()
+            market = self.market(symbol)
+            request['instrument_name'] = market['id']
         if since is not None:
             # maximum date range is one day
             request['start_ts'] = since
@@ -945,9 +943,8 @@ class cryptocom(Exchange):
             request['page_size'] = limit
         marketType, query = self.handle_market_type_and_params('fetchOpenOrders', market, params)
         if marketType == 'spot':
-            if symbol is None:
-                raise ArgumentsRequired(self.id + ' fetchOpenOrders() requires a symbol argument for ' + marketType + ' orders')
-            request['instrument_name'] = market['id']
+            if symbol is not None:
+                request['instrument_name'] = market['id']
         method = self.get_supported_mapping(marketType, {
             'spot': 'spotPrivatePostPrivateGetOpenOrders',
             'future': 'derivativesPrivatePostPrivateGetOpenOrders',


### PR DESCRIPTION
As stated in https://exchange-docs.crypto.com/spot/index.html#private-get-order-history
and https://exchange-docs.crypto.com/spot/index.html#private-get-open-orders,
if instrument_name is not specified in the request, all orders should be returned.
This commit fixes the methods behaviour when symbol is passed as None.