### PR TITLE
ndax - fetchTradingFees

### DIFF
--- a/js/ndax.js
+++ b/js/ndax.js
@@ -65,6 +65,8 @@ module.exports = class ndax extends Exchange {
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTrades': true,
+                'fetchTradingFee': false,
+                'fetchTradingFees': false,
                 'fetchWithdrawals': true,
                 'reduceMargin': false,
                 'setLeverage': false,


### PR DESCRIPTION
- There is no endpoint to return trading Fees.
- Ndax has an endpoint to estimate a trading fee for a specific order, but information like amount, trading type, etc need to be provided ( https://apidoc.ndax.io/#getorderfee )
- Ndax provides some information on trading fees in the account info endpoint but doesn't return specifically maker and taker fees. (https://apidoc.ndax.io/#getaccountinfo)