### PR TITLE
cexio market sort and has futures methods

### DIFF
--- a/js/cex.js
+++ b/js/cex.js
@@ -17,10 +17,10 @@ module.exports = class cex extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined,
-                'swap': undefined,
-                'future': undefined,
-                'option': undefined,
+                'margin': undefined, // has but unimplemented
+                'swap': false,
+                'future': false,
+                'option': false,
                 'cancelOrder': true,
                 'createOrder': true,
                 'editOrder': true,
@@ -28,12 +28,19 @@ module.exports = class cex extends Exchange {
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
+                'fetchFundingHistory': false,
+                'fetchFundingRate': false,
+                'fetchFundingRateHistory': false,
+                'fetchFundingRates': false,
+                'fetchIndexOHLCV': false,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': false,
                 'fetchOHLCV': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,
@@ -309,10 +316,8 @@ module.exports = class cex extends Exchange {
             const market = markets[i];
             const baseId = this.safeString (market, 'symbol1');
             const quoteId = this.safeString (market, 'symbol2');
-            const id = baseId + '/' + quoteId;
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const symbol = base + '/' + quote;
             const baseCurrency = this.safeValue (currenciesById, baseId, {});
             const quoteCurrency = this.safeValue (currenciesById, quoteId, {});
             let pricePrecision = this.safeInteger (quoteCurrency, 'precision', 8);
@@ -325,38 +330,39 @@ module.exports = class cex extends Exchange {
             }
             const baseCcyPrecision = this.safeInteger (baseCurrency, 'precision', 8);
             const baseCcyScale = this.safeInteger (baseCurrency, 'scale', 0);
-            const amountPrecision = baseCcyPrecision - baseCcyScale;
-            const precision = {
-                'amount': amountPrecision,
-                'price': pricePrecision,
-            };
             result.push ({
-                'id': id,
-                'info': market,
-                'symbol': symbol,
+                'id': baseId + '/' + quoteId,
+                'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
+                'settle': undefined,
                 'baseId': baseId,
                 'quoteId': quoteId,
+                'settleId': undefined,
                 'type': 'spot',
                 'spot': true,
-                'margin': false,
+                'margin': undefined,
                 'future': false,
                 'swap': false,
                 'option': false,
-                'optionType': undefined,
-                'strike': undefined,
+                'active': undefined,
+                'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'contract': false,
                 'contractSize': undefined,
-                'settle': undefined,
-                'settleId': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,
-                'active': undefined,
-                'precision': precision,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'price': pricePrecision,
+                    'amount': baseCcyPrecision - baseCcyScale,
+                },
                 'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
                     'amount': {
                         'min': this.safeNumber (market, 'minLotSize'),
                         'max': this.safeNumber (market, 'maxLotSize'),
@@ -370,6 +376,7 @@ module.exports = class cex extends Exchange {
                         'max': undefined,
                     },
                 },
+                'info': market,
             });
         }
         return result;


### PR DESCRIPTION
```
2022-02-01T21:07:56.842Z
Node.js: v14.17.0
CCXT v1.71.56
cex.fetchMarkets ()
4187 ms
        id |     symbol |   base | quote | settle | baseId | quoteId | settleId | type | spot | margin | future |  swap | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |              precision |                                                                                              limits
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   BTC/USD |    BTC/USD |    BTC |   USD |        |    BTC |     USD |          | spot | true |        |  false | false |  false |        |    false |        |         |              |        |                |        |            | {"price":1,"amount":8} |     {"leverage":{},"amount":{"min":0.00018938},"price":{"min":3500,"max":350000},"cost":{"min":10}}
...
   QNT/USD |    QNT/USD |    QNT |   USD |        |    QNT |     USD |          | spot | true |        |  false | false |  false |        |    false |        |         |              |        |                |        |            | {"price":4,"amount":6} |           {"leverage":{},"amount":{"min":0.073467},"price":{"min":19,"max":1900},"cost":{"min":10}}
  AVAX/USD |   AVAX/USD |   AVAX |   USD |        |   AVAX |     USD |          | spot | true |        |  false | false |  false |        |    false |        |         |              |        |                |        |            | {"price":4,"amount":6} |               {"leverage":{},"amount":{"min":0.07},"price":{"min":10,"max":1050},"cost":{"min":10}}
230 objects
```