### PR TITLE
add `amountKey`  in eslint

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -42,7 +42,7 @@
     "no-nested-ternary": "error",
     "eqeqeq": "error",
     "quotes": ["error", "single", { "avoidEscape": true }],
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^(symbol|price|tag|since|limit|params|market|timeframe|api|path|code|currency|response|requestHeaders|requestBody|bidsKey|asksKey|context|config|type|priceKey|amountKey)" }],
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^(symbol|price|tag|since|limit|params|market|timeframe|api|path|code|currency|response|requestHeaders|requestBody|bidsKey|asksKey|amountKey|context|config|type|priceKey|amountKey)" }],
     "new-parens": "error",
     "new-cap": ["error"],
     "no-var": "error",


### PR DESCRIPTION
Needed when parseOrderBook is implemented in derived class, but key is not used.