### PR TITLE
Mexc fetchTicker : handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -698,12 +698,12 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        let method = undefined;
-        if (market['spot']) {
-            method = 'spotPublicGetMarketTicker';
-        } else if (market['swap']) {
-            method = 'contractPublicGetTicker';
-        }
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPublicGetMarketTicker',
+            'swap': 'contractPublicGetTicker',
+        });
         const response = await this[method] (this.extend (request, params));
         //
         // spot


### PR DESCRIPTION
Adjusted fetchTicker to use handleMarketTypeAndParams:
```
mexc.fetchTicker (BTC/USDT)
209 ms
{
  symbol: 'BTC/USDT',
  timestamp: 1642146000000,
  datetime: '2022-01-14T07:40:00.000Z',
  high: 44416.95,
  low: 42323.08,
  bid: 42714.54,
  bidVolume: undefined,
  ask: 42714.57,
  askVolume: undefined,
  vwap: undefined,
  open: 43647.44,
  close: 42714.55,
  last: 42714.55,
  previousClose: undefined,
  change: -932.8899999999994,
  percentage: 1,
  average: 43180.995,
  baseVolume: 3563.293517,
  quoteVolume: undefined,
  info: {
    symbol: 'BTC_USDT',
    volume: '3563.293517',
    high: '44416.95',
    low: '42323.08',
    bid: '42714.54',
    ask: '42714.57',
    open: '43647.44',
    last: '42714.55',
    time: '1642146000000',
    change_rate: '-0.0213733'
  }
}
```