### PR TITLE
Emulate single market method from multi market method

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -329,6 +329,7 @@ module.exports = class Exchange {
                 this[property] = value
             }
         }
+        this.emulateSingleMarketMethod ('fetchPosition');
 
         const agentOptions = {
             'keepAlive': true,
@@ -721,6 +722,15 @@ module.exports = class Exchange {
 
     onJsonResponse (responseBody) {
         return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
+    }
+
+    emulateSingleMarketMethod (emulatedMethod, multiMarketMethod = undefined) {
+        if (multiMarketMethod === undefined) {
+            multiMarketMethod = emulatedMethod + 's';
+        }
+        if (this.has[multiMarketMethod] && this.has[emulatedMethod] === undefined) {
+            this.has[emulatedMethod] = 'emulated';
+        }
     }
 
     setMarkets (markets, currencies = undefined) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -730,6 +730,23 @@ module.exports = class Exchange {
         }
         if (this.has[multiMarketMethod] && this.has[emulatedMethod] === undefined) {
             this.has[emulatedMethod] = 'emulated';
+            this[emulatedMethod] = async (symbol, ...args) => {
+                const response = await this[multiMarketMethod] ([symbol], ...args);
+                let item = undefined;
+                if (Array.isArray (response)) {
+                    item = response.filter(item['symbol'] === symbol)[0];
+                } else if (response instanceof Object) {
+                    item = response[symbol]
+                }
+                if (item === undefined) {
+                    throw new InvalidAddress (this.id + ' ' + emulatedMethod + ' could not get data for ' + symbol);
+                }
+                return item;
+            }
+        } else {
+            this[emulatedMethod] = (symbol, ...args) => {
+                throw new NotSupported (this.id + ' ' + emulatedMethod + ' not supported yet');
+            }
         }
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1590,7 +1590,7 @@ class Exchange {
 
     public function emulate_single_market_method($emulated_method, $multi_market_method=null) {
         if ($multi_market_method === null) {
-            $multi_market_method = $emulated_method + 's';
+            $multi_market_method = $emulated_method . 's';
         }
         if ($this->has[$multi_market_method] && $this->has[$emulated_method] === null) {
             $this->has[$emulated_method] = 'emulated';

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1303,6 +1303,7 @@ class Exchange {
                         $value;
             }
         }
+        $this->emulate_single_market_method('fetchPosition');
 
         $this->tokenBucket = array(
             'delay' => 0.001,
@@ -1585,6 +1586,15 @@ class Exchange {
 
     public function on_json_response($response_body) {
         return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)([,}])/', '":"$1"$2', $response_body) : $response_body;
+    }
+
+    public function emulate_single_market_method($emulated_method, $multi_market_method=null) {
+        if ($multi_market_method === null) {
+            $multi_market_method = $emulated_method + 's';
+        }
+        if ($this->has[$multi_market_method] && $this->has[$emulated_method] === null) {
+            $this->has[$emulated_method] = 'emulated';
+        }
     }
 
     public function fetch($url, $method = 'GET', $headers = null, $body = null) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -401,6 +401,7 @@ class Exchange(object):
         self.userAgent = default_user_agent()
 
         settings = self.deep_extend(self.describe(), config)
+        self.emulate_single_market_method('fetchPosition')
 
         for key in settings:
             if hasattr(self, key) and isinstance(getattr(self, key), dict):
@@ -609,6 +610,12 @@ class Exchange(object):
             return json.loads(response_body, parse_float=str, parse_int=str)
         else:
             return json.loads(response_body)
+
+    def emulate_single_market_method(self, emulated_method, multi_market_method=None):
+        if multi_market_method is None:
+            multi_market_method = emulated_method + 's'
+        if self.has[multi_market_method] and self.has[multi_market_method] is None:
+            self.has[emulated_method] = 'emulated'
 
     def fetch(self, url, method='GET', headers=None, body=None):
         """Perform a HTTP request and return decoded JSON data"""


### PR DESCRIPTION
This could replace the default `fetchTicker` and `fetchBorrowRate` methods on Base.exchange, and will work for any other single market methods

If you like it I'll write the PHP and Python versions as well