### PR TITLE
ftx.fetchBorrowRateHistories limit fix

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2505,6 +2505,11 @@ module.exports = class ftx extends Exchange {
                 'info': item,
             });
         }
+        const keys = Object.keys (borrowRateHistories);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            borrowRateHistories[key] = this.filterByCurrencySinceLimit (borrowRateHistories[key], key, since, limit);
+        }
         return borrowRateHistories;
     }
 
@@ -2514,7 +2519,7 @@ module.exports = class ftx extends Exchange {
         if (borrowRateHistory === undefined) {
             throw new BadRequest (this.id + '.fetchBorrowRateHistory returned no data for ' + code);
         } else {
-            return this.filterByCurrencySinceLimit (borrowRateHistory, code, since, limit);
+            return borrowRateHistory;
         }
     }
 };


### PR DESCRIPTION
The limits weren't working properly before, this returns a limit of the limit amount for each currency. I think this might be a better approach

```
2022-02-04T09:28:14.659Z
Node.js: v14.17.0
CCXT v1.72.19
ftx.fetchBorrowRateHistories (1643673600000, 2)
2654 ms
{
  STSOL: [
    {
      currency: 'STSOL',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'STSOL',
        time: '2022-02-04T09:00:00+00:00',
        size: '2824.00540746',
        rate: '1e-6'
      }
    },
    {
      currency: 'STSOL',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'STSOL',
        time: '2022-02-04T08:00:00+00:00',
        size: '2856.20379956',
        rate: '1e-6'
      }
    }
  ],
  NOK: [
    {
      currency: 'NOK',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'NOK',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.02709015',
        rate: '1e-6'
      }
    },
    {
      currency: 'NOK',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'NOK',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.02709011',
        rate: '1e-6'
      }
    }
  ],
  PYPL: [
    {
      currency: 'PYPL',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'PYPL',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.24102355',
        rate: '1e-6'
      }
    },
    {
      currency: 'PYPL',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'PYPL',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.24102323',
        rate: '1e-6'
      }
    }
  ],
  SLV: [
    {
      currency: 'SLV',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SLV',
        time: '2022-02-04T09:00:00+00:00',
        size: '2.6395908',
        rate: '1e-6'
      }
    },
    {
      currency: 'SLV',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SLV',
        time: '2022-02-04T08:00:00+00:00',
        size: '2.63958727',
        rate: '1e-6'
      }
    }
  ],
  ARKK: [
    {
      currency: 'ARKK',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ARKK',
        time: '2022-02-04T09:00:00+00:00',
        size: '2.00174168',
        rate: '1e-6'
      }
    },
    {
      currency: 'ARKK',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ARKK',
        time: '2022-02-04T08:00:00+00:00',
        size: '2.00173901',
        rate: '1e-6'
      }
    }
  ],
  KNC: [
    {
      currency: 'KNC',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'KNC',
        time: '2022-02-04T09:00:00+00:00',
        size: '146840.2812116',
        rate: '1e-6'
      }
    },
    {
      currency: 'KNC',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'KNC',
        time: '2022-02-04T08:00:00+00:00',
        size: '146840.10028256',
        rate: '1e-6'
      }
    }
  ],
  MSOL: [
    {
      currency: 'MSOL',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'MSOL',
        time: '2022-02-04T09:00:00+00:00',
        size: '2021.2381113',
        rate: '1e-6'
      }
    },
    {
      currency: 'MSOL',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'MSOL',
        time: '2022-02-04T08:00:00+00:00',
        size: '2036.58649042',
        rate: '1e-6'
      }
    }
  ],
  ABNB: [
    {
      currency: 'ABNB',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ABNB',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.30056295',
        rate: '1e-6'
      }
    },
    {
      currency: 'ABNB',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ABNB',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.30056254',
        rate: '1e-6'
      }
    }
  ],
  APHA: [
    {
      currency: 'APHA',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'APHA',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'APHA',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'APHA',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  TOMO: [
    {
      currency: 'TOMO',
      rate: '0.0000292815',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TOMO',
        time: '2022-02-04T09:00:00+00:00',
        size: '185316.08766708',
        rate: '0.00002169'
      }
    },
    {
      currency: 'TOMO',
      rate: '0.0000292815',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TOMO',
        time: '2022-02-04T08:00:00+00:00',
        size: '183832.12450502',
        rate: '0.00002169'
      }
    }
  ],
  OMG: [
    {
      currency: 'OMG',
      rate: '0.0000018495',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'OMG',
        time: '2022-02-04T09:00:00+00:00',
        size: '151485.41820019',
        rate: '1.37e-6'
      }
    },
    {
      currency: 'OMG',
      rate: '0.0000018495',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'OMG',
        time: '2022-02-04T08:00:00+00:00',
        size: '151695.23988659',
        rate: '1.37e-6'
      }
    }
  ],
  SUSHI: [
    {
      currency: 'SUSHI',
      rate: '0.000003078',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SUSHI',
        time: '2022-02-04T09:00:00+00:00',
        size: '697622.65709519',
        rate: '2.28e-6'
      }
    },
    {
      currency: 'SUSHI',
      rate: '0.000006858',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SUSHI',
        time: '2022-02-04T08:00:00+00:00',
        size: '698839.47627254',
        rate: '5.08e-6'
      }
    }
  ],
  UNI: [
    {
      currency: 'UNI',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'UNI',
        time: '2022-02-04T09:00:00+00:00',
        size: '166400.93434975',
        rate: '1e-6'
      }
    },
    {
      currency: 'UNI',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'UNI',
        time: '2022-02-04T08:00:00+00:00',
        size: '167694.17714467',
        rate: '1e-6'
      }
    }
  ],
  XRP: [
    {
      currency: 'XRP',
      rate: '0.000003078',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'XRP',
        time: '2022-02-04T09:00:00+00:00',
        size: '18945844.26166104',
        rate: '2.28e-6'
      }
    },
    {
      currency: 'XRP',
      rate: '0.0000038475',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'XRP',
        time: '2022-02-04T08:00:00+00:00',
        size: '19175676.19862275',
        rate: '2.85e-6'
      }
    }
  ],
  CRON: [
    {
      currency: 'CRON',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'CRON',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'CRON',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'CRON',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  GME: [
    {
      currency: 'GME',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GME',
        time: '2022-02-04T09:00:00+00:00',
        size: '32.75437283',
        rate: '1e-6'
      }
    },
    {
      currency: 'GME',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GME',
        time: '2022-02-04T08:00:00+00:00',
        size: '32.75432965',
        rate: '1e-6'
      }
    }
  ],
  HOOD: [
    {
      currency: 'HOOD',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'HOOD',
        time: '2022-02-04T09:00:00+00:00',
        size: '2101.58248166',
        rate: '1e-6'
      }
    },
    {
      currency: 'HOOD',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'HOOD',
        time: '2022-02-04T08:00:00+00:00',
        size: '2101.57970174',
        rate: '1e-6'
      }
    }
  ],
  USD: [
    {
      currency: 'USD',
      rate: '0.0000044685',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'USD',
        time: '2022-02-04T09:00:00+00:00',
        size: '2064033635.4839036',
        rate: '3.31e-6'
      }
    },
    {
      currency: 'USD',
      rate: '0.0000044685',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'USD',
        time: '2022-02-04T08:00:00+00:00',
        size: '2064505096.4258547',
        rate: '3.31e-6'
      }
    }
  ],
  MKR: [
    {
      currency: 'MKR',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'MKR',
        time: '2022-02-04T09:00:00+00:00',
        size: '429.03526451',
        rate: '1e-6'
      }
    },
    {
      currency: 'MKR',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'MKR',
        time: '2022-02-04T08:00:00+00:00',
        size: '429.03479755',
        rate: '1e-6'
      }
    }
  ],
  BNB: [
    {
      currency: 'BNB',
      rate: '0.00000405',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BNB',
        time: '2022-02-04T09:00:00+00:00',
        size: '106284.57154338',
        rate: '3e-6'
      }
    },
    {
      currency: 'BNB',
      rate: '0.000003078',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BNB',
        time: '2022-02-04T08:00:00+00:00',
        size: '106139.5827332',
        rate: '2.28e-6'
      }
    }
  ],
  SXP: [
    {
      currency: 'SXP',
      rate: '0.00000405',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SXP',
        time: '2022-02-04T09:00:00+00:00',
        size: '727984.91747799',
        rate: '3e-6'
      }
    },
    {
      currency: 'SXP',
      rate: '0.00000405',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SXP',
        time: '2022-02-04T08:00:00+00:00',
        size: '723093.0157308',
        rate: '3e-6'
      }
    }
  ],
  DOT: [
    {
      currency: 'DOT',
      rate: '0.000030807',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'DOT',
        time: '2022-02-04T09:00:00+00:00',
        size: '288909.29886744',
        rate: '0.00002282'
      }
    },
    {
      currency: 'DOT',
      rate: '0.000021573',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'DOT',
        time: '2022-02-04T08:00:00+00:00',
        size: '289423.77519285',
        rate: '0.00001598'
      }
    }
  ],
  BABA: [
    {
      currency: 'BABA',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BABA',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.07653572',
        rate: '1e-6'
      }
    },
    {
      currency: 'BABA',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BABA',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.07653561',
        rate: '1e-6'
      }
    }
  ],
  USO: [
    {
      currency: 'USO',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'USO',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.09249012',
        rate: '1e-6'
      }
    },
    {
      currency: 'USO',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'USO',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.09249',
        rate: '1e-6'
      }
    }
  ],
  MATIC: [
    {
      currency: 'MATIC',
      rate: '0.0000462375',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'MATIC',
        time: '2022-02-04T09:00:00+00:00',
        size: '6085371.39312606',
        rate: '0.00003425'
      }
    },
    {
      currency: 'MATIC',
      rate: '0.0000462375',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'MATIC',
        time: '2022-02-04T08:00:00+00:00',
        size: '5959684.51971024',
        rate: '0.00003425'
      }
    }
  ],
  GDX: [
    {
      currency: 'GDX',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GDX',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.00227325',
        rate: '1e-6'
      }
    },
    {
      currency: 'GDX',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GDX',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.00227324',
        rate: '1e-6'
      }
    }
  ],
  ETHE: [
    {
      currency: 'ETHE',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ETHE',
        time: '2022-02-04T09:00:00+00:00',
        size: '91.15540725',
        rate: '1e-6'
      }
    },
    {
      currency: 'ETHE',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ETHE',
        time: '2022-02-04T08:00:00+00:00',
        size: '91.15530899',
        rate: '1e-6'
      }
    }
  ],
  BAND: [
    {
      currency: 'BAND',
      rate: '0.0000092475',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BAND',
        time: '2022-02-04T09:00:00+00:00',
        size: '65476.0826643',
        rate: '6.85e-6'
      }
    },
    {
      currency: 'BAND',
      rate: '0.0000092475',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BAND',
        time: '2022-02-04T08:00:00+00:00',
        size: '65472.06806465',
        rate: '6.85e-6'
      }
    }
  ],
  GDXJ: [
    {
      currency: 'GDXJ',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GDXJ',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'GDXJ',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GDXJ',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  DOGE: [
    {
      currency: 'DOGE',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'DOGE',
        time: '2022-02-04T09:00:00+00:00',
        size: '77835265.44578609',
        rate: '1e-6'
      }
    },
    {
      currency: 'DOGE',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'DOGE',
        time: '2022-02-04T08:00:00+00:00',
        size: '77852592.56422144',
        rate: '1e-6'
      }
    }
  ],
  BITW: [
    {
      currency: 'BITW',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BITW',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'BITW',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BITW',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  AMC: [
    {
      currency: 'AMC',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AMC',
        time: '2022-02-04T09:00:00+00:00',
        size: '78.19064534',
        rate: '1e-6'
      }
    },
    {
      currency: 'AMC',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AMC',
        time: '2022-02-04T08:00:00+00:00',
        size: '78.19054425',
        rate: '1e-6'
      }
    }
  ],
  LTC: [
    {
      currency: 'LTC',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'LTC',
        time: '2022-02-04T09:00:00+00:00',
        size: '122637.19379904',
        rate: '1e-6'
      }
    },
    {
      currency: 'LTC',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'LTC',
        time: '2022-02-04T08:00:00+00:00',
        size: '122028.05015238',
        rate: '1e-6'
      }
    }
  ],
  ETH: [
    {
      currency: 'ETH',
      rate: '0.000001539',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ETH',
        time: '2022-02-04T09:00:00+00:00',
        size: '149416.37074146',
        rate: '1.14e-6'
      }
    },
    {
      currency: 'ETH',
      rate: '0.000001539',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ETH',
        time: '2022-02-04T08:00:00+00:00',
        size: '147415.83393605',
        rate: '1.14e-6'
      }
    }
  ],
  WNDR: [
    {
      currency: 'WNDR',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'WNDR',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'WNDR',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'WNDR',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  MSTR: [
    {
      currency: 'MSTR',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'MSTR',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.00002951',
        rate: '1e-6'
      }
    },
    {
      currency: 'MSTR',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'MSTR',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.00002951',
        rate: '1e-6'
      }
    }
  ],
  BYND: [
    {
      currency: 'BYND',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BYND',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.01089409',
        rate: '1e-6'
      }
    },
    {
      currency: 'BYND',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BYND',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.01089408',
        rate: '1e-6'
      }
    }
  ],
  TLRY: [
    {
      currency: 'TLRY',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TLRY',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'TLRY',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TLRY',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  GRT: [
    {
      currency: 'GRT',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GRT',
        time: '2022-02-04T09:00:00+00:00',
        size: '129576.21642088',
        rate: '1e-6'
      }
    },
    {
      currency: 'GRT',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GRT',
        time: '2022-02-04T08:00:00+00:00',
        size: '128956.06681678',
        rate: '1e-6'
      }
    }
  ],
  '1INCH': [
    {
      currency: '1INCH',
      rate: '0.000030807',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: '1INCH',
        time: '2022-02-04T09:00:00+00:00',
        size: '3063432.66478311',
        rate: '0.00002282'
      }
    },
    {
      currency: '1INCH',
      rate: '0.000030807',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: '1INCH',
        time: '2022-02-04T08:00:00+00:00',
        size: '3062542.29476768',
        rate: '0.00002282'
      }
    }
  ],
  RAY: [
    {
      currency: 'RAY',
      rate: '0.000031212',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'RAY',
        time: '2022-02-04T09:00:00+00:00',
        size: '651710.34052809',
        rate: '0.00002312'
      }
    },
    {
      currency: 'RAY',
      rate: '0.000035451',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'RAY',
        time: '2022-02-04T08:00:00+00:00',
        size: '655882.49556498',
        rate: '0.00002626'
      }
    }
  ],
  CEL: [
    {
      currency: 'CEL',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'CEL',
        time: '2022-02-04T09:00:00+00:00',
        size: '137888.46893012',
        rate: '1e-6'
      }
    },
    {
      currency: 'CEL',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'CEL',
        time: '2022-02-04T08:00:00+00:00',
        size: '139102.72524785',
        rate: '1e-6'
      }
    }
  ],
  NVDA: [
    {
      currency: 'NVDA',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'NVDA',
        time: '2022-02-04T09:00:00+00:00',
        size: '20.57199123',
        rate: '1e-6'
      }
    },
    {
      currency: 'NVDA',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'NVDA',
        time: '2022-02-04T08:00:00+00:00',
        size: '20.57196488',
        rate: '1e-6'
      }
    }
  ],
  GBTC: [
    {
      currency: 'GBTC',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GBTC',
        time: '2022-02-04T09:00:00+00:00',
        size: '90.33462765',
        rate: '1e-6'
      }
    },
    {
      currency: 'GBTC',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GBTC',
        time: '2022-02-04T08:00:00+00:00',
        size: '90.33453046',
        rate: '1e-6'
      }
    }
  ],
  BB: [
    {
      currency: 'BB',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BB',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0742663',
        rate: '1e-6'
      }
    },
    {
      currency: 'BB',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BB',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.07426621',
        rate: '1e-6'
      }
    }
  ],
  UST: [
    {
      currency: 'UST',
      rate: '0.0000308205',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'UST',
        time: '2022-02-04T09:00:00+00:00',
        size: '341762.10601441',
        rate: '0.00002283'
      }
    },
    {
      currency: 'UST',
      rate: '0.0000308205',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'UST',
        time: '2022-02-04T08:00:00+00:00',
        size: '333326.71347458',
        rate: '0.00002283'
      }
    }
  ],
  OKB: [
    {
      currency: 'OKB',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'OKB',
        time: '2022-02-04T09:00:00+00:00',
        size: '32946.19698018',
        rate: '1e-6'
      }
    },
    {
      currency: 'OKB',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'OKB',
        time: '2022-02-04T08:00:00+00:00',
        size: '32935.4572445',
        rate: '1e-6'
      }
    }
  ],
  ZM: [
    {
      currency: 'ZM',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ZM',
        time: '2022-02-04T09:00:00+00:00',
        size: '3.2e-6',
        rate: '1e-6'
      }
    },
    {
      currency: 'ZM',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ZM',
        time: '2022-02-04T08:00:00+00:00',
        size: '3.2e-6',
        rate: '1e-6'
      }
    }
  ],
  SPY: [
    {
      currency: 'SPY',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SPY',
        time: '2022-02-04T09:00:00+00:00',
        size: '127.00428367',
        rate: '1e-6'
      }
    },
    {
      currency: 'SPY',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SPY',
        time: '2022-02-04T08:00:00+00:00',
        size: '126.92711525',
        rate: '1e-6'
      }
    }
  ],
  HT: [
    {
      currency: 'HT',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'HT',
        time: '2022-02-04T09:00:00+00:00',
        size: '187107.21757281',
        rate: '1e-6'
      }
    },
    {
      currency: 'HT',
      rate: '0.000003078',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'HT',
        time: '2022-02-04T08:00:00+00:00',
        size: '186384.08476907',
        rate: '2.28e-6'
      }
    }
  ],
  SNX: [
    {
      currency: 'SNX',
      rate: '0.000004617',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SNX',
        time: '2022-02-04T09:00:00+00:00',
        size: '231226.26951442',
        rate: '3.42e-6'
      }
    },
    {
      currency: 'SNX',
      rate: '0.000004617',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SNX',
        time: '2022-02-04T08:00:00+00:00',
        size: '230596.15061133',
        rate: '3.42e-6'
      }
    }
  ],
  RSR: [
    {
      currency: 'RSR',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'RSR',
        time: '2022-02-04T09:00:00+00:00',
        size: '15320234.40878539',
        rate: '1e-6'
      }
    },
    {
      currency: 'RSR',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'RSR',
        time: '2022-02-04T08:00:00+00:00',
        size: '15465515.25450211',
        rate: '1e-6'
      }
    }
  ],
  ALPHA: [
    {
      currency: 'ALPHA',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ALPHA',
        time: '2022-02-04T09:00:00+00:00',
        size: '267666.82453801',
        rate: '1e-6'
      }
    },
    {
      currency: 'ALPHA',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ALPHA',
        time: '2022-02-04T08:00:00+00:00',
        size: '261832.71715117',
        rate: '1e-6'
      }
    }
  ],
  REN: [
    {
      currency: 'REN',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'REN',
        time: '2022-02-04T09:00:00+00:00',
        size: '2237732.21578377',
        rate: '1e-6'
      }
    },
    {
      currency: 'REN',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'REN',
        time: '2022-02-04T08:00:00+00:00',
        size: '2232792.59362804',
        rate: '1e-6'
      }
    }
  ],
  BNT: [
    {
      currency: 'BNT',
      rate: '0.0000308205',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BNT',
        time: '2022-02-04T09:00:00+00:00',
        size: '452533.10471448',
        rate: '0.00002283'
      }
    },
    {
      currency: 'BNT',
      rate: '0.0000308205',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BNT',
        time: '2022-02-04T08:00:00+00:00',
        size: '452288.11687672',
        rate: '0.00002283'
      }
    }
  ],
  FTM: [
    {
      currency: 'FTM',
      rate: '0.0000462375',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'FTM',
        time: '2022-02-04T09:00:00+00:00',
        size: '8194263.84956765',
        rate: '0.00003425'
      }
    },
    {
      currency: 'FTM',
      rate: '0.0000462375',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'FTM',
        time: '2022-02-04T08:00:00+00:00',
        size: '8244747.79875424',
        rate: '0.00003425'
      }
    }
  ],
  AXS: [
    {
      currency: 'AXS',
      rate: '0.000054',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AXS',
        time: '2022-02-04T09:00:00+00:00',
        size: '33334.09086708',
        rate: '0.00004'
      }
    },
    {
      currency: 'AXS',
      rate: '0.000054',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AXS',
        time: '2022-02-04T08:00:00+00:00',
        size: '33519.96735779',
        rate: '0.00004'
      }
    }
  ],
  AVAX: [
    {
      currency: 'AVAX',
      rate: '0.0000123255',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AVAX',
        time: '2022-02-04T09:00:00+00:00',
        size: '188944.85357517',
        rate: '9.13e-6'
      }
    },
    {
      currency: 'AVAX',
      rate: '0.0000123255',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AVAX',
        time: '2022-02-04T08:00:00+00:00',
        size: '187749.02940238',
        rate: '9.13e-6'
      }
    }
  ],
  DAI: [
    {
      currency: 'DAI',
      rate: '0.000015417',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'DAI',
        time: '2022-02-04T09:00:00+00:00',
        size: '3954183.65028341',
        rate: '0.00001142'
      }
    },
    {
      currency: 'DAI',
      rate: '0.000018495',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'DAI',
        time: '2022-02-04T08:00:00+00:00',
        size: '3952549.1644385',
        rate: '0.0000137'
      }
    }
  ],
  AMZN: [
    {
      currency: 'AMZN',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AMZN',
        time: '2022-02-04T09:00:00+00:00',
        size: '1.35362982',
        rate: '1e-6'
      }
    },
    {
      currency: 'AMZN',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AMZN',
        time: '2022-02-04T08:00:00+00:00',
        size: '1.35362805',
        rate: '1e-6'
      }
    }
  ],
  TSLA: [
    {
      currency: 'TSLA',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TSLA',
        time: '2022-02-04T09:00:00+00:00',
        size: '887.73844223',
        rate: '1e-6'
      }
    },
    {
      currency: 'TSLA',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TSLA',
        time: '2022-02-04T08:00:00+00:00',
        size: '887.73737774',
        rate: '1e-6'
      }
    }
  ],
  FB: [
    {
      currency: 'FB',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'FB',
        time: '2022-02-04T09:00:00+00:00',
        size: '1.04222025',
        rate: '1e-6'
      }
    },
    {
      currency: 'FB',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'FB',
        time: '2022-02-04T08:00:00+00:00',
        size: '1.04221885',
        rate: '1e-6'
      }
    }
  ],
  NFLX: [
    {
      currency: 'NFLX',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'NFLX',
        time: '2022-02-04T09:00:00+00:00',
        size: '50.00216797',
        rate: '1e-6'
      }
    },
    {
      currency: 'NFLX',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'NFLX',
        time: '2022-02-04T08:00:00+00:00',
        size: '50.00210734',
        rate: '1e-6'
      }
    }
  ],
  TWTR: [
    {
      currency: 'TWTR',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TWTR',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.00077987',
        rate: '1e-6'
      }
    },
    {
      currency: 'TWTR',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TWTR',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.00077987',
        rate: '1e-6'
      }
    }
  ],
  ASD: [
    {
      currency: 'ASD',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ASD',
        time: '2022-02-04T09:00:00+00:00',
        size: '158005.95973511',
        rate: '1e-6'
      }
    },
    {
      currency: 'ASD',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ASD',
        time: '2022-02-04T08:00:00+00:00',
        size: '158005.83721843',
        rate: '1e-6'
      }
    }
  ],
  XAUT: [
    {
      currency: 'XAUT',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'XAUT',
        time: '2022-02-04T09:00:00+00:00',
        size: '12.13922367',
        rate: '1e-6'
      }
    },
    {
      currency: 'XAUT',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'XAUT',
        time: '2022-02-04T08:00:00+00:00',
        size: '12.14020835',
        rate: '1e-6'
      }
    }
  ],
  GOOGL: [
    {
      currency: 'GOOGL',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GOOGL',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.02336891',
        rate: '1e-6'
      }
    },
    {
      currency: 'GOOGL',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GOOGL',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.02336888',
        rate: '1e-6'
      }
    }
  ],
  NIO: [
    {
      currency: 'NIO',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'NIO',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.09037633',
        rate: '1e-6'
      }
    },
    {
      currency: 'NIO',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'NIO',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.09037622',
        rate: '1e-6'
      }
    }
  ],
  TRX: [
    {
      currency: 'TRX',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TRX',
        time: '2022-02-04T09:00:00+00:00',
        size: '35964603.22789604',
        rate: '1e-6'
      }
    },
    {
      currency: 'TRX',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TRX',
        time: '2022-02-04T08:00:00+00:00',
        size: '35860479.89061225',
        rate: '1e-6'
      }
    }
  ],
  CGC: [
    {
      currency: 'CGC',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'CGC',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'CGC',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'CGC',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  MOB: [
    {
      currency: 'MOB',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'MOB',
        time: '2022-02-04T09:00:00+00:00',
        size: '16117.93484028',
        rate: '1e-6'
      }
    },
    {
      currency: 'MOB',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'MOB',
        time: '2022-02-04T08:00:00+00:00',
        size: '16117.91449889',
        rate: '1e-6'
      }
    }
  ],
  BCH: [
    {
      currency: 'BCH',
      rate: '0.000003078',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BCH',
        time: '2022-02-04T09:00:00+00:00',
        size: '12277.64919363',
        rate: '2.28e-6'
      }
    },
    {
      currency: 'BCH',
      rate: '0.000003078',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BCH',
        time: '2022-02-04T08:00:00+00:00',
        size: '11219.90827251',
        rate: '2.28e-6'
      }
    }
  ],
  CAD: [
    {
      currency: 'CAD',
      rate: '0.0000107865',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'CAD',
        time: '2022-02-04T09:00:00+00:00',
        size: '515233.86663929',
        rate: '7.99e-6'
      }
    },
    {
      currency: 'CAD',
      rate: '0.0000107865',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'CAD',
        time: '2022-02-04T08:00:00+00:00',
        size: '514934.49298737',
        rate: '7.99e-6'
      }
    }
  ],
  USDT: [
    {
      currency: 'USDT',
      rate: '0.000003078',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'USDT',
        time: '2022-02-04T09:00:00+00:00',
        size: '597209846.744583',
        rate: '2.28e-6'
      }
    },
    {
      currency: 'USDT',
      rate: '0.000003078',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'USDT',
        time: '2022-02-04T08:00:00+00:00',
        size: '594107218.693107',
        rate: '2.28e-6'
      }
    }
  ],
  AMD: [
    {
      currency: 'AMD',
      rate: '0.000023112',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AMD',
        time: '2022-02-04T09:00:00+00:00',
        size: '438.76763699',
        rate: '0.00001712'
      }
    },
    {
      currency: 'AMD',
      rate: '0.000023112',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AMD',
        time: '2022-02-04T08:00:00+00:00',
        size: '438.75852923',
        rate: '0.00001712'
      }
    }
  ],
  TRYB: [
    {
      currency: 'TRYB',
      rate: '0.000040068',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TRYB',
        time: '2022-02-04T09:00:00+00:00',
        size: '25489616.61386517',
        rate: '0.00002968'
      }
    },
    {
      currency: 'TRYB',
      rate: '0.000040068',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TRYB',
        time: '2022-02-04T08:00:00+00:00',
        size: '25327312.25870725',
        rate: '0.00002968'
      }
    }
  ],
  AUD: [
    {
      currency: 'AUD',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AUD',
        time: '2022-02-04T09:00:00+00:00',
        size: '367928.90915987',
        rate: '1e-6'
      }
    },
    {
      currency: 'AUD',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AUD',
        time: '2022-02-04T08:00:00+00:00',
        size: '367928.44026532',
        rate: '1e-6'
      }
    }
  ],
  LEO: [
    {
      currency: 'LEO',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'LEO',
        time: '2022-02-04T09:00:00+00:00',
        size: '59235.89062081',
        rate: '1e-6'
      }
    },
    {
      currency: 'LEO',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'LEO',
        time: '2022-02-04T08:00:00+00:00',
        size: '59235.81394956',
        rate: '1e-6'
      }
    }
  ],
  PAXG: [
    {
      currency: 'PAXG',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'PAXG',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'PAXG',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'PAXG',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  AAPL: [
    {
      currency: 'AAPL',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AAPL',
        time: '2022-02-04T09:00:00+00:00',
        size: '175.8456134',
        rate: '1e-6'
      }
    },
    {
      currency: 'AAPL',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AAPL',
        time: '2022-02-04T08:00:00+00:00',
        size: '175.84539337',
        rate: '1e-6'
      }
    }
  ],
  WBTC: [
    {
      currency: 'WBTC',
      rate: '0.0000077085',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'WBTC',
        time: '2022-02-04T09:00:00+00:00',
        size: '261.42798667',
        rate: '5.71e-6'
      }
    },
    {
      currency: 'WBTC',
      rate: '0.0000029295',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'WBTC',
        time: '2022-02-04T08:00:00+00:00',
        size: '246.84706055',
        rate: '2.17e-6'
      }
    }
  ],
  BNTX: [
    {
      currency: 'BNTX',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BNTX',
        time: '2022-02-04T09:00:00+00:00',
        size: '3.52165181',
        rate: '1e-6'
      }
    },
    {
      currency: 'BNTX',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BNTX',
        time: '2022-02-04T08:00:00+00:00',
        size: '3.52164718',
        rate: '1e-6'
      }
    }
  ],
  PFE: [
    {
      currency: 'PFE',
      rate: '0.0000308205',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'PFE',
        time: '2022-02-04T09:00:00+00:00',
        size: '943.39045055',
        rate: '0.00002283'
      }
    },
    {
      currency: 'PFE',
      rate: '0.0000308205',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'PFE',
        time: '2022-02-04T08:00:00+00:00',
        size: '943.36429834',
        rate: '0.00002283'
      }
    }
  ],
  RUNE: [
    {
      currency: 'RUNE',
      rate: '0.0000123255',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'RUNE',
        time: '2022-02-04T09:00:00+00:00',
        size: '1465572.68935153',
        rate: '9.13e-6'
      }
    },
    {
      currency: 'RUNE',
      rate: '0.0000123255',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'RUNE',
        time: '2022-02-04T08:00:00+00:00',
        size: '1452555.4883133',
        rate: '9.13e-6'
      }
    }
  ],
  YFI: [
    {
      currency: 'YFI',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'YFI',
        time: '2022-02-04T09:00:00+00:00',
        size: '31.05678481',
        rate: '1e-6'
      }
    },
    {
      currency: 'YFI',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'YFI',
        time: '2022-02-04T08:00:00+00:00',
        size: '28.84805559',
        rate: '1e-6'
      }
    }
  ],
  SQ: [
    {
      currency: 'SQ',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SQ',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.00001368',
        rate: '1e-6'
      }
    },
    {
      currency: 'SQ',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SQ',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.00001368',
        rate: '1e-6'
      }
    }
  ],
  SOL: [
    {
      currency: 'SOL',
      rate: '0.0000027675',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'SOL',
        time: '2022-02-04T09:00:00+00:00',
        size: '498084.29671694',
        rate: '2.05e-6'
      }
    },
    {
      currency: 'SOL',
      rate: '0.000002889',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'SOL',
        time: '2022-02-04T08:00:00+00:00',
        size: '501868.1910142',
        rate: '2.14e-6'
      }
    }
  ],
  AAVE: [
    {
      currency: 'AAVE',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'AAVE',
        time: '2022-02-04T09:00:00+00:00',
        size: '24432.75726018',
        rate: '1e-6'
      }
    },
    {
      currency: 'AAVE',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'AAVE',
        time: '2022-02-04T08:00:00+00:00',
        size: '24815.15325741',
        rate: '1e-6'
      }
    }
  ],
  BTC: [
    {
      currency: 'BTC',
      rate: '0.000002889',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BTC',
        time: '2022-02-04T09:00:00+00:00',
        size: '27307.4117726',
        rate: '2.14e-6'
      }
    },
    {
      currency: 'BTC',
      rate: '0.000002889',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BTC',
        time: '2022-02-04T08:00:00+00:00',
        size: '27242.04619091',
        rate: '2.14e-6'
      }
    }
  ],
  GBP: [
    {
      currency: 'GBP',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GBP',
        time: '2022-02-04T09:00:00+00:00',
        size: '59770.84872841',
        rate: '1e-6'
      }
    },
    {
      currency: 'GBP',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GBP',
        time: '2022-02-04T08:00:00+00:00',
        size: '59205.77393578',
        rate: '1e-6'
      }
    }
  ],
  LINK: [
    {
      currency: 'LINK',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'LINK',
        time: '2022-02-04T09:00:00+00:00',
        size: '268588.86546455',
        rate: '1e-6'
      }
    },
    {
      currency: 'LINK',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'LINK',
        time: '2022-02-04T08:00:00+00:00',
        size: '269494.87984064',
        rate: '1e-6'
      }
    }
  ],
  BRZ: [
    {
      currency: 'BRZ',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BRZ',
        time: '2022-02-04T09:00:00+00:00',
        size: '1967881.97774575',
        rate: '1e-6'
      }
    },
    {
      currency: 'BRZ',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BRZ',
        time: '2022-02-04T08:00:00+00:00',
        size: '1967971.56705012',
        rate: '1e-6'
      }
    }
  ],
  CUSDT: [
    {
      currency: 'CUSDT',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'CUSDT',
        time: '2022-02-04T09:00:00+00:00',
        size: '2972380.72079486',
        rate: '1e-6'
      }
    },
    {
      currency: 'CUSDT',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'CUSDT',
        time: '2022-02-04T08:00:00+00:00',
        size: '2998873.65650035',
        rate: '1e-6'
      }
    }
  ],
  DKNG: [
    {
      currency: 'DKNG',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'DKNG',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.24532992',
        rate: '1e-6'
      }
    },
    {
      currency: 'DKNG',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'DKNG',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.24532959',
        rate: '1e-6'
      }
    }
  ],
  PENN: [
    {
      currency: 'PENN',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'PENN',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'PENN',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'PENN',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  EUR: [
    {
      currency: 'EUR',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'EUR',
        time: '2022-02-04T09:00:00+00:00',
        size: '2829860.93961664',
        rate: '1e-6'
      }
    },
    {
      currency: 'EUR',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'EUR',
        time: '2022-02-04T08:00:00+00:00',
        size: '2828014.65665642',
        rate: '1e-6'
      }
    }
  ],
  MRNA: [
    {
      currency: 'MRNA',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'MRNA',
        time: '2022-02-04T09:00:00+00:00',
        size: '4.23396833',
        rate: '1e-6'
      }
    },
    {
      currency: 'MRNA',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'MRNA',
        time: '2022-02-04T08:00:00+00:00',
        size: '4.23396272',
        rate: '1e-6'
      }
    }
  ],
  TSM: [
    {
      currency: 'TSM',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'TSM',
        time: '2022-02-04T09:00:00+00:00',
        size: '107.1046828',
        rate: '1e-6'
      }
    },
    {
      currency: 'TSM',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'TSM',
        time: '2022-02-04T08:00:00+00:00',
        size: '107.10454945',
        rate: '1e-6'
      }
    }
  ],
  GLXY: [
    {
      currency: 'GLXY',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GLXY',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.000382',
        rate: '1e-6'
      }
    },
    {
      currency: 'GLXY',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GLXY',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.000382',
        rate: '1e-6'
      }
    }
  ],
  GLD: [
    {
      currency: 'GLD',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'GLD',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'GLD',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'GLD',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  UBER: [
    {
      currency: 'UBER',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'UBER',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.00024326',
        rate: '1e-6'
      }
    },
    {
      currency: 'UBER',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'UBER',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.00024326',
        rate: '1e-6'
      }
    }
  ],
  BILI: [
    {
      currency: 'BILI',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'BILI',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.00903563',
        rate: '1e-6'
      }
    },
    {
      currency: 'BILI',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'BILI',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.00903562',
        rate: '1e-6'
      }
    }
  ],
  ACB: [
    {
      currency: 'ACB',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'ACB',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    },
    {
      currency: 'ACB',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'ACB',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.0',
        rate: '1e-6'
      }
    }
  ],
  COIN: [
    {
      currency: 'COIN',
      rate: '0.00000135',
      timestamp: 1643965200000,
      datetime: '2022-02-04T09:00:00+00:00',
      info: {
        coin: 'COIN',
        time: '2022-02-04T09:00:00+00:00',
        size: '0.38835518',
        rate: '1e-6'
      }
    },
    {
      currency: 'COIN',
      rate: '0.00000135',
      timestamp: 1643961600000,
      datetime: '2022-02-04T08:00:00+00:00',
      info: {
        coin: 'COIN',
        time: '2022-02-04T08:00:00+00:00',
        size: '0.3883547',
        rate: '1e-6'
      }
    }
  ]
}
```