### PR TITLE
ZB fetchOrderBook

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -684,16 +684,15 @@ module.exports = class zb extends Exchange {
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        let request = {};
-        if (market['type'] === 'swap') {
-            request = {
-                'symbol': market['id'],
-            };
-        } else {
-            request = {
-                'market': market['id'],
-            };
-        }
+        const request = {
+            // 'market': market['id'], // only applicable to SPOT
+            // 'symbol': market['id'], // only applicable to SWAP
+            // 'size': limit, // 1-50 applicable to SPOT and SWAP
+            // 'merge': 5.0, // float default depth only applicable to SPOT
+            // 'scale': 5, // int accuracy, only applicable to SWAP
+        };
+        const marketIdField = market['swap'] ? 'symbol' : 'market';
+        request[marketIdField] = market['id'];
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'spotV1PublicGetDepth',
             'swap': 'contractV1PublicGetDepth',

--- a/js/zb.js
+++ b/js/zb.js
@@ -686,11 +686,18 @@ module.exports = class zb extends Exchange {
         const market = this.market (symbol);
         const request = {
             'market': market['id'],
+            'symbol': market['id'],
         };
+        const method = this.getSupportedMapping (market['type'], {
+            'spot': 'spotV1PublicGetDepth',
+            'swap': 'contractV1PublicGetDepth',
+        });
         if (limit !== undefined) {
             request['size'] = limit;
         }
-        const response = await this.spotV1PublicGetDepth (this.extend (request, params));
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Spot
         //
         //     {
         //         "asks":[
@@ -706,7 +713,36 @@ module.exports = class zb extends Exchange {
         //         "timestamp":1624536510
         //     }
         //
-        return this.parseOrderBook (response, symbol);
+        // Swap
+        //
+        //     {
+        //         "code": 10000,
+        //         "desc": "操作成功",
+        //         "data": {
+        //             "asks": [
+        //                 [43416.6,0.02],
+        //                 [43418.25,0.04],
+        //                 [43425.82,0.02]
+        //             ],
+        //             "bids": [
+        //                 [43414.61,0.1],
+        //                 [43414.18,0.04],
+        //                 [43413.03,0.05]
+        //             ],
+        //             "time": 1645087743071
+        //         }
+        //     }
+        //
+        let result = undefined;
+        let timestamp = undefined;
+        if (market['type'] === 'swap') {
+            result = this.safeValue (response, 'data');
+            timestamp = this.safeInteger (result, 'time');
+        } else {
+            result = response;
+            timestamp = this.safeTimestamp (response, 'timestamp');
+        }
+        return this.parseOrderBook (result, symbol, timestamp);
     }
 
     async fetchTickers (symbols = undefined, params = {}) {

--- a/js/zb.js
+++ b/js/zb.js
@@ -684,10 +684,16 @@ module.exports = class zb extends Exchange {
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const request = {
-            'market': market['id'],
-            'symbol': market['id'],
-        };
+        let request = {};
+        if (market['type'] === 'swap') {
+            request = {
+                'symbol': market['id'],
+            };
+        } else {
+            request = {
+                'market': market['id'],
+            };
+        }
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'spotV1PublicGetDepth',
             'swap': 'contractV1PublicGetDepth',


### PR DESCRIPTION
Added contract support for fetchOrderBook:

Spot:
```
zb.fetchOrderBook (BTC/USDT, 3)
338 ms
{
  symbol: 'BTC/USDT',
  bids: [ [ 43423.04, 0.15 ], [ 43414.94, 0.15 ], [ 43397.32, 0.426 ] ],
  asks: [ [ 43441.02, 0.15 ], [ 43445.39, 0.2 ], [ 43449.12, 0.15 ] ],
  timestamp: 1645088710000,
  datetime: '2022-02-17T09:05:10.000Z',
  nonce: undefined
}
```
Swap:
```
zb.fetchOrderBook (BTC/USDT:USDT, 3)
331 ms
{
  symbol: 'BTC/USDT:USDT',
  bids: [ [ 43408.42, 0.12 ], [ 43408.41, 0.26 ], [ 43407.62, 0.136 ] ],
  asks: [ [ 43441.69, 0.309 ], [ 43442.47, 0.138 ], [ 43442.59, 0.15 ] ],
  timestamp: 1645088716217,
  datetime: '2022-02-17T09:05:16.217Z',
  nonce: undefined
}
```