### PR TITLE
JS base tests fix removed mocha

### DIFF
--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -19,8 +19,8 @@ const prop = (o, k) => (isObject (o) ? o[k] : undefined)
 
 /*  .............................................   */
 
-const asFloat   = x => ((isNumber (x) || isString (x)) ? parseFloat (x)     : NaN)
-    , asInteger = x => ((isNumber (x) || isString (x)) ? Math.round(Number(x)) : NaN)
+const asFloat   = x => ((isNumber (x) || (isString (x) && x.length !== 0)) ? parseFloat (x)     : NaN)
+    , asInteger = x => ((isNumber (x) || (isString (x) && x.length !== 0)) ? Math.round(Number(x)) : NaN)
 
 /*  .............................................   */
 

--- a/js/base/functions/type.js
+++ b/js/base/functions/type.js
@@ -20,7 +20,7 @@ const prop = (o, k) => (isObject (o) ? o[k] : undefined)
 /*  .............................................   */
 
 const asFloat   = x => ((isNumber (x) || (isString (x) && x.length !== 0)) ? parseFloat (x)     : NaN)
-    , asInteger = x => ((isNumber (x) || (isString (x) && x.length !== 0)) ? Math.round(Number(x)) : NaN)
+    , asInteger = x => ((isNumber (x) || (isString (x) && x.length !== 0)) ? Math.trunc(Number(x)) : NaN)
 
 /*  .............................................   */
 

--- a/js/test/base/functions/test.generic.js
+++ b/js/test/base/functions/test.generic.js
@@ -7,7 +7,7 @@ const { strictEqual: equal, deepEqual } = require ('assert')
 
 /*  ------------------------------------------------------------------------ */
 
-it ('deepExtend() works', () => {
+function testDeepExtend() {
 
     let count = 0
 
@@ -56,11 +56,11 @@ it ('deepExtend() works', () => {
     })
 
     deepEqual (deepExtend (undefined, undefined, {'foo': 'bar' }), { 'foo': 'bar' })
-})
+}
 
 /*  ------------------------------------------------------------------------ */
 
