### PR TITLE
Hitbtc3 fetchOrderTrades

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1190,7 +1190,14 @@ module.exports = class hitbtc3 extends Exchange {
         const request = {
             'order_id': id, // exchange assigned order id as oppose to the client order id
         };
-        const response = await this.privateGetSpotHistoryTrade (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrderTrades', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotHistoryTrade',
+            'swap': 'privateGetFuturesHistoryTrade',
+        });
+        const response = await this[method] (this.extend (request, query));
+        //
+        // Spot
         //
         //     [
         //       {
@@ -1205,6 +1212,26 @@ module.exports = class hitbtc3 extends Exchange {
         //         "timestamp": "2021-09-19T05:35:56.601Z",
         //         "taker": true
         //       }
+        //     ]
+        //
+        // Swap
+        //
+        //     [
+        //         {
+        //             "id": 4718551,
+        //             "order_id": 58730748700,
+        //             "client_order_id": "dcbcd8549e3445ee922665946002ef67",
+        //             "symbol": "BTCUSDT_PERP",
+        //             "side": "buy",
+        //             "quantity": "0.0001",
+        //             "price": "41095.96",
+        //             "fee": "0.002054798000",
+        //             "timestamp": "2022-03-17T05:23:02.217Z",
+        //             "taker": true,
+        //             "position_id": 2350122,
+        //             "pnl": "0",
+        //             "liquidation": false
+        //         }
         //     ]
         //
         return this.parseTrades (response, market, since, limit);


### PR DESCRIPTION
Added swap functionality to fetchOrderTrades:
```
hitbtc3.fetchOrderTrades (58730748700)
2022-03-17T05:27:04.370Z iteration 0 passed in 237 ms

     id | order |     timestamp |                 datetime |        symbol | type | side | takerOrMaker |    price  | amount |     cost |                                    fee |                                     fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4718551 |       | 1647494582217 | 2022-03-17T05:23:02.217Z | BTC/USDT:USDT |      |  buy |        taker | 41095.96  | 0.0001 | 4.109596 | {"cost":0.002054798,"currency":"USDT"} | [{"currency":"USDT","cost":0.002054798}]
1 objects
```