### PR TITLE
FTX: throw an informative error message if the FTX future has no expiry

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -4,7 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { TICK_SIZE } = require ('./base/functions/number');
-const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId } = require ('./base/errors');
+const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId, BadResponse } = require ('./base/errors');
 const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------
@@ -575,6 +575,9 @@ module.exports = class ftx extends Exchange {
             } else if (isFuture) {
                 type = 'future';
                 expiry = this.parse8601 (expiryDatetime);
+                if (expiry === undefined) {
+                    throw new BadResponse (this.id + " symbol '" + id + "' is a future contract but with invalid expiry datetime: " + expiryDatetime);
+                }
                 const parsedId = id.split ('-');
                 const length = parsedId.length;
                 if (length > 2) {


### PR DESCRIPTION
To be able to debug issue #11544, it is important that the FTX client returns an informative error message if a future trading couple has no expiry datetime associated.

Note that the function will crash exactly as it does now in that (rare) case, but instead of returning a `TypeError` on a division, it now returns an informative error message.