### PR TITLE
Add timeframes options in poloniex

### DIFF
--- a/python/ccxt/async_support/poloniex.py
+++ b/python/ccxt/async_support/poloniex.py
@@ -69,9 +69,11 @@ class poloniex(Exchange):
                 'withdraw': True,
             },
             'timeframes': {
+                '1m': 60,
                 '5m': 300,
                 '15m': 900,
                 '30m': 1800,
+                '1h': 3600,
                 '2h': 7200,
                 '4h': 14400,
                 '1d': 86400,


### PR DESCRIPTION
1h timeframe is a necessary option to retrieve the history data.