### PR TITLE
Hitbtc3 editOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1385,7 +1385,11 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const response = await this.privatePatchSpotOrderClientOrderId (this.extend (request, params));
+        const method = this.getSupportedMapping (market['type'], {
+            'spot': 'privatePatchSpotOrderClientOrderId',
+            'swap': 'privatePatchFuturesOrderClientOrderId',
+        });
+        const response = await this[method] (this.extend (request, params));
         return this.parseOrder (response, market);
     }
 


### PR DESCRIPTION
Added swap functionality to editOrder:
```
hitbtc3.editOrder (89ESaY3WADuwqSW9kzB3oU-mIRnqpoaH, BTC/USDT:USDT, limit, buy, 0.0006, 30100)
2022-03-19T07:30:54.746Z iteration 0 passed in 203 ms

{
  info: {
    id: '59406937163',
    client_order_id: 'BphmnSlqU2ajsitjalEcTLTHCO4rstRB',
    symbol: 'BTCUSDT_PERP',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.0006',
    quantity_cumulative: '0',
    price: '30100.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-19T07:29:15.89Z',
    updated_at: '2022-03-19T07:30:54.959Z'
  },
  id: 'BphmnSlqU2ajsitjalEcTLTHCO4rstRB',
  clientOrderId: 'BphmnSlqU2ajsitjalEcTLTHCO4rstRB',
  timestamp: 1647674955890,
  datetime: '2022-03-19T07:29:15.890Z',
  lastTradeTimestamp: 1647675054959,
  symbol: 'BTC/USDT:USDT',
  price: 30100,
  amount: 0.0006,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.0006,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```