### PR TITLE
fix[Gate.io]: extract settle currency from the correct variable

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2490,7 +2490,7 @@ module.exports = class gateio extends Exchange {
         const tkfr = this.safeNumber (order, 'tkfr');
         if (mkfr) {
             fees.push ({
-                'currency': this.safeCurrencyCode (this.safeString (order, 'settleId')),
+                'currency': this.safeCurrencyCode (this.safeString (market, 'settleId')),
                 'cost': mkfr,
             });
         }


### PR DESCRIPTION
There is no settle currency information in the order response. Neither for spot nor swap symbols. I assume this was wrongly assigned by accident.