### PR TITLE
ZB fetchTrades

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -1111,8 +1111,6 @@ module.exports = class zb extends Exchange {
         const timeField = market['swap'] ? 'createTime' : 'date';
         const timeMethod = market['swap'] ? 'safeInteger' : 'safeTimestamp';
         const timestamp = this[timeMethod] (trade, timeField);
-        const idField = market['swap'] ? 'orderId' : 'tid';
-        const id = this.safeString (trade, idField);
         const price = this.safeString (trade, 'price');
         const amount = this.safeString (trade, 'amount');
         let fee = undefined;
@@ -1127,13 +1125,13 @@ module.exports = class zb extends Exchange {
         market = this.safeMarket (undefined, market);
         return this.safeTrade ({
             'info': trade,
-            'id': id,
+            'id': this.safeString (trade, 'tid'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'symbol': market['symbol'],
             'type': undefined,
             'side': side,
-            'order': undefined,
+            'order': this.safeString (trade, 'orderId'),
             'takerOrMaker': maker,
             'price': price,
             'amount': amount,

--- a/js/zb.js
+++ b/js/zb.js
@@ -1093,7 +1093,11 @@ module.exports = class zb extends Exchange {
         //
         const sideField = market['swap'] ? 'side' : 'trade_type';
         let side = this.safeString (trade, sideField);
-        let maker = this.safeValue (trade, 'maker');
+        let takerOrMaker = undefined;
+        const maker = this.safeValue (trade, 'maker');
+        if (maker !== undefined) {
+            takerOrMaker = maker ? 'maker' : 'taker';
+        }
         if (market['spot']) {
             side = (side === 'bid') ? 'buy' : 'sell';
         } else {
@@ -1106,20 +1110,22 @@ module.exports = class zb extends Exchange {
             } else if (side === '2') {
                 side = 'sell'; // open short
             }
-            maker = (maker) ? 'maker' : 'taker';
         }
-        const timeField = market['swap'] ? 'createTime' : 'date';
-        const timeMethod = market['swap'] ? 'safeInteger' : 'safeTimestamp';
-        const timestamp = this[timeMethod] (trade, timeField);
+        let timestamp = undefined;
+        if (market['swap']) {
+            timestamp = this.safeInteger (trade, 'createTime');
+        } else {
+            timestamp = this.safeTimestamp (trade, 'date');
+        }
         const price = this.safeString (trade, 'price');
         const amount = this.safeString (trade, 'amount');
         let fee = undefined;
         const feeCostString = this.safeString (trade, 'feeAmount');
-        const feeCurrencyString = this.safeString (trade, 'feeCurrency');
         if (feeCostString !== undefined) {
+            const feeCurrencyId = this.safeString (trade, 'feeCurrency');
             fee = {
                 'cost': feeCostString,
-                'currency': this.safeCurrencyCode (feeCurrencyString),
+                'currency': this.safeCurrencyCode (feeCurrencyId),
             };
         }
         market = this.safeMarket (undefined, market);

--- a/js/zb.js
+++ b/js/zb.js
@@ -1138,7 +1138,7 @@ module.exports = class zb extends Exchange {
             'type': undefined,
             'side': side,
             'order': this.safeString (trade, 'orderId'),
-            'takerOrMaker': maker,
+            'takerOrMaker': takerOrMaker,
             'price': price,
             'amount': amount,
             'cost': undefined,

--- a/js/zb.js
+++ b/js/zb.js
@@ -1093,7 +1093,7 @@ module.exports = class zb extends Exchange {
         //
         const sideField = market['swap'] ? 'side' : 'trade_type';
         let side = this.safeString (trade, sideField);
-        let maker = this.safeString (trade, 'maker');
+        let maker = this.safeValue (trade, 'maker');
         if (market['spot']) {
             side = (side === 'bid') ? 'buy' : 'sell';
         } else {
@@ -1106,7 +1106,7 @@ module.exports = class zb extends Exchange {
             } else if (side === '2') {
                 side = 'sell'; // open short
             }
-            maker = (maker === 'false') ? 'taker' : 'maker';
+            maker = (maker === false) ? 'taker' : 'maker';
         }
         const timeField = market['swap'] ? 'createTime' : 'date';
         const timeMethod = market['swap'] ? 'safeInteger' : 'safeTimestamp';
@@ -1115,6 +1115,15 @@ module.exports = class zb extends Exchange {
         const id = this.safeString (trade, idField);
         const price = this.safeString (trade, 'price');
         const amount = this.safeString (trade, 'amount');
+        let fee = undefined;
+        const feeCostString = this.safeString (trade, 'feeAmount');
+        const feeCurrencyString = this.safeString (trade, 'feeCurrency');
+        if (feeCostString !== undefined) {
+            fee = {
+                'cost': feeCostString,
+                'currency': this.safeCurrencyCode (feeCurrencyString),
+            };
+        }
         market = this.safeMarket (undefined, market);
         return this.safeTrade ({
             'info': trade,
@@ -1129,7 +1138,7 @@ module.exports = class zb extends Exchange {
             'price': price,
             'amount': amount,
             'cost': undefined,
-            'fee': undefined,
+            'fee': fee,
         }, market);
     }
 

--- a/js/zb.js
+++ b/js/zb.js
@@ -1106,7 +1106,7 @@ module.exports = class zb extends Exchange {
             } else if (side === '2') {
                 side = 'sell'; // open short
             }
-            maker = (maker === false) ? 'taker' : 'maker';
+            maker = (maker) ? 'maker' : 'taker';
         }
         const timeField = market['swap'] ? 'createTime' : 'date';
         const timeMethod = market['swap'] ? 'safeInteger' : 'safeTimestamp';


### PR DESCRIPTION
Added swap functionality to fetchTrades:
```
zb.fetchTrades (BTC/USDT:USDT)
2022-02-26T09:33:11.472Z iteration 0 passed in 346 ms

                 id |     timestamp |                 datetime |        symbol | type | side | order | takerOrMaker |    price | amount |      cost | fee | fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------
6902504759069188101 | 1645685376988 | 2022-02-24T06:49:36.988Z | BTC/USDT:USDT |      |  buy |       |        maker |    35000 |  0.002 |        70 |     |   []
6902510344586076160 | 1645686708592 | 2022-02-24T07:11:48.592Z | BTC/USDT:USDT |      | sell |       |        taker | 34609.05 |  0.002 |   69.2181 |     |   []
6902542846772060160 | 1645694457718 | 2022-02-24T09:20:57.718Z | BTC/USDT:USDT |      |  buy |       |        taker | 35641.64 |  0.003 | 106.92492 |     |   []
6902543364101709824 | 1645694581069 | 2022-02-24T09:23:01.069Z | BTC/USDT:USDT |      | sell |       |        taker | 35545.97 |  0.003 | 106.63791 |     |   []
6902921567102247232 | 1645784751863 | 2022-02-25T10:25:51.863Z | BTC/USDT:USDT |      | sell |       |        maker |    38570 |  0.002 |     77.14 |     |   []
6902932868042006528 | 1645787446034 | 2022-02-25T11:10:46.034Z | BTC/USDT:USDT |      |  buy |       |        taker | 38417.99 |  0.002 |  76.83598 |     |   []
6 objects
```