### PR TITLE
Ascendex createReduceOnlyOrder

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -27,6 +27,7 @@ module.exports = class ascendex extends Exchange {
                 'cancelOrder': true,
                 'CORS': undefined,
                 'createOrder': true,
+                'createReduceOnlyOrder': true,
                 'fetchAccounts': true,
                 'fetchBalance': true,
                 'fetchClosedOrders': true,

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1148,6 +1148,12 @@ module.exports = class ascendex extends Exchange {
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const clientOrderId = this.safeString2 (params, 'clientOrderId', 'id');
+        const reduceOnly = this.safeValue (params, 'execInst');
+        if (reduceOnly !== undefined) {
+            if ((style !== 'swap')) {
+                throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + style + ' orders, reduceOnly orders are supported for perpetuals only');
+            }
+        }
         const request = {
             'account-group': accountGroup,
             'account-category': accountCategory,
@@ -1258,6 +1264,13 @@ module.exports = class ascendex extends Exchange {
         const data = this.safeValue (response, 'data', {});
         const order = this.safeValue2 (data, 'order', 'info', {});
         return this.parseOrder (order, market);
+    }
+
+    async createReduceOnlyOrder (symbol, type, side, amount, price = undefined, params = {}) {
+        const request = {
+            'execInst': 'reduceOnly',
+        };
+        return await this.createOrder (symbol, type, side, amount, price, this.extend (request, params));
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {


### PR DESCRIPTION
Added createReduceOnlyOrder method to ascendex:
```
ascendex.createReduceOnlyOrder (BTC/USDT:USDT, limit, buy, 0.003, 30000)
1633 ms
{
  info: {
    ac: 'FUTURES',
    accountId: 'fut2ODPhGiY71Pl4vtXnOZ00ssgD7QGn',
    time: '1643070984430',
    orderId: 'a17e8ea98cdcU0711043490HWiV9FC0e',
    seqNum: '-1',
    orderType: 'Limit',
    execInst: 'ReduceOnly',
    side: 'Buy',
    symbol: 'BTC-PERP',
    price: '30000',
    orderQty: '0.003',
    stopPrice: '0',
    stopBy: 'ref-px',
    status: 'Ack',
    lastExecTime: '1643070984430',
    lastQty: '0',
    lastPx: '0',
    avgFilledPx: '0',
    cumFilledQty: '0',
    fee: '0',
    cumFee: '0',
    feeAsset: '',
    errorCode: '',
    posStopLossPrice: '0',
    posStopLossTrigger: 'market',
    posTakeProfitPrice: '0',
    posTakeProfitTrigger: 'market',
    liquidityInd: 'n'
  },
  id: 'a17e8ea98cdcU0711043490HWiV9FC0e',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: 1643070984430,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 30000,
  stopPrice: 0,
  amount: 0.003,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 0.003,
  status: 'Ack',
  fee: { cost: 0, currency: '' },
  trades: [],
  fees: [ { cost: 0, currency: '' } ]
}
```