### PR TITLE
Hitbtc3 fetchClosedOrders

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1196,6 +1196,7 @@ module.exports = class hitbtc3 extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotHistoryOrder',
             'swap': 'privateGetFuturesHistoryOrder',
+            'margin': 'privateGetMarginHistoryOrder',
         });
         const response = await this[method] (this.extend (request, query));
         const parsed = this.parseOrders (response, market, since, limit);


### PR DESCRIPTION
Added margin functionality to fetchClosedOrders:
```
hitbtc3.fetchClosedOrders ()
2022-03-26T06:05:56.803Z iteration 0 passed in 247 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |   price |  amount |   type | side | timeInForce | postOnly |  filled | remaining |      cost |   status |  average | trades | fee | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1f4a2e68aee44a8482688d864ef996cf | 1f4a2e68aee44a8482688d864ef996cf | 1648086557205 | 2022-03-24T01:49:17.205Z |                    | BTC/USDT | 47029.87 | 0.00002 | market |  buy |         IOC |          | 0.00002 |         0 | 0.8550886 |   closed | 42754.43 |     [] |     |   []
bfe837e8234d911b970eec282c1c6449 | bfe837e8234d911b970eec282c1c6449 | 1648088865487 | 2022-03-24T02:27:45.487Z |                    | BTC/USDT | 38495.21 | 0.00002 | market | sell |         IOC |          | 0.00002 |         0 |  0.855449 |   closed | 42772.45 |     [] |     |   []
44493ce0de4e48a4ae31c236092c6140 | 44493ce0de4e48a4ae31c236092c6140 | 1648190877536 | 2022-03-25T06:47:57.536Z |      1648190885242 | BTC/USDT |    30000 | 0.00006 |  limit |  buy |         GTC |          |       0 |   0.00006 |         0 | canceled |          |     [] |     |   []
```