### PR TITLE
kucoinfutures.parseOrder fix

### DIFF
--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1141,10 +1141,11 @@ module.exports = class kucoinfutures extends kucoin {
         const cost = Precise.stringDiv (rawCost, leverage);
         let average = undefined;
         if (Precise.stringGt (filled, '0')) {
+            const contractSize = this.safeString (market, 'contractSize');
             if (market['linear']) {
-                average = Precise.stringDiv (rawCost, Precise.stringMul (market['contractSize'], filled));
+                average = Precise.stringDiv (rawCost, Precise.stringMul (contractSize, filled));
             } else {
-                average = Precise.stringDiv (Precise.stringMul (market['contractSize'], filled), rawCost);
+                average = Precise.stringDiv (Precise.stringMul (contractSize, filled), rawCost);
             }
         }
         // precision reported by their api is 8 d.p.


### PR DESCRIPTION
`contractSize` was changed to a number in markets, but this code using the contract size is still expecting a string. I expect there might be other locations in the ccxt where `contractSize` is accessed  and is still expecting a string