### PR TITLE
binance.parsePositions contractSize key error fix

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4405,7 +4405,7 @@ module.exports = class binance extends Exchange {
         //
         const marketId = this.safeString (position, 'symbol');
         market = this.safeMarket (marketId, market);
-        const symbol = market['symbol'];
+        const symbol = this.safeString (market, 'symbol');
         const leverageString = this.safeString (position, 'leverage');
         const leverage = parseInt (leverageString);
         const initialMarginString = this.safeString (position, 'initialMargin');
@@ -4430,7 +4430,8 @@ module.exports = class binance extends Exchange {
         let contractsStringAbs = Precise.stringAbs (contractsString);
         if (contractsString === undefined) {
             const entryNotional = Precise.stringMul (Precise.stringMul (leverageString, initialMarginString), entryPriceString);
-            contractsString = Precise.stringDiv (entryNotional, market['contractSize']);
+            const contractSize = this.safeString (market, 'contractSize');
+            contractsString = Precise.stringDiv (entryNotional, contractSize);
             contractsStringAbs = Precise.stringDiv (Precise.stringAdd (contractsString, '0.5'), '1', 0);
         }
         const contracts = this.parseNumber (contractsStringAbs);


### PR DESCRIPTION
Solution to https://github.com/ccxt/ccxt/issues/11296

I believe market could be `undefined`

```
2022-01-21T02:19:28.251Z
Node.js: v14.17.0
CCXT v1.68.84
binanceusdm.fetchPositions ()
358 ms
        symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral | notional |      markPrice | entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | marginRatio |                 datetime | marginType | side | hedged | percentage
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      RAY/USDT |         0 |            1 |             0 |       20 |                  |          0 |        0 |                |          0 |               |             0 |                    0.05 |                 0 |                        0.01 |             |                          |      cross |      |  false |           
...
     DUSK/USDT |         0 |            1 |             0 |       20 |                  |          0 |        0 |                |          0 |               |             0 |                    0.05 |                 0 |                        0.01 |             |                          |      cross |      |  false |           
     CTSI/USDT |         0 |            1 |             0 |       20 |                  |          0 |        0 |                |          0 |               |             0 |                    0.05 |                 0 |                        0.01 |             |                          |      cross |      |  false |           
148 objects
```