### PR TITLE
Build :: Add step to order exchange capabilities/meta info

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -689,7 +689,7 @@ class Transpiler {
         const lineBreak = '\n';
         const capabilitiesObjectRegex = /(?<='has': {[\n])([^|})]*)(?=\n([ ]+}))/;
         const found = capabilitiesObjectRegex.exec (code);
-        if (found === undefined) {
+        if (found === null) {
             return null; // capabilities not found
         }
         let capabilities = found[0].split (lineBreak); 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1078,7 +1078,7 @@ class Transpiler {
 
     // ========================================================================
 
-    transpileDerivedExchangeFile (jsFolder, filename, options, force = false) {
+    transpileDerivedExchangeFile (jsFolder, filename, options, force = false, order = false) {
 
         // todo normalize jsFolder and other arguments
 
@@ -1103,10 +1103,13 @@ class Transpiler {
             const jsPath = jsFolder + filename
             let contents = fs.readFileSync (jsPath, 'utf8')
 
-            const orderedContent = this.orderExchangeCapabilities(contents)
-            if (orderedContent !== null) {
-                contents = orderedContent
-                fs.writeFileSync(jsPath, contents, {encoding:'utf8',flag:'w'})
+            let orderedContent = null
+            if (order) {
+                orderedContent = this.orderExchangeCapabilities(contents)
+                if (orderedContent !== null) {
+                    contents = orderedContent
+                    fs.writeFileSync(jsPath, contents, {encoding:'utf8',flag:'w'})
+                }
             }
 
             if (orderedContent !==null || 
@@ -1149,7 +1152,7 @@ class Transpiler {
 
     //-------------------------------------------------------------------------
 
-    transpileDerivedExchangeFiles (jsFolder, options, pattern = '.js', force = false) {
+    transpileDerivedExchangeFiles (jsFolder, options, pattern = '.js', force = false, order = false) {
 
         // todo normalize jsFolder and other arguments
 
@@ -1166,7 +1169,7 @@ class Transpiler {
 
         const classNames = fs.readdirSync (jsFolder)
             .filter (file => file.match (regex) && (!ids || ids.includes (basename (file, '.js'))))
-            .map (file => this.transpileDerivedExchangeFile (jsFolder, file, options, force))
+            .map (file => this.transpileDerivedExchangeFile (jsFolder, file, options, force, order))
 
         const classes = {}
 
@@ -1643,7 +1646,7 @@ class Transpiler {
 
     // ============================================================================
 
-    transpileEverything (force = false) {
+    transpileEverything (force = false, order = false) {
 
         // default pattern is '.js'
         const [ /* node */, /* script */, pattern ] = process.argv.filter (x => !x.startsWith ('--'))
@@ -1660,7 +1663,7 @@ class Transpiler {
 
         //*
 
-        const classes = this.transpileDerivedExchangeFiles ('./js/', options, pattern, force)
+        const classes = this.transpileDerivedExchangeFiles ('./js/', options, pattern, force, order)
 
         if (classes === null) {
             log.bright.yellow ('0 files transpiled.')
@@ -1696,13 +1699,14 @@ if (require.main === module) { // called directly like `node module`
     const test = process.argv.includes ('--test') || process.argv.includes ('--tests')
     const errors = process.argv.includes ('--error') || process.argv.includes ('--errors')
     const force = process.argv.includes ('--force')
+    const order = process.argv.includes('--order')
     log.bright.green ({ force })
     if (test) {
         transpiler.transpileTests ()
     } else if (errors) {
         transpiler.transpileErrorHierarchy ()
     } else {
-        transpiler.transpileEverything (force)
+        transpiler.transpileEverything (force, order)
     }
 
 } else { // if required as a module

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -676,35 +676,48 @@ class Transpiler {
     // ========================================================================
     // exchange capabilities ordering
 
-    areCapabilitiesAlreadySorted (capabilities) {
-        let secondIndex;
-        for(let firstIndex = 0; firstIndex < capabilities.length; firstIndex++){
-            secondIndex = firstIndex + 1;
-            if (capabilities[firstIndex].localeCompare (capabilities[secondIndex]) > 0) return false;
-        }
-        return true;
-    }
-    
-    orderExchangeCapabilities (code) {
+    sortExchangeCapabilities (code, filename) {
         const lineBreak = '\n';
-        const capabilitiesObjectRegex = /(?<='has': {[\n])([^|})]*)(?=\n([ ]+}))/;
+        const capabilitiesObjectRegex = /(?<='has': {[\n])([^|})]*)(?=\n(\s+}))/;
         const found = capabilitiesObjectRegex.exec (code);
         if (found === null) {
-            return null; // capabilities not found
+            return false // capabilities not found
         }
-        let capabilities = found[0].split (lineBreak); 
-        if (this.areCapabilitiesAlreadySorted (capabilities)) {
-            return null;
+        let capabilities = found[0].split (lineBreak);
+        const exchange = new Exchange ()
+        const sortingOrder = {
+            'CORS': 'undefined,',
+            'spot': 'true,',
+            'margin': 'undefined,',
+            'swap': 'undefined,',
+            'future': 'undefined,',
+            'option': 'undefined,',
+            // then everything else
         }
-        capabilities.sort (function (a, b) {
-            return a.localeCompare (b);
-        });
-        const sortedCapabilities = capabilities.join (lineBreak);
-        const finalResult = code.replace (capabilitiesObjectRegex, sortedCapabilities)
-        if (finalResult.length !== code.length) {
-            return null; // something went wrong
+        const features = {}
+        let indentation = '                ' // 16 spaces
+        for (let i = 0; i < capabilities.length; i++) {
+            const capability = capabilities[i]
+            const match = capability.match (/(\s+)\'(.+)\': (.+)$/)
+            if (match) {
+                indentation = match[1]
+                const feature = match[2]
+                const value = match[3]
+                features[feature] = value
+            }
         }
-        return finalResult;
+        let keys = Object.keys (features)
+        keys.sort ((a, b) => a.localeCompare (b))
+        const allKeys = Object.keys (sortingOrder).concat (keys)
+        for (let i = 0; i < allKeys.length; i++) {
+            const key = allKeys[i]
+            sortingOrder[key] = (key in features) ? features[key] : sortingOrder[key]
+        }
+        const result = Object.entries (sortingOrder).map (([ key, value ]) => indentation + "'" + key + "': " + value).join (lineBreak)
+        if (result === found[0]) {
+            return false
+        }
+        return code.replace (capabilitiesObjectRegex, result)
     }
 
     // ------------------------------------------------------------------------
@@ -1082,7 +1095,16 @@ class Transpiler {
             const pythonFilename = filename.replace ('.js', '.py')
             const phpFilename = filename.replace ('.js', '.php')
 
-            const jsMtime = fs.statSync (jsFolder + filename).mtime.getTime ()
+            const jsPath = jsFolder + filename
+
+            let contents = fs.readFileSync (jsPath, 'utf8')
+            const sortedExchangeCapabilities = this.sortExchangeCapabilities (contents, filename)
+            if (sortedExchangeCapabilities) {
+                contents = sortedExchangeCapabilities
+                overwriteFile (jsPath, contents)
+            }
+
+            const jsMtime = fs.statSync (jsPath).mtime.getTime ()
 
             const python2Path  = python2Folder  ? (python2Folder  + pythonFilename) : undefined
             const python3Path  = python3Folder  ? (python3Folder  + pythonFilename) : undefined
@@ -1094,17 +1116,7 @@ class Transpiler {
             const phpAsyncMtime = phpAsyncFolder ? (fs.existsSync (phpAsyncPath) ? fs.statSync (phpAsyncPath).mtime.getTime () : 0) : undefined
             const phpMtime      = phpPath        ? (fs.existsSync (phpPath)      ? fs.statSync (phpPath).mtime.getTime ()      : 0) : undefined
 
-            const jsPath = jsFolder + filename
-            let contents = fs.readFileSync (jsPath, 'utf8')
-
-            let orderedContent = this.orderExchangeCapabilities (contents)
-            if (orderedContent !== null) {
-                contents = orderedContent
-                overwriteFile (jsPath, contents)
-            }
-
-            if (orderedContent !==null || 
-                force ||
+            if (force ||
                 (python3Folder  && (jsMtime > python3Mtime))  ||
                 (phpFolder      && (jsMtime > phpMtime))      ||
                 (phpAsyncFolder && (jsMtime > phpAsyncMtime)) ||

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1109,7 +1109,8 @@ class Transpiler {
                 fs.writeFileSync(jsPath, contents, {encoding:'utf8',flag:'w'})
             }
 
-            if (force ||
+            if (orderedContent !==null || 
+                force ||
                 (python3Folder  && (jsMtime > python3Mtime))  ||
                 (phpFolder      && (jsMtime > phpMtime))      ||
                 (phpAsyncFolder && (jsMtime > phpAsyncMtime)) ||

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -687,28 +687,20 @@ class Transpiler {
     
     orderExchangeCapabilities(code) {
         const lineBreak = '\n';
-        const capabilitiesPrefix = "'has': {" + lineBreak;
-        const capabilitiesSufix = '}';
-        const initHasObjectIndex = code.indexOf (capabilitiesPrefix);
-        if (initHasObjectIndex === -1) {
+        const capabilitiesObjectRegex = /(?<='has': {[\r\n])([^}]*)(?=})/;
+        const found = capabilitiesObjectRegex.exec(code);
+        if (found === undefined) {
             return null; // capabilities not found
         }
-        const initExchangeCapabilities = code.substring (initHasObjectIndex).replace (capabilitiesPrefix, '');
-        const lastHasObjectIndex = initExchangeCapabilities.indexOf (capabilitiesSufix);
-        const exchangeCapabilitiesOnly = initExchangeCapabilities.substring (0, lastHasObjectIndex);
-        let capabilities = exchangeCapabilitiesOnly.split (lineBreak);
-        capabilities = capabilities.filter(item=>item != lineBreak)
-        const lastSpace = capabilities.pop();
+        let capabilities = found[0].split('\n'); 
         if (this.areCapabilitiesAlreadySorted(capabilities)) {
             return null;
         }
         capabilities.sort(function (a, b) {
             return a.localeCompare(b);
         });
-        const orderedCapabilities = capabilities.join (lineBreak);
-        const newCapabilitiesObject = capabilitiesPrefix + orderedCapabilities + lineBreak + lastSpace;
-        const currentCapabilitiesObject = capabilitiesPrefix + exchangeCapabilitiesOnly;
-        const finalResult = code.replace (currentCapabilitiesObject, newCapabilitiesObject);
+        sortedCapabilities = capabilities.join ('\n');
+        const finalResult = code.replace(capabilitiesObjectRegex, sortedCapabilities)
         if (finalResult.length !== code.length) {
             return null; // something went wrong
         }

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -702,7 +702,9 @@ class Transpiler {
         if (this.areCapabilitiesAlreadySorted(capabilities)) {
             return null;
         }
-        capabilities.sort ();
+        capabilities.sort(function (a, b) {
+            return a.localeCompare(b);
+        });
         const orderedCapabilities = capabilities.join (lineBreak);
         const newCapabilitiesObject = capabilitiesPrefix + orderedCapabilities + lineBreak + lastSpace;
         const currentCapabilitiesObject = capabilitiesPrefix + exchangeCapabilitiesOnly;

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1100,8 +1100,14 @@ class Transpiler {
             const phpAsyncMtime = phpAsyncFolder ? (fs.existsSync (phpAsyncPath) ? fs.statSync (phpAsyncPath).mtime.getTime () : 0) : undefined
             const phpMtime      = phpPath        ? (fs.existsSync (phpPath)      ? fs.statSync (phpPath).mtime.getTime ()      : 0) : undefined
 
-            const jsPath = jsFolder + filename;
-            const contents = fs.readFileSync (jsPath, 'utf8')
+            const jsPath = jsFolder + filename
+            let contents = fs.readFileSync (jsPath, 'utf8')
+
+            const orderedContent = this.orderExchangeCapabilities(contents)
+            if (orderedContent !== null) {
+                contents = orderedContent
+                fs.writeFileSync(jsPath, contents, {encoding:'utf8',flag:'w'})
+            }
 
             if (force ||
                 (python3Folder  && (jsMtime > python3Mtime))  ||

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -699,7 +699,7 @@ class Transpiler {
         let capabilities = exchangeCapabilitiesOnly.split (lineBreak);
         capabilities = capabilities.filter(item=>item != lineBreak)
         const lastSpace = capabilities.pop();
-        if (areCapabilitiesAlreadySorted(capabilities)) {
+        if (this.areCapabilitiesAlreadySorted(capabilities)) {
             return null;
         }
         capabilities.sort ();

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -680,7 +680,7 @@ class Transpiler {
         let secondIndex;
         for(let firstIndex = 0; firstIndex < capabilities.length; firstIndex++){
             secondIndex = firstIndex + 1;
-            if(capabilities[firstIndex] > capabilities[secondIndex]) return false;
+            if (capabilities[firstIndex].localeCompare(capabilities[secondIndex]) > 0) return false;
         }
         return true;
     }

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -692,14 +692,14 @@ class Transpiler {
         if (found === undefined) {
             return null; // capabilities not found
         }
-        let capabilities = found[0].split ('\n'); 
+        let capabilities = found[0].split (lineBreak); 
         if (this.areCapabilitiesAlreadySorted (capabilities)) {
             return null;
         }
         capabilities.sort (function (a, b) {
             return a.localeCompare (b);
         });
-        sortedCapabilities = capabilities.join ('\n');
+        sortedCapabilities = capabilities.join (lineBreak);
         const finalResult = code.replace (capabilitiesObjectRegex, sortedCapabilities)
         if (finalResult.length !== code.length) {
             return null; // something went wrong
@@ -1102,7 +1102,7 @@ class Transpiler {
                 orderedContent = this.orderExchangeCapabilities (contents)
                 if (orderedContent !== null) {
                     contents = orderedContent
-                    fs.writeFileSync(jsPath, contents, {encoding:'utf8',flag:'w'})
+                    overwriteFile (jsPath, contents)
                 }
             }
 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1097,13 +1097,10 @@ class Transpiler {
             const jsPath = jsFolder + filename
             let contents = fs.readFileSync (jsPath, 'utf8')
 
-            let orderedContent = null
-            if (order) {
-                orderedContent = this.orderExchangeCapabilities (contents)
-                if (orderedContent !== null) {
-                    contents = orderedContent
-                    overwriteFile (jsPath, contents)
-                }
+            let orderedContent = this.orderExchangeCapabilities (contents)
+            if (orderedContent !== null) {
+                contents = orderedContent
+                overwriteFile (jsPath, contents)
             }
 
             if (orderedContent !==null || 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -676,31 +676,31 @@ class Transpiler {
     // ========================================================================
     // exchange capabilities ordering
 
-    areCapabilitiesAlreadySorted(capabilities) {
+    areCapabilitiesAlreadySorted (capabilities) {
         let secondIndex;
         for(let firstIndex = 0; firstIndex < capabilities.length; firstIndex++){
             secondIndex = firstIndex + 1;
-            if (capabilities[firstIndex].localeCompare(capabilities[secondIndex]) > 0) return false;
+            if (capabilities[firstIndex].localeCompare (capabilities[secondIndex]) > 0) return false;
         }
         return true;
     }
     
-    orderExchangeCapabilities(code) {
+    orderExchangeCapabilities (code) {
         const lineBreak = '\n';
         const capabilitiesObjectRegex = /(?<='has': {[\r\n])([^}]*)(?=})/;
-        const found = capabilitiesObjectRegex.exec(code);
+        const found = capabilitiesObjectRegex.exec (code);
         if (found === undefined) {
             return null; // capabilities not found
         }
-        let capabilities = found[0].split('\n'); 
-        if (this.areCapabilitiesAlreadySorted(capabilities)) {
+        let capabilities = found[0].split ('\n'); 
+        if (this.areCapabilitiesAlreadySorted (capabilities)) {
             return null;
         }
-        capabilities.sort(function (a, b) {
-            return a.localeCompare(b);
+        capabilities.sort (function (a, b) {
+            return a.localeCompare (b);
         });
         sortedCapabilities = capabilities.join ('\n');
-        const finalResult = code.replace(capabilitiesObjectRegex, sortedCapabilities)
+        const finalResult = code.replace (capabilitiesObjectRegex, sortedCapabilities)
         if (finalResult.length !== code.length) {
             return null; // something went wrong
         }
@@ -1099,7 +1099,7 @@ class Transpiler {
 
             let orderedContent = null
             if (order) {
-                orderedContent = this.orderExchangeCapabilities(contents)
+                orderedContent = this.orderExchangeCapabilities (contents)
                 if (orderedContent !== null) {
                     contents = orderedContent
                     fs.writeFileSync(jsPath, contents, {encoding:'utf8',flag:'w'})

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1701,6 +1701,7 @@ if (require.main === module) { // called directly like `node module`
     const force = process.argv.includes ('--force')
     const order = process.argv.includes('--order')
     log.bright.green ({ force })
+    log.bright.green ({ order })
     if (test) {
         transpiler.transpileTests ()
     } else if (errors) {

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -687,7 +687,7 @@ class Transpiler {
     
     orderExchangeCapabilities (code) {
         const lineBreak = '\n';
-        const capabilitiesObjectRegex = /(?<='has': {[\r\n])([^}]*)(?=})/;
+        const capabilitiesObjectRegex = /(?<='has': {[\n])([^|})]*)(?=\n([ ]+}))/;
         const found = capabilitiesObjectRegex.exec (code);
         if (found === undefined) {
             return null; // capabilities not found
@@ -699,7 +699,7 @@ class Transpiler {
         capabilities.sort (function (a, b) {
             return a.localeCompare (b);
         });
-        sortedCapabilities = capabilities.join (lineBreak);
+        const sortedCapabilities = capabilities.join (lineBreak);
         const finalResult = code.replace (capabilitiesObjectRegex, sortedCapabilities)
         if (finalResult.length !== code.length) {
             return null; // something went wrong

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1694,7 +1694,6 @@ if (require.main === module) { // called directly like `node module`
     const errors = process.argv.includes ('--error') || process.argv.includes ('--errors')
     const force = process.argv.includes ('--force')
     log.bright.green ({ force })
-    log.bright.green ({ order })
     if (test) {
         transpiler.transpileTests ()
     } else if (errors) {

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1072,7 +1072,7 @@ class Transpiler {
 
     // ========================================================================
 
-    transpileDerivedExchangeFile (jsFolder, filename, options, force = false, order = false) {
+    transpileDerivedExchangeFile (jsFolder, filename, options, force = false) {
 
         // todo normalize jsFolder and other arguments
 
@@ -1146,7 +1146,7 @@ class Transpiler {
 
     //-------------------------------------------------------------------------
 
-    transpileDerivedExchangeFiles (jsFolder, options, pattern = '.js', force = false, order = false) {
+    transpileDerivedExchangeFiles (jsFolder, options, pattern = '.js', force = false) {
 
         // todo normalize jsFolder and other arguments
 
@@ -1163,7 +1163,7 @@ class Transpiler {
 
         const classNames = fs.readdirSync (jsFolder)
             .filter (file => file.match (regex) && (!ids || ids.includes (basename (file, '.js'))))
-            .map (file => this.transpileDerivedExchangeFile (jsFolder, file, options, force, order))
+            .map (file => this.transpileDerivedExchangeFile (jsFolder, file, options, force))
 
         const classes = {}
 
@@ -1640,7 +1640,7 @@ class Transpiler {
 
     // ============================================================================
 
-    transpileEverything (force = false, order = false) {
+    transpileEverything (force = false) {
 
         // default pattern is '.js'
         const [ /* node */, /* script */, pattern ] = process.argv.filter (x => !x.startsWith ('--'))
@@ -1657,7 +1657,7 @@ class Transpiler {
 
         //*
 
-        const classes = this.transpileDerivedExchangeFiles ('./js/', options, pattern, force, order)
+        const classes = this.transpileDerivedExchangeFiles ('./js/', options, pattern, force)
 
         if (classes === null) {
             log.bright.yellow ('0 files transpiled.')
@@ -1693,7 +1693,6 @@ if (require.main === module) { // called directly like `node module`
     const test = process.argv.includes ('--test') || process.argv.includes ('--tests')
     const errors = process.argv.includes ('--error') || process.argv.includes ('--errors')
     const force = process.argv.includes ('--force')
-    const order = process.argv.includes('--order')
     log.bright.green ({ force })
     log.bright.green ({ order })
     if (test) {
@@ -1701,7 +1700,7 @@ if (require.main === module) { // called directly like `node module`
     } else if (errors) {
         transpiler.transpileErrorHierarchy ()
     } else {
-        transpiler.transpileEverything (force, order)
+        transpiler.transpileEverything (force)
     }
 
 } else { // if required as a module

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "scripts": {
     "docker": "docker-compose run --rm ccxt",
     "build": "npm run pre-transpile && npm run transpile && npm run post-transpile && npm run update-badges",
-    "order-build": "npm run pre-transpile && npm run order-transpile && npm run post-transpile && npm run update-badges",
     "force-build": "npm run pre-transpile && npm run force-transpile && npm run post-transpile && npm run update-badges",
     "pre-transpile": "npm run export-exchanges && npm run vss && npm run copy-python-files && npm run check-js-syntax && npm run browserify",
     "post-transpile": "npm run check-python-syntax && npm run check-php-syntax",
@@ -39,7 +38,6 @@
     "update-badges": "node build/update-badges",
     "update-links": "node build/update-links",
     "transpile": "node build/transpile",
-    "order-transpile": "node build/transpile --order",
     "force-transpile": "node build/transpile --force",
     "vss": "node build/vss",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "docker": "docker-compose run --rm ccxt",
     "build": "npm run pre-transpile && npm run transpile && npm run post-transpile && npm run update-badges",
+    "order-build": "npm run pre-transpile && npm run order-transpile && npm run post-transpile && npm run update-badges",
     "force-build": "npm run pre-transpile && npm run force-transpile && npm run post-transpile && npm run update-badges",
     "pre-transpile": "npm run export-exchanges && npm run vss && npm run copy-python-files && npm run check-js-syntax && npm run browserify",
     "post-transpile": "npm run check-python-syntax && npm run check-php-syntax",
@@ -38,6 +39,7 @@
     "update-badges": "node build/update-badges",
     "update-links": "node build/update-links",
     "transpile": "node build/transpile",
+    "order-transpile": "node build/transpile --order",
     "force-transpile": "node build/transpile --force",
     "vss": "node build/vss",
     "lint": "eslint",


### PR DESCRIPTION
As requested, I've added a build step to order the exchanges capabilities in all the languages (Javascript, Python, PHP). Since this step might increase the build time and/or produce unwanted changes (for instance, order an exchange you did not touch), I created another `npm` command, named `npm run order-build`, making this metainfo ordering optional.

**Implementation notes:**
- If the exchange is already sorted, we will skip it
- If for some reason the ordering for a certain exchange fails, it will perform no operation as well.