### PR TITLE
Gateio ::  fetchMarkets refactor

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -36,7 +36,7 @@ module.exports = class gateio extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': true,
-                'option': undefined,
+                'option': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createMarketOrder': false,
@@ -370,16 +370,6 @@ module.exports = class gateio extends Exchange {
                 'fetchMarkets': {
                     'settlementCurrencies': [ 'usdt', 'btc' ],
                 },
-                'swap': {
-                    'fetchMarkets': {
-                        'settlementCurrencies': [ 'usdt', 'btc' ],
-                    },
-                },
-                'future': {
-                    'fetchMarkets': {
-                        'settlementCurrencies': [ 'usdt', 'btc' ],
-                    },
-                },
             },
             'precisionMode': TICK_SIZE,
             'fees': {
@@ -578,7 +568,7 @@ module.exports = class gateio extends Exchange {
 
     async fetchMarkets (params = {}) {
         const spotMarkets = await this.fetchSpotMarkets (params);
-        const derivativeMarkets = await this.fetchDerivativesMarkets (params); // futures and swaps
+        const derivativeMarkets = await this.fetchDerivativeMarkets (params); // futures and swaps
         const optionMarkets = await this.fetchOptionMarkets (params);
         let result = spotMarkets.concat (derivativeMarkets);
         result = result.concat (optionMarkets);
@@ -690,7 +680,7 @@ module.exports = class gateio extends Exchange {
         return result;
     }
 
-    async fetchDerivativesMarkets (params) {
+    async fetchDerivativeMarkets (params) {
         const result = [];
         const settlementCurrencies = this.getSettlementCurrencies ('fetchMarkets');
         for (let c = 0; c < settlementCurrencies.length; c++) {
@@ -873,7 +863,7 @@ module.exports = class gateio extends Exchange {
 
     async fetchOptionMarkets (params = {}) {
         const result = [];
-        const underlyings = await this.fetchOptionsUnderlyings ();
+        const underlyings = await this.fetchOptionUnderlyings ();
         for (let i = 0; i < underlyings.length; i++) {
             const underlying = underlyings[i];
             const query = params;
@@ -995,7 +985,7 @@ module.exports = class gateio extends Exchange {
         return result;
     }
 
-    async fetchOptionsUnderlyings () {
+    async fetchOptionUnderlyings () {
         const underlyingsResponse = await this.publicOptionsGetUnderlyings ();
         // [
         //     {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -367,6 +367,9 @@ module.exports = class gateio extends Exchange {
                     'delivery': 'delivery',
                 },
                 'defaultType': 'spot',
+                'fetchMarkets': {
+                    'settlementCurrencies': [ 'usdt', 'btc' ],
+                },
                 'swap': {
                     'fetchMarkets': {
                         'settlementCurrencies': [ 'usdt', 'btc' ],
@@ -576,297 +579,300 @@ module.exports = class gateio extends Exchange {
     async fetchMarkets (params = {}) {
         // :param params['type']: 'spot', 'margin', 'future' or 'delivery'
         // :param params['settle']: The quote currency
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
-        const spot = (type === 'spot');
-        const margin = (type === 'margin');
-        const future = (type === 'future');
-        const swap = (type === 'swap');
-        const option = (type === 'option');
-        if (!spot && !margin && !future && !swap) {
-            throw new ExchangeError (this.id + " does not support '" + type + "' type, set exchange.options['defaultType'] to " + "'spot', 'margin', 'swap' or 'future'"); // eslint-disable-line quotes
-        }
-        let response = undefined;
+        // const [ type, query ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
+        // const spot = (type === 'spot');
+        // const margin = (type === 'margin');
+        // const future = (type === 'future');
+        // const swap = (type === 'swap');
+        // const option = (type === 'option');
+        // if (!spot && !margin && !future && !swap) {
+        //     throw new ExchangeError (this.id + " does not support '" + type + "' type, set exchange.options['defaultType'] to " + "'spot', 'margin', 'swap' or 'future'"); // eslint-disable-line quotes
+        // }
+        // const response = undefined;
         const result = [];
-        const method = this.getSupportedMapping (type, {
-            'spot': 'publicSpotGetCurrencyPairs',
-            'margin': 'publicMarginGetCurrencyPairs',
-            'swap': 'publicFuturesGetSettleContracts',
-            'future': 'publicDeliveryGetSettleContracts',
-        });
-        if (swap || future || option) {
-            const settlementCurrencies = this.getSettlementCurrencies (type, 'fetchMarkets');
-            for (let c = 0; c < settlementCurrencies.length; c++) {
-                const settleId = settlementCurrencies[c];
-                query['settle'] = settleId;
-                response = await this[method] (query);
-                //  Perpetual swap
-                //      [
-                //          {
-                //              "name": "BTC_USDT",
-                //              "type": "direct",
-                //              "quanto_multiplier": "0.0001",
-                //              "ref_discount_rate": "0",
-                //              "order_price_deviate": "0.5",
-                //              "maintenance_rate": "0.005",
-                //              "mark_type": "index",
-                //              "last_price": "38026",
-                //              "mark_price": "37985.6",
-                //              "index_price": "37954.92",
-                //              "funding_rate_indicative": "0.000219",
-                //              "mark_price_round": "0.01",
-                //              "funding_offset": 0,
-                //              "in_delisting": false,
-                //              "risk_limit_base": "1000000",
-                //              "interest_rate": "0.0003",
-                //              "order_price_round": "0.1",
-                //              "order_size_min": 1,
-                //              "ref_rebate_rate": "0.2",
-                //              "funding_interval": 28800,
-                //              "risk_limit_step": "1000000",
-                //              "leverage_min": "1",
-                //              "leverage_max": "100",
-                //              "risk_limit_max": "8000000",
-                //              "maker_fee_rate": "-0.00025",
-                //              "taker_fee_rate": "0.00075",
-                //              "funding_rate": "0.002053",
-                //              "order_size_max": 1000000,
-                //              "funding_next_apply": 1610035200,
-                //              "short_users": 977,
-                //              "config_change_time": 1609899548,
-                //              "trade_size": 28530850594,
-                //              "position_size": 5223816,
-                //              "long_users": 455,
-                //              "funding_impact_value": "60000",
-                //              "orders_limit": 50,
-                //              "trade_id": 10851092,
-                //              "orderbook_id": 2129638396
-                //          }
-                //      ]
-                //
-                //  Delivery Futures
-                //      [
-                //          {
-                //            "name": "BTC_USDT_20200814",
-                //            "underlying": "BTC_USDT",
-                //            "cycle": "WEEKLY",
-                //            "type": "direct",
-                //            "quanto_multiplier": "0.0001",
-                //            "mark_type": "index",
-                //            "last_price": "9017",
-                //            "mark_price": "9019",
-                //            "index_price": "9005.3",
-                //            "basis_rate": "0.185095",
-                //            "basis_value": "13.7",
-                //            "basis_impact_value": "100000",
-                //            "settle_price": "0",
-                //            "settle_price_interval": 60,
-                //            "settle_price_duration": 1800,
-                //            "settle_fee_rate": "0.0015",
-                //            "expire_time": 1593763200,
-                //            "order_price_round": "0.1",
-                //            "mark_price_round": "0.1",
-                //            "leverage_min": "1",
-                //            "leverage_max": "100",
-                //            "maintenance_rate": "1000000",
-                //            "risk_limit_base": "140.726652109199",
-                //            "risk_limit_step": "1000000",
-                //            "risk_limit_max": "8000000",
-                //            "maker_fee_rate": "-0.00025",
-                //            "taker_fee_rate": "0.00075",
-                //            "ref_discount_rate": "0",
-                //            "ref_rebate_rate": "0.2",
-                //            "order_price_deviate": "0.5",
-                //            "order_size_min": 1,
-                //            "order_size_max": 1000000,
-                //            "orders_limit": 50,
-                //            "orderbook_id": 63,
-                //            "trade_id": 26,
-                //            "trade_size": 435,
-                //            "position_size": 130,
-                //            "config_change_time": 1593158867,
-                //            "in_delisting": false
-                //          }
-                //        ]
-                //
-                for (let i = 0; i < response.length; i++) {
-                    const market = response[i];
-                    const id = this.safeString (market, 'name');
-                    const parts = id.split ('_');
-                    const baseId = this.safeString (parts, 0);
-                    const quoteId = this.safeString (parts, 1);
-                    const date = this.safeString (parts, 2);
-                    const base = this.safeCurrencyCode (baseId);
-                    const quote = this.safeCurrencyCode (quoteId);
-                    const settle = this.safeCurrencyCode (settleId);
-                    const expiry = this.safeTimestamp (market, 'expire_time');
-                    let symbol = '';
-                    if (date !== undefined) {
-                        symbol = base + '/' + quote + ':' + settle + '-' + this.yymmdd (expiry, '');
-                    } else {
-                        symbol = base + '/' + quote + ':' + settle;
-                    }
-                    const priceDeviate = this.safeString (market, 'order_price_deviate');
-                    const markPrice = this.safeString (market, 'mark_price');
-                    const minMultiplier = Precise.stringSub ('1', priceDeviate);
-                    const maxMultiplier = Precise.stringAdd ('1', priceDeviate);
-                    const minPrice = Precise.stringMul (minMultiplier, markPrice);
-                    const maxPrice = Precise.stringMul (maxMultiplier, markPrice);
-                    const takerPercent = this.safeString (market, 'taker_fee_rate');
-                    const makerPercent = this.safeString (market, 'maker_fee_rate', takerPercent);
-                    result.push ({
-                        'id': id,
-                        'symbol': symbol,
-                        'base': base,
-                        'quote': quote,
-                        'settle': settle,
-                        'baseId': baseId,
-                        'quoteId': quoteId,
-                        'settleId': settleId,
-                        'type': type,
-                        'spot': spot,
-                        'margin': margin,
-                        'swap': swap,
-                        'future': future,
-                        'option': option,
-                        'active': true,
-                        'contract': true,
-                        'linear': (quote === settle),
-                        'inverse': (base === settle),
-                        'taker': this.parseNumber (Precise.stringDiv (takerPercent, '100')), // Fee is in %, so divide by 100
-                        'maker': this.parseNumber (Precise.stringDiv (makerPercent, '100')),
-                        'contractSize': this.safeNumber (market, 'quanto_multiplier'),
-                        'expiry': expiry,
-                        'expiryDatetime': this.iso8601 (expiry),
-                        'strike': undefined,
-                        'optionType': undefined,
-                        'precision': {
-                            'amount': this.parseNumber ('1'),
-                            'price': this.safeNumber (market, 'order_price_round'),
-                        },
-                        'limits': {
-                            'leverage': {
-                                'min': this.safeNumber (market, 'leverage_min'),
-                                'max': this.safeNumber (market, 'leverage_max'),
-                            },
-                            'amount': {
-                                'min': this.safeNumber (market, 'order_size_min'),
-                                'max': this.safeNumber (market, 'order_size_max'),
-                            },
-                            'price': {
-                                'min': this.parseNumber (minPrice),
-                                'max': this.parseNumber (maxPrice),
-                            },
-                            'cost': {
-                                'min': undefined,
-                                'max': undefined,
-                            },
-                        },
-                        'info': market,
-                    });
-                }
-            }
-        } else {
-            response = await this[method] (query);
-            let spotMarkets = {};
-            if (margin) {
-                const spotMarketsResponse = await this.publicSpotGetCurrencyPairs (query);
-                spotMarkets = this.indexBy (spotMarketsResponse, 'id');
-            }
-            //
-            //  Spot
+        // const method = this.getSupportedMapping (type, {
+        //     'spot': 'publicSpotGetCurrencyPairs',
+        //     'margin': 'publicMarginGetCurrencyPairs',
+        //     'swap': 'publicFuturesGetSettleContracts',
+        //     'future': 'publicDeliveryGetSettleContracts',
+        // });
+        // swaps and futures
+        const settlementCurrencies = this.getSettlementCurrencies ('fetchMarkets');
+        for (let c = 0; c < settlementCurrencies.length; c++) {
+            const settleId = settlementCurrencies[c];
+            const query = params;
+            query['settle'] = settleId;
+            const swapResponse = await this.publicFuturesGetSettleContracts (query);
+            const futureResponse = await this.publicDeliveryGetSettleContracts (query);
+            const derivatesResponse = swapResponse.concat (futureResponse);
+            //  Perpetual swap
             //      [
-            //           {
-            //             "id": "DEGO_USDT",
-            //             "base": "DEGO",
-            //             "quote": "USDT",
-            //             "fee": "0.2",
-            //             "min_quote_amount": "1",
-            //             "amount_precision": "4",
-            //             "precision": "4",
-            //             "trade_status": "tradable",
-            //             "sell_start": "0",
-            //             "buy_start": "0"
-            //           }
+            //          {
+            //              "name": "BTC_USDT",
+            //              "type": "direct",
+            //              "quanto_multiplier": "0.0001",
+            //              "ref_discount_rate": "0",
+            //              "order_price_deviate": "0.5",
+            //              "maintenance_rate": "0.005",
+            //              "mark_type": "index",
+            //              "last_price": "38026",
+            //              "mark_price": "37985.6",
+            //              "index_price": "37954.92",
+            //              "funding_rate_indicative": "0.000219",
+            //              "mark_price_round": "0.01",
+            //              "funding_offset": 0,
+            //              "in_delisting": false,
+            //              "risk_limit_base": "1000000",
+            //              "interest_rate": "0.0003",
+            //              "order_price_round": "0.1",
+            //              "order_size_min": 1,
+            //              "ref_rebate_rate": "0.2",
+            //              "funding_interval": 28800,
+            //              "risk_limit_step": "1000000",
+            //              "leverage_min": "1",
+            //              "leverage_max": "100",
+            //              "risk_limit_max": "8000000",
+            //              "maker_fee_rate": "-0.00025",
+            //              "taker_fee_rate": "0.00075",
+            //              "funding_rate": "0.002053",
+            //              "order_size_max": 1000000,
+            //              "funding_next_apply": 1610035200,
+            //              "short_users": 977,
+            //              "config_change_time": 1609899548,
+            //              "trade_size": 28530850594,
+            //              "position_size": 5223816,
+            //              "long_users": 455,
+            //              "funding_impact_value": "60000",
+            //              "orders_limit": 50,
+            //              "trade_id": 10851092,
+            //              "orderbook_id": 2129638396
+            //          }
             //      ]
             //
-            //  Margin
+            //  Delivery Futures
             //      [
-            //         {
-            //           "id": "ETH_USDT",
-            //           "base": "ETH",
-            //           "quote": "USDT",
-            //           "leverage": 3,
-            //           "min_base_amount": "0.01",
-            //           "min_quote_amount": "100",
-            //           "max_quote_amount": "1000000"
-            //         }
-            //       ]
+            //          {
+            //            "name": "BTC_USDT_20200814",
+            //            "underlying": "BTC_USDT",
+            //            "cycle": "WEEKLY",
+            //            "type": "direct",
+            //            "quanto_multiplier": "0.0001",
+            //            "mark_type": "index",
+            //            "last_price": "9017",
+            //            "mark_price": "9019",
+            //            "index_price": "9005.3",
+            //            "basis_rate": "0.185095",
+            //            "basis_value": "13.7",
+            //            "basis_impact_value": "100000",
+            //            "settle_price": "0",
+            //            "settle_price_interval": 60,
+            //            "settle_price_duration": 1800,
+            //            "settle_fee_rate": "0.0015",
+            //            "expire_time": 1593763200,
+            //            "order_price_round": "0.1",
+            //            "mark_price_round": "0.1",
+            //            "leverage_min": "1",
+            //            "leverage_max": "100",
+            //            "maintenance_rate": "1000000",
+            //            "risk_limit_base": "140.726652109199",
+            //            "risk_limit_step": "1000000",
+            //            "risk_limit_max": "8000000",
+            //            "maker_fee_rate": "-0.00025",
+            //            "taker_fee_rate": "0.00075",
+            //            "ref_discount_rate": "0",
+            //            "ref_rebate_rate": "0.2",
+            //            "order_price_deviate": "0.5",
+            //            "order_size_min": 1,
+            //            "order_size_max": 1000000,
+            //            "orders_limit": 50,
+            //            "orderbook_id": 63,
+            //            "trade_id": 26,
+            //            "trade_size": 435,
+            //            "position_size": 130,
+            //            "config_change_time": 1593158867,
+            //            "in_delisting": false
+            //          }
+            //        ]
             //
-            for (let i = 0; i < response.length; i++) {
-                let market = response[i];
-                const id = this.safeString (market, 'id');
-                const spotMarket = this.safeValue (spotMarkets, id);
-                market = this.deepExtend (spotMarket, market);
-                const [ baseId, quoteId ] = id.split ('_');
+            for (let i = 0; i < derivatesResponse.length; i++) {
+                const market = derivatesResponse[i];
+                const id = this.safeString (market, 'name');
+                const parts = id.split ('_');
+                const baseId = this.safeString (parts, 0);
+                const quoteId = this.safeString (parts, 1);
+                const date = this.safeString (parts, 2);
                 const base = this.safeCurrencyCode (baseId);
                 const quote = this.safeCurrencyCode (quoteId);
-                const takerPercent = this.safeString (market, 'fee');
+                const settle = this.safeCurrencyCode (settleId);
+                const expiry = this.safeTimestamp (market, 'expire_time');
+                let symbol = '';
+                let marketType = 'swap';
+                if (date !== undefined) {
+                    symbol = base + '/' + quote + ':' + settle + '-' + this.yymmdd (expiry, '');
+                    marketType = 'future';
+                } else {
+                    symbol = base + '/' + quote + ':' + settle;
+                }
+                const priceDeviate = this.safeString (market, 'order_price_deviate');
+                const markPrice = this.safeString (market, 'mark_price');
+                const minMultiplier = Precise.stringSub ('1', priceDeviate);
+                const maxMultiplier = Precise.stringAdd ('1', priceDeviate);
+                const minPrice = Precise.stringMul (minMultiplier, markPrice);
+                const maxPrice = Precise.stringMul (maxMultiplier, markPrice);
+                const takerPercent = this.safeString (market, 'taker_fee_rate');
                 const makerPercent = this.safeString (market, 'maker_fee_rate', takerPercent);
-                const amountPrecisionString = this.safeString (market, 'amount_precision');
-                const pricePrecisionString = this.safeString (market, 'precision');
-                const tradeStatus = this.safeString (market, 'trade_status');
                 result.push ({
                     'id': id,
-                    'symbol': base + '/' + quote,
+                    'symbol': symbol,
                     'base': base,
                     'quote': quote,
-                    'settle': undefined,
+                    'settle': settle,
                     'baseId': baseId,
                     'quoteId': quoteId,
-                    'settleId': undefined,
-                    'type': type,
-                    'spot': true,
-                    'margin': margin,
-                    'swap': false,
-                    'future': false,
-                    'option': false,
-                    'active': (tradeStatus === 'tradable'),
-                    'contract': false,
-                    'linear': undefined,
-                    'inverse': undefined,
-                    // Fee is in %, so divide by 100
-                    'taker': this.parseNumber (Precise.stringDiv (takerPercent, '100')),
+                    'settleId': settleId,
+                    'type': marketType,
+                    'spot': false,
+                    'margin': false,
+                    'swap': marketType === 'swap',
+                    'future': marketType === 'future',
+                    'option': marketType === 'option',
+                    'active': true,
+                    'contract': true,
+                    'linear': (quote === settle),
+                    'inverse': (base === settle),
+                    'taker': this.parseNumber (Precise.stringDiv (takerPercent, '100')), // Fee is in %, so divide by 100
                     'maker': this.parseNumber (Precise.stringDiv (makerPercent, '100')),
-                    'contractSize': undefined,
-                    'expiry': undefined,
-                    'expiryDatetime': undefined,
+                    'contractSize': this.safeNumber (market, 'quanto_multiplier'),
+                    'expiry': expiry,
+                    'expiryDatetime': this.iso8601 (expiry),
                     'strike': undefined,
                     'optionType': undefined,
                     'precision': {
-                        'amount': this.parseNumber (this.parsePrecision (amountPrecisionString)),
-                        'price': this.parseNumber (this.parsePrecision (pricePrecisionString)),
+                        'amount': this.parseNumber ('1'),
+                        'price': this.safeNumber (market, 'order_price_round'),
                     },
                     'limits': {
                         'leverage': {
-                            'min': this.parseNumber ('1'),
-                            'max': this.safeNumber (market, 'leverage', 1),
+                            'min': this.safeNumber (market, 'leverage_min'),
+                            'max': this.safeNumber (market, 'leverage_max'),
                         },
                         'amount': {
-                            'min': undefined,
-                            'max': undefined,
+                            'min': this.safeNumber (market, 'order_size_min'),
+                            'max': this.safeNumber (market, 'order_size_max'),
                         },
                         'price': {
-                            'min': undefined,
-                            'max': undefined,
+                            'min': this.parseNumber (minPrice),
+                            'max': this.parseNumber (maxPrice),
                         },
                         'cost': {
-                            'min': this.safeNumber (market, 'min_quote_amount'),
+                            'min': undefined,
                             'max': undefined,
                         },
                     },
                     'info': market,
                 });
             }
+        }
+        const marginResponse = await this.publicMarginGetCurrencyPairs (params);
+        const spotMarketsResponse = await this.publicSpotGetCurrencyPairs (params);
+        const spotMarkets = this.indexBy (spotMarketsResponse, 'id');
+        const spotResponses = marginResponse.concat (spotMarketsResponse);
+        //
+        //  Spot
+        //      [
+        //           {
+        //             "id": "DEGO_USDT",
+        //             "base": "DEGO",
+        //             "quote": "USDT",
+        //             "fee": "0.2",
+        //             "min_quote_amount": "1",
+        //             "amount_precision": "4",
+        //             "precision": "4",
+        //             "trade_status": "tradable",
+        //             "sell_start": "0",
+        //             "buy_start": "0"
+        //           }
+        //      ]
+        //
+        //  Margin
+        //      [
+        //         {
+        //           "id": "ETH_USDT",
+        //           "base": "ETH",
+        //           "quote": "USDT",
+        //           "leverage": 3,
+        //           "min_base_amount": "0.01",
+        //           "min_quote_amount": "100",
+        //           "max_quote_amount": "1000000"
+        //         }
+        //       ]
+        //
+        for (let i = 0; i < spotResponses.length; i++) {
+            let market = spotResponses[i];
+            const id = this.safeString (market, 'id');
+            const spotMarket = this.safeValue (spotMarkets, id);
+            market = this.deepExtend (spotMarket, market);
+            const [ baseId, quoteId ] = id.split ('_');
+            const base = this.safeCurrencyCode (baseId);
+            const quote = this.safeCurrencyCode (quoteId);
+            const takerPercent = this.safeString (market, 'fee');
+            const makerPercent = this.safeString (market, 'maker_fee_rate', takerPercent);
+            const amountPrecisionString = this.safeString (market, 'amount_precision');
+            const pricePrecisionString = this.safeString (market, 'precision');
+            const tradeStatus = this.safeString (market, 'trade_status');
+            const leverage = this.safeNumber (market, 'leverage');
+            const margin = leverage !== undefined;
+            result.push ({
+                'id': id,
+                'symbol': base + '/' + quote,
+                'base': base,
+                'quote': quote,
+                'settle': undefined,
+                'baseId': baseId,
+                'quoteId': quoteId,
+                'settleId': undefined,
+                'type': 'spot',
+                'spot': true,
+                'margin': margin,
+                'swap': false,
+                'future': false,
+                'option': false,
+                'active': (tradeStatus === 'tradable'),
+                'contract': false,
+                'linear': undefined,
+                'inverse': undefined,
+                // Fee is in %, so divide by 100
+                'taker': this.parseNumber (Precise.stringDiv (takerPercent, '100')),
+                'maker': this.parseNumber (Precise.stringDiv (makerPercent, '100')),
+                'contractSize': undefined,
+                'expiry': undefined,
+                'expiryDatetime': undefined,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'amount': this.parseNumber (this.parsePrecision (amountPrecisionString)),
+                    'price': this.parseNumber (this.parsePrecision (pricePrecisionString)),
+                },
+                'limits': {
+                    'leverage': {
+                        'min': this.parseNumber ('1'),
+                        'max': this.safeNumber (market, 'leverage', 1),
+                    },
+                    'amount': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'price': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'cost': {
+                        'min': this.safeNumber (market, 'min_quote_amount'),
+                        'max': undefined,
+                    },
+                },
+                'info': market,
+            });
         }
         return result;
     }
@@ -884,10 +890,9 @@ module.exports = class gateio extends Exchange {
         }
     }
 
-    getSettlementCurrencies (type, method) {
-        const options = this.safeValue (this.options, type, {}); // [ 'BTC', 'USDT' ] unified codes
-        const fetchMarketsContractOptions = this.safeValue (options, method, {});
-        const defaultSettle = (type === 'swap') ? [ 'usdt' ] : [ 'btc' ];
+    getSettlementCurrencies (method) {
+        const fetchMarketsContractOptions = this.safeValue (this.options, method, {});
+        const defaultSettle = [ 'usdt', 'btc' ];
         return this.safeValue (fetchMarketsContractOptions, 'settlementCurrencies', defaultSettle);
     }
 

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -367,7 +367,7 @@ module.exports = class gateio extends Exchange {
                     'delivery': 'delivery',
                 },
                 'defaultType': 'spot',
-                'fetchMarkets': {
+                'derivates': {
                     'settlementCurrencies': [ 'usdt', 'btc' ],
                 },
             },
@@ -691,7 +691,7 @@ module.exports = class gateio extends Exchange {
 
     async fetchDerivativeMarkets (params) {
         const result = [];
-        const settlementCurrencies = this.getSettlementCurrencies ('fetchMarkets');
+        const settlementCurrencies = this.getSettlementCurrencies ();
         for (let c = 0; c < settlementCurrencies.length; c++) {
             const settleId = settlementCurrencies[c];
             const query = params;
@@ -1028,8 +1028,8 @@ module.exports = class gateio extends Exchange {
         }
     }
 
-    getSettlementCurrencies (method) {
-        const fetchMarketsContractOptions = this.safeValue (this.options, method, {});
+    getSettlementCurrencies () {
+        const fetchMarketsContractOptions = this.safeValue (this.options, 'derivatives', {});
         const defaultSettle = [ 'usdt', 'btc' ];
         return this.safeValue (fetchMarketsContractOptions, 'settlementCurrencies', defaultSettle);
     }


### PR DESCRIPTION
**FetchMarkets refactor:**
- split fetchMarkets in several methods depending on the market type (will ease the effort in the future of fetching them all at once)
- grouping market types that can be loaded together (swap+futures) and (spot+margin)
- added options fetching
- fixed inverse-linear problem on markets settled in a different currency from the pair (Example: XMR/USD:BTC)