### PR TITLE
AAX fetchIndexOHLCV, fetchMarkOHLCV, fetchPremiumIndexOHLCV

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -59,7 +59,7 @@ module.exports = class aax extends Exchange {
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
                 'fetchFundingRates': false,
-                'fetchIndexOHLCV': true,
+                'fetchIndexOHLCV': false,
                 'fetchIsolatedPositions': undefined,
                 'fetchL3OrderBook': undefined,
                 'fetchLedger': undefined,
@@ -68,7 +68,7 @@ module.exports = class aax extends Exchange {
                 'fetchLeverageTiers': true,
                 'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
-                'fetchMarkOHLCV': true,
+                'fetchMarkOHLCV': false,
                 'fetchMyBuys': undefined,
                 'fetchMySells': undefined,
                 'fetchMyTrades': true,
@@ -83,7 +83,7 @@ module.exports = class aax extends Exchange {
                 'fetchPosition': undefined,
                 'fetchPositions': undefined,
                 'fetchPositionsRisk': false,
-                'fetchPremiumIndexOHLCV': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
                 'fetchTicker': 'emulated',
                 'fetchTickers': true,
@@ -895,27 +895,6 @@ module.exports = class aax extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         return this.parseOHLCVs (data, market, timeframe, since, limit);
-    }
-
-    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
-        const request = {
-            'price': 'mark',
-        };
-        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
-    }
-
-    async fetchPremiumIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
-        const request = {
-            'price': 'premiumIndex',
-        };
-        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
-    }
-
-    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
-        const request = {
-            'price': 'index',
-        };
-        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     async fetchBalance (params = {}) {


### PR DESCRIPTION
Removed fetchIndexOHLCV, fetchPremiumIndexOHLCV and fetchMarkOHLCV and set them to false.

AAX doesn't have an endpoint for fetchMarkOHLCV and fetchPremiumIndexOHLCV.

There is an endpoint for fetchIndexOHLCV but it only returns a single candlestick so I set it to false also.
https://www.aax.com/apidoc/index.html#get-current-index-candlestick