### PR TITLE
[gateio] Restore `clientOrderId` parsing on gate.io

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2652,7 +2652,7 @@ module.exports = class gateio extends Exchange {
         const multipleFeeCurrencies = numFeeCurrencies > 1;
         return this.safeOrder ({
             'id': this.safeNumber (order, 'id'),
-            'clientOrderId': this.safeNumber (order, 'user'),
+            'clientOrderId': this.safeString (order, 'text'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': this.safeTimestamp2 (order, 'update_time', 'finish_time'),


### PR DESCRIPTION
- CCXT version: 1.74.44
- CCXT Pro version: 1.0.13

[This commit](https://github.com/ccxt/ccxt/commit/be99f3ddb085a4603622e92a760559da15efc349#diff-2b549c8f023fdff5faf2ecf640b282db0732803be2fe30bb206807a3c31d354eR2668) broke the correct parsing of the `clientOrderId` field of orders in Gate.io.

Indeed, the client order ID is contained into the `text` field, both for [spot orders](https://www.gate.io/docs/developers/apiv4/#order) and for [futures orders](https://www.gate.io/docs/developers/apiv4/#futuresorder).

The `user` field is defined only for the futures orders and it contains the user ID, which has nothing to do with the client order ID.
I noticed this error from my failing integration tests.
