### PR TITLE
ftx fetchOHLCV fixes #12258

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -867,10 +867,11 @@ module.exports = class ftx extends Exchange {
             // from (independent the fact if you provide 'start_time' argument or not). So, if we want the exchange
             // to return from 'start_time' argument realistically, we have to provide the appropriate 'end_time',
             // which must not be far than 1499[or limit] candles equivalent.
-            let selectedAmount = (limit !== undefined) ? limit : 1499;
-            selectedAmount = Math.min (selectedAmount, 5000); // maximum allowed currently is 5000
+            let limitChosen = (limit !== undefined) ? limit : 1499;
+            limitChosen = Math.min (limitChosen, 5000); // maximum allowed currently is 5000
             request['start_time'] = parseInt (since / 1000);
-            request['end_time'] = this.sum (request['start_time'], selectedAmount * this.parseTimeframe (timeframe));
+            request['limit'] = limitChosen;
+            request['end_time'] = this.sum (request['start_time'], limitChosen * this.parseTimeframe (timeframe));
             // we need to limit 'end_time' to avoid the number to be too far in future
             request['end_time'] = Math.min (request['end_time'], this.seconds ());
         }

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -98,7 +98,7 @@ module.exports = class ftx extends Exchange {
                 '1h': '3600',
                 '4h': '14400',
                 '1d': '86400',
-                // Above 1 day, all timeframes removed from 'supported' approach. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149
+                // See comments under 'fetchOHLCV' method
                 // '3d': '259200',
                 // '1w': '604800',
                 // '2w': '1209600',
@@ -851,6 +851,7 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        // this method doesn't accept `timeframe` above 1 day. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149
         await this.loadMarkets ();
         const [ market, marketId ] = this.getMarketParams (symbol, 'market_name', params);
         const request = {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -851,7 +851,7 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
-        // this method doesn't accept `timeframe` above 1 day. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149
+        // This method doesn't accept `timeframe` argument above 1 day. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149 , however, you can still call them by `params`
         await this.loadMarkets ();
         const [ market, marketId ] = this.getMarketParams (symbol, 'market_name', params);
         const request = {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -853,8 +853,11 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
-        if (this.exceptionTimeframes.indexOf (timeframe) >= 0) {
-            throw new BadRequest (this.id + ' fetchOHLCV () no longer supports provided timeframe. Please see the reason and workaround at https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149');
+        // To avoid confusion and reactions, we should throw meaningful exception message, so everyone knows the reason
+        for (let i = 0; i < this.exceptionTimeframes.length; i++) {
+            if (this.exceptionTimeframes[i] === timeframe) {
+                throw new BadRequest (this.id + ' fetchOHLCV () no longer supports provided timeframe. Please see the reason and workaround at https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149');
+            }
         }
         // This method doesn't accept `timeframe` argument above 1 day. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149 , however, you can still call them by `params`
         await this.loadMarkets ();

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -104,6 +104,8 @@ module.exports = class ftx extends Exchange {
                 // '2w': '1209600',
                 // '1M': '2592000',
             },
+            // temporarily, to give meaningful exception message to current users, we might retain the exclusion list
+            'exceptionTimeframes': [ '3d', '1w', '2w', '1M' ],
             'api': {
                 'public': {
                     'get': {
@@ -851,6 +853,9 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+        if (this.exceptionTimeframes.indexOf (timeframe) >= 0) {
+            throw new BadRequest (this.id + ' fetchOHLCV () no longer supports provided timeframe. Please see the reason and solution at https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149');
+        }
         // This method doesn't accept `timeframe` argument above 1 day. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149 , however, you can still call them by `params`
         await this.loadMarkets ();
         const [ market, marketId ] = this.getMarketParams (symbol, 'market_name', params);

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -854,7 +854,7 @@ module.exports = class ftx extends Exchange {
 
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         if (this.exceptionTimeframes.indexOf (timeframe) >= 0) {
-            throw new BadRequest (this.id + ' fetchOHLCV () no longer supports provided timeframe. Please see the reason and solution at https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149');
+            throw new BadRequest (this.id + ' fetchOHLCV () no longer supports provided timeframe. Please see the reason and workaround at https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149');
         }
         // This method doesn't accept `timeframe` argument above 1 day. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149 , however, you can still call them by `params`
         await this.loadMarkets ();

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -98,10 +98,11 @@ module.exports = class ftx extends Exchange {
                 '1h': '3600',
                 '4h': '14400',
                 '1d': '86400',
-                '3d': '259200',
-                '1w': '604800',
-                '2w': '1209600',
-                '1M': '2592000',
+                // Above 1 day, all timeframes removed from 'supported' approach. See: https://github.com/ccxt/ccxt/pull/12326#issuecomment-1066094149
+                // '3d': '259200',
+                // '1w': '604800',
+                // '2w': '1209600',
+                // '1M': '2592000',
             },
             'api': {
                 'public': {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -101,7 +101,6 @@ module.exports = class ftx extends Exchange {
                 '3d': '259200',
                 '1w': '604800',
                 '2w': '1209600',
-                '1M': '2592000',
             },
             'api': {
                 'public': {


### PR DESCRIPTION
The realistic way to achieve best results, seems this approach.
notes: the default amount was not 1501, but it seems to be 1499  (i.e. [check this](https://ftx.com/api/markets/BTC/USD/candles?resolution=60)). 

_[fixes #12258]_