### PR TITLE
probit HUSL, AZU, CTK, PYE, CLR mapping

### DIFF
--- a/js/probit.js
+++ b/js/probit.js
@@ -178,6 +178,7 @@ module.exports = class probit extends Exchange {
             },
             'commonCurrencies': {
                 'AUTO': 'Cube',
+                'AZU': 'Azultec',
                 'BCC': 'BCC',
                 'BDP': 'BidiPass',
                 'BIRD': 'Birdchain',
@@ -185,6 +186,8 @@ module.exports = class probit extends Exchange {
                 'BTCBULL': 'BULL',
                 'CBC': 'CryptoBharatCoin',
                 'CHE': 'Chellit',
+                'CLR': 'Color Platform',
+                'CTK': 'Cryptyk',
                 'DIP': 'Dipper',
                 'EGC': 'EcoG9coin',
                 'EPS': 'Epanus',  // conflict with EPS Ellipsis https://github.com/ccxt/ccxt/issues/8909
@@ -195,8 +198,10 @@ module.exports = class probit extends Exchange {
                 'GOL': 'Goldofir',
                 'GRB': 'Global Reward Bank',
                 'HBC': 'Hybrid Bank Cash',
+                'HUSL': 'The Hustle App',
                 'LBK': 'Legal Block',
                 'ORC': 'Oracle System',
+                'PYE': 'CreamPYE',
                 'ROOK': 'Reckoon',
                 'SOC': 'Soda Coin',
                 'SST': 'SocialSwap',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/the-hustle-app/markets/
conflict with https://coinmarketcap.com/currencies/the-husl/markets/

https://support.probit.com/hc/en-us/articles/360035131552-ProBit-Exchange-Lists-Azultec-AZU-
conflict with https://thehdgr.com/azus/exchange

https://www.coingecko.com/en/coins/cryptyk#markets
conflict with https://www.coingecko.com/en/coins/certik#markets

https://coinmarketcap.com/currencies/creampye/markets/
conflict with https://coinmarketcap.com/currencies/pye/markets/

https://coinmarketcap.com/currencies/color-platform/markets/
conflict with https://www.coingecko.com/en/coins/clear-coin#markets