### PR TITLE
Hitbtc3 cancelAllOrders

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1361,7 +1361,7 @@ module.exports = class hitbtc3 extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', undefined, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateDeleteSpotOrder',
             'swap': 'privateDeleteFuturesOrder',

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1361,10 +1361,11 @@ module.exports = class hitbtc3 extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', undefined, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateDeleteSpotOrder',
             'swap': 'privateDeleteFuturesOrder',
+            'margin': 'privateDeleteMarginOrder',
         });
         const response = await this[method] (this.extend (request, query));
         return this.parseOrders (response, market);


### PR DESCRIPTION
Added margin functionality to cancelAllOrders, need to set market in handleMarketTypeAndParams to undefined:
```
hitbtc3.cancelAllOrders (BTC/USDT)
2022-03-25T21:51:19.486Z iteration 0 passed in 203 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol | price |  amount |  type | side | timeInForce | postOnly | filled | remaining | cost | status | average | trades | fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
104cc4fe1b2747a8b156ac3b59fead84 | 104cc4fe1b2747a8b156ac3b59fead84 | 1648244988601 | 2022-03-25T21:49:48.601Z |                    | BTC/USDT | 30000 | 0.00069 | limit |  buy |         GTC |    false |      0 |   0.00069 |    0 |   open |         |     [] |     |   []
1 objects
```