### PR TITLE
ZB fetchOHLCV

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -54,20 +54,31 @@ module.exports = class zb extends Exchange {
                 'withdraw': true,
             },
             'timeframes': {
-                '1m': '1m',
-                '3m': '3m',
-                '5m': '5m',
-                '15m': '15m',
-                '30m': '30m',
-                '1h': '1h',
-                '2h': '2h',
-                '4h': '4h',
-                '6h': '6h',
-                '12h': '12h',
-                '1d': '1d',
-                '3d': '3d',
-                '5d': '5d',
-                '1w': '1w',
+                'spot': {
+                    '1m': '1min',
+                    '3m': '3min',
+                    '5m': '5min',
+                    '15m': '15min',
+                    '30m': '30min',
+                    '1h': '1hour',
+                    '2h': '2hour',
+                    '4h': '4hour',
+                    '6h': '6hour',
+                    '12h': '12hour',
+                    '1d': '1day',
+                    '3d': '3day',
+                    '1w': '1week',
+                },
+                'swap': {
+                    '1m': '1M',
+                    '5m': '5M',
+                    '15m': '15M',
+                    '30m': '30M',
+                    '1h': '1H',
+                    '6h': '6H',
+                    '1d': '1D',
+                    '5d': '5D',
+                },
             },
             'exceptions': {
                 'ws': {
@@ -454,35 +465,6 @@ module.exports = class zb extends Exchange {
                                 'trade/updateOrderAlgo',
                             ],
                         },
-                    },
-                },
-            },
-            'options': {
-                'timeframes': {
-                    'spot': {
-                        '1m': '1min',
-                        '3m': '3min',
-                        '5m': '5min',
-                        '15m': '15min',
-                        '30m': '30min',
-                        '1h': '1hour',
-                        '2h': '2hour',
-                        '4h': '4hour',
-                        '6h': '6hour',
-                        '12h': '12hour',
-                        '1d': '1day',
-                        '3d': '3day',
-                        '1w': '1week',
-                    },
-                    'swap': {
-                        '1m': '1M',
-                        '5m': '5M',
-                        '15m': '15M',
-                        '30m': '30M',
-                        '1h': '1H',
-                        '6h': '6H',
-                        '1d': '1D',
-                        '5d': '5D',
                     },
                 },
             },
@@ -1201,8 +1183,7 @@ module.exports = class zb extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const swap = market['swap'];
-        const options = this.safeValue (this.options, 'timeframes', {});
-        const timeframes = this.safeValue (options, market['type'], {});
+        const timeframes = this.safeValue (this.timeframes, market['type'], {});
         const timeframeValue = this.safeString (timeframes, timeframe);
         if (timeframeValue === undefined) {
             throw new NotSupported (this.id + ' fetchOHLCV() does not support ' + timeframe + ' timeframe for ' + market['type'] + ' markets');

--- a/js/zb.js
+++ b/js/zb.js
@@ -70,7 +70,7 @@ module.exports = class zb extends Exchange {
             },
             'exceptions': {
                 'ws': {
-                    //  '1000': ExchangeError, // The call is successful.
+                    // '1000': ExchangeError, // The call is successful.
                     '1001': ExchangeError, // General error prompt
                     '1002': ExchangeError, // Internal Error
                     '1003': AuthenticationError, // Fail to verify
@@ -1175,12 +1175,12 @@ module.exports = class zb extends Exchange {
             limit = 1000;
         }
         const request = {
-        //     'market': market['id'], // SPOT
-        //     'symbol': market['id'], // SWAP
-        //     'type': this.timeframes[timeframe], // SPOT
-        //     'period': this.timeframes[timeframe], // SWAP might need to change data type
-        //     'limit': limit, // SPOT
-        //     'size': limit, // SWAP
+            // 'market': market['id'], // SPOT
+            // 'symbol': market['id'], // SWAP
+            // 'type': this.timeframes[timeframe], // SPOT
+            // 'period': this.timeframes[timeframe], // SWAP might need to change data type
+            // 'limit': limit, // SPOT
+            // 'size': limit, // SWAP
         };
         const marketIdField = swap ? 'symbol' : 'market';
         request[marketIdField] = market['id'];

--- a/js/zb.js
+++ b/js/zb.js
@@ -1175,12 +1175,13 @@ module.exports = class zb extends Exchange {
             limit = 1000;
         }
         const request = {
-            // 'market': market['id'], // SPOT
-            // 'symbol': market['id'], // SWAP
-            // 'type': this.timeframes[timeframe], // SPOT
-            // 'period': this.timeframes[timeframe], // SWAP might need to change data type
-            // 'limit': limit, // SPOT
-            // 'size': limit, // SWAP
+            // 'market': market['id'], // spot
+            // 'symbol': market['id'], // swap
+            // 'type': this.timeframes[timeframe], // spot
+            // 'period': this.timeframes[timeframe], // swap might need to change data type
+            // 'since': since, // spot only
+            // 'limit': limit, // spot only
+            // 'size': limit, // swap
         };
         const marketIdField = swap ? 'symbol' : 'market';
         request[marketIdField] = market['id'];


### PR DESCRIPTION
Added fetchOHLCV for swap markets:
```
zb.fetchOHLCV (BTC/USDT:USDT)
2022-03-04T04:08:52.461Z iteration 0 passed in 338 ms

1646366760 | 41335.84 | 41336.57 | 41324.74 |  41327.4 |  19.85
1646366820 | 41327.86 | 41355.81 | 41324.51 | 41355.81 |  28.06
1646366880 | 41356.59 | 41356.71 | 41352.96 | 41354.16 | 14.018
...
```