### PR TITLE
fix(lbank): add `market.amount.min`

### DIFF
--- a/js/lbank.js
+++ b/js/lbank.js
@@ -194,7 +194,7 @@ module.exports = class lbank extends Exchange {
                         'max': undefined,
                     },
                     'amount': {
-                        'min': undefined,
+                        'min': this.safeFloat (market, 'minTranQua'),
                         'max': undefined,
                     },
                     'price': {


### PR DESCRIPTION
Lbank api has `minTranQua` provided, while it is not used by ccxt for now.

API: https://api.lbank.info/v1/accuracy.do
docs: https://docs.lbkex.net/en/#trading-pairs
> The doc is for v2, but they have the same meaning, so it can be a referrence.