### PR TITLE
Added support for SGB to Bitstamp

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -230,6 +230,8 @@ module.exports = class bitstamp extends Exchange {
                         'shib_address/',
                         'amp_withdrawal/',
                         'amp_address/',
+                        'sgb_withdrawal/',
+                        'sgb_address/',
                         'transfer-to-main/',
                         'transfer-from-main/',
                         'withdrawal-requests/',


### PR DESCRIPTION
Bitstamp is adding SGB to their platform: https://blog.bitstamp.net/post/were-enabling-deposits-and-withdrawals-of-sgb