### PR TITLE
fixed candles being downloaded from the future in waves.exchange

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -14,7 +14,6 @@ module.exports = class wavesexchange extends Exchange {
             'id': 'wavesexchange',
             'name': 'Waves.Exchange',
             'countries': [ 'CH' ], // Switzerland
-            'rateLimit': 500,
             'certified': true,
             'pro': false,
             'has': {
@@ -882,17 +881,17 @@ module.exports = class wavesexchange extends Exchange {
         return result;
     }
 
-    filterFutureCandles (result) {
-        const filtered_result = [];
+    filterFutureCandles (ohlcvs) {
+        const result = [];
         const timestamp = this.milliseconds ();
-        for (let i = 0; i < result.length; i++) {
-            if (result[i][0] > timestamp) {
-                // Stop when getting data from the future
+        for (let i = 0; i < ohlcvs.length; i++) {
+            if (ohlcvs[i][0] > timestamp) {
+                // stop when getting data from the future
                 break;
             }
-            filtered_result.push (result[i]);
+            result.push (ohlcvs[i]);
         }
-        return filtered_result;
+        return result;
     }
 
     parseOHLCV (ohlcv, market = undefined) {


### PR DESCRIPTION
When running the following test script on the latest commit (at this time of writing it is `bef1aaa7af8155e23199770c62c4fad9c61f9657`) you will get a lot of future datapoints with None values:

```py
import ccxt
import time

exchange = ccxt.wavesexchange()
symbol = 'WAVES/BTC'
timeframe = '5m'
test_timestamp = int(time.time() * 1000) - (60 * 30 * 1000)
print(f"test_timestamp: {test_timestamp}")
ohlcv = exchange.fetch_ohlcv(symbol, timeframe, since=test_timestamp)
print(ohlcv)
```

Results look like this:

```
root@da9b081a90cb:/ccxt# python3 test_peter.py 
test_timestamp: 1646686057592
[[1646686200000, 0.000565, 0.000565, 0.00056356, 0.000565, 59.18602508], [1646686500000, 0.000565, 0.00057054, 0.000565, 0.00057054, 505.81999792], [1646686800000, 0.00056994, 0.00057189, 0.00056991, 0.00056994, 38.34509789], [1646687100000, 0.00056534, 0.00056534, 0.00056534, 0.00056534, 9.113843], [1646687400000, 0.00056391, 0.00056391, 0.00056391, 0.00056391, 0], [1646687700000, 0.00056391, 0.00056391, 0.00056391, 0.00056391, 3.9360891], [1646688000000, None, None, None, None, 0], [1646688300000, None, None, None, None, 0], [1646688600000, None, None, None, None, 0], [1646688900000, None, None, None, None, 0], [1646689200000, None, None, None, None, 0], [1646689500000, None, None, None, None, 0], [1646689800000, None, None, None, None, 0], [1646690100000, None, None, None, None, 0], [1646690400000, None, None, None, None, 0], [1646690700000, None, None, None, None, 0], [1646691000000, None, None, None, None, 0], [1646691300000, None, None, None, None, 0], [1646691600000, None, None, None, None, 0], [1646691900000, None, None, None, None, 0], [1646692200000, None, None, None, None, 0], [1646692500000, None, None, None, None, 0], [1646692800000, None, None, None, None, 0], [1646693100000, None, None, None, None, 0], [1646693400000, None, None, None, None, 0], [1646693700000, None, None, None, None, 0], [1646694000000, None, None, None, ....
```

This patch takes the current timestamp and filters out all OHLC data that has a timestamp beyond the current time, filtering out all the unnecessary None's.