### PR TITLE
bittrex.fetchMarkets - sort fetchMarkets, code reduction

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -295,7 +295,6 @@ module.exports = class bittrex extends Exchange {
             const quoteId = this.safeString (market, 'quoteCurrencySymbol');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const pricePrecision = this.safeInteger (market, 'precision', 8);
             const status = this.safeString (market, 'status');
             result.push ({
                 'id': this.safeString (market, 'symbol'),
@@ -322,10 +321,14 @@ module.exports = class bittrex extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
+                    'price': this.safeInteger (market, 'precision', 8),
                     'amount': parseInt ('8'),
-                    'price': pricePrecision,
                 },
                 'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
                     'amount': {
                         'min': this.safeNumber (market, 'minTradeSize'),
                         'max': undefined,
@@ -335,10 +338,6 @@ module.exports = class bittrex extends Exchange {
                         'max': undefined,
                     },
                     'cost': {
-                        'min': undefined,
-                        'max': undefined,
-                    },
-                    'leverage': {
                         'min': undefined,
                         'max': undefined,
                     },


### PR DESCRIPTION
```
2022-02-08T05:36:12.492Z
Node.js: v14.17.0
CCXT v1.72.39
bittrex.fetchMarkets ()
1563 ms
              id |              symbol |            base | quote | settle |      baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |              precision |                                                              limits
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        1ECO-BTC |            1ECO/BTC |            1ECO |   BTC |        |        1ECO |     BTC |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"price":8,"amount":8} |            {"leverage":{},"amount":{"min":10},"price":{},"cost":{}}
...
        ZRX-USDT |            ZRX/USDT |             ZRX |  USDT |        |         ZRX |    USDT |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"price":8,"amount":8} |     {"leverage":{},"amount":{"min":3.9790139},"price":{},"cost":{}}
       ZUSD-USDT |           ZUSD/USDT |            ZUSD |  USDT |        |        ZUSD |    USDT |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"price":4,"amount":8} |     {"leverage":{},"amount":{"min":3.0791337},"price":{},"cost":{}}
1117 objects
```