### PR TITLE
Mexc fetchBalance : adjust handleMarketTypeAndParams

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1142,14 +1142,14 @@ module.exports = class mexc extends Exchange {
 
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivateGetAccountInfo',
+            'margin': 'spotPrivateGetAccountInfo',
             'swap': 'contractPrivateGetAccountAssets',
         });
         const spot = (marketType === 'spot');
-        const response = await this[method] (params);
+        const response = await this[method] (query);
         //
         // spot
         //


### PR DESCRIPTION
Adjusted handleMarketTypeAndParams so that it's on one line. Added margin market type:
```
mexc.fetchBalance ()
226 ms
{
  info: {
    code: '200',
    data: {
      USDT: { frozen: '0', available: '0.00000000368' }
    }
  },
  timestamp: 1642649547352,
  datetime: '2022-01-20T03:32:27.352Z',
  USDT: { free: 3.68e-9, used: 0, total: 3.68e-9 },
  free: {
    USDT: 3.68e-9
  },
  used: { USDT: 0 },
  total: {
    USDT: 3.68e-9
  }
}
```