### PR TITLE
Bybit :: fix fetchFundingRate

### DIFF
--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -20,7 +20,7 @@ const prop = (o, k) => (isObject (o) ? o[k] : undefined)
 /*  .............................................   */
 
 const asFloat   = x => ((isNumber (x) || isString (x)) ? parseFloat (x)     : NaN)
-    , asInteger = x => ((isNumber (x) || isString (x)) ? parseInt   (x, 10) : NaN)
+    , asInteger = x => ((isNumber (x) || isString (x)) ? Math.round(Number(x)) : NaN)
 
 /*  .............................................   */
 

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1241,14 +1241,9 @@ module.exports = class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result');
         const fundingRate = this.safeNumber (result, 'funding_rate');
-        let fundingTime = this.safeInteger (result, 'funding_rate_timestamp');
-        let dateTime = undefined;
-        if (fundingTime !== undefined) {
-            fundingTime = fundingTime * 1000;
-            dateTime = this.iso8601 (fundingTime);
-        } else {
-            dateTime = this.safeString (result, 'funding_rate_timestamp');
-            fundingTime = this.parse8601 (dateTime);
+        let fundingTimestamp = this.safeTimestamp (result, 'funding_rate_timestamp');
+        if (fundingTimestamp === undefined) {
+            fundingTimestamp = this.parse8601 (this.safeString (result, 'funding_rate_timestamp'));
         }
         const nextFundingTime = this.sum (fundingTime, 8 * 3600000);
         const currentTime = this.milliseconds ();
@@ -1262,8 +1257,8 @@ module.exports = class bybit extends Exchange {
             'timestamp': currentTime,
             'datetime': dateTime,
             'fundingRate': fundingRate,
-            'fundingTimestamp': fundingTime,
-            'fundingDatetime': this.iso8601 (fundingTime),
+            'fundingTimestamp': fundingTimestamp,
+            'fundingDatetime': this.iso8601 (fundingTimestamp),
             'nextFundingRate': undefined,
             'nextFundingTimestamp': nextFundingTime,
             'nextFundingDatetime': this.iso8601 (nextFundingTime),

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1245,7 +1245,7 @@ module.exports = class bybit extends Exchange {
         if (fundingTimestamp === undefined) {
             fundingTimestamp = this.parse8601 (this.safeString (result, 'funding_rate_timestamp'));
         }
-        const nextFundingTime = this.sum (fundingTimestamp, 8 * 3600000);
+        const nextFundingTimestamp = this.sum (fundingTimestamp, 8 * 3600000);
         const currentTime = this.milliseconds ();
         return {
             'info': result,
@@ -1260,8 +1260,8 @@ module.exports = class bybit extends Exchange {
             'fundingTimestamp': fundingTimestamp,
             'fundingDatetime': this.iso8601 (fundingTimestamp),
             'nextFundingRate': undefined,
-            'nextFundingTimestamp': nextFundingTime,
-            'nextFundingDatetime': this.iso8601 (nextFundingTime),
+            'nextFundingTimestamp': nextFundingTimestamp,
+            'nextFundingDatetime': this.iso8601 (nextFundingTimestamp),
             'previousFundingRate': undefined,
             'previousFundingTimestamp': undefined,
             'previousFundingDatetime': undefined,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1245,7 +1245,7 @@ module.exports = class bybit extends Exchange {
         if (fundingTimestamp === undefined) {
             fundingTimestamp = this.parse8601 (this.safeString (result, 'funding_rate_timestamp'));
         }
-        const nextFundingTime = this.sum (fundingTime, 8 * 3600000);
+        const nextFundingTime = this.sum (fundingTimestamp, 8 * 3600000);
         const currentTime = this.milliseconds ();
         return {
             'info': result,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1255,7 +1255,7 @@ module.exports = class bybit extends Exchange {
             'interestRate': undefined,
             'estimatedSettlePrice': undefined,
             'timestamp': currentTime,
-            'datetime': dateTime,
+            'datetime': this.iso8601 (currentTime),
             'fundingRate': fundingRate,
             'fundingTimestamp': fundingTimestamp,
             'fundingDatetime': this.iso8601 (fundingTimestamp),

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1228,6 +1228,9 @@ module.exports = class bybit extends Exchange {
         //         "symbol": "BTCUSD",
         //         "funding_rate": "0.00010000",
         //         "funding_rate_timestamp": 1577433600
+        //          OR for some pairs (ex: BTC/USDT)
+        //         "funding_rate_timestamp":"2022-02-05T08:00:00.000Z"
+        //
         //     },
         //     "ext_info": null,
         //     "time_now": "1577445586.446797",
@@ -1238,7 +1241,15 @@ module.exports = class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result');
         const fundingRate = this.safeNumber (result, 'funding_rate');
-        const fundingTime = this.safeInteger (result, 'funding_rate_timestamp') * 1000;
+        let fundingTime = this.safeInteger (result, 'funding_rate_timestamp');
+        let dateTime = undefined;
+        if (fundingTime !== undefined) {
+            fundingTime = fundingTime * 1000;
+            dateTime = this.iso8601 (fundingTime);
+        } else {
+            dateTime = this.safeString (result, 'funding_rate_timestamp');
+            fundingTime = this.parse8601 (dateTime);
+        }
         const nextFundingTime = this.sum (fundingTime, 8 * 3600000);
         const currentTime = this.milliseconds ();
         return {
@@ -1249,7 +1260,7 @@ module.exports = class bybit extends Exchange {
             'interestRate': undefined,
             'estimatedSettlePrice': undefined,
             'timestamp': currentTime,
-            'datetime': this.iso8601 (currentTime),
+            'datetime': dateTime,
             'fundingRate': fundingRate,
             'fundingTimestamp': fundingTime,
             'fundingDatetime': this.iso8601 (fundingTime),

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1228,8 +1228,8 @@ module.exports = class bybit extends Exchange {
         //         "symbol": "BTCUSD",
         //         "funding_rate": "0.00010000",
         //         "funding_rate_timestamp": 1577433600
-        //          OR for some pairs (ex: BTC/USDT)
-        //         "funding_rate_timestamp":"2022-02-05T08:00:00.000Z"
+        //         // some pairs like BTC/USDT return an iso8601 string in funding_rate_timestamp
+        //         // "funding_rate_timestamp":"2022-02-05T08:00:00.000Z"
         //
         //     },
         //     "ext_info": null,


### PR DESCRIPTION
fixes #11861 

For the reasons mentioned before I've decided to change the `safeInteger` method to return undefined in cases where the string is not a pure integer (everything else works the same).

Before:
`this.safeInteger({"funding_rate_timestamp":"2022-02-05T08:00:00.000Z"}, 'funding_rate_timestamp)` -> 2022
Now:
`this.safeInteger({"funding_rate_timestamp":"2022-02-05T08:00:00.000Z"}, 'funding_rate_timestamp)` -> undefined

As always if you don't agree with that approach, just let me know and I'll revert it