### PR TITLE
WhiteBIT: fix error message for error

### DIFF
--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -1232,13 +1232,15 @@ module.exports = class whitebit extends Exchange {
             // For cases where we have a meaningful status
             // {"response":null,"status":422,"errors":{"orderId":["Finished order id 435453454535 not found on your account"]},"notification":null,"warning":"Finished order id 435453454535 not found on your account","_token":null}
             const status = this.safeInteger (response, 'status');
+            // {"code":10,"message":"Unauthorized request."}
+			const message = this.safeString(response, 'message');
             // For these cases where we have a generic code variable error key
             // {"code":0,"message":"Validation failed","errors":{"amount":["Amount must be greater than 0"]}}
             const code = this.safeInteger (response, 'code');
             const hasErrorStatus = status !== undefined && status !== '200';
             if (hasErrorStatus || code !== undefined) {
                 const feedback = this.id + ' ' + body;
-                let errorInfo = undefined;
+                let errorInfo = message;
                 if (hasErrorStatus) {
                     errorInfo = status;
                 } else {


### PR DESCRIPTION
We received `{"code":10,"message":"Unauthorized request."}` from the API, and the handleErrors parsed it incorrectly as `undefined` error message.