### PR TITLE
okex.fetchPositions fix

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -647,6 +647,7 @@ module.exports = class okx extends Exchange {
                     'SPOT': 'SPOT',
                     'MARGIN': 'MARGIN',
                     'SWAP': 'SWAP',
+                    'FUTURE': 'FUTURES',
                     'FUTURES': 'FUTURES',
                     'OPTION': 'OPTION',
                 },
@@ -3304,11 +3305,12 @@ module.exports = class okx extends Exchange {
             // instId String No Instrument ID, e.g. BTC-USD-190927-5000-C
             // posId String No Single position ID or multiple position IDs (no more than 20) separated with comma
         };
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchPosition', undefined, params);
+        const type = this.safeString (params, 'type');
+        params = this.omit (params, 'type');
         if (type !== undefined) {
             request['instType'] = this.convertToInstrumentType (type);
         }
-        const response = await this.privateGetAccountPositions (this.extend (request, query));
+        const response = await this.privateGetAccountPositions (this.extend (request, params));
         //
         //     {
         //         "code": "0",


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/12431

-----------------

```
2022-03-22T11:19:30.316Z
Node.js: v14.17.0
CCXT v1.76.73
okx.fetchPositions ()
2022-03-22T11:19:32.355Z iteration 0 passed in 289 ms

        symbol |           notional | marginType |   liquidationPrice | entryPrice |      unrealizedPnl |       percentage | contracts | contractSize | markPrice | side | hedged |     timestamp |                 datetime |  maintenanceMargin | maintenanceMarginPercentage |        collateral | initialMargin | initialMarginPercentage | leverage | marginRatio
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT:USDT | 124.01582565000001 |      cross | 0.1050481165275059 |   0.123948 | 0.0170000000000031 | 0.27430858101773 |         1 |         1000 |  0.123965 | long |   true | 1647947944102 | 2022-03-22T11:19:04.102Z | 1.2396500000000001 |                        0.01 | 6.215250000000003 |       6.19825 |                  0.0499 |       20 |      0.1994
1 objects
```