### PR TITLE
mexc BIFI -> BIFIF

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -243,6 +243,7 @@ module.exports = class mexc extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'BIFI': 'BIFIF',
                 'BYN': 'BeyondFi',
                 'COFI': 'COFIX', // conflict with CoinFi
                 'DFI': 'DfiStarter',

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -243,6 +243,7 @@ module.exports = class mexc extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'BEYONDPROTOCOL': 'BEYOND',
                 'BIFI': 'BIFIF',
                 'BYN': 'BeyondFi',
                 'COFI': 'COFIX', // conflict with CoinFi


### PR DESCRIPTION
https://coinmarketcap.com/currencies/bifi/markets/
conflict with https://coinmarketcap.com/currencies/beefy-finance/markets/
naming like on Gate.io