### PR TITLE
ZB fetchMarkets

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -401,10 +401,10 @@ module.exports = class zb extends Exchange {
             const [ baseId, quoteId ] = id.split ('_');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
-            const settleId = this.safeValue (market, 'buyerCurrencyName');
+            const settleId = this.safeValue (market, 'marginCurrencyName');
             const settle = this.safeCurrencyCode (settleId);
             const spot = settle === undefined;
-            const swap = !spot;
+            const swap = this.safeValue (market, 'futures', false);
             const linear = swap ? true : undefined;
             let status = '1';
             let symbol = base + '/' + quote;

--- a/js/zb.js
+++ b/js/zb.js
@@ -406,7 +406,7 @@ module.exports = class zb extends Exchange {
             const spot = settle === undefined;
             const swap = this.safeValue (market, 'futures', false);
             const linear = swap ? true : undefined;
-            let status = '1';
+            let active = true;
             let symbol = base + '/' + quote;
             let amountPrecisionString = this.safeString (market, 'amountScale');
             let pricePrecisionString = this.safeString (market, 'priceScale');
@@ -415,7 +415,8 @@ module.exports = class zb extends Exchange {
             let minPrice = this.safeNumber (market, 'minSize');
             let maxPrice = undefined;
             if (swap) {
-                status = this.safeString (market, 'status');
+                const status = this.safeString (market, 'status');
+                active = (status === '1');
                 minQty = this.safeNumber (market, 'minAmount');
                 maxQty = this.safeNumber (market, 'maxAmount');
                 minPrice = this.safeNumber (market, 'minTradeMoney');
@@ -439,7 +440,7 @@ module.exports = class zb extends Exchange {
                 'swap': swap,
                 'future': false,
                 'option': false,
-                'active': (status === '1'),
+                'active': active,
                 'contract': swap,
                 'linear': linear,
                 'inverse': swap ? !linear : undefined,

--- a/js/zb.js
+++ b/js/zb.js
@@ -408,21 +408,11 @@ module.exports = class zb extends Exchange {
             const linear = swap ? true : undefined;
             let active = true;
             let symbol = base + '/' + quote;
-            let amountPrecisionString = this.safeString (market, 'amountScale');
-            let pricePrecisionString = this.safeString (market, 'priceScale');
-            let minQty = this.safeNumber (market, 'minAmount');
-            let maxQty = undefined;
-            let minPrice = this.safeNumber (market, 'minSize');
-            let maxPrice = undefined;
+            const amountPrecisionString = this.safeString2 (market, 'amountScale', 'amountDecimal');
+            const pricePrecisionString = this.safeString2 (market, 'priceScale', 'priceDecimal');
             if (swap) {
                 const status = this.safeString (market, 'status');
                 active = (status === '1');
-                minQty = this.safeNumber (market, 'minAmount');
-                maxQty = this.safeNumber (market, 'maxAmount');
-                minPrice = this.safeNumber (market, 'minTradeMoney');
-                maxPrice = this.safeNumber (market, 'maxTradeMoney');
-                amountPrecisionString = this.safeString (market, 'amountDecimal');
-                pricePrecisionString = this.safeString (market, 'priceDecimal');
                 symbol = base + '/' + quote + ':' + settle;
             }
             result.push ({
@@ -459,16 +449,16 @@ module.exports = class zb extends Exchange {
                         'max': this.safeNumber (market, 'maxLeverage'),
                     },
                     'amount': {
-                        'min': minQty,
-                        'max': maxQty,
+                        'min': this.safeNumber (market, 'minAmount'),
+                        'max': this.safeNumber (market, 'maxAmount'),
                     },
                     'price': {
                         'min': minPrice,
                         'max': maxPrice,
                     },
                     'cost': {
-                        'min': undefined,
-                        'max': undefined,
+                        'min': this.safeNumber2 (market, 'minSize', 'minTradeMoney'),
+                        'max': this.safeNumber (market, 'maxTradeMoney'),
                     },
                 },
                 'info': market,

--- a/js/zb.js
+++ b/js/zb.js
@@ -453,8 +453,8 @@ module.exports = class zb extends Exchange {
                         'max': this.safeNumber (market, 'maxAmount'),
                     },
                     'price': {
-                        'min': minPrice,
-                        'max': maxPrice,
+                        'min': undefined,
+                        'max': undefined,
                     },
                     'cost': {
                         'min': this.safeNumber2 (market, 'minSize', 'minTradeMoney'),


### PR DESCRIPTION
Added contract support for fetchMarkets:
I wasn't able to paste the rest of the output (linear, inverse, expiry, expiryDateTime, contractSize, strike, optionType, precision, limits)
```
zb.fetchMarkets ()
            id |             symbol |      base | quote | settle |    baseId | quoteId | settleId | type |  spot | margin |  swap | future | option | active | contract
      BTC_USDT |      BTC/USDT:USDT |       BTC |  USDT |   USDT |       BTC |    USDT |     usdt | swap | false |  false |  true |  false |  false |   true |     true     
      ETH_USDT |      ETH/USDT:USDT |       ETH |  USDT |   USDT |       ETH |    USDT |     usdt | swap | false |  false |  true |  false |  false |   true |     true    
      EOS_USDT |      EOS/USDT:USDT |       EOS |  USDT |   USDT |       EOS |    USDT |     usdt | swap | false |  false |  true |  false |  false |   true |     true       
...     
         zb_qc |              ZB/QC |        ZB |    QC |        |        zb |      qc |          | spot |  true |  false | false |  false |  false |   true |    false       
       zb_usdt |            ZB/USDT |        ZB |  USDT |        |        zb |    usdt |          | spot |  true |  false | false |  false |  false |   true |    false        
        zb_btc |             ZB/BTC |        ZB |   BTC |        |        zb |     btc |          | spot |  true |  false | false |  false |  false |   true |    false
...
```