### PR TITLE
Missing 'await' on javascript example

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1983,7 +1983,7 @@ In order to get current best price (query market price) and calculate bidask spr
 
 ```JavaScript
 // JavaScript
-let orderbook = exchange.fetchOrderBook (exchange.symbols[0])
+let orderbook = await exchange.fetchOrderBook (exchange.symbols[0])
 let bid = orderbook.bids.length ? orderbook.bids[0][0] : undefined
 let ask = orderbook.asks.length ? orderbook.asks[0][0] : undefined
 let spread = (bid && ask) ? ask - bid : undefined


### PR DESCRIPTION
Without 'await', the function `exchange.fetchOrderBook()` doesn't work properly, making the doc example dysfunctional.
https://docs.ccxt.com/en/latest/manual.html#market-price
Line 1986, on 'Market Price' section