### PR TITLE
Gate.io: added parsing for GateCode transfer

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2103,12 +2103,14 @@ module.exports = class gateio extends Exchange {
             'DMOVE': 'pending',
             'CANCEL': 'failed',
             'DONE': 'ok',
+            'BCODE': 'ok', // GateCode withdrawal
         };
         return this.safeString (statuses, status, status);
     }
 
     parseTransactionType (type) {
         const types = {
+            'b': 'deposit', // GateCode redemption
             'd': 'deposit',
             'w': 'withdrawal',
         };


### PR DESCRIPTION
GateCode: https://www.gateio.ch/help/guide/deposit_withdrawa/16446/Withdrew-asset-as-Gatecode.-How-to-solve-it-video
It's a fee-free transfer on Gate.io.

withdraw to GateCode
```
{
    "id": "w2231xxxx",
    "currency": "MANA",
    "address": "",
    "amount": "13",
    "fee": "0",
    "txid": "MANABC9xxxxx (Get complete code on web')",
    "chain": "",
    "timestamp": "1644523652",
    "status": "BCODE",
    "memo": ""
}
```
redeem from GateCode
```
{
    "id": "b8391xxxx",
    "currency": "MANA",
    "address": "",
    "amount": "13",
    "txid": "gatecode",
    "chain": "",
    "timestamp": "1644523744",
    "status": "DONE",
    "memo": ""
}
```