### PR TITLE
fix[Gate.io]: add missing 'side' information for swap orders

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2443,7 +2443,7 @@ module.exports = class gateio extends Exchange {
         let side = undefined;
         const contract = this.safeValue (market, 'contract');
         if (contract) {
-            if (amount) {
+            if (amount || 'size') {
                 side = Precise.stringGt (amountRaw, '0') ? 'buy' : 'sell';
             } else {
                 side = undefined;


### PR DESCRIPTION
Small fix. For perpetual futures there is no ```amount``` returned, but ```size```. A few lines above you also search for ```size``` with  ```const amountRaw = this.safeString2 (order, 'amount', 'size');```, but it was forgotten when setting the side.

edit: There is a mistake in my PR, I'll fixt it