### PR TITLE
Hitbtc3 fetchFundingRate

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1777,7 +1777,7 @@ module.exports = class hitbtc3 extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, market['id']);
+        const data = this.safeValue (response, market['id'], {});
         return this.parseFundingRate (data, market);
     }
 
@@ -1801,7 +1801,7 @@ module.exports = class hitbtc3 extends Exchange {
         const datetime = this.safeString (contract, 'timestamp');
         return {
             'info': contract,
-            'symbol': this.safeSymbol (market['id'], market),
+            'symbol': this.safeSymbol (undefined, market),
             'markPrice': this.safeNumber (contract, 'mark_price'),
             'indexPrice': this.safeNumber (contract, 'index_price'),
             'interestRate': this.safeNumber (contract, 'interest_rate'),


### PR DESCRIPTION
Added fetchFundingRate to Hitbtc3:
```
hitbtc3.fetchFundingRate (BTC/USDT:USDT)
2022-03-22T08:49:06.669Z iteration 0 passed in 198 ms

{
  info: {
    contract_type: 'perpetual',
    mark_price: '42657.35',
    index_price: '42653.52',
    funding_rate: '0.0001',
    open_interest: '30.9861',
    next_funding_time: '2022-03-22T16:00:00.000Z',
    indicative_funding_rate: '0.0001',
    premium_index: '0',
    avg_premium_index: '0.000029587712038098',
    interest_rate: '0.0001',
    timestamp: '2022-03-22T08:49:05.685Z'
  },
  symbol: 'BTC/USDT:USDT',
  markPrice: 42657.35,
  indexPrice: 42653.52,
  interestRate: 0.0001,
  estimatedSettlePrice: undefined,
  timestamp: 1647938945685,
  datetime: '2022-03-22T08:49:05.685Z',
  fundingRate: 0.0001,
  fundingTimestamp: undefined,
  fundingDatetime: undefined,
  nextFundingRate: 0.0001,
  nextFundingTimestamp: 1647964800000,
  nextFundingDatetime: '2022-03-22T16:00:00.000Z',
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
```