### PR TITLE
binance.setMarginMode no need to set margin mode error squelch in python

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -639,7 +639,6 @@ class Exchange(object):
         response.raise_for_status()
         return json_response
 
-
     def fetch(self, url, method='GET', headers=None, body=None):
         """Perform a HTTP request and return decoded JSON data"""
         request_headers = self.prepare_request_headers(headers)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -609,7 +609,7 @@ class Exchange(object):
         else:
             return json.loads(response_body)
 
-    def handleRestResponse(self, response, url, method, request_headers, request_body):
+    def handle_rest_response(self, response, url, method, request_headers, request_body):
         # does not try to detect encoding
         response.encoding = 'utf-8'
         headers = response.headers
@@ -668,7 +668,7 @@ class Exchange(object):
                 proxies=self.proxies,
                 verify=self.verify
             )
-            json_response = self.handleRestResponse(response, url, method, request_headers, request_body)
+            json_response = self.handle_rest_response(response, url, method, request_headers, request_body)
 
         except Timeout as e:
             details = ' '.join([self.id, method, url])
@@ -689,7 +689,7 @@ class Exchange(object):
                 self.handle_http_status_code(http_status_code, http_status_text, url, method, http_response)
                 raise ExchangeError(details) from e
             response = response['text'] if response and 'text' in response else None
-            return self.handleRestResponse(response, url, method, request_headers, request_body)
+            return self.handle_rest_response(response, url, method, request_headers, request_body)
 
         except requestsConnectionError as e:
             error_string = str(e)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -689,7 +689,7 @@ class Exchange(object):
                 self.handle_http_status_code(http_status_code, http_status_text, url, method, http_response)
                 raise ExchangeError(details) from e
             response = response['text'] if response and 'text' in response else None
-            return self.handleRestRespone(response, url, method, request_headers, request_body)
+            return self.handleRestResponse(response, url, method, request_headers, request_body)
 
         except requestsConnectionError as e:
             error_string = str(e)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -674,7 +674,9 @@ class Exchange(object):
             skip_further_error_handling = self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
             if not skip_further_error_handling:
                 self.handle_http_status_code(http_status_code, http_status_text, url, method, http_response)
-            raise ExchangeError(details) from e
+                raise ExchangeError(details) from e
+            response = response['text'] if response and 'text' in response else None
+            return json_response or response
 
         except requestsConnectionError as e:
             error_string = str(e)


### PR DESCRIPTION
The change on [this PR](https://github.com/ccxt/ccxt/pull/11821/files) only squelched the error in Javascript, it still shows up in Python, I think this might be a fix, but I'm not sure what else it would affect. 