### PR TITLE
binance.parseTrades taker key for fetchTrades

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -2353,10 +2353,11 @@ module.exports = class binance extends Exchange {
         id = this.safeString2 (trade, 'id', 'tradeId', id);
         let side = undefined;
         const orderId = this.safeString (trade, 'orderId');
-        if ('m' in trade) {
-            side = trade['m'] ? 'sell' : 'buy'; // this is reversed intentionally
-        } else if ('isBuyerMaker' in trade) {
-            side = trade['isBuyerMaker'] ? 'sell' : 'buy';
+        const buyerMaker = this.safeValue (trade, 'm', 'isBuyerMaker');
+        let takerOrMaker = undefined;
+        if (buyerMaker !== undefined) {
+            side = buyerMaker ? 'sell' : 'buy'; // this is reversed intentionally
+            takerOrMaker = 'taker';
         } else if ('side' in trade) {
             side = this.safeStringLower (trade, 'side');
         } else {
@@ -2371,7 +2372,6 @@ module.exports = class binance extends Exchange {
                 'currency': this.safeCurrencyCode (this.safeString (trade, 'commissionAsset')),
             };
         }
-        let takerOrMaker = undefined;
         if ('isMaker' in trade) {
             takerOrMaker = trade['isMaker'] ? 'maker' : 'taker';
         }


### PR DESCRIPTION
Because of this line `side = buyerMaker ? 'sell' : 'buy'; // this is reversed intentionally`, CCXT is declaring a trade as a sell when the buyer is the maker order, so then the seller is the taker order, when the buyer is not the maker order, CCXT is declaring that trade as a buy, so it is a taker order because the buyer is the taker. This means that all trades returned from `fetchTrades` are taker orders

```
2022-03-26T17:57:35.358Z
Node.js: v14.17.0
CCXT v1.77.26
binance.fetchTrades (XRP/USDT)
2022-03-26T17:57:36.663Z iteration 0 passed in 647 ms
    timestamp |                 datetime |   symbol |        id | order | type | side | takerOrMaker |  price | amount |       cost | fee | fees
------------------------------------------------------------------------------------------------------------------------------------------------
1648316566804 | 2022-03-26T17:42:46.804Z | XRP/USDT | 330423506 |       |      |  buy |        taker | 0.8313 |     12 |     9.9756 |     |   []
...
1648317451524 | 2022-03-26T17:57:31.524Z | XRP/USDT | 330424004 |       |      | sell |        taker | 0.8313 |   1011 |   840.4443 |     |   []
1648317456527 | 2022-03-26T17:57:36.527Z | XRP/USDT | 330424005 |       |      | sell |        taker | 0.8313 |   1840 |   1529.592 |     |   []
500 objects
```

```
2022-03-26T17:58:01.946Z
Node.js: v14.17.0
CCXT v1.77.26
binanceusdm.fetchTrades (XRP/USDT)
2022-03-26T17:58:02.979Z iteration 0 passed in 218 ms
    timestamp |                 datetime |   symbol |        id | order | type | side | takerOrMaker |  price |  amount |        cost | fee | fees
--------------------------------------------------------------------------------------------------------------------------------------------------
1648317097016 | 2022-03-26T17:51:37.016Z | XRP/USDT | 269582695 |       |      |  buy |        taker | 0.8311 |     0.1 |     0.08311 |     |   []
...
1648317481470 | 2022-03-26T17:58:01.470Z | XRP/USDT | 269583193 |       |      | sell |        taker |  0.831 |     6.2 |      5.1522 |     |   []
1648317482399 | 2022-03-26T17:58:02.399Z | XRP/USDT | 269583194 |       |      |  buy |        taker | 0.8311 |      13 |     10.8043 |     |   []
500 objects
```