### PR TITLE
bytetrade maxAmount, maxPrice fix

### DIFF
--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -197,13 +197,13 @@ module.exports = class bytetrade extends Exchange {
             const limits = this.safeValue (currency, 'limits');
             const deposit = this.safeValue (limits, 'deposit');
             const amountPrecision = this.safeInteger (currency, 'basePrecision');
-            let maxDeposit = this.safeNumber (deposit, 'max');
-            if (maxDeposit === -1.0) {
+            let maxDeposit = this.safeString (deposit, 'max');
+            if (Precise.stringEquals (maxDeposit, '-1')) {
                 maxDeposit = undefined;
             }
             const withdraw = this.safeValue (limits, 'withdraw');
-            let maxWithdraw = this.safeNumber (withdraw, 'max');
-            if (maxWithdraw === -1.0) {
+            let maxWithdraw = this.safeString (withdraw, 'max');
+            if (Precise.stringEquals (maxWithdraw, '-1')) {
                 maxWithdraw = undefined;
             }
             result[code] = {
@@ -219,11 +219,11 @@ module.exports = class bytetrade extends Exchange {
                     'amount': { 'min': undefined, 'max': undefined },
                     'deposit': {
                         'min': this.safeNumber (deposit, 'min'),
-                        'max': maxDeposit,
+                        'max': this.parseNumber (maxDeposit),
                     },
                     'withdraw': {
                         'min': this.safeNumber (withdraw, 'min'),
-                        'max': maxWithdraw,
+                        'max': this.parseNumber (maxWithdraw),
                     },
                 },
                 'info': currency,

--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -291,12 +291,12 @@ module.exports = class bytetrade extends Exchange {
             const price = this.safeValue (limits, 'price', {});
             const precision = this.safeValue (market, 'precision', {});
             const active = this.safeString (market, 'active');
-            let maxAmount = this.safeNumber (amount, 'max');
-            if (maxAmount === -1.0) {
+            let maxAmount = this.safeString (amount, 'max');
+            if (Precise.stringEquals (maxAmount, '-1')) {
                 maxAmount = undefined;
             }
-            let maxPrice = this.safeNumber (price, 'max');
-            if (maxPrice === -1.0) {
+            let maxPrice = this.safeString (price, 'max');
+            if (Precise.stringEquals (maxPrice, '-1')) {
                 maxPrice = undefined;
             }
             const entry = {
@@ -318,11 +318,11 @@ module.exports = class bytetrade extends Exchange {
                 'limits': {
                     'amount': {
                         'min': this.safeNumber (amount, 'min'),
-                        'max': maxAmount,
+                        'max': this.parseNumber (maxAmount),
                     },
                     'price': {
                         'min': this.safeNumber (price, 'min'),
-                        'max': maxPrice,
+                        'max': this.parseNumber (maxPrice),
                     },
                     'cost': {
                         'min': undefined,

--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -234,6 +234,37 @@ module.exports = class bytetrade extends Exchange {
 
     async fetchMarkets (params = {}) {
         const markets = await this.publicGetSymbols (params);
+        //
+        //     [
+        //         {
+        //             "symbol": "122406567911",
+        //             "name": "BTC/USDT",
+        //             "base": "32",
+        //             "quote": "57",
+        //             "marketStatus": 0,
+        //             "baseName": "BTC",
+        //             "quoteName": "USDT",
+        //             "active": true,
+        //             "maker": "0.0008",
+        //             "taker": "0.0008",
+        //             "precision": {
+        //                 "amount": 6,
+        //                 "price": 2,
+        //                 "minPrice":1
+        //             },
+        //             "limits": {
+        //                 "amount": {
+        //                     "min": "0.000001",
+        //                     "max": "-1"
+        //                 },
+        //                 "price": {
+        //                     "min": "0.01",
+        //                     "max": "-1"
+        //                 }
+        //             }
+        //        }
+        //    ]
+        //
         const result = [];
         for (let i = 0; i < markets.length; i++) {
             const market = markets[i];
@@ -260,6 +291,14 @@ module.exports = class bytetrade extends Exchange {
             const price = this.safeValue (limits, 'price', {});
             const precision = this.safeValue (market, 'precision', {});
             const active = this.safeString (market, 'active');
+            let maxAmount = this.safeNumber (amount, 'max');
+            if (maxAmount === -1.0) {
+                maxAmount = undefined;
+            }
+            let maxPrice = this.safeNumber (price, 'max');
+            if (maxPrice === -1.0) {
+                maxPrice = undefined;
+            }
             const entry = {
                 'id': id,
                 'symbol': symbol,
@@ -279,11 +318,11 @@ module.exports = class bytetrade extends Exchange {
                 'limits': {
                     'amount': {
                         'min': this.safeNumber (amount, 'min'),
-                        'max': this.safeNumber (amount, 'max'),
+                        'max': maxAmount,
                     },
                     'price': {
                         'min': this.safeNumber (price, 'min'),
-                        'max': this.safeNumber (price, 'max'),
+                        'max': maxPrice,
                     },
                     'cost': {
                         'min': undefined,


### PR DESCRIPTION
https://docs.byte-trade.com/#get-all-supported-symbols
https://api-v2.bttcdn.com/symbols
For all symbols `max price` and` max amount` is `-1`.

I think it's like on this endpoint https://docs.byte-trade.com/#get-all-supported-currencies with deposit/witdraw limits `-1` means unlimited.
