### PR TITLE
Mexc createOrder

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1715,10 +1715,11 @@ module.exports = class mexc extends Exchange {
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (market['spot']) {
-            return await this.createSpotOrder (symbol, type, side, amount, price, params);
-        } else if (market['swap']) {
-            return await this.createSwapOrder (symbol, type, side, amount, price, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('createOrder', market, params);
+        if (marketType === 'spot') {
+            return await this.createSpotOrder (symbol, type, side, amount, price, query);
+        } else if (marketType === 'swap') {
+            return await this.createSwapOrder (symbol, type, side, amount, price, query);
         }
     }
 


### PR DESCRIPTION
Fixes #12458
Added handleMarketTypeAndParams to fix a createOrder error for swap markets:
```
mexc.createOrder (XRP_USDT, 5, 3, 1, , [object Object])
2022-03-24T02:56:24.468Z iteration 0 passed in 288 ms

{
  id: '261809230917536256',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'XRP/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  trades: [],
  info: { success: true, code: '0', data: '261809230917536256' },
  fees: []
}
```