### PR TITLE
allow to run CCXT on the waves testnet

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -1050,6 +1050,23 @@ module.exports = class wavesexchange extends Exchange {
         return this.fromPrecision (price, scale);
     }
 
+    safeGetDynamic (settings) {
+        const orderFee = this.safeValue (settings, 'orderFee');
+        if ('dynamic' in orderFee) {
+            return this.safeValue (orderFee, 'dynamic');
+        } else {
+            return this.safeValue (orderFee['composite']['default'], 'dynamic');
+        }
+    }
+
+    safeGetRates (dynamic) {
+        const rates = this.safeValue (dynamic, 'rates');
+        if (rates === undefined) {
+            return { 'WAVES': 1 };
+        }
+        return rates;
+    }
+
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         this.checkRequiredDependencies ();
         this.checkRequiredKeys ();
@@ -1113,11 +1130,10 @@ module.exports = class wavesexchange extends Exchange {
         //     "4LHHvYGNKJUg5hj65aGD5vgScvCBmLpdRFtjokvCjSL8"
         //   ]
         // }
-        const orderFee = this.safeValue (settings, 'orderFee');
-        const dynamic = this.safeValue (orderFee, 'dynamic');
+        const dynamic = this.safeGetDynamic (settings);
         const baseMatcherFee = this.safeString (dynamic, 'baseFee');
         const wavesMatcherFee = this.currencyFromPrecision ('WAVES', baseMatcherFee);
-        const rates = this.safeValue (dynamic, 'rates');
+        const rates = this.safeGetRates (dynamic);
         // choose sponsored assets from the list of priceAssets above
         const priceAssets = Object.keys (rates);
         let matcherFeeAssetId = undefined;

--- a/php/async/wavesexchange.php
+++ b/php/async/wavesexchange.php
@@ -1056,6 +1056,23 @@ class wavesexchange extends Exchange {
         return $this->from_precision($price, $scale);
     }
 
+    public function safe_get_dynamic($settings) {
+        $orderFee = $this->safe_value($settings, 'orderFee');
+        if (is_array($orderFee) && array_key_exists('dynamic', $orderFee)) {
+            return $this->safe_value($orderFee, 'dynamic');
+        } else {
+            return $this->safe_value($orderFee['composite']['default'], 'dynamic');
+        }
+    }
+
+    public function safe_get_rates($dynamic) {
+        $rates = $this->safe_value($dynamic, 'rates');
+        if ($rates === null) {
+            return array( 'WAVES' => 1 );
+        }
+        return $rates;
+    }
+
     public function create_order($symbol, $type, $side, $amount, $price = null, $params = array ()) {
         $this->check_required_dependencies();
         $this->check_required_keys();
@@ -1119,11 +1136,10 @@ class wavesexchange extends Exchange {
         //     "4LHHvYGNKJUg5hj65aGD5vgScvCBmLpdRFtjokvCjSL8"
         //   )
         // }
-        $orderFee = $this->safe_value($settings, 'orderFee');
-        $dynamic = $this->safe_value($orderFee, 'dynamic');
+        $dynamic = $this->safe_get_dynamic($settings);
         $baseMatcherFee = $this->safe_string($dynamic, 'baseFee');
         $wavesMatcherFee = $this->currency_from_precision('WAVES', $baseMatcherFee);
-        $rates = $this->safe_value($dynamic, 'rates');
+        $rates = $this->safe_get_rates($dynamic);
         // choose sponsored assets from the list of $priceAssets above
         $priceAssets = is_array($rates) ? array_keys($rates) : array();
         $matcherFeeAssetId = null;

--- a/php/wavesexchange.php
+++ b/php/wavesexchange.php
@@ -1055,6 +1055,23 @@ class wavesexchange extends Exchange {
         return $this->from_precision($price, $scale);
     }
 
+    public function safe_get_dynamic($settings) {
+        $orderFee = $this->safe_value($settings, 'orderFee');
+        if (is_array($orderFee) && array_key_exists('dynamic', $orderFee)) {
+            return $this->safe_value($orderFee, 'dynamic');
+        } else {
+            return $this->safe_value($orderFee['composite']['default'], 'dynamic');
+        }
+    }
+
+    public function safe_get_rates($dynamic) {
+        $rates = $this->safe_value($dynamic, 'rates');
+        if ($rates === null) {
+            return array( 'WAVES' => 1 );
+        }
+        return $rates;
+    }
+
     public function create_order($symbol, $type, $side, $amount, $price = null, $params = array ()) {
         $this->check_required_dependencies();
         $this->check_required_keys();
@@ -1118,11 +1135,10 @@ class wavesexchange extends Exchange {
         //     "4LHHvYGNKJUg5hj65aGD5vgScvCBmLpdRFtjokvCjSL8"
         //   )
         // }
-        $orderFee = $this->safe_value($settings, 'orderFee');
-        $dynamic = $this->safe_value($orderFee, 'dynamic');
+        $dynamic = $this->safe_get_dynamic($settings);
         $baseMatcherFee = $this->safe_string($dynamic, 'baseFee');
         $wavesMatcherFee = $this->currency_from_precision('WAVES', $baseMatcherFee);
-        $rates = $this->safe_value($dynamic, 'rates');
+        $rates = $this->safe_get_rates($dynamic);
         // choose sponsored assets from the list of $priceAssets above
         $priceAssets = is_array($rates) ? array_keys($rates) : array();
         $matcherFeeAssetId = null;

--- a/python/ccxt/async_support/wavesexchange.py
+++ b/python/ccxt/async_support/wavesexchange.py
@@ -1001,6 +1001,19 @@ class wavesexchange(Exchange):
         scale = wavesPrecision - market['precision']['amount'] + market['precision']['price']
         return self.from_precision(price, scale)
 
+    def safe_get_dynamic(self, settings):
+        orderFee = self.safe_value(settings, 'orderFee')
+        if 'dynamic' in orderFee:
+            return self.safe_value(orderFee, 'dynamic')
+        else:
+            return self.safe_value(orderFee['composite']['default'], 'dynamic')
+
+    def safe_get_rates(self, dynamic):
+        rates = self.safe_value(dynamic, 'rates')
+        if rates is None:
+            return {'WAVES': 1}
+        return rates
+
     async def create_order(self, symbol, type, side, amount, price=None, params={}):
         self.check_required_dependencies()
         self.check_required_keys()
@@ -1064,11 +1077,10 @@ class wavesexchange(Exchange):
         #     "4LHHvYGNKJUg5hj65aGD5vgScvCBmLpdRFtjokvCjSL8"
         #   ]
         # }
-        orderFee = self.safe_value(settings, 'orderFee')
-        dynamic = self.safe_value(orderFee, 'dynamic')
+        dynamic = self.safe_get_dynamic(settings)
         baseMatcherFee = self.safe_string(dynamic, 'baseFee')
         wavesMatcherFee = self.currency_from_precision('WAVES', baseMatcherFee)
-        rates = self.safe_value(dynamic, 'rates')
+        rates = self.safe_get_rates(dynamic)
         # choose sponsored assets from the list of priceAssets above
         priceAssets = list(rates.keys())
         matcherFeeAssetId = None

--- a/python/ccxt/wavesexchange.py
+++ b/python/ccxt/wavesexchange.py
@@ -1001,6 +1001,19 @@ class wavesexchange(Exchange):
         scale = wavesPrecision - market['precision']['amount'] + market['precision']['price']
         return self.from_precision(price, scale)
 
+    def safe_get_dynamic(self, settings):
+        orderFee = self.safe_value(settings, 'orderFee')
+        if 'dynamic' in orderFee:
+            return self.safe_value(orderFee, 'dynamic')
+        else:
+            return self.safe_value(orderFee['composite']['default'], 'dynamic')
+
+    def safe_get_rates(self, dynamic):
+        rates = self.safe_value(dynamic, 'rates')
+        if rates is None:
+            return {'WAVES': 1}
+        return rates
+
     def create_order(self, symbol, type, side, amount, price=None, params={}):
         self.check_required_dependencies()
         self.check_required_keys()
@@ -1064,11 +1077,10 @@ class wavesexchange(Exchange):
         #     "4LHHvYGNKJUg5hj65aGD5vgScvCBmLpdRFtjokvCjSL8"
         #   ]
         # }
-        orderFee = self.safe_value(settings, 'orderFee')
-        dynamic = self.safe_value(orderFee, 'dynamic')
+        dynamic = self.safe_get_dynamic(settings)
         baseMatcherFee = self.safe_string(dynamic, 'baseFee')
         wavesMatcherFee = self.currency_from_precision('WAVES', baseMatcherFee)
-        rates = self.safe_value(dynamic, 'rates')
+        rates = self.safe_get_rates(dynamic)
         # choose sponsored assets from the list of priceAssets above
         priceAssets = list(rates.keys())
         matcherFeeAssetId = None


### PR DESCRIPTION
There were some errors I had with test net. I fixed them, also tested main net (with real money and actual trades) and this change didn't break the normal main net trades.

Demo code (I loaded the keys with some test funds):

```py
import asyncio
import os
import traceback
import sys
import ccxt.async_support as ccxt  # noqa: E402

async def test():
    exchange = ccxt.wavesexchange({
        'apiKey': '5AhPwpojq2tVaq1uWKY7X44vu8XLGRrdLU71cjthXayF',
        'secret': '5s38BH9JUCqrSyDRkqCYamhttZCdh6HyKCZBPBhmngiw',
        'enableRateLimit': True,  # this is required, as documented in the Manual!
    })
    exchange.set_sandbox_mode(True)

    response = None

    try:

        await exchange.load_markets()  # force-preload markets first

        exchange.verbose = True  # this is for debugging

        symbol = 'WAVES/USDN'  # change for your symbol
        amount = 0.4        # change the amount
        price = 100     # change the price
        response = await exchange.create_limit_sell_order(symbol, amount, price)

    except Exception as e:
        traceback.print_exc(file=sys.stdout)

    await exchange.close()
    return response

if __name__ == '__main__':
    print(asyncio.get_event_loop().run_until_complete(test()))
```