### PR TITLE
AAX setLeverage

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -98,7 +98,7 @@ module.exports = class aax extends Exchange {
                 'fetchWithdrawalWhitelist': undefined,
                 'loadLeverageBrackets': undefined,
                 'reduceMargin': undefined,
-                'setLeverage': undefined,
+                'setLeverage': true,
                 'setMarginMode': undefined,
                 'setPositionMode': undefined,
                 'signIn': undefined,
@@ -2266,6 +2266,25 @@ module.exports = class aax extends Exchange {
             });
         }
         return result;
+    }
+
+    async setLeverage (leverage, symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
+        }
+        if ((leverage < 1) || (leverage > 100)) {
+            throw new BadRequest (this.id + ' leverage should be between 1 and 100');
+        }
+        const market = this.market (symbol);
+        if (market['type'] !== 'swap') {
+            throw new BadSymbol (this.id + ' setLeverage() supports swap contracts only');
+        }
+        const request = {
+            'symbol': market['id'],
+            'leverage': leverage,
+        };
+        return await this.privatePostFuturesPositionLeverage (this.extend (request, params));
     }
 
     nonce () {


### PR DESCRIPTION
Added setLeverage to AAX:
```
aax.setLeverage (9, BTC/USDT:USDT)
1015 ms
{
  code: '1',
  data: {
    autoMarginCall: false,
    avgEntryPrice: '36988.64',
    bankruptPrice: '18479.5245400000',
    base: 'BTC',
    code: 'FP',
    commission: '0.01479546',
    currentQty: '1',
    funding: '0.00678918',
    fundingStatus: null,
    id: '406353527118426112',
    leverage: '9',
    liquidationPrice: '18671.95',
    marketPrice: '0',
    openTime: '2022-01-25T23:49:25.464Z',
    posLeverage: '2.00',
    posMargin: '18.50911546',
    quote: 'USDT',
    realisedPnl: '0',
    riskLimit: '100000000',
    riskyPrice: '25998.63',
    settleType: 'VANILLA',
    stopLossPrice: '0',
    stopLossSource: '1',
    symbol: 'BTCUSDTFP',
    takeProfitPrice: '0',
    takeProfitSource: '1',
    unrealisedPnl: '36.99955000',
    userID: '3376269'
  },
  message: 'success',
  ts: '1643162175539'
}
```