### PR TITLE
Added fetch-funding-rate-history-example

### DIFF
--- a/examples/js/fetch-funding-rate-history.js
+++ b/examples/js/fetch-funding-rate-history.js
@@ -1,0 +1,23 @@
+const ccxt = require('../../ccxt')
+    , asTable  = require ('as-table').configure ({ delimiter: ' | ' })
+
+console.log ('CCXT Version:', ccxt.version)
+
+async function main () {
+
+    const exchange = new ccxt.binanceusdm()
+        , symbol = 'ETH/USDT'
+        , since = undefined
+        , limit = undefined
+        , params = {}
+
+    // ------------------------------------------------------------------------
+    // fetch the history of the funding rate for a symbol
+
+    const response = await exchange.fetchFundingRateHistory (symbol, since, limit, params)
+
+    console.log (asTable (response))
+
+}
+
+main ()


### PR DESCRIPTION
```
node examples/js/fetch-funding-rate-history.js
CCXT Version: 1.66.42
info            | symbol   | fundingRate | timestamp     | datetime                
-----------------------------------------------------------------------------------
[object Object] | ETH/USDT | 0.0001      | 1638748800009 | 2021-12-06T00:00:00.009Z
[object Object] | ETH/USDT | 0.0001      | 1638777600001 | 2021-12-06T08:00:00.001Z
[object Object] | ETH/USDT | 0.0001      | 1638806400000 | 2021-12-06T16:00:00.000Z
[object Object] | ETH/USDT | 0.0001      | 1638835200018 | 2021-12-07T00:00:00.018Z
[object Object] | ETH/USDT | 0.0000706   | 1638864000000 | 2021-12-07T08:00:00.000Z
...
[object Object] | ETH/USDT | 0.0001      | 1641542400000 | 2022-01-07T08:00:00.000Z
[object Object] | ETH/USDT | 0.0001      | 1641571200001 | 2022-01-07T16:00:00.001Z
[object Object] | ETH/USDT | 0.0001      | 1641600000014 | 2022-01-08T00:00:00.014Z
```