### PR TITLE
okx: fix return by network

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -584,6 +584,10 @@ module.exports = class okx extends Exchange {
                     'ETH': 'ERC20',
                     'TRX': 'TRC20',
                     'OMNI': 'Omni',
+                    'SOLANA': 'Solana',
+                    'POLYGON': 'Polygon',
+                    'OEC': 'OEC',
+                    'ALGO': 'ALGO', // temporarily unavailable
                 },
                 'layerTwo': {
                     'Lightning': true,
@@ -2720,7 +2724,46 @@ module.exports = class okx extends Exchange {
         const chain = this.safeString (depositAddress, 'chain');
         const networks = this.safeValue (currency, 'networks', {});
         const networksById = this.indexBy (networks, 'id');
-        const networkData = this.safeValue (networksById, chain);
+        let networkData = this.safeValue (networksById, chain);
+        // inconsistent naming responses from exchange
+        // with respect to network naming provided in currency info vs address chain-names and ids
+        //
+        // response from address endpoint:
+        //      {
+        //          "chain":"USDT-Polygon",
+        //          "ctAddr":"",
+        //          "ccy":"USDT",
+        //          "to":"6",
+        //          "addr":"0x1903441e386cc49d937f6302955b5feb4286dcfa",
+        //          "selected":true
+        //      }
+        // network information from currency['networks'] field:
+        // Polygon: {
+        //       info: {
+        //         canDep: false,
+        //         canInternal: false,
+        //         canWd: false,
+        //         ccy: 'USDT',
+        //         chain: 'USDT-Polygon-Bridge',
+        //         mainNet: false,
+        //         maxFee: '26.879528',
+        //         minFee: '13.439764',
+        //         minWd: '0.001',
+        //         name: ''
+        //       },
+        //       id: 'USDT-Polygon-Bridge',
+        //       network: 'Polygon',
+        //       active: false,
+        //       deposit: false,
+        //       withdraw: false,
+        //       fee: 13.439764,
+        //       precision: undefined,
+        //       limits: { withdraw: { min: 0.001, max: undefined } }
+        //     },
+        //
+        if (chain === 'USDT-Polygon') {
+            networkData = this.safeValue (networksById, 'USDT-Polygon-Bridge');
+        }
         const network = this.safeString (networkData, 'network');
         this.checkAddress (address);
         return {


### PR DESCRIPTION
Notes: Polygon kept getting returned as undefined for some reason so I had to debug for ages to figure it out, it was because of inconsistent namings from the exchange for the USDT Polygon Network. (USDT Polygon network address retrieval now works) (see comments)

- I also noticed this when inspecting the currency object
- `node examples/js/cli okx currency USDT` returns: 
![image](https://user-images.githubusercontent.com/87606888/157657583-84be992a-0613-4285-82cd-27ebbf673c45.png)
within its network properties... however it must also be noted that Omni is not even listed as a available: 
![image](https://user-images.githubusercontent.com/87606888/157657684-d914f6b9-bdba-4b56-8e12-5c4d191d6ca9.png)

nor unavailable network option on okx: 
![image](https://user-images.githubusercontent.com/87606888/157657781-c3aded1a-4a4e-40fa-9525-f686c70edbdb.png)

Note: I did also check that the address returned from `node examples/js/cli okx fetchDepositAddress USDT "{'network': 'Polygon'}"` is the same as the USDT Polygon address on the exchange Web UI

fixes #12206 