### PR TITLE
Updated manual.rst for date-based pagination

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3181,7 +3181,7 @@ This is the type of pagination currently used throughout the CCXT Unified API. T
            const limit = 20 // change for your limit
            const trades = await exchange.fetchTrades (symbol, since, limit)
            if (trades.length) {
-               since = trades[trades.length - 1]['timestamp']
+               since = trades[trades.length - 1]['timestamp'] + 1
                allTrades = allTrades.concat (trades)
            } else {
                break
@@ -3202,7 +3202,7 @@ This is the type of pagination currently used throughout the CCXT Unified API. T
            limit = 20  # change for your limit
            orders = await exchange.fetch_orders(symbol, since, limit)
            if len(orders):
-               since = orders[len(orders) - 1]['timestamp']
+               since = orders[len(orders) - 1]['timestamp'] + 1
                all_orders += orders
            else:
                break
@@ -3220,7 +3220,7 @@ This is the type of pagination currently used throughout the CCXT Unified API. T
            $limit = 20; // change for your limit
            $trades = $exchange->fetchMyTrades ($symbol, $since, $limit);
            if (count($trades)) {
-               $since = $trades[count($trades) - 1]['timestamp'];
+               $since = $trades[count($trades) - 1]['timestamp'] + 1;
                $all_trades = array_merge ($all_trades, $trades);
            } else {
                break;

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1643,7 +1643,7 @@ if (exchange.has['fetchTrades']) {
         const limit = 20 // change for your limit
         const trades = await exchange.fetchTrades (symbol, since, limit)
         if (trades.length) {
-            since = trades[trades.length - 1]['timestamp']
+            since = trades[trades.length - 1]['timestamp'] + 1
             allTrades = allTrades.concat (trades)
         } else {
             break
@@ -1664,7 +1664,7 @@ if exchange.has['fetchOrders']:
         limit = 20  # change for your limit
         orders = await exchange.fetch_orders(symbol, since, limit)
         if len(orders):
-            since = orders[len(orders) - 1]['timestamp']
+            since = orders[len(orders) - 1]['timestamp'] + 1
             all_orders += orders
         else:
             break
@@ -1682,7 +1682,7 @@ if ($exchange->has['fetchMyTrades']) {
         $limit = 20; // change for your limit
         $trades = $exchange->fetchMyTrades ($symbol, $since, $limit);
         if (count($trades)) {
-            $since = $trades[count($trades) - 1]['timestamp'];
+            $since = $trades[count($trades) - 1]['timestamp'] + 1;
             $all_trades = array_merge ($all_trades, $trades);
         } else {
             break;


### PR DESCRIPTION
Updated pseudo-code in manual to not get stuck in a loop by adding 1 to the last order's timestamp. Refrained from adding more code to the example as I thought you want it to stay concise.