### PR TITLE
ftx.fetchBorrowRateHistories bug fixes related to a max limit of 48

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2487,7 +2487,7 @@ module.exports = class ftx extends Exchange {
         const request = {};
         let endTime = this.safeNumber2 (params, 'till', 'end_time');
         if (limit > 48) {
-            throw new BadRequest (this.id + ' fetchBorrowRateHistories limit cannot exceed 48');
+            throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 48');
         }
         const millisecondsPerHour = 3600000;
         const millisecondsPer2Days = 172800000;
@@ -2495,12 +2495,11 @@ module.exports = class ftx extends Exchange {
             throw new BadRequest (this.id + ' fetchBorrowRateHistories() requires the time range between the since time and the end time to be less than 48 hours');
         }
         if (since !== undefined) {
-            request['start_time'] = since / 1000;
+            request['start_time'] = parseInt (since / 1000);
             if (endTime === undefined) {
                 const now = this.milliseconds ();
                 const sinceLimit = (limit === undefined) ? 2 : limit;
-                const timeBetween = millisecondsPerHour * (sinceLimit - 1);
-                endTime = since + timeBetween;
+                endTime = this.sum (since, millisecondsPerHour * (sinceLimit - 1));
                 endTime = Math.min (endTime, now);
             }
         } else {
@@ -2508,13 +2507,12 @@ module.exports = class ftx extends Exchange {
                 if (endTime === undefined) {
                     endTime = this.milliseconds ();
                 }
-                const timeBetween = millisecondsPerHour * limit;
-                const startTime = (endTime - timeBetween) + 1000;
-                request['start_time'] = startTime / 1000;
+                const startTime = this.sum ((endTime - millisecondsPerHour * limit), 1000);
+                request['start_time'] = parseInt (startTime / 1000);
             }
         }
         if (endTime !== undefined) {
-            request['end_time'] = endTime / 1000;
+            request['end_time'] = parseInt (endTime / 1000);
         }
         const response = await this.publicGetSpotMarginHistory (this.extend (request, params));
         //

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2492,7 +2492,7 @@ module.exports = class ftx extends Exchange {
         const millisecondsPerHour = 3600000;
         const millisecondsPer2Days = 172800000;
         if ((endTime - since) > millisecondsPer2Days) {
-            throw new BadRequest ('The time between since and the end time be >= 48 hours using ' + this.id + ' fetchBorrowRateHistories');
+            throw new BadRequest (this.id + ' fetchBorrowRateHistories() requires the time range between the since time and the end time to be less than 48 hours');
         }
         if (since !== undefined) {
             request['start_time'] = since / 1000;

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2485,27 +2485,28 @@ module.exports = class ftx extends Exchange {
     async fetchBorrowRateHistories (since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {};
-        let endTime = this.safeNumber2 (params, 'till', 'end_time');
+        const now = this.milliseconds ();
+        let endTime = this.safeNumber2 (params, 'till', 'end_time', now);
         if (limit > 48) {
             throw new BadRequest (this.id + ' fetchBorrowRateHistories cannot exceed 48');
         }
+        if ((endTime - since) > 172800000) {
+            throw new BadRequest ('The time between since and the end time be >= 48 hours using ' + this.id + ' fetchBorrowRateHistories');
+        }
         if (since !== undefined) {
             request['start_time'] = since / 1000;
-            const since_limit = (limit === undefined) ? 2 : limit;
             if (endTime === undefined) {
-                endTime = since;
+                const sinceLimit = (limit === undefined) ? 2 : limit;
                 const now = this.milliseconds ();
-                for (let i = 0; (i < since_limit && endTime < now); i++) {
-                    endTime = Math.min (endTime + 3600000, now);
-                }
+                endTime = Math.min ((since + (3600000 * (sinceLimit - 1))), now);
+            }
+        } else {
+            if (limit !== undefined) {
+                const startTime = (endTime - (3600000 * limit)) + 1000;
+                request['start_time'] = startTime / 1000;
             }
         }
-        if ((endTime - since) > 172800000) {
-            throw new BadRequest ('The time between since and the end time cannot exceed 48 hours using ' + this.id + ' fetchBorrowRateHistories');
-        }
-        if (endTime !== undefined) {
-            request['end_time'] = endTime / 1000;
-        }
+        request['end_time'] = endTime / 1000;
         const response = await this.publicGetSpotMarginHistory (this.extend (request, params));
         //
         //    {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2558,6 +2558,22 @@ module.exports = class ftx extends Exchange {
         if (borrowRateHistory === undefined) {
             throw new BadRequest (this.id + '.fetchBorrowRateHistory returned no data for ' + code);
         } else {
+            const resultLength = borrowRateHistory.length;
+            if (resultLength === limit - 1) {
+                const hourLength = 3600000;
+                const recentHour = parseInt (this.milliseconds () / hourLength) * hourLength;
+                const penultimateHour = recentHour - hourLength;
+                const lastTimestamp = borrowRateHistory[0]['timestamp'];
+                if (lastTimestamp === penultimateHour) {
+                    borrowRateHistory.push ({
+                        'currency': code,
+                        'rate': undefined,
+                        'timestamp': recentHour,
+                        'datetime': this.iso8601 (recentHour),
+                        'info': {},
+                    });
+                }
+            }
             return borrowRateHistory;
         }
     }

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2485,10 +2485,9 @@ module.exports = class ftx extends Exchange {
     async fetchBorrowRateHistories (since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {};
-        const now = this.milliseconds ();
-        let endTime = this.safeNumber2 (params, 'till', 'end_time', now);
+        let endTime = this.safeNumber2 (params, 'till', 'end_time');
         if (limit > 48) {
-            throw new BadRequest (this.id + ' fetchBorrowRateHistories cannot exceed 48');
+            throw new BadRequest (this.id + ' fetchBorrowRateHistories limit cannot exceed 48');
         }
         if ((endTime - since) > 172800000) {
             throw new BadRequest ('The time between since and the end time be >= 48 hours using ' + this.id + ' fetchBorrowRateHistories');
@@ -2496,17 +2495,22 @@ module.exports = class ftx extends Exchange {
         if (since !== undefined) {
             request['start_time'] = since / 1000;
             if (endTime === undefined) {
-                const sinceLimit = (limit === undefined) ? 2 : limit;
                 const now = this.milliseconds ();
+                const sinceLimit = (limit === undefined) ? 2 : limit;
                 endTime = Math.min ((since + (3600000 * (sinceLimit - 1))), now);
             }
         } else {
             if (limit !== undefined) {
+                if (endTime === undefined) {
+                    endTime = this.milliseconds ();
+                }
                 const startTime = (endTime - (3600000 * limit)) + 1000;
                 request['start_time'] = startTime / 1000;
             }
         }
-        request['end_time'] = endTime / 1000;
+        if (endTime !== undefined) {
+            request['end_time'] = endTime / 1000;
+        }
         const response = await this.publicGetSpotMarginHistory (this.extend (request, params));
         //
         //    {


### PR DESCRIPTION
fixes:https://stackoverflow.com/questions/71722629/ccxt-ftx-fetch-borrow-rate-history-only-get-the-latest-40s-rows

----------

2022-04-04T13:37:25.172Z
Node.js: v14.17.0
CCXT v1.78.4
```
ftx.fetchBorrowRateHistory (USDT, , 5)
2022-04-04T13:37:28.226Z iteration 0 passed in 2550 ms

currency |        rate |     timestamp |                  datetime
------------------------------------------------------------------
    USDT | 0.000003078 | 1649077200000 | 2022-04-04T13:00:00+00:00
    USDT | 0.000003078 | 1649073600000 | 2022-04-04T12:00:00+00:00
    USDT | 0.000003078 | 1649070000000 | 2022-04-04T11:00:00+00:00
    USDT | 0.000003078 | 1649066400000 | 2022-04-04T10:00:00+00:00
    USDT | 0.000003078 | 1649062800000 | 2022-04-04T09:00:00+00:00
5 objects
```
```
ftx.fetchBorrowRateHistory (USDT, 1646092800000)
2022-04-04T13:37:38.528Z iteration 0 passed in 2280 ms

currency |        rate |     timestamp |                  datetime
------------------------------------------------------------------
    USDT | 0.000001539 | 1646096400000 | 2022-03-01T01:00:00+00:00
    USDT | 0.000001539 | 1646092800000 | 2022-03-01T00:00:00+00:00
2 objects
```
```
ftx.fetchBorrowRateHistory (USDT, , , [object Object])
2022-04-04T13:38:11.124Z iteration 0 passed in 1375 ms

currency |         rate |     timestamp |                  datetime
-------------------------------------------------------------------
    USDT | 0.0000023085 | 1646265600000 | 2022-03-03T00:00:00+00:00
    USDT |   0.00000243 | 1646262000000 | 2022-03-02T23:00:00+00:00
2 objects
```
```
ftx.fetchBorrowRateHistory (USDT, , 5, [object Object])
2022-04-04T13:41:12.488Z iteration 0 passed in 2965 ms

currency |         rate |     timestamp |                  datetime
-------------------------------------------------------------------
    USDT | 0.0000023085 | 1646265600000 | 2022-03-03T00:00:00+00:00
    USDT |   0.00000243 | 1646262000000 | 2022-03-02T23:00:00+00:00
    USDT | 0.0000023085 | 1646258400000 | 2022-03-02T22:00:00+00:00
    USDT | 0.0000027675 | 1646254800000 | 2022-03-02T21:00:00+00:00
    USDT |    0.0000027 | 1646251200000 | 2022-03-02T20:00:00+00:00
5 objects
```
```
ftx.fetchBorrowRateHistory (USDT, 1646092800000, 5, [object Object])
2022-04-04T13:43:48.250Z iteration 0 passed in 2530 ms

currency |         rate |     timestamp |                  datetime
-------------------------------------------------------------------
    USDT | 0.0000023085 | 1646265600000 | 2022-03-03T00:00:00+00:00
    USDT |   0.00000243 | 1646262000000 | 2022-03-02T23:00:00+00:00
    USDT | 0.0000023085 | 1646258400000 | 2022-03-02T22:00:00+00:00
    USDT | 0.0000027675 | 1646254800000 | 2022-03-02T21:00:00+00:00
    USDT |    0.0000027 | 1646251200000 | 2022-03-02T20:00:00+00:00
5 objects
```
```
ftx.fetchBorrowRateHistory (USDT, 1646092800000, , [object Object])
2022-04-04T13:44:34.662Z iteration 0 passed in 2583 ms

currency |         rate |     timestamp |                  datetime
-------------------------------------------------------------------
    USDT | 0.0000023085 | 1646265600000 | 2022-03-03T00:00:00+00:00
    ...
    USDT |  0.000001539 | 1646096400000 | 2022-03-01T01:00:00+00:00
```
```
ftx.fetchBorrowRateHistory (USDT, 1646092800000, 48)
2022-04-04T13:46:13.703Z iteration 0 passed in 2344 ms

currency |         rate |     timestamp |                  datetime
-------------------------------------------------------------------
    USDT |   0.00000243 | 1646262000000 | 2022-03-02T23:00:00+00:00
    ...
    USDT |  0.000001539 | 1646092800000 | 2022-03-01T00:00:00+00:00
```
```
ftx.fetchBorrowRateHistory (USDT, 1646092800000, , [object Object])
BadRequest The time between since and the end time be >= 48 hours using ftx fetchBorrowRateHistories
---------------------------------------------------
[BadRequest] The time between since and the end time be >= 48 hours using ftx fetchBorrowRateHistories

    at fetchBorrowRateHistories   ../../ccxt/ccxt/js/ftx.js:2493          throw new BadRequest ('The time between since and the end time be >= 48 hours u…
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at fetchBorrowRateHistory     ../../ccxt/ccxt/js/ftx.js:2560          const histories = await this.fetchBorrowRateHistories (since, limit, params);   
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:269  const result = await exchange[methodName] (... args)                            

The time between since and the end time be >= 48 hours using ftx fetchBorrowRateHistories
```
```
ftx.fetchBorrowRateHistory (USDT, 1646092800000, 49)
BadRequest ftx fetchBorrowRateHistories limit cannot exceed 48
---------------------------------------------------
[BadRequest] ftx fetchBorrowRateHistories limit cannot exceed 48

    at fetchBorrowRateHistories   ../../ccxt/ccxt/js/ftx.js:2490          throw new BadRequest (this.id + ' fetchBorrowRateHistories limit cannot exceed …
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at fetchBorrowRateHistory     ../../ccxt/ccxt/js/ftx.js:2560          const histories = await this.fetchBorrowRateHistories (since, limit, params);   
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:269  const result = await exchange[methodName] (... args)                            

ftx fetchBorrowRateHistories limit cannot exceed 48
```