### PR TITLE
ZB cancelOrder

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -1414,6 +1414,9 @@ module.exports = class zb extends Exchange {
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument');
+        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const swap = market['swap'];

--- a/js/zb.js
+++ b/js/zb.js
@@ -1415,11 +1415,40 @@ module.exports = class zb extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         await this.loadMarkets ();
+        const market = this.market (symbol);
+        const swap = market['swap'];
         const request = {
-            'id': id.toString (),
-            'currency': this.marketId (symbol),
+            // 'currency': this.marketId (symbol), // only applicable to SPOT
+            // 'id': id.toString (), // only applicable to SPOT
+            // 'symbol': this.marketId (symbol), // only applicable to SWAP
+            // 'orderId': id.toString (), // only applicable to SWAP
+            // 'clientOrderId': params['clientOrderId'], // only applicable to SWAP
         };
-        return await this.spotV1PrivateGetCancelOrder (this.extend (request, params));
+        const marketIdField = swap ? 'symbol' : 'currency';
+        request[marketIdField] = this.marketId (symbol);
+        const orderIdField = swap ? 'orderId' : 'id';
+        request[orderIdField] = id.toString ();
+        const method = this.getSupportedMapping (market['type'], {
+            'spot': 'spotV1PrivateGetCancelOrder',
+            'swap': 'contractV2PrivatePostTradeCancelOrder',
+        });
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Spot
+        //
+        //     {
+        //         "code": 1000,
+        //         "message": "Success。"
+        //     }
+        //
+        // Swap
+        //
+        //     {
+        //         "code": 10007,
+        //         "desc": "orderId与clientOrderId选填1个"
+        //     }
+        //
+        return this.parseOrder (response, market);
     }
 
     async cancelAllOrders (symbol = undefined, params = {}) {


### PR DESCRIPTION
Added swap functionality to cancelOrder on ZB:
```
zb.cancelOrder (6904598690179260416, BTC/USDT:USDT)
2022-03-02T01:30:29.688Z iteration 0 passed in 340 ms

{
  info: { code: '10000', data: '6904598690179260416', desc: '操作成功' },
  id: undefined,
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: false,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```