### PR TITLE
Hitbtc3 fetchOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1212,6 +1212,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotHistoryOrder',
             'swap': 'privateGetFuturesHistoryOrder',
+            'margin': 'privateGetMarginHistoryOrder',
         });
         const request = {
             'client_order_id': id,


### PR DESCRIPTION
Added margin functionality to fetchOrder:
```
hitbtc3.fetchOrder (53a8adf8fec742309a79d82228e4b0da)
2022-03-25T21:55:18.479Z iteration 0 passed in 243 ms

{
  info: {
    id: '843011730267',
    client_order_id: '53a8adf8fec742309a79d82228e4b0da',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00069',
    quantity_cumulative: '0',
    price: '30000.00',
    price_average: '0',
    created_at: '2022-03-25T21:54:48.384Z',
    updated_at: '2022-03-25T21:54:48.384Z'
  },
  id: '53a8adf8fec742309a79d82228e4b0da',
  clientOrderId: '53a8adf8fec742309a79d82228e4b0da',
  timestamp: 1648245288384,
  datetime: '2022-03-25T21:54:48.384Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  price: 30000,
  amount: 0.00069,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: undefined,
  filled: 0,
  remaining: 0.00069,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```