### PR TITLE
bittrex BTR -> BTRIPS

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -245,6 +245,7 @@ module.exports = class bittrex extends Exchange {
             },
             'commonCurrencies': {
                 'BIFI': 'Bifrost Finance',
+                'BTR': 'BTRIPS',
                 'MEME': 'Memetic', // conflict with Meme Inu
                 'MER': 'Mercury', // conflict with Mercurial Finance
                 'PROS': 'Pros.Finance',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/btrips#markets
conflict with https://www.coingecko.com/en/coins/bitrue-coin#markets