### PR TITLE
Bybit fetchMyTrades : handleMarketTypeAndParams

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2383,8 +2383,7 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 20, max 50
         }
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
         const marketDefined = (market !== undefined);
         const linear = (marketDefined && market['linear']) || (marketType === 'linear');
         const inverse = (marketDefined && market['swap'] && market['inverse']) || (marketType === 'inverse');
@@ -2397,7 +2396,7 @@ module.exports = class bybit extends Exchange {
         } else if (future) {
             method = 'futuresPrivateGetExecutionList';
         }
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         // inverse
         //


### PR DESCRIPTION
Adjusted handleMarketTypeAndParams to be on one line so that it's cleaner in php and python:
```
bybit.fetchMyTrades (ADA/USDT)
749 ms
                                  id |     timestamp |                 datetime |   symbol |                                order |   type | side | takerOrMaker |  price | amount |      cost |                                                     fee |                                                      fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
9974f67e-8582-5463-882e-add6f15e6ac3 | 1627349805190 | 2021-07-27T01:36:45.190Z | ADA/USDT | 0b246bd9-17bc-466a-b7e0-08283353fd1f | market | sell |        taker | 1.2288 |     74 |   90.9312 |     {"cost":0.0681984,"currency":"USDT","rate":0.00075} |     [{"currency":"USDT","cost":0.0681984,"rate":0.00075}]
a0b38fc1-1a4d-5ed7-a02c-aa92a46d73f3 | 1627349805190 | 2021-07-27T01:36:45.190Z | ADA/USDT | 0b246bd9-17bc-466a-b7e0-08283353fd1f | market | sell |        taker |  1.229 |    200 |     245.8 |       {"cost":0.18435,"currency":"USDT","rate":0.00075} |       [{"currency":"USDT","cost":0.18435,"rate":0.00075}]
dda91388-6f7e-507c-bf8c-6d18168443cf | 1627349805190 | 2021-07-27T01:36:45.190Z | ADA/USDT | 0b246bd9-17bc-466a-b7e0-08283353fd1f | market | sell |        taker |  1.229 |    150 |    184.35 |     {"cost":0.1382625,"currency":"USDT","rate":0.00075} |     [{"currency":"USDT","cost":0.1382625,"rate":0.00075}]
50 objects
```