### PR TITLE
fix api call for therock fetchOrder function

### DIFF
--- a/js/therock.js
+++ b/js/therock.js
@@ -1088,7 +1088,7 @@ module.exports = class therock extends Exchange {
             'id': id,
             'fund_id': market['id'],
         };
-        const response = await this.privatePostFundsFundIdOrdersId (this.extend (request, params));
+        const response = await this.privateGetFundsFundIdOrdersId (this.extend (request, params));
         return this.parseOrder (response);
     }
 


### PR DESCRIPTION
TheRockTrading exchange (therock) use a wrong POST call for the fetchOrder function. This PR fix it calling the correct GET method.