### PR TITLE
AAX fetchIndexOHLCV

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -60,7 +60,7 @@ module.exports = class aax extends Exchange {
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
                 'fetchFundingRates': undefined,
-                'fetchIndexOHLCV': false,
+                'fetchIndexOHLCV': true,
                 'fetchIsolatedPositions': undefined,
                 'fetchL3OrderBook': undefined,
                 'fetchLedger': undefined,
@@ -894,6 +894,36 @@ module.exports = class aax extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         return this.parseOHLCVs (data, market, timeframe, since, limit);
+    }
+
+    async fetchIndexOHLCV (symbol, timeframe = '1h', since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+            'timeFrame': this.timeframes[timeframe],
+        };
+        const response = await this.publicGetMarketIndexCandles (this.extend (request, params));
+        //
+        //     {
+        //         c: '36592.81000000',
+        //         e: 'BTCUSDT_INDEX@1h_candles',
+        //         h: '36669.29000000',
+        //         l: '36555.28000000',
+        //         o: '36555.83000000',
+        //         s: '1643148000',
+        //         t: '1643148978',
+        //         v: '0.00000000'
+        //     }
+        //
+        return [
+            this.safeTimestamp (response, 't'),
+            this.safeNumber (response, 'o'),
+            this.safeNumber (response, 'h'),
+            this.safeNumber (response, 'l'),
+            this.safeNumber (response, 'c'),
+            this.safeNumber (response, 'v'),
+        ];
     }
 
     async fetchBalance (params = {}) {


### PR DESCRIPTION
Added fetchIndexOHLCV to AAX:
```
aax.fetchIndexOHLCV (BTC/USDT)
1176 ms
[ 1643161849000, 36634.8, 36785.1, 36559.14, 36770.35, 0 ]
6 objects
```