### PR TITLE
Kucoin type uni

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -404,6 +404,7 @@ module.exports = class kucoin extends Exchange {
                     'margin': 'margin',
                     'main': 'main',
                     'funding': 'main',
+                    'future': 'contract',
                     'futures': 'contract',
                     'contract': 'contract',
                     'pool': 'pool',
@@ -710,7 +711,7 @@ module.exports = class kucoin extends Exchange {
             throw new ExchangeError (this.id + ' type must be one of ' + keys.join (', '));
         }
         params = this.omit (params, 'type');
-        return (type === 'contract') || (type === 'futures');
+        return (type === 'contract') || (type === 'future') || (type === 'futures'); // * (type === 'futures') deprecated, use (type === 'future')
     }
 
     parseTicker (ticker, market = undefined) {

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1264,8 +1264,8 @@ module.exports = class kucoinfutures extends kucoin {
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {
-        if ((toAccount !== 'spot' && toAccount !== 'trade' && toAccount !== 'trading') || (fromAccount !== 'futures' && fromAccount !== 'future' && fromAccount !== 'contract')) {
-            throw new BadRequest (this.id + ' only supports transfers from contract(future) account to trade(spot) account');
+        if ((toAccount !== 'main' && toAccount !== 'funding') || (fromAccount !== 'futures' && fromAccount !== 'future' && fromAccount !== 'contract')) {
+            throw new BadRequest (this.id + ' only supports transfers from contract(future) account to main(funding) account');
         }
         return this.transferOut (code, amount, params);
     }

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1243,7 +1243,7 @@ module.exports = class kucoinfutures extends kucoin {
         // only fetches one balance at a time
         // by default it will only fetch the BTC balance of the futures account
         // you can send 'currency' in params to fetch other currencies
-        // fetchBalance ({ 'type': 'futures', 'currency': 'USDT' })
+        // fetchBalance ({ 'type': 'future', 'currency': 'USDT' })
         const response = await this.futuresPrivateGetAccountOverview (params);
         //
         //     {
@@ -1264,8 +1264,8 @@ module.exports = class kucoinfutures extends kucoin {
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {
-        if ((toAccount !== 'spot' && toAccount !== 'trade' && toAccount !== 'trading') || (fromAccount !== 'futures' && fromAccount !== 'contract')) {
-            throw new BadRequest (this.id + ' only supports transfers from contract(futures) account to trade(spot) account');
+        if ((toAccount !== 'spot' && toAccount !== 'trade' && toAccount !== 'trading') || (fromAccount !== 'futures' && fromAccount !== 'future' && fromAccount !== 'contract')) {
+            throw new BadRequest (this.id + ' only supports transfers from contract(future) account to trade(spot) account');
         }
         return this.transferOut (code, amount, params);
     }
@@ -1296,7 +1296,7 @@ module.exports = class kucoinfutures extends kucoin {
             'datetime': this.iso8601 (timestamp),
             'currency': code,
             'amount': amount,
-            'fromAccount': 'futures',
+            'fromAccount': 'future',
             'toAccount': 'spot',
             'status': this.safeString (data, 'status'),
         };


### PR DESCRIPTION
@frosty00 doesn't like the change with `futures` -> `future` in transfer, but if I had to use `future` everywhere else, but `futures` within the transfer method, this would be a bug that would probably waste an hour of my time

-----------------

```
% kucoinfutures transfer USDT 1 future funding
2022-01-13T03:20:19.382Z
Node.js: v14.17.0
CCXT v1.67.31
kucoinfutures.transfer (USDT, 1, future, funding)
USDT 1 future funding
297 ms
{
  info: {
    code: '200000',
    data: {
      applyId: '...',
      bizNo: '...',
      payAccountType: 'CONTRACT',
      payTag: 'DEFAULT',
      remark: '',
      recAccountType: 'MAIN',
      recTag: 'DEFAULT',
      recRemark: '',
      recSystem: 'KUCOIN',
      status: 'PROCESSING',
      currency: 'USDT',
      amount: '1',
      fee: '0',
      sn: ...,
      reason: '',
      createdAt: 1642044019000,
      updatedAt: 1642044019000
    }
  },
  id: '...',
  timestamp: '...',
  datetime: '2022-01-13T03:20:19.000Z',
  currency: 'USDT',
  amount: 1,
  fromAccount: 'future',
  toAccount: 'spot',
  status: 'PROCESSING'
}
```
```
% kucoinfutures transfer USDT 1 futures funding
2022-01-13T03:20:23.761Z
Node.js: v14.17.0
CCXT v1.67.31
kucoinfutures.transfer (USDT, 1, futures, funding)
USDT 1 futures funding
284 ms
{
  info: {
    code: '200000',
    data: {
      applyId: '...',
      bizNo: '...',
      payAccountType: 'CONTRACT',
      payTag: 'DEFAULT',
      remark: '',
      recAccountType: 'MAIN',
      recTag: 'DEFAULT',
      recRemark: '',
      recSystem: 'KUCOIN',
      status: 'PROCESSING',
      currency: 'USDT',
      amount: '1',
      fee: '0',
      sn: ...,
      reason: '',
      createdAt: 1642044024000,
      updatedAt: 1642044024000
    }
  },
  id: '...',
  timestamp: '1642044024000',
  datetime: '2022-01-13T03:20:24.000Z',
  currency: 'USDT',
  amount: 1,
  fromAccount: 'future',
  toAccount: 'spot',
  status: 'PROCESSING'
}
```
```
% kucoinfutures transfer USDT 1 contract funding
2022-01-13T03:20:28.702Z
Node.js: v14.17.0
CCXT v1.67.31
kucoinfutures.transfer (USDT, 1, contract, funding)
USDT 1 contract funding
281 ms
{
  info: {
    code: '200000',
    data: {
      applyId: '...',
      bizNo: '...',
      payAccountType: 'CONTRACT',
      payTag: 'DEFAULT',
      remark: '',
      recAccountType: 'MAIN',
      recTag: 'DEFAULT',
      recRemark: '',
      recSystem: 'KUCOIN',
      status: 'PROCESSING',
      currency: 'USDT',
      amount: '1',
      fee: '0',
      sn: ...,
      reason: '',
      createdAt: 1642044029000,
      updatedAt: 1642044029000
    }
  },
  id: '...',
  timestamp: '1642044029000',
  datetime: '2022-01-13T03:20:29.000Z',
  currency: 'USDT',
  amount: 1,
  fromAccount: 'future',
  toAccount: 'spot',
  status: 'PROCESSING'
}
```
---------------

Also heads up, this happens

```
% kucoinfutures transfer USDT 1 contract main  
2022-01-13T03:23:09.115Z
Node.js: v14.17.0
CCXT v1.67.31
kucoinfutures.transfer (USDT, 1, contract, async function main () {

                           if (!exchangeId) {

                               printUsage ()

                           } else {

                               let args = params
                                   .map (s => s.match (/^[0-9]{4}[-]?[0-9]{2}[-]?[0-9]{2}[T\s]?[0-9]{2}[:]?[0-9]{2}[:]?[0-9]{2}/g) ? exchange.parse8601 (s) : s)
                                   .map (s => (() => { try { return eval ('(() => (' + s + ')) ()') } catch (e) { return s } }) ())

                               const www = Array.isArray (exchange.urls.www) ? exchange.urls.www[0] : exchange.urls.www

                               if (cors) {
                                   exchange.proxy = 'https://cors-anywhere.herokuapp.com/';
                                   exchange.origin = exchange.uuid ()
                               }

                               no_load_markets = no_send ? true : no_load_markets

                               if (debug) {
                                   exchange.verbose = verbose
                               }

                               if (!no_load_markets) {
                                   await exchange.loadMarkets ()
                               }

                               if (signIn && exchange.has.signIn) {
                                   await exchange.signIn ()
                               }

                               exchange.verbose = verbose

                               if (no_send) {

                                   exchange.verbose = no_send
                                   exchange.fetch = function fetch (url, method = 'GET', headers = undefined, body = undefined) {
                                       log.dim.noLocate ('-------------------------------------------')
                                       log.dim.noLocate (exchange.iso8601 (exchange.milliseconds ()))
                                       log.green.unlimited ({
                                           url,
                                           method,
                                           headers,
                                           body,
                                       })
                                       process.exit ()
                                   }
                               }

                               if (methodName) {

                                   if (typeof exchange[methodName] === 'function') {

                                       log (exchange.id + '.' + methodName, '(' + args.join (', ') + ')')

                                       let start = exchange.milliseconds ()
                                       let end = exchange.milliseconds ()

                                       while (true) {
```