### PR TITLE
Hitbtc3 fetchOpenOrders

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1218,7 +1218,12 @@ module.exports = class hitbtc3 extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const response = await this.privateGetSpotOrder (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotOrder',
+            'swap': 'privateGetFuturesOrder',
+        });
+        const response = await this[method] (this.extend (request, query));
         //
         //     [
         //       {


### PR DESCRIPTION
Added swap market functionality to fetchOpenOrders:
```
hitbtc3.fetchOpenOrders ()
2022-03-17T04:04:29.683Z iteration 0 passed in 197 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol | price | amount |  type | side | timeInForce | postOnly | filled | remaining | cost | status | average | trades | fee | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
989e3c8cdb894fbe3456fgh45645gfd2 | 989e3c8cdb894fbe3456fgh45645gfd2 | 1647489563140 | 2022-03-17T03:59:23.140Z |                    | BTC/USDT:USDT | 30000 | 0.0037 | limit |  buy |         GTC |    false |      0 |    0.0037 |    0 |   open |         |     [] |     |   []
1 objects
```