### PR TITLE
Place certified exchanges at top of exchange capabilities

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -19,7 +19,26 @@ async function main () {
     let implemented = 0
     let emulated = 0
 
-    const exchanges = ccxt.exchanges.map (id => new ccxt[id] ())
+    const certified = [
+        'aax',
+        'ascendex',
+        'binance',
+        'binancecoinm',
+        'binanceusdm',
+        'bitmart',
+        'bitvavo',
+        'currencycom',
+        'ftx',
+        'gateio',
+        'huobi',
+        'idex',
+        'mexc',
+        'okx',
+        'wavesexchange',
+        'zb',
+    ]
+    const exchangeNames = ccxt.unique (certified.concat (ccxt.exchanges));
+    let exchanges = exchangeNames.map (id => new ccxt[id] ())
     const metainfo = ccxt.flatten (exchanges.map (exchange => Object.keys (exchange.has)))
     const reduced = metainfo.reduce ((previous, current) => {
         previous[current] = (previous[current] || 0) + 1
@@ -74,7 +93,7 @@ async function main () {
                     }
                 }
             } else {
-                coloredString = exchange.id.red.bright
+                coloredString = exchange.id.lightRed
                 notImplemented += 1
             }
 
@@ -98,7 +117,7 @@ async function main () {
         implemented.toString ().green, 'implemented,',
         emulated.toString ().yellow, 'emulated,',
         (inexistentApi.toString ().red.dim), 'inexistentApi,',
-        (notImplemented.toString ().red.bright), 'notImplemented',
+        (notImplemented.toString ().lightRed), 'notImplemented',
     )
 
     log("\nMessy? Try piping to less (e.g. node script.js | less -S -R)\n".red)


### PR DESCRIPTION
- Places certified exchanges at the top. This will result in methods for certified exchanges being implemented earlier.
- Changes the color `red` to `lightRed`, for a more noticeable difference between unimplemented and not supported methods

It would be nice if there was a separator after the certified exchanges

----- All Exchanges ------

but I couldn't figure out how to do it with `as-table`