### PR TITLE
okx.fetchMarkets swap symbol fix

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -826,11 +826,10 @@ module.exports = class okx extends Exchange {
         if (contract) {
             symbol = symbol + ':' + settle;
             expiry = this.safeInteger (market, 'expTime');
-            if (expiry !== undefined) {
+            if (futures) {
                 const ymd = this.yymmdd (expiry);
                 symbol = symbol + '-' + ymd;
-            }
-            if (option) {
+            } else if (option) {
                 strikePrice = this.safeString (market, 'stk');
                 optionType = this.safeString (market, 'optType');
                 symbol = symbol + '-' + strikePrice + '-' + optionType;


### PR DESCRIPTION
The swap symbols right now all look like below with the same expiry date

```
  'BTC/USD:BTC--300101',
  'ETH/USD:ETH--300101',
  'LTC/USD:LTC--300101',
  'DOT/USD:DOT--300101',
```

This put the symbols back to the expected

```
'BTC/USD:BTC',     
'ETH/USD:ETH',        
'LTC/USD:LTC',
 'DOT/USD:DOT',
  ```