### PR TITLE
Okx fetchClosedOrder

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -44,7 +44,7 @@ module.exports = class okx extends Exchange {
                 'fetchBorrowRates': true,
                 'fetchBorrowRatesPerSymbol': false,
                 'fetchCanceledOrders': true,
-                'fetchClosedOrder': undefined,
+                'fetchClosedOrder': true,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDeposit': undefined,
@@ -2385,6 +2385,24 @@ module.exports = class okx extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         return this.parseOrders (data, market, since, limit);
+    }
+
+    async fetchClosedOrder (id, symbol = undefined, params = {}) {
+        if (id === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchClosedOrder() requires an id argument');
+        }
+        const request = {};
+        const orders = await this.fetchClosedOrders (symbol, undefined, undefined, this.extend (request, params));
+        const result = [];
+        for (let i = 0; i < orders.length; i++) {
+            if (orders[i].id === id) {
+                result.push (orders[i]);
+            }
+        }
+        if (result.length === 0) {
+            throw new OrderNotFound (this.id + ' order ' + id + ' not found');
+        }
+        return result;
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Added the fetchclosedOrder method to Okx:
Calling the method only works when setting the id argument with this format:
```
node examples/js/cli okx fetchClosedOrder "'408581807058366470'"
```
```
okx.fetchClosedOrder (408581807058366470)
364 ms
                id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | average |         cost |     amount |     filled | remaining | status |                                       fee | trades |
                      fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
408581807058366470 |               | 1643685493885 | 2022-02-01T03:18:13.885Z |      1643685493889 | BTC/USDT | limit |             |          | sell | 38480 |         0 | 38489.7 | 16.384680393 | 0.00042569 | 0.00042569 |         0 | closed | {"cost":0.016384680393,"currency":"USDT"} |     [] | [{"cost":0.016384680393,"currency":"USDT"}]
1 objects
```