### PR TITLE
Bybit.fetchMarketLeverageTiers

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3193,7 +3193,6 @@ module.exports = class bybit extends Exchange {
                 'notionalCap': notionalCap,
                 'maintenanceMarginRatio': this.safeNumber (item, 'maintain_margin'),
                 'maxLeverage': this.safeNumber (item, 'max_leverage'),
-                'maintenanceAmount': undefined,
                 'info': item,
             });
             tier += 1;

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3107,11 +3107,11 @@ module.exports = class bybit extends Exchange {
             }
             request['symbol'] = market['id'];
         }
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchLeverageTiers', market, params);
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchMarketLeverageTiers', market, params);
         const method = this.getSupportedMapping (type, {
-            'linear': 'publicLinearGetRiskLimit',
+            'linear': 'publicLinearGetRiskLimit', // Symbol required
             'swap': 'publicLinearGetRiskLimit',
-            'inverse': 'v2PublicGetRiskLimitList',
+            'inverse': 'v2PublicGetRiskLimitList', // Symbol not required, could implement fetchLeverageTiers
             'future': 'v2PublicGetRiskLimitList',
         });
         const response = await this[method] (this.extend (request, query));

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3176,52 +3176,50 @@ module.exports = class bybit extends Exchange {
     }
 
     parseMarketLeverageTiers (info, market) {
-        /**
-            @param info: Array of leverage tier info for a single market
-            Linear
-            [
-                {
-                    id: '11',
-                    symbol: 'ETHUSDT',
-                    limit: '800000',
-                    maintain_margin: '0.01',
-                    starting_margin: '0.02',
-                    section: [
-                        '1',  '2',  '3',
-                        '5',  '10', '15',
-                        '25'
-                    ],
-                    is_lowest_risk: '1',
-                    created_at: '2022-02-04 23:30:33.555252',
-                    updated_at: '2022-02-04 23:30:33.555254',
-                    max_leverage: '50'
-                },
-                ...
-            ]
-
-            Inverse
-            [
-                {
-                    id: '180',
-                    is_lowest_risk: '0',
-                    section: [
-                        '1', '2', '3',
-                        '4', '5', '7',
-                        '8', '9'
-                    ],
-                    symbol: 'ETHUSDH22',
-                    limit: '30000',
-                    max_leverage: '9',
-                    starting_margin: '11',
-                    maintain_margin: '5.5',
-                    coin: 'ETH',
-                    created_at: '2021-04-22T15:00:00Z',
-                    updated_at: '2021-04-22T15:00:00Z'
-                }
-                ...
-            ]
-            @param market: CCXT Market
-        */
+        //
+        //    Linear
+        //    [
+        //        {
+        //            id: '11',
+        //            symbol: 'ETHUSDT',
+        //            limit: '800000',
+        //            maintain_margin: '0.01',
+        //            starting_margin: '0.02',
+        //            section: [
+        //                '1',  '2',  '3',
+        //                '5',  '10', '15',
+        //                '25'
+        //            ],
+        //            is_lowest_risk: '1',
+        //            created_at: '2022-02-04 23:30:33.555252',
+        //            updated_at: '2022-02-04 23:30:33.555254',
+        //            max_leverage: '50'
+        //        },
+        //        ...
+        //    ]
+        //
+        //    Inverse
+        //    [
+        //        {
+        //            id: '180',
+        //            is_lowest_risk: '0',
+        //            section: [
+        //                '1', '2', '3',
+        //                '4', '5', '7',
+        //                '8', '9'
+        //            ],
+        //            symbol: 'ETHUSDH22',
+        //            limit: '30000',
+        //            max_leverage: '9',
+        //            starting_margin: '11',
+        //            maintain_margin: '5.5',
+        //            coin: 'ETH',
+        //            created_at: '2021-04-22T15:00:00Z',
+        //            updated_at: '2021-04-22T15:00:00Z'
+        //        }
+        //        ...
+        //    ]
+        //
         let notionalFloor = 0;
         const tiers = [];
         for (let i = 0; i < info.length; i++) {

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3189,9 +3189,10 @@ module.exports = class bybit extends Exchange {
             }
             tiers[symbol].push ({
                 'tier': tier,
+                'notionalCurrency': market['base'],
                 'notionalFloor': notionalFloor,
                 'notionalCap': notionalCap,
-                'maintenanceMarginRatio': this.safeNumber (item, 'maintain_margin'),
+                'maintenanceMarginRate': this.safeNumber (item, 'maintain_margin'),
                 'maxLeverage': this.safeNumber (item, 'max_leverage'),
                 'info': item,
             });

--- a/js/test/Exchange/test.fetchLeverageTiers.js
+++ b/js/test/Exchange/test.fetchLeverageTiers.js
@@ -12,7 +12,7 @@ module.exports = async (exchange, symbol) => {
     //     ],
     // };
     if (exchange.has[method]) {
-        const tiers = await exchange [method] (symbol);
+        const tiers = await exchange [method] ([symbol]);
         const tierKeys = Object.keys (tiers);
         const numTierKeys = tierKeys.length;
         assert (numTierKeys >= 1);

--- a/js/test/Exchange/test.fetchLeverageTiers.js
+++ b/js/test/Exchange/test.fetchLeverageTiers.js
@@ -12,7 +12,7 @@ module.exports = async (exchange, symbol) => {
     //     ],
     // };
     if (exchange.has[method]) {
-        const tiers = await exchange [method] ([symbol]);
+        const tiers = await exchange [method] ([ symbol ]);
         const tierKeys = Object.keys (tiers);
         const numTierKeys = tierKeys.length;
         assert (numTierKeys >= 1);

--- a/js/test/Exchange/test.fetchMarketLeverageTiers.js
+++ b/js/test/Exchange/test.fetchMarketLeverageTiers.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require ('assert')
+    , testLeverageTier = require ('./test.leverageTier.js')
+
+
+module.exports = async (exchange, symbol) => {
+    const method = 'fetchMarketLeverageTiers';
+    if (exchange.has[method]) {
+        const tiers = await exchange [method] (symbol);
+        console.log (method + 'for ' + symbol);
+        const arrayLength = tiers.length;
+        assert (arrayLength >= 1);
+        for (let j=0; j < tiers.length; j++) {
+            const tier = tiers[j];
+            testLeverageTier (exchange, method, tier);
+        }
+        return tiers;
+    } else {
+        console.log (method + ' not supported');
+    }
+}


### PR DESCRIPTION
```
Node.js: v14.17.0
CCXT v1.74.3
bybit.fetchMarketLeverageTiers (BTC/USDT)
2022-02-24T12:20:42.390Z iteration 0 passed in 787 ms
tier | currency | notionalFloor | notionalCap | maintenanceMarginRate | maxLeverage
-----------------------------------------------------------------------------------
   1 |      BTC |             0 |     1000000 |                 0.005 |         100
   2 |      BTC |       1000000 |     2000000 |                  0.01 |       66.67
   3 |      BTC |       2000000 |     3000000 |                 0.015 |          50
   4 |      BTC |       3000000 |     4000000 |                  0.02 |          40
   5 |      BTC |       4000000 |     5000000 |                 0.025 |       33.34
   6 |      BTC |       5000000 |     6000000 |                  0.03 |       28.58
   7 |      BTC |       6000000 |     7000000 |                 0.035 |          25
   8 |      BTC |       7000000 |     8000000 |                  0.04 |       22.23
   9 |      BTC |       8000000 |     9000000 |                 0.045 |          20
  10 |      BTC |       9000000 |    10000000 |                  0.05 |       18.19
  11 |      BTC |      10000000 |    11000000 |                 0.055 |       16.67
  12 |      BTC |      11000000 |    12000000 |                  0.06 |       15.39
  13 |      BTC |      12000000 |    13000000 |                 0.065 |       14.29
  14 |      BTC |      13000000 |    14000000 |                  0.07 |       13.34
  15 |      BTC |      14000000 |    15000000 |                 0.075 |        12.5
  16 |      BTC |      15000000 |    16000000 |                  0.08 |       11.77
  17 |      BTC |      16000000 |    17000000 |                 0.085 |       11.12
  18 |      BTC |      17000000 |    18000000 |                  0.09 |       10.53
  19 |      BTC |      18000000 |    19000000 |                 0.095 |          10
  20 |      BTC |      19000000 |    20000000 |                   0.1 |        9.53
  ```