### PR TITLE
Bitmart fetchOrder : handleMarketTypeAndParams

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2016,20 +2016,23 @@ module.exports = class bitmart extends Exchange {
         await this.loadMarkets ();
         const request = {};
         const market = this.market (symbol);
-        let method = undefined;
         if (typeof id !== 'string') {
             id = id.toString ();
         }
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         if (market['spot']) {
             request['symbol'] = market['id'];
             request['order_id'] = id;
-            method = 'privateSpotGetOrderDetail';
         } else if (market['swap'] || market['future']) {
             request['contractID'] = market['id'];
             request['orderID'] = id;
-            method = 'privateContractGetUserOrderInfo';
         }
-        const response = await this[method] (this.extend (request, params));
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateSpotGetOrderDetail',
+            'swap': 'privateContractGetUserOrderInfo',
+            'future': 'privateContractGetUserOrderInfo',
+        });
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOrder:
```
bitmart.fetchOrder (20378567609, SOL/USDT)
691 ms
{
  id: '20378567609',
  clientOrderId: undefined,
  info: {
    order_id: '20378567609',
    symbol: 'SOL_USDT',
    create_time: '1642653144000',
    side: 'buy',
    type: 'limit',
    price: '10.00',
    price_avg: '0.00',
    size: '2.38',
    notional: '23.80000000',
    filled_notional: '0.00000000',
    filled_size: '0.00',
    status: '4',
    unfilled_volume: '2.38000000'
  },
  timestamp: 1642653144000,
  datetime: '2022-01-20T04:32:24.000Z',
  lastTradeTimestamp: undefined,
  symbol: 'SOL/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 10,
  stopPrice: undefined,
  amount: 2.38,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 2.38,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: []
}
```