### PR TITLE
binance.fetchPositionRisk KeyError: precision bug fix

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4629,7 +4629,7 @@ module.exports = class binance extends Exchange {
         //
         const marketId = this.safeString (position, 'symbol');
         market = this.safeMarket (marketId, market);
-        const symbol = market['symbol'];
+        const symbol = this.safeString (market, 'symbol');
         const leverageBrackets = this.safeValue (this.options, 'leverageBrackets', {});
         const leverageBracket = this.safeValue (leverageBrackets, symbol, []);
         const notionalString = this.safeString2 (position, 'notional', 'notionalValue');
@@ -4669,6 +4669,7 @@ module.exports = class binance extends Exchange {
         const linear = ('notional' in position);
         if (marginType === 'cross') {
             // calculate collateral
+            const precision = this.safeValue (market, 'precision');
             if (linear) {
                 // walletBalance = (liquidationPrice * (±1 + mmp) ± entryPrice) * contracts
                 let onePlusMaintenanceMarginPercentageString = undefined;
@@ -4681,7 +4682,8 @@ module.exports = class binance extends Exchange {
                 }
                 const inner = Precise.stringMul (liquidationPriceString, onePlusMaintenanceMarginPercentageString);
                 const leftSide = Precise.stringAdd (inner, entryPriceSignString);
-                collateralString = Precise.stringDiv (Precise.stringMul (leftSide, contractsAbs), '1', market['precision']['quote']);
+                const quotePrecision = this.safeString (precision, 'quote');
+                collateralString = Precise.stringDiv (Precise.stringMul (leftSide, contractsAbs), '1', quotePrecision);
             } else {
                 // walletBalance = (contracts * contractSize) * (±1/entryPrice - (±1 - mmp) / liquidationPrice)
                 let onePlusMaintenanceMarginPercentageString = undefined;
@@ -4694,7 +4696,8 @@ module.exports = class binance extends Exchange {
                 }
                 const leftSide = Precise.stringMul (contractsAbs, contractSizeString);
                 const rightSide = Precise.stringSub (Precise.stringDiv ('1', entryPriceSignString), Precise.stringDiv (onePlusMaintenanceMarginPercentageString, liquidationPriceString));
-                collateralString = Precise.stringDiv (Precise.stringMul (leftSide, rightSide), '1', market['precision']['base']);
+                const basePrecision = this.safeString (precision, 'base');
+                collateralString = Precise.stringDiv (Precise.stringMul (leftSide, rightSide), '1', basePrecision);
             }
         } else {
             collateralString = this.safeString (position, 'isolatedMargin');


### PR DESCRIPTION
Fixes this bug https://pastebin.com/BuxDVYV4

```
2022-03-09T05:52:35.218Z
Node.js: v14.17.0
CCXT v1.75.30
binanceusdm.fetchPositionsRisk ()
2022-03-09T05:52:36.356Z iteration 0 passed in 375 ms
        symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral |  notional |      markPrice | entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | marginRatio |                 datetime | marginType |  side | hedged | percentage
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      RAY/USDT |         0 |            1 |             0 |       20 |                  |          0 |         0 |                |          0 |               |             0 |                    0.05 |                 0 |                        0.01 |             |                          |      cross |       |  false |           
...
     DUSK/USDT |         0 |            1 |             0 |       20 |                  |          0 |         0 |                |          0 |               |             0 |                    0.05 |                 0 |                        0.01 |             |                          |      cross |       |  false |           
     CTSI/USDT |         0 |            1 |             0 |       20 |                  |          0 |         0 |                |          0 |               |             0 |                    0.05 |                 0 |                        0.01 |             |                          |      cross |       |  false |           
150 objects
```