### PR TITLE
Fixed fetching OHLC for Waves 

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -770,7 +770,7 @@ module.exports = class wavesexchange extends Exchange {
         limit = Math.min (allowedCandles, limit);
         const duration = this.parseTimeframe (timeframe) * 1000;
         if (since === undefined) {
-            const currentTime = Math.floor (this.milliseconds () / duration) * duration;
+            const currentTime = parseInt (this.milliseconds () / duration) * duration;
             const delta = (limit - 1) * duration;
             const timeStart = currentTime - delta;
             request['timeStart'] = timeStart.toString ();

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -765,6 +765,9 @@ module.exports = class wavesexchange extends Exchange {
         };
         if (since !== undefined) {
             request['timeStart'] = since.toString ();
+            const timeframeUnix = this.parseTimeframe (timeframe) * 1000;
+            request['timeEnd'] = since + (timeframeUnix * limit);
+            request['timeEnd'] = request['timeEnd'].toString ();
         } else {
             const allowedCandles = this.safeInteger (this.options, 'allowedCandles', 1440);
             const timeframeUnix = this.parseTimeframe (timeframe) * 1000;

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -763,18 +763,21 @@ module.exports = class wavesexchange extends Exchange {
             'quoteId': market['quoteId'],
             'interval': this.timeframes[timeframe],
         };
-        if (since !== undefined) {
-            request['timeStart'] = since.toString ();
-            const timeframeUnix = this.parseTimeframe (timeframe) * 1000;
-            request['timeEnd'] = since + (timeframeUnix * limit);
-            request['timeEnd'] = request['timeEnd'].toString ();
-        } else {
-            const allowedCandles = this.safeInteger (this.options, 'allowedCandles', 1440);
-            const timeframeUnix = this.parseTimeframe (timeframe) * 1000;
-            const currentTime = Math.floor (this.milliseconds () / timeframeUnix) * timeframeUnix;
-            const delta = (allowedCandles - 1) * timeframeUnix;
+        const allowedCandles = this.safeInteger (this.options, 'allowedCandles', 1440);
+        if (limit === undefined) {
+            limit = allowedCandles;
+        }
+        limit = Math.min (allowedCandles, limit);
+        const duration = this.parseTimeframe (timeframe) * 1000;
+        if (since === undefined) {
+            const currentTime = Math.floor (this.milliseconds () / duration) * duration;
+            const delta = (limit - 1) * duration;
             const timeStart = currentTime - delta;
             request['timeStart'] = timeStart.toString ();
+        } else {
+            request['timeStart'] = since.toString ();
+            const timeEnd = this.sum (since, duration * limit);
+            request['timeEnd'] = timeEnd.toString ();
         }
         const response = await this.publicGetCandlesBaseIdQuoteId (this.extend (request, params));
         //


### PR DESCRIPTION
Using `fetchOHLCV` with Waves will trigger errors like this (from Freqtrade logs, CCXT commit `64ba54653e83fb765776c22b9099691af4edcd04`):

```
2022-01-30 22:30:43,007 - freqtrade.exchange.exchange - WARNING - Async code raised an exception: TemporaryError('Could not fetch historical candle (OHLCV) data for pair WAVES/USDN due to ExchangeNotAvailable. Message: wavesexchange GET https://api-testnet.wavesplatform.com/v0/candles/WAVES/25FEqEjRkqK6yCkiT7Lz6SAYz7gUFCtxfCChnrVFD5AT?interval=5m&timeStart=1642718100000 400 Bad Request {"message":"Bad Request","meta":[{"message":"2880 of candles is more then allowed of 1440. Try to decrease requested period of time."}]}')
```

The reason for this is that `/candles` does not have a `limit` parameter (despite the docs claiming it does, maybe it's outdated?):

![Screenshot_20220131_000246](https://user-images.githubusercontent.com/1212814/151721653-42ec3ede-1d3a-4176-8816-808611fc3383.png)

You can try to call something like this: https://api-testnet.wavesplatform.com/v0/candles/WAVES/25FEqEjRkqK6yCkiT7Lz6SAYz7gUFCtxfCChnrVFD5AT?interval=5m&timeStart=1642718100000&limit=10

And still get the error. This change allows users to still use `since` like before, but if they set a `limit` (according to the Waves-docs linked above), internally we set the `timeEnd` such that the response will equal the same amount of candles as set in `limit`.

This is the last one I swear :joy: 