### PR TITLE
bibox unified sorted

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -220,44 +220,46 @@ module.exports = class bibox extends Exchange {
                 // TODO: update to v3 api
                 continue;
             }
-            const precision = {
-                'amount': this.safeNumber (market, 'amount_scale'),
-                'price': this.safeNumber (market, 'decimal'),
-            };
             result.push ({
                 'id': id,
                 'numericId': numericId,
                 'symbol': symbol,
                 'base': base,
                 'quote': quote,
+                'settle': undefined,
                 'baseId': baseId,
                 'quoteId': quoteId,
+                'settleId': undefined,
                 'type': type,
                 'spot': spot,
                 'margin': false,
                 'future': false,
                 'swap': false,
                 'option': false,
-                'optionType': undefined,
-                'strike': undefined,
+                'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'contract': false,
                 'contractSize': undefined,
-                'settle': undefined,
-                'settleId': undefined,
+                'active': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,
-                'active': undefined,
-                'info': market,
-                'precision': precision,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'price': this.safeNumber (market, 'decimal'),
+                    'amount': this.safeNumber (market, 'amount_scale'),
+                },
                 'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
                     'amount': {
-                        'min': Math.pow (10, -precision['amount']),
+                        'min': undefined,
                         'max': undefined,
                     },
                     'price': {
-                        'min': Math.pow (10, -precision['price']),
+                        'min': undefined,
                         'max': undefined,
                     },
                     'cost': {
@@ -265,6 +267,7 @@ module.exports = class bibox extends Exchange {
                         'max': undefined,
                     },
                 },
+                'info': market,
             });
         }
         return result;


### PR DESCRIPTION
```
2022-02-04T10:04:21.032Z
Node.js: v14.17.0
CCXT v1.72.19
bibox.fetchMarkets ()
4608 ms
              id | numericId |            symbol |         base | quote | settle |      baseId | quoteId | settleId | type | spot | margin | future |  swap | option | contract | linear | inverse | contractSize | active | expiry | expiryDatetime | strike | optionType |               precision |                                                       limits
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
         BIX_BTC |         1 |           BIX/BTC |          BIX |   BTC |        |         BIX |     BTC |          | spot | true |  false |  false | false |  false |    false |        |         |              |        |        |                |        |            |  {"price":8,"amount":4} | {"leverage":{},"amount":{},"price":{},"cost":{"min":0.0002}}
...
         i7_USDT |      1021 |           I7/USDT |           I7 |  USDT |        |          i7 |    USDT |          | spot | true |  false |  false | false |  false |    false |        |         |              |        |        |                |        |            |  {"price":4,"amount":2} |      {"leverage":{},"amount":{},"price":{},"cost":{"min":1}}
       CAND_USDT |      1022 |         CAND/USDT |         CAND |  USDT |        |        CAND |    USDT |          | spot | true |  false |  false | false |  false |    false |        |         |              |        |        |                |        |            |  {"price":6,"amount":4} |      {"leverage":{},"amount":{},"price":{},"cost":{"min":1}}
401 objects
```