### PR TITLE
FTX: patch fetchFundingRateHistory

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1169,6 +1169,7 @@ module.exports = class ftx extends Exchange {
         const request = {};
         if (symbol !== undefined) {
             const market = this.market (symbol);
+            symbol = market['symbol'];
             request['future'] = market['id'];
         }
         if (since !== undefined) {


### PR DESCRIPTION
patch fetchFundingRateHistory

In master branch, run this `node examples/js/cli ftx fetchFundingRateHistory BTC-PERP` will return empty array.

In this PR, return
```
BTC/USD:USD |           0 | 1645678800000 | 2022-02-24T05:00:00.000Z
BTC/USD:USD |   -0.000002 | 1645682400000 | 2022-02-24T06:00:00.000Z
BTC/USD:USD |    0.000003 | 1645686000000 | 2022-02-24T07:00:00.000Z
BTC/USD:USD |    0.000005 | 1645689600000 | 2022-02-24T08:00:00.000Z
BTC/USD:USD |   -0.000009 | 1645693200000 | 2022-02-24T09:00:00.000Z
BTC/USD:USD |   -0.000006 | 1645696800000 | 2022-02-24T10:00:00.000Z
BTC/USD:USD |    0.000008 | 1645700400000 | 2022-02-24T11:00:00.000Z
...
```
