### PR TITLE
aax type unification

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -1002,7 +1002,7 @@ module.exports = class aax extends Exchange {
         let method = undefined;
         if (market['spot']) {
             method = 'privatePostSpotOrders';
-        } else if (market['futures']) {
+        } else if (market['contract']) {
             method = 'privatePostFuturesOrders';
         }
         const response = await this[method] (this.extend (request, params));
@@ -1113,7 +1113,7 @@ module.exports = class aax extends Exchange {
         let method = undefined;
         if (market['spot']) {
             method = 'privatePutSpotOrders';
-        } else if (market['futures']) {
+        } else if (market['contract']) {
             method = 'privatePutFuturesOrders';
         }
         const response = await this[method] (this.extend (request, params));
@@ -1217,7 +1217,7 @@ module.exports = class aax extends Exchange {
         }
         if (type === 'spot') {
             method = 'privateDeleteSpotOrdersCancelOrderID';
-        } else if (type === 'futures') {
+        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
             method = 'privateDeleteFuturesOrdersCancelOrderID';
         }
         const response = await this[method] (this.extend (request, params));
@@ -1316,7 +1316,7 @@ module.exports = class aax extends Exchange {
         let method = undefined;
         if (market['spot']) {
             method = 'privateDeleteSpotOrdersCancelAll';
-        } else if (market['futures']) {
+        } else if (market['contract']) {
             method = 'privateDeleteFuturesOrdersCancelAll';
         }
         const response = await this[method] (this.extend (request, params));
@@ -1385,7 +1385,7 @@ module.exports = class aax extends Exchange {
         let method = undefined;
         if (type === 'spot') {
             method = 'privateGetSpotOpenOrders';
-        } else if (type === 'futures') {
+        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
             method = 'privateGetFuturesOpenOrders';
         }
         if (limit !== undefined) {
@@ -1532,7 +1532,7 @@ module.exports = class aax extends Exchange {
         }
         if (type === 'spot') {
             method = 'privateGetSpotOrders';
-        } else if (type === 'futures') {
+        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
             method = 'privateGetFuturesOrders';
         }
         const clientOrderId = this.safeString2 (params, 'clOrdID', 'clientOrderId');
@@ -1819,7 +1819,7 @@ module.exports = class aax extends Exchange {
         }
         if (type === 'spot') {
             method = 'privateGetSpotTrades';
-        } else if (type === 'futures') {
+        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
             method = 'privateGetFuturesTrades';
         }
         if (limit !== undefined) {


### PR DESCRIPTION
2022-01-11T16:35:29.460Z
Node.js: v14.17.0
CCXT v1.67.1

### fetchMyTrades

```
aax.fetchMyTrades ()
920 ms
          id |     timestamp |                 datetime |        symbol |   type | side |      order | takerOrMaker |   price | amount |      cost |                                   fee |                                    fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
E08fttOC57Ck | 1641041821353 | 2022-01-01T12:57:01.353Z | ETH/USDT:USDT | market |  buy | 1PMwVQRkly |        taker | 3715.36 |      2 |   74.3072 |  {"currency":"ETH","cost":0.02972288} |  [{"currency":"ETH","cost":0.02972288}]
...
E08mQWjXdB5d | 1641814009717 | 2022-01-10T11:26:49.717Z | ETH/USDT:USDT | market | sell | 1QI0JjgwPm |        taker | 3100.75 |    -11 | -341.0825 |   {"currency":"USDT","cost":0.136433} |   [{"currency":"USDT","cost":0.136433}]
E08n9UDUDN8U | 1641908267615 | 2022-01-11T13:37:47.615Z | ETH/USDT:USDT |  limit |  buy | 1QOCWXU2QM |        maker | 3112.41 |      7 |  217.8687 |  {"currency":"ETH","cost":0.04357374} |  [{"currency":"ETH","cost":0.04357374}]
```

### fetchOrders

```
aax.fetchOrders ()
935 ms
        id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |        symbol |      type | timeInForce | postOnly | side |   price | stopPrice | average | amount | filled | remaining |     cost | trades |                                   fee |                                    fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1QGxcwX0JO |               | 1641794177652 | 2022-01-10T05:56:17.652Z |      1641794177666 |   closed | ETH/USDT:USDT |    market |         GTC |    false | sell | 3143.94 |         0 | 3168.94 |     22 |     22 |         0 | 697.1668 |     [] | {"currency":"USDT","cost":0.27886672} | [{"currency":"USDT","cost":0.27886672}]
...
1QPSiasrJK |               | 1641919652585 | 2022-01-11T16:47:32.585Z |      1641919652601 |   closed | ETH/USDT:USDT |     limit |             |    false | sell | 3208.34 |         0 | 3214.24 |      7 |      7 |         0 | 224.9968 |     [] | {"currency":"USDT","cost":0.08999872} | [{"currency":"USDT","cost":0.08999872}]
1QPSEnOM1y |               | 1641919730223 | 2022-01-11T16:48:50.223Z |      1641919730240 |     open | ETH/USDT:USDT |     limit |         GTC |    false |  buy |    3163 |         0 |         |     11 |      0 |        11 |        0 |     [] |           {"currency":"ETH","cost":0} |           [{"currency":"ETH","cost":0}]
10 objects
```

### fetchOpenOrders

```
aax.fetchOpenOrders ()
926 ms
        id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | amount | filled | remaining | cost | trades |                         fee |                          fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1QPSEnOM1y |               | 1641919730223 | 2022-01-11T16:48:50.223Z |      1641919730240 |   open | ETH/USDT:USDT | limit |         GTC |    false |  buy |  3163 |         0 |         |     11 |      0 |        11 |    0 |     [] | {"currency":"ETH","cost":0} | [{"currency":"ETH","cost":0}]
1 objects
```

### cancelAllOrders

```
aax.cancelAllOrders (ETH/USDT:USDT)
929 ms
{
  code: '1',
  data: [ '1QPSEnOM1y' ],
  message: 'success',
  ts: '1641920251505'
}
```

### createOrder

```
aax.createOrder (ADA/USDT:USDT, limit, buy, 11, 1)
907 ms
{
  id: '1QPVo8qfT2',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '2',
    leverage: '5',
    marketPrice: '1.18014',
    code: 'FP',
    avgPrice: '0',
    execInst: 'Post-Only',
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '1',
    orderQty: '11',
    commission: '0',
    id: '401178145708765185',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '1QPVo8qfT2',
    leavesQty: '11',
    cumQty: '0',
    updateTime: null,
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-01-11T16:58:43.464Z',
    transactTime: null,
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1641920323464,
  datetime: '2022-01-11T16:58:43.464Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 1,
  stopPrice: 0,
  average: undefined,
  amount: 11,
  filled: 0,
  remaining: 11,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
```

### editOrder

```
aax.editOrder (1QPYgkwso0, ADA/USDT:USDT, limit, buy, 11, 1.01)
881 ms
{
  id: '1QPYgkwso0',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '2',
    leverage: '5',
    marketPrice: '1.18771',
    code: 'FP',
    avgPrice: '0',
    execInst: 'Post-Only',
    orderStatus: '1',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '1.01',
    orderQty: '11',
    commission: '0',
    id: '401180757715775488',
    timeInForce: '1',
    tradeID: 'E08nsRhKedFf',
    isTriggered: false,
    side: '1',
    orderID: '1QPYgkwso0',
    leavesQty: '11.0',
    cumQty: '0',
    updateTime: '2022-01-11T17:09:06.243Z',
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-01-11T17:09:06.217Z',
    transactTime: '2022-01-11T17:09:06.237Z',
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1641920946217,
  datetime: '2022-01-11T17:09:06.217Z',
  lastTradeTimestamp: 1641920946237,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 1.01,
  stopPrice: 0,
  average: undefined,
  amount: 11,
  filled: 0,
  remaining: 11,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
```

### cancelOrder

```
aax.cancelOrder (1QPVo8qfT2)
909 ms
{
  id: '1QPVo8qfT2',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '2',
    leverage: '5',
    marketPrice: '1.18014',
    code: 'FP',
    avgPrice: '0',
    execInst: 'Post-Only',
    orderStatus: '1',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '1',
    orderQty: '11.0',
    commission: '0',
    id: '401178145708765185',
    timeInForce: '1',
    tradeID: 'E08nsRhKbOUY',
    isTriggered: false,
    side: '1',
    orderID: '1QPVo8qfT2',
    leavesQty: '11.0',
    cumQty: '0',
    updateTime: '2022-01-11T16:58:43.502Z',
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-01-11T16:58:43.464Z',
    transactTime: '2022-01-11T16:58:43.496Z',
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1641920323464,
  datetime: '2022-01-11T16:58:43.464Z',
  lastTradeTimestamp: 1641920323496,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 1,
  stopPrice: 0,
  average: undefined,
  amount: 11,
  filled: 0,
  remaining: 11,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
```