### PR TITLE
Mexc parsePosition, parsePositions

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1550,7 +1550,7 @@ module.exports = class mexc extends Exchange {
         };
         const response = await this.fetchPositions (this.extend (request, params));
         const firstPosition = this.safeValue (response, 0);
-        return this.parsePosition (firstPosition);
+        return this.parsePosition (firstPosition, market);
     }
 
     async fetchPositions (symbols = undefined, params = {}) {
@@ -1615,7 +1615,7 @@ module.exports = class mexc extends Exchange {
         //         "autoAddIm": false
         //     }
         //
-        market = this.safeMarket (this.safeString (position, 'symbol'));
+        market = this.safeMarket (this.safeString (position, 'symbol'), market);
         const symbol = market['symbol'];
         const contracts = this.safeString (position, 'holdVol');
         const entryPrice = this.safeNumber (position, 'openAvgPrice');

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1550,7 +1550,7 @@ module.exports = class mexc extends Exchange {
         };
         const response = await this.fetchPositions (this.extend (request, params));
         const firstPosition = this.safeValue (response, 0);
-        return firstPosition;
+        return this.parsePosition (firstPosition);
     }
 
     async fetchPositions (symbols = undefined, params = {}) {
@@ -1586,9 +1586,71 @@ module.exports = class mexc extends Exchange {
         //         ]
         //     }
         //
-        // todo add parsePositions, parsePosition
+        // todo add parsePositions
         const data = this.safeValue (response, 'data', []);
         return data;
+    }
+
+    parsePosition (position, market = undefined) {
+        //
+        //     {
+        //         "positionId": 1394650,
+        //         "symbol": "ETH_USDT",
+        //         "positionType": 1,
+        //         "openType": 1,
+        //         "state": 1,
+        //         "holdVol": 1,
+        //         "frozenVol": 0,
+        //         "closeVol": 0,
+        //         "holdAvgPrice": 1217.3,
+        //         "openAvgPrice": 1217.3,
+        //         "closeAvgPrice": 0,
+        //         "liquidatePrice": 1211.2,
+        //         "oim": 0.1290338,
+        //         "im": 0.1290338,
+        //         "holdFee": 0,
+        //         "realised": -0.0073,
+        //         "leverage": 100,
+        //         "createTime": 1609991676000,
+        //         "updateTime": 1609991676000,
+        //         "autoAddIm": false
+        //     }
+        //
+        market = this.safeMarket (this.safeString (position, 'symbol'));
+        const symbol = market['symbol'];
+        const contracts = this.safeString (position, 'holdVol');
+        const entryPrice = this.safeNumber (position, 'openAvgPrice');
+        const initialMargin = this.safeString (position, 'im');
+        const rawSide = this.safeString (position, 'positionType');
+        const side = (rawSide === '1') ? 'long' : 'short';
+        const openType = this.safeString (position, 'margin_mode');
+        const marginType = (openType === '1') ? 'isolated' : 'cross';
+        const leverage = this.safeString (position, 'leverage');
+        const liquidationPrice = this.safeNumber (position, 'liquidatePrice');
+        const timestamp = this.safeNumber (position, 'updateTime');
+        return {
+            'info': position,
+            'symbol': symbol,
+            'contracts': this.parseNumber (contracts),
+            'contractSize': undefined,
+            'entryPrice': entryPrice,
+            'collateral': undefined,
+            'side': side,
+            'unrealizedProfit': undefined,
+            'leverage': this.parseNumber (leverage),
+            'percentage': undefined,
+            'marginType': marginType,
+            'notional': undefined,
+            'markPrice': undefined,
+            'liquidationPrice': liquidationPrice,
+            'initialMargin': this.parseNumber (initialMargin),
+            'initialMarginPercentage': undefined,
+            'maintenanceMargin': undefined,
+            'maintenanceMarginPercentage': undefined,
+            'marginRatio': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+        };
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1586,9 +1586,8 @@ module.exports = class mexc extends Exchange {
         //         ]
         //     }
         //
-        // todo add parsePositions
         const data = this.safeValue (response, 'data', []);
-        return data;
+        return this.parsePositions (data);
     }
 
     parsePosition (position, market = undefined) {
@@ -1651,6 +1650,14 @@ module.exports = class mexc extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
         };
+    }
+
+    parsePositions (positions) {
+        const result = [];
+        for (let i = 0; i < positions.length; i++) {
+            result.push (this.parsePosition (positions[i]));
+        }
+        return result;
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {


### PR DESCRIPTION
Added parsePosition and parsePositions to Mexc:
```
mexc.fetchPosition (BTC/USDT)
465 ms
{
  info: {
    positionId: '16581904',
    symbol: 'BTC_USDT',
    positionType: '1',
    openType: '1',
    state: '1',
    holdVol: '2',
    frozenVol: '0',
    closeVol: '0',
    holdAvgPrice: '43000.5',
    openAvgPrice: '43000.5',
    closeAvgPrice: '0',
    liquidatePrice: '21659.44',
    oim: '4.30521006',
    im: '4.30521006',
    holdFee: '0',
    realised: '-0.0051',
    adlLevel: '1',
    leverage: '2',
    createTime: '1644554646000',
    updateTime: '1644554646000',
    autoAddIm: false
  },
  symbol: 'BTC/USDT',
  contracts: 2,
  contractSize: undefined,
  entryPrice: 43000.5,
  collateral: undefined,
  side: 'long',
  unrealizedProfit: undefined,
  leverage: 2,
  percentage: undefined,
  marginType: 'cross',
  notional: undefined,
  markPrice: undefined,
  liquidationPrice: 21659.44,
  initialMargin: 4.30521006,
  initialMarginPercentage: undefined,
  maintenanceMargin: undefined,
  maintenanceMarginPercentage: undefined,
  marginRatio: undefined,
  timestamp: 1644554646000,
  datetime: '2022-02-11T04:44:06.000Z'
}
```
```
mexc.fetchPositions (BTC/USDT)
332 ms
  symbol | contracts | contractSize | entryPrice | collateral | side | unrealizedProfit | leverage | percentage | marginType | notional | markPrice | liquidationPrice | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | marginRatio |     timestamp |                 datetime
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT |         2 |              |    43000.5 |            | long |                  |        2 |            |      cross |          |           |         21659.44 |    4.30521006 |                         |                   |                             |             | 1644554646000 | 2022-02-11T04:44:06.000Z
1 objects
```