### PR TITLE
Mexc fetchOrderBook : handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -843,15 +843,18 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        let method = undefined;
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPublicGetMarketDepth',
+            'swap': 'contractPublicGetDepthSymbol',
+        });
         if (market['spot']) {
-            method = 'spotPublicGetMarketDepth';
             if (limit === undefined) {
                 limit = 100; // the spot api requires a limit
             }
             request['depth'] = limit;
         } else if (market['swap']) {
-            method = 'contractPublicGetDepthSymbol';
             if (limit !== undefined) {
                 request['limit'] = limit;
             }


### PR DESCRIPTION
Added handleMarketTypeAndParams usage to fetchOrderBook:
```
mexc.fetchOrderBook (BTC/USDT)
216 ms
{
  symbol: 'BTC/USDT',
  bids: [
    [ 42908.88, 1.804748 ], [ 42908.3, 0.478465 ],  [ 42908.29, 0.114131 ],
    [ 42906.87, 0.4753 ],   [ 42906.86, 0.604199 ], [ 42905.35, 1.0878 ],
    [ 42905.34, 0.763498 ], [ 42904.16, 0.9996 ],   [ 42904.15, 0.089072 ],
    [ 42904.14, 0.3136 ],   [ 42903.76, 0.089082 ], [ 42903.75, 0.037293 ],
    [ 42903.71, 0.7056 ],   [ 42902.7, 0.114141 ],  [ 42901.82, 0.15582 ],
    [ 42901.66, 0.15632 ],  [ 42901.59, 0.229026 ], [ 42901.41, 0.123392 ],
    [ 42901.4, 0.045805 ],  [ 42901.22, 0.001127 ], [ 42900.98, 0.530004 ],
    [ 42900.69, 0.049 ],    [ 42899.84, 0.068502 ], [ 42899.33, 0.334454 ],
    [ 42899.32, 0.597143 ], [ 42899.31, 2.465631 ], [ 42898.4, 0.22836 ],
    [ 42898.13, 0.089092 ], [ 42898.09, 0.002293 ], [ 42898.08, 0.107986 ],
    [ 42896.86, 0.556885 ], [ 42896.85, 0.334484 ], [ 42896.69, 0.040062 ],
    [ 42895.1, 0.904618 ],  [ 42895.06, 0.491343 ], [ 42894.54, 0.005743 ],
    [ 42894.42, 0.73206 ],  [ 42893.89, 0.106967 ], [ 42893.38, 0.972964 ],
    [ 42893.37, 0.0245 ],   [ 42893.36, 0.067796 ], [ 42893.35, 0.056338 ],
    [ 42893.11, 0.106967 ], [ 42892.97, 0.000235 ], [ 42892.31, 0.004577 ],
    [ 42892.19, 0.535178 ], [ 42890.95, 0.196 ],    [ 42890.79, 0.098 ],
    [ 42885.98, 0.272859 ], [ 42884.77, 0.154929 ], [ 42879.27, 4.153872 ],
    [ 42878.97, 0.001382 ], [ 42878.87, 0.01764 ],  [ 42878.77, 2.890144 ],
    [ 42877.4, 1.135549 ],  [ 42877.35, 0.393032 ], [ 42876.96, 0.007781 ],
    [ 42876.67, 1.468628 ], [ 42876.47, 0.000375 ], [ 42876.37, 0.001124 ],
    [ 42876.27, 0.001873 ], [ 42876.17, 0.002623 ], [ 42876.07, 0.003372 ],
    [ 42875.77, 0.000196 ], [ 42875.67, 0.00441 ],  [ 42875.57, 0.009799 ],
    [ 42874.97, 0.00196 ],  [ 42874.87, 0.228249 ], [ 42874.67, 1.161104 ],
    [ 42874.57, 0.00098 ],  [ 42874.17, 0.012599 ], [ 42874.16, 0.002284 ],
    [ 42873.67, 1.141308 ], [ 42872.67, 0.8526 ],   [ 42872.27, 0.0098 ],
    [ 42872.07, 0.09161 ],  [ 42871.89, 0.196 ],    [ 42871.88, 0.0049 ],
    [ 42871.48, 1.770375 ], [ 42871.38, 0.007252 ], [ 42871.34, 0.65766 ],
    [ 42871.33, 0.012121 ], [ 42870.68, 0.456487 ], [ 42870.55, 1.617 ],
    [ 42870.54, 0.321303 ], [ 42870.04, 0.15876 ],  [ 42869.79, 0.686157 ],
    [ 42869.78, 0.002096 ], [ 42869.69, 0.3969 ],   [ 42869.68, 1.123531 ],
    [ 42868.98, 0.0686 ],   [ 42867.6, 0.436468 ],  [ 42861.3, 0.00411 ],
    [ 42860.24, 1.796478 ], [ 42825.7, 0.01007 ],   [ 42801.9, 0.02064 ],
    [ 42675.55, 0.20382 ],  [ 42477.93, 0.08027 ],  [ 42448.27, 0.041 ],
    [ 42302.38, 0.02003 ]
  ],
  asks: [
    [ 42908.91, 0.000245 ], [ 42909.18, 0.000245 ], [ 42909.2, 1.235662 ],
    [ 42909.53, 0.004577 ], [ 42910.43, 0.343391 ], [ 42910.51, 0.375908 ],
    [ 42910.52, 1.619685 ], [ 42911.19, 0.01126 ],  [ 42911.2, 0.029694 ],
    [ 42912.03, 0.002822 ], [ 42912.56, 0.00343 ],  [ 42913.23, 0.145893 ],
    [ 42913.28, 0.320431 ], [ 42914.09, 0.002254 ], [ 42914.88, 0.114199 ],
    [ 42915.88, 0.128713 ], [ 42915.89, 0.288336 ], [ 42915.9, 0.361189 ],
    [ 42915.95, 0.2254 ],   [ 42916.01, 0.102182 ], [ 42916.26, 0.07938 ],
    [ 42917.1, 0.196 ],     [ 42917.38, 0.006968 ], [ 42918.65, 0.02254 ],
    [ 42918.99, 0.012475 ], [ 42919.04, 0.22736 ],  [ 42919.05, 0.3136 ],
    [ 42919.2, 0.24353 ],   [ 42919.39, 0.098 ],    [ 42919.91, 0.3136 ],
    [ 42919.93, 0.2254 ],   [ 42919.98, 0.57821 ],  [ 42920.3, 0.233289 ],
    [ 42920.31, 0.561589 ], [ 42920.32, 0.025353 ], [ 42920.66, 0.07938 ],
    [ 42922.49, 1.203009 ], [ 42922.53, 0.751944 ], [ 42922.87, 0.86338 ],
    [ 42922.88, 0.86338 ],  [ 42924.21, 0.50864 ],  [ 42924.22, 0.961968 ],
    [ 42924.23, 0.491303 ], [ 42924.59, 0.261273 ], [ 42926.68, 0.890203 ],
    [ 42926.69, 0.225498 ], [ 42926.7, 0.556209 ],  [ 42926.71, 0.068492 ],
    [ 42926.92, 0.0196 ],   [ 42927.1, 0.73206 ],   [ 42927.68, 0.036727 ],
    [ 42928.2, 0.004567 ],  [ 42928.25, 0.049 ],    [ 42928.6, 0.024108 ],
    [ 42928.87, 0.01715 ],  [ 42928.98, 0.07938 ],  [ 42936.26, 0.143455 ],
    [ 42941.75, 0.636545 ], [ 42949.15, 0.263537 ], [ 42949.76, 0.029694 ],
    [ 42951.18, 0.00343 ],  [ 42951.85, 0.196715 ], [ 42951.9, 0.320431 ],
    [ 42952.71, 0.002254 ], [ 42953.43, 0.319816 ], [ 42954.51, 0.128713 ],
    [ 42954.52, 0.288336 ], [ 42954.63, 0.096197 ], [ 42954.89, 0.07938 ],
    [ 42955.73, 0.196 ],    [ 42956.01, 0.006968 ], [ 42956.04, 0.000196 ],
    [ 42956.34, 0.004704 ], [ 42956.38, 0.2254 ],   [ 42956.64, 0.010051 ],
    [ 42956.74, 0.006375 ], [ 42957.28, 0.02254 ],  [ 42957.34, 0.002744 ],
    [ 42957.62, 0.012475 ], [ 42957.67, 0.22736 ],  [ 42957.68, 0.3136 ],
    [ 42957.83, 0.24353 ],  [ 42958.02, 0.098 ],    [ 42958.34, 0.341726 ],
    [ 42958.54, 0.3136 ],   [ 42958.61, 0.57821 ],  [ 42958.95, 0.025353 ],
    [ 42959, 0.098 ],       [ 42959.14, 0.0049 ],   [ 42959.29, 0.07938 ],
    [ 42959.4, 0.00098 ],   [ 42959.6, 0.00411 ],   [ 42959.83, 0.17052 ],
    [ 42960.25, 0.392 ],    [ 42960.52, 0.3136 ],   [ 42961.07, 0.15778 ],
    [ 42961.12, 1.203009 ], [ 42961.16, 0.751944 ], [ 42961.28, 0.00171 ],
    [ 42961.33, 0.009164 ]
  ],
  timestamp: undefined,
  datetime: undefined,
  nonce: 51940351
}
```