### PR TITLE
Fix wrong order ID parsing in gate.io

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2691,7 +2691,7 @@ module.exports = class gateio extends Exchange {
         const multipleFeeCurrencies = numFeeCurrencies > 1;
         const status = this.parseOrderStatus (rawStatus);
         return this.safeOrder ({
-            'id': this.safeNumber (order, 'id'),
+            'id': this.safeString (order, 'id'),
             'clientOrderId': this.safeString (order, 'text'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),


### PR DESCRIPTION
while the order-id is numeric, we can't use parseNumber as that will create a float.

This means, the output of "id" can no longer be used in subsequent calls (`fetch_order(128022598591.0, pair)` fails with `ccxt.base.errors.BadRequest: gateio {"label":"INVALID_PARAM_VALUE","message":"Empty order ID, 128022598591.0"}`).


``` before
{'id': 128022598591.0,
 'clientOrderId': 'api',
 'timestamp': 1644757076123,
 'datetime': '2022-02-13T12:57:56.123Z',
 'lastTradeTimestamp': 1644757076123,
 'status': 'closed',
```

after:
``` output
{'id': '128022598591',
 'clientOrderId': 'api',
 'timestamp': 1644757076123,
 'datetime': '2022-02-13T12:57:56.123Z',
 'lastTradeTimestamp': 1644757076123,
 'status': 'closed',
```