### PR TITLE
fix [Ftx]: symbol ID clash

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -538,7 +538,7 @@ module.exports = class ftx extends Exchange {
             const baseId = this.safeString2 (market, 'baseCurrency', 'underlying');
             const quoteId = this.safeString (market, 'quoteCurrency', 'USD');
             const settleId = contract ? 'USD' : undefined;
-            const base = this.safeCurrencyCode (baseId);
+            let base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const settle = this.safeCurrencyCode (settleId);
             const spot = !contract;
@@ -557,6 +557,11 @@ module.exports = class ftx extends Exchange {
             } else if (isFuture) {
                 type = 'future';
                 expiry = this.parse8601 (expiryDatetime);
+                const parsedId = id.split ('-').splice (1);
+                parsedId.splice (parsedId.length - 1, 1);
+                if (parsedId.length > 0) {
+                    base += '-' + parsedId.join ('-');
+                }
                 symbol = base + '/' + quote + ':' + settle + '-' + this.yymmdd (expiry, '');
             }
             // check if a market is a spot or future market


### PR DESCRIPTION
This PR fix symbol ID clash in ftx futures and move #11129:

```JS
await client.load_markets()
console.log(
  client.market("BTC/USD:USD-220325")["id"],
  client.market("BTC-MOVE/USD:USD-220325")["id"],
  client.market("BTC-MOVE-WK/USD:USD-220115")["id"]
)
```

```
BTC-0325
BTC-MOVE-2022Q1
BTC-MOVE-WK-0114
```

The BTC-MOVE-WK future was not clashed but it need to meet naming conventions.