### PR TITLE
kucoin fetchTradingFee

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1675,14 +1675,11 @@ module.exports = class kucoin extends Exchange {
         const data = this.safeValue (response, 'data', []);
         const first = this.safeValue (data, 0);
         const marketId = this.safeString (first, 'symbol');
-        const safeSymbol = this.safeSymbol (marketId, market);
-        const makerFee = this.safeFloat (first, 'makerFeeRate');
-        const takerFee = this.safeFloat (first, 'takerFeeRate');
         return {
             'info': response,
-            'symbol': safeSymbol,
-            'maker': makerFee,
-            'taker': takerFee,
+            'symbol': this.safeSymbol (marketId, market),
+            'maker': this.safeNumber (first, 'makerFeeRate'),
+            'taker': this.safeNumber (first, 'takerFeeRate'),
         };
     }
 

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1662,16 +1662,18 @@ module.exports = class kucoin extends Exchange {
             'symbols': market['id'],
         };
         const response = await this.privateGetTradeFees (this.extend (request, params));
-        // {
-        //     code: '200000',
-        //     data: [
-        //       {
-        //         symbol: 'BTC-USDT',
-        //         takerFeeRate: '0.001',
-        //         makerFeeRate: '0.001'
-        //       }
-        //     ]
-        // }
+        //
+        //     {
+        //         code: '200000',
+        //         data: [
+        //           {
+        //             symbol: 'BTC-USDT',
+        //             takerFeeRate: '0.001',
+        //             makerFeeRate: '0.001'
+        //           }
+        //         ]
+        //     }
+        //
         const data = this.safeValue (response, 'data', []);
         const first = this.safeValue (data, 0);
         const marketId = this.safeString (first, 'symbol');

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1672,12 +1672,12 @@ module.exports = class kucoin extends Exchange {
         //       }
         //     ]
         // }
-        const data = this.safeValue (response, 'data', [ {} ]);
-        const fee = data[0];
-        const feeSymbol = this.safeString ('symbol', fee);
-        const safeSymbol = this.safeSymbol (feeSymbol, market);
-        const makerFee = this.safeFloat (fee, 'makerFeeRate');
-        const takerFee = this.safeFloat (fee, 'takerFeeRate');
+        const data = this.safeValue (response, 'data', []);
+        const first = this.safeValue (data, 0);
+        const marketId = this.safeString (first, 'symbol');
+        const safeSymbol = this.safeSymbol (marketId, market);
+        const makerFee = this.safeFloat (first, 'makerFeeRate');
+        const takerFee = this.safeFloat (first, 'takerFeeRate');
         return {
             'info': response,
             'symbol': safeSymbol,


### PR DESCRIPTION
This PR adds function `fetchTradingFee`

Notes:

1. `fetchTradingFees` is not included in this PR but it could be done by calling `/v1/trade-fees` with all the symbols. However `/trade-fees` limits the query to 10 symbols so it would have to be called several times to get all the symbols in the exchange. Is this something we want to do?

2.  `fetchFundingFees` is currently implemented calling `privateGetWithdrawalsQuotas` however withdrawal fees can also be retrieved from `/v1/symbols` therefore following previous logic.  (We can probably add some code in the base class to propagate the fees from .currencies into fetchTradingFees, but we shouldn't really reuse the same implicit endpoint as fetchCurrencies there) Therefore should we remove this function?