### PR TITLE
latoken GDX, WAR, IMC mapping

### DIFF
--- a/js/latoken.js
+++ b/js/latoken.js
@@ -120,10 +120,13 @@ module.exports = class latoken extends Exchange {
             },
             'commonCurrencies': {
                 'CTC': 'CyberTronchain',
+                'GDX': 'GoldenX',
+                'IMC': 'IMCoin',
                 'MT': 'Monarch',
                 'TPAY': 'Tetra Pay',
                 'TRADE': 'Smart Trade Coin',
                 'TSL': 'Treasure SL',
+                'WAR': 'Warrior Token',
             },
             'exceptions': {
                 'exact': {


### PR DESCRIPTION
https://latoken.com/exchange/GDX_BTC
conflict with https://ftx.com/ru/trade/GDX/USD

https://www.coingecko.com/en/coins/warrior-token#markets
conflict with https://www.coingecko.com/en/coins/westarter#markets

https://latoken.com/exchange/IMC_USDT (https://imcoinproject.com/)
conflict with https://www.coingecko.com/en/coins/i-money-crypto#markets