### PR TITLE
fix[Gate.io]: change position sides from buy/sell to long/short

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2946,9 +2946,9 @@ module.exports = class gateio extends Exchange {
         const size = this.safeString (position, 'size');
         let side = undefined;
         if (Precise.stringGt (size, '0')) {
-            side = 'buy';
+            side = 'long';
         } else if (Precise.stringLt (size, '0')) {
-            side = 'sell';
+            side = 'short';
         }
         const maintenanceRate = this.safeString (position, 'maintenance_rate');
         const notional = this.safeString (position, 'value');


### PR DESCRIPTION
According to the documentation [here](https://docs.ccxt.com/en/latest/manual.html#positions), the ```side``` of a position is either ```long``` or ```short```.