### PR TITLE
handleMarketTypeAndParams - resolve market `type` only to `spot/swap/future/option...`

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2173,7 +2173,7 @@ module.exports = class Exchange {
     }
 
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
-        const allowedTypes = ['spot', 'swap', 'future', 'option', 'margin'];
+        const allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives']; // [binance : savings & funding & linear & inverse ] [bitfinex2: exchange, derivatives]
         const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
         const methodOptions = this.safeValue (this.options, methodName);
         let methodType = defaultType;

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2173,6 +2173,7 @@ module.exports = class Exchange {
     }
 
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
+        const allowedTypes = ['spot', 'swap', 'future', 'option', 'margin'];
         const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
         const methodOptions = this.safeValue (this.options, methodName);
         let methodType = defaultType;
@@ -2184,8 +2185,18 @@ module.exports = class Exchange {
             }
         }
         const marketType = (market === undefined) ? methodType : market['type'];
-        const type = this.safeString2 (params, 'defaultType', 'type', marketType);
-        params = this.omit (params, [ 'defaultType', 'type' ]);
+        let type = this.safeString (params, 'defaultType');
+        if (type !== undefined) {
+            params = this.omit (params, 'defaultType');
+        } else {
+            const temptType = this.safeString (params, 'type');
+            if ((temptType !== undefined) && allowedTypes.includes (type)) {
+                type = temptType;
+                params = this.omit (params, 'type');
+            } else {
+                type = marketType;
+            }
+        }
         return [ type, params ];
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2173,7 +2173,7 @@ module.exports = class Exchange {
     }
 
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
-        const allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account']; // [binance : savings & funding & linear & inverse ] [bitfinex2: exchange, derivatives] [gateio: cross_margin] [kucoin: contract] [okcoin: account]
+        const allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account', 'SPOT', 'MARGIN', 'SWAP', 'FUTURES', 'OPTION']; // exotic cases: [binance : savings, funding] [bitfinex2: exchange, derivatives] [gateio: cross_margin] [kucoin: contract] [okcoin: account] [okex: funding, futures, <and uppercased-> SPOT, MARGIN, SWAP, FUTURES, OPTION] [bitmart: account, contract]
         const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
         const methodOptions = this.safeValue (this.options, methodName);
         let methodType = defaultType;

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2189,9 +2189,9 @@ module.exports = class Exchange {
         if (type !== undefined) {
             params = this.omit (params, 'defaultType');
         } else {
-            const temptType = this.safeString (params, 'type');
-            if ((temptType !== undefined) && allowedTypes.includes (type)) {
-                type = temptType;
+            const tempType = this.safeString (params, 'type');
+            if ((tempType !== undefined) && allowedTypes.includes (type)) {
+                type = tempType;
                 params = this.omit (params, 'type');
             } else {
                 type = marketType;

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2173,7 +2173,7 @@ module.exports = class Exchange {
     }
 
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
-        const allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives']; // [binance : savings & funding & linear & inverse ] [bitfinex2: exchange, derivatives]
+        const allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account']; // [binance : savings & funding & linear & inverse ] [bitfinex2: exchange, derivatives] [gateio: cross_margin] [kucoin: contract] [okcoin: account]
         const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
         const methodOptions = this.safeValue (this.options, methodName);
         let methodType = defaultType;

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3679,7 +3679,7 @@ class Exchange {
     }
 
     public function handle_market_type_and_params($method_name, $market = null, $params = array()) {
-        $allowedTypes = array( 'spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account' ); // [binance : savings & funding & linear & inverse ] [bitfinex2: exchange, derivatives] [gateio: cross_margin] [kucoin: contract] [okcoin: account]
+        $allowedTypes = array( 'spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account' );
         $default_type = $this->safe_string_2($this->options, 'defaultType', 'type', 'spot');
         $method_options = $this->safe_value($this->options, $method_name);
         $method_type = $default_type;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2762,7 +2762,7 @@ class Exchange(object):
         return rate
 
     def handle_market_type_and_params(self, method_name, market=None, params={}):
-        allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account']  # [binance : savings & funding & linear & inverse] [bitfinex2: exchange, derivatives] [gateio: cross_margin] [kucoin: contract] [okcoin: account]
+        allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account']
         default_type = self.safe_string_2(self.options, 'defaultType', 'type', 'spot')
         method_options = self.safe_value(self.options, method_name)
         method_type = default_type

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2762,6 +2762,7 @@ class Exchange(object):
         return rate
 
     def handle_market_type_and_params(self, method_name, market=None, params={}):
+        allowedTypes = ['spot', 'swap', 'future', 'delivery', 'option', 'margin', 'savings', 'funding', 'linear', 'inverse', 'exchange', 'derivatives', 'cross_margin', 'contract', 'account']  # [binance : savings & funding & linear & inverse] [bitfinex2: exchange, derivatives] [gateio: cross_margin] [kucoin: contract] [okcoin: account]
         default_type = self.safe_string_2(self.options, 'defaultType', 'type', 'spot')
         method_options = self.safe_value(self.options, method_name)
         method_type = default_type
@@ -2771,8 +2772,16 @@ class Exchange(object):
             else:
                 method_type = self.safe_string_2(method_options, 'defaultType', 'type', method_type)
         market_type = method_type if market is None else market['type']
-        type = self.safe_string_2(params, 'defaultType', 'type', market_type)
-        params = self.omit(params, ['defaultType', 'type'])
+        type = self.safe_string(params, 'defaultType')
+        if type is not None:
+            params = self.omit(params, 'defaultType')
+        else:
+            temptType = self.safe_string(params, 'type')
+            if (temptType is not None) and (type in allowedTypes):
+                type = temptType
+                params = self.omit(params, 'type')
+            else:
+                type = market_type
         return [type, params]
 
     def load_time_difference(self, params={}):


### PR DESCRIPTION
# **Purpose:**
This PR should solve the current and possible future conflicts with `type` key collision inside `handleMarketTypeAndParams` (_hMTAP_) method. 

# **Problem:**
We (till date) use unified `type`(in addition to `defaultType`) param key for defining market-type (which is handled by `hMTAP` well).
However, the problem is that there are cases/exchanges where `type` key is being used in request as a parameter for some endpoint-specific meaning (like `type: takeProfit` or etc..).
for example, in FTX createOrder (....,.., {type:'takeProfit'}) the  `type` parameter is the exchange-specific key to designate `takeProfit` or `stopLoss` values. I can't name at this moment, but I am sure there are other places/exchange endpoints where `type` key is being also used as a native exchange-specific param.
So , FTX-like exchanges will have conflicts :
`createOrder(..., ..., ..., ...,  {type: 'takeProfit'})` 
-- vs --
`createOrder(..., ..., ..., ...,  {type: 'swap'})` 

as the below implementation:
```
const [marketType, query] = this.handleMarketTypeAndParams(...,.., params);
```
will define `marketType` as `takeProfit` and will trim-out that from `query` object. Thus, exchange will not receive user's `type:'takeProfit'`.  So, I've made a small research and found all possible occasions of what can be `markeType` (checked all occurrences across ccxt exchange files) and they are mostly same  (i.e. `spot, swap, future, margin,  etc...` ).  So, I think that it will solve the problem if we check `type` param (inside `hMTAP`) only against those pre-defined market-lists (`spot, swap...`) and only in case it matches , it resolves to `marketType` value.  Otherwise, user-provided `param['type']`  should be left as is in `query`  for further processing (to be sent to exchange in `query`).



# about Tests

Tests will not do any help for the issue, as our tests will still pass well even when the above problem exists. They just check 'if developer has implemented method well', the purpose of this method is quite different, and moving it into 'tests' defeats the purpose...   `hMTAP` itself should check the end-user usage of method, independent to any exchange-specific endpoints.
1) the method itself, has sole purpose  to check `type/defaultType` of market, and not other goal.
2) we have a unified concept for types (when passing with unified key names `type/defaultType`) - we expect that user provides also one of those string (as implementation expects) specifically. There will be a very rare occasion if we will ever need to add any new key there (and even if it will be needed, it is not a problem).
3) lastly, there is obvious conflict I said above.

# about solution
- I've searched `handleMarketTypeAndParams` string across the lib, and found that the method is always being used with only 2 names of variables. either:
- `const [ marketType, query ] = this.handleMarketTypeAndParams(`
or
- `const [ type, query ] = this.handleMarketTypeAndParams(`
so, the variable name used is always `type` or `marketType`. 

Then, i've searched (in vscode) with regex:
```
type === '(?!(spot|future|swap|option|margin|delivery|savings|funding|linear|inverse|exchange|derivatives|cross_margin|contract|account|stop'|market'|stoplimit|stop_limit|stop_market|stop |stop-limit|stoploss|stop_loss|stop-loss|take_profit|takeprofit|take-profit|limit|trailing|deposit|transfer|withdraw|ioc'|fok'))
```
and all my found strings (market-type values) are collected in PR ( I've left note in comment for some exotic/distinctive exchanges too) In addition, after that (to ensure) I've searched all occurrences of `handleMarketTypeAndParams` method across lib  (116 cases) and manually checked how those two variables ( `type/marketType` ) were being used after they were defined by `hMTAP`, and collected all possible variations in PR.  So, in my mind, this implementation could be future-proof.

You can list arguments and contrarguments for this implementation.