### PR TITLE
Huobi: Add orderstate mapping for Created orderstatus

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3070,6 +3070,7 @@ module.exports = class huobi extends Exchange {
             'filled': 'closed',
             'canceled': 'canceled',
             'submitted': 'open',
+            'created': 'open',  // For stop orders
             // contract
             '1': 'open',
             '2': 'open',


### PR DESCRIPTION
Map order-state for "created" orders to "open".

[docs source](https://huobiapi.github.io/docs/spot/v1/en/#introduction-7)

