### PR TITLE
New exchange - Bitazza

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -53,6 +53,7 @@ const exchanges = {
     'binanceus':               require ('./js/binanceus.js'),
     'binanceusdm':             require ('./js/binanceusdm.js'),
     'bit2c':                   require ('./js/bit2c.js'),
+    'bitazza':                 require ('./js/bitazza'),
     'bitbank':                 require ('./js/bitbank.js'),
     'bitbay':                  require ('./js/bitbay.js'),
     'bitbns':                  require ('./js/bitbns.js'),

--- a/js/bitazza.js
+++ b/js/bitazza.js
@@ -6,6 +6,7 @@
 // - 'secret',
 // - 'uid' (userId in the api info)
 // - 'login' (the email address used to log into the UI)
+// - 'password' (the password used to log into the UI)
 
 const ndax = require ('./ndax.js');
 

--- a/js/bitazza.js
+++ b/js/bitazza.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// Bitazza uses Alphapoint, also used by ndax
+// In order to use private endpoints, the following are required:
+// - 'apiKey'
+// - 'secret',
+// - 'uid' (userId in the api info)
+// - 'login' (the email address used to log into the UI)
+
+const ndax = require ('./ndax.js');
+
+//  ---------------------------------------------------------------------------
+
+module.exports = class bitazza extends ndax {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'bitazza',
+            'name': 'Bitazza',
+            'countries': [ 'THA' ],
+            'certified': false,
+            'pro': false,
+            'urls': {
+                'test': undefined,
+                'api': {
+                    'public': 'https://apexapi.bitazza.com:8443/AP',
+                    'private': 'https://apexapi.bitazza.com:8443/AP',
+                },
+                'www': 'https://bitazza.com/',
+                'referral': '',
+                'fees': 'https://bitazza.com/fees.html',
+                'doc': [
+                    'https://api-doc.bitazza.com/',
+                ],
+            },
+            'fees': {
+                'trading': {
+                    'tierBased': true,
+                    'percentage': true,
+                    'taker': this.parseNumber ('0.0025'),
+                    'maker': this.parseNumber ('0.0025'),
+                },
+            },
+        });
+    }
+};


### PR DESCRIPTION
This adds support for the Bitazza exchange, and uses ndax.js which shares its API format due to using AlphaPoint. Modeled after https://github.com/ccxt/ccxt/blob/master/js/zipmex.js