### PR TITLE
ZB fetchBorrowRates

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -21,7 +21,7 @@ module.exports = class zb extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined, // has but unimplemented
+                'margin': true,
                 'swap': true,
                 'future': undefined,
                 'option': undefined,
@@ -33,6 +33,9 @@ module.exports = class zb extends Exchange {
                 'createReduceOnlyOrder': false,
                 'fetchBalance': true,
                 'fetchBorrowRate': true,
+                'fetchBorrowRateHistory': false,
+                'fetchBorrowRateHistories': false,
+                'fetchBorrowRates': true,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
@@ -3316,6 +3319,46 @@ module.exports = class zb extends Exchange {
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
         const currency = this.currency (code);
+        const request = {
+            'coin': currency['id'],
+        };
+        const response = await this.spotV1PrivateGetGetLoans (this.extend (request, params));
+        //
+        //     {
+        //         code: '1000',
+        //         message: '操作成功',
+        //         result: [
+        //             {
+        //                 interestRateOfDay: '0.0005',
+        //                 repaymentDay: '30',
+        //                 amount: '148804.4841',
+        //                 balance: '148804.4841',
+        //                 rateOfDayShow: '0.05 %',
+        //                 coinName: 'USDT',
+        //                 lowestAmount: '0.01'
+        //             },
+        //         ]
+        //     }
+        //
+        const timestamp = this.milliseconds ();
+        const data = this.safeValue (response, 'result');
+        const rate = this.safeValue (data, 0);
+        return {
+            'currency': this.safeCurrencyCode (this.safeString (rate, 'coinName')),
+            'rate': this.safeNumber (rate, 'interestRateOfDay'),
+            'period': this.safeNumber (rate, 'repaymentDay'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': rate,
+        };
+    }
+
+    async fetchBorrowRates (params = {}) {
+        if (params['coin'] === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchBorrowRates() requires a coin argument in the params');
+        }
+        await this.loadMarkets ();
+        const currency = this.currency (this.safeString (params, 'coin'));
         const request = {
             'coin': currency['id'],
         };

--- a/js/zb.js
+++ b/js/zb.js
@@ -3341,8 +3341,8 @@ module.exports = class zb extends Exchange {
         //     }
         //
         const timestamp = this.milliseconds ();
-        const data = this.safeValue (response, 'result');
-        const rate = this.safeValue (data, 0);
+        const data = this.safeValue (response, 'result', []);
+        const rate = this.safeValue (data, 0, {});
         return {
             'currency': this.safeCurrencyCode (this.safeString (rate, 'coinName')),
             'rate': this.safeNumber (rate, 'interestRateOfDay'),


### PR DESCRIPTION
Adjusted fetchBorrowRate and added fetchBorrowRates:
```
zb.fetchBorrowRate (BTC)
2022-03-10T08:57:54.671Z iteration 0 passed in 351 ms

{
  currency: 'BTC',
  rate: 0.0005,
  period: 30,
  timestamp: 1646902674671,
  datetime: '2022-03-10T08:57:54.671Z',
  info: {
    interestRateOfDay: '0.0005',
    repaymentDay: '30',
    amount: '2.1981',
    balance: '2.1981',
    rateOfDayShow: '0.05 %',
    coinName: 'BTC',
    lowestAmount: '0.0001'
  }
}
```
```
zb.fetchBorrowRates ([object Object])
2022-03-10T09:00:29.825Z iteration 0 passed in 350 ms

currency |    rate | period |     timestamp |                 datetime
----------------------------------------------------------------------
     BTC |  0.0005 |     30 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |  0.0005 |     20 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |  0.0005 |     10 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC | 0.00051 |     30 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |  0.0006 |     10 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |   0.001 |     30 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |  0.0015 |     30 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |  0.0015 |     10 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |  0.0019 |     10 | 1646902829825 | 2022-03-10T09:00:29.825Z
     BTC |   0.002 |     30 | 1646902829825 | 2022-03-10T09:00:29.825Z
10 objects
```