### PR TITLE
Hollaex :: createOrder fix

### DIFF
--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -933,17 +933,14 @@ module.exports = class hollaex extends Exchange {
         const request = {
             'symbol': market['id'],
             'side': side,
-            'size': amount,
+            'size': this.normalizeNumberIfNeeded (amount),
             'type': type,
             // 'stop': parseFloat (this.priceToPrecision (symbol, stopPrice)),
             // 'meta': {}, // other options such as post_only
         };
         if (type !== 'market') {
-            let convertedPrice = parseFloat (this.priceToPrecision (symbol, price));
-            if (convertedPrice % 1 === 0) {
-                convertedPrice = parseInt (convertedPrice);
-            }
-            request['price'] = convertedPrice;
+            const convertedPrice = parseFloat (this.priceToPrecision (symbol, price));
+            request['price'] = this.normalizeNumberIfNeeded (convertedPrice);
         }
         const stopPrice = this.safeFloat2 (params, 'stopPrice', 'stop');
         if (stopPrice !== undefined) {
@@ -1359,6 +1356,13 @@ module.exports = class hollaex extends Exchange {
             'info': response,
             'id': undefined,
         };
+    }
+
+    normalizeNumberIfNeeded (number) {
+        if (number % 1 === 0) {
+            number = parseInt (number);
+        }
+        return number;
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -939,7 +939,11 @@ module.exports = class hollaex extends Exchange {
             // 'meta': {}, // other options such as post_only
         };
         if (type !== 'market') {
-            request['price'] = price;
+            let convertedPrice = parseFloat (this.priceToPrecision (symbol, price));
+            if (convertedPrice % 1 === 0) {
+                convertedPrice = parseInt (convertedPrice);
+            }
+            request['price'] = convertedPrice;
         }
         const stopPrice = this.safeFloat2 (params, 'stopPrice', 'stop');
         if (stopPrice !== undefined) {

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -944,7 +944,7 @@ module.exports = class hollaex extends Exchange {
         }
         const stopPrice = this.safeFloat2 (params, 'stopPrice', 'stop');
         if (stopPrice !== undefined) {
-            request['stop'] = parseFloat (this.priceToPrecision (symbol, stopPrice));
+            request['stop'] = this.normalizeNumberIfNeeded (parseFloat (this.priceToPrecision (symbol, stopPrice)));
             params = this.omit (params, [ 'stopPrice', 'stop' ]);
         }
         const response = await this.privatePostOrder (this.extend (request, params));


### PR DESCRIPTION

This issue comes from the way different languages (Javascript, Python, Php) represent numbers. 

In Javascript, all numbers are floating points, so 1 is of the same type as 1.0 but all parsing methods default to the first representation. 

Example: 
```Javascript
parseInt(1) -> 1
parseInt(1.0) -> 1
parseInt("1.0")-> 1
```

However, in Python, different types of numbers are supported (int, float, complex) and its representation depends on the type.

Example:
```Python
int(1.0000) -> 1
float(1) -> 1.0

```
Being that, when using, let's say 1.0 for the price parameter, in the javascript side this price will be represented as 1 and in the Python side as 1.0. This difference ultimately leads to a different signature across languages. Since this was working on the JS side, is likely that Halloex servers are Javascript based and explains why the python version isn't currently working.

To fix this problem, I'm explicitly converting integer prices in a pure integer number (removing the fraction part), so the number 1.0 is converted to 1 in all the languages, fixing the above-mentioned problem.

The con of this approach is that needs to be applied manually to all the number parameters in the exchange (currently I'm only applying it to createOrder). 

Should I try to fix this globally for every exchange (I suspect that many others will suffer from this)/ Is there a better way of handling it?

Fixes #11872
