### PR TITLE
Bybit fetchOrders : handleMarketTypeAndParams

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2172,10 +2172,8 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const options = this.safeValue (this.options, 'fetchOrders', {});
-        const defaultType = this.safeString (this.options, 'defaultType', 'linear');
-        const marketTypes = this.safeValue (this.options, 'marketTypes', {});
-        const marketType = this.safeString (marketTypes, symbol, defaultType);
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         let defaultMethod = undefined;
         const marketDefined = (market !== undefined);
         const linear = (marketDefined && market['linear']) || (marketType === 'linear');
@@ -2206,8 +2204,7 @@ module.exports = class bybit extends Exchange {
                 defaultMethod = 'futuresPrivateGetStopOrderList';
             }
         }
-        const method = this.safeString (options, 'method', defaultMethod);
-        const response = await this[method] (this.extend (request, query));
+        const response = await this[defaultMethod] (this.extend (request, query));
         //
         //     {
         //         "ret_code": 0,


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOrders:
```
bybit.fetchOrders (ADA/USDT, , , [object Object])
364 ms
                                  id | clientOrderId | timestamp | datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | side |  price | stopPrice | amount |     cost | average | filled | remaining | status |                                   fee | trades |                                    fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
a7443c89-eaaa-4f4d-90f6-aef294a44c12 |               |           |          |                    | ADA/USDT | limit |         GTC |    false |  buy | 2.1629 |           |    530 | 1146.337 |  2.1629 |    530 |         0 | closed | {"cost":0.85975275,"currency":"USDT"} |     [] | [{"cost":0.85975275,"currency":"USDT"}]
1 objects
```