### PR TITLE
ftx.fetchBorrowRateHistory and ftx.fetchBorrowRateHistories

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -37,6 +37,7 @@ module.exports = class binance extends Exchange {
                 'fetchBalance': true,
                 'fetchBidsAsks': true,
                 'fetchBorrowRate': true,
+                'fetchBorrowRateHistories': true,
                 'fetchBorrowRateHistory': true,
                 'fetchBorrowRates': false,
                 'fetchBorrowRatesPerSymbol': false,

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2452,7 +2452,7 @@ module.exports = class ftx extends Exchange {
         if (since !== undefined) {
             request['start_time'] = since / 1000;
             if (endTime === undefined) {
-                request['end_time'] = this.milliseconds ();
+                request['end_time'] = this.milliseconds () / 1000;
             }
         }
         if (endTime !== undefined) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -40,6 +40,7 @@ module.exports = class gateio extends Exchange {
                 'createOrder': true,
                 'fetchBalance': true,
                 'fetchBorrowRate': false,
+                'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
                 'fetchBorrowRates': false,
                 'fetchClosedOrders': true,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -41,6 +41,7 @@ module.exports = class huobi extends Exchange {
                 'fetchBalance': true,
                 'fetchBidsAsks': undefined,
                 'fetchBorrowRate': true,
+                'fetchBorrowRateHistories': undefined,
                 'fetchBorrowRateHistory': undefined,
                 'fetchBorrowRates': true,
                 'fetchBorrowRatesPerSymbol': true,

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -34,6 +34,7 @@ module.exports = class kraken extends Exchange {
                 'createReduceOnlyOrder': false,
                 'fetchBalance': true,
                 'fetchBorrowRate': false,
+                'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
                 'fetchBorrowRates': false,
                 'fetchClosedOrders': true,

--- a/js/okex.js
+++ b/js/okex.js
@@ -37,6 +37,7 @@ module.exports = class okex extends Exchange {
                 'fetchBalance': true,
                 'fetchBidsAsks': undefined,
                 'fetchBorrowRate': true,
+                'fetchBorrowRateHistories': undefined,
                 'fetchBorrowRateHistory': undefined,
                 'fetchBorrowRates': true,
                 'fetchBorrowRatesPerSymbol': false,


### PR DESCRIPTION
[Requested here](https://github.com/ccxt/ccxt/pull/10704#issuecomment-1019454168)

---------------------------

2022-01-24T14:14:31.613Z
Node.js: v14.17.0
CCXT v1.70.31

```
ftx.fetchBorrowRateHistories ()
198 ms
{
  MSOL: [
    {
      currency: 'MSOL',
      rate: '0.00000135',
      timestamp: 1643032800000,
      datetime: '2022-01-24T14:00:00+00:00',
      info: {
        coin: 'MSOL',
        time: '2022-01-24T14:00:00+00:00',
        size: '2239.00924068',
        rate: '1e-6'
      }
    },
   ...
    }
  ],
```

```
% node examples/js/cli ftx fetchBorrowRateHistory USD 1642896000000 7 '{"till": "1643032692000"}'
ftx.fetchBorrowRateHistory (USD, 1642896000000, 7, [object Object])
1378 ms
currency |      rate |     timestamp |                  datetime
----------------------------------------------------------------
     USD | 0.0000054 | 1643029200000 | 2022-01-24T13:00:00+00:00
...
     USD | 0.0000054 | 1643011200000 | 2022-01-24T08:00:00+00:00
     USD | 0.0000054 | 1643007600000 | 2022-01-24T07:00:00+00:00
7 objects
Waiting for the debugger to disconnect...
```

```
ftx.fetchBorrowRateHistory (USD, 1642896000000)
1459 ms
currency |         rate |     timestamp |                  datetime
-------------------------------------------------------------------
     USD |    0.0000054 | 1643032800000 | 2022-01-24T14:00:00+00:00
...
     USD | 0.0000061695 | 1642899600000 | 2022-01-23T01:00:00+00:00
     USD | 0.0000061695 | 1642896000000 | 2022-01-23T00:00:00+00:00
39 objects
```

```
ftx.fetchBorrowRateHistory (USD, 1642896000000, 7)
2380 ms
currency |      rate |     timestamp |                  datetime
----------------------------------------------------------------
     USD | 0.0000054 | 1643032800000 | 2022-01-24T14:00:00+00:00
...
     USD | 0.0000054 | 1643014800000 | 2022-01-24T09:00:00+00:00
     USD | 0.0000054 | 1643011200000 | 2022-01-24T08:00:00+00:00
7 objects
```

```
ftx.fetchBorrowRateHistory (USD, , 7)
79 ms
currency |      rate |     timestamp |                  datetime
----------------------------------------------------------------
     USD | 0.0000054 | 1643032800000 | 2022-01-24T14:00:00+00:00
     USD | 0.0000054 | 1643029200000 | 2022-01-24T13:00:00+00:00
2 objects
```

```
% node examples/js/cli ftx fetchBorrowRateHistory MSOL undefined undefined '{"till": "1643032692000"}'
ftx.fetchBorrowRateHistory (MSOL, , , [object Object])
989 ms
currency |       rate |     timestamp |                  datetime
-----------------------------------------------------------------
    MSOL | 0.00000135 | 1643029200000 | 2022-01-24T13:00:00+00:00
    MSOL | 0.00000135 | 1643025600000 | 2022-01-24T12:00:00+00:00
2 objects
```