### PR TITLE
bibox remove GTC mapping

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -139,7 +139,6 @@ module.exports = class bibox extends Exchange {
                 'APENFT(NFT)': 'NFT',
                 'BOX': 'DefiBox',
                 'BPT': 'BlockPool Token',
-                'GTC': 'Game.com',
                 'KEY': 'Bihu',
                 'MTC': 'MTC Mesh Network', // conflict with MTC Docademic doc.com Token https://github.com/ccxt/ccxt/issues/6081 https://github.com/ccxt/ccxt/issues/3025
                 'NFT': 'NFT Protocol',


### PR DESCRIPTION
https://coinmarketcap.com/currencies/gitcoin/markets/
probably old mapping, now there is Gitcoin on Bibox