### PR TITLE
bitmex.fetchMarkets code reduction, unification

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -350,8 +350,6 @@ module.exports = class bitmex extends Exchange {
             const positionId = this.safeString2 (market, 'positionCurrency', 'quoteCurrency');
             const position = this.safeCurrencyCode (positionId);
             const positionIsQuote = (position === quote);
-            const lotSize = this.safeNumber (market, 'lotSize');
-            const tickSize = this.safeNumber (market, 'tickSize');
             const maxOrderQty = this.safeNumber (market, 'maxOrderQty');
             const contract = !index;
             const initMargin = this.safeString (market, 'initMargin', '1');
@@ -373,20 +371,20 @@ module.exports = class bitmex extends Exchange {
                 'option': false,
                 'prediction': prediction,
                 'index': index,
+                'active': active,
                 'contract': contract,
                 'linear': contract ? !inverse : undefined,
                 'inverse': contract ? inverse : undefined,
                 'taker': this.safeNumber (market, 'takerFee'),
                 'maker': this.safeNumber (market, 'makerFee'),
                 'contractSize': this.safeNumber (market, 'multiplier'),
-                'active': active,
                 'expiry': expiry,
                 'expiryDatetime': expiryDatetime,
                 'strike': this.safeNumber (market, 'optionStrikePrice'),
                 'optionType': undefined,
                 'precision': {
-                    'amount': lotSize,
-                    'price': tickSize,
+                    'price': this.safeNumber (market, 'tickSize'),
+                    'amount': this.safeNumber (market, 'lotSize'),
                 },
                 'limits': {
                     'leverage': {
@@ -394,15 +392,15 @@ module.exports = class bitmex extends Exchange {
                         'max': contract ? maxLeverage : undefined,
                     },
                     'amount': {
-                        'min': positionIsQuote ? undefined : lotSize,
+                        'min': undefined,
                         'max': positionIsQuote ? undefined : maxOrderQty,
                     },
                     'price': {
-                        'min': tickSize,
+                        'min': undefined,
                         'max': this.safeNumber (market, 'maxPrice'),
                     },
                     'cost': {
-                        'min': positionIsQuote ? lotSize : undefined,
+                        'min': undefined,
                         'max': positionIsQuote ? maxOrderQty : undefined,
                     },
                 },


### PR DESCRIPTION
```
2022-02-08T05:49:16.617Z
Node.js: v14.17.0
CCXT v1.72.39
bitmex.fetchMarkets ()
2239 ms
               id |               symbol |     base | quote | settle |   baseId | quoteId | settleId |       type |  spot | margin |  swap | future | option | prediction | index | active | contract | linear | inverse |  taker |   maker | contractSize |        expiry |           expiryDatetime | strike | optionType |                       precision |                                                                                         limits
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
          .EVOL7D |              .EVOL7D |      ETH |   XXX |        |      ETH |     XXX |          |      index | false |  false | false |  false |  false |      false |  true |  false |    false |        |         |        |         |              |               |                          |        |            |                  {"price":0.01} |                                               {"leverage":{},"amount":{},"price":{},"cost":{}}
Waiting for the debugger to disconnect...
...
           LTCUSD |          LTC/USD:BTC |      LTC |   USD |    BTC |      LTC |     USD |      XBt |       swap | false |  false |  true |  false |  false |      false | false |   true |     true |   true |   false | 0.0005 | -0.0001 |          200 |               |                          |        |            |       {"price":0.01,"amount":1} |   {"leverage":{"min":1,"max":50},"amount":{"max":100000000},"price":{"max":1000000},"cost":{}}
          LTCUSDT |        LTC/USDT:USDT |      LTC |  USDT |   USDT |      LTC |    USDT |     USDt |       swap | false |  false |  true |  false |  false |      false | false |   true |     true |   true |   false | 0.0005 | -0.0001 |          100 |               |                          |        |            |    {"price":0.01,"amount":1000} |                                                                                [object Object]
378 objects
```