### PR TITLE
Bitflyer: fix futures market parsing without alias

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -181,7 +181,7 @@ module.exports = class bitflyer extends Exchange {
                 quoteId = this.safeString (currencies, 2);
             } else if (future) {
                 const alias = this.safeString (market, 'alias');
-                if (!alias) {
+                if (alias === undefined) {
                     // no alias:
                     // { product_code: 'BTCJPY11MAR2022', market_type: 'Futures' }
                     // TODO this will break if there are products with 4 chars

--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -181,13 +181,24 @@ module.exports = class bitflyer extends Exchange {
                 quoteId = this.safeString (currencies, 2);
             } else if (future) {
                 const alias = this.safeString (market, 'alias');
-                const splitAlias = alias.split ('_');
-                const currencyIds = this.safeString (splitAlias, 0);
-                baseId = currencyIds.slice (0, -3);
-                quoteId = currencyIds.slice (-3);
-                const splitId = id.split (currencyIds);
-                const expiryDate = this.safeString (splitId, 1);
-                expiry = this.parseExpiryDate (expiryDate);
+                if (!alias) {
+                    // no alias: 
+                    // { product_code: 'BTCJPY11MAR2022', market_type: 'Futures' }
+                    // TODO this will break if there are products with 4 chars
+                    baseId = id.slice (0, 3);
+                    quoteId = id.slice (3, 6);
+                    // last 9 chars are expiry date
+                    const expiryDate = id.slice (-9);
+                    expiry = this.parseExpiryDate(expiryDate);
+                } else {
+                    const splitAlias = alias.split ('_');
+                    const currencyIds = this.safeString (splitAlias, 0);
+                    baseId = currencyIds.slice (0, -3);
+                    quoteId = currencyIds.slice (-3);
+                    const splitId = id.split (currencyIds);
+                    const expiryDate = this.safeString (splitId, 1);
+                    expiry = this.parseExpiryDate (expiryDate);
+                }
                 type = 'future';
             }
             const base = this.safeCurrencyCode (baseId);

--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -182,7 +182,7 @@ module.exports = class bitflyer extends Exchange {
             } else if (future) {
                 const alias = this.safeString (market, 'alias');
                 if (!alias) {
-                    // no alias: 
+                    // no alias:
                     // { product_code: 'BTCJPY11MAR2022', market_type: 'Futures' }
                     // TODO this will break if there are products with 4 chars
                     baseId = id.slice (0, 3);

--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -189,7 +189,7 @@ module.exports = class bitflyer extends Exchange {
                     quoteId = id.slice (3, 6);
                     // last 9 chars are expiry date
                     const expiryDate = id.slice (-9);
-                    expiry = this.parseExpiryDate(expiryDate);
+                    expiry = this.parseExpiryDate (expiryDate);
                 } else {
                     const splitAlias = alias.split ('_');
                     const currencyIds = this.safeString (splitAlias, 0);


### PR DESCRIPTION
```
bitflyer GET https://api.bitflyer.com/v1/getmarkets

[
 { product_code: 'BTC_JPY', market_type: 'Spot' },
 { product_code: 'XRP_JPY', market_type: 'Spot' },
 { product_code: 'ETH_JPY', market_type: 'Spot' },
 { product_code: 'XLM_JPY', market_type: 'Spot' },
 { product_code: 'MONA_JPY', market_type: 'Spot' },
 { product_code: 'ETH_BTC', market_type: 'Spot' },
 { product_code: 'BCH_BTC', market_type: 'Spot' },
 { product_code: 'FX_BTC_JPY', market_type: 'FX' },
 { product_code: 'BTCJPY11MAR2022', market_type: 'Futures' }, 🔴 <<<<<<<<<<<<<<<<<
 { product_code: 'BTCJPY18MAR2022', alias: 'BTCJPY_MAT1WK', market_type: 'Futures' },
 { product_code: 'BTCJPY25MAR2022', alias: 'BTCJPY_MAT2WK', market_type: 'Futures' },
 { product_code: 'BTCJPY24JUN2022', alias: 'BTCJPY_MAT3M', market_type: 'Futures' },
];
```

results in:
**Cannot read properties of undefined (reading 'split')
at Bitflyer.fetchMarkets (.../node_modules/ccxt/js/bitflyer.js:184:42)**

---

Not sure why there is no alias, maybe because its TODAY? _11 March 2022_ 😄  Would be a stupid bug by the exchange API.

Do you have direct contact to the exchange to address this?