### PR TITLE
Mexc fetchOrderBook : adjust handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -843,15 +843,18 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        let method = undefined;
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPublicGetMarketDepth',
+            'swap': 'contractPublicGetDepthSymbol',
+        });
         if (market['spot']) {
-            method = 'spotPublicGetMarketDepth';
             if (limit === undefined) {
                 limit = 100; // the spot api requires a limit
             }
             request['depth'] = limit;
         } else if (market['swap']) {
-            method = 'contractPublicGetDepthSymbol';
             if (limit !== undefined) {
                 request['limit'] = limit;
             }

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -843,10 +843,10 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPublicGetMarketDepth',
+            'margin': 'spotPublicGetMarketDepth',
             'swap': 'contractPublicGetDepthSymbol',
         });
         if (market['spot']) {
@@ -859,7 +859,7 @@ module.exports = class mexc extends Exchange {
                 request['limit'] = limit;
             }
         }
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //


### PR DESCRIPTION
Adjusted handleMarketTypeAndParams so that it's on one line. Added margin market type:
```
mexc.fetchOrderBook (BTC/USDT)
212 ms
{
  symbol: 'BTC/USDT',
  bids: [
    [ 41963, 0.154231 ],    [ 41962.39, 2.009 ],    [ 41960.99, 0.254359 ],
    [ 41960.12, 0.189297 ], [ 41959.48, 0.214444 ], [ 41958.99, 0.0098 ],
    [ 41958.64, 0.07742 ],  [ 41958.54, 0.049 ],    [ 41958.48, 0.002332 ],
    [ 41958.21, 0.058359 ], [ 41957.89, 0.003695 ], [ 41956.23, 0.023363 ],
    [ 41956.17, 0.242834 ], [ 41956.16, 0.446939 ], [ 41956.15, 0.207299 ],
    [ 41955.6, 0.147 ],     [ 41955.58, 0.002323 ], [ 41955.57, 0.151782 ],
    [ 41955.52, 0.392 ],    [ 41955.46, 0.2254 ],   [ 41954.85, 0.1372 ],
    [ 41954.2, 0.107682 ],  [ 41954.02, 0.091081 ], [ 41954.01, 0.07742 ],
    [ 41953.5, 0.0392 ],    [ 41953.12, 0.000461 ], [ 41952.83, 0.0245 ],
    [ 41952.82, 0.213317 ], [ 41951.91, 0.381367 ], [ 41951.9, 0.116718 ],
    [ 41951.59, 0.000911 ], [ 41951.07, 0.971974 ], [ 41951.06, 0.203409 ],
    [ 41951.05, 0.477338 ], [ 41951.01, 0.000461 ], [ 41950.75, 0.098 ],
    [ 41950.34, 0.73206 ],  [ 41950.28, 0.005841 ], [ 41949.67, 0.306593 ],
    [ 41949.49, 0.210288 ], [ 41948.33, 0.315412 ], [ 41946.23, 0.077035 ],
    [ 41939.94, 0.997266 ], [ 41937.84, 0.225721 ], [ 41934.7, 0.00417 ],
    [ 41931.13, 1.486791 ], [ 41930.03, 0.000242 ], [ 41927.73, 0.195804 ],
    [ 41927.63, 0.547442 ], [ 41927.03, 0.04802 ],  [ 41926.93, 0.00196 ],
    [ 41925.63, 0.19598 ],  [ 41925.53, 0.043904 ], [ 41925.33, 0.0196 ],
    [ 41925.24, 0.153831 ], [ 41924.83, 1.048798 ], [ 41924.81, 0.000167 ],
    [ 41924.8, 0.000167 ],  [ 41924.79, 0.000167 ], [ 41924.73, 0.116731 ],
    [ 41924.63, 2.009027 ], [ 41924.35, 0.116719 ], [ 41923.63, 1.372 ],
    [ 41923.43, 0.098 ],    [ 41923.3, 0.01043 ],   [ 41923.23, 0.254359 ],
    [ 41923.15, 2.095809 ], [ 41922.8, 0.461765 ],  [ 41922.73, 0.177162 ],
    [ 41922.43, 0.0147 ],   [ 41922.37, 0.189297 ], [ 41922.24, 0.009958 ],
    [ 41921.73, 0.214444 ], [ 41921.64, 0.175082 ], [ 41921.24, 0.0098 ],
    [ 41921.05, 0.419861 ], [ 41920.89, 0.07742 ],  [ 41920.84, 0.233422 ],
    [ 41920.79, 0.049 ],    [ 41920.73, 0.002332 ], [ 41920.46, 0.058359 ],
    [ 41920.34, 0.147 ],    [ 41920.14, 0.003695 ], [ 41920.03, 0.3871 ],
    [ 41920.01, 0.049 ],    [ 41919.06, 0.196 ],    [ 41919.04, 0.0098 ],
    [ 41918.9, 0.018326 ],  [ 41881.3, 0.02094 ],   [ 41829.5, 0.001299 ],
    [ 41817.19, 0.20991 ],  [ 41752.5, 0.001356 ],  [ 41603.25, 0.08335 ],
    [ 41550, 0.000122 ],    [ 41534, 0.247005 ],    [ 41500, 0.00024 ],
    [ 41457, 0.125999 ],    [ 41433, 0.001106 ],    [ 41329, 0.052 ],
    [ 41300, 0.0005 ]
  ],
  asks: [
    [ 41963.03, 0.9403 ],   [ 41964.54, 0.029469 ], [ 41965.74, 0.088847 ],
    [ 41965.75, 0.005292 ], [ 41969.07, 0.128439 ], [ 41969.13, 0.151753 ],
    [ 41969.14, 0.214365 ], [ 41969.2, 0.191962 ],  [ 41969.22, 0.257093 ],
    [ 41970.01, 0.0392 ],   [ 41970.89, 0.143668 ], [ 41970.97, 0.091081 ],
    [ 41971.1, 0.0784 ],    [ 41971.28, 0.07742 ],  [ 41971.31, 0.013661 ],
    [ 41971.75, 0.327555 ], [ 41971.76, 0.31702 ],  [ 41971.77, 1.555877 ],
    [ 41971.85, 0.0392 ],   [ 41972.12, 0.0098 ],   [ 41972.13, 0.000461 ],
    [ 41972.35, 0.430387 ], [ 41972.5, 2.651214 ],  [ 41972.96, 0.0196 ],
    [ 41974.1, 0.309592 ],  [ 41974.11, 0.548124 ], [ 41974.12, 0.233573 ],
    [ 41974.24, 0.000461 ], [ 41974.26, 0.098 ],    [ 41975.23, 0.379427 ],
    [ 41975.49, 0.94768 ],  [ 41975.88, 0.424379 ], [ 41975.89, 0.07742 ],
    [ 41976.2, 0.327065 ],  [ 41976.21, 0.001303 ], [ 41976.35, 0.000461 ],
    [ 41977.22, 0.514667 ], [ 41977.7, 0.082909 ],  [ 41978.41, 0.477338 ],
    [ 41978.46, 0.000461 ], [ 41979.8, 0.048545 ],  [ 41980.09, 0.07742 ],
    [ 41986.09, 0.308727 ], [ 41988.19, 0.161182 ], [ 42000.38, 0.365697 ],
    [ 42000.79, 0.9403 ],   [ 42002.3, 0.029469 ],  [ 42002.88, 0.608362 ],
    [ 42003.51, 0.088847 ], [ 42003.52, 0.005292 ], [ 42004.77, 0.010223 ],
    [ 42004.78, 0.0098 ],   [ 42004.97, 0.00098 ],  [ 42004.98, 0.290273 ],
    [ 42005.48, 0.09212 ],  [ 42005.56, 0.0784 ],   [ 42005.63, 0.0098 ],
    [ 42005.65, 0.049 ],    [ 42005.7, 0.049 ],     [ 42006.18, 0.0294 ],
    [ 42006.73, 0.0098 ],   [ 42006.78, 2.990524 ], [ 42006.82, 0.049 ],
    [ 42006.84, 0.128439 ], [ 42006.9, 0.151753 ],  [ 42006.91, 0.214365 ],
    [ 42006.99, 0.257093 ], [ 42007.42, 0.196 ],    [ 42007.78, 0.049 ],
    [ 42007.88, 0.018718 ], [ 42007.97, 0.196 ],    [ 42008.17, 2.583218 ],
    [ 42008.28, 0.0049 ],   [ 42008.66, 0.143668 ], [ 42008.74, 0.091081 ],
    [ 42008.87, 0.0784 ],   [ 42009.05, 0.07742 ],  [ 42009.07, 0.4067 ],
    [ 42009.08, 0.013661 ], [ 42009.11, 0.098 ],    [ 42009.28, 0.0147 ],
    [ 42009.52, 0.327555 ], [ 42009.53, 0.31702 ],  [ 42009.54, 1.555877 ],
    [ 42009.62, 0.0392 ],   [ 42009.78, 0.02403 ],  [ 42020, 0.032799 ],
    [ 42048.8, 0.00417 ],   [ 42065.03, 0.015724 ], [ 42079.9, 0.01043 ],
    [ 42084.11, 0.001051 ], [ 42100, 0.02534 ],     [ 42110, 0.26411 ],
    [ 42123, 0.02094 ],     [ 42200, 0.007961 ],    [ 42223.27, 0.20689 ],
    [ 42250.11, 0.000194 ], [ 42290, 0.005854 ],    [ 42308.52, 0.04779 ],
    [ 42319.99, 0.000234 ]
  ],
  timestamp: undefined,
  datetime: undefined,
  nonce: 98313251
}
```