### PR TITLE
ZB fetchFundingRate

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { BadRequest, ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, OrderNotFound, ExchangeNotAvailable, RateLimitExceeded, PermissionDenied, InvalidOrder, InvalidAddress, OnMaintenance, RequestTimeout, AccountSuspended } = require ('./base/errors');
+const { BadRequest, ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, OrderNotFound, ExchangeNotAvailable, RateLimitExceeded, PermissionDenied, InvalidOrder, InvalidAddress, OnMaintenance, RequestTimeout, AccountSuspended, NotSupported } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -1272,7 +1272,7 @@ module.exports = class zb extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadRequest ('Funding rates only exist for swap contracts');
+            throw new NotSupported (this.id + ' fetchFundingRate() does not supports contracts only');
         }
         const request = {
             'symbol': market['id'],


### PR DESCRIPTION
Added fetchFundingRate to ZB:
```
zb.fetchFundingRate (BTC/USDT:USDT)
BTC_USDT
443 ms
{
  info: { fundingRate: '0.0001', nextCalculateTime: '2022-02-19 00:00:00' },
  symbol: 'BTC/USDT:USDT',
  markPrice: undefined,
  indexPrice: undefined,
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: undefined,
  datetime: undefined,
  fundingRate: 0.0001,
  fundingTimestamp: undefined,
  fundingDatetime: undefined,
  nextFundingRate: undefined,
  nextFundingTimestamp: 1645228800000,
  nextFundingDatetime: '2022-02-19 00:00:00',
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
```