### PR TITLE
Coinex safeTicker

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -274,7 +274,7 @@ module.exports = class coinex extends Exchange {
         }
         ticker = this.safeValue (ticker, 'ticker', {});
         const last = this.safeNumber (ticker, 'last');
-        return {
+        return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -295,7 +295,7 @@ module.exports = class coinex extends Exchange {
             'baseVolume': this.safeNumber2 (ticker, 'vol', 'volume'),
             'quoteVolume': undefined,
             'info': ticker,
-        };
+        }, market);
     }
 
     async fetchTicker (symbol, params = {}) {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -268,10 +268,7 @@ module.exports = class coinex extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         const timestamp = this.safeInteger (ticker, 'date');
-        let symbol = undefined;
-        if (market !== undefined) {
-            symbol = market['symbol'];
-        }
+        const symbol = this.safeSymbol (undefined, market);
         ticker = this.safeValue (ticker, 'ticker', {});
         const last = this.safeNumber (ticker, 'last');
         return this.safeTicker ({


### PR DESCRIPTION
Added safeTicker to Coinex #11079 
```
coinex.fetchTicker (ETHBTC)
1223 ms
{
  symbol: 'ETH/BTC',
  timestamp: 1641970536529,
  datetime: '2022-01-12T06:55:36.529Z',
  high: 0.07610343,
  low: 0.07372285,
  bid: 0.07578003,
  bidVolume: undefined,
  ask: 0.07593931,
  askVolume: undefined,
  vwap: undefined,
  open: undefined,
  close: 0.07591433,
  last: 0.07591433,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: 19.1904743,
  quoteVolume: undefined,
  info: {
    vol: '19.19047430',
    low: '0.07372285',
    open: '0.07381265',
    high: '0.07610343',
    last: '0.07591433',
    buy: '0.07578003',
    buy_amount: '0.74220226',
    sell: '0.07593931',
    sell_amount: '0.07740336'
  }
}
```