### PR TITLE
Ascendex :: restructure api

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -85,8 +85,12 @@ module.exports = class ascendex extends Exchange {
             'version': 'v2',
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/112027508-47984600-8b48-11eb-9e17-d26459cc36c6.jpg',
-                'api': 'https://ascendex.com',
-                'test': 'https://api-test.ascendex-sandbox.com',
+                'api': {
+                    'rest': 'https://ascendex.com',
+                },
+                'test': {
+                    'rest': 'https://api-test.ascendex-sandbox.com',
+                },
                 'www': 'https://ascendex.com',
                 'doc': [
                     'https://bitmax-exchange.github.io/bitmax-pro-api/#bitmax-pro-api-documentation',
@@ -2450,7 +2454,7 @@ module.exports = class ascendex extends Exchange {
                 body = this.json (params);
             }
         }
-        url = this.urls['api'] + url;
+        url = this.urls['api']['rest'] + url;
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 


### PR DESCRIPTION
- 'api' needs to be an object suitable to be extended on the pro side without breaking any of the ends (ccxt, pro). 

Doing that I just need to do on the other side:

```Javascript
'api': {
    'ws': (....)
}
```