### PR TITLE
Kucoin: added error "The interface has been deprecated"

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -291,6 +291,7 @@ module.exports = class kucoin extends Exchange {
                     '400100': BadRequest,
                     '400350': InvalidOrder, // {"code":"400350","msg":"Upper limit for holding: 10,000USDT, you can still buy 10,000USDT worth of coin."}
                     '400500': InvalidOrder, // {"code":"400500","msg":"Your located country/region is currently not supported for the trading of this token"}
+                    '401000': BadRequest, // {"code":"401000","msg":"The interface has been deprecated"}
                     '411100': AccountSuspended,
                     '415000': BadRequest, // {"code":"415000","msg":"Unsupported Media Type"}
                     '500000': ExchangeNotAvailable, // {"code":"500000","msg":"Internal Server Error"}


### PR DESCRIPTION
GET https://openapi-v2.kucoin.com/api/v1/hist-orders?pageSize=200&startAt=1483228800&currentPage=1

Response:
{"code":"401000","msg":"The interface has been deprecated"}