### PR TITLE
huobijp: patch fetchTrades

### DIFF
--- a/js/huobijp.js
+++ b/js/huobijp.js
@@ -841,7 +841,7 @@ module.exports = class huobijp extends Exchange {
             }
         }
         result = this.sortBy (result, 'timestamp');
-        return this.filterBySymbolSinceLimit (result, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (result, market['symbol'], since, limit);
     }
 
     parseOHLCV (ohlcv, market = undefined) {


### PR DESCRIPTION
old:
```
$ node examples/js/cli huobijp fetchTrades btcjpy 0 1 
huobijp.fetchTrades (btcjpy, 0, 1)
2022-03-09T03:42:08.620Z iteration 0 passed in 161 ms

[]
```

new:
```
$ node examples/js/cli huobijp fetchTrades btcjpy 0 1
huobijp.fetchTrades (btcjpy, 0, 1)
2022-03-09T03:42:15.611Z iteration 0 passed in 275 ms

                         id | order |     timestamp |                 datetime |  symbol | type | side | takerOrMaker |   price |  amount |     cost | fee
----------------------------------------------------------------------------------------------------------------------------------------------------------
101814208899493355407016705 |       | 1646797323840 | 2022-03-09T03:42:03.840Z | BTC/JPY |      |  buy |              | 4716272 | 0.00001 | 47.16272 |    
```