### PR TITLE
buda - fetchTradingFee

### DIFF
--- a/js/buda.js
+++ b/js/buda.js
@@ -60,6 +60,8 @@ module.exports = class buda extends Exchange {
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTrades': true,
+                'fetchTradingFee': false,
+                'fetchTradingFees': false,
                 'fetchWithdrawals': true,
                 'reduceMargin': false,
                 'setLeverage': false,


### PR DESCRIPTION
There is an endpoint to get a fee for a future order, but you need to specify the amount in the order. Therefore I don't think we can use it as part of our unified api.
https://api.buda.com/#cotizaciones