### PR TITLE
Hitbtc3 fetchOpenOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1341,6 +1341,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotOrderClientOrderId',
             'swap': 'privateGetFuturesOrderClientOrderId',
+            'margin': 'privateGetMarginOrderClientOrderId',
         });
         const request = {
             'client_order_id': id,
@@ -1529,7 +1530,7 @@ module.exports = class hitbtc3 extends Exchange {
         //       ]
         //     }
         //
-        // swap
+        // swap and margin
         //
         //     {
         //         "id": 58418961892,


### PR DESCRIPTION
Added margin functionality to fetchOpenOrder:
```
hitbtc3.fetchOpenOrder (52b33a9c8c1b460990951de3d0b2d3c4)
2022-03-24T02:24:30.625Z iteration 0 passed in 192 ms

{
  info: {
    id: '841293849239',
    client_order_id: '52b33a9c8c1b460990951de3d0b2d3c4',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00009',
    quantity_cumulative: '0',
    price: '30000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-24T02:10:07.15Z',
    updated_at: '2022-03-24T02:10:07.15Z'
  },
  id: '52b33a9c8c1b460990951de3d0b2d3c4',
  clientOrderId: '52b33a9c8c1b460990951de3d0b2d3c4',
  timestamp: 1648087807150,
  datetime: '2022-03-24T02:10:07.150Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  price: 30000,
  amount: 0.00009,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.00009,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```