### PR TITLE
gateio fetchMyTrades symbol is optional

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1866,7 +1866,7 @@ module.exports = class gateio extends Exchange {
             type = market['type'];
         } else {
             if (type === 'swap' || type === 'future') {
-                const settle = this.safeString (params, 'settle');
+                const settle = this.safeStringLower (params, 'settle');
                 if (!settle) {
                     throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol argument or a settle parameter for ' + type + ' markets');
                 }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1868,7 +1868,7 @@ module.exports = class gateio extends Exchange {
             if (type === 'swap' || type === 'future') {
                 const settle = this.safeString (params, 'settle');
                 if (!settle) {
-                    throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol or a settle parameter for ' + type + ' markets');
+                    throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol argument or a settle parameter for ' + type + ' markets');
                 }
                 request['settle'] = settle;
             }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1866,9 +1866,9 @@ module.exports = class gateio extends Exchange {
             type = market['type'];
         } else {
             if (type === 'swap' || type === 'future') {
-                const settle = this.safeStringLower (params, 'settle');
+                const settle = this.safeString (params, 'settle');
                 if (!settle) {
-                    throw new ArgumentsRequired (this.id + '.fetchMyTrades requires one of symbol or params.settle when trading ' + type);
+                    throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol or a settle parameter for ' + type + ' markets');
                 }
                 request['settle'] = settle;
             }


### PR DESCRIPTION
Solves: https://github.com/ccxt/ccxt/issues/11842

```
2022-02-04T09:49:38.337Z
Node.js: v14.17.0
CCXT v1.72.19
gateio.fetchMyTrades ()
191 ms
        id |     timestamp |                 datetime |   symbol |        order | type | side | takerOrMaker |  price | amount |   cost |                                    fee |                                     fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2756573185 | 1643952267682 | 2022-02-04T05:24:27.682Z | ADA/USDT | 121239719614 |      |  buy |        taker | 1.0702 |      1 | 1.0702 |      {"cost":0.00195,"currency":"ADA"} |      [{"currency":"ADA","cost":0.00195}]
2756573187 | 1643952267690 | 2022-02-04T05:24:27.690Z | ADA/USDT | 121239719680 |      |  buy |        taker | 1.0702 |      1 | 1.0702 |      {"cost":0.00195,"currency":"ADA"} |      [{"currency":"ADA","cost":0.00195}]
2757334884 | 1643962764091 | 2022-02-04T08:19:24.091Z | ADA/USDT | 121272785099 |      | sell |        taker | 1.0685 |      1 | 1.0685 | {"cost":0.002083575,"currency":"USDT"} | [{"currency":"USDT","cost":0.002083575}]
3 objects
```

```
gateio.fetchMyTrades (ADA/USDT)
183 ms
        id |     timestamp |                 datetime |   symbol |        order | type | side | takerOrMaker |  price | amount |   cost |                                    fee |                                     fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2756573185 | 1643952267682 | 2022-02-04T05:24:27.682Z | ADA/USDT | 121239719614 |      |  buy |        taker | 1.0702 |      1 | 1.0702 |      {"cost":0.00195,"currency":"ADA"} |      [{"currency":"ADA","cost":0.00195}]
2756573187 | 1643952267690 | 2022-02-04T05:24:27.690Z | ADA/USDT | 121239719680 |      |  buy |        taker | 1.0702 |      1 | 1.0702 |      {"cost":0.00195,"currency":"ADA"} |      [{"currency":"ADA","cost":0.00195}]
2757334884 | 1643962764091 | 2022-02-04T08:19:24.091Z | ADA/USDT | 121272785099 |      | sell |        taker | 1.0685 |      1 | 1.0685 | {"cost":0.002083575,"currency":"USDT"} | [{"currency":"USDT","cost":0.002083575}]
3 objects
```


# SWAP
```
% gateio fetchMyTrades undefined undefined undefined '{"settle": "usdt"}' | condense
gateio.fetchMyTrades (, , , [object Object])
283 ms
      id | timestamp | datetime |         symbol |        order | type | side | takerOrMaker |       price | amount |        cost |               fee |                fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
23180942 |           |          | SHIB/USDT:USDT | 101522079437 |      | sell |        taker | 0.000049494 |   1634 | 0.080873196 | {"currency":"GT"} | [{"currency":"GT"}]
...
54817714 |           |          |  ETH/USDT:USDT | 114425472293 |      | sell |        taker |      3609.6 |      1 |      3609.6 | {"currency":"GT"} | [{"currency":"GT"}]
54817715 |           |          |  ETH/USDT:USDT | 114425472293 |      | sell |        taker |      3609.6 |      4 |     14438.4 | {"currency":"GT"} | [{"currency":"GT"}]
100 objects
```

```
gateio.fetchMyTrades (ETH/USDT:USDT)
206 ms
      id | timestamp | datetime |        symbol |        order | type | side | takerOrMaker |   price | amount |      cost |               fee |                fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
45334734 |           |          | ETH/USDT:USDT |  96431984046 |      | sell |        taker |  4372.3 |     44 |  1923.812 | {"currency":"GT"} | [{"currency":"GT"}]
...
54817714 |           |          | ETH/USDT:USDT | 114425472293 |      | sell |        taker |  3609.6 |      1 |    36.096 | {"currency":"GT"} | [{"currency":"GT"}]
54817715 |           |          | ETH/USDT:USDT | 114425472293 |      | sell |        taker |  3609.6 |      4 |   144.384 | {"currency":"GT"} | [{"currency":"GT"}]
98 objects
```

```
gateio.fetchMyTrades ()
ArgumentsRequired gateio.fetchMyTrades requires one of symbol or params.settle when trading swap
---------------------------------------------------
[ArgumentsRequired] gateio.fetchMyTrades requires one of symbol or params.settle when trading swap

    at fetchMyTrades              ../../ccxt/ccxt/js/gateio.js:1871       throw new ArgumentsRequired (this.id + '.fetchMyTrades requires one of symbol o…
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:256  const result = await exchange[methodName] (... args)                            

gateio.fetchMyTrades requires one of symbol or params.settle when trading swap
```