### PR TITLE
Proposal - automated mappings for `parse` functions

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -13,7 +13,7 @@ const {
     , clone
     , flatten
     , unique
-    , changeKeyValue
+    , changeMappingKeyValue
     , indexBy
     , sortBy
     , sortBy2
@@ -2225,7 +2225,7 @@ module.exports = class Exchange {
                 const typeObject = mainObject[typeKey]
                 const lowercaseType = typeKey.toLowerCase ()
                 const camelcaseType = this.capitalize (typeKey)
-                const typeObjectReversed = changeKeyValue (typeObject)
+                const typeObjectReversed = changeMappingKeyValue (typeObject)
                 // define parser
                 const parseMethodCamelcase = prefixParse + camelcaseMain + camelcaseType;
                 const parseMethodUnderscored = prefixParse + '_' + lowercaseMain + '_' + lowercaseType;

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -236,6 +236,7 @@ module.exports = class Exchange {
                         'stop': undefined, // i think we can name it 'stop-market'
                         'stop-limit': undefined,
                         'stop-loss': undefined,
+                        'trailing-stop-loss': undefined,
                         'take-profit': undefined,
                     },
                     'status': {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -414,7 +414,7 @@ module.exports = class Exchange {
         if (this.api) {
             this.defineRestApi (this.api, 'request')
         }
-        
+
         this.initRestRateLimiter ()
 
         if (this.markets) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2212,7 +2212,7 @@ module.exports = class Exchange {
     defineParseMappings () {
         const prefixParse = 'parse';
         const prefixConvert = 'to';
-        const allMappings = this.parseColletion;
+        const allMappings = this.parseCollection;
         const allMappingsKeys = Object.keys (allMappings);
         for (let i = 0; i < allMappingsKeys.length; i++) {
             const mainKey = allMappingsKeys[i] // i.e. 'order', 'transaction'...

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -13,7 +13,7 @@ const {
     , clone
     , flatten
     , unique
-    , changeMappingKeyValue
+    , transposeParseMappings
     , indexBy
     , sortBy
     , sortBy2
@@ -2226,7 +2226,7 @@ module.exports = class Exchange {
                 const typeObject = mainObject[typeKey]
                 const lowercaseType = typeKey.toLowerCase ()
                 const camelcaseType = this.capitalize (typeKey)
-                const typeObjectReversed = changeMappingKeyValue (typeObject)
+                const typeObjectReversed = transposeParseMappings (typeObject)
                 // define parser
                 const parseMethodCamelcase = prefixParse + camelcaseMain + camelcaseType;
                 const parseMethodUnderscored = prefixParse + '_' + lowercaseMain + '_' + lowercaseType;

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -56,7 +56,7 @@ module.exports = {
 
     // ------------------------------------------------------------------------
 
-    , changeKeyValue (obj) {
+    , changeMappingKeyValue (obj) {
         const result = {};
         const keys = Object.keys (obj);
         for (let i = 0; i < keys.length; i++) {

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -56,7 +56,7 @@ module.exports = {
 
     // ------------------------------------------------------------------------
 
-    , changeMappingKeyValue (obj) {
+    , transposeParseMappings (obj) {
         const result = {};
         const keys = Object.keys (obj);
         for (let i = 0; i < keys.length; i++) {

--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -56,6 +56,27 @@ module.exports = {
 
     // ------------------------------------------------------------------------
 
+    , changeKeyValue (obj) {
+        const result = {};
+        const keys = Object.keys (obj);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            const value = obj[key];
+            if (value !== undefined) {
+                if (Array.isArray (value)){
+                    for (let i = 0; i < value.length; i++) {
+                        const itemValue = value[i];
+                        result[itemValue] = key;
+                    }
+                } else {
+                    result[value] = key;
+                }
+            }
+        }
+        return result;
+    }
+
+    // ------------------------------------------------------------------------
     /*
         Accepts a map/array of objects and a key name to be used as an index:
         array = [

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1365,6 +1365,8 @@ class Exchange {
         if ($this->markets) {
             $this->set_markets($this->markets);
         }
+
+        $this->define_parse_mappings();
     }
 
     public function set_sandbox_mode($enabled) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -119,6 +119,7 @@ class Exchange {
         'delta',
         'deribit',
         'digifinex',
+        'dydx',
         'eqonex',
         'equos',
         'exmo',
@@ -188,7 +189,7 @@ class Exchange {
         'inArray' => 'in_array',
         'toArray' => 'to_array',
         'isEmpty' => 'is_empty',
-        'change_mapping_key_value' => 'change_mapping_key_value',
+        'transposeParseMappings' => 'transpose_parse_mappings',
         'indexBy' => 'index_by',
         'groupBy' => 'group_by',
         'filterBy' => 'filter_by',
@@ -675,7 +676,7 @@ class Exchange {
         return $result;
     }
 
-    public static function change_mapping_key_value ($array) {
+    public static function transpose_parse_mappings ($array) {
         $result = [];
         foreach ($array as $key => $value) {
             if ($value !== null) {
@@ -3756,7 +3757,7 @@ class Exchange {
             foreach ($mainObject as $typeKey => $typeObject) { // key: i.e. 'side', 'status'...
                 $lowercaseType = strToLower($typeKey);
                 $camelcaseType = $this->capitalize($typeKey);
-                $typeObjectReversed = self::change_mapping_key_value($typeObject);
+                $typeObjectReversed = self::transpose_parse_mappings($typeObject);
                 // define parser
                 $parseMethodCamelcase = $prefixParse . $camelcaseMain . $camelcaseType;
                 $parseMethodUnderscored = $prefixParse . '_' . $lowercaseMain . '_' . $lowercaseType;


### PR DESCRIPTION
I've been trying to structure the possible best solution to have a map for parse-converter methods, which can parse exchange specific value into unified value, and in reverse - unified value into 'exchange specific' value. 
So, with this way, we will be able to back-and-forth set the values safely. 


### Example
we set i.e. example array:
``` 
describe() {
   ...
   'parseCollection': 
        'order': {
	    'status': {
		'open': 'Open',
		'closed': 'Filled',
		...
	    },
	    'side': {
		'buy': 'BUY_ORDER',
		'sell': 'SELL_ORDER',
		...
	    },
```
Thus, when parsing the response, we can use:
`... 
const rawString = this.safeString (response, 'state'); //i.e. response is 'Open'
const status = this.parseOrderStatus(rawString ); 
...  // now status is set to unified 'open'
```
Likewise, when making request, i.e. inside fetch-order method,  and exchange API endpoint needs the 'status' parameter to be in request, there we can use:
```... 
const status = 'open';
const request = {
   'state' : this.toOrderStatus( status )  //now 'state' param is set to exchange-specific 'Open' value
}
```
now second example - in createOrder, we have:
```
async createOrder (symbol, type, side .... )
    const request = {
        'side': this.toOrderSide (side)   // turns 'buy' or 'sell' into exchange-specific 'BUY_ORDER'  or 'SELL_ORDER'
    }
...
parseOrder (order) {
   ...
   const rawString = this.safeString (response, 'side');
   const side = this.toOrderSide (rawString); // turns into 'buy' or 'sell' unified string
   ...
}
```



So, we have those failsafe and simplified approach to use all such parse/to methods across derived classes, if we just once define the mapping, and it will have great flexibility.

The demonstrational use is shown in this PR: https://github.com/ccxt/ccxt/pull/11978
Where you can find calls like `parseOrderStatus`, `parseOrderSide` and etc, all variations built from `parseCollection` mappings, so there will be no need to implement those methods in derived class (if there is specific need, user can of course override with custom method).


