### PR TITLE
fix `code` undefined

### DIFF
--- a/js/test/test.js
+++ b/js/test/test.js
@@ -226,7 +226,7 @@ async function testExchange (exchange) {
         'ZRX',
     ]
 
-    let code = codes[0]
+    let code = undefined
     for (let i = 0; i < codes.length; i++) {
         if (codes[i] in exchange.currencies) {
             code = codes[i]


### PR DESCRIPTION
When exchange doesn't contain any of the hardcoded 'test' codes, build throws error. This needs to be fixed.