### PR TITLE
[Binance] Convert 'GTX' timeInForce to 'PO'

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -2601,8 +2601,12 @@ module.exports = class binance extends Exchange {
         const side = this.safeStringLower (order, 'side');
         const fills = this.safeValue (order, 'fills', []);
         const clientOrderId = this.safeString (order, 'clientOrderId');
-        const timeInForce = this.safeString (order, 'timeInForce');
-        const postOnly = (type === 'limit_maker') || (timeInForce === 'GTX');
+        let timeInForce = this.safeString (order, 'timeInForce');
+        if (timeInForce === 'GTX') {
+            // GTX means "Good Till Crossing" and is an equivalent way of saying Post Only
+            timeInForce = 'PO';
+        }
+        const postOnly = (type === 'limit_maker') || (timeInForce === 'PO');
         if (type === 'limit_maker') {
             type = 'limit';
         }


### PR DESCRIPTION
See [this issue](https://github.com/ccxt/ccxt/issues/11830).

To fix the bug, the same needs to be done in `parseWsOrder`: see the [corresponding PR](https://github.com/kroitor/ccxt.pro/pull/236) in CCXT-pro.