### PR TITLE
huobi: patch filterBySymbolSinceLimit

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2067,7 +2067,7 @@ module.exports = class huobi extends Exchange {
             }
         }
         result = this.sortBy (result, 'timestamp');
-        return this.filterBySymbolSinceLimit (result, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (result, market['symbol'], since, limit);
     }
 
     parseOHLCV (ohlcv, market = undefined) {
@@ -4482,7 +4482,7 @@ module.exports = class huobi extends Exchange {
             });
         }
         const sorted = this.sortBy (rates, 'timestamp');
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit);
     }
 
     parseFundingRate (fundingRate, market = undefined) {


### PR DESCRIPTION
## fetchTrades
old
```
node examples/js/cli huobi fetchTrades BTC-USDT 0 1
huobi.fetchTrades (BTC-USDT, 0, 1)
2022-03-09T03:30:35.878Z iteration 0 passed in 160 ms

[]
```

new
```
$ node examples/js/cli huobi fetchTrades BTC-USDT 0 1
huobi.fetchTrades (BTC-USDT, 0, 1)
2022-03-09T03:29:48.944Z iteration 0 passed in 254 ms

             id | order |     timestamp |                 datetime |        symbol | type | side | takerOrMaker |   price | amount |    cost | fee | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------
990151511390000 |       | 1646796587786 | 2022-03-09T03:29:47.786Z | BTC/USDT:USDT |      | sell |              | 40238.7 |      2 | 80.4774 |     |   []
```

## fetchFundingRateHistory
old
```
node examples/js/cli huobi fetchFundingRateHistory BTC-USDT 0 1    
2022-03-09T03:26:11.659Z
huobi.fetchFundingRateHistory (BTC-USDT, 0, 1)
2022-03-09T03:26:13.800Z iteration 0 passed in 172 ms

[]


```

new
```
$ node examples/js/cli huobi fetchFundingRateHistory BTC-USDT 0 1
huobi.fetchFundingRateHistory (BTC-USDT, 0, 1)
2022-03-09T03:26:46.883Z iteration 0 passed in 175 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
BTC/USDT:USDT |      0.0001 | 1646236800000 | 2022-03-02T16:00:00.000Z
```