### PR TITLE
feat[Gate.io]: add end-timestamp support for funding history

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1286,6 +1286,10 @@ module.exports = class gateio extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
+        const toTimestamp = this.safeInteger (params, 'to');
+        if (toTimestamp !== undefined) {
+            request['to'] = toTimestamp
+        }
         const method = this.getSupportedMapping (market['type'], {
             'swap': 'privateFuturesGetSettleAccountBook',
             'future': 'privateDeliveryGetSettleAccountBook',


### PR DESCRIPTION
As per Gate.io documentation ([swap](https://www.gate.io/docs/developers/apiv4/en/#query-account-book
), [delivery](https://www.gate.io/docs/developers/apiv4/en/#query-account-book-2)), there is a parameter to define the timestamp where the requested data should end.

However, when passing it to the method, the param is not attached to the request. This PR adds support for it.