### PR TITLE
Mexc fetchTicker : handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -698,12 +698,12 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        let method = undefined;
-        if (market['spot']) {
-            method = 'spotPublicGetMarketTicker';
-        } else if (market['swap']) {
-            method = 'contractPublicGetTicker';
-        }
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPublicGetMarketTicker',
+            'swap': 'contractPublicGetTicker',
+        });
         const response = await this[method] (this.extend (request, params));
         //
         // spot

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -698,13 +698,13 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPublicGetMarketTicker',
+            'margin': 'spotPublicGetMarketTicker',
             'swap': 'contractPublicGetTicker',
         });
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //


### PR DESCRIPTION
Adjusted handleMarketTypeAndParams to be on one line so that it's cleaner in php and python. Added margin market type:
```
mexc.fetchTicker (BTC/USDT)
206 ms
{
  symbol: 'BTC/USDT',
  timestamp: 1642648200000,
  datetime: '2022-01-20T03:10:00.000Z',
  high: 42559.01,
  low: 41148.98,
  bid: 41974.76,
  bidVolume: undefined,
  ask: 41974.79,
  askVolume: undefined,
  vwap: undefined,
  open: 42292.15,
  close: 41978.28,
  last: 41978.28,
  previousClose: undefined,
  change: -313.8700000000026,
  percentage: 1,
  average: 42135.215,
  baseVolume: 3244.399568,
  quoteVolume: undefined,
  info: {
    symbol: 'BTC_USDT',
    volume: '3244.399568',
    high: '42559.01',
    low: '41148.98',
    bid: '41974.76',
    ask: '41974.79',
    open: '42292.15',
    last: '41978.28',
    time: '1642648200000',
    change_rate: '-0.00742147'
  }
}
```