### PR TITLE
mexc: patch fetchFundingRateHistory

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2509,7 +2509,7 @@ module.exports = class mexc extends Exchange {
             });
         }
         const sorted = this.sortBy (rates, 'timestamp');
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit);
     }
 
     async fetchLeverageTiers (symbols = undefined, params = {}) {


### PR DESCRIPTION
old:
```
$ node examples/js/cli mexc fetchFundingRateHistory BTC_USDT 0 1
mexc.fetchFundingRateHistory (BTC_USDT, 0, 1)
2022-03-09T04:12:14.613Z iteration 0 passed in 139 ms

[]
```

new:
```
$ node examples/js/cli mexc fetchFundingRateHistory BTC_USDT 0 1
mexc.fetchFundingRateHistory (BTC_USDT, 0, 1)
2022-03-09T04:12:30.708Z iteration 0 passed in 154 ms

  symbol | fundingRate |     timestamp |                 datetime
-----------------------------------------------------------------
BTC/USDT |    0.000118 | 1646784000000 | 2022-03-09T00:00:00.000Z
```