### PR TITLE
Hitbtc3 editOrder

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1405,7 +1405,7 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('editOrder', undefined, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('editOrder', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privatePatchSpotOrderClientOrderId',
             'swap': 'privatePatchFuturesOrderClientOrderId',

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1405,11 +1405,13 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const method = this.getSupportedMapping (market['type'], {
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('editOrder', undefined, params);
+        const method = this.getSupportedMapping (marketType, {
             'spot': 'privatePatchSpotOrderClientOrderId',
             'swap': 'privatePatchFuturesOrderClientOrderId',
+            'margin': 'privatePatchMarginOrderClientOrderId',
         });
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }
 


### PR DESCRIPTION
Added editOrder for margin, needed to include handleMarketTypeAndParams and set market to undefined:
```
hitbtc3.editOrder (53a8adf8fec742309a79d82228e4b0da, BTC/USDT, limit, buy, 0.0006, 30100)
2022-03-26T06:14:24.868Z iteration 0 passed in 198 ms

{
  info: {
    id: '843299870762',
    client_order_id: 'Yqu2b9jXKFbmGeurBWnlEn4b1-c3McXS',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00060',
    quantity_cumulative: '0',
    price: '30100.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-03-25T21:54:48.384Z',
    updated_at: '2022-03-26T06:14:25.417Z'
  },
  id: 'Yqu2b9jXKFbmGeurBWnlEn4b1-c3McXS',
  clientOrderId: 'Yqu2b9jXKFbmGeurBWnlEn4b1-c3McXS',
  timestamp: 1648245288384,
  datetime: '2022-03-25T21:54:48.384Z',
  lastTradeTimestamp: 1648275265417,
  symbol: 'BTC/USDT',
  price: 30100,
  amount: 0.0006,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  filled: 0,
  remaining: 0.0006,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```