### PR TITLE
fix: add 'filled' information when parsing orders (Gate.io)

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2517,7 +2517,7 @@ module.exports = class gateio extends Exchange {
             'average': undefined,
             'amount': amount,
             'cost': cost,
-            'filled': undefined,
+            'filled': this.safeFloat2 (order, 'amount', 'size') - this.safeFloat (order, 'left'),
             'remaining': remaining,
             'fee': undefined,
             'fees': fees,


### PR DESCRIPTION
Since the initial amount and the remaining amount is known, the filled amount can be calculated.

Please modify this PR ("allow edits by maintainers is checked) if the code is not optimal. I wanted to write ```Number(amount) - Number(remaining)``` but wasn't sure whether this breaks the compilation. Maybe there also need to be a check that both values are not ```None```