### PR TITLE
Mexc: error for trade read permission

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -292,6 +292,7 @@ module.exports = class mexc extends Exchange {
                     '401': AuthenticationError, // Invalid signature, fail to pass the validation
                     '403': PermissionDenied, // {"msg":"no permission to access the endpoint","code":403}
                     '429': RateLimitExceeded, // too many requests, rate limit rule is violated
+                    '703': PermissionDenied, // Require trade read permission!
                     '1000': AccountNotEnabled, // {"success":false,"code":1000,"message":"Please open contract account first!"}
                     '1002': InvalidOrder, // {"success":false,"code":1002,"message":"Contract not allow place order!"}
                     '10072': AuthenticationError, // Invalid access key


### PR DESCRIPTION
`contractPrivateGetPositionListHistoryPositions()`

`{"success":false,"code":"703","message":"Require trade read permission!"}`

url: https://contract.mexc.com/api/v1/private/position/list/history_positions?page_num=1&page_size=100