### PR TITLE
binance withdrawOrderId

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3952,6 +3952,10 @@ module.exports = class binance extends Exchange {
             request['network'] = network;
             params = this.omit (params, 'network');
         }
+        const withdrawOrderId = this.safeString (params, 'withdrawOrderId');
+        if (withdrawOrderId === undefined) {
+            request['withdrawOrderId'] = this.uuid22 ();
+        }
         const response = await this.sapiPostCapitalWithdrawApply (this.extend (request, params));
         //     { id: '9a67628b16ba4988ae20d329333f16bc' }
         return {


### PR DESCRIPTION
add withdrawOrderId to withdraw by default so that withdrawHistory can get send the optional `withdrawOrderId`, if the argument is not present in withdraw it is not possible to filter it later

https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data

