### PR TITLE
bitstamp.fetchMarkets code reduction/sort

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -344,17 +344,12 @@ module.exports = class bitstamp extends Exchange {
             const quoteId = quote.toLowerCase ();
             base = this.safeCurrencyCode (base);
             quote = this.safeCurrencyCode (quote);
-            const amountPrecisionString = this.safeString (market, 'base_decimals');
-            const pricePrecisionString = this.safeString (market, 'counter_decimals');
-            const amountLimit = this.parsePrecision (amountPrecisionString);
-            const priceLimit = this.parsePrecision (pricePrecisionString);
             const minimumOrder = this.safeString (market, 'minimum_order');
             const parts = minimumOrder.split (' ');
-            const cost = parts[0];
-            // let [ cost, currency ] = market['minimum_order'].split (' ');
-            const trading = this.safeString (market, 'trading');
+            const status = this.safeString (market, 'trading');
             result.push ({
                 'id': this.safeString (market, 'url_symbol'),
+                'marketId': baseId + '_' + quoteId,
                 'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
@@ -362,14 +357,13 @@ module.exports = class bitstamp extends Exchange {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'settleId': undefined,
-                'marketId': baseId + '_' + quoteId,
                 'type': 'spot',
                 'spot': true,
                 'margin': false,
                 'future': false,
                 'swap': false,
                 'option': false,
-                'active': (trading === 'Enabled'),
+                'active': (status === 'Enabled'),
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
@@ -379,8 +373,8 @@ module.exports = class bitstamp extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'price': parseInt (pricePrecisionString),
-                    'amount': parseInt (amountPrecisionString),
+                    'price': this.parsePrecision (this.safeString (market, 'counter_decimals')),
+                    'amount': this.parsePrecision (this.safeString (market, 'base_decimals')),
                 },
                 'limits': {
                     'leverage': {
@@ -388,15 +382,15 @@ module.exports = class bitstamp extends Exchange {
                         'max': undefined,
                     },
                     'amount': {
-                        'min': this.parseNumber (amountLimit),
+                        'min': undefined,
                         'max': undefined,
                     },
                     'price': {
-                        'min': this.parseNumber (priceLimit),
+                        'min': undefined,
                         'max': undefined,
                     },
                     'cost': {
-                        'min': this.parseNumber (cost),
+                        'min': this.safeNumber (parts, 0),
                         'max': undefined,
                     },
                 },


### PR DESCRIPTION
```
2022-02-08T05:57:24.254Z
Node.js: v14.17.0
CCXT v1.72.39
bitstamp.fetchMarkets ()
2 ms
      id |  marketId |    symbol |  base | quote | settle | baseId | quoteId | settleId | type | spot | margin | future |  swap | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |                        precision |                                                       limits
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  btcusd |   btc_usd |   BTC/USD |   BTC |   USD |        |    btc |     usd |          | spot | true |  false |  false | false |  false |   true |    false |        |         |              |        |                |        |            | {"price":"1e-2","amount":"1e-8"} |     {"leverage":{},"amount":{},"price":{},"cost":{"min":20}}
...
 perpusd |  perp_usd |  PERP/USD |  PERP |   USD |        |   perp |     usd |          | spot | true |  false |  false | false |  false |   true |    false |        |         |              |        |                |        |            | {"price":"1e-3","amount":"1e-8"} |     {"leverage":{},"amount":{},"price":{},"cost":{"min":20}}
 perpeur |  perp_eur |  PERP/EUR |  PERP |   EUR |        |   perp |     eur |          | spot | true |  false |  false | false |  false |   true |    false |        |         |              |        |                |        |            | {"price":"1e-3","amount":"1e-8"} |     {"leverage":{},"amount":{},"price":{},"cost":{"min":20}}
144 objects
```