### PR TITLE
Mexc fetchIndexOHLCV

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -39,6 +39,7 @@ module.exports = class mexc extends Exchange {
                 'fetchDeposits': true,
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
+                'fetchIndexOHLCV': true,
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
@@ -1148,6 +1149,13 @@ module.exports = class mexc extends Exchange {
             this.safeNumber (ohlcv, market['spot'] ? 2 : 4),
             this.safeNumber (ohlcv, 5),
         ];
+    }
+
+    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        const request = {
+            'price': 'index',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     async fetchBalance (params = {}) {


### PR DESCRIPTION
Added fetchIndexOHLCV to Mexc:
```
mexc.fetchIndexOHLCV (BTC/USDT)
201 ms
1643361240000 | 36668.24 | 36712.38 | 36659.49 | 36712.37 |  3.088876
1643361300000 | 36712.37 |  36715.7 | 36690.96 | 36699.96 |  1.017901
1643361360000 | 36699.96 | 36701.35 | 36677.09 | 36688.14 |  0.345655
...
```