### PR TITLE
Fix kucoin trigger order status

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1370,8 +1370,8 @@ module.exports = class kucoin extends Exchange {
         const stop = this.safeString (order, 'stop');
         const stopTriggered = this.safeValue (order, 'stopTriggered', false);
         let status = isActive ? 'open' : 'closed';
-        const canceleExistWithStop = cancelExist || (!isActive && stop && !stopTriggered);
-        status = canceleExistWithStop ? 'canceled' : status;
+        const cancelExistWithStop = cancelExist || (!isActive && stop && !stopTriggered);
+        status = cancelExistWithStop ? 'canceled' : status;
         const fee = {
             'currency': feeCurrency,
             'cost': feeCost,

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1367,8 +1367,11 @@ module.exports = class kucoin extends Exchange {
         // bool
         const isActive = this.safeValue (order, 'isActive', false);
         const cancelExist = this.safeValue (order, 'cancelExist', false);
+        const stop = this.safeString (order, 'stop');
+        const stopTriggered = this.safeValue (order, 'stopTriggered', false);
         let status = isActive ? 'open' : 'closed';
-        status = cancelExist ? 'canceled' : status;
+        const canceleExistWithStop = cancelExist || (!isActive && stop && !stopTriggered);
+        status = canceleExistWithStop ? 'canceled' : status;
         const fee = {
             'currency': feeCurrency,
             'cost': feeCost,


### PR DESCRIPTION

using `fetch_order` on a canceled stoploss order returns a wrong result status.
i think for stop orders (orders that have the `stop`-field set) - we need to also look at "triggered" to correctly determine the status.

``` python
import ccxt
ct = ccxt.kucoin(<keys>)
_ = ct.load_markets()
pair = 'ETH/USDT
params = {
    'stopPrice': 2500,
    'stop': 'loss'
    # "operator": 'lte',
}
order = ct.create_order(pair, 'market', 'buy', 0.001, 2501, params=params)
order_f = ct.fetch_order(order['id'])

order_c = ct.cancel_order(order['id'], pair)

print(order_c)
```

On the below order, the correct status would be "canceled" - but it's showing as "closed" - as the order is no longer active (but it also didn't trigger - i placed it "off-spot" intentionally to test this.

```
{'amount': 0.2067,
 'average': None,
 'clientOrderId': '1b88e1b6-2c44-4c7f-8795-3376a3a8860c',
 'cost': 0.0,
 'datetime': '2022-02-03T06:02:54.497Z',
 'fee': {'cost': 0.0, 'currency': 'USDT'},
 'fees': [{'cost': 0.0, 'currency': 'USDT'}],
 'filled': 0.0,
 'id': 'vs898ofre03luvv8000qviat',
 'info': {'cancelAfter': 0,
          'cancelExist': False,
          'channel': 'API',
          'clientOid': '1b88e1b6-2c44-4c7f-8795-3376a3a8860c',
          'createdAt': 1643868174497,
          'dealFunds': '0',
          'dealSize': '0',
          'fee': '0',
          'feeCurrency': 'USDT',
          'funds': '0',
          'hidden': False,
          'iceberg': False,
          'id': 'vs898ofre03luvv8000qviat',
          'isActive': False,
          'opType': 'DEAL',
          'postOnly': False,
          'price': '43.4909',
          'remark': None,
          'side': 'sell',
          'size': '0.2067',
          'stop': 'loss',
          'stopPrice': '43.5344',
          'stopTriggered': False,
          'stp': None,
          'symbol': 'LUNA-USDT',
          'tags': None,
          'timeInForce': 'GTC',
          'tradeType': 'TRADE',
          'type': 'limit',
          'visibleSize': None},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 43.4909,
 'remaining': 0.2067,
 'side': 'sell',
 'status': 'closed',
 'stopPrice': 43.5344,
 'symbol': 'LUNA/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1643868174497,
 'trades': [],
 'type': 'limit'}
```

This PR aims to fix it. Unfortunately, the logic now becomes quite complex - as the interpretation of active will also depend on the stop status.