### PR TITLE
Huobi: add error for contract account not found

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -756,6 +756,7 @@ module.exports = class huobi extends Exchange {
                 },
                 'exact': {
                     // err-code
+                    '1010': AccountNotEnabled, // {"status":"error","err_code":1010,"err_msg":"Account doesnt exist.","ts":1648137970490}
                     '1017': OrderNotFound, // {"status":"error","err_code":1017,"err_msg":"Order doesnt exist.","ts":1640550859242}
                     '1034': InvalidOrder, // {"status":"error","err_code":1034,"err_msg":"Incorrect field of order price type.","ts":1643802870182}
                     '1036': InvalidOrder, // {"status":"error","err_code":1036,"err_msg":"Incorrect field of open long form.","ts":1643802518986}


### PR DESCRIPTION
`https://api.hbdm.com/api/v1/contract_account_info` does throw error `{"status":"error","err_code":1010,"err_msg":"Account doesnt exist.","ts":1648137970490}`
The other endpoints like spot `https://api.huobi.pro/v1/account/accounts/:id/balance`