### PR TITLE
fetchOpenInterestHistory - Binance, Bybit, OKX, Huobi

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2226,6 +2226,16 @@ module.exports = class Exchange {
         } else {
             throw new NotSupported (this.id + ' fetchMarketLeverageTiers() is not supported yet');
         }
+    }
 
+    parseOpenInterests (response, symbol, since, limit) {
+        const interests = [];
+        for (let i = 0; i < response.length; i++) {
+            const entry = response[i];
+            const interest = this.parseOpenInterest (entry);
+            interests.push (interest);
+        }
+        const sorted = this.sortBy (interests, 'timestamp');
+        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
     }
 }

--- a/js/binance.js
+++ b/js/binance.js
@@ -5562,6 +5562,18 @@ module.exports = class binance extends Exchange {
     }
 
     async fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name binance#fetchOpenInterestHistory
+         * @description Retrieves the open intestest history of a currency
+         * @param {str} symbol Unified CCXT market symbol
+         * @param {str} timeframe "5m","15m","30m","1h","2h","4h","6h","12h", or "1d"
+         * @param {int} since The time(ms) of the earliest record to retrieve as a unix timestamp
+         * @param {int} limit default 30, max 500
+         * @param {dict} params Exchange specific parameters
+         * @param {int} params.till The time(ms) of the latest record to retrieve as a unix timestamp
+         * @returns An array of open interest structures
+         */
         if (timeframe === '1m') {
             throw new BadRequest (this.id + 'fetchOpenInterestHistory cannot use the 1m timeframe');
         }

--- a/js/binance.js
+++ b/js/binance.js
@@ -5618,9 +5618,9 @@ module.exports = class binance extends Exchange {
         market = this.safeMarket (id, market);
         return {
             'symbol': this.safeSymbol (id),
-            'numContracts': this.safeNumber (interest, 'sumOpenInterest'),
-            'totalValue': this.safeNumber (interest, 'sumOpenInterestValue'),
-            'valueCurrency': market['quote'],
+            'volume': this.safeNumber (interest, 'sumOpenInterest'),
+            'value': this.safeNumber (interest, 'sumOpenInterestValue'),
+            'currency': market['quote'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/binance.js
+++ b/js/binance.js
@@ -69,6 +69,7 @@ module.exports = class binance extends Exchange {
                 'fetchMySells': undefined,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': true,
                 'fetchOpenOrder': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
@@ -5558,5 +5559,70 @@ module.exports = class binance extends Exchange {
             });
         }
         return this.filterByCurrencySinceLimit (interest, code, since, limit);
+    }
+
+    async fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+        if (timeframe === '1m') {
+            throw new BadRequest (this.id + 'fetchOpenInterestHistory cannot use the 1m timeframe');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'period': this.timeframes[timeframe],
+        };
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const symbolKey = market['future'] ? 'symbol' : 'pair';
+        request[symbolKey] = market['id'];
+        if (market['delivery']) {
+            request['contractType'] = this.safeString (params, 'contractType', 'CURRENT_QUARTER');
+        }
+        if (since !== undefined) {
+            request['startTime'] = since;
+        }
+        const till = this.safeInteger (params, 'till'); // unified in milliseconds
+        const endTime = this.safeString (params, 'endTime', till); // exchange-specific in milliseconds
+        params = this.omit (params, [ 'endTime', 'till' ]);
+        if (endTime) {
+            request['endTime'] = endTime;
+        } else if (since) {
+            if (limit === undefined) {
+                limit = 30; // Exchange default
+            }
+            const duration = this.parseTimeframe (timeframe);
+            request['endTime'] = this.sum (since, duration * limit * 1000);
+        }
+        let method = 'fapiDataGetOpenInterestHist';
+        if (market['delivery']) {
+            method = 'dapiDataGetOpenInterestHist';
+        }
+        const response = await this[method] (this.extend (request, params));
+        //
+        //  [
+        //      {
+        //          "symbol":"BTCUSDT",
+        //          "sumOpenInterest":"75375.61700000",
+        //          "sumOpenInterestValue":"3248828883.71251440",
+        //          "timestamp":1642179900000
+        //      },
+        //      ...
+        //  ]
+        //
+        const openInterest = [];
+        for (let i = 0; i < response.length; i++) {
+            const entry = response[i];
+            const timestamp = this.safeInteger (entry, 'timestamp');
+            openInterest.push ({
+                'info': entry,
+                'symbol': this.safeSymbol (this.safeString (entry, 'symbol')),
+                'sumOpenInterest': this.safeNumber (entry, 'sumOpenInterest'),
+                'sumOpenInterestValue': this.safeNumber (entry, 'sumOpenInterestValue'),
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+            });
+        }
+        const sorted = this.sortBy (openInterest, 'timestamp');
+        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
     }
 };

