### PR TITLE
okx: switch all futures -> future

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -637,6 +637,20 @@ module.exports = class okx extends Exchange {
                     '12': 'option',
                     '18': 'trading', // unified trading account
                 },
+                'exchangeType': {
+                    'spot': 'SPOT',
+                    'margin': 'MARGIN',
+                    'swap': 'SWAP',
+                    'future': 'FUTURES',
+                    'futures': 'FUTURES',
+                    'option': 'OPTION',
+                    'SPOT': 'SPOT',
+                    'MARGIN': 'MARGIN',
+                    'SWAP': 'SWAP',
+                    'FUTURE': 'FUTURES',
+                    'FUTURES': 'FUTURES',
+                    'OPTION': 'OPTION',
+                },
                 'brokerId': 'e847386590ce4dBC',
             },
             'commonCurrencies': {
@@ -652,14 +666,6 @@ module.exports = class okx extends Exchange {
                 'WIN': 'WinToken', // https://github.com/ccxt/ccxt/issues/5701
             },
         });
-    }
-
-    typeToExchangeType (type) {
-        type = type.toUpperCase ();
-        if (type === 'FUTURE') {
-            return 'FUTURES';
-        }
-        return type;
     }
 
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
@@ -936,7 +942,7 @@ module.exports = class okx extends Exchange {
     async fetchMarketsByType (type, params = {}) {
         const uppercaseType = type.toUpperCase ();
         const request = {
-            'instType': this.typeToExchangeType (uppercaseType),
+            'instType': this.options['exchangeType'][uppercaseType],
         };
         if (uppercaseType === 'OPTION') {
             const defaultUnderlying = this.safeValue (this.options, 'defaultUnderlying', 'BTC-USD');
@@ -1245,7 +1251,7 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         const uppercaseType = type.toUpperCase ();
         const request = {
-            'instType': this.typeToExchangeType (uppercaseType),
+            'instType': this.options['exchangeType'][uppercaseType],
         };
         if (uppercaseType === 'OPTION') {
             const defaultUnderlying = this.safeValue (this.options, 'defaultUnderlying', 'BTC-USD');
@@ -1614,7 +1620,7 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'instType': this.typeToExchangeType (market['type']), // SPOT, MARGIN, SWAP, FUTURES, OPTION
+            'instType': this.options['exchangeType'][market['type']], // SPOT, MARGIN, SWAP, FUTURES, OPTION
             // 'instId': market['id'], // only applicable to SPOT/MARGIN
             // 'uly': market['id'], // only applicable to FUTURES/SWAP/OPTION
             // 'category': '1', // 1 = Class A, 2 = Class B, 3 = Class C, 4 = Class D
@@ -2310,7 +2316,7 @@ module.exports = class okx extends Exchange {
             request['instId'] = market['id'];
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchCanceledOrders', market, params);
-        request['instType'] = this.typeToExchangeType (type);
+        request['instType'] = this.options['exchangeType'][type];
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 100
         }
@@ -2385,7 +2391,7 @@ module.exports = class okx extends Exchange {
             request['instId'] = market['id'];
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchClosedOrders', market, params);
-        request['instType'] = this.typeToExchangeType (type);
+        request['instType'] = this.options['exchangeType'][type];
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 100
         }
@@ -2455,7 +2461,7 @@ module.exports = class okx extends Exchange {
             request['instId'] = market['id'];
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
-        request['instType'] = this.typeToExchangeType (type);
+        request['instType'] = this.options['exchangeType'][type];
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 100
         }
@@ -2569,7 +2575,7 @@ module.exports = class okx extends Exchange {
         };
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchLedger', undefined, params);
         if (type !== undefined) {
-            request['instType'] = this.typeToExchangeType (type);
+            request['instType'] = this.options['exchangeType'][type];
         }
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -3231,7 +3237,7 @@ module.exports = class okx extends Exchange {
             // posId String No Single position ID or multiple position IDs (no more than 20) separated with comma
         };
         if (type !== undefined) {
-            request['instType'] = this.typeToExchangeType (type);
+            request['instType'] = this.options['exchangeType'][type];
         }
         const response = await this.privateGetAccountPositions (query);
         //
@@ -3299,7 +3305,7 @@ module.exports = class okx extends Exchange {
         };
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchPosition', undefined, params);
         if (type !== undefined) {
-            request['instType'] = this.typeToExchangeType (type);
+            request['instType'] = this.options['exchangeType'][type];
         }
         const response = await this.privateGetAccountPositions (this.extend (request, query));
         //
@@ -3816,7 +3822,7 @@ module.exports = class okx extends Exchange {
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchPosition', undefined, params);
         if (type !== undefined) {
-            request['instType'] = this.typeToExchangeType (type);
+            request['instType'] = this.options['exchangeType'][type];
         }
         const response = await this.privateGetAccountBills (this.extend (request, query));
         //
@@ -4152,7 +4158,7 @@ module.exports = class okx extends Exchange {
     async fetchMarketLeverageTiers (symbol, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const type = market['spot'] ? 'MARGIN' : this.typeToExchangeType (market['type']);
+        const type = market['spot'] ? 'MARGIN' : this.options['exchangeType'][market['type']];
         const uly = this.safeString (market['info'], 'uly');
         if (!uly) {
             throw new BadRequest (this.id + ' fetchLeverageTiers() cannot fetch leverage tiers for ' + symbol);

--- a/js/okx.js
+++ b/js/okx.js
@@ -906,7 +906,6 @@ module.exports = class okx extends Exchange {
             'margin': spot && (Precise.stringGt (maxLeverage, '1')),
             'swap': swap,
             'future': future,
-            'futures': future, // deprecated
             'option': option,
             'active': true,
             'contract': contract,
@@ -1297,7 +1296,7 @@ module.exports = class okx extends Exchange {
 
     async fetchTickers (symbols = undefined, params = {}) {
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
-        return await this.fetchTickersByType (type, symbols, this.omit (query, 'type'));
+        return await this.fetchTickersByType (type, symbols, query);
     }
 
     parseTrade (trade, market = undefined) {

--- a/js/okx.js
+++ b/js/okx.js
@@ -666,7 +666,7 @@ module.exports = class okx extends Exchange {
         const instType = this.safeString (params, 'instType');
         params = this.omit (params, 'instType');
         const type = this.safeString (params, 'type');
-        if (type === undefined) {
+        if (type === undefined && instType !== undefined) {
             params['type'] = instType;
         }
         return super.handleMarketTypeAndParams (methodName, market, params);
@@ -949,7 +949,7 @@ module.exports = class okx extends Exchange {
         }
         const response = await this.publicGetPublicInstruments (this.extend (request, params));
         //
-        // spot, future, swaps, options
+        // spot, future, swap, option
         //
         //     {
         //         "code":"0",
@@ -1288,9 +1288,8 @@ module.exports = class okx extends Exchange {
     }
 
     async fetchTickers (symbols = undefined, params = {}) {
-        const defaultType = this.safeString2 (this.options, 'fetchTickers', 'defaultType');
-        const type = this.safeString (params, 'type', defaultType);
-        return await this.fetchTickersByType (type, symbols, this.omit (params, 'type'));
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        return await this.fetchTickersByType (type, symbols, this.omit (query, 'type'));
     }
 
     parseTrade (trade, market = undefined) {
@@ -2568,7 +2567,7 @@ module.exports = class okx extends Exchange {
             // 'before': 'id', // return records newer than the requested bill id
             // 'limit': 100, // default 100, max 100
         };
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchPosition', undefined, params);
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchLedger', undefined, params);
         if (type !== undefined) {
             request['instType'] = this.typeToExchangeType (type);
         }


### PR DESCRIPTION
I can't get fetchLedger to return anything, even without type

I also keep getting this on private methods, so I can't test them out

```
okx {"code":"51000","data":[],"msg":"Parameter posSide  error"}
```

Here's the full output

```
 % ccxt okx setLeverage 50 DOT/USDT:USDT-220624 '{"mgnMode": "isolated"}' --verbose
2022-03-19T04:49:47.994Z
Node.js: v14.17.0
CCXT v1.76.55
okx.setLeverage (50, DOT/USDT:USDT-220624, [object Object])
fetch Request:
 okx POST https://www.okx.com/api/v5/account/set-leverage 
RequestHeaders:
 {
  'OK-ACCESS-KEY': '...',
  'OK-ACCESS-PASSPHRASE': '...',
  'OK-ACCESS-TIMESTAMP': '2022-03-19T04:49:49.944Z',
  'Content-Type': 'application/json',
  'OK-ACCESS-SIGN': '...'
} 
RequestBody:
 {"lever":50,"mgnMode":"isolated","instId":"DOT-USDT-220624"} 

handleRestResponse:
 okx POST https://www.okx.com/api/v5/account/set-leverage 400 Bad Request 
ResponseHeaders:
 {
  'Cf-Cache-Status': 'DYNAMIC',
  'Cf-Ray': '6ee39570592f8429-YVR',
  Connection: 'keep-alive',
  'Content-Length': '59',
  'Content-Type': 'application/json',
  Date: 'Sat, 19 Mar 2022 04:49:50 GMT',
  'Expect-Ct': 'max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"',
  Server: 'cloudflare',
  'Set-Cookie': 'locale=en-US; Max-Age=604800; Expires=Sat, 26-Mar-2022 04:49:50 GMT; Path=/, locale=en-US; Max-Age=604800; Expires=Sat, 26-Mar-2022 04:49:50 GMT; Path=/',
  'X-Brokerid': '0'
} 
ResponseBody:
 {"code":"51000","data":[],"msg":"Parameter posSide  error"} 

BadRequest okx {"code":"51000","data":[],"msg":"Parameter posSide  error"}
---------------------------------------------------
[BadRequest] okx {"code":"51000","data":[],"msg":"Parameter posSide  error"}

    at throwExactlyMatchedException  ../../ccxt/ccxt/js/base/Exchange.js:639        throw new exact[string] (message)                                               
    at handleErrors                  ../../ccxt/ccxt/js/okx.js:4259                 this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);   
    at                               ../../ccxt/ccxt/js/base/Exchange.js:716        const skipFurtherErrorHandling = this.handleErrors (response.status, response.s…
    at processTicksAndRejections     internal/process/task_queues.js:95                                                                                             
    at async timeout                 ../../ccxt/ccxt/js/base/functions/time.js:203  return await Promise.race ([promise, expires.then (() => { throw new TimedOut (…
    at setLeverage                   ../../ccxt/ccxt/js/okx.js:3888                 const response = await this.privatePostAccountSetLeverage (this.extend (request…
    at async main                    ../../ccxt/ccxt/examples/js/cli.js:269         const result = await exchange[methodName] (... args)                            

okx {"code":"51000","data":[],"msg":"Parameter posSide  error"}
```

---------------------------

# fetchMarkets

```
2022-03-19T01:59:30.037Z
Node.js: v14.17.0
CCXT v1.76.55
okex.fetchMarkets ()
2022-03-19T01:59:32.510Z iteration 0 passed in 1217 ms
 taker |  maker |                      id |                symbol |     base | quote | settle |   baseId | quoteId | settleId |    type |  spot | margin |  swap | future | futures | option | active | contract | linear | inverse | contractSize |        expiry |           expiryDatetime | strike | optionType |                            precision |                                                                                     limits | tierBased | percentage
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.0015 |  0.001 |                BTC-USDT |              BTC/USDT |      BTC |  USDT |        |      BTC |    USDT |          |    spot |  true |   true | false |  false |   false |  false |   true |    false |        |         |              |               |                          |        |            |          {"amount":1e-8,"price":0.1} |     {"leverage":{"min":1,"max":10},"amount":{"min":0.00001},"price":{"min":0.1},"cost":{}} |           |           
...
0.0005 | 0.0002 |         XRP-USDT-220930 |  XRP/USDT:USDT-220930 |      XRP |  USDT |   USDT |      XRP |    USDT |     USDT | future | false |  false | false |   true |    true |  false |   true |     true |   true |   false |          100 | 1664524800000 | 2022-09-30T08:00:00.000Z |        |            |         {"amount":1,"price":0.00001} |       {"leverage":{"min":1,"max":75},"amount":{"min":1},"price":{"min":0.00001},"cost":{}} |           |           
0.0015 |  0.001 | BTC-USD-220930-120000-C |  BTC/USD:BTC-120000-C |      BTC |   USD |    BTC |      BTC |     USD |      BTC |  option | false |  false | false |  false |   false |   true |   true |     true |  false |    true |            1 | 1664524800000 | 2022-09-30T08:00:00.000Z | 120000 |       call |          {"amount":1,"price":0.0005} |         {"leverage":{"min":1,"max":1},"amount":{"min":1},"price":{"min":0.0005},"cost":{}} |           |           
0.0015 |  0.001 | BTC-USD-220930-120000-P |  BTC/USD:BTC-120000-P |      BTC |   USD |    BTC |      BTC |     USD |      BTC |  option | false |  false | false |  false |   false |   true |   true |     true |  false |    true |            1 | 1664524800000 | 2022-09-30T08:00:00.000Z | 120000 |        put |          {"amount":1,"price":0.0005} |         {"leverage":{"min":1,"max":1},"amount":{"min":1},"price":{"min":0.0005},"cost":{}} |           |           
1070 objects
```

# fetchTickers

```
2022-03-19T03:57:29.844Z
Node.js: v14.17.0
CCXT v1.76.55
okx.fetchTickers (, [object Object])
2022-03-19T03:57:32.094Z iteration 0 passed in 296 ms

{
  'DOT/USDT:USDT-220624': {
    symbol: 'DOT/USDT:USDT-220624',
    timestamp: 1647662251222,
    datetime: '2022-03-19T03:57:31.222Z',
    high: 19.154,
    low: 17.98,
    bid: 18.862,
    bidVolume: 542,
    ask: 18.873,
    askVolume: 478,
    vwap: undefined,
    open: 18.268,
    close: 18.871,
    last: 18.871,
    previousClose: undefined,
    change: 0.603,
    percentage: 3.300853952266258,
    average: 18.5695,
    baseVolume: 164662,
    quoteVolume: undefined,
    info: {
      instType: 'FUTURES',
      instId: 'DOT-USDT-220624',
      last: '18.871',
      lastSz: '5',
      askPx: '18.873',
      askSz: '478',
      bidPx: '18.862',
      bidSz: '542',
      open24h: '18.268',
      high24h: '19.154',
      low24h: '17.98',
      volCcy24h: '164662',
      vol24h: '164662',
      ts: '1647662251222',
      sodUtc0: '18.788',
      sodUtc8: '18.416'
    }
  },
  ...
}
```

# fetchTradingFee

```
2022-03-19T04:02:04.844Z
Node.js: v14.17.0
CCXT v1.76.55
okx.fetchTradingFee (DOT/USDT:USDT-220624)
2022-03-19T04:02:07.138Z iteration 0 passed in 297 ms

{
  info: {
    category: '2',
    delivery: '0.0003',
    exercise: '',
    instType: 'FUTURES',
    isSpecial: '0',
    level: 'Lv1',
    maker: '-0.00015',
    taker: '-0.0003',
    ts: '1647662527172'
  },
  symbol: 'DOT/USDT:USDT-220624',
  maker: -0.00015,
  taker: -0.0003
}
```

# fetchMarketLeverageTiers

```
okex.fetchMarketLeverageTiers (DOT/USDT:USDT-220624)
2022-03-19T04:11:49.602Z iteration 0 passed in 289 ms
tier | currency | notionalFloor | notionalCap | maintenanceMarginRate | maxLeverage
-----------------------------------------------------------------------------------
   1 |     USDT |             0 |         500 |                 0.008 |          75
...
  99 |     USDT |        192001 |      194000 |                 0.495 |        1.96
 100 |     USDT |        194001 |      196000 |                   0.5 |        1.94
100 objects
```