### PR TITLE
Bitmart fetchBalance : handleMarketTypeAndParams

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1456,8 +1456,7 @@ module.exports = class bitmart extends Exchange {
 
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotGetWallet',
             'swap': 'privateContractGetAccounts',
@@ -1465,7 +1464,7 @@ module.exports = class bitmart extends Exchange {
             'contract': 'privateContractGetAccounts',
             'account': 'privateAccountGetWallet',
         });
-        const response = await this[method] (params);
+        const response = await this[method] (query);
         //
         // spot
         //

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1456,19 +1456,15 @@ module.exports = class bitmart extends Exchange {
 
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
-        let method = undefined;
-        const options = this.safeValue (this.options, 'fetchBalance', {});
-        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
-        let type = this.safeString (options, 'type', defaultType);
-        type = this.safeString (params, 'type', type);
-        params = this.omit (params, 'type');
-        if (type === 'spot') {
-            method = 'privateSpotGetWallet';
-        } else if (type === 'account') {
-            method = 'privateAccountGetWallet';
-        } else if ((type === 'swap') || (type === 'future') || (type === 'contract')) {
-            method = 'privateContractGetAccounts';
-        }
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateSpotGetWallet',
+            'swap': 'privateContractGetAccounts',
+            'future': 'privateContractGetAccounts',
+            'contract': 'privateContractGetAccounts',
+            'account': 'privateAccountGetWallet',
+        });
         const response = await this[method] (params);
         //
         // spot


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchBalance:
```
bitmart.fetchBalance ()
573 ms
{
  info: {
    message: 'OK',
    code: '1000',
    trace: '98e8d3c0-f154-417e-bc53-4f81049aa4d8',
    data: {
      wallet: [
        {
          id: 'SOL',
          name: 'Solana',
          available: '0.35000000',
          frozen: '0.00000000',
          total: '0.35000000'
        }
      ]
    }
  },
  SOL: { free: 0.35, used: 0, total: 0.35 },
  free: { SOL: 0.35 },
  used: { SOL: 0 },
  total: { SOL: 0.35 }
}
```