### PR TITLE
AAX fetchMyTrades : handleMarketTypeAndParams

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -1799,13 +1799,11 @@ module.exports = class aax extends Exchange {
             // 'side': 'undefined', // BUY, SELL
         };
         let market = undefined;
-        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
-            marketType = market['type'];
         }
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotTrades',
             'swap': 'privateGetFuturesTrades',
@@ -1817,7 +1815,7 @@ module.exports = class aax extends Exchange {
         if (since !== undefined) {
             request['startDate'] = this.yyyymmdd (since);
         }
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         //     {
         //         "code":1,

--- a/js/aax.js
+++ b/js/aax.js
@@ -1798,21 +1798,19 @@ module.exports = class aax extends Exchange {
             // 'orderType': undefined, // MARKET, LIMIT, STOP, STOP-LIMIT
             // 'side': 'undefined', // BUY, SELL
         };
-        let method = undefined;
-        const defaultType = this.safeString2 (this.options, 'fetchMyTrades', 'defaultType', 'spot');
-        let type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, 'type');
         let market = undefined;
+        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
-            type = market['type'];
+            marketType = market['type'];
         }
-        if (type === 'spot') {
-            method = 'privateGetSpotTrades';
-        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
-            method = 'privateGetFuturesTrades';
-        }
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotTrades',
+            'swap': 'privateGetFuturesTrades',
+            'future': 'privateGetFuturesTrades',
+        });
         if (limit !== undefined) {
             request['pageSize'] = limit; // default 10
         }


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchMyTrades:
```
aax.fetchMyTrades (SOL/USDT)
1277 ms
          id |     timestamp |                 datetime |   symbol |  type | side |      order | takerOrMaker |   price | amount |    cost |         fee | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
E08tg7G0blSH | 1642624033515 | 2022-01-19T20:27:13.515Z | SOL/USDT | limit | sell | 1RGj9484q4 |        taker | 136.138 |    0.3 | 40.8414 | {"currency":"USDT","cost":0.0408414} | [{"currency":"USDT","cost":0.0408414}]
1 objects
```