### PR TITLE
deribit - transfer

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -62,6 +62,7 @@ module.exports = class deribit extends Exchange {
                 'fetchTrades': true,
                 'fetchTransactions': undefined,
                 'fetchWithdrawals': true,
+                'transfer': false,
                 'withdraw': true,
             },
             'timeframes': {


### PR DESCRIPTION
Deribit has no endpoint to transfer between account types. It only has endpoints for transfers to sub accounts and to transfer to other users.