-it ('groupBy() works', () => {
+function testGroupBy() {
 
     const array = [
         { 'foo': 'a' },
@@ -76,11 +76,11 @@ it ('groupBy() works', () => {
         'b': [ { 'foo': 'b' }, { 'foo': 'b' } ],
         'c': [ { 'foo': 'c' }, { 'foo': 'c' }, { 'foo': 'c' } ],
     })
-})
+}
 
 /*  ------------------------------------------------------------------------ */
 
-it ('filterBy() works', () => {
+function testFilterBy() {
 
     const array = [
         { 'foo': 'a' },
@@ -99,11 +99,11 @@ it ('filterBy() works', () => {
         { 'foo': 'a' },
         { 'foo': 'a', 'bar': 'b' },
     ])
-})
+}
 
 /*  ------------------------------------------------------------------------ */
 
-it ('omit works', () => {
+function testOmit() {
 
     deepEqual (omit ({ }, 'foo'), {})
     deepEqual (omit ({ foo: 2 }, 'foo'), { })
@@ -114,21 +114,21 @@ it ('omit works', () => {
     deepEqual (omit ({ foo: 2, bar: 3 }, ['foo'], 'bar'), {})
     deepEqual (omit ({ 5: 2, bar: 3 }, [ 5 ]), { bar: 3 })
     deepEqual (omit ({ 5: 2, bar: 3 }, 5), { bar: 3 })
-})
+}
 
 /*  ------------------------------------------------------------------------ */
 
-it ('sum works', () => {
+function testSum() {
 
     equal (undefined, sum ())
     equal (2,   sum (2))
     equal (432, sum (2, 30, 400))
     equal (432, sum (2, undefined, [ 88 ], 30, '7', 400, null))
-})
+}
 
 /*  ------------------------------------------------------------------------ */
 
-it ('sortBy works', () => {
+function testSortBy() {
 
     const arr = [{ 'x': 5 }, { 'x': 2 }, { 'x': 4 }, { 'x': 0 }, { 'x': 1 }, { 'x': 3 }]
     sortBy (arr, 'x')
@@ -152,6 +152,19 @@ it ('sortBy works', () => {
     ])
 
     deepEqual (sortBy ([], 'x'), [])
-})
+}
 
 /*  ------------------------------------------------------------------------ */
+
+function testGeneric() {
+	testDeepExtend()
+	testGroupBy()
+	testFilterBy()
+	testOmit()
+	testSum()
+	testSortBy()
+}
+
+/*  ------------------------------------------------------------------------ */
+
+testGeneric()

--- a/js/test/base/functions/test.type.js
+++ b/js/test/base/functions/test.type.js
@@ -7,7 +7,7 @@ const { strictEqual: equal, deepEqual } = require ('assert')
 
 /*  ------------------------------------------------------------------------ */
 
-it ('safeFloat/safeInteger is robust', async () => {
+function testSafeFloatSafeInteger() {
 
     const $default = {}
 
@@ -38,17 +38,24 @@ it ('safeFloat/safeInteger is robust', async () => {
 
     equal (safeFloat   ({ 'x': 1.59999999 }, 'x'), 1.59999999)
     equal (safeInteger ({ 'x': 1.59999999 }, 'x'), 1)
-})
+}
 
 /*  ------------------------------------------------------------------------ */
 
-it ('safeValue works', () => {
+function testSafeValue() {
 
     equal (safeValue ({}, 'foo'), undefined)
     equal (safeValue ({}, 'foo', 'bar'), 'bar')
     equal (safeValue ({ 'foo': 'bar' }, 'foo'), 'bar')
     equal (safeValue ({ 'foo': '' }, 'foo'), '')
     equal (safeValue ({ 'foo': 0 }, 'foo'), 0)
-})
+}
 
 /*  ------------------------------------------------------------------------ */
+
+function testType() {
+	testSafeFloatSafeInteger()
+	testSafeValue()
+} 
+
+testType()

--- a/js/test/base/test.base.js
+++ b/js/test/base/test.base.js
@@ -1,6 +1,5 @@
 'use strict'
 
-/*
 // ----------------------------------------------------------------------------
 
 global.log = require ('ololog') // for easier debugging
@@ -12,208 +11,206 @@ const { strictEqual: equal, deepEqual } = require ('assert')
 
 // ----------------------------------------------------------------------------
 
-describe ('ccxt base code', () => {
 
-    // ------------------------------------------------------------------------
+require ('./functions/test.generic')
+require ('./functions/test.time')
+require ('./functions/test.type')
+// Some test files are transpiled to other languages and must be kept very simple so we put `it` call externally to them
+// Some mocha reporters will swallow `assert` failures if they are outside of `it` clause so we must call `it`
+require ('./functions/test.number')
+require ('./functions/test.datetime')
+require ('./functions/test.crypto')
 
-    require ('./functions/test.generic')
-    require ('./functions/test.time')
-    require ('./functions/test.type')
-    // Some test files are transpiled to other languages and must be kept very simple so we put `it` call externally to them
-    // Some mocha reporters will swallow `assert` failures if they are outside of `it` clause so we must call `it`
-    it ('decimalToPrecision() works', () => {
-        require ('./functions/test.number')
+// ------------------------------------------------------------------------
+
+function testCalculateFee() {
+    const price  = 100.00
+    const amount = 10.00
+    const taker  = 0.0025
+    const maker  = 0.0010
+    const fees   = { taker, maker }
+    const market = {
+        'id':     'foobar',
+        'symbol': 'FOO/BAR',
+        'base':   'FOO',
+        'quote':  'BAR',
+        'taker':   taker,
+        'maker':   maker,
+        'precision': {
+            'amount': 8,
+            'price': 8,
+        },
+    }
+
+    const exchange = new Exchange ({
+        'id': 'mock',
+        'markets': {
+            'FOO/BAR': market,
+        },
     })
-    it ('date&time functions work', () => {
-        require('./functions/test.datetime')
-    })
-    it ('cryptography code works', () => {
-        require('./functions/test.crypto')
-    })
 
-    // ------------------------------------------------------------------------
+    Object.keys (fees).forEach ((takerOrMaker) => {
 
-    it ('calculateFee() works', () => {
+        const result = exchange.calculateFee (market['symbol'], 'limit', 'sell', amount, price, takerOrMaker, {})
 
-        const price  = 100.00
-        const amount = 10.00
-        const taker  = 0.0025
-        const maker  = 0.0010
-        const fees   = { taker, maker }
-        const market = {
-            'id':     'foobar',
-            'symbol': 'FOO/BAR',
-            'base':   'FOO',
-            'quote':  'BAR',
-            'taker':   taker,
-            'maker':   maker,
-            'precision': {
-                'amount': 8,
-                'price': 8,
-            },
-        }
-
-        const exchange = new Exchange ({
-            'id': 'mock',
-            'markets': {
-                'FOO/BAR': market,
-            },
-        })
-
-        Object.keys (fees).forEach ((takerOrMaker) => {
-
-            const result = exchange.calculateFee (market['symbol'], 'limit', 'sell', amount, price, takerOrMaker, {})
-
-            deepEqual (result, {
-                'type': takerOrMaker,
-                'currency': 'BAR',
-                'rate': fees[takerOrMaker],
-                'cost': fees[takerOrMaker] * amount * price,
-            })
+        deepEqual (result, {
+            'type': takerOrMaker,
+            'currency': 'BAR',
+            'rate': fees[takerOrMaker],
+            'cost': fees[takerOrMaker] * amount * price,
         })
     })
+}
 
-    // ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
-    it.skip ('exchange config extension works', () => {
+function testExchangeConfigExtension() {
 
 
-        const cost = { 'min': 0.001, 'max': 1000 }
-        const precision = { 'amount': 3 }
-        const exchange = new binance ({
-            'markets': {
-                'ETH/BTC': { 'limits': { cost }, precision },
-            },
-        })
-
-        deepEqual (exchange.markets['ETH/BTC'].limits.cost, cost)
-        deepEqual (exchange.markets['ETH/BTC'].precision, { 'price': 6, 'amount': 3 })
-        deepEqual (exchange.markets['ETH/BTC'].symbol, 'ETH/BTC')
+    const cost = { 'min': 0.001, 'max': 1000 }
+    const precision = { 'amount': 3 }
+    const exchange = new binance ({
+        'markets': {
+            'ETH/BTC': { 'limits': { cost }, precision },
+        },
     })
 
-    // ------------------------------------------------------------------------
+    deepEqual (exchange.markets['ETH/BTC'].limits.cost, cost)
+    deepEqual (exchange.markets['ETH/BTC'].precision, { 'price': 6, 'amount': 3 })
+    deepEqual (exchange.markets['ETH/BTC'].symbol, 'ETH/BTC')
+}
 
-    it ('aggregate() works', () => {
+// ------------------------------------------------------------------------
 
-        const bids = [
-            [ 789.1, 123.0 ],
-            [ 789.100, 123.0 ],
-            [ 123.0, 456.0 ],
-            [ 789.0, 123.0 ],
-            [ 789.10, 123.0 ],
-        ]
+function testAggregate() {
 
-        const asks = [
-            [ 123.0, 456.0 ],
-            [ 789.0, 123.0 ],
-            [ 789.10, 123.0 ],
-        ]
+    const bids = [
+        [ 789.1, 123.0 ],
+        [ 789.100, 123.0 ],
+        [ 123.0, 456.0 ],
+        [ 789.0, 123.0 ],
+        [ 789.10, 123.0 ],
+    ]
 
-        deepEqual (aggregate (bids.sort ()), [
-            [ 123.0, 456.0 ],
-            [ 789.0, 123.0 ],
-            [ 789.1, 369.0 ],
-        ])
+    const asks = [
+        [ 123.0, 456.0 ],
+        [ 789.0, 123.0 ],
+        [ 789.10, 123.0 ],
+    ]
 
-        deepEqual (aggregate (asks.sort ()), [
-            [ 123.0, 456.0 ],
-            [ 789.0, 123.0 ],
-            [ 789.10, 123.0 ],
-        ])
+    deepEqual (aggregate (bids.sort ()), [
+        [ 123.0, 456.0 ],
+        [ 789.0, 123.0 ],
+        [ 789.1, 369.0 ],
+    ])
 
-        deepEqual (aggregate ([]), [])
-    })
+    deepEqual (aggregate (asks.sort ()), [
+        [ 123.0, 456.0 ],
+        [ 789.0, 123.0 ],
+        [ 789.10, 123.0 ],
+    ])
 
-    // ------------------------------------------------------------------------
+    deepEqual (aggregate ([]), [])
+}
 
-    it ('safeBalance() works', () => {
+// ------------------------------------------------------------------------
 
-        const exchange = new Exchange ({
-            'markets': {
-                'ETH/BTC': { 'id': 'ETH/BTC', 'symbol': 'ETH/BTC', 'base': 'ETH', 'quote': 'BTC', }
-            }
-        })
+function testSafeBalance() {
 
-        const input = {
-            'ETH': { 'free': 10, 'used': 10, 'total': 20 },
-            'ZEC': { 'free': 0, 'used': 0, 'total': 0 },
+    const exchange = new Exchange ({
+        'markets': {
+            'ETH/BTC': { 'id': 'ETH/BTC', 'symbol': 'ETH/BTC', 'base': 'ETH', 'quote': 'BTC', }
         }
+    })
 
-        const expected = {
-            'ETH': { 'free': 10, 'used': 10, 'total': 20 },
-            'ZEC': { 'free': 0, 'used': 0, 'total': 0 },
-            'free': {
-                'ETH': 10,
-                'ZEC': 0,
-            },
-            'used': {
-                'ETH': 10,
-                'ZEC': 0,
-            },
-            'total': {
-                'ETH': 20,
-                'ZEC': 0,
-            },
+    const input = {
+        'ETH': { 'free': 10, 'used': 10, 'total': 20 },
+        'ZEC': { 'free': 0, 'used': 0, 'total': 0 },
+    }
+
+    const expected = {
+        'ETH': { 'free': 10, 'used': 10, 'total': 20 },
+        'ZEC': { 'free': 0, 'used': 0, 'total': 0 },
+        'free': {
+            'ETH': 10,
+            'ZEC': 0,
+        },
+        'used': {
+            'ETH': 10,
+            'ZEC': 0,
+        },
+        'total': {
+            'ETH': 20,
+            'ZEC': 0,
+        },
+    }
+
+    const actual = exchange.safeBalance (input)
+
+    deepEqual (actual, expected)
+}
+
+// ------------------------------------------------------------------------
+
+function testCamelCasePropertyConversion() {
+
+    const exchange = new Exchange ({ 'id': 'mock' })
+
+    const propsSeenBefore = index (
+        ["isNode", "empty", "keys", "values", "extend", "clone", "index", "ordered", "unique", "keysort", "indexBy", "groupBy", "filterBy", "sortBy", "flatten", "pluck", "omit", "sum", "deepExtend", "uuid", "unCamelCase", "capitalize", "isNumber", "isArray", "isObject", "isString", "isStringCoercible", "isDictionary", "hasProps", "prop", "asFloat", "asInteger", "safeFloat", "safeInteger", "safeValue", "safeString", "decimal", "toFixed", "truncate", "truncateToString", "precisionFromString", "stringToBinary", "stringToBase64", "base64ToBinary", "base64ToString", "binaryToString", "binaryConcat", "urlencode", "rawencode", "urlencodeBase64", "hash", "hmac", "jwt", "time", "setTimeout_safe", "sleep", "TimedOut", "timeout", "throttle", "json", "aggregate", "is_node", "index_by", "group_by", "filter_by", "sort_by", "deep_extend", "un_camel_case", "is_number", "is_array", "is_object", "is_string", "is_string_coercible", "is_dictionary", "has_props", "as_float", "as_integer", "safe_float", "safe_integer", "safe_value", "safe_string", "to_fixed", "truncate_to_string", "precision_from_string", "string_to_binary", "string_to_base64", "utf16To_base64", "base64To_binary", "base64To_string", "binary_to_string", "binary_concat", "urlencode_base64", "set_timeout_safe", "Timed_out", "encode", "decode", "userAgents", "headers", "proxy", "origin", "iso8601", "parse8601", "milliseconds", "microseconds", "seconds", "id", "enableRateLimit", "rateLimit", "parseJsonResponse", "substituteCommonCurrencyCodes", "verbose", "debug", "journal", "userAgent", "twofa", "timeframes", "hasPublicAPI", "hasPrivateAPI", "hasCORS", "hasDeposit", "hasFetchBalance", "hasFetchClosedOrders", "hasFetchCurrencies", "hasFetchMyTrades", "hasFetchOHLCV", "hasFetchOpenOrders", "hasFetchOrder", "hasFetchOrderBook", "hasFetchOrders", "hasFetchTicker", "hasFetchTickers", "hasFetchBidsAsks", "hasFetchTrades", "hasWithdraw", "hasCreateOrder", "hasCancelOrder", "apiKey", "secret", "uid", "login", "password", "requiredCredentials", "exceptions", "balance", "orderbooks", "tickers", "fees", "orders", "trades", "currencies", "last_http_response", "last_json_response", "arrayConcat", "market_id", "market_ids", "array_concat", "implode_params", "extract_params", "fetch_balance", "fetch_free_balance", "fetch_used_balance","fetch_total_balance", "fetch_l2_order_book", "fetch_order_book", "fetch_bids_asks", "fetch_tickers", "fetch_ticker", "fetch_trades", "fetch_order", "fetch_orders", "fetch_open_orders", "fetch_closed_orders", "fetch_order_status", "fetch_markets", "load_markets", "set_markets", "parse_balance", "parse_bid_ask", "parse_bids_asks", "parse_order_book", "parse_trades", "parse_orders", "parse_ohlcv", "parse_ohlcvs", "edit_limit_buy_order", "edit_limit_sell_order", "edit_limit_order", "edit_order", "create_limit_buy_order", "create_limit_sell_order", "create_market_buy_order", "create_market_sell_order", "create_order", "calculate_fee", "common_currency_code", "price_to_precision", "amount_to_precision", "amount_to_string", "fee_to_precision", "cost_to_precision", "constructor", "getMarket", "describe", "defaults", "nonce", "encodeURIComponent", "checkRequiredCredentials", "initRestRateLimiter", "defineRestApi", "fetch", "fetch2", "request", "handleErrors", "defaultErrorHandler", "handleRestErrors", "handleRestResponse", "setMarkets", "loadMarkets", "fetchBidsAsks", "fetchTickers", "fetchOrder", "fetchOrders", "fetchOpenOrders", "fetchClosedOrders", "fetchMyTrades", "fetchCurrencies", "fetchMarkets", "fetchOrderStatus", "account", "commonCurrencyCode", "currency", "market", "marketId", "marketIds", "symbol", "extractParams", "implodeParams", "url", "parseBidAsk", "parseBidsAsks", "fetchL2OrderBook", "parseOrderBook", "safeBalance", "fetchPartialBalance", "fetchFreeBalance", "fetchUsedBalance", "fetchTotalBalance", "filterBySinceLimit", "parseTrades", "parseOrders", "filterOrdersBySymbol", "parseOHLCV", "parseOHLCVs", "editLimitBuyOrder", "editLimitSellOrder", "editLimitOrder", "editOrder", "createLimitBuyOrder", "createLimitSellOrder", "createMarketBuyOrder", "createMarketSellOrder", "costToPrecision", "priceToPrecision", "amountToPrecision", "amountToLots", "feeToPrecision", "calculateFee", "Ymd", "YmdHMS"]
+    )
+
+    const props = index (Object.getOwnPropertyNames (exchange).concat (Object.getOwnPropertyNames (exchange.constructor.prototype)))
+
+    for (const k of Array.from (propsSeenBefore)) {
+        if (this[k] && !props.has (k)) {
+            throw new Error (`missing prop: ${k}`)
         }
+    }
 
-        const actual = exchange.safeBalance (input)
-
-        deepEqual (actual, expected)
-    })
-
-    // ------------------------------------------------------------------------
-
-    it ('camelCase/camel_case property conversion works', () => {
-
-        const exchange = new Exchange ({ 'id': 'mock' })
-
-        const propsSeenBefore = index (
-            ["isNode", "empty", "keys", "values", "extend", "clone", "index", "ordered", "unique", "keysort", "indexBy", "groupBy", "filterBy", "sortBy", "flatten", "pluck", "omit", "sum", "deepExtend", "uuid", "unCamelCase", "capitalize", "isNumber", "isArray", "isObject", "isString", "isStringCoercible", "isDictionary", "hasProps", "prop", "asFloat", "asInteger", "safeFloat", "safeInteger", "safeValue", "safeString", "decimal", "toFixed", "truncate", "truncateToString", "precisionFromString", "stringToBinary", "stringToBase64", "base64ToBinary", "base64ToString", "binaryToString", "binaryConcat", "urlencode", "rawencode", "urlencodeBase64", "hash", "hmac", "jwt", "time", "setTimeout_safe", "sleep", "TimedOut", "timeout", "throttle", "json", "aggregate", "is_node", "index_by", "group_by", "filter_by", "sort_by", "deep_extend", "un_camel_case", "is_number", "is_array", "is_object", "is_string", "is_string_coercible", "is_dictionary", "has_props", "as_float", "as_integer", "safe_float", "safe_integer", "safe_value", "safe_string", "to_fixed", "truncate_to_string", "precision_from_string", "string_to_binary", "string_to_base64", "utf16To_base64", "base64To_binary", "base64To_string", "binary_to_string", "binary_concat", "urlencode_base64", "set_timeout_safe", "Timed_out", "encode", "decode", "userAgents", "headers", "proxy", "origin", "iso8601", "parse8601", "milliseconds", "microseconds", "seconds", "id", "enableRateLimit", "rateLimit", "parseJsonResponse", "substituteCommonCurrencyCodes", "verbose", "debug", "journal", "userAgent", "twofa", "timeframes", "hasPublicAPI", "hasPrivateAPI", "hasCORS", "hasDeposit", "hasFetchBalance", "hasFetchClosedOrders", "hasFetchCurrencies", "hasFetchMyTrades", "hasFetchOHLCV", "hasFetchOpenOrders", "hasFetchOrder", "hasFetchOrderBook", "hasFetchOrders", "hasFetchTicker", "hasFetchTickers", "hasFetchBidsAsks", "hasFetchTrades", "hasWithdraw", "hasCreateOrder", "hasCancelOrder", "apiKey", "secret", "uid", "login", "password", "requiredCredentials", "exceptions", "balance", "orderbooks", "tickers", "fees", "orders", "trades", "currencies", "last_http_response", "last_json_response", "arrayConcat", "market_id", "market_ids", "array_concat", "implode_params", "extract_params", "fetch_balance", "fetch_free_balance", "fetch_used_balance","fetch_total_balance", "fetch_l2_order_book", "fetch_order_book", "fetch_bids_asks", "fetch_tickers", "fetch_ticker", "fetch_trades", "fetch_order", "fetch_orders", "fetch_open_orders", "fetch_closed_orders", "fetch_order_status", "fetch_markets", "load_markets", "set_markets", "parse_balance", "parse_bid_ask", "parse_bids_asks", "parse_order_book", "parse_trades", "parse_orders", "parse_ohlcv", "parse_ohlcvs", "edit_limit_buy_order", "edit_limit_sell_order", "edit_limit_order", "edit_order", "create_limit_buy_order", "create_limit_sell_order", "create_market_buy_order", "create_market_sell_order", "create_order", "calculate_fee", "common_currency_code", "price_to_precision", "amount_to_precision", "amount_to_string", "fee_to_precision", "cost_to_precision", "constructor", "getMarket", "describe", "defaults", "nonce", "encodeURIComponent", "checkRequiredCredentials", "initRestRateLimiter", "defineRestApi", "fetch", "fetch2", "request", "handleErrors", "defaultErrorHandler", "handleRestErrors", "handleRestResponse", "setMarkets", "loadMarkets", "fetchBidsAsks", "fetchTickers", "fetchOrder", "fetchOrders", "fetchOpenOrders", "fetchClosedOrders", "fetchMyTrades", "fetchCurrencies", "fetchMarkets", "fetchOrderStatus", "account", "commonCurrencyCode", "currency", "market", "marketId", "marketIds", "symbol", "extractParams", "implodeParams", "url", "parseBidAsk", "parseBidsAsks", "fetchL2OrderBook", "parseOrderBook", "safeBalance", "fetchPartialBalance", "fetchFreeBalance", "fetchUsedBalance", "fetchTotalBalance", "filterBySinceLimit", "parseTrades", "parseOrders", "filterOrdersBySymbol", "parseOHLCV", "parseOHLCVs", "editLimitBuyOrder", "editLimitSellOrder", "editLimitOrder", "editOrder", "createLimitBuyOrder", "createLimitSellOrder", "createMarketBuyOrder", "createMarketSellOrder", "costToPrecision", "priceToPrecision", "amountToPrecision", "amountToLots", "feeToPrecision", "calculateFee", "Ymd", "YmdHMS"]
-        )
-
-        const props = index (Object.getOwnPropertyNames (exchange).concat (Object.getOwnPropertyNames (exchange.constructor.prototype)))
-
-        for (const k of Array.from (propsSeenBefore)) {
-            if (this[k] && !props.has (k)) {
-                throw new Error (`missing prop: ${k}`)
-            }
+    for (const k of Array.from (props)) {
+        if (!propsSeenBefore.has (k)) {
+            log.magenta.noLocate (`+ ${k}`)
         }
+    }
 
-        for (const k of Array.from (props)) {
-            if (!propsSeenBefore.has (k)) {
-                log.magenta.noLocate (`+ ${k}`)
-            }
+}
+
+// ------------------------------------------------------------------------
+
+function testCamelCasePropertyConversion2() {
+
+    class Derived extends Exchange {}
+    const derived = new Derived ()
+    equal (typeof derived.load_markets, 'function')
+}
+
+// ------------------------------------------------------------------------
+
+function testLegacyHasSomething() {
+
+    const exchange = new Exchange ({
+        'id': 'mock',
+        'has': {
+            'CORS': true,
+            'publicAPI': false,
+            'fetchDepositAddress': 'emulated'
         }
-
     })
 
-    // ------------------------------------------------------------------------
-
-    it ('camelCase/camel_case property conversion works #2', () => {
-
-        class Derived extends Exchange {}
-        const derived = new Derived ()
-        equal (typeof derived.load_markets, 'function')
-    })
-
-    // ------------------------------------------------------------------------
-
-    it ('legacy .hasSomething maps to has.something automatically', () => {
-
-        const exchange = new Exchange ({
-            'id': 'mock',
-            'has': {
-                'CORS': true,
-                'publicAPI': false,
-                'fetchDepositAddress': 'emulated'
-            }
-        })
-
-        equal (exchange.hasCORS, true)
-        equal (exchange.hasPublicAPI, false)
-        equal (exchange.hasFetchDepositAddress, true)
-    })
-})
+    equal (exchange.hasCORS, true)
+    equal (exchange.hasPublicAPI, false)
+    equal (exchange.hasFetchDepositAddress, true)
+}
 
 // ----------------------------------------------------------------------------
-*/
+
+function testBase() {
+	testCalculateFee()
+	// testExchangeConfigExtension() // skipped
+	testAggregate()
+	testSafeBalance()
+	testCamelCasePropertyConversion()
+	testCamelCasePropertyConversion2()
+	testLegacyHasSomething()
+}


### PR DESCRIPTION
JavaScript base tests were disabled by removing the MochaJS testing framework (part of removing external dependencies).
This PR re-works the JavaScript base tests to function without MochaJS.
The restructure is very simple. It just creates a family of functions called by a master testing function.
Passes/Fails are not counted or displayed. Fails are simply asserted and indicated by a stack trace.
Note that test.time.js remains disabled and awaiting a future fix.