### PR TITLE
CryptoCom: margin error ACCOUNT_NOT_FOUND

### DIFF
--- a/js/base/errorHierarchy.js
+++ b/js/base/errorHierarchy.js
@@ -6,6 +6,7 @@ const errorHierarchy = {
             'AuthenticationError': {
                 'PermissionDenied': {},
                 'AccountSuspended': {},
+                'AccountNotEnabled': {},
             },
             'ArgumentsRequired': {},
             'BadRequest': {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -234,6 +234,7 @@ module.exports = class cryptocom extends Exchange {
                     '10009': BadRequest,
                     '20001': BadRequest,
                     '20002': InsufficientFunds,
+                    '20005': NotSupported, // {"id":"123xxx","method":"private/margin/xxx","code":"20005","message":"ACCOUNT_NOT_FOUND"}
                     '30003': BadSymbol,
                     '30004': BadRequest,
                     '30005': BadRequest,

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { AuthenticationError, ArgumentsRequired, ExchangeError, InsufficientFunds, DDoSProtection, InvalidNonce, PermissionDenied, BadRequest, BadSymbol, NotSupported } = require ('./base/errors');
+const { AuthenticationError, ArgumentsRequired, ExchangeError, InsufficientFunds, DDoSProtection, InvalidNonce, PermissionDenied, BadRequest, BadSymbol, NotSupported, AccountNotEnabled } = require ('./base/errors');
 const Precise = require ('./base/Precise');
 
 module.exports = class cryptocom extends Exchange {
@@ -234,7 +234,7 @@ module.exports = class cryptocom extends Exchange {
                     '10009': BadRequest,
                     '20001': BadRequest,
                     '20002': InsufficientFunds,
-                    '20005': NotSupported, // {"id":"123xxx","method":"private/margin/xxx","code":"20005","message":"ACCOUNT_NOT_FOUND"}
+                    '20005': AccountNotEnabled, // {"id":"123xxx","method":"private/margin/xxx","code":"20005","message":"ACCOUNT_NOT_FOUND"}
                     '30003': BadSymbol,
                     '30004': BadRequest,
                     '30005': BadRequest,


### PR DESCRIPTION
When a user has not activated the **margin** account, then we receive a 20005 error.
Response: `{"id":"123xxx","method":"private/margin/xxx","code":"20005","message":"ACCOUNT_NOT_FOUND"}`

@kroitor I am not sure what the error should be? your suggestion?