### PR TITLE
unify accountType names "funding", "spot", "margin", and "future"

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -323,6 +323,7 @@ module.exports = class bitfinex2 extends bitfinex {
                     'funding': 'funding',
                     'margin': 'margin',
                     'derivatives': 'margin',
+                    'future': 'margin',
                 },
             },
             'exceptions': {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -211,6 +211,7 @@ module.exports = class cryptocom extends Exchange {
             'options': {
                 'defaultType': 'spot',
                 'accountsByType': {
+                    'funding': 'SPOT',
                     'spot': 'SPOT',
                     'derivatives': 'DERIVATIVES',
                     'swap': 'DERIVATIVES',

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -360,6 +360,7 @@ module.exports = class gateio extends Exchange {
                     'BEP20': 'BSC',
                 },
                 'accountsByType': {
+                    'funding': 'spot',
                     'spot': 'spot',
                     'margin': 'margin',
                     'future': 'futures',

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -276,7 +276,9 @@ module.exports = class hitbtc3 extends Exchange {
                 },
                 'accountsByType': {
                     'spot': 'spot',
+                    'funding': 'wallet',
                     'wallet': 'wallet',
+                    'future': 'derivatives',
                     'derivatives': 'derivatives',
                 },
             },

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -836,6 +836,7 @@ module.exports = class huobi extends Exchange {
                 },
                 'accountsByType': {
                     'spot': 'pro',
+                    'funding': 'pro',
                     'future': 'futures',
                 },
                 'typesByAccount': {

--- a/js/okx.js
+++ b/js/okx.js
@@ -619,6 +619,7 @@ module.exports = class okx extends Exchange {
                 // 1 = SPOT, 3 = FUTURES, 5 = MARGIN, 6 = FUNDING, 9 = SWAP, 12 = OPTION, 18 = Unified account
                 'accountsByType': {
                     'spot': '1',
+                    'future': '3',
                     'futures': '3',
                     'margin': '5',
                     'funding': '6',


### PR DESCRIPTION
On any exchange the types `funding` `spot` `margin` and `future` will tranfer to the correct account if that account type is present on the exchange

For example

```
gateio.transfer (USDT, 1, future, spot)
2022-03-11T01:30:22.727Z iteration 0 passed in 216 ms

{ info: '', from: 'futures', to: 'spot', amount: '1', code: 'USDT' }
Waiting for the debugger to disconnect...
```