### PR TITLE
Wazirx :: fix  ohlcv

### DIFF
--- a/js/wazirx.js
+++ b/js/wazirx.js
@@ -348,7 +348,7 @@ module.exports = class wazirx extends Exchange {
         //     }
         //
         const id = this.safeString (trade, 'id');
-        const timestamp = this.parse8601 (this.safeString (trade, 'time'));
+        const timestamp = this.safeInteger (trade, 'time');
         const datetime = this.iso8601 (timestamp);
         let symbol = undefined;
         if (market !== undefined) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1800,10 +1800,12 @@ class Exchange(object):
             trade = trades[i]
             if (since is not None) and (trade['timestamp'] < since):
                 continue
-            opening_time = int(math.floor(trade['timestamp'] / ms) * ms)  # Shift the edge of the m/h/d (but not M)
+            opening_time = None
+            if trade['timestamp']:
+                opening_time = int(math.floor(trade['timestamp'] / ms) * ms)  # Shift the edge of the m/h/d (but not M)
             j = len(ohlcvs)
             candle = j - 1
-            if (j == 0) or opening_time >= ohlcvs[candle][timestamp] + ms:
+            if (j == 0) or (opening_time and opening_time >= ohlcvs[candle][timestamp] + ms):
                 # moved to a new timeframe -> create a new candle from opening trade
                 ohlcvs.append([
                     opening_time,


### PR DESCRIPTION
fixes #11996 

I've fixed the problem for this particular exchange by correctly parsing the trade timestamp, and also protected the code to avoid crashing when the timestamp is not available since this is a thing we don't control upon emulating ohlcvs