### PR TITLE
Okex.loadLeverageBrackets

### DIFF
--- a/js/okex.js
+++ b/js/okex.js
@@ -3836,18 +3836,13 @@ module.exports = class okex extends Exchange {
             const response = await this.publicGetPublicPositionTiers (this.extend (request, params));
             this.options['leverageBrackets'] = {};
             const data = this.safeValue (response, 'data');
-            const leverageBrackets = {};
+            const leverageBrackets = [];
             for (let i = 0; i < data.length; i++) {
                 const entry = data[i];
-                const marketId = this.safeString (entry, 'instId');
-                const symbol = this.safeSymbol (marketId);
-                if (!(symbol in leverageBrackets)) {
-                    leverageBrackets[symbol] = [];
-                }
                 // we use floats here internally on purpose
                 const floorValue = this.safeFloat (entry, 'minSz');
                 const maintenanceMarginPercentage = this.safeString (entry, 'mmr');
-                leverageBrackets[symbol].push ([ floorValue, maintenanceMarginPercentage ]);
+                leverageBrackets.push ([ floorValue, maintenanceMarginPercentage ]);
             }
             this.options['leverageBrackets'] = leverageBrackets;
         }

--- a/js/okex.js
+++ b/js/okex.js
@@ -3839,7 +3839,7 @@ module.exports = class okex extends Exchange {
             const leverageBrackets = {};
             for (let i = 0; i < data.length; i++) {
                 const entry = data[i];
-                const marketId = this.safeString (entry, 'uly');
+                const marketId = this.safeString (entry, 'instId');
                 const symbol = this.safeSymbol (marketId);
                 if (!(symbol in leverageBrackets)) {
                     leverageBrackets[symbol] = [];


### PR DESCRIPTION
Okex's version of loadLeverageBrackets is a bit different from Binances, it requires that symbol be passed in, and requires the underlying for swap, futures and options. Maybe we could add symbol as an argument for this method, but I'm not really sure what to do about the underlying. I need this method to get the maintenance margin ratio in freqtrade.

# Documentation

![](https://i.imgur.com/XBT1wsn.png)
![](https://i.imgur.com/e3wC9qh.png)

------------------------------

# Current response (MARGIN)

```% okex loadLeverageBrackets undefined '{"symbol": "BTC/USDT"}'          
2022-01-30T02:56:24.733Z
Node.js: v14.17.0
CCXT v1.71.33
okex.loadLeverageBrackets (, [object Object])
289 ms
   0 | 0.03
  25 | 0.04
  50 | 0.05
  75 | 0.06
 100 | 0.07
 125 | 0.08
 150 | 0.09
 175 |  0.1
 200 | 0.11
 225 | 0.12
 250 | 0.13
 275 | 0.14
 300 | 0.15
 325 | 0.16
 350 | 0.17
 375 | 0.18
 400 | 0.19
 425 |  0.2
 450 | 0.21
 475 | 0.22
 500 | 0.23
 525 | 0.24
 550 | 0.25
 575 | 0.26
 600 | 0.27
 625 | 0.28
 650 | 0.29
 675 |  0.3
 700 | 0.31
 725 | 0.32
 750 | 0.33
 775 | 0.34
 800 | 0.35
 825 | 0.36
 850 | 0.37
 875 | 0.38
 900 | 0.39
 925 |  0.4
 950 | 0.41
 975 | 0.42
1000 | 0.43
1025 | 0.44
1050 | 0.45
1075 | 0.46
1100 | 0.47
1125 | 0.48
1150 | 0.49
1175 |  0.5
1200 | 0.51
1225 | 0.52
1250 | 0.53
1275 | 0.54
1300 | 0.55
1325 | 0.56
1350 | 0.57
1375 | 0.58
1400 | 0.59
1425 |  0.6
1450 | 0.61
1475 | 0.62
1500 | 0.63
1525 | 0.64
1550 | 0.65
1575 | 0.66
1600 | 0.67
1625 | 0.68
1650 | 0.69
1675 |  0.7
1700 | 0.71
1725 | 0.72
1750 | 0.73
1775 | 0.74
1800 | 0.75
1825 | 0.76
1850 | 0.77
1875 | 0.78
1900 | 0.79
1925 |  0.8
1950 | 0.81
1975 | 0.82
2000 | 0.83
2025 | 0.84
2050 | 0.85
2075 | 0.86
2100 | 0.87
2125 | 0.88
2150 | 0.89
2175 |  0.9
2200 | 0.91
2225 | 0.92
2250 | 0.93
91 objects
```

# Current Response (SWAP)

```
% okex loadLeverageBrackets undefined '{"symbol": "BTC/USDT:USDT"}'
2022-01-30T02:51:48.223Z
Node.js: v14.17.0
CCXT v1.71.33
okex.loadLeverageBrackets (, [object Object])
BadRequest okex {"code":"50014","data":[],"msg":"Parameter uly can not be empty."}
---------------------------------------------------
[BadRequest] okex {"code":"50014","data":[],"msg":"Parameter uly can not be empty."}

    at throwExactlyMatchedException  ../../ccxt/ccxt/js/base/Exchange.js:632        throw new exact[string] (message)                                               
    at handleErrors                  ../../ccxt/ccxt/js/okex.js:3884                this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);   
    at                               ../../ccxt/ccxt/js/base/Exchange.js:709        this.handleErrors (response.status, response.statusText, url, method, responseH…
    at processTicksAndRejections     internal/process/task_queues.js:95                                                                                             
    at async timeout                 ../../ccxt/ccxt/js/base/functions/time.js:203  return await Promise.race ([promise, expires.then (() => { throw new TimedOut (…
    at loadLeverageBrackets          ../../ccxt/ccxt/js/okex.js:3836                const response = await this.publicGetPublicPositionTiers (this.extend (request,…
    at async main                    ../../ccxt/ccxt/examples/js/cli.js:261         const result = await exchange[methodName] (... args)                            

okex {"code":"50014","data":[],"msg":"Parameter uly can not be empty."}
```