### PR TITLE
zb: patch fetchFundingRateHistory

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -2256,6 +2256,7 @@ module.exports = class zb extends Exchange {
         };
         if (symbol !== undefined) {
             const market = this.market (symbol);
+            symbol = market['symbol'];
             request['symbol'] = market['id'];
         }
         if (since !== undefined) {


### PR DESCRIPTION
old:
```
$ node examples/js/cli zb fetchFundingRateHistory BTC_USDT 0 1         
zb.fetchFundingRateHistory (BTC_USDT, 0, 1)
2022-03-09T04:33:21.031Z iteration 0 passed in 164 ms

[]
```

new:
```
$ node examples/js/cli zb fetchFundingRateHistory BTC_USDT 0 1
zb.fetchFundingRateHistory (BTC_USDT, 0, 1)
2022-03-09T04:33:29.252Z iteration 0 passed in 167 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
BTC/USDT:USDT |      0.0001 | 1646784000000 | 2022-03-09T00:00:00.000Z
```