### PR TITLE
ZB fetchMarkOHLCV, fetchIndexOHLCV

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -1179,7 +1179,8 @@ module.exports = class zb extends Exchange {
 
     parseOHLCV (ohlcv, market = undefined) {
         if (market['swap']) {
-            if (this.safeInteger (ohlcv, 5)) {
+            const ohlcvLength = ohlcv.length;
+            if (ohlcvLength > 5) {
                 return [
                     this.safeInteger (ohlcv, 5),
                     this.safeNumber (ohlcv, 0),

--- a/js/zb.js
+++ b/js/zb.js
@@ -1179,14 +1179,25 @@ module.exports = class zb extends Exchange {
 
     parseOHLCV (ohlcv, market = undefined) {
         if (market['swap']) {
-            return [
-                this.safeInteger (ohlcv, 5),
-                this.safeNumber (ohlcv, 0),
-                this.safeNumber (ohlcv, 1),
-                this.safeNumber (ohlcv, 2),
-                this.safeNumber (ohlcv, 3),
-                this.safeNumber (ohlcv, 4),
-            ];
+            if (this.safeInteger (ohlcv, 5)) {
+                return [
+                    this.safeInteger (ohlcv, 5),
+                    this.safeNumber (ohlcv, 0),
+                    this.safeNumber (ohlcv, 1),
+                    this.safeNumber (ohlcv, 2),
+                    this.safeNumber (ohlcv, 3),
+                    this.safeNumber (ohlcv, 4),
+                ];
+            } else {
+                return [
+                    this.safeInteger (ohlcv, 4),
+                    this.safeNumber (ohlcv, 0),
+                    this.safeNumber (ohlcv, 1),
+                    this.safeNumber (ohlcv, 2),
+                    this.safeNumber (ohlcv, 3),
+                    undefined,
+                ];
+            }
         } else {
             return [
                 this.safeInteger (ohlcv, 0),
@@ -1260,6 +1271,84 @@ module.exports = class zb extends Exchange {
         //             [41433.44,41433.44,41405.88,41408.75,21.368,1646366460],
         //             [41409.25,41423.74,41408.8,41423.42,9.828,1646366520],
         //             [41423.96,41429.39,41369.98,41370.31,123.104,1646366580]
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        return this.parseOHLCVs (data, market, timeframe, since, limit);
+    }
+
+    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const options = this.safeValue (this.options, 'timeframes', {});
+        const timeframes = this.safeValue (options, market['type'], {});
+        const timeframeValue = this.safeString (timeframes, timeframe);
+        if (timeframeValue === undefined) {
+            throw new NotSupported (this.id + ' fetchMarkOHLCV() does not support ' + timeframe + ' timeframe for ' + market['type'] + ' markets');
+        }
+        if (limit === undefined) {
+            limit = 1000;
+        }
+        const request = {
+            'symbol': market['id'],
+            'period': timeframeValue,
+            'size': limit,
+        };
+        if (since !== undefined) {
+            request['since'] = since;
+        }
+        if (limit !== undefined) {
+            request['size'] = limit;
+        }
+        const response = await this.contractV1PublicGetMarkKline (this.extend (request, params));
+        //
+        //     {
+        //         "code": 10000,
+        //         "desc": "操作成功",
+        //         "data": [
+        //             [41603.39,41603.39,41591.59,41600.81,1646381760],
+        //             [41600.36,41605.75,41587.69,41601.97,1646381820],
+        //             [41601.97,41601.97,41562.62,41593.96,1646381880]
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        return this.parseOHLCVs (data, market, timeframe, since, limit);
+    }
+
+    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const options = this.safeValue (this.options, 'timeframes', {});
+        const timeframes = this.safeValue (options, market['type'], {});
+        const timeframeValue = this.safeString (timeframes, timeframe);
+        if (timeframeValue === undefined) {
+            throw new NotSupported (this.id + ' fetchIndexOHLCV() does not support ' + timeframe + ' timeframe for ' + market['type'] + ' markets');
+        }
+        if (limit === undefined) {
+            limit = 1000;
+        }
+        const request = {
+            'symbol': market['id'],
+            'period': timeframeValue,
+            'size': limit,
+        };
+        if (since !== undefined) {
+            request['since'] = since;
+        }
+        if (limit !== undefined) {
+            request['size'] = limit;
+        }
+        const response = await this.contractV1PublicGetIndexKline (this.extend (request, params));
+        //
+        //     {
+        //         "code": 10000,
+        //         "desc": "操作成功",
+        //         "data": [
+        //             [41697.53,41722.29,41689.16,41689.16,1646381640],
+        //             [41690.1,41691.73,41611.61,41611.61,1646381700],
+        //             [41611.61,41619.49,41594.87,41594.87,1646381760]
         //         ]
         //     }
         //


### PR DESCRIPTION
Added fetchMarkOHLCV and fetchIndexOHLCV. They don't have a volume field:
https://github.com/ZBFuture/docs_en/blob/main/API%20V2%20_en.md#78-mark-price-candlestick

fetchMarkOHLCV:
```
zb.fetchMarkOHLCV (BTC/USDT:USDT)
2022-03-04T20:50:40.020Z iteration 0 passed in 335 ms

1646426880 | 39435.97 | 39435.97 | 39369.89 | 39395.86 |
1646426940 | 39412.35 | 39425.66 | 39381.19 | 39418.52 |
1646427000 | 39402.03 | 39470.44 | 39402.03 | 39450.31 |
...
```

fetchIndexOHLCV:
```
zb.fetchIndexOHLCV (BTC/USDT:USDT)
2022-03-04T20:50:51.313Z iteration 0 passed in 336 ms

1646426880 | 39446.29 | 39446.29 | 39380.23 | 39406.42 |
1646426940 | 39422.91 | 39432.06 | 39391.69 |  39429.2 |
1646427000 | 39412.71 | 39473.78 | 39412.71 | 39471.93 |
...
```

This approach didn't work:
```
    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
        const request = {
            'price': 'mark',
        };
        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
    }
```