### PR TITLE
Deribit Historical Volatility

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -30,6 +30,7 @@ module.exports = class deribit extends Exchange {
                 'fetchClosedOrders': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
+                'fetchHistoricalVolatility': true,
                 'fetchIndexOHLCV': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1764,6 +1764,42 @@ module.exports = class deribit extends Exchange {
         return result;
     }
 
+    async fetchHistoricalVolatility (code, params = {}) {
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'currency': currency['id'],
+        };
+        const response = await this.publicGetGetHistoricalVolatility (this.extend (request, params));
+        //
+        //     {
+        //         "jsonrpc": "2.0",
+        //         "result": [
+        //             [1640142000000,63.828320460740585],
+        //             [1640142000000,63.828320460740585],
+        //             [1640145600000,64.03821964123213]
+        //         ],
+        //         "usIn": 1641515379467734,
+        //         "usOut": 1641515379468095,
+        //         "usDiff": 361,
+        //         "testnet": false
+        //     }
+        //
+        const volatilityResult = this.safeValue (response, 'result', {});
+        const result = [];
+        for (let i = 0; i < volatilityResult.length; i++) {
+            const timestamp = this.safeInteger (volatilityResult[i], 0);
+            const volatility = this.safeNumber (volatilityResult[i], 1);
+            result.push ({
+                'info': response,
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+                'volatility': volatility,
+            });
+        }
+        return result;
+    }
+
     async withdraw (code, amount, address, tag = undefined, params = {}) {
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         this.checkAddress (address);


### PR DESCRIPTION
Created a fetchHistoricalVolatility method for deribit:
Since volatility is a main component of an options price, options traders often compare historical volatility with implied volatility before entering a trade.
```
deribit.fetchHistoricalVolatility (BTC)
178 ms
    timestamp |                 datetime |         volatility
-------------------------------------------------------------
1640149200000 | 2021-12-22T05:00:00.000Z |  63.76803463248656
1640149200000 | 2021-12-22T05:00:00.000Z |  63.76803463248656
1640152800000 | 2021-12-22T06:00:00.000Z |  63.77117740085217
...
1641517200000 | 2022-01-07T01:00:00.000Z | 51.743521996300004
1641520800000 | 2022-01-07T02:00:00.000Z | 51.733586514121505
1641524400000 | 2022-01-07T03:00:00.000Z |  51.69772909680771
384 objects
```