### PR TITLE
DigiFinex: parse correct trade side when *_market trade

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -670,8 +670,8 @@ module.exports = class digifinex extends Exchange {
         const orderId = this.safeString (trade, 'order_id');
         const timestamp = this.safeTimestamp2 (trade, 'date', 'timestamp');
         let side = this.safeString2 (trade, 'type', 'side');
-        if (side.includes('_market')) {
-            side = side.replace(/_market/, '');
+        if (side.includes ('_market')) {
+            side = side.replace (/_market/, '');
         }
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -670,11 +670,9 @@ module.exports = class digifinex extends Exchange {
         const orderId = this.safeString (trade, 'order_id');
         const timestamp = this.safeTimestamp2 (trade, 'date', 'timestamp');
         let side = this.safeString2 (trade, 'type', 'side');
-        let type = undefined;
-        if (side.indexOf ('_market') >= 0) {
-            side = side.replace ('_market', '');
-            type = 'market';
-        }
+        const parts = side.split ('_');
+        side = this.safeString (parts, 0);
+        const type = this.safeString (parts, 1);
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');
         const marketId = this.safeString (trade, 'symbol');

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -670,7 +670,11 @@ module.exports = class digifinex extends Exchange {
         const orderId = this.safeString (trade, 'order_id');
         const timestamp = this.safeTimestamp2 (trade, 'date', 'timestamp');
         let side = this.safeString2 (trade, 'type', 'side');
-        side = side.replace ('_market', '');
+        let type = undefined;
+        if (side.indexOf ('_market') >= 0) {
+            side = side.replace ('_market', '');
+            type = 'market';
+        }
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');
         const marketId = this.safeString (trade, 'symbol');
@@ -692,7 +696,7 @@ module.exports = class digifinex extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'symbol': symbol,
-            'type': undefined,
+            'type': type,
             'order': orderId,
             'side': side,
             'price': priceString,

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -662,7 +662,7 @@ module.exports = class digifinex extends Exchange {
         //         "fee": 0.096,
         //         "fee_currency": "USDT",
         //         "timestamp": 1499865549,
-        //         "side": "buy", // or "side":"sell_market"
+        //         "side": "buy", // or "side": "sell_market"
         //         "is_maker": true
         //     }
         //

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -662,14 +662,17 @@ module.exports = class digifinex extends Exchange {
         //         "fee": 0.096,
         //         "fee_currency": "USDT",
         //         "timestamp": 1499865549,
-        //         "side": "buy",
+        //         "side": "buy", // or "side":"sell_market"
         //         "is_maker": true
         //     }
         //
         const id = this.safeString (trade, 'id');
         const orderId = this.safeString (trade, 'order_id');
         const timestamp = this.safeTimestamp2 (trade, 'date', 'timestamp');
-        const side = this.safeString2 (trade, 'type', 'side');
+        let side = this.safeString2 (trade, 'type', 'side');
+        if (side.includes('_market')) {
+            side = side.replace(/_market/, '');
+        }
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');
         const marketId = this.safeString (trade, 'symbol');

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -671,7 +671,7 @@ module.exports = class digifinex extends Exchange {
         const timestamp = this.safeTimestamp2 (trade, 'date', 'timestamp');
         let side = this.safeString2 (trade, 'type', 'side');
         if (side.includes ('_market')) {
-            side = side.replace (/_market/, '');
+            side = side.replace ('_market', '');
         }
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -670,9 +670,7 @@ module.exports = class digifinex extends Exchange {
         const orderId = this.safeString (trade, 'order_id');
         const timestamp = this.safeTimestamp2 (trade, 'date', 'timestamp');
         let side = this.safeString2 (trade, 'type', 'side');
-        if (side.includes ('_market')) {
-            side = side.replace ('_market', '');
-        }
+        side = side.replace ('_market', '');
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');
         const marketId = this.safeString (trade, 'symbol');


### PR DESCRIPTION
DigiFinex has the following Trading Types (side): `buy, sell, buy_market, sell_market` (https://docs.digifinex.com/en-ww/v3/#customer-39-s-trades)
```
{
"timestamp":1643790631,
"is_maker":false,
"id":"9587038712",
"amount":0.01,
"side":"sell_market",
"symbol":"BTC_USDT",
"fee_currency":"USDT",
"fee":0.7672146,
"order_id":"2bb1f8070e5679c7349238664cb7f0b3",
"price":38360.73
}
```
![image](https://user-images.githubusercontent.com/3694800/154866965-3ac8fe73-2443-4e45-a15e-3a1ef587e0a0.png)


So I added a fix for the *_market side.

Not sure if you like the implementation. You can change it you have a better solution :) 