### PR TITLE
Hitbtc3 fetchTradingFee

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1043,7 +1043,11 @@ module.exports = class hitbtc3 extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const response = await this.privateGetSpotFeeSymbol (this.extend (request, params));
+        const method = this.getSupportedMapping (market['type'], {
+            'spot': 'privateGetSpotFeeSymbol',
+            'swap': 'privateGetFuturesFeeSymbol',
+        });
+        const response = await this[method] (this.extend (request, params));
         //
         //     {
         //         "take_rate":"0.0009",


### PR DESCRIPTION
Added fetchTradingFee to hitbtc3 for swap markets:
```
hitbtc3.fetchTradingFee (BTC/USDT:USDT)
2022-03-17T03:25:54.481Z iteration 0 passed in 193 ms

{
  info: { take_rate: '0.0005', make_rate: '0.0002' },
  symbol: 'BTC/USDT:USDT',
  taker: 0.0005,
  maker: 0.0002
}
```