### PR TITLE
Added binance vanilla options api paths

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -122,6 +122,8 @@ module.exports = class binance extends Exchange {
                 'test': {
                     'dapiPublic': 'https://testnet.binancefuture.com/dapi/v1',
                     'dapiPrivate': 'https://testnet.binancefuture.com/dapi/v1',
+                    'vapiPublic': 'https://testnet.binanceops.com/vapi/v1',
+                    'vapiPrivate': 'https://testnet.binanceops.com/vapi/v1',
                     'fapiPublic': 'https://testnet.binancefuture.com/fapi/v1',
                     'fapiPrivate': 'https://testnet.binancefuture.com/fapi/v1',
                     'fapiPrivateV2': 'https://testnet.binancefuture.com/fapi/v2',
@@ -134,6 +136,8 @@ module.exports = class binance extends Exchange {
                     'sapi': 'https://api.binance.com/sapi/v1',
                     'dapiPublic': 'https://dapi.binance.com/dapi/v1',
                     'dapiPrivate': 'https://dapi.binance.com/dapi/v1',
+                    'vapiPublic': 'https://vapi.binance.com/vapi/v1',
+                    'vapiPrivate': 'https://vapi.binance.com/vapi/v1',
                     'dapiPrivateV2': 'https://dapi.binance.com/dapi/v2',
                     'dapiData': 'https://dapi.binance.com/futures/data',
                     'fapiPublic': 'https://fapi.binance.com/fapi/v1',
@@ -584,6 +588,47 @@ module.exports = class binance extends Exchange {
                         'positionRisk': 1,
                     },
                 },
+                'vapiPublic': {
+                    'get': [
+                        'ping',
+                        'time',
+                        'optionInfo',
+                        'exchangeInfo',
+                        'index',
+                        'ticker',
+                        'mark',
+                        'depth',
+                        'klines',
+                        'trades',
+                        'historicalTrades',
+                    ],
+                },
+                'vapiPrivate': {
+                    'get': [
+                        'account',
+                        'position',
+                        'order',
+                        'openOrders',
+                        'historyOrders',
+                        'userTrades',
+                    ],
+                    'post': [
+                        'transfer',
+                        'bill',
+                        'order',
+                        'batchOrders',
+                        'userDataStream',
+                    ],
+                    'put': [
+                        'userDataStream',
+                    ],
+                    'delete': [
+                        'order',
+                        'batchOrders',
+                        'allOpenOrders',
+                        'userDataStream',
+                    ],
+                },
                 'public': {
                     'get': {
                         'ping': 1,
@@ -710,6 +755,7 @@ module.exports = class binance extends Exchange {
                         },
                     },
                 },
+                'option': {},
             },
             'commonCurrencies': {
                 'BCC': 'BCC', // kept for backward-compatibility https://github.com/ccxt/ccxt/issues/4848


### PR DESCRIPTION
```
% binance vapiPublicGetTime                   
Debugger listening on ws://127.0.0.1:49681/c8100969-4af4-47bf-83de-61aa3c444ab9
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2022-01-13T13:27:28.732Z
Node.js: v14.17.0
CCXT v1.67.31
binance.vapiPublicGetTime ()
1041 ms
{ code: '0', msg: 'success', data: '1642080450611' }
Waiting for the debugger to disconnect...
```

--------------------------

We'll have to figure how to record the [fee structure](https://www.binance.com/en/support/faq/374321c9317c473480243365298b8706)

> Fee Calculation
> Options fees have two parts: the transaction fee and the fee to exercise.
> Transaction fee will be charged after the transaction.
> Premiums are unidirectional, so if the buyer's profit when the Options is exercised is >0, the buyer will pay a fee.
> 
>  Transaction fee = Index price × Transaction fee rate.
>     Fee to exercise = Exercise price × Fee to exercise rate.
>     The transaction fee will not exceed 10% of the amount of the transaction.
>     The fee to exercise will not exceed 10% of the profit gained by exercising the Options.
> 
> Transaction fees for each transaction are calculated based on the index price at the time of order completion.
> Transaction fee rate：0.03% of the underlying value
> Exercise fee rate ： 0.1% of the underlying value