### PR TITLE
poloniex createDepositAddress fix

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1220,7 +1220,8 @@ module.exports = class poloniex extends Exchange {
         const response = await this.privatePostGenerateNewAddress (this.extend (request, params));
         let address = undefined;
         let tag = undefined;
-        if (response['success'] === 1) {
+        const success = this.safeString (response, 'success');
+        if (success === '1') {
             address = this.safeString (response, 'response');
         }
         this.checkAddress (address);


### PR DESCRIPTION
https://docs.poloniex.com/#returndepositaddresses
here `success` specified like `number` but it look it comes like `string`