### PR TITLE
fix[Gate.io]: ensure correct order values

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2454,15 +2454,15 @@ module.exports = class gateio extends Exchange {
         const status = this.parseOrderStatus (rawStatus);
         let timeInForce = this.safeStringUpper2 (order, 'time_in_force', 'tif');
         if (timeInForce === 'POC') {
-            timeInForce = 'PO'
+            timeInForce = 'PO';
         }
         let type = this.safeString (order, 'type');
         if (type === undefined) {
             // response for swaps doesn't include the type information
             if (timeInForce === 'PO' || timeInForce === 'GTC' || timeInForce === 'IOC' || timeInForce === 'FOK') {
-                type = 'limit'
+                type = 'limit';
             } else {
-                type = 'market'
+                type = 'market';
             }
         }
         const fees = [];

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2459,10 +2459,9 @@ module.exports = class gateio extends Exchange {
         const type = this.safeString (order, 'type');
         if (type === undefined) {
             // response for swaps doesn't include the type information
-            if (timeInForce === 'PO' || timeInForce === 'GTC') {
+            if (timeInForce === 'PO' || timeInForce === 'GTC' || timeInForce === 'IOC' || timeInForce === 'FOK') {
                 type = 'limit'
             } else {
-                // IOC, FOK
                 type = 'market'
             }
         }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2452,8 +2452,20 @@ module.exports = class gateio extends Exchange {
             side = this.safeString (order, 'side');
         }
         const status = this.parseOrderStatus (rawStatus);
-        const type = this.safeString (order, 'type');
         const timeInForce = this.safeStringUpper2 (order, 'time_in_force', 'tif');
+        if (timeInForce === 'POC') {
+            timeInForce = 'PO'
+        }
+        const type = this.safeString (order, 'type');
+        if (type === undefined) {
+            // response for swaps doesn't include the type information
+            if (timeInForce === 'PO' || timeInForce === 'GTC') {
+                type = 'limit'
+            } else {
+                // IOC, FOK
+                type = 'market'
+            }
+        }
         const fees = [];
         const gtFee = this.safeNumber (order, 'gt_fee');
         if (gtFee) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2452,7 +2452,7 @@ module.exports = class gateio extends Exchange {
             side = this.safeString (order, 'side');
         }
         const status = this.parseOrderStatus (rawStatus);
-        const timeInForce = this.safeStringUpper2 (order, 'time_in_force', 'tif');
+        let timeInForce = this.safeStringUpper2 (order, 'time_in_force', 'tif');
         if (timeInForce === 'POC') {
             timeInForce = 'PO'
         }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2456,7 +2456,7 @@ module.exports = class gateio extends Exchange {
         if (timeInForce === 'POC') {
             timeInForce = 'PO'
         }
-        const type = this.safeString (order, 'type');
+        let type = this.safeString (order, 'type');
         if (type === undefined) {
             // response for swaps doesn't include the type information
             if (timeInForce === 'PO' || timeInForce === 'GTC' || timeInForce === 'IOC' || timeInForce === 'FOK') {


### PR DESCRIPTION
According to [this](https://docs.ccxt.com/en/latest/manual.html#order-structure) part in the CCXT documentation, an order has one of the following values for ```timeInForce```: ```'GTC', 'IOC', 'FOK', 'PO'``` AND one of the following values for ```type```: ```'market', 'limit'```.

This PR ensures the structure mentioned above to ensure that the user doesn't receive unexpected values that differ from the defined CCXT values.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201640356146331
  - https://app.asana.com/0/0/1201640356146333