### PR TITLE
xena.fetchLeverageTiers

### DIFF
--- a/js/xena.js
+++ b/js/xena.js
@@ -1689,202 +1689,124 @@ module.exports = class xena extends Exchange {
 
     async fetchLeverageTiers (symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        let symbols = undefined;
-        if (symbol) {
+        const symbolDefined = symbol !== undefined;
+        if (symbolDefined) {
             const market = this.market (symbol);
             if (!market['contract']) {
                 throw new BadRequest (this.id + ' fetchLeverageTiers symbol supports contract markets only');
             }
-            symbols = [ symbol ];
-        } else {
-            symbols = this.symbols;
         }
-        const tiers = {};
-        for (let i = 0; i < symbols.length; i++) {
-            const market = this.market (symbols[i]);
-            //
-            //    {
-            //        limits: {
-            //            leverage: {
-            //                min: undefined,
-            //                max: undefined
-            //            },
-            //            amount: {
-            //                min: undefined,
-            //                max: undefined
-            //            },
-            //            price: {
-            //                min: undefined,
-            //                max: undefined
-            //            },
-            //            cost: {
-            //                min: 0.0001,
-            //                max: 10
-            //            }
-            //        },
-            //        precision: {
-            //            price: 0,
-            //            amount: 0
-            //        },
-            //        tierBased: true,
-            //        percentage: true,
-            //        taker: 0.001,
-            //        maker: 0.0005,
-            //        id: 'XBTUSD',
-            //        symbol: 'BTC/USD:USDC',
-            //        base: 'BTC',
-            //        quote: 'USD',
-            //        settle: 'USDC',
-            //        baseId: 'BTC',
-            //        quoteId: 'USD',
-            //        settleId: 'USDC',
-            //        numericId: '100',
-            //        type: 'swap',
-            //        spot: false,
-            //        margin: false,
-            //        swap: true,
-            //        future: false,
-            //        option: false,
-            //        active: true,
-            //        contract: true,
-            //        linear: true,
-            //        inverse: false,
-            //        contractSize: 1,
-            //        expiry: undefined,
-            //        expiryDatetime: undefined,
-            //        strike: undefined,
-            //        optionType: undefined,
-            //        info: {
-            //            id: '100',
-            //            type: 'Margin',
-            //            marginType: 'XenaListedPerpetual',
-            //            symbol: 'XBTUSD',
-            //            baseCurrency: 'BTC',
-            //            quoteCurrency: 'USD',
-            //            settlCurrency: 'USDC',
-            //            tickSize: '0',
-            //            minOrderQuantity: '0.0001',
-            //            orderQtyStep: '0.0001',
-            //            limitOrderMaxDistance: '10',
-            //            priceInputMask: '00000.0',
-            //            enabled: true,
-            //            liquidationMaxDistance: '0.01',
-            //            contractValue: '1',
-            //            contractCurrency: 'BTC',
-            //            lotSize: '1',
-            //            maxOrderQty: '10',
-            //            maxPosVolume: '200',
-            //            mark: '.XBTUSD_Mark',
-            //            underlying: '.BTC3',
-            //            openInterest: '.XBTUSD_OpenInterest',
-            //            floatingPL: 'BidAsk',
-            //            addUvmToFreeMargin: 'ProfitAndLoss',
-            //            margin: {
-            //                netting: 'PositionsAndOrders',
-            //                rates: [
-            //                    {
-            //                        maxVolume: '10',
-            //                        initialRate: '0.05',
-            //                        maintenanceRate: '0.025'
-            //                    },
-            //                    {
-            //                        maxVolume: '20',
-            //                        initialRate: '0.1',
-            //                        maintenanceRate: '0.05'
-            //                    },
-            //                    {
-            //                        maxVolume: '30',
-            //                        initialRate: '0.2',
-            //                        maintenanceRate: '0.1'
-            //                    },
-            //                    {
-            //                        maxVolume: '40',
-            //                        initialRate: '0.3',
-            //                        maintenanceRate: '0.15'
-            //                    },
-            //                    {
-            //                        maxVolume: '60',
-            //                        initialRate: '0.4',
-            //                        maintenanceRate: '0.2'
-            //                    },
-            //                    {
-            //                        maxVolume: '150',
-            //                        initialRate: '0.5',
-            //                        maintenanceRate: '0.25'
-            //                    },
-            //                    {
-            //                        maxVolume: '200',
-            //                        initialRate: '1',
-            //                        maintenanceRate: '0.5'
-            //                    }
-            //                ],
-            //                rateMultipliers: {
-            //                    LimitBuy: '1',
-            //                    LimitSell: '1',
-            //                    Long: '1',
-            //                    MarketBuy: '1',
-            //                    MarketSell: '1',
-            //                    Short: '1',
-            //                    StopBuy: '0',
-            //                    StopSell: '0'
-            //                }
-            //            },
-            //            clearing: {
-            //                enabled: true,
-            //                index: '.XBTUSD_Mark'
-            //            },
-            //            premium: {
-            //                enabled: true,
-            //                index: '.XBTUSD_Premium_Rate_TWAP'
-            //            },
-            //            riskAdjustment: {
-            //                enabled: true,
-            //                index: '.RiskAdjustment_IR'
-            //            },
-            //            priceRange: {
-            //                enabled: true,
-            //                distance: '0.1',
-            //                movingBoundary: '0',
-            //                lowIndex: '.XBTUSD_LOWRANGE',
-            //                highIndex: '.XBTUSD_HIGHRANGE'
-            //            },
-            //            priceLimits: {
-            //                enabled: true,
-            //                distance: '0.1',
-            //                movingBoundary: '0',
-            //                lowIndex: '.XBTUSD_LOWLIMIT',
-            //                highIndex: '.XBTUSD_HIGHLIMIT'
-            //            },
-            //            tradingStartDate: '0001-01-01 00:00:00'
-            //        }
-            //    }
-            //
+        const result = {};
+        const response = await this.publicGetCommonInstruments (params);
+        //
+        //    [
+        //        {
+        //            "id": "XBTUSD_3M_240622",
+        //            "type": "Margin",
+        //            "marginType": "XenaFuture",
+        //            "symbol": "XBTUSD_3M_240622",
+        //            "baseCurrency": "BTC",
+        //            "quoteCurrency": "USD",
+        //            "settlCurrency": "USDC",
+        //            "tickSize": 0,
+        //            "minOrderQuantity": "0.0001",
+        //            "orderQtyStep": "0.0001",
+        //            "limitOrderMaxDistance": "10",
+        //            "priceInputMask": "00000.0",
+        //            "enabled": true,
+        //            "liquidationMaxDistance": "0.01",
+        //            "contractValue": "1",
+        //            "contractCurrency": "BTC",
+        //            "lotSize": "1",
+        //            "maxOrderQty": "10",
+        //            "maxPosVolume": "200",
+        //            "mark": ".XBTUSD_3M_240622",
+        //            "underlying": ".BTC3_TWAP",
+        //            "openInterest": ".XBTUSD_3M_240622_OpenInterest",
+        //            "addUvmToFreeMargin": "ProfitAndLoss",
+        //            "margin": {
+        //                "netting": "PositionsAndOrders",
+        //                "rates": [
+        //                    { "maxVolume": "10", "initialRate": "0.05", "maintenanceRate": "0.025" },
+        //                    { "maxVolume": "20", "initialRate": "0.1", "maintenanceRate": "0.05" },
+        //                    { "maxVolume": "30", "initialRate": "0.2", "maintenanceRate": "0.1" },
+        //                    { "maxVolume": "40", "initialRate": "0.3", "maintenanceRate": "0.15" },
+        //                    { "maxVolume": "60", "initialRate": "0.4", "maintenanceRate": "0.2" },
+        //                    { "maxVolume": "150", "initialRate": "0.5", "maintenanceRate": "0.25" },
+        //                    { "maxVolume": "200", "initialRate": "1", "maintenanceRate": "0.5" }
+        //               ],
+        //               "rateMultipliers": {
+        //                    "LimitBuy": "1",
+        //                    "LimitSell": "1",
+        //                    "Long": "1",
+        //                    "MarketBuy": "1",
+        //                    "MarketSell": "1",
+        //                    "Short": "1",
+        //                    "StopBuy": "0",
+        //                    "StopSell": "0"
+        //                }
+        //            },
+        //            "clearing": { "enabled": true, "index": ".XBTUSD_3M_240622" },
+        //            "riskAdjustment": { "enabled": true, "index": ".RiskAdjustment_IR" },
+        //            "expiration": { "enabled": true, "index": ".BTC3_TWAP" },
+        //            "pricePrecision": 1,
+        //            "priceRange": {
+        //                "enabled": true,
+        //                "distance": "0.2",
+        //                "movingBoundary": "0",
+        //                "lowIndex": ".XBTUSD_3M_240622_LOWRANGE",
+        //                "highIndex": ".XBTUSD_3M_240622_HIGHRANGE"
+        //            },
+        //            "priceLimits": {
+        //                "enabled": true,
+        //                "distance": "0.5",
+        //                "movingBoundary": "0",
+        //                "lowIndex": ".XBTUSD_3M_240622_LOWLIMIT",
+        //                "highIndex": ".XBTUSD_3M_240622_HIGHLIMIT"
+        //            },
+        //            "serie": "XBTUSD",
+        //            "tradingStartDate": "2021-12-31 07:00:00",
+        //            "expiryDate": "2022-06-24 08:00:00"
+        //           },
+        //           ...
+        //        ]
+        //
+        for (let i = 0; i < response.length; i++) {
+            const item = response[i];
+            const margin = this.safeValue (item, 'margin');
+            const rates = this.safeValue (margin, 'rates');
+            let floor = 0;
+            const id = this.safeString (item, 'symbol');
+            const market = this.market (id);
             if (market['contract']) {
-                const margin = this.safeValue (market['info'], 'margin');
-                const rates = this.safeValue (margin, 'rates');
-                let floor = 0;
-                if (rates) {
-                    const brackets = [];
+                if (rates !== undefined) {
+                    const tiers = [];
                     for (let j = 0; j < rates.length; j++) {
-                        const bracket = rates[j];
-                        const cap = this.safeNumber (bracket, 'maxVolume');
-                        const initialRate = this.safeString (bracket, 'initialRate');
-                        brackets.push ({
+                        const tier = rates[j];
+                        const cap = this.safeNumber (tier, 'maxVolume');
+                        const initialRate = this.safeString (tier, 'initialRate');
+                        tiers.push ({
                             'tier': j + 1,
                             'notionalCurrency': market['base'],
                             'notionalFloor': floor,
                             'notionalCap': cap,
-                            'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),
+                            'maintenanceMarginRatio': this.safeNumber (tier, 'maintenanceRate'),
                             'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialRate)),
-                            'info': bracket,
+                            'info': tier,
                         });
                         floor = cap;
                     }
-                    tiers[market['symbol']] = brackets;
+                    result[market['symbol']] = tiers;
                 }
             }
         }
-        return tiers;
+        if (symbolDefined) {
+            const finalResult = {};
+            finalResult[symbol] = this.safeValue (result, symbol);
+            return finalResult;
+        } else {
+            return result;
+        }
     }
 
     nonce () {

--- a/js/xena.js
+++ b/js/xena.js
@@ -1871,10 +1871,8 @@ module.exports = class xena extends Exchange {
                         const initialRate = this.safeString (bracket, 'initialRate');
                         brackets.push ({
                             'tier': j + 1,
-                            'minBase': undefined,
-                            'maxBase': undefined,
-                            'minQuote': floor,
-                            'maxQuote': cap,
+                            'notionalFloor': floor,
+                            'notionalCap': cap,
                             'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),
                             'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialRate)),
                             'info': bracket,

--- a/js/xena.js
+++ b/js/xena.js
@@ -1870,7 +1870,7 @@ module.exports = class xena extends Exchange {
                         const cap = this.safeNumber (bracket, 'maxVolume');
                         const initialRate = this.safeString (bracket, 'initialRate');
                         brackets.push ({
-                            'tier': j,
+                            'tier': j + 1,
                             'notionalFloor': floor,
                             'notionalCap': cap,
                             'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),

--- a/js/xena.js
+++ b/js/xena.js
@@ -1871,8 +1871,10 @@ module.exports = class xena extends Exchange {
                         const initialRate = this.safeString (bracket, 'initialRate');
                         brackets.push ({
                             'tier': j + 1,
-                            'notionalFloor': floor,
-                            'notionalCap': cap,
+                            'minBase': undefined,
+                            'maxBase': undefined,
+                            'minQuote': floor,
+                            'maxQuote': cap,
                             'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),
                             'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialRate)),
                             'info': bracket,

--- a/js/xena.js
+++ b/js/xena.js
@@ -1786,7 +1786,7 @@ module.exports = class xena extends Exchange {
                         const cap = this.safeNumber (tier, 'maxVolume');
                         const initialRate = this.safeString (tier, 'initialRate');
                         tiers.push ({
-                            'tier': j + 1,
+                            'tier': this.sum (j, 1),
                             'notionalCurrency': market['base'],
                             'notionalFloor': floor,
                             'notionalCap': cap,

--- a/js/xena.js
+++ b/js/xena.js
@@ -1871,6 +1871,7 @@ module.exports = class xena extends Exchange {
                         const initialRate = this.safeString (bracket, 'initialRate');
                         brackets.push ({
                             'tier': j + 1,
+                            'notionalCurrency': market['quote'],
                             'notionalFloor': floor,
                             'notionalCap': cap,
                             'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),

--- a/js/xena.js
+++ b/js/xena.js
@@ -1871,7 +1871,7 @@ module.exports = class xena extends Exchange {
                         const initialRate = this.safeString (bracket, 'initialRate');
                         brackets.push ({
                             'tier': j + 1,
-                            'notionalCurrency': market['quote'],
+                            'notionalCurrency': market['base'],
                             'notionalFloor': floor,
                             'notionalCap': cap,
                             'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),

--- a/js/xena.js
+++ b/js/xena.js
@@ -35,6 +35,7 @@ module.exports = class xena extends Exchange {
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
                 'fetchLedger': true,
+                'fetchLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
@@ -1684,6 +1685,205 @@ module.exports = class xena extends Exchange {
         //     ]
         //
         return this.parseLedger (response, currency, since, limit);
+    }
+
+    async fetchLeverageTiers (symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        let symbols = undefined;
+        if (symbol) {
+            const market = this.market (symbol);
+            if (!market['contract']) {
+                throw new BadRequest (this.id + ' fetchLeverageTiers symbol supports contract markets only');
+            }
+            symbols = [ symbol ];
+        } else {
+            symbols = this.symbols;
+        }
+        const tiers = {};
+        for (let i = 0; i < symbols.length; i++) {
+            const market = this.market (symbols[i]);
+            //
+            //    {
+            //        limits: {
+            //            leverage: {
+            //                min: undefined,
+            //                max: undefined
+            //            },
+            //            amount: {
+            //                min: undefined,
+            //                max: undefined
+            //            },
+            //            price: {
+            //                min: undefined,
+            //                max: undefined
+            //            },
+            //            cost: {
+            //                min: 0.0001,
+            //                max: 10
+            //            }
+            //        },
+            //        precision: {
+            //            price: 0,
+            //            amount: 0
+            //        },
+            //        tierBased: true,
+            //        percentage: true,
+            //        taker: 0.001,
+            //        maker: 0.0005,
+            //        id: 'XBTUSD',
+            //        symbol: 'BTC/USD:USDC',
+            //        base: 'BTC',
+            //        quote: 'USD',
+            //        settle: 'USDC',
+            //        baseId: 'BTC',
+            //        quoteId: 'USD',
+            //        settleId: 'USDC',
+            //        numericId: '100',
+            //        type: 'swap',
+            //        spot: false,
+            //        margin: false,
+            //        swap: true,
+            //        future: false,
+            //        option: false,
+            //        active: true,
+            //        contract: true,
+            //        linear: true,
+            //        inverse: false,
+            //        contractSize: 1,
+            //        expiry: undefined,
+            //        expiryDatetime: undefined,
+            //        strike: undefined,
+            //        optionType: undefined,
+            //        info: {
+            //            id: '100',
+            //            type: 'Margin',
+            //            marginType: 'XenaListedPerpetual',
+            //            symbol: 'XBTUSD',
+            //            baseCurrency: 'BTC',
+            //            quoteCurrency: 'USD',
+            //            settlCurrency: 'USDC',
+            //            tickSize: '0',
+            //            minOrderQuantity: '0.0001',
+            //            orderQtyStep: '0.0001',
+            //            limitOrderMaxDistance: '10',
+            //            priceInputMask: '00000.0',
+            //            enabled: true,
+            //            liquidationMaxDistance: '0.01',
+            //            contractValue: '1',
+            //            contractCurrency: 'BTC',
+            //            lotSize: '1',
+            //            maxOrderQty: '10',
+            //            maxPosVolume: '200',
+            //            mark: '.XBTUSD_Mark',
+            //            underlying: '.BTC3',
+            //            openInterest: '.XBTUSD_OpenInterest',
+            //            floatingPL: 'BidAsk',
+            //            addUvmToFreeMargin: 'ProfitAndLoss',
+            //            margin: {
+            //                netting: 'PositionsAndOrders',
+            //                rates: [
+            //                    {
+            //                        maxVolume: '10',
+            //                        initialRate: '0.05',
+            //                        maintenanceRate: '0.025'
+            //                    },
+            //                    {
+            //                        maxVolume: '20',
+            //                        initialRate: '0.1',
+            //                        maintenanceRate: '0.05'
+            //                    },
+            //                    {
+            //                        maxVolume: '30',
+            //                        initialRate: '0.2',
+            //                        maintenanceRate: '0.1'
+            //                    },
+            //                    {
+            //                        maxVolume: '40',
+            //                        initialRate: '0.3',
+            //                        maintenanceRate: '0.15'
+            //                    },
+            //                    {
+            //                        maxVolume: '60',
+            //                        initialRate: '0.4',
+            //                        maintenanceRate: '0.2'
+            //                    },
+            //                    {
+            //                        maxVolume: '150',
+            //                        initialRate: '0.5',
+            //                        maintenanceRate: '0.25'
+            //                    },
+            //                    {
+            //                        maxVolume: '200',
+            //                        initialRate: '1',
+            //                        maintenanceRate: '0.5'
+            //                    }
+            //                ],
+            //                rateMultipliers: {
+            //                    LimitBuy: '1',
+            //                    LimitSell: '1',
+            //                    Long: '1',
+            //                    MarketBuy: '1',
+            //                    MarketSell: '1',
+            //                    Short: '1',
+            //                    StopBuy: '0',
+            //                    StopSell: '0'
+            //                }
+            //            },
+            //            clearing: {
+            //                enabled: true,
+            //                index: '.XBTUSD_Mark'
+            //            },
+            //            premium: {
+            //                enabled: true,
+            //                index: '.XBTUSD_Premium_Rate_TWAP'
+            //            },
+            //            riskAdjustment: {
+            //                enabled: true,
+            //                index: '.RiskAdjustment_IR'
+            //            },
+            //            priceRange: {
+            //                enabled: true,
+            //                distance: '0.1',
+            //                movingBoundary: '0',
+            //                lowIndex: '.XBTUSD_LOWRANGE',
+            //                highIndex: '.XBTUSD_HIGHRANGE'
+            //            },
+            //            priceLimits: {
+            //                enabled: true,
+            //                distance: '0.1',
+            //                movingBoundary: '0',
+            //                lowIndex: '.XBTUSD_LOWLIMIT',
+            //                highIndex: '.XBTUSD_HIGHLIMIT'
+            //            },
+            //            tradingStartDate: '0001-01-01 00:00:00'
+            //        }
+            //    }
+            //
+            if (market['contract']) {
+                const margin = this.safeValue (market['info'], 'margin');
+                const rates = this.safeValue (margin, 'rates');
+                let floor = 0;
+                if (rates) {
+                    const brackets = [];
+                    for (let j = 0; j < rates.length; j++) {
+                        const bracket = rates[j];
+                        const cap = this.safeNumber (bracket, 'maxVolume');
+                        const initialRate = this.safeString (bracket, 'initialRate');
+                        brackets.push ({
+                            'tier': j,
+                            'notionalFloor': floor,
+                            'notionalCap': cap,
+                            'maintenanceMarginRatio': this.safeNumber (bracket, 'maintenanceRate'),
+                            'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialRate)),
+                            'info': bracket,
+                        });
+                        floor = cap;
+                    }
+                    tiers[market['symbol']] = brackets;
+                }
+            }
+        }
+        return tiers;
     }
 
     nonce () {


### PR DESCRIPTION
```
Node.js: v14.17.0
CCXT v1.72.84
xena.fetchLeverageTiers (BTC/USD:USDC)
1 ms
{
  'BTC/USD:USDC': [
    {
      tier: 1,
      notionalCurrency: 'BTC',
      notionalFloor: 0,
      notionalCap: 10,
      maintenanceMarginRatio: 0.025,
      maxLeverage: 20,
      info: {
        maxVolume: '10',
        initialRate: '0.05',
        maintenanceRate: '0.025'
      }
    },
    {
      tier: 2,
      notionalCurrency: 'BTC',
      notionalFloor: 10,
      notionalCap: 20,
      maintenanceMarginRatio: 0.05,
      maxLeverage: 10,
      info: { maxVolume: '20', initialRate: '0.1', maintenanceRate: '0.05' }
    },
    {
      tier: 3,
      notionalCurrency: 'BTC',
      notionalFloor: 20,
      notionalCap: 30,
      maintenanceMarginRatio: 0.1,
      maxLeverage: 5,
      info: { maxVolume: '30', initialRate: '0.2', maintenanceRate: '0.1' }
    },
    {
      tier: 4,
      notionalCurrency: 'BTC',
      notionalFloor: 30,
      notionalCap: 40,
      maintenanceMarginRatio: 0.15,
      maxLeverage: 3.3333333333333335,
      info: { maxVolume: '40', initialRate: '0.3', maintenanceRate: '0.15' }
    },
    {
      tier: 5,
      notionalCurrency: 'BTC',
      notionalFloor: 40,
      notionalCap: 60,
      maintenanceMarginRatio: 0.2,
      maxLeverage: 2.5,
      info: { maxVolume: '60', initialRate: '0.4', maintenanceRate: '0.2' }
    },
    {
      tier: 6,
      notionalCurrency: 'BTC',
      notionalFloor: 60,
      notionalCap: 150,
      maintenanceMarginRatio: 0.25,
      maxLeverage: 2,
      info: { maxVolume: '150', initialRate: '0.5', maintenanceRate: '0.25' }
    },
    {
      tier: 7,
      notionalCurrency: 'BTC',
      notionalFloor: 150,
      notionalCap: 200,
      maintenanceMarginRatio: 0.5,
      maxLeverage: 1,
      info: { maxVolume: '200', initialRate: '1', maintenanceRate: '0.5' }
    }
  ]
}
```

```
xena.fetchLeverageTiers ()
1 ms
{
  'AAVE/USD:USDC': [
    {
...
    }
  ]
}
```