### PR TITLE
Mexc fetchMarkOHLCV

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -40,6 +40,7 @@ module.exports = class mexc extends Exchange {
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1150,6 +1150,13 @@ module.exports = class mexc extends Exchange {
         ];
     }
 
+    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'mark',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+    }
+
     async fetchBalance (params = {}) {
         await this.loadMarkets ();
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);


### PR DESCRIPTION
Added the fetchMarkOHLCV method to mexc:
```
mexc.fetchMarkOHLCV (BTC/USDT)
217 ms
1643360340000 | 36650.01 |  36666.7 | 36649.26 | 36655.02 |  0.322914
1643360400000 | 36655.02 | 36673.59 | 36633.68 | 36663.52 |   0.30485
1643360460000 | 36663.52 | 36673.58 | 36620.27 | 36626.88 |  2.026368
...
```