### PR TITLE
[gateio] Correctly parse order status

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2654,7 +2654,6 @@ module.exports = class gateio extends Exchange {
         const numFeeCurrencies = fees.length;
         const multipleFeeCurrencies = numFeeCurrencies > 1;
         const status = this.parseOrderStatus (rawStatus);
-        
         return this.safeOrder ({
             'id': this.safeNumber (order, 'id'),
             'clientOrderId': this.safeNumber (order, 'user'),


### PR DESCRIPTION
Just picking `order['status']` is not enough, as swaps and spot orders store the detailed order status in a different field.

Restoring the logic that was in place [before this commit](https://github.com/ccxt/ccxt/commit/be99f3ddb085a4603622e92a760559da15efc349#diff-2b549c8f023fdff5faf2ecf640b282db0732803be2fe30bb206807a3c31d354eL2518-L2531).