### PR TITLE
AAX fetchOrders : handleMarketTypeAndParams

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -1512,13 +1512,11 @@ module.exports = class aax extends Exchange {
             // 'clOrdID': clientOrderId,
         };
         let market = undefined;
-        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
-            marketType = market['type'];
         }
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotOrders',
             'swap': 'privateGetFuturesOrders',
@@ -1535,7 +1533,7 @@ module.exports = class aax extends Exchange {
         if (since !== undefined) {
             request['startDate'] = this.yyyymmdd (since);
         }
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //

--- a/js/aax.js
+++ b/js/aax.js
@@ -1511,21 +1511,19 @@ module.exports = class aax extends Exchange {
             // 'side': 'undefined', // BUY, SELL
             // 'clOrdID': clientOrderId,
         };
-        let method = undefined;
-        const defaultType = this.safeString2 (this.options, 'fetchOrders', 'defaultType', 'spot');
-        let type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, 'type');
         let market = undefined;
+        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
-            type = market['type'];
+            marketType = market['type'];
         }
-        if (type === 'spot') {
-            method = 'privateGetSpotOrders';
-        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
-            method = 'privateGetFuturesOrders';
-        }
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotOrders',
+            'swap': 'privateGetFuturesOrders',
+            'future': 'privateGetFuturesOrders',
+        });
         const clientOrderId = this.safeString2 (params, 'clOrdID', 'clientOrderId');
         if (clientOrderId !== undefined) {
             request['clOrdID'] = clientOrderId;


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOrders:
```
aax.fetchOrders (SOL/USDT)
896 ms
        id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |   symbol |  type | timeInForce | postOnly | side | price | 
1RGiYeMxpe |               | 1642623995645 | 2022-01-19T20:26:35.645Z |      1642624008596 | canceled | SOL/USDT | limit |         GTC |    false | sell | 136.2 |   
1RGj9484q4 |               | 1642624033487 | 2022-01-19T20:27:13.487Z |      1642624033505 |   closed | SOL/USDT | limit |         GTC |    false | sell | 136.1 |   
2 objects
```