### PR TITLE
bitrue MIM -> MIM Swarm

### DIFF
--- a/js/bitrue.js
+++ b/js/bitrue.js
@@ -236,6 +236,9 @@ module.exports = class bitrue extends Exchange {
                     'ADA': 'Cardano',
                 },
             },
+            'commonCurrencies': {
+                'MIM': 'MIM Swarm',
+            },
             // https://binance-docs.github.io/apidocs/spot/en/#error-codes-2
             'exceptions': {
                 'exact': {


### PR DESCRIPTION
https://www.coingecko.com/en/coins/mim#markets
conflict with https://www.coingecko.com/en/coins/magic-internet-money#markets
naming like on BitMart