### PR TITLE
fix assigning to const variables

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1260,8 +1260,8 @@ module.exports = class Exchange {
                 symbol = this.safeSymbol (undefined, market);
             }
             const timestamp = this.safeInteger (ticker, 'timestamp');
-            const baseVolume = this.safeValue (ticker, 'baseVolume');
-            const quoteVolume = this.safeValue (ticker, 'quoteVolume');
+            let baseVolume = this.safeValue (ticker, 'baseVolume');
+            let quoteVolume = this.safeValue (ticker, 'quoteVolume');
             let vwap = this.safeValue (ticker, 'vwap');
             if (vwap === undefined) {
                 vwap = this.vwap (baseVolume, quoteVolume);


### PR DESCRIPTION
At line 1298 and 1301, there are assigning statement to constant variables.

```js
            if ((vwap !== undefined) && (baseVolume !== undefined) && (quoteVolume === undefined)) {
                quoteVolume = vwap / baseVolume;
            }
            if ((vwap !== undefined) && (quoteVolume !== undefined) && (baseVolume === undefined)) {
                baseVolume = quoteVolume / vwap;
            }
```

Introduced at this commit: https://github.com/ccxt/ccxt/commit/48d0953dd36b20597b558eb42dec6044d93e345f
