### PR TITLE
Support for market orders in Waves.exchange

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -26,7 +26,7 @@ module.exports = class wavesexchange extends Exchange {
                 'option': false,
                 'addMargin': false,
                 'cancelOrder': true,
-                'createMarketOrder': undefined,
+                'createMarketOrder': true,
                 'createOrder': true,
                 'createReduceOnlyOrder': false,
                 'fetchBalance': true,
@@ -1076,6 +1076,26 @@ module.exports = class wavesexchange extends Exchange {
         const amountAsset = this.getAssetId (market['baseId']);
         const priceAsset = this.getAssetId (market['quoteId']);
         amount = this.amountToPrecision (symbol, amount);
+        if (type === 'market') {
+            if (price === undefined) {
+                // Waves forces us to pick a minimum buy or sell price (see: https://docs.waves.exchange/en/waves-matcher/matcher-api#order).
+                // To work around this the best way possible without forcing the user to do the same (as it's behaviour unique to this exchange)
+                // We'll get the price from the order book.
+                const orderbook = await this.fetchOrderBook (symbol);
+                let orderbookSide = null;
+                if (side === 'buy') {
+                    orderbookSide = 'asks';
+                } else if (side === 'sell') {
+                    orderbookSide = 'bids';
+                }
+                if (orderbook[orderbookSide].length > 0) {
+                    const orderbookIndex = Math.min (orderbook[orderbookSide].length - 1, 3);
+                    price = orderbook[orderbookSide][orderbookIndex][0];
+                } else {
+                    throw new InvalidOrder ('Orderbook "' + orderbookSide + '" is empty. Can\'t make a market ' + side + '-order!');
+                }
+            }
+        }
         price = this.priceToPrecision (symbol, price);
         const orderType = (side === 'buy') ? 0 : 1;
         const timestamp = this.milliseconds ();
@@ -1210,7 +1230,15 @@ module.exports = class wavesexchange extends Exchange {
         if (matcherFeeAssetId !== 'WAVES') {
             body['matcherFeeAssetId'] = matcherFeeAssetId;
         }
-        const response = await this.matcherPostMatcherOrderbook (body);
+        if (type === 'market') {
+            const response = await this.matcherPostMatcherOrderbookMarket (body);
+            const value = this.safeValue (response, 'message');
+            return this.parseOrder (value, market);
+        } else {
+            const response = await this.matcherPostMatcherOrderbook (body);
+            const value = this.safeValue (response, 'message');
+            return this.parseOrder (value, market);
+        }
         // { success: true,
         //   message:
         //    { version: 3,
@@ -1232,8 +1260,6 @@ module.exports = class wavesexchange extends Exchange {
         //      proofs:
         //       [ '2EG8zgE6Ze1X5EYA8DbfFiPXAtC7NniYBAMFbJUbzwVbHmmCKHornQfS5F32NwkHF4623KWq1U6K126h4TTqyVq' ] },
         //   status: 'OrderAccepted' }
-        const value = this.safeValue (response, 'message');
-        return this.parseOrder (value, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -1076,8 +1076,9 @@ module.exports = class wavesexchange extends Exchange {
         const amountAsset = this.getAssetId (market['baseId']);
         const priceAsset = this.getAssetId (market['quoteId']);
         amount = this.amountToPrecision (symbol, amount);
-        if (price === undefined) {
-            throw new InvalidOrder (this.id + ' market order requires price argument to determine the max price for buy and the min price for sell.');
+        const isMarketOrder = (type === 'market');
+        if ((isMarketOrder) && (price === undefined)) {
+            throw new InvalidOrder (this.id + ' createOrder() requires a price argument for ' + type + ' orders to determine the max price for buy and the min price for sell');
         }
         price = this.priceToPrecision (symbol, price);
         const orderType = (side === 'buy') ? 0 : 1;
@@ -1213,7 +1214,7 @@ module.exports = class wavesexchange extends Exchange {
         if (matcherFeeAssetId !== 'WAVES') {
             body['matcherFeeAssetId'] = matcherFeeAssetId;
         }
-        if (type === 'market') {
+        if (isMarketOrder) {
             const response = await this.matcherPostMatcherOrderbookMarket (body);
             const value = this.safeValue (response, 'message');
             return this.parseOrder (value, market);

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -1076,25 +1076,8 @@ module.exports = class wavesexchange extends Exchange {
         const amountAsset = this.getAssetId (market['baseId']);
         const priceAsset = this.getAssetId (market['quoteId']);
         amount = this.amountToPrecision (symbol, amount);
-        if (type === 'market') {
-            if (price === undefined) {
-                // Waves forces us to pick a minimum buy or sell price (see: https://docs.waves.exchange/en/waves-matcher/matcher-api#order).
-                // To work around this the best way possible without forcing the user to do the same (as it's behaviour unique to this exchange)
-                // We'll get the price from the order book.
-                const orderbook = await this.fetchOrderBook (symbol);
-                let orderbookSide = null;
-                if (side === 'buy') {
-                    orderbookSide = 'asks';
-                } else if (side === 'sell') {
-                    orderbookSide = 'bids';
-                }
-                if (orderbook[orderbookSide].length > 0) {
-                    const orderbookIndex = Math.min (orderbook[orderbookSide].length - 1, 3);
-                    price = orderbook[orderbookSide][orderbookIndex][0];
-                } else {
-                    throw new InvalidOrder ('Orderbook "' + orderbookSide + '" is empty. Can\'t make a market ' + side + '-order!');
-                }
-            }
+        if (price === undefined) {
+            throw new InvalidOrder (this.id + ' market order requires price argument to determine the max price for buy and the min price for sell.');
         }
         price = this.priceToPrecision (symbol, price);
         const orderType = (side === 'buy') ? 0 : 1;


### PR DESCRIPTION
# Intro

The waves.exchange docs claims [there's no support for market orders](https://docs.waves.exchange/en/ccxt/#createorder) on the Waves CCXT API.

![Screenshot_20220130_223659](https://user-images.githubusercontent.com/1212814/151718931-5b69793b-6b3c-4c9f-a1b3-fd3569891b85.png)


However, they didn't claim it's not supported in their own API. I needed this feature for my trading bot, and I decided to give it a go based on my previous assumption it could still be there.

I launched Waves.exchange in testnet and I managed to see how the market order worked and replicated it in this PR.

Some notes:

1. Unlike any other exchange I encountered, Waves forces you to set a price for market orders (used as minimum or maximum depending on if you sell or buy). Based on tests, I found out Waves.exchange (the web front-end) looks for prices in order book and bases the price that goes with the market order on the state of the order book. I did something similar, where I take the 4th cheapest/most expensive (again, depending on buy/sell) from the order book. 

    I took the 4th to give some leverage when bandwidth/slow internet will make an order arrive at Waves when the best option already left the order book (this rejects your market order). Note that Waves still finds the best price, so you won't have a disadvantage when you set a slightly worse price from the order book.

2. Waves.exchange claims in their docs market orders aren't supported. If this gets merged we probably need to inform them.