### PR TITLE
bybit.setMarginMode catch error and throw BadRequest when marginType set to current marginType

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -570,7 +570,7 @@ module.exports = class bybit extends Exchange {
                     '30068': ExchangeError, // exit value must be positive
                     '30074': InvalidOrder, // can't create the stop order, because you expect the order will be triggered when the LastPrice(or IndexPrice、 MarkPrice, determined by trigger_by) is raising to stop_px, but the LastPrice(or IndexPrice、 MarkPrice) is already equal to or greater than stop_px, please adjust base_price or stop_px
                     '30075': InvalidOrder, // can't create the stop order, because you expect the order will be triggered when the LastPrice(or IndexPrice、 MarkPrice, determined by trigger_by) is falling to stop_px, but the LastPrice(or IndexPrice、 MarkPrice) is already equal to or less than stop_px, please adjust base_price or stop_px
-                    '30084': BadRequest, // Isolated not modified
+                    // '30084': BadRequest, // Isolated not modified, see handleErrors below
                     '33004': AuthenticationError, // apikey already expired
                     '34026': ExchangeError, // the limit is no change
                 },
@@ -2883,17 +2883,21 @@ module.exports = class bybit extends Exchange {
             'buy_leverage': leverage,
             'sell_leverage': leverage,
         };
-        try {
-            return await this[method] (this.extend (request, params));
-        } catch (e) {
-            if (this.last_http_response) {
-                if (this.last_http_response.indexOf ('not modified') >= 0) {
-                    throw new BadRequest ('marginType for ' + symbol + ' already set to ' + marginType + '. Nothing was changed.');
-                }
-            } else {
-                throw e;
-            }
-        }
+        const response = await this[method] (this.extend (request, params));
+        //
+        //     {
+        //         "ret_code": 0,
+        //         "ret_msg": "OK",
+        //         "ext_code": "",
+        //         "ext_info": "",
+        //         "result": null,
+        //         "time_now": "1585881597.006026",
+        //         "rate_limit_status": 74,
+        //         "rate_limit_reset_ms": 1585881597004,
+        //         "rate_limit": 75
+        //     }
+        //
+        return response;
     }
 
     async setLeverage (leverage, symbol = undefined, params = {}) {
@@ -3051,6 +3055,14 @@ module.exports = class bybit extends Exchange {
         //
         const errorCode = this.safeString2 (response, 'ret_code', 'retCode');
         if (errorCode !== '0') {
+            if (errorCode === '30084') {
+                // not an error
+                // https://github.com/ccxt/ccxt/issues/11268
+                // https://github.com/ccxt/ccxt/pull/11624
+                // POST https://api.bybit.com/v2/private/position/switch-isolated 200 OK
+                // {"ret_code":30084,"ret_msg":"Isolated not modified","ext_code":"","ext_info":"","result":null,"time_now":"1642005219.937988","rate_limit_status":73,"rate_limit_reset_ms":1642005219894,"rate_limit":75}
+                return undefined;
+            }
             const feedback = this.id + ' ' + body;
             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
             this.throwBroadlyMatchedException (this.exceptions['broad'], body, feedback);


### PR DESCRIPTION
More clear error message for bybit.setMarginMode when setting the `marginType` to the type it is already set to.

fix #11268

---------------------

On a side note, I don't like that the `marginType` is `CROSSED` instead of `CROSS`, I've never seen `CROSSED` used before, and other places in the library look for `cross` as a marginType

---------------

```
2022-01-24T11:31:24.441Z
Node.js: v14.17.0
CCXT v1.70.31
bybit.setMarginMode (ISOLATED, BTC/USD, [object Object])
BadRequest marginType for BTC/USD already set to ISOLATED. Nothing was changed.
---------------------------------------------------
[BadRequest] marginType for BTC/USD already set to ISOLATED. Nothing was changed.

    at setMarginMode              ../../ccxt/ccxt/js/bybit.js:2891        throw new BadRequest ('marginType for ' + symbol + ' already set to ' + marginT…
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:261  const result = await exchange[methodName] (... args)                            

marginType for BTC/USD already set to ISOLATED. Nothing was changed.
```

```
2022-01-24T11:33:56.623Z
Node.js: v14.17.0
CCXT v1.70.31
bybit.setMarginMode (CROSSED, BTC/USD, [object Object])
BadRequest marginType for BTC/USD already set to CROSSED. Nothing was changed.
---------------------------------------------------
[BadRequest] marginType for BTC/USD already set to CROSSED. Nothing was changed.

    at setMarginMode              ../../ccxt/ccxt/js/bybit.js:2891        throw new BadRequest ('marginType for ' + symbol + ' already set to ' + marginT…
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:261  const result = await exchange[methodName] (... args)                            

marginType for BTC/USD already set to CROSSED. Nothing was changed.
```