### PR TITLE
bitfinex type unification

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -374,8 +374,8 @@ module.exports = class bitfinex2 extends bitfinex {
             if (this.inArray (id, futuresMarketIds)) {
                 spot = false;
             }
-            const futures = !spot;
-            const type = spot ? 'spot' : 'futures';
+            const future = !spot;
+            const type = spot ? 'spot' : 'future';
             let baseId = undefined;
             let quoteId = undefined;
             if (id.indexOf (':') >= 0) {
@@ -428,7 +428,7 @@ module.exports = class bitfinex2 extends bitfinex {
                 'swap': false,
                 'spot': spot,
                 'margin': margin,
-                'futures': futures,
+                'future': future,
             });
         }
         return result;


### PR DESCRIPTION
The updates should be correct, but I can't test because it looks like every market is `spot`

---

```
% bitfinex fetchMarkets
2022-01-08T04:50:19.979Z
Node.js: v14.17.0
CCXT v1.66.42
bitfinex.fetchMarkets ()
3103 ms
                  id |               symbol |          base |      quote |        baseId |    quoteId | active | type | spot | margin |              precision |                                                                   limits
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
              BTCUSD |              BTC/USD |           BTC |        USD |           BTC |        USD |   true | spot | true |   true | {"price":5,"amount":8} |     {"amount":{"min":0.00006,"max":2000},"price":{"min":1e-8},"cost":{}}
...
         ZECF0:USTF0 |          ZECF0/USTF0 |         ZECF0 |      USTF0 |         ZECF0 |      USTF0 |   true | spot | true |   true | {"price":5,"amount":8} |      {"amount":{"min":0.001,"max":20000},"price":{"min":1e-8},"cost":{}}
         CRVF0:USTF0 |          CRVF0/USTF0 |         CRVF0 |      USTF0 |         CRVF0 |      USTF0 |   true | spot | true |   true | {"price":5,"amount":8} |      {"amount":{"min":0.001,"max":50000},"price":{"min":1e-8},"cost":{}}
429 objects
```