### PR TITLE
huobi parseTrade feeCurrency

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1771,6 +1771,11 @@ module.exports = class huobi extends Exchange {
                 feeCurrency = this.safeCurrencyCode (this.safeString (trade, 'fee-deduct-currency'));
             }
         }
+        if ((feeCurrency = '') && Precise.stringEquals (feeCost, '0')) {
+            const parts = symbol.split ('/');
+            const quote = this.safeString (parts, 1);
+            feeCurrency = quote;
+        }
         if (feeCost !== undefined) {
             fee = {
                 'cost': feeCost,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1767,14 +1767,12 @@ module.exports = class huobi extends Exchange {
         const filledPoints = this.safeString (trade, 'filled-points');
         if (filledPoints !== undefined) {
             if ((feeCost === undefined) || Precise.stringEquals (feeCost, '0')) {
-                feeCost = filledPoints;
-                feeCurrency = this.safeCurrencyCode (this.safeString (trade, 'fee-deduct-currency'));
+                const feeDeductCurrency = this.safeString (trade, 'fee-deduct-currency');
+                if (feeDeductCurrency !== '') {
+                    feeCost = filledPoints;
+                    feeCurrency = this.safeCurrencyCode (feeDeductCurrency);
+                }
             }
-        }
-        if ((feeCurrency === '') && Precise.stringEquals (feeCost, '0')) {
-            const parts = symbol.split ('/');
-            const quote = this.safeString (parts, 1);
-            feeCurrency = quote;
         }
         if (feeCost !== undefined) {
             fee = {

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1771,7 +1771,7 @@ module.exports = class huobi extends Exchange {
                 feeCurrency = this.safeCurrencyCode (this.safeString (trade, 'fee-deduct-currency'));
             }
         }
-        if ((feeCurrency = '') && Precise.stringEquals (feeCost, '0')) {
+        if ((feeCurrency === '') && Precise.stringEquals (feeCost, '0')) {
             const parts = symbol.split ('/');
             const quote = this.safeString (parts, 1);
             feeCurrency = quote;


### PR DESCRIPTION
```
 {
    id: '463087708439518',
    info: {
      symbol: 'daihusd',
      'fee-currency': 'husd',
      source: 'spot-api',
      role: 'maker',
      'created-at': '1643633213058',
      price: '0.9998',
      'filled-points': '0.0',
      'fee-deduct-currency': '',
      'fee-deduct-state': 'done',
      'order-id': '464344133079273',
      'filled-amount': '112.07',
      'filled-fees': '0',
      'match-id': '100031762569',
      'trade-id': '758005',
      id: '463087708439518',
      type: 'buy-limit'
    },
    order: '464344133079273',
    timestamp: 1643633213058,
    datetime: '2022-01-31T12:46:53.058Z',
    symbol: 'DAI/HUSD',
    type: 'limit',
    side: 'buy',
    takerOrMaker: 'maker',
    price: 0.9998,
    amount: 112.07,
    cost: 112.047586,
    fee: { cost: 0, currency: '' },
    fees: [ [Object] ]
  },
```

In some cases, probably on fee promotion markets with HUSD with zero fee currency comes as empty string