### PR TITLE
binance.fetchLeverageTiers

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4823,7 +4823,7 @@ module.exports = class binance extends Exchange {
                 const bracket = brackets[j];
                 result.push ({
                     'tier': this.safeNumber (bracket, 'bracket'),
-                    'notionalCurrency': market['base'],
+                    'notionalCurrency': market['quote'],
                     'notionalFloor': this.safeFloat2 (bracket, 'notionalFloor', 'qtyFloor'),
                     'notionalCap': this.safeNumber (bracket, 'notionalCap'),
                     'maintenanceMarginRate': this.safeNumber (bracket, 'maintMarginRatio'),

--- a/js/binance.js
+++ b/js/binance.js
@@ -4813,7 +4813,7 @@ module.exports = class binance extends Exchange {
             const entry = response[i];
             const marketId = this.safeString (entry, 'symbol');
             const safeSymbol = this.safeSymbol (marketId);
-            let market = {'base': undefined};
+            let market = { 'base': undefined };
             if (safeSymbol in this.markets) {
                 market = this.market (safeSymbol);
             }

--- a/js/binance.js
+++ b/js/binance.js
@@ -63,6 +63,7 @@ module.exports = class binance extends Exchange {
                 'fetchL3OrderBook': undefined,
                 'fetchLedger': undefined,
                 'fetchLeverage': undefined,
+                'fetchLeverageTiers': true,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': true,
                 'fetchMyBuys': undefined,
@@ -4775,6 +4776,68 @@ module.exports = class binance extends Exchange {
             }
         }
         return this.options['leverageBrackets'];
+    }
+
+    async fetchLeverageTiers (symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchLeverageTiers', undefined, params);
+        let method = undefined;
+        if (type === 'future') {
+            method = 'fapiPrivateGetLeverageBracket';
+        } else if (type === 'delivery') {
+            method = 'dapiPrivateV2GetLeverageBracket';
+        } else {
+            throw new NotSupported (this.id + ' fetchLeverageTiers() supports linear and inverse contracts only');
+        }
+        const response = await this[method] (query);
+        //
+        //    [
+        //        {
+        //            "symbol": "SUSHIUSDT",
+        //            "brackets": [
+        //                {
+        //                    "bracket": 1,
+        //                    "initialLeverage": 50,
+        //                    "notionalCap": 50000,
+        //                    "notionalFloor": 0,
+        //                    "maintMarginRatio": 0.01,
+        //                    "cum": 0.0
+        //                },
+        //                ...
+        //            ]
+        //        }
+        //    ]
+        //
+        const leverageBrackets = {};
+        for (let i = 0; i < response.length; i++) {
+            const entry = response[i];
+            const marketId = this.safeString (entry, 'symbol');
+            const safeSymbol = this.safeSymbol (marketId);
+            let market = {'base': undefined};
+            if (safeSymbol in this.markets) {
+                market = this.market (safeSymbol);
+            }
+            const brackets = this.safeValue (entry, 'brackets');
+            const result = [];
+            for (let j = 0; j < brackets.length; j++) {
+                const bracket = brackets[j];
+                result.push ({
+                    'tier': this.safeNumber (bracket, 'bracket'),
+                    'notionalCurrency': market['base'],
+                    'notionalFloor': this.safeFloat2 (bracket, 'notionalFloor', 'qtyFloor'),
+                    'notionalCap': this.safeNumber (bracket, 'notionalCap'),
+                    'maintenanceMarginRate': this.safeNumber (bracket, 'maintMarginRatio'),
+                    'maxLeverage': this.safeNumber (bracket, 'initialLeverage'),
+                    'info': bracket,
+                });
+            }
+            leverageBrackets[safeSymbol] = result;
+        }
+        if (symbol !== undefined) {
+            return this.safeValue (leverageBrackets, symbol);
+        } else {
+            return leverageBrackets;
+        }
     }
 
     async fetchPositions (symbols = undefined, params = {}) {


### PR DESCRIPTION
2022-02-11T23:33:37.260Z
Node.js: v14.17.0
CCXT v1.72.84


```
binanceusdm.fetchLeverageTiers (BTC/USDT)
183 ms
tier | notionalCurrency | notionalFloor | notionalCap | maintenanceMarginRate | maxLeverage
-------------------------------------------------------------------------------------------
   1 |             USDT |             0 |       50000 |                 0.004 |         125
   2 |             USDT |         50000 |      250000 |                 0.005 |         100
   3 |             USDT |        250000 |     1000000 |                  0.01 |          50
   4 |             USDT |       1000000 |     7500000 |                 0.025 |          20
   5 |             USDT |       7500000 |    40000000 |                  0.05 |          10
   6 |             USDT |      40000000 |   100000000 |                   0.1 |           5
   7 |             USDT |     100000000 |   200000000 |                 0.125 |           4
   8 |             USDT |     200000000 |   400000000 |                  0.15 |           3
   9 |             USDT |     400000000 |   600000000 |                  0.25 |           2
  10 |             USDT |     600000000 |  1000000000 |                   0.5 |           1
```

```
binanceusdm.fetchLeverageTiers ()
185 ms
{
  'RAY/USDT': [
    {
...
    }
  ]
}
```