### PR TITLE
Bitmart fetchTickers : handleMarketTypeAndParams

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -824,15 +824,13 @@ module.exports = class bitmart extends Exchange {
 
     async fetchTickers (symbols = undefined, params = {}) {
         await this.loadMarkets ();
-        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, 'type');
-        let method = undefined;
-        if ((type === 'swap') || (type === 'future')) {
-            method = 'publicContractGetTickers';
-        } else if (type === 'spot') {
-            method = 'publicSpotGetTicker';
-        }
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'publicSpotGetTicker',
+            'swap': 'publicContractGetTickers',
+            'future': 'publicContractGetTickers',
+        });
         const response = await this[method] (params);
         const data = this.safeValue (response, 'data', {});
         const tickers = this.safeValue (data, 'tickers', []);

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2172,8 +2172,10 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
+        const options = this.safeValue (this.options, 'fetchOrders', {});
+        const defaultType = this.safeString (this.options, 'defaultType', 'linear');
+        const marketTypes = this.safeValue (this.options, 'marketTypes', {});
+        const marketType = this.safeString (marketTypes, symbol, defaultType);
         let defaultMethod = undefined;
         const marketDefined = (market !== undefined);
         const linear = (marketDefined && market['linear']) || (marketType === 'linear');
@@ -2204,7 +2206,8 @@ module.exports = class bybit extends Exchange {
                 defaultMethod = 'futuresPrivateGetStopOrderList';
             }
         }
-        const response = await this[defaultMethod] (this.extend (request, query));
+        const method = this.safeString (options, 'method', defaultMethod);
+        const response = await this[method] (this.extend (request, query));
         //
         //     {
         //         "ret_code": 0,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2172,10 +2172,8 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const options = this.safeValue (this.options, 'fetchOrders', {});
-        const defaultType = this.safeString (this.options, 'defaultType', 'linear');
-        const marketTypes = this.safeValue (this.options, 'marketTypes', {});
-        const marketType = this.safeString (marketTypes, symbol, defaultType);
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         let defaultMethod = undefined;
         const marketDefined = (market !== undefined);
         const linear = (marketDefined && market['linear']) || (marketType === 'linear');
@@ -2206,8 +2204,7 @@ module.exports = class bybit extends Exchange {
                 defaultMethod = 'futuresPrivateGetStopOrderList';
             }
         }
-        const method = this.safeString (options, 'method', defaultMethod);
-        const response = await this[method] (this.extend (request, query));
+        const response = await this[defaultMethod] (this.extend (request, query));
         //
         //     {
         //         "ret_code": 0,


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchTickers:
```
bitmart.fetchTickers (BTC/USDT)
2023 ms
{
  'BTC/USDT': {
    symbol: 'BTC/USDT',
    timestamp: 1642558610869,
    datetime: '2022-01-19T02:16:50.869Z',
    high: 42653,
    low: 41292.24,
    bid: 42445.04,
    bidVolume: 0.01069,
    ask: 42453.23,
    askVolume: 0.00017,
    vwap: 42046.804865964936,
    open: 42213.29,
    close: 42447.23,
    last: 42447.23,
    previousClose: undefined,
    change: 233.94000000000233,
    percentage: 0.5499999999999999,
    average: 42330.26,
    baseVolume: 1366.59246,
    quoteVolume: 57460846.496919,
    info: {
      symbol: 'BTC_USDT',
      last_price: '42447.23',
      quote_volume_24h: '57460846.4969190',
      base_volume_24h: '1366.592460000000000000000000000000',
      high_24h: '42653.00',
      low_24h: '41292.24',
      open_24h: '42213.29',
      close_24h: '42447.23',
      best_ask: '42453.23',
      best_ask_size: '0.00017',
      best_bid: '42445.04',
      best_bid_size: '0.01069',
      fluctuation: '+0.0055',
      url: 'https://www.bitmart.com/trade?symbol=BTC_USDT'
    }
  }
}
```