### PR TITLE
Mexc fetchTime : handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -274,13 +274,13 @@ module.exports = class mexc extends Exchange {
     }
 
     async fetchTime (params = {}) {
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTime', undefined, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTime', undefined, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPublicGetCommonTimestamp',
+            'margin': 'spotPublicGetCommonTimestamp',
             'swap': 'contractPublicGetPing',
         });
-        const response = await this[method] (this.extend (params));
+        const response = await this[method] (this.extend (query));
         //
         // spot
         //

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -277,7 +277,6 @@ module.exports = class mexc extends Exchange {
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTime', undefined, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPublicGetCommonTimestamp',
-            'margin': 'spotPublicGetCommonTimestamp',
             'swap': 'contractPublicGetPing',
         });
         const response = await this[method] (this.extend (query));


### PR DESCRIPTION
Adjusted handleMarketTypeAndParams to be one line so that it's cleaner in php and python. Added margin market type:
```
2022-01-20T03:06:37.387Z
Node.js: v16.9.1
CCXT v1.67.58
mexc.fetchTime ()
314 ms
1642647998933
```