### PR TITLE
Hitbtc3 fetchClosedOrders

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1143,7 +1143,12 @@ module.exports = class hitbtc3 extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.privateGetSpotHistoryOrder (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchClosedOrders', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotHistoryOrder',
+            'swap': 'privateGetFuturesHistoryOrder',
+        });
+        const response = await this[method] (this.extend (request, query));
         const parsed = this.parseOrders (response, market, since, limit);
         return this.filterByArray (parsed, 'status', [ 'closed', 'canceled' ], false);
     }


### PR DESCRIPTION
Added swap functionality to fetchClosedOrders:
```
hitbtc3.fetchClosedOrders ()
2022-03-17T05:10:18.829Z iteration 0 passed in 230 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol | price | amount |  type | side | timeInForce | postOnly | filled | remaining | cost |   status | average | trades | fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
de034ab4ec154ea4a20e257cb1bb373e | de034ab4ec154ea4a20e257cb1bb373e | 1647418594360 | 2022-03-16T08:16:34.360Z | 1647418601435      | BTC/USDT:USDT | 30000 | 0.0046 | limit |  buy |         GTC |          |      0 |    0.0046 |    0 | canceled |         |     [] |     |   []
...
3 objects
```