### PR TITLE
ftx-close-position-reduceOnly removed safeValue

### DIFF
--- a/examples/py/ftx-close-position-reduceOnly.py
+++ b/examples/py/ftx-close-position-reduceOnly.py
@@ -25,17 +25,16 @@ exchange.load_markets()
 symbol = 'BTC-PERP'  # change for your symbol
 positions = exchange.fetch_positions()
 positions_by_symbol = exchange.index_by(positions, 'symbol')
-position = exchange.safe_value(positions_by_symbol, symbol)
-
-if position is None:
+if symbol in positions_by_symbol:
+    position = positions_by_symbol[symbol]
+    type = 'market'
+    side = 'sell' if position['side'] == 'long' else 'buy'
+    amount = position['contracts']
+    price = None
+    params = {
+        'reduceOnly': True
+    }
+    order = exchange.create_order(symbol, type, side, amount, price, params)
+    pprint(order)
+else:
     print('You do not have an open', symbol, 'position')
-
-type = 'market'
-side = 'sell' if position['side'] == 'long' else 'buy'
-amount = position['contracts']
-price = None
-params = {
-    'reduceOnly': True
-}
-order = exchange.create_order(symbol, type, side, amount, price, params)
-pprint(order)


### PR DESCRIPTION
I don't think that `safe_value` should be used in examples, it adds a layer of complexity to users

The previous example file will also error at the lines

`side = 'sell' if position['side'] == 'long' else 'buy'` and `amount = position['contracts']`

if position is None