### PR TITLE
[FTX] Change text matched in RateLimitExceeded

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -303,7 +303,7 @@ module.exports = class ftx extends Exchange {
             },
             'exceptions': {
                 'exact': {
-                    'Please slow down': RateLimitExceeded, // {"error":"Please slow down","success":false}
+                    'Slow down': RateLimitExceeded, // {"error":"Slow down","success":false}
                     'Size too small for provide': InvalidOrder, // {"error":"Size too small for provide","success":false}
                     'Not enough balances': InsufficientFunds, // {"error":"Not enough balances","success":false}
                     'InvalidPrice': InvalidOrder, // {"error":"Invalid price","success":false}


### PR DESCRIPTION
**Problem**: FTX's "Slow down" error is not matched as `RateLimitExceeded` because of a difference in the text.
Instead it ends up being a generic `ExchangeError`:

```
ExchangeError: ftx {"success":false,"error":"Slow down"}
```

This PR simply changes the matched text.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201649947682928