### PR TITLE
Hitbtc3 cancelAllOrders

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1271,7 +1271,12 @@ module.exports = class hitbtc3 extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const response = await this.privateDeleteSpotOrder (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'privateDeleteSpotOrder',
+            'swap': 'privateDeleteFuturesOrder',
+        });
+        const response = await this[method] (this.extend (request, query));
         return this.parseOrders (response, market);
     }
 


### PR DESCRIPTION
Added swap functionality to cancelAllOrders:
```
hitbtc3.cancelAllOrders (BTC/USDT:USDT)
2022-03-18T05:28:29.373Z iteration 0 passed in 211 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol | price | amount |  type | side | timeInForce | postOnly | filled | remaining | cost | status | average | trades | fee | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2Y3MFZ8NWUu-F42COo3hg76O3Mg6-dff | 2Y3MFZ8NWUu-F42COo3hg76O3Mg6-dff | 1647581288610 | 2022-03-18T05:28:08.610Z |                    | BTC/USDT:USDT | 30000 | 0.0005 | limit |  buy |         GTC |    false |      0 |    0.0005 |    0 |   open |         |     [] |     |   []
1 objects
```