### PR TITLE
gateio cancelOrder stop order matches fetchOrder

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2926,6 +2926,14 @@ module.exports = class gateio extends Exchange {
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {
+        /**
+         * Retrieves information on an order
+         * @param {string} id: Order id
+         * @param {string} symbol: Unified market symbol
+         * @param {boolean} params.stop: True if the order being fetched is a trigger order
+         * @param {dictionary} params: Parameters specified by the exchange api
+         * @returns Order structure
+         */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
@@ -3099,6 +3107,14 @@ module.exports = class gateio extends Exchange {
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
+        /**
+         * Cancels an open order
+         * @param {string} id: Order id
+         * @param {string} symbol: Unified market symbol
+         * @param {boolean} params.stop: True if the order to be cancelled is a trigger order
+         * @param {dictionary} params: Parameters specified by the exchange api
+         * @returns Order structure
+         */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument');
         }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -3112,8 +3112,9 @@ module.exports = class gateio extends Exchange {
         } else {
             request['currency_pair'] = market['id'];
         }
-        const isStop = this.safeValue (params, 'isStop', false);
-        const pathMiddle = isStop ? 'Price' : '';
+        const stop = this.safeValue2 (params, 'is_stop_order', 'stop', false);
+        params = this.omit (params, [ 'is_stop_order', 'stop' ]);
+        const pathMiddle = stop ? 'Price' : '';
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'privateSpotDelete' + pathMiddle + 'OrdersOrderId',
             'margin': 'privateSpotDelete' + pathMiddle + 'OrdersOrderId',


### PR DESCRIPTION
```
% gateio cancelOrder 14943519 XRP/USDT:USDT '{"stop": true}'
2022-03-13T01:56:28.342Z
Node.js: v14.17.0
CCXT v1.75.93
gateio.cancelOrder (14943519, XRP/USDT:USDT, [object Object])
2022-03-13T01:56:30.073Z iteration 0 passed in 192 ms

{
  id: '14943519',
  clientOrderId: undefined,
  timestamp: 1647136547000,
  datetime: '2022-03-13T01:55:47.000Z',
  lastTradeTimestamp: 1647136590000,
  status: 'canceled',
  symbol: 'XRP/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  price: 0.75,
  stopPrice: 0.75,
  average: undefined,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  fee: undefined,
  fees: [],
  trades: [],
  info: {
    user: '6693577',
    trigger: {
      strategy_type: '0',
      price_type: '0',
      price: '0.75',
      rule: '2',
      expiration: '0'
    },
    initial: {
      contract: 'XRP_USDT',
      size: '-1',
      price: '0.75',
      tif: 'gtc',
      text: '',
      iceberg: '0',
      is_close: false,
      is_reduce_only: false,
      auto_size: ''
    },
    id: '14943519',
    trade_id: '0',
    status: 'finished',
    finish_as: 'cancelled',
    reason: '',
    create_time: '1647136547',
    finish_time: '1647136590',
    name: 'price_autoorders',
    is_stop_order: false,
    stop_trigger: { rule: '0', trigger_price: '', order_price: '' },
    me_order_id: '0',
    order_type: ''
  }
}
```