### PR TITLE
binance: patch fetchFundingRateHistory

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4244,6 +4244,7 @@ module.exports = class binance extends Exchange {
         }
         if (symbol !== undefined) {
             const market = this.market (symbol);
+            symbol = market['symbol'];
             request['symbol'] = market['id'];
             if (market['linear']) {
                 method = 'fapiPublicGetFundingRate';


### PR DESCRIPTION
old
```
$ node examples/js/cli binance fetchFundingRateHistory BTCUSDT 0 100 '{"type":"future"}' 
binance.fetchFundingRateHistory (BTCUSDT, 0, 100, [object Object])

[]
```

now
```
$ node examples/js/cli binance fetchFundingRateHistory BTCUSDT 0 100 '{"type":"future"}'
binance.fetchFundingRateHistory (BTCUSDT, 0, 100, [object Object])

  symbol | fundingRate |     timestamp |                 datetime
-----------------------------------------------------------------
BTC/USDT |  0.00001462 | 1643932800018 | 2022-02-04T00:00:00.018Z
```