### PR TITLE
blockchaincom - transfer, fetchTransfer, fetchTransfers

### DIFF
--- a/js/blockchaincom.js
+++ b/js/blockchaincom.js
@@ -54,9 +54,12 @@ module.exports = class blockchaincom extends Exchange {
                 'fetchTrades': false,
                 'fetchTradingFee': false,
                 'fetchTradingFees': true,
+                'fetchTransfer': false,
+                'fetchTransfers': false,
                 'fetchWithdrawal': true,
                 'fetchWithdrawals': true,
                 'fetchWithdrawalWhitelist': true, // fetches exchange specific benficiary-ids needed for withdrawals
+                'transfer': false,
                 'withdraw': true,
             },
             'timeframes': undefined,


### PR DESCRIPTION
No endpoint to `transfer`, `fetchTransfer` or `fetchTransfers`

doc: https://api.blockchain.com/v3/