### PR TITLE
Added support for AMP to Bitstamp

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -205,6 +205,8 @@ module.exports = class bitstamp extends Exchange {
                         'gala_address/',
                         'shib_withdrawal/',
                         'shib_address/',
+                        'amp_withdrawal/',
+                        'amp_address/',
                         'transfer-to-main/',
                         'transfer-from-main/',
                         'withdrawal-requests/',


### PR DESCRIPTION
Bitstamp is adding AMP to their platform: https://blog.bitstamp.net/post/were-listing-ftm-and-amp

FTM was already added previously, but they delayed the launch until this week.