### PR TITLE
Docstrings are transpiled from Javascript to Python

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -323,6 +323,8 @@ class Transpiler {
             [ /\=\=\sTrue/g, 'is True' ], // a correction for PEP8 E712, it likes "is True", not "== True"
             [ /\sdelete\s/g, ' del ' ],
             [ /(?<!#.+)null/, 'None' ],
+            [ /\/\*\*/, '\'\'\'' ], // Doc strings
+            [ / \*\//, '\'\'\'' ], // Doc strings
         ])
     }
 


### PR DESCRIPTION
Javascript and PHP docstrings look the same, and for Python you just need to replace `/**` with `'''` and ` */` with `'''`