### PR TITLE
AAX fetchOpenOrders : handleMarketTypeAndParams

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -1360,13 +1360,11 @@ module.exports = class aax extends Exchange {
             // 'clOrdID': clientOrderId,
         };
         let market = undefined;
-        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
-            marketType = market['type'];
         }
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotOpenOrders',
             'swap': 'privateGetFuturesOpenOrders',
@@ -1380,7 +1378,7 @@ module.exports = class aax extends Exchange {
         if (limit !== undefined) {
             request['pageSize'] = limit; // default 10
         }
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //

--- a/js/aax.js
+++ b/js/aax.js
@@ -1359,25 +1359,23 @@ module.exports = class aax extends Exchange {
             // 'side': 'undefined', // BUY, SELL
             // 'clOrdID': clientOrderId,
         };
-        const defaultType = this.safeString2 (this.options, 'fetchOpenOrders', 'defaultType', 'spot');
-        let type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, 'type');
         let market = undefined;
+        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
-            type = market['type'];
+            marketType = market['type'];
         }
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotOpenOrders',
+            'swap': 'privateGetFuturesOpenOrders',
+            'future': 'privateGetFuturesOpenOrders',
+        });
         const clientOrderId = this.safeString2 (params, 'clOrdID', 'clientOrderId');
         if (clientOrderId !== undefined) {
             request['clOrdID'] = clientOrderId;
             params = this.omit (params, [ 'clOrdID', 'clientOrderId' ]);
-        }
-        let method = undefined;
-        if (type === 'spot') {
-            method = 'privateGetSpotOpenOrders';
-        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
-            method = 'privateGetFuturesOpenOrders';
         }
         if (limit !== undefined) {
             request['pageSize'] = limit; // default 10


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOpenOrders:
```
aax.fetchOpenOrders (SATS/USDT)
921 ms
        id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |    symbol |  type | timeInForce | postOnly | side |      price | stopPrice | average | amount | filled | remaining | cost | trades |                          fee |                           fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1RH1B7f7jO |               | 1642633665247 | 2022-01-19T23:07:45.247Z |                    |   open | SATS/USDT | limit |         GTC |    false |  buy | 0.00019922 |         0 |         |  50000 |      0 |     50000 |    0 |     [] | {"currency":"SATS","cost":0} | [{"currency":"SATS","cost":0}]
1 objects
```