### PR TITLE
Mexc fetchTickers : handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -653,14 +653,13 @@ module.exports = class mexc extends Exchange {
 
     async fetchTickers (symbols = undefined, params = {}) {
         await this.loadMarkets ();
-        const defaultType = this.safeString2 (this.options, 'fetchTickers', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
-        const query = this.omit (params, 'type');
-        let method = 'spotPublicGetMarketTicker';
-        if (type === 'swap') {
-            method = 'contractPublicGetTicker';
-        }
-        const response = await this[method] (this.extend (query));
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPublicGetMarketTicker',
+            'swap': 'contractPublicGetTicker',
+        });
+        const response = await this[method] (this.extend (params));
         //
         //     {
         //         "success":true,


### PR DESCRIPTION
Changed fetchTickers to use handleMarketTypeAndParams:
```
mexc.fetchTickers (BTC/USDT)
507 ms
{
  'BTC/USDT': {
    symbol: 'BTC/USDT',
    timestamp: 1642142400000,
    datetime: '2022-01-14T06:40:00.000Z',
    high: 44416.95,
    low: 42323.08,
    bid: 42841.07,
    bidVolume: undefined,
    ask: 42841.1,
    askVolume: undefined,
    vwap: undefined,
    open: 43772.24,
    close: 42841.09,
    last: 42841.09,
    previousClose: undefined,
    change: -931.1500000000015,
    percentage: 1,
    average: 43306.66499999999,
    baseVolume: 3547.067822,
    quoteVolume: undefined,
    info: {
      symbol: 'BTC_USDT',
      volume: '3547.067822',
      high: '44416.95',
      low: '42323.08',
      bid: '42841.07',
      ask: '42841.1',
      open: '43772.24',
      last: '42841.09',
      time: '1642142400000',
      change_rate: '-0.02127261'
    }
  }
}
```