### PR TITLE
ftx: don't crash while concatenating str and None in Python

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -583,7 +583,7 @@ module.exports = class ftx extends Exchange {
                 type = 'future';
                 expiry = this.parse8601 (expiryDatetime);
                 if (expiry === undefined) {
-                    throw new BadResponse (this.id + " symbol '" + id + "' is a future contract but with invalid expiry datetime: " + expiryDatetime);
+                    throw new BadResponse (this.id + " symbol '" + id + "' is a future contract but with an invalid expiry datetime.");
                 }
                 const parsedId = id.split ('-');
                 const length = parsedId.length;


### PR DESCRIPTION
- CCXT version: 1.77.40
- Python version: 3.10.3


While calling `ftx.load_markets()` in Python, I got this error in production:

```
TypeError: can only concatenate str (not "NoneType") to str

File "ccxt/async_support/base/exchange.py", line 201, in load_markets
    raise e
  File "ccxt/async_support/base/exchange.py", line 197, in load_markets
    result = await self.markets_loading
  File "ccxt/async_support/base/exchange.py", line 187, in load_markets_helper
    markets = await self.fetch_markets(params)
  File "ccxt/async_support/ftx.py", line 597, in fetch_markets
    raise BadResponse(self.id + " symbol '" + id + "' is a future contract but with invalid expiry datetime: " + expiryDatetime)
```

What happens is that for some reason FTX returns a delivery future with a `null` expiry date, and Python crashes _while raising the exception_ because it can't concatenate a string with a `None`.