### PR TITLE
fix[Gate.io]: add missing remapping when clientOrderId is modified

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2230,9 +2230,8 @@ module.exports = class gateio extends Exchange {
                 }
                 params = this.omit (params, [ 'text', 'clientOrderId' ]);
                 if (clientOrderId[0] !== 't') {
-                    clientOrderId = 't-' + clientOrderId;
+                    request['text'] = 't-' + clientOrderId;
                 }
-                request['text'] = clientOrderId;
             }
         } else {
             if (contract) {
@@ -2367,6 +2366,11 @@ module.exports = class gateio extends Exchange {
         //
         //     {"id":7615567}
         //
+        const modifiedClientOrderId = this.safeString (response, 'text');
+        if (clientOrderId !== undefined && modifiedClientOrderId && modifiedClientOrderId !== clientOrderId) {
+            // 't-' was appended to perform the request and needs to be removed here to reconstruct the order id provided by the caller
+            response['text'] = clientOrderId;
+        }
         return this.parseOrder (response, market);
     }
 


### PR DESCRIPTION
Gate.io requires the prefix ```t-``` for the ```clientOrderId``` which is correctly appended if not present by ```createOrder```.

However, the mapping back is not implemented.

## Example
Calling ```createOrder``` with  ```clientOrderId: "abcd"``` returns a parsed response with ```clientOrderId: "t-abcd"```
The differs to the expected response value of ```clientOrderId: "abcd"```

Please update my PR if the naming/position/logic is not optimal.