### PR TITLE
Bitmart fetchMyTrades : handleMarketTypeAndParams

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1286,7 +1286,7 @@ module.exports = class bitmart extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        let method = undefined;
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
         const request = {};
         if (market['spot']) {
             request['symbol'] = market['id'];
@@ -1295,16 +1295,19 @@ module.exports = class bitmart extends Exchange {
                 limit = 100; // max 100
             }
             request['limit'] = limit;
-            method = 'privateSpotGetTrades';
         } else if (market['swap'] || market['future']) {
             request['contractID'] = market['id'];
             // request['offset'] = 1;
             if (limit !== undefined) {
                 request['size'] = limit; // max 60
             }
-            method = 'privateContractGetUserTrades';
         }
-        const response = await this[method] (this.extend (request, params));
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateSpotGetTrades',
+            'swap': 'privateContractGetUserTrades',
+            'future': 'privateContractGetUserTrades',
+        });
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchMyTrades:
```
bitmart.fetchMyTrades (SOL/USDT)
513 ms
        id |       order |     timestamp |                 datetime |   symbol | type | side |  price | amount |   cost | takerOrMaker |
    fee |                                   fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3356166199 | 20377550463 | 1642652127000 | 2022-01-20T04:15:27.000Z | SOL/USDT |      | sell | 136.51 |    0.2 | 27.302 |        taker |  {"cost":0.068255,"currency":"USDT"} |  [{"currency":"USDT","cost":0.068255}]
3356166203 | 20377550463 | 1642652127000 | 2022-01-20T04:15:27.000Z | SOL/USDT |      | sell |  136.5 |   0.15 | 20.475 |        taker | {"cost":0.0511875,"currency":"USDT"} | [{"currency":"USDT","cost":0.0511875}]
2 objects
```