### PR TITLE
AAX cancelOrder : handleMarketTypeAndParams

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -1198,18 +1198,16 @@ module.exports = class aax extends Exchange {
             'orderID': id,
         };
         let market = undefined;
-        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            marketType = market['type'];
         }
-        [ marketType, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateDeleteSpotOrdersCancelOrderID',
             'swap': 'privateDeleteFuturesOrdersCancelOrderID',
             'future': 'privateDeleteFuturesOrdersCancelOrderID',
         });
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //

--- a/js/aax.js
+++ b/js/aax.js
@@ -1197,20 +1197,18 @@ module.exports = class aax extends Exchange {
         const request = {
             'orderID': id,
         };
-        let method = undefined;
-        const defaultType = this.safeString2 (this.options, 'cancelOrder', 'defaultType', 'spot');
-        let type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, 'type');
         let market = undefined;
+        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            type = market['type'];
+            marketType = market['type'];
         }
-        if (type === 'spot') {
-            method = 'privateDeleteSpotOrdersCancelOrderID';
-        } else if (type === 'swap' || type === 'future' || type === 'futures') { // type === 'futures' deprecated, use type === 'swap'
-            method = 'privateDeleteFuturesOrdersCancelOrderID';
-        }
+        [ marketType, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateDeleteSpotOrdersCancelOrderID',
+            'swap': 'privateDeleteFuturesOrdersCancelOrderID',
+            'future': 'privateDeleteFuturesOrdersCancelOrderID',
+        });
         const response = await this[method] (this.extend (request, params));
         //
         // spot


### PR DESCRIPTION
Added handleMarketTypeAndParams to cancelOrder:
```
aax.cancelOrder (1RHe9TXXLW, BTC/USDT)
924 ms
{
  id: '1RHe9TXXLW',
  info: {
    symbol: 'BTCUSDT',
    orderType: '2',
    avgPrice: '0',
    execInst: null,
    orderStatus: '1',
    userID: '3376269',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '30000',
    orderQty: '0.0006',
    commission: '0',
    id: '404181533534908416',
    timeInForce: '1',
    tradeID: 'E08tg7WPAYeK',
    isTriggered: false,
    side: '1',
    orderID: '1RHe9TXXLW',
    leavesQty: '0',
    cumQty: '0',
    updateTime: '2022-01-19T23:53:06.946Z',
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-01-19T23:53:06.924Z',
    transactTime: '2022-01-19T23:53:06.941Z',
    base: 'BTC',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1642636386924,
  datetime: '2022-01-19T23:53:06.924Z',
  lastTradeTimestamp: 1642636386941,
  status: 'open',
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 30000,
  stopPrice: 0,
  average: undefined,
  amount: 0.0006,
  filled: 0,
  remaining: 0.0006,
  cost: 0,
  trades: [],
  fee: { currency: 'BTC', cost: 0 },
  fees: [ { currency: 'BTC', cost: 0 } ]
}
```