### PR TITLE
btcalpha fetchMarkets unified and has leverage methods

### DIFF
--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -16,19 +16,46 @@ module.exports = class btcalpha extends Exchange {
             'countries': [ 'US' ],
             'version': 'v1',
             'has': {
+                'spot': true,
+                'margin': false,
+                'swap': false,
+                'future': false,
+                'option': false,
+                'addMargin': false,
                 'cancelOrder': true,
                 'createOrder': true,
+                'createReduceOnlyOrder': false,
                 'fetchBalance': true,
+                'fetchBorrowRate': false,
+                'fetchBorrowRateHistory': false,
+                'fetchBorrowRates': false,
+                'fetchBorrowRatesPerSymbol': false,
                 'fetchClosedOrders': true,
+                'fetchFundingHistory': false,
+                'fetchFundingRate': false,
+                'fetchFundingRateHistory': false,
+                'fetchFundingRates': false,
+                'fetchIndexOHLCV': false,
+                'fetchIsolatedPositions': false,
+                'fetchLeverage': false,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchPosition': false,
+                'fetchPositions': false,
+                'fetchPositionsRisk': false,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': undefined,
                 'fetchTrades': true,
+                'reduceMargin': false,
+                'setLeverage': false,
+                'setMarginMode': false,
+                'setPositionMode': false,
             },
             'timeframes': {
                 '1m': '1',
@@ -103,24 +130,42 @@ module.exports = class btcalpha extends Exchange {
             const quoteId = this.safeString (market, 'currency2');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const symbol = base + '/' + quote;
             const pricePrecision = this.safeString (market, 'price_precision');
             const priceLimit = this.parsePrecision (pricePrecision);
-            const precision = {
-                'amount': 8,
-                'price': parseInt (pricePrecision),
-            };
             const amountLimit = this.safeString (market, 'minimum_order_size');
             result.push ({
                 'id': id,
-                'symbol': symbol,
+                'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
+                'settle': undefined,
+                'baseId': baseId,
+                'quoteId': quoteId,
+                'settleId': undefined,
                 'type': 'spot',
                 'spot': true,
+                'margin': false,
+                'swap': false,
+                'future': false,
+                'option': false,
                 'active': true,
-                'precision': precision,
+                'contract': false,
+                'linear': undefined,
+                'inverse': undefined,
+                'contractSize': undefined,
+                'expiry': undefined,
+                'expiryDatetime': undefined,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'amount': parseInt ('8'),
+                    'price': parseInt (pricePrecision),
+                },
                 'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
                     'amount': {
                         'min': this.parseNumber (amountLimit),
                         'max': this.safeNumber (market, 'maximum_order_size'),
@@ -135,8 +180,6 @@ module.exports = class btcalpha extends Exchange {
                     },
                 },
                 'info': market,
-                'baseId': undefined,
-                'quoteId': undefined,
             });
         }
         return result;


### PR DESCRIPTION
```
2022-01-19T01:01:29.021Z
Node.js: v14.17.0
CCXT v1.68.48
btcalpha.fetchMarkets ()
2376 ms
        id |     symbol |  base | quote | settle | baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |              precision |                                                                                              limits
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1INCH_USDT | 1INCH/USDT | 1INCH |  USDT |        |  1INCH |    USDT |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"amount":8,"price":4} |   {"leverage":{},"amount":{"min":0.01,"max":900000},"price":{"min":0.0001},"cost":{"min":0.000001}}
...
  ZHC_USDT |   ZHC/USDT |   ZHC |  USDT |        |    ZHC |    USDT |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"amount":8,"price":5} |                                                                                     [object Object]
  ZRX_USDT |   ZRX/USDT |   ZRX |  USDT |        |    ZRX |    USDT |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"amount":8,"price":4} |     {"leverage":{},"amount":{"min":0.1,"max":900000},"price":{"min":0.0001},"cost":{"min":0.00001}}
100 objects
```