### PR TITLE
coinbase - fetchTradingFees

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -73,6 +73,8 @@ module.exports = class coinbase extends Exchange {
                 'fetchTickers': true,
                 'fetchTime': true,
                 'fetchTrades': undefined,
+                'fetchTradingFee': false,
+                'fetchTradingFees': false,
                 'fetchTransactions': undefined,
                 'fetchWithdrawals': true,
                 'reduceMargin': false,


### PR DESCRIPTION
Coinbase api does not have an endpoint to retrieve trading fees.