### PR TITLE
Huobi orderbook add "depth" support

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1924,7 +1924,7 @@ module.exports = class binance extends Exchange {
             'symbol': market['id'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit; // default 100, max 5000, see https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#order-book
+            request['limit'] = limit; // default 100, max 5000, see https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#order-book
         }
         let method = 'publicGetDepth';
         if (market['linear']) {

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1660,6 +1660,14 @@ module.exports = class huobi extends Exchange {
                 method = 'contractPublicGetSwapExMarketDepth';
                 fieldName = 'contract_code';
             }
+        } else {
+            if (limit !== undefined) {
+                // Valid depths are 5, 10, 20 or empty https://huobiapi.github.io/docs/spot/v1/en/#get-market-depth
+                if ((limit !== 5) && (limit !== 10) && (limit !== 20)) {
+                    throw new BadRequest (this.id + ' fetchOrderBook() limit argument must be undefined, 5, 10 or 20, default is 150');
+                }
+                request['depth'] = limit;
+            }
         }
         request[fieldName] = market['id'];
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
Huobi allows to specify the required market depth [docs](https://huobiapi.github.io/docs/spot/v1/en/#get-market-depth).
This seems only possible in spot markets, and requires the attribute to be missing, 5, 10 or 20 (all other values fail).

I've also updated the link tot he binance documentation - as i've looked at how it was done there first.
The method itself is however copied from bittrex, which implements it almost identically.