### PR TITLE
exchange-capabilities, colors, windows, spot and option at front

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -10,7 +10,6 @@ const csv = process.argv.includes ('--csv')
 
 console.log (ccxt.iso8601 (ccxt.milliseconds ()))
 console.log ('CCXT v' + ccxt.version)
-const isWindows = process.platform == 'win32' // fix for windows, as it doesn't show darkred-VS-red well enough
 
 async function main () {
 
@@ -34,9 +33,11 @@ async function main () {
             'publicAPI',
             'privateAPI',
             'CORS',
+            'spot',
             'margin',
             'swap',
             'future',
+            'option',
             'CORS',
         ];
 
@@ -52,7 +53,7 @@ async function main () {
 
             if (feature === false) {
                 // if explicitly set to 'false' in exchange.has (to exclude mistake, we check if it's undefined too)
-                coloredString = isWindows ? exchange.id.lightMagenta : exchange.id.red
+                coloredString = exchange.id.red.dim
                 inexistentApi += 1
             } else if (feature === 'emulated') {
                 // if explicitly set to 'emulated' in exchange.has
@@ -70,11 +71,11 @@ async function main () {
                     } else {
                         // the feature is available in exchange.has and not implemented
                         // this is an error
-                        coloredString = exchange.id.red.bright
+                        coloredString = exchange.id.lightMagenta
                     }
                 }
             } else {
-                coloredString = isWindows ? exchange.id.red : exchange.id.red.dim
+                coloredString = exchange.id.red.bright
                 notImplemented += 1
             }
 
@@ -97,8 +98,8 @@ async function main () {
         'Methods [' + total.toString () + ' total]: ',
         implemented.toString ().green, 'implemented,',
         emulated.toString ().yellow, 'emulated,',
-        (isWindows ? inexistentApi.toString ().lightMagenta : inexistentApi.toString ().red), 'inexistentApi,',
-        (isWindows ? notImplemented.toString ().red : notImplemented.toString ().red.dim), 'notImplemented',
+        (inexistentApi.toString ().red.dim), 'inexistentApi,',
+        (notImplemented.toString ().red.bright), 'notImplemented',
     )
 
     log("\nMessy? Try piping to less (e.g. node script.js | less -S -R)\n".red)


### PR DESCRIPTION
- Puts spot and option at the front
- Removes windows check from exchange capabilities (It's a source of confusion, i replaced magenta with red.bright and red.dim as oppossed to just red and red.dim)
- Non-existant on api is `red.bright`
- not implemented is `red.dim`