### PR TITLE
liquid BIFI -> BIFIF

### DIFF
--- a/js/liquid.js
+++ b/js/liquid.js
@@ -212,9 +212,8 @@ module.exports = class liquid extends Exchange {
                 'BIFI': 'BIFIF',
                 'HOT': 'HOT Token',
                 'MIOTA': 'IOTA', // https://github.com/ccxt/ccxt/issues/7487
-                'TON': 'Tokamak Network',
-                'BIFI': 'Bifrost Finance',
                 'P-BTC': 'BTC',
+                'TON': 'Tokamak Network',
             },
             'options': {
                 'cancelOrderException': true,

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -209,6 +209,7 @@ module.exports = class liquid extends Exchange {
                 'product_disabled': BadSymbol, // {"errors":{"order":["product_disabled"]}}
             },
             'commonCurrencies': {
+                'BIFI': 'BIFIF',
                 'HOT': 'HOT Token',
                 'MIOTA': 'IOTA', // https://github.com/ccxt/ccxt/issues/7487
                 'TON': 'Tokamak Network',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/bifi/markets/
conflict with https://coinmarketcap.com/currencies/beefy-finance/markets/
naming like on Gate.io