### PR TITLE
Bitmart safeTicker

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -733,7 +733,7 @@ module.exports = class bitmart extends Exchange {
         }
         average = this.safeNumber (ticker, 'avg_price', average);
         const price = this.safeValue (ticker, 'depth_price', ticker);
-        return {
+        return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -754,7 +754,7 @@ module.exports = class bitmart extends Exchange {
             'baseVolume': baseVolume,
             'quoteVolume': quoteVolume,
             'info': ticker,
-        };
+        }, market);
     }
 
     async fetchTicker (symbol, params = {}) {


### PR DESCRIPTION
Bitmart added safeTicker #11079 :
```
bitmart.fetchTicker (ETH_BTC)
488 ms
{
  symbol: 'ETH/BTC',
  timestamp: 1641969787854,
  datetime: '2022-01-12T06:43:07.854Z',
  high: 0.076167,
  low: 0.073775,
  bid: 0.075856,
  bidVolume: 2.3929,
  ask: 0.075922,
  askVolume: 2.3688,
  vwap: 0.07519199169561745,
  open: 0.073809,
  close: 0.075882,
  last: 0.075882,
  previousClose: undefined,
  change: 0.0020730000000000054,
  percentage: 2.81,
  average: 0.07484550000000001,
  baseVolume: 1990.2744,
  quoteVolume: 149.6526961568,
  info: {
    symbol: 'ETH_BTC',
    last_price: '0.075882',
    quote_volume_24h: '149.6526961568',
    base_volume_24h: '1990.2744',
    high_24h: '0.076167',
    low_24h: '0.073775',
    open_24h: '0.073809',
    close_24h: '0.075882',
    best_ask: '0.075922',
    best_ask_size: '2.3688',
    best_bid: '0.075856',
    best_bid_size: '2.3929',
    fluctuation: '+0.0281',
    url: 'https://www.bitmart.com/trade?symbol=ETH_BTC'
  }
}
```