### PR TITLE
Mexc fetchBalance : handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1142,18 +1142,14 @@ module.exports = class mexc extends Exchange {
 
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
-        const defaultType = this.safeString2 (this.options, 'fetchBalance', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
-        const spot = (type === 'spot');
-        const swap = (type === 'swap');
-        let method = undefined;
-        if (spot) {
-            method = 'spotPrivateGetAccountInfo';
-        } else if (swap) {
-            method = 'contractPrivateGetAccountAssets';
-        }
-        const query = this.omit (params, 'type');
-        const response = await this[method] (query);
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPrivateGetAccountInfo',
+            'swap': 'contractPrivateGetAccountAssets',
+        });
+        const spot = (marketType === 'spot');
+        const response = await this[method] (this.extend (params));
         //
         // spot
         //

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1173,10 +1173,11 @@ module.exports = class mexc extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', {});
+        const currentTime = this.milliseconds ();
         const result = {
             'info': response,
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': currentTime,
+            'datetime': this.iso8601 (currentTime),
         };
         if (spot) {
             const currencyIds = Object.keys (data);

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1149,7 +1149,7 @@ module.exports = class mexc extends Exchange {
             'swap': 'contractPrivateGetAccountAssets',
         });
         const spot = (marketType === 'spot');
-        const response = await this[method] (this.extend (params));
+        const response = await this[method] (params);
         //
         // spot
         //


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchBalance:
```
mexc.fetchBalance ()
220 ms
{
  info: {
    code: '200',
    data: {
      MATIC: { frozen: '0', available: '0.02' },
      SOL: { frozen: '0', available: '0.000000001' },
      YLDY: { frozen: '0', available: '0.009495' },
      ETH: { frozen: '0', available: '0.0000000097434' },
      USDT: { frozen: '0', available: '0.00000000368' }
    }
  },
  timestamp: undefined,
  datetime: undefined,
  MATIC: { free: 0.02, used: 0, total: 0.02 },
  SOL: { free: 1e-9, used: 0, total: 1e-9 },
  YLDY: { free: 0.009495, used: 0, total: 0.009495 },
  ETH: { free: 9.7434e-9, used: 0, total: 9.7434e-9 },
  USDT: { free: 3.68e-9, used: 0, total: 3.68e-9 },
  free: {
    MATIC: 0.02,
    SOL: 1e-9,
    YLDY: 0.009495,
    ETH: 9.7434e-9,
    USDT: 3.68e-9
  },
  used: { MATIC: 0, SOL: 0, YLDY: 0, ETH: 0, USDT: 0 },
  total: {
    MATIC: 0.02,
    SOL: 1e-9,
    YLDY: 0.009495,
    ETH: 9.7434e-9,
    USDT: 3.68e-9
  }
}
```