### PR TITLE
latoken GEC -> Geco One

### DIFF
--- a/js/latoken.js
+++ b/js/latoken.js
@@ -136,6 +136,7 @@ module.exports = class latoken extends Exchange {
                 'DMD': 'Diamond Coin',
                 'FREN': 'Frenchie',
                 'GDX': 'GoldenX',
+                'GEC': 'Geco One',
                 'GEM': 'NFTmall',
                 'IMC': 'IMCoin',
                 'MT': 'Monarch',


### PR DESCRIPTION
https://latoken.com/exchange/GEC_USDT
conflict with https://coinmarketcap.com/currencies/geckolands/markets/