### PR TITLE
ZB cancelAllOrders

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { BadRequest, BadSymbol, ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, OrderNotFound, ExchangeNotAvailable, RateLimitExceeded, PermissionDenied, InvalidOrder, InvalidAddress, OnMaintenance, RequestTimeout, AccountSuspended } = require ('./base/errors');
+const { BadRequest, BadSymbol, ExchangeError, ArgumentsRequired, AuthenticationError, InsufficientFunds, NotSupported, OrderNotFound, ExchangeNotAvailable, RateLimitExceeded, PermissionDenied, InvalidOrder, InvalidAddress, OnMaintenance, RequestTimeout, AccountSuspended } = require ('./base/errors');
 
 //  ---------------------------------------------------------------------------
 
@@ -997,8 +997,14 @@ module.exports = class zb extends Exchange {
     }
 
     async cancelAllOrders (symbol = undefined, params = {}) {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol argument');
+        }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (market['spot']) {
+            throw new NotSupported (this.id + ' cancelAllOrders() is not supported on ' + market['type'] + ' markets');
+        }
         const request = {
             'symbol': market['id'],
         };

--- a/js/zb.js
+++ b/js/zb.js
@@ -24,6 +24,7 @@ module.exports = class zb extends Exchange {
                 'swap': undefined, // has but unimplemented
                 'future': undefined,
                 'option': undefined,
+                'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createMarketOrder': undefined,
                 'createOrder': true,

--- a/js/zb.js
+++ b/js/zb.js
@@ -995,6 +995,15 @@ module.exports = class zb extends Exchange {
         return await this.spotV1PrivateGetCancelOrder (this.extend (request, params));
     }
 
+    async cancelAllOrders (symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        return await this.contractV2PrivatePostTradeCancelAllOrders (this.extend (request, params));
+    }
+
     async fetchOrder (id, symbol = undefined, params = {}) {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');


### PR DESCRIPTION
Added cancelAllOrders to ZB:
```
zb.cancelAllOrders (BTC/USDT:USDT)
337 ms
{ code: '10000', data: [], desc: '操作成功' }
```