--- a/js/binance.js
+++ b/js/binance.js
@@ -5620,7 +5620,7 @@ module.exports = class binance extends Exchange {
             'symbol': this.safeSymbol (id),
             'volume': this.safeNumber (interest, 'sumOpenInterest'),
             'value': this.safeNumber (interest, 'sumOpenInterestValue'),
-            'currency': market['quote'],
+            'valueCurrency': market['quote'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/binance.js
+++ b/js/binance.js
@@ -5609,20 +5609,21 @@ module.exports = class binance extends Exchange {
         //      ...
         //  ]
         //
-        const openInterest = [];
-        for (let i = 0; i < response.length; i++) {
-            const entry = response[i];
-            const timestamp = this.safeInteger (entry, 'timestamp');
-            openInterest.push ({
-                'info': entry,
-                'symbol': this.safeSymbol (this.safeString (entry, 'symbol')),
-                'sumOpenInterest': this.safeNumber (entry, 'sumOpenInterest'),
-                'sumOpenInterestValue': this.safeNumber (entry, 'sumOpenInterestValue'),
-                'timestamp': timestamp,
-                'datetime': this.iso8601 (timestamp),
-            });
-        }
-        const sorted = this.sortBy (openInterest, 'timestamp');
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+        return this.parseOpenInterests (response, symbol, since, limit);
+    }
+
+    parseOpenInterest (interest) {
+        const timestamp = this.safeInteger (interest, 'timestamp');
+        const id = this.safeString (interest, 'symbol');
+        const market = this.market (id);
+        return {
+            'symbol': this.safeSymbol (id),
+            'numContracts': this.safeNumber (interest, 'sumOpenInterest'),
+            'totalValue': this.safeNumber (interest, 'sumOpenInterestValue'),
+            'valueCurrency': market['quote'],
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
+        };
     }
 };

--- a/js/binance.js
+++ b/js/binance.js
@@ -5612,10 +5612,10 @@ module.exports = class binance extends Exchange {
         return this.parseOpenInterests (response, symbol, since, limit);
     }
 
-    parseOpenInterest (interest) {
+    parseOpenInterest (interest, market = undefined) {
         const timestamp = this.safeInteger (interest, 'timestamp');
         const id = this.safeString (interest, 'symbol');
-        const market = this.market (id);
+        market = this.safeMarket (id, market);
         return {
             'symbol': this.safeSymbol (id),
             'numContracts': this.safeNumber (interest, 'sumOpenInterest'),

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -41,6 +41,7 @@ module.exports = class bit2c extends Exchange {
                 'fetchLeverageTiers': false,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchPosition': false,

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -42,6 +42,7 @@ module.exports = class bitbank extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -43,6 +43,7 @@ module.exports = class bithumb extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bitopro.js
+++ b/js/bitopro.js
@@ -46,6 +46,7 @@ module.exports = class bitopro extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bitpanda.js
+++ b/js/bitpanda.js
@@ -51,6 +51,7 @@ module.exports = class bitpanda extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -47,6 +47,7 @@ module.exports = class bitso extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -50,6 +50,7 @@ module.exports = class bitstamp extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bitstamp1.js
+++ b/js/bitstamp1.js
@@ -41,6 +41,7 @@ module.exports = class bitstamp1 extends Exchange {
                 'fetchLeverage': false,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchPosition': false,

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -55,6 +55,7 @@ module.exports = class bittrex extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': 'emulated',
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -51,6 +51,7 @@ module.exports = class bitvavo extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bl3p.js
+++ b/js/bl3p.js
@@ -40,6 +40,7 @@ module.exports = class bl3p extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchLeverage': false,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOrderBook': true,
                 'fetchPosition': false,
                 'fetchPositions': false,

--- a/js/blockchaincom.js
+++ b/js/blockchaincom.js
@@ -45,6 +45,7 @@ module.exports = class blockchaincom extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -43,6 +43,7 @@ module.exports = class btcalpha extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/btcbox.js
+++ b/js/btcbox.js
@@ -40,6 +40,7 @@ module.exports = class btcbox extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchLeverage': false,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -45,6 +45,7 @@ module.exports = class btcmarkets extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/btctradeua.js
+++ b/js/btctradeua.js
@@ -40,6 +40,7 @@ module.exports = class btctradeua extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchLeverage': false,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchPosition': false,

--- a/js/btcturk.js
+++ b/js/btcturk.js
@@ -42,6 +42,7 @@ module.exports = class btcturk extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,

--- a/js/buda.js
+++ b/js/buda.js
@@ -49,6 +49,7 @@ module.exports = class buda extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': undefined,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3036,7 +3036,7 @@ module.exports = class bybit extends Exchange {
             'symbol': this.safeSymbol (id),
             'volume': this.parseNumber (numContracts),
             'value': Precise.stringMul (numContracts, contractSize),
-            'currency': market['base'],
+            'valueCurrency': market['base'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3026,9 +3026,9 @@ module.exports = class bybit extends Exchange {
         return this.parseOpenInterests (result);
     }
 
-    parseOpenInterest (interest) {
+    parseOpenInterest (interest, market = undefined) {
         const id = this.safeString (interest, 'symbol');
-        const market = this.market (id);
+        market = this.safeMarket (id, market);
         const timestamp = this.safeTimestamp (interest, 'timestamp');
         const numContracts = this.safeString (interest, 'open_interest');
         const contractSize = market['contractSize'];

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2992,6 +2992,17 @@ module.exports = class bybit extends Exchange {
     }
 
     async fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name bybit#fetchOpenInterestHistory
+         * @description Gets the total amount of unsettled contracts. In other words, the total number of contracts held in open positions
+         * @param {str} symbol Unified market symbol
+         * @param {str} timeframe "5m", 15m, 30m, 1h, 4h, 1d
+         * @param {int} since Not used by Bybit
+         * @param {int} limit The number of open interest structures to return. Max 200, default 50
+         * @param {dict} params Exchange specific parameters
+         * @returns An array of open interest structures
+         */
         if (timeframe === '1m') {
             throw new BadRequest (this.id + 'fetchOpenInterestHistory cannot use the 1m timeframe');
         }

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3034,9 +3034,9 @@ module.exports = class bybit extends Exchange {
         const contractSize = market['contractSize'];
         return {
             'symbol': this.safeSymbol (id),
-            'numContracts': this.parseNumber (numContracts),
-            'totalValue': Precise.stringMul (numContracts, contractSize),
-            'valueCurrency': market['base'],
+            'volume': this.parseNumber (numContracts),
+            'value': Precise.stringMul (numContracts, contractSize),
+            'currency': market['base'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3026,17 +3026,6 @@ module.exports = class bybit extends Exchange {
         return this.parseOpenInterests (result);
     }
 
-    parseOpenInterests (response, symbol, since, limit) {
-        const interests = [];
-        for (let i = 0; i < response.length; i++) {
-            const entry = response[i];
-            const interest = this.parseOpenInterest (entry);
-            interests.push (interest);
-        }
-        const sorted = this.sortBy (interests, 'timestamp');
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
-    }
-
     parseOpenInterest (interest) {
         const id = this.safeString (interest, 'symbol');
         const market = this.market (id);

--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -52,6 +52,7 @@ module.exports = class bytetrade extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/cex.js
+++ b/js/cex.js
@@ -37,6 +37,7 @@ module.exports = class cex extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -59,6 +59,7 @@ module.exports = class coinbase extends Exchange {
                 'fetchMySells': true,
                 'fetchMyTrades': undefined,
                 'fetchOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': undefined,
                 'fetchOrder': undefined,
                 'fetchOrderBook': false,

--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -40,6 +40,7 @@ module.exports = class coincheck extends Exchange {
                 'fetchLeverage': false,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchPosition': false,

--- a/js/coinfalcon.js
+++ b/js/coinfalcon.js
@@ -44,6 +44,7 @@ module.exports = class coinfalcon extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/coinmate.js
+++ b/js/coinmate.js
@@ -42,6 +42,7 @@ module.exports = class coinmate extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -47,6 +47,7 @@ module.exports = class coinone extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/coinspot.js
+++ b/js/coinspot.js
@@ -40,6 +40,7 @@ module.exports = class coinspot extends Exchange {
                 'fetchLeverage': false,
                 'fetchLeverageTiers': false,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOrderBook': true,
                 'fetchPosition': false,
                 'fetchPositions': false,

--- a/js/crex24.js
+++ b/js/crex24.js
@@ -54,6 +54,7 @@ module.exports = class crex24 extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -38,6 +38,7 @@ module.exports = class exmo extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': 'emulated',
                 'fetchOrderBook': true,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -71,6 +71,7 @@ module.exports = class ftx extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/ftxus.js
+++ b/js/ftxus.js
@@ -25,6 +25,7 @@ module.exports = class ftxus extends ftx {
                 'fetchFundingRates': false,
                 'fetchIndexOHLCV': false,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchPremiumIndexOHLCV': false,
             },
             'urls': {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -89,6 +89,7 @@ module.exports = class gateio extends Exchange {
                 'fetchMyTrades': true,
                 'fetchNetworkDepositAddress': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -54,6 +54,7 @@ module.exports = class gemini extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -55,6 +55,7 @@ module.exports = class hitbtc extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -55,6 +55,7 @@ module.exports = class hollaex extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -5823,7 +5823,7 @@ module.exports = class huobi extends Exchange {
             'symbol': this.safeString (market, 'symbol'),
             'volume': this.safeNumber (interest, 'volume'),
             'value': this.safeValue (interest, 'value'),
-            'currency': this.safeString (market, 'quote'),
+            'valueCurrency': this.safeString (market, 'quote'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -5826,8 +5826,8 @@ module.exports = class huobi extends Exchange {
         return {
             'symbol': this.safeString (market, 'symbol'),
             'volume': this.safeNumber (interest, 'volume'),
-            'totalValue': this.safeValue (interest, 'value'),
-            'valueCurrency': this.safeString (market, 'quote'),
+            'value': this.safeValue (interest, 'value'),
+            'currency': this.safeString (market, 'quote'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/idex.js
+++ b/js/idex.js
@@ -53,6 +53,7 @@ module.exports = class idex extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/independentreserve.js
+++ b/js/independentreserve.js
@@ -42,6 +42,7 @@ module.exports = class independentreserve extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/indodax.js
+++ b/js/indodax.js
@@ -45,6 +45,7 @@ module.exports = class indodax extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': undefined,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/itbit.js
+++ b/js/itbit.js
@@ -44,6 +44,7 @@ module.exports = class itbit extends Exchange {
                 'fetchLeverageTiers': false,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -52,6 +52,7 @@ module.exports = class kraken extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -55,6 +55,7 @@ module.exports = class kucoin extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -37,6 +37,7 @@ module.exports = class kuna extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': 'emulated',
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -43,6 +43,7 @@ module.exports = class lbank extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': undefined, // status 0 API doesn't work
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/luno.js
+++ b/js/luno.js
@@ -46,6 +46,7 @@ module.exports = class luno extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/lykke.js
+++ b/js/lykke.js
@@ -48,6 +48,7 @@ module.exports = class lykke extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': 'emulated',
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -43,6 +43,7 @@ module.exports = class mercado extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': 'emulated',
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -50,6 +50,7 @@ module.exports = class mexc extends Exchange {
                 'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/ndax.js
+++ b/js/ndax.js
@@ -53,6 +53,7 @@ module.exports = class ndax extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/novadax.js
+++ b/js/novadax.js
@@ -51,6 +51,7 @@ module.exports = class novadax extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/okx.js
+++ b/js/okx.js
@@ -4590,7 +4590,7 @@ module.exports = class okx extends Exchange {
             'symbol': undefined,
             'volume': undefined,
             'value': openInterest,
-            'currency': 'USD',
+            'valueCurrency': 'USD',
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/okx.js
+++ b/js/okx.js
@@ -4576,7 +4576,7 @@ module.exports = class okx extends Exchange {
         return this.parseOpenInterests (data);
     }
 
-    parseOpenInterest (interest) {
+    parseOpenInterest (interest, market = undefined) {
         //
         //    [
         //        '1648221300000',  // timestamp

--- a/js/okx.js
+++ b/js/okx.js
@@ -4588,9 +4588,9 @@ module.exports = class okx extends Exchange {
         const openInterest = this.safeNumber (interest, 1);
         return {
             'symbol': undefined,
-            'numContracts': undefined,
-            'totalValue': openInterest,
-            'valueCurrency': 'USD',
+            'volume': undefined,
+            'value': openInterest,
+            'currency': 'USD',
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/okx.js
+++ b/js/okx.js
@@ -69,6 +69,7 @@ module.exports = class okx extends Exchange {
                 'fetchMySells': undefined,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': true,
                 'fetchOpenOrder': undefined,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
@@ -4524,6 +4525,75 @@ module.exports = class okx extends Exchange {
             'timestamp': timestamp,  // Interest accrued time
             'datetime': this.iso8601 (timestamp),
             'info': info,
+        };
+    }
+
+    async fetchOpenInterestHistory (code, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name okx#fetchOpenInterestHistory
+         * @description Retrieves the open interest history of a currency
+         * @param {str} code Unified CCXT currency code
+         * @param {str} timeframe "5m", "1h", or "1d"
+         * @param {int} since The time in ms of the earliest record to retrieve as a unix timestamp
+         * @param {int} limit Not used by okx
+         * @param {dict} params Exchange specific parameters
+         * @param {int} params.till The time in ms of the latest record to retrieve as a unix timestamp
+         * @returns An array of open interest structures
+         */
+        if (timeframe !== '5m' && timeframe !== '1h' && timeframe !== '1d') {
+            throw new BadRequest (this.id + ' fetchOpenInterestHistory cannot only use the 5m, 1h, and 1d timeframe');
+        }
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'ccy': currency['id'],
+            'period': timeframe,
+        };
+        if (since !== undefined) {
+            request['begin'] = since;
+        }
+        const till = this.safeInteger2 (params, 'till', 'end');
+        if (till !== undefined) {
+            request['end'] = till;
+        }
+        const response = await this.publicGetRubikStatContractsOpenInterestVolume (this.extend (request, params));
+        //
+        //    {
+        //        code: '0',
+        //        data: [
+        //            [
+        //                '1648221300000',  // timestamp
+        //                '2183354317.945',  // open interest (USD)
+        //                '74285877.617',  // volume (USD)
+        //            ],
+        //            ...
+        //        ],
+        //        msg: ''
+        //    }
+        //
+        const data = this.safeValue (response, 'data');
+        return this.parseOpenInterests (data);
+    }
+
+    parseOpenInterest (interest) {
+        //
+        //    [
+        //        '1648221300000',  // timestamp
+        //        '2183354317.945',  // open interest (USD)
+        //        '74285877.617',  // volume (USD)
+        //    ]
+        //
+        const timestamp = this.safeNumber (interest, 0);
+        const openInterest = this.safeNumber (interest, 1);
+        return {
+            'symbol': undefined,
+            'numContracts': undefined,
+            'totalValue': openInterest,
+            'valueCurrency': 'USD',
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
         };
     }
 

--- a/js/paymium.js
+++ b/js/paymium.js
@@ -32,6 +32,7 @@ module.exports = class paymium extends Exchange {
                 'fetchFundingRates': false,
                 'fetchIndexOHLCV': false,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOrderBook': true,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -38,6 +38,7 @@ module.exports = class poloniex extends Exchange {
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': true, // true endpoint for a single open order
                 'fetchOpenOrders': true, // true endpoint for open orders
                 'fetchOrderBook': true,

--- a/js/probit.js
+++ b/js/probit.js
@@ -49,6 +49,7 @@ module.exports = class probit extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/qtrade.js
+++ b/js/qtrade.js
@@ -58,6 +58,7 @@ module.exports = class qtrade extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/ripio.js
+++ b/js/ripio.js
@@ -47,6 +47,7 @@ module.exports = class ripio extends Exchange {
                 'fetchLeverageTiers': false,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/stex.js
+++ b/js/stex.js
@@ -53,6 +53,7 @@ module.exports = class stex extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/test/Exchange/test.fetchOpenInterestHistory.js
+++ b/js/test/Exchange/test.fetchOpenInterestHistory.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// ----------------------------------------------------------------------------
+
+const testOpenInterest = require('./test.openInterest.js');
+
+// ----------------------------------------------------------------------------
+
+module.exports = async (exchange, symbol) => {
+    const method = 'fetchOpenInterestHistory';
+    if (exchange.has[method]) {
+        const openInterestHistory = await exchange[method] (symbol);
+        console.log ('fetched ', openInterestHistory.length, ' records of open interest');
+        for (let i = 0; i < openInterestHistory.length; i++) {
+            const openInterest = openInterestHistory[i];
+            testOpenInterest (exchange, openInterest, method)
+        }
+        return openInterestHistory;
+    } else {
+        console.log ('fetching open interest history not supported');
+    }
+}

--- a/js/test/Exchange/test.openInterest.js
+++ b/js/test/Exchange/test.openInterest.js
@@ -1,0 +1,42 @@
+'use strict'
+
+// ----------------------------------------------------------------------------
+
+const assert = require ('assert');
+
+// ----------------------------------------------------------------------------
+
+
+module.exports = (exchange, openInterest, method) => {
+    const format = {
+        symbol: 'BTC/USDT',
+        volume: 81094.084,
+        value: 3544581864.598,
+        valueCurrency: 'USDT',
+        timestamp: 1649373600000,
+        datetime: '2022-04-07T23:20:00.000Z',
+        info: {},
+    };
+    const keys = Object.keys (format);
+    for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        assert (key in openInterest);
+    }
+    console.log (openInterest['datetime'], exchange.id, method, openInterest['symbol'], openInterest['value'], openInterest['volume']);
+    if (openInterest['value'] !== undefined) {
+        assert (typeof openInterest['value'] === 'number');
+        assert (openInterest['value'] > 0);
+    }
+    if (openInterest['volume'] !== undefined) {
+        assert (typeof openInterest['volume'] === 'number');
+        assert (openInterest['volume'] > 0);
+    }
+    if (openInterest['timestamp'] !== undefined) {
+        assert (typeof openInterest['timestamp'] === 'number');
+        assert (openInterest['timestamp'] > 1199145600000); // Timestamp for Jan 1 2008
+    }
+    assert (typeof openInterest['symbol'] === 'string' || typeof openInterest['symbol'] === undefined);
+    assert (typeof openInterest['valueCurrency'] === 'string' || typeof openInterest['valueCurrency'] === undefined);
+    assert (typeof openInterest['datetime'] === 'string' || typeof openInterest['datetime'] === undefined);
+    return openInterest;
+}

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -306,6 +306,7 @@ async function testExchange (exchange) {
     await test ('fetchClosedOrders', exchange, symbol)
     await test ('fetchMyTrades', exchange, symbol)
     await test ('fetchLeverageTiers', exchange, symbol)
+    await test ('fetchOpenInterestHistory', exchange, symbol)
 
     await test ('fetchPositions', exchange, symbol)
 

--- a/js/therock.js
+++ b/js/therock.js
@@ -39,6 +39,7 @@ module.exports = class therock extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -43,6 +43,7 @@ module.exports = class tidebit extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOrderBook': true,
                 'fetchPosition': false,
                 'fetchPositions': false,

--- a/js/tidex.js
+++ b/js/tidex.js
@@ -42,6 +42,7 @@ module.exports = class tidex extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/timex.js
+++ b/js/timex.js
@@ -44,6 +44,7 @@ module.exports = class timex extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/upbit.js
+++ b/js/upbit.js
@@ -45,6 +45,7 @@ module.exports = class upbit extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': undefined,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/vcc.js
+++ b/js/vcc.js
@@ -51,6 +51,7 @@ module.exports = class vcc extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -47,6 +47,7 @@ module.exports = class wavesexchange extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/wazirx.js
+++ b/js/wazirx.js
@@ -39,6 +39,7 @@ module.exports = class wazirx extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': false,
                 'fetchOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -43,6 +43,7 @@ module.exports = class whitebit extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchOrderTrades': true,

--- a/js/woo.js
+++ b/js/woo.js
@@ -49,6 +49,7 @@ module.exports = class woo extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': false,
                 'fetchOpenOrders': false,
                 'fetchOrder': true,

--- a/js/yobit.js
+++ b/js/yobit.js
@@ -47,6 +47,7 @@ module.exports = class yobit extends Exchange {
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,

--- a/js/zaif.js
+++ b/js/zaif.js
@@ -36,6 +36,7 @@ module.exports = class zaif extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchPremiumIndexOHLCV': false,

--- a/js/zonda.js
+++ b/js/zonda.js
@@ -43,6 +43,7 @@ module.exports = class zonda extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchPosition': false,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3737,4 +3737,15 @@ class Exchange {
     public function sleep($milliseconds) {
         sleep($milliseconds / 1000);
     }
+
+    public function parse_open_interests($response, $symbol, $since, $limit) {
+        $interests = array();
+        for ($i = 0; $i < count($response); $i++) {
+            $entry = &$response[$i];
+            $interest = $this->parseOpenInterest($entry);
+            array_push($interests, $interest);
+        }
+        $sorted = $this->sortBy ($interests, 'timestamp');
+        return $this->filterBySymbolSinceLimit ($sorted, $symbol, $since, $limit);
+    }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2804,3 +2804,12 @@ class Exchange(object):
             return self.safe_value(tiers, symbol)
         else:
             raise NotSupported(self.id + 'fetch_market_leverage_tiers() is not supported yet')
+
+    def parse_open_interests(self, response, symbol, since, limit):
+        interests = []
+        for i in range(len(response)):
+            entry = response[i]
+            interest = self.parseOpenInterest(entry)
+            interests.append(interest)
+        sorted = self.sortBy(interests, 'timestamp')
+        return self.filterBySymbolSinceLimit(sorted, symbol, since, limit)

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1875,6 +1875,7 @@ if ($exchange->has['fetchMyTrades']) {
 - [Funding Rate](#funding-rate)
 - [Funding Rate History](#funding-rate-history)
 - [Positions Risk](#positions-risk)
+- [Open Interest History](#open-interest-history)
 - [Borrow Rates](#borrow-rates)
 - [Borrow Rate History](#borrow-rate-history)
 
@@ -2691,6 +2692,47 @@ Returns
     fundingRate: -0.000068,
     timestamp: 1642953600000,
     datetime: "2022-01-23T16:00:00.000Z"
+}
+```
+
+## Open Interest History
+
+*contract only*
+
+Use the `fetchOpenInterestHistory` method to get a history of open interest for a symbol from the exchange.
+
+```JavaScript
+fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {})
+```
+
+Parameters
+
+- **symbol** (String) Unified CCXT market symbol (e.g. `"BTC/USDT:USDT"`)
+- **timeframe** (String) Check exchange.timeframes for available values
+- **since** (Integer) Timestamp for the earliest open interest record (e.g. `1645807945000`)
+- **limit** (Integer) The maximum number of [open interest structures](#open-interest-structures) to retrieve (e.g. `10`)
+- **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"endTime": 1645807945000}`)
+
+Returns
+
+- An array of [open interest structures](#open-interest-structure)
+
+### Open Interest Structure
+
+```JavaScript
+{
+    symbol: 'BTC/USDT',
+    volume: 80872.801,
+    value: 3508262107.38,
+    valueCurrency: 'USDT',
+    timestamp: 1649379000000,
+    datetime: '2022-04-08T00:50:00.000Z',
+    info: {
+        symbol: 'BTCUSDT',
+        sumOpenInterest: '80872.80100000',
+        sumOpenInterestValue: '3508262107.38000000',
+        timestamp: '1649379000000'
+    }
 }
 ```
 


### PR DESCRIPTION
The `dapi` endpoint always returns an empty list

----------------

2022-01-14T20:11:01.294Z
Node.js: v14.17.0
CCXT v1.67.75


```
binanceusdm.fetchOpenInterestHistory (BTC/USDT)
170 ms
  symbol | sumOpenInterest | sumOpenInterestValue |     timestamp |                 datetime
--------------------------------------------------------------------------------------------
BTC/USDT |         75520.4 |       3242467618.796 | 1642182300000 | 2022-01-14T17:45:00.000Z
...
BTC/USDT |       74831.059 |    3228448432.598139 | 1642190700000 | 2022-01-14T20:05:00.000Z
BTC/USDT |       74805.703 |   3222463175.1755724 | 1642191000000 | 2022-01-14T20:10:00.000Z
30 objects
```

```
binanceusdm.fetchOpenInterestHistory (BTC/USDT, 1h)
189 ms
  symbol | sumOpenInterest | sumOpenInterestValue |     timestamp |                 datetime
--------------------------------------------------------------------------------------------
BTC/USDT |       77716.335 |    3430298333.662944 | 1642086000000 | 2022-01-13T15:00:00.000Z
...
BTC/USDT |       75043.168 |    3230165247.444806 | 1642186800000 | 2022-01-14T19:00:00.000Z
BTC/USDT |       74836.449 |    3223139566.183359 | 1642190400000 | 2022-01-14T20:00:00.000Z
30 objects
```

```
binanceusdm.fetchOpenInterestHistory (BTC/USDT, 1h, 1640995200000)
182 ms
  symbol | sumOpenInterest | sumOpenInterestValue |     timestamp |                 datetime
--------------------------------------------------------------------------------------------
BTC/USDT |       74940.944 |     3495994288.19056 | 1640998800000 | 2022-01-01T01:00:00.000Z
...
BTC/USDT |       73717.584 |   3457622385.4620805 | 1641099600000 | 2022-01-02T05:00:00.000Z
BTC/USDT |       73728.734 |     3470881898.70292 | 1641103200000 | 2022-01-02T06:00:00.000Z
30 objects
```

```
binanceusdm.fetchOpenInterestHistory (BTC/USDT, 1h, 1640995200000, 3)
179 ms
  symbol | sumOpenInterest | sumOpenInterestValue |     timestamp |                 datetime
--------------------------------------------------------------------------------------------
BTC/USDT |       74940.944 |     3495994288.19056 | 1640998800000 | 2022-01-01T01:00:00.000Z
BTC/USDT |       74695.212 |    3493630019.936612 | 1641002400000 | 2022-01-01T02:00:00.000Z
BTC/USDT |       74842.709 |     3502350636.77035 | 1641006000000 | 2022-01-01T03:00:00.000Z
3 objects
```

It looks like the `endTime` argument takes priority

```
binanceusdm.fetchOpenInterestHistory (BTC/USDT, 1h, 1640995200000, 100, [object Object])
186 ms
  symbol | sumOpenInterest | sumOpenInterestValue |     timestamp |                 datetime
--------------------------------------------------------------------------------------------
BTC/USDT |       78190.247 |   3275566335.7742963 | 1641834000000 | 2022-01-10T17:00:00.000Z
...
BTC/USDT |       75043.168 |    3230165247.444806 | 1642186800000 | 2022-01-14T19:00:00.000Z
BTC/USDT |       74836.449 |    3223139566.183359 | 1642190400000 | 2022-01-14T20:00:00.000Z
100 objects
```

```
binancecoinm.fetchOpenInterestHistory (BTC/USD, 1h)
181 ms
[]
0 objects
```