### PR TITLE
Fix gateio parse-order

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2913,7 +2913,7 @@ module.exports = class gateio extends Exchange {
             'side': side,
             'price': this.parseNumber (price),
             'stopPrice': this.safeNumber (trigger, 'price'),
-            'average': this.safeNumber (order, 'fill_price'),
+            'average': this.safeNumber (order, 'price'),
             'amount': this.parseNumber (Precise.stringAbs (amount)),
             'cost': cost,
             'filled': this.parseNumber (filled),

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2869,7 +2869,7 @@ module.exports = class gateio extends Exchange {
             type = isMarketOrder ? 'market' : 'limit';
             side = Precise.stringGt (amount, '0') ? 'buy' : 'sell';
             rawStatus = this.safeString (order, 'finish_as', 'open');
-            average = this.safeNumber(order, 'fill_price');
+            average = this.safeNumber (order, 'fill_price');
         } else {
             rawStatus = this.safeString (order, 'status');
         }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2858,6 +2858,7 @@ module.exports = class gateio extends Exchange {
         let filled = Precise.stringSub (amount, remaining);
         let cost = this.safeNumber (order, 'filled_total');
         let rawStatus = undefined;
+        let average = undefined;
         if (put) {
             remaining = amount;
             filled = '0';
@@ -2868,6 +2869,7 @@ module.exports = class gateio extends Exchange {
             type = isMarketOrder ? 'market' : 'limit';
             side = Precise.stringGt (amount, '0') ? 'buy' : 'sell';
             rawStatus = this.safeString (order, 'finish_as', 'open');
+            average = this.safeNumber(order, 'fill_price');
         } else {
             rawStatus = this.safeString (order, 'status');
         }
@@ -2913,7 +2915,7 @@ module.exports = class gateio extends Exchange {
             'side': side,
             'price': this.parseNumber (price),
             'stopPrice': this.safeNumber (trigger, 'price'),
-            'average': this.safeNumber (order, 'price'),
+            'average': average,
             'amount': this.parseNumber (Precise.stringAbs (amount)),
             'cost': cost,
             'filled': this.parseNumber (filled),


### PR DESCRIPTION
running fetch_order returns the following result:

``` 
{'id': '132110258368',
 'clientOrderId': 'apiv4',
 'timestamp': 1647097806000,
 'datetime': '2022-03-12T15:10:06.000Z',
 'lastTradeTimestamp': 1647097806000,
 'status': 'closed',
 'symbol': 'JASMY/USDT',
 'type': 'limit',
 'timeInForce': 'GTC',
 'postOnly': False,
 'side': 'buy',
 'price': 0.013581,
 'stopPrice': None,
 'average': 19.998944618,
 'amount': 1472.754,
 'cost': 19.998944618,
 'filled': 1472.754,
 'remaining': 0.0,
 'fee': None,
 'fees': [{'currency': 'GT', 'cost': '0'},
  {'currency': 'JASMY', 'cost': '0'},
  {'currency': 'USDT', 'cost': '0'}],
 'trades': [],
 'info': {'id': '132110258368',
  'text': 'apiv4',
  'create_time': '1647097806',
  'update_time': '1647097806',
  'create_time_ms': '1647097806771',
  'update_time_ms': '1647097806771',
  'status': 'closed',
  'currency_pair': 'JASMY_USDT',
  'type': 'limit',
  'account': 'spot',
  'side': 'buy',
  'amount': '1472.754',
  'price': '0.013581',
  'time_in_force': 'gtc',
  'iceberg': '0',
  'left': '0.000',
  'fill_price': '19.998944618',
  'filled_total': '19.998944618',
  'fee': '0',
  'fee_currency': 'JASMY',
  'point_fee': '0.039997889236',
  'gt_fee': '0',
  'gt_discount': False,
  'rebated_fee': '0',
  'rebated_fee_currency': 'USDT'}}
```

Now the problem is - average is completely wrong (the corresponding order in the UI):

![image](https://user-images.githubusercontent.com/5024695/158023943-23d4aacb-1c2a-49fa-85e1-8a21cd976d79.png)

ccxt seems to use `fill_price` for this - which seems incorrect based on the result (and based on the documentation)

The [v4 documentation](https://www.gate.io/docs/apiv4/en/#order) lists this as "Total filled in quote currency. Deprecated in favor of filled_total" - so i don't think this should be used.

![image](https://user-images.githubusercontent.com/5024695/158024122-f8db34db-adb3-420e-bd9e-7d48c2722242.png)



New output:

``` 
{'id': '132110258368',
 'clientOrderId': 'apiv4',
 'timestamp': 1647097806000,
 'datetime': '2022-03-12T15:10:06.000Z',
 'lastTradeTimestamp': 1647097806000,
 'status': 'closed',
 'symbol': 'JASMY/USDT',
 'type': 'limit',
 'timeInForce': 'GTC',
 'postOnly': False,
 'side': 'buy',
 'price': 0.013581,
 'stopPrice': None,
 'average': 0.013581,  <-- updated to be price.
 'amount': 1472.754,
 'cost': 19.998944618,
 'filled': 1472.754,
 'remaining': 0.0,
 'fee': None,
 'fees': [{'currency': 'GT', 'cost': '0'},
  {'currency': 'JASMY', 'cost': '0'},
  {'currency': 'USDT', 'cost': '0'}],
 'trades': [],
 'info': {'id': '132110258368',
  'text': 'apiv4',
  'create_time': '1647097806',
  'update_time': '1647097806',
  'create_time_ms': '1647097806771',
  'update_time_ms': '1647097806771',
  'status': 'closed',
  'currency_pair': 'JASMY_USDT',
  'type': 'limit',
  'account': 'spot',
  'side': 'buy',
  'amount': '1472.754',
  'price': '0.013581',
  'time_in_force': 'gtc',
  'iceberg': '0',
  'left': '0.000',
  'fill_price': '19.998944618',
  'filled_total': '19.998944618',
  'fee': '0',
  'fee_currency': 'JASMY',
  'point_fee': '0.039997889236',
  'gt_fee': '0',
  'gt_discount': False,
  'rebated_fee': '0',
  'rebated_fee_currency': 'USDT'}}
```