### PR TITLE
Okx fetchLeverageTiers

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4034,10 +4034,8 @@ module.exports = class okx extends Exchange {
             const tier = data[i];
             brackets.push ({
                 'tier': this.safeInteger (tier, 'tier'),
-                'minBase': this.safeNumber (tier, 'minSz'),
-                'maxBase': this.safeNumber (tier, 'maxSz'),
-                'minQuote': undefined,
-                'maxQuote': undefined,
+                'notionalFloor': this.safeNumber (tier, 'minSz'),
+                'notionalCap': this.safeNumber (tier, 'maxSz'),
                 'maintenanceMarginRatio': this.safeNumber (tier, 'mmr'),
                 'maxLeverage': this.safeNumber (tier, 'maxLever'),
                 'info': tier,

--- a/js/okx.js
+++ b/js/okx.js
@@ -4034,8 +4034,10 @@ module.exports = class okx extends Exchange {
             const tier = data[i];
             brackets.push ({
                 'tier': this.safeInteger (tier, 'tier'),
-                'notionalFloor': this.safeNumber (tier, 'minSz'),
-                'notionalCap': this.safeNumber (tier, 'maxSz'),
+                'minBase': this.safeNumber (tier, 'minSz'),
+                'maxBase': this.safeNumber (tier, 'maxSz'),
+                'minQuote': undefined,
+                'maxQuote': undefined,
                 'maintenanceMarginRatio': this.safeNumber (tier, 'mmr'),
                 'maxLeverage': this.safeNumber (tier, 'maxLever'),
                 'info': tier,

--- a/js/okx.js
+++ b/js/okx.js
@@ -3986,6 +3986,41 @@ module.exports = class okx extends Exchange {
         return await this.modifyMarginHelper (symbol, amount, 'add', params);
     }
 
+    async loadLeverageBrackets (reload = false, params = {}) {
+        await this.loadMarkets ();
+        // by default cache the leverage bracket
+        // it contains useful stuff like the maintenance margin and initial margin for positions
+        const symbol = this.safeString (params, 'symbol');
+        if (!symbol) {
+            throw new ArgumentsRequired (this.id + '.loadLeverageBrackets requires params.symbol');
+        }
+        const market = this.market (symbol);
+        const type = market['spot'] ? 'MARGIN' : market['type'].toUpperCase ();
+        const request = {
+            'instType': type,
+            'tdMode': this.safeString (params, 'tdMode', 'isolated'),
+        };
+        if (type === 'MARGIN') {
+            request['instId'] = market['id'];
+        }
+        const leverageBrackets = this.safeValue (this.options, 'leverageBrackets');
+        if ((leverageBrackets === undefined) || (reload)) {
+            const response = await this.publicGetPublicPositionTiers (this.extend (request, params));
+            this.options['leverageBrackets'] = {};
+            const data = this.safeValue (response, 'data');
+            const leverageBrackets = [];
+            for (let i = 0; i < data.length; i++) {
+                const entry = data[i];
+                // we use floats here internally on purpose
+                const floorValue = this.safeFloat (entry, 'minSz');
+                const maintenanceMarginPercentage = this.safeString (entry, 'mmr');
+                leverageBrackets.push ([ floorValue, maintenanceMarginPercentage ]);
+            }
+            this.options['leverageBrackets'] = leverageBrackets;
+        }
+        return this.options['leverageBrackets'];
+    }
+
     setSandboxMode (enable) {
         super.setSandboxMode (enable);
         if (enable) {

--- a/js/okx.js
+++ b/js/okx.js
@@ -4034,7 +4034,7 @@ module.exports = class okx extends Exchange {
             const tier = data[i];
             brackets.push ({
                 'tier': this.safeInteger (tier, 'tier'),
-                'notionalCurrency': market['base'],
+                'notionalCurrency': market['quote'],
                 'notionalFloor': this.safeNumber (tier, 'minSz'),
                 'notionalCap': this.safeNumber (tier, 'maxSz'),
                 'maintenanceMarginRatio': this.safeNumber (tier, 'mmr'),

--- a/js/okx.js
+++ b/js/okx.js
@@ -4034,6 +4034,7 @@ module.exports = class okx extends Exchange {
             const tier = data[i];
             brackets.push ({
                 'tier': this.safeInteger (tier, 'tier'),
+                'notionalCurrency': market['base'],
                 'notionalFloor': this.safeNumber (tier, 'minSz'),
                 'notionalCap': this.safeNumber (tier, 'maxSz'),
                 'maintenanceMarginRatio': this.safeNumber (tier, 'mmr'),

--- a/js/okx.js
+++ b/js/okx.js
@@ -3106,7 +3106,7 @@ module.exports = class okx extends Exchange {
         const marginMode = this.safeStringLower (params, 'mgnMode');
         params = this.omit (params, [ 'mgnMode' ]);
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
-            throw new BadRequest (this.id + ' fetchLeverage params["mgnMode"] must be either cross or isolated');
+            throw new BadRequest (this.id + ' fetchLeverage() requires a mgnMode parameter that must be either cross or isolated');
         }
         const market = this.market (symbol);
         const request = {
@@ -3989,14 +3989,14 @@ module.exports = class okx extends Exchange {
 
     async fetchLeverageTiers (symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        if (!symbol) {
-            throw new ArgumentsRequired (this.id + '.fetchLeverageTiers requires params.symbol');
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchLeverageTiers() requires a symbol argument');
         }
         const market = this.market (symbol);
         const type = market['spot'] ? 'MARGIN' : market['type'].toUpperCase ();
         const uly = this.safeString (market['info'], 'uly');
         if (!uly) {
-            throw new BadRequest (this.id + '.fetchLeverageTiers cannot fetch leverage tiers for ' + symbol);
+            throw new BadRequest (this.id + ' fetchLeverageTiers() cannot fetch leverage tiers for ' + symbol);
         }
         const request = {
             'instType': type,


### PR DESCRIPTION
```
2022-02-11T23:45:19.050Z
Node.js: v14.17.0
CCXT v1.72.84
okx.fetchLeverageTiers (BTC/USDT:USDT)
285 ms
{
  'BTC/USDT:USDT': [
    {
      tier: 1,
      notionalCurrency: 'USDT',
      notionalFloor: 0,
      notionalCap: 500,
      maintenanceMarginRatio: 0.004,
      maxLeverage: 125,
      info: {
        baseMaxLoan: '',
        imr: '0.008',
        instId: '',
        maxLever: '125',
        maxSz: '500',
        minSz: '0',
        mmr: '0.004',
        optMgnFactor: '0',
        quoteMaxLoan: '',
        tier: '1',
        uly: 'BTC-USDT'
      }
    },
    ...
    {
      tier: 100,
      notionalCurrency: 'USDT',
      notionalFloor: 972001,
      notionalCap: 982000,
      maintenanceMarginRatio: 0.495,
      maxLeverage: 2,
      info: {
        baseMaxLoan: '',
        imr: '0.5',
        instId: '',
        maxLever: '2',
        maxSz: '982000',
        minSz: '972001',
        mmr: '0.495',
        optMgnFactor: '0',
        quoteMaxLoan: '',
        tier: '100',
        uly: 'BTC-USDT'
      }
    },
    ... 100 more items
  ]
}
```