### PR TITLE
Hitbtc3 fetchMyTrades

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -760,6 +760,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotHistoryTrade',
             'swap': 'privateGetFuturesHistoryTrade',
+            'margin': 'privateGetMarginHistoryTrade',
         });
         const response = await this[method] (this.extend (request, query));
         return this.parseTrades (response, market, since, limit);
@@ -804,7 +805,7 @@ module.exports = class hitbtc3 extends Exchange {
         //      taker: true
         //  }
         //
-        // fetchMyTrades swap
+        // fetchMyTrades swap and margin
         //
         //  {
         //      "id": 4718564,


### PR DESCRIPTION
Added margin functionality to fetchMyTrades:
```
hitbtc3.fetchMyTrades ()
2022-03-24T01:52:55.193Z iteration 0 passed in 224 ms

        id | order |     timestamp |                 datetime |   symbol | type | side | takerOrMaker |    price |  amount |      cost |                                     fee |                                      fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1655137410 |       | 1648086557205 | 2022-03-24T01:49:17.205Z | BTC/USDT |      |  buy |        taker | 42754.43 | 0.00002 | 0.8550886 | {"cost":0.0021377215,"currency":"USDT"} | [{"currency":"USDT","cost":0.0021377215}]
1 objects
```