### PR TITLE
ZB fetchIndexOHLCV, fetchMarkOHLCV

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -1450,6 +1450,7 @@ module.exports = class zb extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const swap = market['swap'];
+        const spot = market['spot'];
         const options = this.safeValue (this.options, 'timeframes', {});
         const timeframes = this.safeValue (options, market['type'], {});
         const timeframeValue = this.safeString (timeframes, timeframe);
@@ -1477,13 +1478,13 @@ module.exports = class zb extends Exchange {
             'spot': 'spotV1PublicGetKline',
             'swap': 'contractV1PublicGetKline',
         });
-        if (market['swap']) {
+        if (swap) {
             if (price === 'mark') {
                 method = 'contractV1PublicGetMarkKline';
             } else if (price === 'index') {
                 method = 'contractV1PublicGetIndexKline';
             }
-        } else if (market['spot']) {
+        } else if (spot) {
             if (since !== undefined) {
                 request['since'] = since;
             }

--- a/js/zb.js
+++ b/js/zb.js
@@ -1465,15 +1465,12 @@ module.exports = class zb extends Exchange {
             // 'type': timeframeValue, // spot only
             // 'period': timeframeValue, // swap only
             // 'since': since, // spot only
-            // 'limit': limit, // spot only
-            // 'size': limit, // swap only
+            // 'size': limit, // spot and swap
         };
         const marketIdField = swap ? 'symbol' : 'market';
         request[marketIdField] = market['id'];
         const periodField = swap ? 'period' : 'type';
         request[periodField] = timeframeValue;
-        const sizeField = swap ? 'size' : 'limit';
-        request[sizeField] = limit;
         const price = this.safeString (params, 'price');
         params = this.omit (params, 'price');
         let method = this.getSupportedMapping (market['type'], {
@@ -1486,9 +1483,13 @@ module.exports = class zb extends Exchange {
             } else if (price === 'index') {
                 method = 'contractV1PublicGetIndexKline';
             }
+        } else if (market['spot']) {
+            if (since !== undefined) {
+                request['since'] = since;
+            }
         }
-        if (since !== undefined) {
-            request['since'] = since;
+        if (limit !== undefined) {
+            request['size'] = limit;
         }
         const response = await this[method] (this.extend (request, params));
         //

--- a/js/zb.js
+++ b/js/zb.js
@@ -1486,10 +1486,9 @@ module.exports = class zb extends Exchange {
             } else if (price === 'index') {
                 method = 'contractV1PublicGetIndexKline';
             }
-        } else if (market['spot']) {
-            if (since !== undefined) {
-                request['since'] = since;
-            }
+        }
+        if (since !== undefined) {
+            request['since'] = since;
         }
         const response = await this[method] (this.extend (request, params));
         //


### PR DESCRIPTION
Cleaned up the implementation of fetchIndexOHLCV and fetchMarkOHLCV on ZB:

fetchOHLCV spot:
```
zb.fetchOHLCV (BTC/USDT)
2022-03-24T22:09:10.799Z iteration 0 passed in 1358 ms

1648159620000 | 43977.31 | 44009.26 | 43957.01 | 43968.79 | 0.7272
1648159680000 | 43959.57 | 44004.19 | 43925.07 | 43987.54 | 9.5995
1648159740000 | 43952.64 |  43997.4 | 43931.74 | 43976.11 | 0.0412
```

fetchOHLCV swap:
```
zb.fetchOHLCV (BTC/USDT:USDT)
2022-03-24T22:09:16.568Z iteration 0 passed in 338 ms

1648159620000 | 43807.09 | 43811.01 | 43806.19 | 43809.55 |   9.194
1648159680000 | 43809.28 | 43809.28 | 43775.02 | 43782.67 | 128.054
1648159740000 | 43781.82 | 43782.95 | 43780.37 | 43782.91 |   3.242
```

fetchMarkOHLCV:
```
zb.fetchMarkOHLCV (BTC/USDT:USDT)
2022-03-24T22:09:24.628Z iteration 0 passed in 331 ms

1648159620000 | 43807.17 | 43810.59 | 43806.19 | 43807.73 |
1648159680000 | 43807.09 | 43807.09 | 43779.86 | 43781.52 |
1648159740000 | 43782.67 | 43782.95 | 43780.37 | 43781.29 |
```

fetchIndexOHLCV:
```
zb.fetchIndexOHLCV (BTC/USDT:USDT)
2022-03-24T22:09:32.376Z iteration 0 passed in 336 ms

1648159620000 | 43993.77 | 44008.55 | 43993.77 | 44004.92 |
1648159680000 | 44004.92 | 44004.92 |  43903.2 |  43947.4 |
1648159740000 | 43948.04 | 43948.34 | 43946.37 | 43947.53 |
```