### PR TITLE
fix[Gate.io]: assign average cost value to correct variable

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2432,13 +2432,16 @@ module.exports = class gateio extends Exchange {
         const amountRaw = this.safeString2 (order, 'amount', 'size');
         const amount = Precise.stringAbs (amountRaw);
         const price = this.safeString (order, 'price');
-        // const average = this.safeString (order, 'fill_price');
         const remaining = this.safeString (order, 'left');
-        const cost = this.safeString (order, 'filled_total'); // same as filled_price
+        // 'filled_total': same as fill_price (spots), not existing (swap)
+        const cost = this.safeString (order, 'filled_total');
         let rawStatus = undefined;
         let side = undefined;
+        let average = undefined;
         const contract = this.safeValue (market, 'contract');
         if (contract) {
+            // fill price is the price per contract for swaps, but the cost for spot
+            average = this.safeString (order, 'fill_price');
             if (amount) {
                 side = Precise.stringGt (amountRaw, '0') ? 'buy' : 'sell';
             } else {
@@ -2514,7 +2517,7 @@ module.exports = class gateio extends Exchange {
             'side': side,
             'price': price,
             'stopPrice': undefined,
-            'average': undefined,
+            'average': average,
             'amount': amount,
             'cost': cost,
             'filled': undefined,


### PR DESCRIPTION
For spots, `fill_total` and `fill_price` always indicate the cost (as reflected in the CCXT code).

For swaps, however, the `fill_price` is the price paid per contract which means it needs to be assigned to `average`.

Proof of the second statement (short swap position on REEF/USDT [101 contracts]):
```python
{
"id": Decimal("123750385701"),
"contract": "REEF_USDT",
"mkfr": "-0.00005",
"tkfr": "0.0004",
"tif": "ioc",
"is_reduce_only": False,
"create_time": Decimal("1643625948.669"),
"finish_time": Decimal("1643625948.669"),
"price": "0",
"size": Decimal("-101"),
"refr": "0",
"left": Decimal("0"),
"text": "t-083G30-96cf5f08276d4dee36",
"fill_price": "0.00979",
"user": Decimal("xxxxx"),
"finish_as": "filled",
"status": "finished",
"is_liq": False,
"refu": Decimal("0"),
"is_close": False,
"iceberg": Decimal("0"),
}
```