### PR TITLE
Hitbtc3 fetchOpenOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1247,10 +1247,15 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrder', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotOrderClientOrderId',
+            'swap': 'privateGetFuturesOrderClientOrderId',
+        });
         const request = {
             'client_order_id': id,
         };
-        const response = await this.privateGetSpotOrderClientOrderId (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }
 


### PR DESCRIPTION
Added swap market functionality to fetchOpenOrder:
```
hitbtc3.fetchOpenOrder (976e3c8tru894fbea73ee6a55gfe6dh4)
2022-03-17T04:31:41.100Z iteration 0 passed in 196 ms

{
  info: {
    id: '58713668384',
    client_order_id: '976e3c8tru894fbea73ee6a55gfe6dh4',
    symbol: 'BTCUSDT_PERP',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.0037',
    quantity_cumulative: '0',
    price: '30000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-17T03:59:23.14Z',
    updated_at: '2022-03-17T03:59:23.14Z'
  },
  id: '976e3c8tru894fbea73ee6a55gfe6dh4',
  clientOrderId: '976e3c8tru894fbea73ee6a55gfe6dh4',
  timestamp: 1647489563140,
  datetime: '2022-03-17T03:59:23.140Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  price: 30000,
  amount: 0.0037,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.0037,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```