### PR TITLE
bigone: use string in safeTicker ccxt/ccxt#11379

### DIFF
--- a/js/bigone.js
+++ b/js/bigone.js
@@ -270,31 +270,31 @@ module.exports = class bigone extends Exchange {
         const marketId = this.safeString (ticker, 'asset_pair_name');
         const symbol = this.safeSymbol (marketId, market, '-');
         const timestamp = undefined;
-        const close = this.safeNumber (ticker, 'close');
+        const close = this.safeString (ticker, 'close');
         const bid = this.safeValue (ticker, 'bid', {});
         const ask = this.safeValue (ticker, 'ask', {});
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeNumber (ticker, 'high'),
-            'low': this.safeNumber (ticker, 'low'),
-            'bid': this.safeNumber (bid, 'price'),
-            'bidVolume': this.safeNumber (bid, 'quantity'),
-            'ask': this.safeNumber (ask, 'price'),
-            'askVolume': this.safeNumber (ask, 'quantity'),
+            'high': this.safeString (ticker, 'high'),
+            'low': this.safeString (ticker, 'low'),
+            'bid': this.safeString (bid, 'price'),
+            'bidVolume': this.safeString (bid, 'quantity'),
+            'ask': this.safeString (ask, 'price'),
+            'askVolume': this.safeString (ask, 'quantity'),
             'vwap': undefined,
-            'open': this.safeNumber (ticker, 'open'),
+            'open': this.safeString (ticker, 'open'),
             'close': close,
             'last': close,
             'previousClose': undefined,
-            'change': this.safeNumber (ticker, 'daily_change'),
+            'change': this.safeString (ticker, 'daily_change'),
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeNumber (ticker, 'volume'),
+            'baseVolume': this.safeString (ticker, 'volume'),
             'quoteVolume': undefined,
             'info': ticker,
-        }, market);
+        }, market, false);
     }
 
     async fetchTicker (symbol, params = {}) {


### PR DESCRIPTION
ccxt/ccxt#11379

```BASH
$ node examples/js/cli bigone fetchTicker SHIB/USDT --verbose --debug
```

```JS
{
  symbol: 'SHIB/USDT',
  timestamp: undefined,
  datetime: undefined,
  high: 0.0000293451,
  low: 0.000028165,
  bid: undefined,
  bidVolume: 51381424,
  ask: 0.0000288974,
  askVolume: 186086413,
  vwap: undefined,
  open: 0.000029288,
  close: 0.0000289376,
  last: 0.0000289376,
  previousClose: undefined,
  change: -3.504e-7,
  percentage: -1.1963944277519802,
  average: 0.0000291128,
  baseVolume: 118082217,
  quoteVolume: undefined,
  info: {
    asset_pair_name: 'SHIB-USDT',
    bid: { price: '0.0000285327', order_count: '1', quantity: '51381424' },
    ask: { price: '0.0000288974', order_count: '1', quantity: '186086413' },
    open: '0.000029288',
    high: '0.0000293451',
    low: '0.000028165',
    close: '0.0000289376',
    volume: '118082217',
    daily_change: '-0.0000003504'
  }
}
```