### PR TITLE
Hitbtc3 cancelOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1284,7 +1284,12 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const response = await this.privateDeleteSpotOrderClientOrderId (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateDeleteSpotOrderClientOrderId',
+            'swap': 'privateDeleteFuturesOrderClientOrderId',
+        });
+        const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }
 


### PR DESCRIPTION
Added swap functionality to cancelOrder:
```
hitbtc3.cancelOrder (ZuJpQqqcnwxWAftbqytHapGhl6KaWteU)
2022-03-18T05:00:35.682Z iteration 0 passed in 219 ms

{
  info: {
    id: '59139284364',
    client_order_id: 'ZuJpQqdcnwxWAftbqytHapGhl6KaWteU',
    symbol: 'BTCUSDT_PERP',
    side: 'buy',
    status: 'canceled',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.0005',
    quantity_cumulative: '0',
    price: '30000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-18T05:00:12.098Z',
    updated_at: '2022-03-18T05:00:36.596Z'
  },
  id: 'ZuJpQqdcnwxWAftbqytHapGhl6KaWteU',
  clientOrderId: 'ZuJpQqdcnwxWAftbqytHapGhl6KaWteU',
  timestamp: 1647579612098,
  datetime: '2022-03-18T05:00:12.098Z',
  lastTradeTimestamp: 1647579636596,
  symbol: 'BTC/USDT:USDT',
  price: 30000,
  amount: 0.0005,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.0005,
  cost: 0,
  status: 'canceled',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```