### PR TITLE
gateio.stoploss rule fix

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2356,7 +2356,7 @@ module.exports = class gateio extends Exchange {
         } else {
             if (contract) {
                 // contract conditional order
-                const rule = (side === 'buy') ? 1 : 2;
+                const rule = (side === 'buy') ? 2 : 1;
                 request = {
                     'initial': {
                         'contract': market['id'],


### PR DESCRIPTION
## Buy

```
2022-03-09T21:27:54.326Z
Node.js: v14.17.0
CCXT v1.75.30
gateio.createOrder (XRP/USDT:USDT, limit, buy, 5, 0.75, [object Object])
2022-03-09T21:27:55.640Z iteration 0 passed in 187 ms

{
  id: '38274823',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: false,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  fees: [],
  trades: [],
  info: { id: '38274823' }
}
```

## Sell

```
2022-03-09T21:33:31.604Z
Node.js: v14.17.0
CCXT v1.75.30
gateio.createOrder (XRP/USDT:USDT, limit, sell, 5, 0.77, [object Object])
2022-03-09T21:33:32.920Z iteration 0 passed in 182 ms

{
  id: '32947298',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: false,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  fees: [],
  trades: [],
  info: { id: '32947298' }
}
```