### PR TITLE
Bitmart fetchOrderTrades : handleMarketTypeAndParams

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1367,18 +1367,21 @@ module.exports = class bitmart extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        let method = undefined;
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrderTrades', market, params);
         const request = {};
         if (market['spot']) {
             request['symbol'] = market['id'];
             request['order_id'] = id;
-            method = 'privateSpotGetTrades';
         } else if (market['swap'] || market['future']) {
             request['contractID'] = market['id'];
             request['orderID'] = id;
-            method = 'privateContractGetOrderTrades';
         }
-        const response = await this[method] (this.extend (request, params));
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateSpotGetTrades',
+            'swap': 'privateContractGetOrderTrades',
+            'future': 'privateContractGetOrderTrades',
+        });
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOrderTrades:
```
bitmart.fetchOrderTrades (20377550463, SOL/USDT)
563 ms
        id |       order |     timestamp |                 datetime |   symbol | type | side |  price | amount |   cost | takerOrMaker |fee |                                   fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3356166199 | 20377550463 | 1642652127000 | 2022-01-20T04:15:27.000Z | SOL/USDT |      | sell | 136.51 |    0.2 | 27.302 |        taker |  {"cost":0.068255,"currency":"USDT"} |  [{"currency":"USDT","cost":0.068255}]
3356166203 | 20377550463 | 1642652127000 | 2022-01-20T04:15:27.000Z | SOL/USDT |      | sell |  136.5 |   0.15 | 20.475 |        taker | {"cost":0.0511875,"currency":"USDT"} | [{"currency":"USDT","cost":0.0511875}]
2 objects
```