### PR TITLE
Gateio.setLeverage cross leverage 

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -3291,12 +3291,17 @@ module.exports = class gateio extends Exchange {
         let marginType = this.safeString (params, 'marginType', defaultMarginType);
         if (crossLeverageLimit !== undefined) {
             marginType = 'cross';
+            leverage = crossLeverageLimit;
         }
         if (marginType === 'cross') {
-            request['cross_leverage_limit'] = leverage.toString ();
-            request['leverage'] = '0';
+            request['query'] = {
+                'cross_leverage_limit': leverage.toString (),
+                'leverage': '0',
+            };
         } else {
-            request['leverage'] = leverage.toString ();
+            request['query'] = {
+                'leverage': leverage.toString (),
+            };
         }
         const response = await this[method] (this.extend (request, params));
         //


### PR DESCRIPTION
- fixes errors with setting cross leverage explained in https://github.com/ccxt/ccxt/issues/12257
- adds unification of `marginType='cross'` to `setLeverage` https://github.com/ccxt/ccxt/issues/11756

[This bug](https://github.com/ccxt/ccxt/issues/12257) was introduced in [this commit](https://github.com/ccxt/ccxt/pull/10314/commits/b5694496ebe9a521a8bf0374ec1651f91ed79a73) when the sign method was updated on gateio so that `request['query']['leverage'] = leverage` instead of `request['leverage'] = leverage` because `request['cross_leverage_limit']` was still set, but `request['query']['cross_leverage_limit']` was not set

-------------

```
% gateio setLeverage 0 XRP/USDT:USDT '{"cross_leverage_limit": "1"}'   % gateio setLeverage 2 XRP/USDT:USDT '{"marginType": "cross"}'   % gateio setLeverage 3 XRP/USDT:USDT '{"marginType": "isolated"}'  % gateio setLeverage 4 XRP/USDT:USDT
2022-03-16T02:31:03.914Z                                               2022-03-16T02:31:17.669Z                                         2022-03-16T02:31:40.911Z                                          2022-03-16T02:42:09.197Z
Node.js: v14.17.0                                                      Node.js: v14.17.0                                                Node.js: v14.17.0                                                 Node.js: v14.17.0
CCXT v1.75.93                                                          CCXT v1.75.93                                                    CCXT v1.75.93                                                     CCXT v1.75.93
gateio.setLeverage (0, XRP/USDT:USDT, [object Object])                 gateio.setLeverage (2, XRP/USDT:USDT, [object Object])           gateio.setLeverage (3, XRP/USDT:USDT, [object Object])            gateio.setLeverage (4, XRP/USDT:USDT)
2022-03-16T02:31:05.598Z iteration 0 passed in 177 ms                  2022-03-16T02:31:19.331Z iteration 0 passed in 183 ms            2022-03-16T02:31:42.593Z iteration 0 passed in 173 ms             2022-03-16T02:42:10.919Z iteration 0 passed in 181 ms
                                                                                                                                                                                                          
{                                                                       {                                                               {                                                                 {
  leverage: '0',                                                         leverage: '0',                                                   leverage: '3',                                                    leverage: '4',
  mode: 'single',                                                        mode: 'single',                                                  mode: 'single',                                                   mode: 'single',
  realised_point: '0',                                                   realised_point: '0',                                             realised_point: '0',                                              realised_point: '0',
  contract: 'XRP_USDT',                                                  contract: 'XRP_USDT',                                            contract: 'XRP_USDT',                                             contract: 'XRP_USDT',
  entry_price: '0',                                                      entry_price: '0',                                                entry_price: '0',                                                 entry_price: '0',
  mark_price: '0.7767',                                                  mark_price: '0.7764',                                            mark_price: '0.7768',                                             mark_price: '0.7777',
  history_point: '0',                                                    history_point: '0',                                              history_point: '0',                                               history_point: '0',
  realised_pnl: '0',                                                     realised_pnl: '0',                                               realised_pnl: '0',                                                realised_pnl: '0',
  close_order: null,                                                     close_order: null,                                               close_order: null,                                                close_order: null,
  size: '0',                                                             size: '0',                                                       size: '0',                                                        size: '0',
  cross_leverage_limit: '1',                                             cross_leverage_limit: '2',                                       cross_leverage_limit: '2',                                        cross_leverage_limit: '2',
  pending_orders: '0',                                                   pending_orders: '0',                                             pending_orders: '0',                                              pending_orders: '0',
  adl_ranking: '6',                                                      adl_ranking: '6',                                                adl_ranking: '6',                                                 adl_ranking: '6',
  maintenance_rate: '0.025',                                             maintenance_rate: '0.025',                                       maintenance_rate: '0.025',                                        maintenance_rate: '0.025',
  unrealised_pnl: '0',                                                   unrealised_pnl: '0',                                             unrealised_pnl: '0',                                              unrealised_pnl: '0',
  user: '6693577',                                                       user: '6693577',                                                 user: '6693577',                                                  user: '6693577',
  leverage_max: '20',                                                    leverage_max: '20',                                              leverage_max: '20',                                               leverage_max: '20',
  history_pnl: '0.295457385',                                            history_pnl: '0.295457385',                                      history_pnl: '0.295457385',                                       history_pnl: '0.295457385',
  risk_limit: '500000',                                                  risk_limit: '500000',                                            risk_limit: '500000',                                             risk_limit: '500000',
  margin: '0',                                                           margin: '0',                                                     margin: '0',                                                      margin: '0',
  last_close_pnl: '11.48556142012',                                      last_close_pnl: '11.48556142012',                                last_close_pnl: '11.48556142012',                                 last_close_pnl: '11.48556142012',
  liq_price: '0'                                                         liq_price: '0'                                                   liq_price: '0'                                                    liq_price: '0'
}                                                                      }                                                                }                                                                  
```