### PR TITLE
Hitbtc3 fetchOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1154,10 +1154,15 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotHistoryOrder',
+            'swap': 'privateGetFuturesHistoryOrder',
+        });
         const request = {
             'client_order_id': id,
         };
-        const response = await this.privateGetSpotHistoryOrder (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         //     [
         //       {


### PR DESCRIPTION
Added swap functionality to fetchOrder:
```
hitbtc3.fetchOrder (973e3c8cdb8956bea70ee5a13ade6gs9)
2022-03-17T05:04:13.105Z iteration 0 passed in 227 ms

{
  info: {
    id: '58713668384',
    client_order_id: '973e3c8cdb8956bea70ee5a13ade6gs9',
    symbol: 'BTCUSDT_PERP',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.0037',
    quantity_cumulative: '0',
    price: '30000.00',
    price_average: '0',
    created_at: '2022-03-17T03:59:23.14Z',
    updated_at: '2022-03-17T03:59:23.14Z'
  },
  id: '973e3c8cdb8956bea70ee5a13ade6gs9',
  clientOrderId: '973e3c8cdb8956bea70ee5a13ade6gs9',
  timestamp: 1647489563140,
  datetime: '2022-03-17T03:59:23.140Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  price: 30000,
  amount: 0.0037,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: undefined,
  filled: 0,
  remaining: 0.0037,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```