### PR TITLE
bw.fetchMarkets unified

### DIFF
--- a/js/bw.js
+++ b/js/bw.js
@@ -183,47 +183,46 @@ module.exports = class bw extends Exchange {
             quote = this.safeCurrencyCode (quote);
             const baseId = this.safeString (market, 'sellerCurrencyId');
             const quoteId = this.safeString (market, 'buyerCurrencyId');
-            const baseNumericId = parseInt (baseId);
-            const quoteNumericId = parseInt (quoteId);
-            const symbol = base + '/' + quote;
             const state = this.safeInteger (market, 'state');
-            const active = (state === 1);
             const fee = this.safeNumber (market, 'defaultFee');
             result.push ({
                 'id': id,
                 'numericId': numericId,
-                'symbol': symbol,
+                'symbol': base + '/' + quote,
                 'base': base,
                 'quote': quote,
+                'settle': undefined,
                 'baseId': baseId,
                 'quoteId': quoteId,
-                'baseNumericId': baseNumericId,
-                'quoteNumericId': quoteNumericId,
+                'settleId': undefined,
+                'baseNumericId': parseInt (baseId),
+                'quoteNumericId': parseInt (quoteId),
                 'type': 'spot',
                 'spot': true,
                 'margin': false,
-                'future': false,
                 'swap': false,
+                'future': false,
                 'option': false,
-                'optionType': undefined,
-                'strike': undefined,
+                'active': (state === 1),
+                'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'contract': false,
+                'taker': fee,
+                'maker': fee,
                 'contractSize': undefined,
-                'settle': undefined,
-                'settleId': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,
-                'active': active,
-                'maker': fee,
-                'taker': fee,
-                'info': market,
+                'strike': undefined,
+                'optionType': undefined,
                 'precision': {
                     'amount': this.safeInteger (market, 'amountDecimal'),
                     'price': this.safeInteger (market, 'priceDecimal'),
                 },
                 'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
                     'amount': {
                         'min': this.safeNumber (market, 'minAmount'),
                         'max': undefined,
@@ -237,6 +236,7 @@ module.exports = class bw extends Exchange {
                         'max': undefined,
                     },
                 },
+                'info': market,
             });
         }
         return result;

--- a/js/bw.js
+++ b/js/bw.js
@@ -228,11 +228,11 @@ module.exports = class bw extends Exchange {
                         'max': undefined,
                     },
                     'price': {
-                        'min': 0,
+                        'min': this.parseNumber ('0'),
                         'max': undefined,
                     },
                     'cost': {
-                        'min': 0,
+                        'min': this.parseNumber ('0'),
                         'max': undefined,
                     },
                 },


### PR DESCRIPTION
```
2022-02-09T04:47:36.124Z
Node.js: v14.17.0
CCXT v1.72.56
bw.fetchMarkets ()
1756 ms
  id | numericId |      symbol |   base | quote | settle | baseId | quoteId | settleId | baseNumericId | quoteNumericId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | taker | maker | contractSize | expiry | expiryDatetime | strike | optionType |               precision |                                                                     limits
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 291 |       291 |    EOS/USDT |    EOS |  USDT |        |      7 |      11 |          |             7 |             11 | spot | true |  false | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |        |                |        |            |  {"amount":4,"price":3} |   {"leverage":{},"amount":{"min":0.01},"price":{"min":0},"cost":{"min":0}}
...
4330 |      4330 |   GOTG/USDT |   GOTG |  USDT |        |    698 |      11 |          |           698 |             11 | spot | true |  false | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |        |                |        |            |  {"amount":2,"price":5} |    {"leverage":{},"amount":{"min":2.7},"price":{"min":0},"cost":{"min":0}}
4331 |      4331 |   IMPT/USDT |   IMPT |  USDT |        |    700 |      11 |          |           700 |             11 | spot | true |  false | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |        |                |        |            |  {"amount":2,"price":5} |     {"leverage":{},"amount":{"min":42},"price":{"min":0},"cost":{"min":0}}
62 objects
```