### PR TITLE
`resolvePath` in base

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1064,9 +1064,10 @@ module.exports = class Exchange {
     }
 
     resolvePath (path, params) {
-        const resolvedPath = this.implodeParams (path, params);
-        params = this.omit (params, this.extractParams (path));
-        return [resolvedPath, params];
+        return [
+            this.implodeParams (path, params),
+            this.omit (params, this.extractParams (path))
+        ];
     }
 
     parseBidAsk (bidask, priceKey = 0, amountKey = 1) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1063,6 +1063,12 @@ module.exports = class Exchange {
         return this.implodeParams (url, { 'hostname': this.hostname })
     }
 
+    resolvePath (path, params) {
+        const resolvedPath = this.implodeParams (path, params);
+        params = this.omit (params, this.extractParams (path));
+        return [resolvedPath, params];
+    }
+
     parseBidAsk (bidask, priceKey = 0, amountKey = 1) {
         const price = this.safeNumber (bidask, priceKey)
         const amount = this.safeNumber (bidask, amountKey)

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -740,6 +740,12 @@ class Exchange {
         return static::implode_params($url, array('hostname' => $this->hostname));
     }
 
+    public function resolve_path ($path, $params) {
+        $resolvedPath = $this->implode_params ($path, $params);
+        $params = $this->omit ($params, $this->extractParams ($path));
+        return [$resolvedPath, $params];
+    }
+
     public static function deep_extend() {
         //
         //     extend associative dictionaries only, replace everything else
@@ -1953,12 +1959,6 @@ class Exchange {
             $result[] = $this->parse_bid_ask($bidask, $price_key, $amount_key);
         }
         return $result;
-    }
-
-    public function resolve_path ($path, $params) {
-        $resolvedPath = $this->implode_params ($path, $params);
-        $params = $this->omit ($params, $this->extractParams ($path));
-        return [$resolvedPath, $params];
     }
 
     public function fetch_l2_order_book($symbol, $limit = null, $params = array()) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1955,6 +1955,12 @@ class Exchange {
         return $result;
     }
 
+    public function resolvePath ($path, $params) {
+        $resolvedPath = $this->implode_params ($path, $params);
+        $params = $this->omit ($params, $this->extractParams ($path));
+        return [$resolvedPath, $params];
+    }
+
     public function fetch_l2_order_book($symbol, $limit = null, $params = array()) {
         $orderbook = $this->fetch_order_book($symbol, $limit, $params);
         return array_merge($orderbook, array(

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -740,10 +740,11 @@ class Exchange {
         return static::implode_params($url, array('hostname' => $this->hostname));
     }
 
-    public function resolve_path ($path, $params) {
-        $resolvedPath = $this->implode_params ($path, $params);
-        $params = $this->omit ($params, $this->extractParams ($path));
-        return [$resolvedPath, $params];
+    public function resolve_path($path, $params) {
+        return [
+            $this->implode_params($path, $params),
+            $this->omit($params, $this->extract_params($path))
+        ];
     }
 
     public static function deep_extend() {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1955,7 +1955,7 @@ class Exchange {
         return $result;
     }
 
-    public function resolvePath ($path, $params) {
+    public function resolve_path ($path, $params) {
         $resolvedPath = $this->implode_params ($path, $params);
         $params = $this->omit ($params, $this->extractParams ($path));
         return [$resolvedPath, $params];

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -992,9 +992,6 @@ class Exchange(object):
     def extract_params(string):
         return re.findall(r'{([\w-]+)}', string)
 
-    def implode_hostname(self, url):
-        return Exchange.implode_params(url, {'hostname': self.hostname})
-
     @staticmethod
     def implode_params(string, params):
         if isinstance(params, dict):
@@ -1002,6 +999,14 @@ class Exchange(object):
                 if not isinstance(params[key], list):
                     string = string.replace('{' + key + '}', str(params[key]))
         return string
+
+    def implode_hostname(self, url):
+        return Exchange.implode_params(url, {'hostname': self.hostname})
+
+    def resolve_path (self, path, params):
+        resolvedPath = self.implode_params (path, params)
+        params = self.omit (params, self.extractParams (path))
+        return [resolvedPath, params]
 
     @staticmethod
     def urlencode(params={}, doseq=False):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1003,10 +1003,11 @@ class Exchange(object):
     def implode_hostname(self, url):
         return Exchange.implode_params(url, {'hostname': self.hostname})
 
-    def resolve_path (self, path, params):
-        resolvedPath = self.implode_params (path, params)
-        params = self.omit (params, self.extractParams (path))
-        return [resolvedPath, params]
+    def resolve_path(self, path, params):
+        return [
+            self.implode_params(path, params),
+            self.omit(params, self.extract_params(path))
+        ]
 
     @staticmethod
     def urlencode(params={}, doseq=False):


### PR DESCRIPTION
this is last try to solve specific scenario: `resolevPath` method for `sign` simplification - does all the job of 3 methods in the background from user.

use case - in many cases, user have to use 3 nested methods :
```
sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
    let url = '/' + this.implodeParams (path, params);
    const query = this.omit (params, this.extractParams (path));
```
into one method:
```
sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
    [path, params] = this.resolvePath (path, params);
```
and then `path` can be used down below anywhere, where is url constructed, like : `... url = this.hostname(...) + '/' + this.version + '/' + path; ...`


If user wants (have to) define them with `const` depending particular exchange, they can do:
```
    const [pathResolved, paramsResolved] = this.resolvePath (path, params);
```