### PR TITLE
removed taker:undefined, maker:undefined bitmart, bitvavo, waves, zb

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -457,8 +457,6 @@ module.exports = class bitmart extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': undefined,
-                'maker': undefined,
                 'contractSize': undefined,
                 'active': true,
                 'expiry': undefined,

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -306,8 +306,6 @@ module.exports = class bitvavo extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': undefined,
-                'maker': undefined,
                 'contractSize': undefined,
                 'active': (status === 'trading'),
                 'expiry': undefined,

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -436,8 +436,6 @@ module.exports = class wavesexchange extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': undefined,
-                'maker': undefined,
                 'contractSize': undefined,
                 'active': undefined,
                 'expiry': undefined,

--- a/js/zb.js
+++ b/js/zb.js
@@ -280,8 +280,6 @@ module.exports = class zb extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': undefined,
-                'maker': undefined,
                 'contractSize': undefined,
                 'active': true,
                 'expiry': undefined,


### PR DESCRIPTION
Fixes issue #11124 

---

I'm think for other exchanges like  ascendex, bitbank, bitmex ... that do something like `const fee = this.safeNumber (market, 'commissionReserveRate');` we might need to use the default as a backup like

```
const defaultFee = fees['trading']['maker'];
const fee = this.safeNumber (market, 'commissionReserveRate', defaultFee);
```