### PR TITLE
Bitget fetchClosedOrders : handleMarketTypeAndParams

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2334,13 +2334,11 @@ module.exports = class bitget extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const type = this.safeString (params, 'type', market['type']);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchClosedOrders', market, params);
         const request = {
             'symbol': market['id'],
         };
-        let method = undefined;
-        if (type === 'spot') {
-            method = 'apiGetOrderOrdersHistory';
+        if (marketType === 'spot') {
             // Value range [((end_time) – 48h), (end_time)]
             // the query window is 48 hours at most
             // the window shift range is the last 30 days
@@ -2354,8 +2352,7 @@ module.exports = class bitget extends Exchange {
             if (limit === undefined) {
                 request['size'] = limit; // default 100, max 1000
             }
-        } else if (type === 'swap') {
-            method = 'swapGetOrderOrders';
+        } else if (marketType === 'swap') {
             request['status'] = '2'; // 0 Failed, 1 Partially Filled, 2 Fully Filled 3 = Open + Partially Filled, 4 Canceling
             request['from'] = '1';
             request['to'] = '1';
@@ -2363,7 +2360,10 @@ module.exports = class bitget extends Exchange {
                 request['limit'] = 100; // default 100, max 100
             }
         }
-        const query = this.omit (params, 'type');
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'apiGetOrderOrdersHistory',
+            'swap': 'swapGetOrderOrders',
+        });
         const response = await this[method] (this.extend (request, query));
         //
         //  spot


### PR DESCRIPTION
Added handleMarketTypeAndParams to fetchClosedOrders:
```
bitget.fetchClosedOrders (BTC/USDT)
1261 ms
                id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | side |    price | stopPrice | average |     cost | amount |   filled | remaining |   status | fee | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
867937769556971520 |               | 1642658410443 | 2022-01-20T06:00:10.443Z |                    | BTC/USDT | limit |             |          |  buy | 41895.37 |           |       1 | 8.378798 | 0.0002 | 8.378798 | -8.378598 |   closed |     |     [] |   []
867938201075355648 |               | 1642658513325 | 2022-01-20T06:01:53.325Z |                    | BTC/USDT | limit |             |          |  buy |    30000 |           |         |        0 | 0.0002 |        0 |    0.0002 | canceled |     |     [] |   []
2 objects
```