### PR TITLE
fetch_leverage_tiers fix (python)

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2792,9 +2792,9 @@ class Exchange(object):
             symbol = market['symbol']
             symbols_length = 0
             if (symbols is not None):
-                symbols_length = symbols.length
+                symbols_length = len(symbols)
             contract = self.safe_value(market, 'contract', False)
-            if (contract and (symbols_length == 0 or symbols.includes(symbol))):
+            if (contract and (symbols_length == 0 or symbol in symbols)):
                 tiers[symbol] = self.parse_market_leverage_tiers(item, market)
         return tiers
 


### PR DESCRIPTION
```
% python3 examples/py/cli.py gateio fetch_market_leverage_tiers XRP/USDT:USDT
Python v3.9.5
CCXT v1.75.86
[{'currency': 'USDT',
  'info': {'config_change_time': '1614652379',
           'enable_bonus': True,
           'funding_impact_value': '5000',
           'funding_interval': '28800',
           'funding_next_apply': '1647043200',
           'funding_offset': '0',
           'funding_rate': '0.0001',
           'funding_rate_indicative': '-0.000154',
           'in_delisting': False,
           'index_price': '0.7995',
           'interest_rate': '0.0003',
           'last_price': '0.7984',
           'leverage_max': '20',
           'leverage_min': '1',
           'long_users': '432',
           'maintenance_rate': '0.025',
           'maker_fee_rate': '-0.00025',
           'mark_price': '0.7995',
           'mark_price_round': '0.0001',
           'mark_type': 'index',
           'name': 'XRP_USDT',
           'order_price_deviate': '0.5',
           'order_price_round': '0.0001',
           'order_size_max': '1000000',
           'order_size_min': '1',
           'orderbook_id': '5644370664',
           'orders_limit': '50',
           'position_size': '2343498',
           'quanto_multiplier': '10',
           'ref_discount_rate': '0',
           'ref_rebate_rate': '0.2',
           'risk_limit_base': '500000',
           'risk_limit_max': '5000000',
           'risk_limit_step': '500000',
           'short_users': '305',
           'taker_fee_rate': '0.00075',
           'trade_id': '10379587',
           'trade_size': '881930319',
           'type': 'direct'},
  'maintenanceMarginRate': 0.025,
  'maxLeverage': 20.0,
  'notionalCap': 500000.0,
  'notionalFloor': 0.0,
  'tier': 1.0},
...
 {'currency': 'USDT',
  'info': {'config_change_time': '1614652379',
           'enable_bonus': True,
           'funding_impact_value': '5000',
           'funding_interval': '28800',
           'funding_next_apply': '1647043200',
           'funding_offset': '0',
           'funding_rate': '0.0001',
           'funding_rate_indicative': '-0.000154',
           'in_delisting': False,
           'index_price': '0.7995',
           'interest_rate': '0.0003',
           'last_price': '0.7984',
           'leverage_max': '20',
           'leverage_min': '1',
           'long_users': '432',
           'maintenance_rate': '0.025',
           'maker_fee_rate': '-0.00025',
           'mark_price': '0.7995',
           'mark_price_round': '0.0001',
           'mark_type': 'index',
           'name': 'XRP_USDT',
           'order_price_deviate': '0.5',
           'order_price_round': '0.0001',
           'order_size_max': '1000000',
           'order_size_min': '1',
           'orderbook_id': '5644370664',
           'orders_limit': '50',
           'position_size': '2343498',
           'quanto_multiplier': '10',
           'ref_discount_rate': '0',
           'ref_rebate_rate': '0.2',
           'risk_limit_base': '500000',
           'risk_limit_max': '5000000',
           'risk_limit_step': '500000',
           'short_users': '305',
           'taker_fee_rate': '0.00075',
           'trade_id': '10379587',
           'trade_size': '881930319',
           'type': 'direct'},
  'maintenanceMarginRate': 0.25,
  'maxLeverage': 2.0,
  'notionalCap': 5000000.0,
  'notionalFloor': 4500000.0,
  'tier': 10.0}]
  ```
  
  ```
  Python v3.9.5
CCXT v1.75.86
{'1INCH/USDT:USDT': [{'currency': 'USDT',
                      'info': {'config_change_time': '1646622186',
                               'enable_bonus': False,
                               'funding_impact_value': '5000',
                               'funding_interval': '28800',
                               'funding_next_apply': '1647043200',
                               'funding_offset': '0',
                               'funding_rate': '-0.000176',
                               'funding_rate_indicative': '0.00003',
                               'in_delisting': False,
                               'index_price': '1.3236',
                               'interest_rate': '0.0003',
                               'last_price': '1.3229',
                               'leverage_max': '20',
                               'leverage_min': '1',
                               'long_users': '105',
                               'maintenance_rate': '0.025',
                               'maker_fee_rate': '-0.00025',
                               'mark_price': '1.3236',
                               'mark_price_round': '0.0001',
                               'mark_type': 'index',
                               'name': '1INCH_USDT',
                               'order_price_deviate': '0.1',
                               'order_price_round': '0.0001',
                               'order_size_max': '1000000',
                               'order_size_min': '1',
                               'orderbook_id': '2652578661',
                               'orders_limit': '50',
                               'position_size': '581504',
                               'quanto_multiplier': '1',
                               'ref_discount_rate': '0',
                               'ref_rebate_rate': '0.2',
                               'risk_limit_base': '500000',
                               'risk_limit_max': '5000000',
                               'risk_limit_step': '500000',
                               'short_users': '54',
                               'taker_fee_rate': '0.00075',
                               'trade_id': '1663195',
                               'trade_size': '184249652',
                               'type': 'direct'},
                      'maintenanceMarginRate': 0.025,
                      'maxLeverage': 20.0,
                      'notionalCap': 500000.0,
                      'notionalFloor': 0.0,
                      'tier': 1.0},
...
                   {'currency': 'USDT',
                    'info': {'config_change_time': '1644807785',
                             'enable_bonus': False,
                             'funding_impact_value': '5000',
                             'funding_interval': '28800',
                             'funding_next_apply': '1647043200',
                             'funding_offset': '0',
                             'funding_rate': '0.0001',
                             'funding_rate_indicative': '0.0001',
                             'in_delisting': False,
                             'index_price': '0.1036',
                             'interest_rate': '0.0003',
                             'last_price': '0.1031',
                             'leverage_max': '20',
                             'leverage_min': '1',
                             'long_users': '95',
                             'maintenance_rate': '0.025',
                             'maker_fee_rate': '-0.00025',
                             'mark_price': '0.1036',
                             'mark_price_round': '0.0001',
                             'mark_type': 'index',
                             'name': 'ZKS_USDT',
                             'order_price_deviate': '0.3',
                             'order_price_round': '0.0001',
                             'order_size_max': '1000000',
                             'order_size_min': '1',
                             'orderbook_id': '213337125',
                             'orders_limit': '50',
                             'position_size': '12249678',
                             'quanto_multiplier': '1',
                             'ref_discount_rate': '0',
                             'ref_rebate_rate': '0.2',
                             'risk_limit_base': '500000',
                             'risk_limit_max': '5000000',
                             'risk_limit_step': '500000',
                             'short_users': '89',
                             'taker_fee_rate': '0.00075',
                             'trade_id': '1041513',
                             'trade_size': '409574901',
                             'type': 'direct'},
                    'maintenanceMarginRate': 0.25,
                    'maxLeverage': 2.0,
                    'notionalCap': 5000000.0,
                    'notionalFloor': 4500000.0,
                    'tier': 10.0}]}
```