### PR TITLE
Mexc fetchIndexOHLCV

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -38,6 +38,7 @@ module.exports = class mexc extends Exchange {
                 'fetchDepositAddressesByNetwork': true,
                 'fetchDeposits': true,
                 'fetchFundingRateHistory': true,
+                'fetchIndexOHLCV': true,
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
@@ -1147,6 +1148,13 @@ module.exports = class mexc extends Exchange {
             this.safeNumber (ohlcv, market['spot'] ? 2 : 4),
             this.safeNumber (ohlcv, 5),
         ];
+    }
+
+    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'index',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     async fetchBalance (params = {}) {


### PR DESCRIPTION
Added fetchIndexOHLCV to mexc:
```
mexc.fetchIndexOHLCV (BTC/USDT)
207 ms
1643235780000 | 36388.53 | 36402.01 | 36333.84 | 36333.85 |  2.820568
1643235840000 | 36333.85 | 36350.66 | 36311.06 | 36349.72 |  7.693343
1643235900000 | 36349.72 | 36389.53 | 36311.18 | 36389.47 |  1.184109
...
```