### PR TITLE
digifinex fetchMarketsV1 unified, has leverage methods removed

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -18,9 +18,9 @@ module.exports = class digifinex extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined,
-                'swap': false,
-                'future': false,
+                'margin': undefined, // has but unimplemented
+                'swap': undefined, // has but unimplemented
+                'future': undefined, // has but unimplemented
                 'option': false,
                 'cancelOrder': true,
                 'cancelOrders': true,
@@ -29,34 +29,20 @@ module.exports = class digifinex extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
-                'fetchFundingHistory': false,
-                'fetchFundingRate': false,
-                'fetchFundingRateHistory': false,
-                'fetchFundingRates': false,
-                'fetchIndexOHLCV': false,
-                'fetchIsolatedPositions': false,
                 'fetchLedger': true,
-                'fetchLeverage': false,
                 'fetchMarkets': true,
-                'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
-                'fetchPositions': false,
-                'fetchPositionsRisk': false,
-                'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,
                 'fetchTrades': true,
                 'fetchWithdrawals': true,
-                'reduceMargin': false,
-                'setLeverage': false,
-                'setPositionMode': false,
                 'withdraw': true,
             },
             'timeframes': {
@@ -358,7 +344,7 @@ module.exports = class digifinex extends Exchange {
                 'settleId': undefined,
                 'type': 'spot',
                 'spot': true,
-                'margin': false,
+                'margin': undefined,
                 'swap': false,
                 'future': false,
                 'option': false,
@@ -372,8 +358,8 @@ module.exports = class digifinex extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.safeInteger (market, 'amount_precision'),
                     'price': this.safeInteger (market, 'price_precision'),
+                    'amount': this.safeInteger (market, 'amount_precision'),
                 },
                 'limits': {
                     'leverage': {
@@ -424,36 +410,52 @@ module.exports = class digifinex extends Exchange {
             const [ baseId, quoteId ] = id.split ('_');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const symbol = base + '/' + quote;
-            const precision = {
-                'amount': this.safeInteger (market, 'volume_precision'),
-                'price': this.safeInteger (market, 'price_precision'),
-            };
-            const limits = {
-                'amount': {
-                    'min': this.safeNumber (market, 'min_volume'),
-                    'max': undefined,
-                },
-                'price': {
-                    'min': undefined,
-                    'max': undefined,
-                },
-                'cost': {
-                    'min': this.safeNumber (market, 'min_amount'),
-                    'max': undefined,
-                },
-            };
-            const active = undefined;
             result.push ({
                 'id': id,
-                'symbol': symbol,
+                'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
+                'settle': undefined,
                 'baseId': baseId,
                 'quoteId': quoteId,
-                'active': active,
-                'precision': precision,
-                'limits': limits,
+                'settleId': undefined,
+                'type': 'spot',
+                'spot': true,
+                'margin': undefined,
+                'swap': false,
+                'future': false,
+                'option': false,
+                'active': undefined,
+                'contract': false,
+                'linear': undefined,
+                'inverse': undefined,
+                'contractSize': undefined,
+                'expiry': undefined,
+                'expiryDatetime': undefined,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'price': this.safeInteger (market, 'price_precision'),
+                    'amount': this.safeInteger (market, 'volume_precision'),
+                },
+                'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'amount': {
+                        'min': this.safeNumber (market, 'min_volume'),
+                        'max': undefined,
+                    },
+                    'price': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'cost': {
+                        'min': this.safeNumber (market, 'min_amount'),
+                        'max': undefined,
+                    },
+                },
                 'info': market,
             });
         }


### PR DESCRIPTION
```
2022-01-31T22:05:20.228Z
Node.js: v14.17.0
CCXT v1.71.53
digifinex.fetchMarketsV2 ()
1164 ms
              id |           symbol |        base | quote | settle |      baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |               precision |                                                                           limits
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        BTC_USDT |         BTC/USDT |         BTC |  USDT |        |         BTC |    USDT |          | spot | true |        | false |  false |  false |   true |    false |        |         |              |        |                |        |            |  {"price":2,"amount":8} |             {"leverage":{},"amount":{"min":0.00005},"price":{},"cost":{"min":2}}
...
       VEMP_USDT |        VEMP/USDT |        VEMP |  USDT |        |        VEMP |    USDT |          | spot | true |        | false |  false |  false |   true |    false |        |         |              |        |                |        |            |  {"price":5,"amount":5} |                  {"leverage":{},"amount":{"min":21},"price":{},"cost":{"min":2}}
       GDSC_USDT |        GDSC/USDT |        GDSC |  USDT |        |        GDSC |    USDT |          | spot | true |        | false |  false |  false |   true |    false |        |         |              |        |                |        |            |  {"price":4,"amount":4} |                  {"leverage":{},"amount":{"min":40},"price":{},"cost":{"min":2}}
217 objects
```

```
2022-01-31T22:07:10.313Z
Node.js: v14.17.0
CCXT v1.71.53
digifinex.fetchMarketsV1 ()
1217 ms
              id |           symbol |        base | quote | settle |      baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |               precision |                                                                           limits
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        btc_usdt |         BTC/USDT |         BTC |  USDT |        |         btc |    usdt |          | spot | true |        | false |  false |  false |        |    false |        |         |              |        |                |        |            |  {"price":2,"amount":8} |             {"leverage":{},"amount":{"min":0.00005},"price":{},"cost":{"min":2}}
Waiting for the debugger to disconnect...
...
       gdsc_usdt |        GDSC/USDT |        GDSC |  USDT |        |        gdsc |    usdt |          | spot | true |        | false |  false |  false |        |    false |        |         |              |        |                |        |            |  {"price":4,"amount":4} |                  {"leverage":{},"amount":{"min":40},"price":{},"cost":{"min":2}}
        avn_usdt |         AVN/USDT |         AVN |  USDT |        |         avn |    usdt |          | spot | true |        | false |  false |  false |        |    false |        |         |              |        |                |        |            |  {"price":7,"amount":5} |                  {"leverage":{},"amount":{"min":45},"price":{},"cost":{"min":2}}
386 objects
```