### PR TITLE
Hitbtc3 createOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1459,11 +1459,13 @@ module.exports = class hitbtc3 extends Exchange {
             }
             request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
         }
-        const method = this.getSupportedMapping (market['type'], {
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('createOrder', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
             'spot': 'privatePostSpotOrder',
             'swap': 'privatePostFuturesOrder',
+            'margin': 'privatePostMarginOrder',
         });
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }
 

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1459,7 +1459,7 @@ module.exports = class hitbtc3 extends Exchange {
             }
             request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('createOrder', undefined, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('createOrder', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privatePostSpotOrder',
             'swap': 'privatePostFuturesOrder',


### PR DESCRIPTION
Added margin functionality to createOrder:
```
hitbtc3.createOrder (BTC/USDT, limit, buy, 0.00001, 30000)
2022-03-25T06:59:29.239Z iteration 0 passed in 196 ms

{
  info: {
    id: '842367718052',
    client_order_id: 'gsCe2U6GCYE0LdYBzZGATbux6u_07DL-',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00001',
    quantity_cumulative: '0',
    price: '30000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-25T06:59:29.171Z',
    updated_at: '2022-03-25T06:59:29.171Z'
  },
  id: 'gsCe2U6GCYE0LdYBzZGATbux6u_07DL-',
  clientOrderId: 'gsCe2U6GCYE0LdYBzZGATbux6u_07DL-',
  timestamp: 1648191569171,
  datetime: '2022-03-25T06:59:29.171Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  price: 30000,
  amount: 0.00001,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.00001,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```