### PR TITLE
Bitmart fetchOrdersByStatus : handleMarketTypeAndParams

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1875,10 +1875,9 @@ module.exports = class bitmart extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrdersByStatus', market, params);
         const request = {};
-        let method = undefined;
         if (market['spot']) {
-            method = 'privateSpotGetOrders';
             request['symbol'] = market['id'];
             request['offset'] = 1; // max offset * limit < 500
             request['limit'] = 100; // max limit is 100
@@ -1902,7 +1901,6 @@ module.exports = class bitmart extends Exchange {
                 request['status'] = status;
             }
         } else if (market['swap'] || market['future']) {
-            method = 'privateContractGetUserOrders';
             request['contractID'] = market['id'];
             // request['offset'] = 1;
             if (limit !== undefined) {
@@ -1921,7 +1919,12 @@ module.exports = class bitmart extends Exchange {
                 request['status'] = status;
             }
         }
-        const response = await this[method] (this.extend (request, params));
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateSpotGetOrders',
+            'swap': 'privateContractGetUserOrders',
+            'future': 'privateContractGetUserOrders',
+        });
+        const response = await this[method] (this.extend (request, query));
         //
         // spot
         //


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOrdersByStatus:
```
bitmart.fetchOrdersByStatus (open, SOL/USDT)
515 ms
         id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | amount | cost | average | filled | remaining | status | fee | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
20378567609 |               | 1642653144000 | 2022-01-20T04:32:24.000Z |                    | SOL/USDT | limit |             |          |  buy |    10 |           | 2.38 |    0 |         |      0 |      2.38 |   open |     |     [] |   []
1 objects
```