### PR TITLE
feat[Gate.io]: add marginType when parsing positions

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2954,7 +2954,7 @@ module.exports = class gateio extends Exchange {
         const notional = this.safeString (position, 'value');
         const leverage = this.safeString (position, 'leverage');
         let marginType = undefined;
-        if (leverage === 0) {
+        if (leverage === "0") {
             marginType = 'cross';
         } else {
             marginType = 'isolated';

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2953,6 +2953,12 @@ module.exports = class gateio extends Exchange {
         const maintenanceRate = this.safeString (position, 'maintenance_rate');
         const notional = this.safeString (position, 'value');
         const leverage = this.safeString (position, 'leverage');
+        let marginType = undefined;
+        if (leverage === 0) {
+            marginType = 'cross';
+        } else {
+            marginType = 'isolated';
+        }
         const unrealisedPnl = this.safeString (position, 'unrealised_pnl');
         // Initial Position Margin = ( Position Value / Leverage ) + Close Position Fee
         // *The default leverage under the full position is the highest leverage in the market.
@@ -2981,7 +2987,7 @@ module.exports = class gateio extends Exchange {
             'liquidationPrice': this.safeNumber (position, 'liq_price'),
             'markPrice': this.safeNumber (position, 'mark_price'),
             'collateral': this.safeNumber (position, 'margin'),
-            'marginType': undefined,
+            'marginType': marginType,
             'side': side,
             'percentage': this.parseNumber (percentage),
         };

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2954,7 +2954,7 @@ module.exports = class gateio extends Exchange {
         const notional = this.safeString (position, 'value');
         const leverage = this.safeString (position, 'leverage');
         let marginType = undefined;
-        if (leverage === "0") {
+        if (leverage === '0') {
             marginType = 'cross';
         } else {
             marginType = 'isolated';


### PR DESCRIPTION
## Problem 
Gate.io does not clearly tell whether a position is covered by cross-margin or isolated-margin which I assume is why currently CCXT returns ```None``` for ```marginType```. So I decided to analyze this further.

## Data
The first Gate.io response here is for an isolated-margin position while the second is a cross-margin position.
```{'value': '3.591586', 'leverage': '1', 'mode': 'single', 'realised_point': '0', 'contract': 'BTC_USDT', 'entry_price': '33394.2', 'mark_price': '35915.86', 'history_point': '0', 'realised_pnl': '-0.001623092688', 'close_order': None, 'size': Decimal('1'), 'cross_leverage_limit': '1', 'pending_orders': Decimal('0'), 'adl_ranking': Decimal('4'), 'maintenance_rate': '0.005', 'unrealised_pnl': '0.252166', 'user': Decimal('xxxx'), 'leverage_max': '100', 'history_pnl': '0.004121732', 'risk_limit': '1000000', 'margin': '3.341924565', 'last_close_pnl': '0.004121732', 'liq_price': '0'}```

```{'value': '23.6338', 'leverage': '0', 'mode': 'single', 'realised_point': '0', 'contract': 'ETH_USDT', 'entry_price': '2188.25', 'mark_price': '2363.38', 'history_point': '0', 'realised_pnl': '-0.01102542', 'close_order': None, 'size': Decimal('1'), 'cross_leverage_limit': '1', 'pending_orders': Decimal('0'), 'adl_ranking': Decimal('4'), 'maintenance_rate': '0.005', 'unrealised_pnl': '1.7513', 'user': Decimal('xxxx'), 'leverage_max': '100', 'history_pnl': '-0.0645384', 'risk_limit': '500000', 'margin': '259.052961254312', 'last_close_pnl': '-0.0645384', 'liq_price': '0'}```

I tried many more examples and found a way to distinguish isolated-margin from cross-margin.

## Observation
The leverage key seems to indicate whether it is cross-margin or not. No matter what I do, ```leverage``` is always set to ```0``` when using cross margin, while the ```cross_leverage_limit``` updates accordingly. When using margin, however, ```leverage``` changes based on the selected leverage in the UI (e.g. 1x->```1```, 5x->```5```, 20x->```20```). In those cases, I’d expect ```cross_leverage_limit``` to be ```0```, but it is ```1``` - this is not a problem though.

## Solution
We can easily just check for  ```"isolated" if leverage == 0 else "cross"```

This is working because ```leverage``` is the leverage selected by the user when opening a position, not the effective leverage depending on the current portfolio value and unrealized PNL!