### PR TITLE
Hitbtc3 fetchOpenOrders

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1307,6 +1307,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotOrder',
             'swap': 'privateGetFuturesOrder',
+            'margin': 'privateGetMarginOrder',
         });
         const response = await this[method] (this.extend (request, query));
         //
@@ -1529,7 +1530,7 @@ module.exports = class hitbtc3 extends Exchange {
         //       ]
         //     }
         //
-        // swap
+        // swap and margin
         //
         //     {
         //         "id": 58418961892,


### PR DESCRIPTION
Added margin functionality for fetchOpenOrders:
```
hitbtc3.fetchOpenOrders ()
2022-03-24T02:14:11.646Z iteration 0 passed in 195 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol | price |  amount |  type | side | timeInForce | postOnly | filled | remaining | cost | status | average | trades | fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
52b33a9c8c1b460990951de3d0b2d3c4 | 52b33a9c8c1b460990951de3d0b2d3c4 | 1648087807150 | 2022-03-24T02:10:07.150Z |                    | BTC/USDT | 30000 | 0.00009 | limit |  buy |         GTC |    false |      0 |   0.00009 |    0 |   open |         |     [] |     |   []
1 objects
```