### PR TITLE
Hitbtc3 fetchMyTrades

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -738,9 +738,14 @@ module.exports = class hitbtc3 extends Exchange {
             request['limit'] = limit;
         }
         if (since !== undefined) {
-            request['since'] = since;
+            request['from'] = since;
         }
-        const response = await this.privateGetSpotHistoryTrade (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateGetSpotHistoryTrade',
+            'swap': 'privateGetFuturesHistoryTrade',
+        });
+        const response = await this[method] (this.extend (request, query));
         return this.parseTrades (response, market, since, limit);
     }
 
@@ -768,7 +773,7 @@ module.exports = class hitbtc3 extends Exchange {
         //      timestamp: '2020-10-16T12:57:39.846Z'
         //  }
         //
-        // fetchMyTrades
+        // fetchMyTrades spot
         //
         //  {
         //      id: 277210397,
@@ -781,6 +786,24 @@ module.exports = class hitbtc3 extends Exchange {
         //      fee: '0.000000147',
         //      timestamp: '2018-04-28T18:39:55.345Z',
         //      taker: true
+        //  }
+        //
+        // fetchMyTrades swap
+        //
+        //  {
+        //      "id": 4718564,
+        //      "order_id": 58730811958,
+        //      "client_order_id": "475c47d97f867f09726186eb22b4c3d4",
+        //      "symbol": "BTCUSDT_PERP",
+        //      "side": "sell",
+        //      "quantity": "0.0001",
+        //      "price": "41118.51",
+        //      "fee": "0.002055925500",
+        //      "timestamp": "2022-03-17T05:23:17.795Z",
+        //      "taker": true,
+        //      "position_id": 2350122,
+        //      "pnl": "0.002255000000",
+        //      "liquidation": false
         //  }
         //
         const timestamp = this.parse8601 (trade['timestamp']);


### PR DESCRIPTION
Added swap functionality for fetchMyTrades:
```
hitbtc3.fetchMyTrades ()
2022-03-17T05:38:24.384Z iteration 0 passed in 240 ms

     id | order |     timestamp |                 datetime |        symbol | type | side | takerOrMaker |    price  | amount |     cost |                                     fee |                                      fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4718551 |       | 1647494582217 | 2022-03-17T05:23:02.217Z | BTC/USDT:USDT |      |  buy |        taker | 41095.96  | 0.0001 | 4.109596 |  {"cost":0.002054798,"currency":"USDT"} |  [{"currency":"USDT","cost":0.002054798}]
4718564 |       | 1647494597795 | 2022-03-17T05:23:17.795Z | BTC/USDT:USDT |      | sell |        taker | 41118.51  | 0.0001 | 4.111851 | {"cost":0.0020559255,"currency":"USDT"} | [{"currency":"USDT","cost":0.0020559255}]
2 objects
```