### PR TITLE
Hitbtc3 cancelOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1383,6 +1383,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateDeleteSpotOrderClientOrderId',
             'swap': 'privateDeleteFuturesOrderClientOrderId',
+            'margin': 'privateDeleteMarginOrderClientOrderId',
         });
         const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);


### PR DESCRIPTION
Added margin functionality to cancelOrder:
```
hitbtc3.cancelOrder (Mcj6LFJVmq-n32Xd1Zoj0nYPnWDh4K9E)
2022-03-25T07:07:01.116Z iteration 0 passed in 198 ms

{
  info: {
    id: '842370488483',
    client_order_id: 'Mcj6LFJVmq-n32Xd1Zoj0nYPnWDh4K9E',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'canceled',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00001',
    quantity_cumulative: '0',
    price: '30000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-25T07:04:09.216Z',
    updated_at: '2022-03-25T07:07:01.048Z'
  },
  id: 'Mcj6LFJVmq-n32Xd1Zoj0nYPnWDh4K9E',
  clientOrderId: 'Mcj6LFJVmq-n32Xd1Zoj0nYPnWDh4K9E',
  timestamp: 1648191849216,
  datetime: '2022-03-25T07:04:09.216Z',
  lastTradeTimestamp: 1648192021048,
  symbol: 'BTC/USDT',
  price: 30000,
  amount: 0.00001,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.00001,
  cost: 0,
  status: 'canceled',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```