### PR TITLE
bitget: parse_ticker should pass number to vwap

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1101,7 +1101,7 @@ module.exports = class bitget extends Exchange {
         }
         const baseVolume = this.safeString2 (ticker, 'amount', 'volume_24h');
         const quoteVolume = this.safeString (ticker, 'vol');
-        const vwap = this.vwap (baseVolume, quoteVolume);
+        const vwap = this.vwap (this.parseNumber (baseVolume), this.parseNumber (quoteVolume));
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1101,7 +1101,6 @@ module.exports = class bitget extends Exchange {
         }
         const baseVolume = this.safeString2 (ticker, 'amount', 'volume_24h');
         const quoteVolume = this.safeString (ticker, 'vol');
-        const vwap = this.vwap (this.parseNumber (baseVolume), this.parseNumber (quoteVolume));
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
@@ -1112,7 +1111,7 @@ module.exports = class bitget extends Exchange {
             'bidVolume': bidVolume,
             'ask': ask,
             'askVolume': askVolume,
-            'vwap': vwap,
+            'vwap': undefined,
             'open': open,
             'close': last,
             'last': last,


### PR DESCRIPTION
Get this error when calling `parse_ticker` in python. 
```
TypeError: '>' not supported between instances of 'str' and 'int'
```
I think we should pass number to vwap just like other exchanges do. e.g. ndax & novadax.