### PR TITLE
ZB fetchTicker

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -731,9 +731,11 @@ module.exports = class zb extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'market': market['id'],
-            'symbol': market['id'],
+            // 'market': market['id'], // only applicable to SPOT
+            // 'symbol': market['id'], // only applicable to SWAP
         };
+        const marketIdField = market['swap'] ? 'symbol' : 'market';
+        request[marketIdField] = market['id'];
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'spotV1PublicGetTicker',
             'swap': 'contractV1PublicGetTicker',

--- a/js/zb.js
+++ b/js/zb.js
@@ -732,8 +732,15 @@ module.exports = class zb extends Exchange {
         const market = this.market (symbol);
         const request = {
             'market': market['id'],
+            'symbol': market['id'],
         };
-        const response = await this.spotV1PublicGetTicker (this.extend (request, params));
+        const method = this.getSupportedMapping (market['type'], {
+            'spot': 'spotV1PublicGetTicker',
+            'swap': 'contractV1PublicGetTicker',
+        });
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Spot
         //
         //     {
         //         "date":"1624399623587",
@@ -750,12 +757,39 @@ module.exports = class zb extends Exchange {
         //         }
         //     }
         //
-        const ticker = this.safeValue (response, 'ticker', {});
-        ticker['date'] = this.safeValue (response, 'date');
+        // Swap
+        //
+        //     {
+        //         "code": 10000,
+        //         "desc": "操作成功",
+        //         "data": {
+        //             "BTC_USDT": [44053.47,44357.77,42911.54,43297.79,53471.264,-1.72,1645093002,302201.255084]
+        //         }
+        //     }
+        //
+        let ticker = undefined;
+        if (market['type'] === 'swap') {
+            ticker = {};
+            const data = this.safeValue (response, 'data');
+            const values = this.safeValue (data, market['id']);
+            for (let i = 0; i < values.length; i++) {
+                ticker['open'] = this.safeValue (values, 0);
+                ticker['high'] = this.safeValue (values, 1);
+                ticker['low'] = this.safeValue (values, 2);
+                ticker['last'] = this.safeValue (values, 3);
+                ticker['vol'] = this.safeValue (values, 4);
+                ticker['riseRate'] = this.safeValue (values, 5);
+            }
+        } else {
+            ticker = this.safeValue (response, 'ticker', {});
+            ticker['date'] = this.safeValue (response, 'date');
+        }
         return this.parseTicker (ticker, market);
     }
 
     parseTicker (ticker, market = undefined) {
+        //
+        // Spot
         //
         //     {
         //         "date":"1624399623587", // injected from outside
@@ -768,6 +802,17 @@ module.exports = class zb extends Exchange {
         //         "turnover":"1764201303.6100",
         //         "open":"31664.85",
         //         "riseRate":"2.89"
+        //     }
+        //
+        // Swap
+        //
+        //     {
+        //         open: 44083.82,
+        //         high: 44357.77,
+        //         low: 42911.54,
+        //         last: 43097.87,
+        //         vol: 53451.641,
+        //         riseRate: -2.24
         //     }
         //
         const timestamp = this.safeInteger (ticker, 'date', this.milliseconds ());


### PR DESCRIPTION
Added contract support for fetchTicker:

Spot:
```
zb.fetchTicker (BTC/USDT)
343 ms
{
  symbol: 'BTC/USDT',
  timestamp: 1645095714120,
  datetime: '2022-02-17T11:01:54.120Z',
  high: 44381.76,
  low: 42933.91,
  bid: 43071.18,
  bidVolume: undefined,
  ask: 43088.72,
  askVolume: undefined,
  vwap: undefined,
  open: 44109.71,
  close: 43079.66,
  last: 43079.66,
  previousClose: undefined,
  change: -1030.05,
  percentage: -2.3352001180692414,
  average: 43594.685,
  baseVolume: 4982.0231,
  quoteVolume: undefined,
  info: {
    high: '44381.76',
    vol: '4982.0231',
    last: '43079.66',
    low: '42933.91',
    buy: '43071.18',
    sell: '43088.72',
    turnover: '217812388.4900',
    open: '44109.71',
    riseRate: '-2.33',
    date: '1645095714120'
  }
}
```
Swap:
```
zb.fetchTicker (BTC/USDT:USDT)
335 ms
{
  symbol: 'BTC/USDT:USDT',
  timestamp: 1645095778978,
  datetime: '2022-02-17T11:02:58.978Z',
  high: 44357.77,
  low: 42902.66,
  bid: undefined,
  bidVolume: undefined,
  ask: undefined,
  askVolume: undefined,
  vwap: undefined,
  open: 44098.03,
  close: 43101.41,
  last: 43101.41,
  previousClose: undefined,
  change: -996.62,
  percentage: -2.2600102544263314,
  average: 43599.72,
  baseVolume: 54021.234,
  quoteVolume: undefined,
  info: {
    open: 44098.03,
    high: 44357.77,
    low: 42902.66,
    last: 43101.41,
    vol: 54021.234,
    riseRate: -2.26
  }
}
```