### PR TITLE
Hitbtc3 createOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1320,6 +1320,8 @@ module.exports = class hitbtc3 extends Exchange {
             // 'make_rate': 0.001, // Optional
         };
         const timeInForce = this.safeString2 (params, 'timeInForce', 'time_in_force');
+        const expireTime = this.safeString (params, 'expire_time');
+        const stopPrice = this.safeNumber2 (params, 'stopPrice', 'stop_price');
         if ((type === 'limit') || (type === 'stopLimit') || (type === 'takeProfitLimit')) {
             if (price === undefined) {
                 throw new ExchangeError (this.id + ' limit order requires price');
@@ -1327,16 +1329,16 @@ module.exports = class hitbtc3 extends Exchange {
             request['price'] = this.priceToPrecision (symbol, price);
         }
         if ((timeInForce === 'GTD')) {
-            if (price === undefined) {
+            if (expireTime === undefined) {
                 throw new ExchangeError (this.id + ' GTD order requires expire_time');
             }
-            request['expire_time'] = this.safeString (params, 'expire_time');
+            request['expire_time'] = expireTime;
         }
         if ((type === 'stopLimit') || (type === 'stopMarket') || (type === 'takeProfitLimit') || (type === 'takeProfitMarket')) {
-            if (price === undefined) {
+            if (stopPrice === undefined) {
                 throw new ExchangeError (this.id + ' Stop and take profit orders require stop_price');
             }
-            request['stop_price'] = this.safeNumber (params, 'stop_price');
+            request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
         }
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'privatePostSpotOrder',

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1324,19 +1324,19 @@ module.exports = class hitbtc3 extends Exchange {
         const stopPrice = this.safeNumber2 (params, 'stopPrice', 'stop_price');
         if ((type === 'limit') || (type === 'stopLimit') || (type === 'takeProfitLimit')) {
             if (price === undefined) {
-                throw new ExchangeError (this.id + ' limit order requires price');
+                throw new ExchangeError (this.id + ' createOrder() requires a price argument for limit orders');
             }
             request['price'] = this.priceToPrecision (symbol, price);
         }
         if ((timeInForce === 'GTD')) {
             if (expireTime === undefined) {
-                throw new ExchangeError (this.id + ' GTD order requires expire_time');
+                throw new ExchangeError (this.id + ' createOrder() requires an expire_time parameter for a GTD order');
             }
             request['expire_time'] = expireTime;
         }
         if ((type === 'stopLimit') || (type === 'stopMarket') || (type === 'takeProfitLimit') || (type === 'takeProfitMarket')) {
             if (stopPrice === undefined) {
-                throw new ExchangeError (this.id + ' Stop and take profit orders require stop_price');
+                throw new ExchangeError (this.id + ' createOrder() requires a stopPrice parameter for stop-loss and take-profit orders');
             }
             request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
         }


### PR DESCRIPTION
Added swap functionality to createOrder on hitbtc3:
```
hitbtc3.createOrder (BTC/USDT:USDT, limit, buy, 0.0005, 30000, [object Object])
2022-03-16T08:24:19.771Z iteration 0 passed in 197 ms

{
  info: {
    id: '58420900936',
    client_order_id: 'sd_pHXtPiW6FTkXUSkMOiHgoxE28nMtU',
    symbol: 'BTCUSDT_PERP',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.0005',
    quantity_cumulative: '0',
    price: '30000.00',
    post_only: true,
    reduce_only: false,
    created_at: '2022-03-16T08:24:20.063Z',
    updated_at: '2022-03-16T08:24:20.063Z'
  },
  id: 'sd_pHXtPiW6FTkXUSkMOiHgoxE28nMtU',
  clientOrderId: 'sd_pHXtPiW34gd5USkMOiHgoxsdf4MtU',
  timestamp: 1647419060063,
  datetime: '2022-03-16T08:24:20.063Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  price: 30000,
  amount: 0.0005,
  type: 'limit',
  side: 'buy',
  timeInForce: 'PO',
  postOnly: true,
  filled: 0,
  remaining: 0.0005,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```