### PR TITLE
Kraken safeTicker

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -656,10 +656,7 @@ module.exports = class kraken extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         const timestamp = this.milliseconds ();
-        let symbol = undefined;
-        if (market) {
-            symbol = market['symbol'];
-        }
+        const symbol = this.safeSymbol (undefined, market);
         const baseVolume = parseFloat (ticker['v'][1]);
         const vwap = parseFloat (ticker['p'][1]);
         let quoteVolume = undefined;

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -667,7 +667,7 @@ module.exports = class kraken extends Exchange {
             quoteVolume = baseVolume * vwap;
         }
         const last = parseFloat (ticker['c'][0]);
-        return {
+        return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -688,7 +688,7 @@ module.exports = class kraken extends Exchange {
             'baseVolume': baseVolume,
             'quoteVolume': quoteVolume,
             'info': ticker,
-        };
+        }, market);
     }
 
     async fetchTickers (symbols = undefined, params = {}) {


### PR DESCRIPTION
Kraken added safeTicker #11079 :
```
kraken.fetchTicker (BTC/USDT)
3231 ms
{
  symbol: 'BTC/USDT',
  timestamp: 1641972180474,
  datetime: '2022-01-12T07:23:00.474Z',
  high: 43078,
  low: 41301.1,
  bid: 42493.6,
  bidVolume: undefined,
  ask: 42504.3,
  askVolume: undefined,
  vwap: 42304.44917,
  open: 42703.9,
  close: 42505,
  last: 42505,
  previousClose: undefined,
  change: -198.90000000000146,
  percentage: -0.46576542189355413,
  average: 42604.45,
  baseVolume: 234.99430403,
  quoteVolume: 9941304.59007666,
  info: {
    a: [ '42504.30000', '1', '1.000' ],
    b: [ '42493.60000', '1', '1.000' ],
    c: [ '42505.00000', '0.00700000' ],
    v: [ '30.20061645', '234.99430403' ],
    p: [ '42626.36957', '42304.44917' ],
    t: [ 424, 3266 ],
    l: [ '42483.00000', '41301.10000' ],
    h: [ '42941.20000', '43078.00000' ],
    o: '42703.90000'
  }
}
```