### PR TITLE
fix ticker.bid in Exchange#safeTicker

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1301,7 +1301,7 @@ module.exports = class Exchange {
             // timestamp and symbol operations don't belong in safeTicker
             // they should be done in the derived classes
             return this.extend (ticker, {
-                'bid': this.safeNumber (ticker, 'buy'),
+                'bid': this.safeNumber (ticker, 'bid'),
                 'bidVolume': this.safeNumber (ticker, 'bidVolume'),
                 'ask': this.safeNumber (ticker, 'ask'),
                 'askVolume': this.safeNumber (ticker, 'askVolume'),


### PR DESCRIPTION
It should use `ticker.bid` instead of `ticker.buy` in the last step of safeTicker , otherwise `result.bid` is undefined.

```
import ccxt from 'ccxt';
const exchange = new ccxt.bitmex();
const result = await exchange.fetchTicker('BTC/USD');
console.log(result.bid);  // is undefined now. expected to print bid price
```
