### PR TITLE
Bitget fetchOpenOrders : handleMarketTypeAndParams

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2249,21 +2249,18 @@ module.exports = class bitget extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const type = this.safeString (params, 'type', market['type']);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
         const request = {
             'symbol': market['id'],
         };
-        let method = undefined;
-        if (type === 'spot') {
-            method = 'apiGetOrderOrdersOpenOrders';
+        if (marketType === 'spot') {
             // request['from'] = this.safeString (params, 'from'); // order id
             // request['direct'] = 'next'; // or 'prev'
             request['method'] = 'openOrders';
             if (limit === undefined) {
                 request['size'] = limit; // default 100, max 1000
             }
-        } else if (type === 'swap') {
-            method = 'swapGetOrderOrders';
+        } else if (marketType === 'swap') {
             request['status'] = '3'; // 0 Failed, 1 Partially Filled, 2 Fully Filled 3 = Open + Partially Filled, 4 Canceling
             request['from'] = '1';
             request['to'] = '1';
@@ -2271,7 +2268,10 @@ module.exports = class bitget extends Exchange {
                 request['limit'] = 100; // default 100, max 100
             }
         }
-        const query = this.omit (params, 'type');
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'apiGetOrderOrdersOpenOrders',
+            'swap': 'swapGetOrderOrders',
+        });
         const response = await this[method] (this.extend (request, query));
         //
         //  spot


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchOpenOrders:
```
bitget.fetchOpenOrders (BTC/USDT)
1254 ms
                id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | cost | amount | filled | remaining | status | fee | trades | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
867938201075355648 |               | 1642658513325 | 2022-01-20T06:01:53.325Z |                    | BTC/USDT | limit |             |          |  buy | 30000 |           |         |    0 | 0.0002 |      0 |    0.0002 |   open |     |     [] |   []
1 objects
```