### PR TITLE
Hitbtc3 fetchOrderTrades

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1252,6 +1252,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotHistoryTrade',
             'swap': 'privateGetFuturesHistoryTrade',
+            'margin': 'privateGetMarginHistoryTrade',
         });
         const response = await this[method] (this.extend (request, query));
         //
@@ -1272,7 +1273,7 @@ module.exports = class hitbtc3 extends Exchange {
         //       }
         //     ]
         //
-        // Swap
+        // Swap and Margin
         //
         //     [
         //         {


### PR DESCRIPTION
Added margin functionality to fetchOrderTrades:
```
hitbtc3.fetchOrderTrades (841283764693)
2022-03-24T02:18:04.714Z iteration 0 passed in 243 ms

        id | order |     timestamp |                 datetime |   symbol | type | side | takerOrMaker |    price |  amount |      cost |                                     fee |                                      fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1655137410 |       | 1648086557205 | 2022-03-24T01:49:17.205Z | BTC/USDT |      |  buy |        taker | 42754.43 | 0.00002 | 0.8550886 | {"cost":0.0021377215,"currency":"USDT"} | [{"currency":"USDT","cost":0.0021377215}]
1 objects
```