### PR TITLE
currencycom - `fetchAccounts` change of `info`

### DIFF
--- a/js/currencycom.js
+++ b/js/currencycom.js
@@ -587,7 +587,7 @@ module.exports = class currencycom extends Exchange {
                 'id': accountId,
                 'type': undefined,
                 'currency': currencyCode,
-                'info': response,
+                'info': account,
             });
         }
         return result;


### PR DESCRIPTION
Though I don't think this might be ideal. `fetchAccounts` (as term express) should somehow fetch account-related information. if not unified, at least somewhere in `info`. but now, the part of data is lost. there is neither fetchUserInfo or etc,  (i assume many users might call fetchAccounts to extract account-related information from `info`). but with current structure across lib , we cut-out data from `info`. which I think, needs reorganization. 