### PR TITLE
add missing Gate.io error

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -506,6 +506,7 @@ module.exports = class gateio extends Exchange {
                     'INVALID_CURRENCY_PAIR': BadSymbol,
                     'POC_FILL_IMMEDIATELY': ExchangeError,
                     'ORDER_NOT_FOUND': OrderNotFound,
+                    'CLIENT_ID_NOT_FOUND': OrderNotFound,
                     'ORDER_CLOSED': InvalidOrder,
                     'ORDER_CANCELLED': InvalidOrder,
                     'QUANTITY_NOT_ENOUGH': InvalidOrder,


### PR DESCRIPTION
Today I stumbled upon this error and saw that it is not present in CCXT yet.
```python
ccxt.base.errors.ExchangeError: gateio {"label":"CLIENT_ID_NOT_FOUND","message":"Order with client ID t-gusqlw-278749710ae439bb0c not found"}

.venv/lib/python3.9/site-packages/ccxt/async_support/gateio.py:2970: ExchangeError
```