### PR TITLE
Hitbtc3 fetchTradingFees

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1055,7 +1055,12 @@ module.exports = class hitbtc3 extends Exchange {
 
     async fetchTradingFees (symbols = undefined, params = {}) {
         await this.loadMarkets ();
-        const response = await this.privateGetSpotFee (params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTradingFees', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotFee',
+            'swap': 'privateGetFuturesFee',
+        });
+        const response = await this[method] (query);
         //
         //     [
         //         {


### PR DESCRIPTION
Added fetchTradingFees for swap markets on hitbtc3:
```
hitbtc3.fetchTradingFees ()
2022-03-17T03:20:55.929Z iteration 0 passed in 194 ms

{
  'BTC/USDT:USDT': {
    info: {
      symbol: 'BTCUSDT_PERP',
      take_rate: '0.0005',
      make_rate: '0.0002'
    },
    symbol: 'BTC/USDT:USDT',
    taker: 0.0005,
    maker: 0.0002
  },
  'ETH/USDT:USDT': {
    info: {
      symbol: 'ETHUSDT_PERP',
      take_rate: '0.0005',
      make_rate: '0.0002'
    },
    symbol: 'ETH/USDT:USDT',
    taker: 0.0005,
    maker: 0.0002
  },
  'ADA/USDT:USDT': {
    info: {
      symbol: 'ADAUSDT_PERP',
      take_rate: '0.0005',
      make_rate: '0.0002'
    },
    symbol: 'ADA/USDT:USDT',
    taker: 0.0005,
    maker: 0.0002
  },
...
}
```