### PR TITLE
Mexc fetchMarkOHLCV

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -39,6 +39,7 @@ module.exports = class mexc extends Exchange {
                 'fetchDeposits': true,
                 'fetchFundingRateHistory': true,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
@@ -1147,6 +1148,13 @@ module.exports = class mexc extends Exchange {
             this.safeNumber (ohlcv, market['spot'] ? 2 : 4),
             this.safeNumber (ohlcv, 5),
         ];
+    }
+
+    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'mark',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     async fetchBalance (params = {}) {


### PR DESCRIPTION
Added fetchMarkOHLCV to Mexc:
```
mexc.fetchMarkOHLCV (BTC/USDT)
206 ms
1643236020000 | 36353.15 | 36371.95 | 36329.14 | 36365.84 |   0.87426
1643236080000 | 36365.84 | 36377.17 | 36350.14 | 36350.14 |  0.736816
1643236140000 | 36350.14 | 36350.14 | 36327.64 | 36328.59 |  0.993049
...
```