### PR TITLE
bybit: add trading fee rate api

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -315,7 +315,7 @@ module.exports = class bybit extends Exchange {
                         'v2/private/stop-order/list': 5,
                         'v2/private/stop-order': 1,
                         'v2/private/position/list': 25,
-                        'v2/private/position/fee-rate': 1,
+                        'v2/private/position/fee-rate': 40,
                         'v2/private/execution/list': 25,
                         'v2/private/trade/closed-pnl/list': 1,
                         'v2/public/risk-limit/list': 1, // TODO check

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -315,6 +315,7 @@ module.exports = class bybit extends Exchange {
                         'v2/private/stop-order/list': 5,
                         'v2/private/stop-order': 1,
                         'v2/private/position/list': 25,
+                        'v2/private/position/fee-rate': 1,
                         'v2/private/execution/list': 25,
                         'v2/private/trade/closed-pnl/list': 1,
                         'v2/public/risk-limit/list': 1, // TODO check

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -206,6 +206,7 @@ module.exports = class bybit extends Exchange {
                             'stop-order/list',
                             'stop-order',
                             'position/list',
+                            'position/fee-rate',
                             'execution/list',
                             'trade/closed-pnl/list',
                             'funding/prev-funding-rate',


### PR DESCRIPTION
There is new api to fetch trading fee rate in Bybit.

In this PR, I added this api. Also I was curious about the api rate limit settings, is there any reason they were separated, eg: `v2/private/wallet/balance`?

Reference: https://bybit-exchange.github.io/docs/inverse/#t-queryfeerate