### PR TITLE
Margin mode types

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2221,8 +2221,12 @@ module.exports = class ascendex extends Exchange {
     }
 
     async setMarginMode (marginType, symbol = undefined, params = {}) {
+        marginType = marginType.toLowerCase ();
+        if (marginType === 'cross') {
+            marginType = 'crossed'
+        }
         if (marginType !== 'isolated' && marginType !== 'crossed') {
-            throw new BadRequest (this.id + ' setMarginMode() marginType argument should be isolated or crossed');
+            throw new BadRequest (this.id + ' setMarginMode() marginType argument should be ISOLATED or CROSS');
         }
         await this.loadMarkets ();
         await this.loadAccounts ();

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2223,10 +2223,10 @@ module.exports = class ascendex extends Exchange {
     async setMarginMode (marginType, symbol = undefined, params = {}) {
         marginType = marginType.toLowerCase ();
         if (marginType === 'cross') {
-            marginType = 'crossed'
+            marginType = 'crossed';
         }
         if (marginType !== 'isolated' && marginType !== 'crossed') {
-            throw new BadRequest (this.id + ' setMarginMode() marginType argument should be ISOLATED or CROSS');
+            throw new BadRequest (this.id + ' setMarginMode() marginType argument should be isolated or cross');
         }
         await this.loadMarkets ();
         await this.loadAccounts ();

--- a/js/binance.js
+++ b/js/binance.js
@@ -4961,8 +4961,11 @@ module.exports = class binance extends Exchange {
         // { "code": 200, "msg": "success" }
         //
         marginType = marginType.toUpperCase ();
+        if (marginType === 'CROSS') {
+            marginType = 'CROSSED';
+        }
         if ((marginType !== 'ISOLATED') && (marginType !== 'CROSSED')) {
-            throw new BadRequest (this.id + ' marginType must be either isolated or crossed');
+            throw new BadRequest (this.id + ' marginType must be either isolated or cross');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2859,8 +2859,11 @@ module.exports = class bybit extends Exchange {
             throw new ArgumentsRequired (this.id + '.setMarginMode requires a leverage parameter');
         }
         marginType = marginType.toUpperCase ();
-        if ((marginType !== 'ISOLATED') && (marginType !== 'CROSSED')) {
-            throw new BadRequest (this.id + ' marginType must be either isolated or crossed');
+        if (marginType === 'CROSSED') { // * Deprecated, use 'CROSS' instead
+            marginType = 'CROSS';
+        }
+        if ((marginType !== 'ISOLATED') && (marginType !== 'CROSS')) {
+            throw new BadRequest (this.id + ' marginType must be either isolated or cross');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);

--- a/js/okex.js
+++ b/js/okex.js
@@ -2985,7 +2985,7 @@ module.exports = class okex extends Exchange {
         const marginMode = this.safeStringLower (params, 'mgnMode');
         params = this.omit (params, [ 'mgnMode' ]);
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
-            throw new BadRequest (this.id + ' setLeverage params["mgnMode"] must be either "cross" or "isolated"');
+            throw new BadRequest (this.id + ' fetchLeverage params["mgnMode"] must be either cross or isolated');
         }
         const market = this.market (symbol);
         const request = {
@@ -3609,7 +3609,7 @@ module.exports = class okex extends Exchange {
         const marginMode = this.safeStringLower (params, 'mgnMode');
         params = this.omit (params, [ 'mgnMode' ]);
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
-            throw new BadRequest (this.id + ' setLeverage params["mgnMode"] must be either "cross" or "isolated"');
+            throw new BadRequest (this.id + ' setLeverage params["mgnMode"] must be either cross or isolated');
         }
         const request = {
             'lever': leverage,
@@ -3665,8 +3665,9 @@ module.exports = class okex extends Exchange {
         }
         // WARNING: THIS WILL INCREASE LIQUIDATION PRICE FOR OPEN ISOLATED LONG POSITIONS
         // AND DECREASE LIQUIDATION PRICE FOR OPEN ISOLATED SHORT POSITIONS
+        marginType = marginType.toLowerCase ();
         if ((marginType !== 'cross') && (marginType !== 'isolated')) {
-            throw new BadRequest (this.id + ' setMarginMode marginType must be either "cross" or "isolated"');
+            throw new BadRequest (this.id + ' setMarginMode marginType must be either cross or isolated');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);


### PR DESCRIPTION
All setMarginMode methods now accept `CROSS` or `ISOLATED`. The error messages say to pass the type in capital letters because all caps is used for order types and symbols and I wanted to make it consistent. No user code will be broken with these changes.

------------------------------------------------------------------

```
bybit setMarginMode cross ETH/USDT '{"leverage": "10"}'
2022-02-02T07:32:17.204Z
Node.js: v14.17.0
CCXT v1.71.84
bybit.setMarginMode (cross, ETH/USDT, [object Object])
350 ms
{
  ret_code: '0',
  ret_msg: 'OK',
  ext_code: '',
  ext_info: '',
  result: null,
  time_now: '1643787138.038292',
  rate_limit_status: '72',
  rate_limit_reset_ms: '1643787138034',
  rate_limit: '75'
}
```
```
% okex setMarginMode cross ETH/USDT:USDT '{"lever": "10"}'   
2022-02-02T07:32:39.703Z
Node.js: v14.17.0
CCXT v1.71.84
okex.setMarginMode (cross, ETH/USDT:USDT, [object Object])
291 ms
{
  code: '0',
  data: [
    {
      instId: 'ETH-USDT-SWAP',
      lever: '10',
      mgnMode: 'cross',
      posSide: ''
    }
  ],
  msg: ''
}
```
```
% binanceusdm setMarginMode cross BTC/USDT               
2022-02-02T07:32:57.205Z
Node.js: v14.17.0
CCXT v1.71.84
binanceusdm.setMarginMode (cross, BTC/USDT)
349 ms
{ code: 200, msg: 'success' }
```

```
% okex setLeverage 10 ETH/USDT:USDT '{"mgnMode": "cross"}'           
2022-02-02T07:37:11.697Z
Node.js: v14.17.0
CCXT v1.71.84
okex.setLeverage (10, ETH/USDT:USDT, [object Object])
289 ms
{
  code: '0',
  data: [
    {
      instId: 'ETH-USDT-SWAP',
      lever: '10',
      mgnMode: 'cross',
      posSide: ''
    }
  ],
  msg: ''
}
```
```
% okex fetchLeverage ETH/USDT:USDT '{"mgnMode": "cross"}'            
2022-02-02T07:37:22.856Z
Node.js: v14.17.0
CCXT v1.71.84
okex.fetchLeverage (ETH/USDT:USDT, [object Object])
301 ms
{
  code: '0',
  data: [
    {
      instId: 'ETH-USDT-SWAP',
      lever: '10',
      mgnMode: 'cross',
      posSide: 'long'
    },
    {
      instId: 'ETH-USDT-SWAP',
      lever: '10',
      mgnMode: 'cross',
      posSide: 'short'
    }
  ],
  msg: ''
}
```