### PR TITLE
fix[Gate.io]: transfer between wallets

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2814,7 +2814,7 @@ module.exports = class gateio extends Exchange {
             'to': toId,
             'amount': truncated,
         };
-        if ((toId === 'future') || (toId === 'delivery')) {
+        if ((toId === 'futures') || (toId === 'delivery') || (fromId === 'futures') || (fromId === 'delivery')) {
             request['settle'] = currency['lowerCaseId'];
         }
         const response = await this.privateWalletPostTransfers (this.extend (request, params));


### PR DESCRIPTION
First: ```future``` needs to be changed to ```futures``` (see [this part of the Gate.io documentation](https://www.gate.io/docs/developers/apiv4/en/#transfer-between-trading-accounts))

Second: if the transfer from ```spot -> swap``` needs a settle currency, then the transfer from ```swap -> spot``` needs one as well

I've tested both changes in python and was able to successfully transfer from spot -> swap and from swap -> spot.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201640356146329