### PR TITLE
cex.fetchMakets stringSub

### DIFF
--- a/js/cex.js
+++ b/js/cex.js
@@ -356,7 +356,7 @@ module.exports = class cex extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.parseNumber (Precise.stringSub (baseCcyPrecision, baseCcyScale)),
+                    'amount': parseInt (Precise.stringSub (baseCcyPrecision, baseCcyScale)),
                     'price': pricePrecision,
                 },
                 'limits': {

--- a/js/cex.js
+++ b/js/cex.js
@@ -4,6 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { ExchangeError, ArgumentsRequired, AuthenticationError, NullResponse, InvalidOrder, NotSupported, InsufficientFunds, InvalidNonce, OrderNotFound, RateLimitExceeded, DDoSProtection } = require ('./base/errors');
+const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------
 
@@ -328,8 +329,8 @@ module.exports = class cex extends Exchange {
                     pricePrecision = this.safeInteger (pair, 'pricePrecision', pricePrecision);
                 }
             }
-            const baseCcyPrecision = this.safeInteger (baseCurrency, 'precision', 8);
-            const baseCcyScale = this.safeInteger (baseCurrency, 'scale', 0);
+            const baseCcyPrecision = this.safeString (baseCurrency, 'precision', '8');
+            const baseCcyScale = this.safeString (baseCurrency, 'scale', '0');
             result.push ({
                 'id': baseId + '/' + quoteId,
                 'symbol': base + '/' + quote,
@@ -342,8 +343,8 @@ module.exports = class cex extends Exchange {
                 'type': 'spot',
                 'spot': true,
                 'margin': undefined,
-                'future': false,
                 'swap': false,
+                'future': false,
                 'option': false,
                 'active': undefined,
                 'contract': false,
@@ -355,8 +356,8 @@ module.exports = class cex extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
+                    'amount': this.parseNumber (Precise.stringSub (baseCcyPrecision, baseCcyScale)),
                     'price': pricePrecision,
-                    'amount': baseCcyPrecision - baseCcyScale,
                 },
                 'limits': {
                     'leverage': {


### PR DESCRIPTION
```
2022-02-09T04:45:26.632Z
Node.js: v14.17.0
CCXT v1.72.56
cex.fetchMarkets ()
3426 ms
        id |     symbol |   base | quote | settle | baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |              precision |                                                                                              limits
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   BTC/USD |    BTC/USD |    BTC |   USD |        |    BTC |     USD |          | spot | true |        | false |  false |  false |        |    false |        |         |              |        |                |        |            | {"amount":8,"price":1} |     {"leverage":{},"amount":{"min":0.00018939},"price":{"min":3500,"max":350000},"cost":{"min":10}}
...
   QNT/USD |    QNT/USD |    QNT |   USD |        |    QNT |     USD |          | spot | true |        | false |  false |  false |        |    false |        |         |              |        |                |        |            | {"amount":6,"price":4} |           {"leverage":{},"amount":{"min":0.061392},"price":{"min":19,"max":1900},"cost":{"min":10}}
  AVAX/USD |   AVAX/USD |   AVAX |   USD |        |   AVAX |     USD |          | spot | true |        | false |  false |  false |        |    false |        |         |              |        |                |        |            | {"amount":6,"price":4} |               {"leverage":{},"amount":{"min":0.07},"price":{"min":10,"max":1050},"cost":{"min":10}}
230 objects
```