### PR TITLE
bitfinex - fetchTradingFees

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -367,6 +367,13 @@ module.exports = class bitfinex extends Exchange {
                     'limit': 'exchange limit',
                     'market': 'exchange market',
                 },
+                'fiat': {
+                    'USD': 'USD',
+                    'EUR': 'EUR',
+                    'JPY': 'JPY',
+                    'GBP': 'GBP',
+                    'CNH': 'CNH',
+                },
                 'accountsByType': {
                     'spot': 'exchange',
                     'margin': 'trading',
@@ -443,16 +450,30 @@ module.exports = class bitfinex extends Exchange {
         const result = {
             'info': response,
         };
+        const fiat = this.safeValue (this.options, 'fiat', {});
         const makerFee = this.safeNumber (response, 'maker_fee');
         const takerFee = this.safeNumber (response, 'taker_fee');
+        const makerFee2Fiat = this.safeNumber (response, 'maker_fee_2fiat');
+        const takerFee2Fiat = this.safeNumber (response, 'taker_fee_2fiat');
+        const makerFee2Deriv = this.safeNumber (response, 'maker_fee_2deriv');
+        const takerFee2Deriv = this.safeNumber (response, 'taker_fee_2deriv');
         for (let i = 0; i < this.symbols.length; i++) {
             const symbol = this.symbols[i];
+            const market = this.market (symbol);
             const fee = {
                 'info': {},
                 'symbol': symbol,
-                'maker': makerFee,
-                'taker': takerFee,
             };
+            if (market['quote'] in fiat) {
+                fee['maker'] = makerFee2Fiat;
+                fee['taker'] = takerFee2Fiat;
+            } else if (market['contract']) {
+                fee['maker'] = makerFee2Deriv;
+                fee['taker'] = takerFee2Deriv;
+            } else {
+                fee['maker'] = makerFee;
+                fee['taker'] = takerFee;
+            }
             result[symbol] = fee;
         }
         return result;

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -461,6 +461,8 @@ module.exports = class bitfinex extends Exchange {
             const fee = {
                 'info': response,
                 'symbol': symbol,
+                'percentage': true,
+                'tierBased': true,
             };
             if (market['quote'] in fiat) {
                 fee['maker'] = makerFee2Fiat;

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -400,7 +400,7 @@ module.exports = class bitfinex extends Exchange {
 
     async fetchTradingFee (symbol, params = {}) {
         await this.loadMarkets ();
-        const safeSymbol = this.safeSymbol (symbol);
+        const market = this.market (symbol);
         const response = await this.privatePostSummary (params);
         //
         //     {
@@ -445,7 +445,7 @@ module.exports = class bitfinex extends Exchange {
         const takerFee = this.safeNumber (response, 'taker_fee');
         return {
             'info': response,
-            'symbol': safeSymbol,
+            'symbol': market['symbol'],
             'maker': makerFee,
             'taker': takerFee,
         };

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -52,7 +52,7 @@ module.exports = class bitfinex extends Exchange {
                 'fetchTickers': true,
                 'fetchTime': false,
                 'fetchTrades': true,
-                'fetchTradingFee': true,
+                'fetchTradingFee': false,
                 'fetchTradingFees': true,
                 'fetchTransactions': true,
                 'fetchWithdrawals': undefined,
@@ -395,59 +395,6 @@ module.exports = class bitfinex extends Exchange {
             'info': response,
             'withdraw': withdraw,
             'deposit': withdraw,  // only for deposits of less than $1000
-        };
-    }
-
-    async fetchTradingFee (symbol, params = {}) {
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        const response = await this.privatePostSummary (params);
-        //
-        //     {
-        //          time: '2022-02-23T16:05:47.659000Z',
-        //          status: { resid_hint: null, login_last: '2022-02-23T16:05:48Z' },
-        //          is_locked: false,
-        //          leo_lev: '0',
-        //          leo_amount_avg: '0.0',
-        //          trade_vol_30d: [
-        //          {
-        //              curr: 'Total (USD)',
-        //              vol: '0.0',
-        //              vol_safe: '0.0',
-        //              vol_maker: '0.0',
-        //              vol_BFX: '0.0',
-        //              vol_BFX_safe: '0.0',
-        //              vol_BFX_maker: '0.0'
-        //          }
-        //          ],
-        //          fees_funding_30d: {},
-        //          fees_funding_total_30d: '0',
-        //          fees_trading_30d: {},
-        //          fees_trading_total_30d: '0',
-        //          rebates_trading_30d: {},
-        //          rebates_trading_total_30d: '0',
-        //          maker_fee: '0.001',
-        //          taker_fee: '0.002',
-        //          maker_fee_2crypto: '0.001',
-        //          maker_fee_2stablecoin: '0.001',
-        //          maker_fee_2fiat: '0.001',
-        //          maker_fee_2deriv: '0.0002',
-        //          taker_fee_2crypto: '0.002',
-        //          taker_fee_2stablecoin: '0.002',
-        //          taker_fee_2fiat: '0.002',
-        //          taker_fee_2deriv: '0.00065',
-        //          deriv_maker_rebate: '0.0002',
-        //          deriv_taker_fee: '0.00065',
-        //          trade_last: null
-        //     }
-        //
-        const makerFee = this.safeNumber (response, 'maker_fee');
-        const takerFee = this.safeNumber (response, 'taker_fee');
-        return {
-            'info': response,
-            'symbol': market['symbol'],
-            'maker': makerFee,
-            'taker': takerFee,
         };
     }
 

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -447,9 +447,7 @@ module.exports = class bitfinex extends Exchange {
         //          trade_last: null
         //     }
         //
-        const result = {
-            'info': response,
-        };
+        const result = {};
         const fiat = this.safeValue (this.options, 'fiat', {});
         const makerFee = this.safeNumber (response, 'maker_fee');
         const takerFee = this.safeNumber (response, 'taker_fee');
@@ -461,7 +459,7 @@ module.exports = class bitfinex extends Exchange {
             const symbol = this.symbols[i];
             const market = this.market (symbol);
             const fee = {
-                'info': {},
+                'info': response,
                 'symbol': symbol,
             };
             if (market['quote'] in fiat) {

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -398,36 +398,117 @@ module.exports = class bitfinex extends Exchange {
         };
     }
 
+    async fetchTradingFee (symbol, params = {}) {
+        await this.loadMarkets ();
+        const safeSymbol = this.safeSymbol (symbol);
+        const response = await this.privatePostSummary (params);
+        //
+        //     {
+        //          time: '2022-02-23T16:05:47.659000Z',
+        //          status: { resid_hint: null, login_last: '2022-02-23T16:05:48Z' },
+        //          is_locked: false,
+        //          leo_lev: '0',
+        //          leo_amount_avg: '0.0',
+        //          trade_vol_30d: [
+        //          {
+        //              curr: 'Total (USD)',
+        //              vol: '0.0',
+        //              vol_safe: '0.0',
+        //              vol_maker: '0.0',
+        //              vol_BFX: '0.0',
+        //              vol_BFX_safe: '0.0',
+        //              vol_BFX_maker: '0.0'
+        //          }
+        //          ],
+        //          fees_funding_30d: {},
+        //          fees_funding_total_30d: '0',
+        //          fees_trading_30d: {},
+        //          fees_trading_total_30d: '0',
+        //          rebates_trading_30d: {},
+        //          rebates_trading_total_30d: '0',
+        //          maker_fee: '0.001',
+        //          taker_fee: '0.002',
+        //          maker_fee_2crypto: '0.001',
+        //          maker_fee_2stablecoin: '0.001',
+        //          maker_fee_2fiat: '0.001',
+        //          maker_fee_2deriv: '0.0002',
+        //          taker_fee_2crypto: '0.002',
+        //          taker_fee_2stablecoin: '0.002',
+        //          taker_fee_2fiat: '0.002',
+        //          taker_fee_2deriv: '0.00065',
+        //          deriv_maker_rebate: '0.0002',
+        //          deriv_taker_fee: '0.00065',
+        //          trade_last: null
+        //     }
+        //
+        const makerFee = this.safeNumber (response, 'maker_fee');
+        const takerFee = this.safeNumber (response, 'taker_fee');
+        return {
+            'info': response,
+            'symbol': safeSymbol,
+            'maker': makerFee,
+            'taker': takerFee,
+        };
+    }
+
     async fetchTradingFees (params = {}) {
         await this.loadMarkets ();
         const response = await this.privatePostSummary (params);
         //
         //     {
-        //         time: '2019-02-20T15:50:19.152000Z',
-        //         trade_vol_30d: [
-        //             {
-        //                 curr: 'Total (USD)',
-        //                 vol: 0,
-        //                 vol_maker: 0,
-        //                 vol_BFX: 0,
-        //                 vol_BFX_maker: 0,
-        //                 vol_ETHFX: 0,
-        //                 vol_ETHFX_maker: 0
-        //             }
-        //         ],
-        //         fees_funding_30d: {},
-        //         fees_funding_total_30d: 0,
-        //         fees_trading_30d: {},
-        //         fees_trading_total_30d: 0,
-        //         maker_fee: 0.001,
-        //         taker_fee: 0.002
+        //          time: '2022-02-23T16:05:47.659000Z',
+        //          status: { resid_hint: null, login_last: '2022-02-23T16:05:48Z' },
+        //          is_locked: false,
+        //          leo_lev: '0',
+        //          leo_amount_avg: '0.0',
+        //          trade_vol_30d: [
+        //          {
+        //              curr: 'Total (USD)',
+        //              vol: '0.0',
+        //              vol_safe: '0.0',
+        //              vol_maker: '0.0',
+        //              vol_BFX: '0.0',
+        //              vol_BFX_safe: '0.0',
+        //              vol_BFX_maker: '0.0'
+        //          }
+        //          ],
+        //          fees_funding_30d: {},
+        //          fees_funding_total_30d: '0',
+        //          fees_trading_30d: {},
+        //          fees_trading_total_30d: '0',
+        //          rebates_trading_30d: {},
+        //          rebates_trading_total_30d: '0',
+        //          maker_fee: '0.001',
+        //          taker_fee: '0.002',
+        //          maker_fee_2crypto: '0.001',
+        //          maker_fee_2stablecoin: '0.001',
+        //          maker_fee_2fiat: '0.001',
+        //          maker_fee_2deriv: '0.0002',
+        //          taker_fee_2crypto: '0.002',
+        //          taker_fee_2stablecoin: '0.002',
+        //          taker_fee_2fiat: '0.002',
+        //          taker_fee_2deriv: '0.00065',
+        //          deriv_maker_rebate: '0.0002',
+        //          deriv_taker_fee: '0.00065',
+        //          trade_last: null
         //     }
         //
-        return {
+        const result = {
             'info': response,
-            'maker': this.safeNumber (response, 'maker_fee'),
-            'taker': this.safeNumber (response, 'taker_fee'),
         };
+        const makerFee = this.safeNumber (response, 'maker_fee');
+        const takerFee = this.safeNumber (response, 'taker_fee');
+        for (let i = 0; i < this.symbols.length; i++) {
+            const symbol = this.symbols[i];
+            const fee = {
+                'info': {},
+                'symbol': symbol,
+                'maker': makerFee,
+                'taker': takerFee,
+            };
+            result[symbol] = fee;
+        }
+        return result;
     }
 
     async fetchMarkets (params = {}) {


### PR DESCRIPTION
- Add `fetchTradingFee`
- Refactor `fetchTradingFees` to include common format with the fee under all traded symbols

Note: Bitfinex can return different fees depending if crypto, fiat or derivates are traded. Currently there is no function in ccxt that I know of to discern between the type of different symbols. Therefore this PR assumes all symbols have the same trading fee as crypto.