### PR TITLE
Support for SAPIV3 methods

### DIFF
--- a/python/ccxt/binance.py
+++ b/python/ccxt/binance.py
@@ -158,6 +158,7 @@ class binance(Exchange):
                 'api': {
                     'wapi': 'https://api.binance.com/wapi/v3',
                     'sapi': 'https://api.binance.com/sapi/v1',
+                    'sapiV3': 'https://api.binance.com/sapi/v3',
                     'dapiPublic': 'https://dapi.binance.com/dapi/v1',
                     'dapiPrivate': 'https://dapi.binance.com/dapi/v1',
                     'vapiPublic': 'https://vapi.binance.com/vapi/v1',
@@ -436,6 +437,11 @@ class binance(Exchange):
                         'broker/subAccountApi': 1,
                         'broker/subAccountApi/ipRestriction/ipList': 1,
                     },
+                },
+				'sapiV3': {
+                    'get': {
+                        'sub-account/assets': 1,
+                    }
                 },
                 # deprecated
                 'wapi': {
@@ -4891,7 +4897,7 @@ class binance(Exchange):
                     body = self.urlencode(params)
             else:
                 raise AuthenticationError(self.id + ' userDataStream endpoint requires `apiKey` credential')
-        elif (api == 'private') or (api == 'sapi' and path != 'system/status') or (api == 'wapi' and path != 'systemStatus') or (api == 'dapiPrivate') or (api == 'dapiPrivateV2') or (api == 'fapiPrivate') or (api == 'fapiPrivateV2'):
+        elif (api == 'private') or (api == 'sapi' and path != 'system/status') or (api == 'wapi' and path != 'systemStatus') or or (api == 'sapiv3' and path != 'systemStatus') or (api == 'dapiPrivate') or (api == 'dapiPrivateV2') or (api == 'fapiPrivate') or (api == 'fapiPrivateV2'):
             self.check_required_credentials()
             query = None
             recvWindow = self.safe_integer(self.options, 'recvWindow', 5000)
@@ -4997,7 +5003,7 @@ class binance(Exchange):
     def request(self, path, api='public', method='GET', params={}, headers=None, body=None, config={}, context={}):
         response = self.fetch2(path, api, method, params, headers, body, config, context)
         # a workaround for {"code":-2015,"msg":"Invalid API-key, IP, or permissions for action."}
-        if (api == 'private') or (api == 'wapi'):
+        if (api == 'private') or (api == 'wapi') or (api == 'sapiv3'):
             self.options['hasAlreadyAuthenticatedSuccessfully'] = True
         return response
 


### PR DESCRIPTION
Currently, when using SAPI methods they are always using version v2. 
There are some endpoinds using SAPI that need V3. For example, 'sub-account/assets'
I added this endpoint as well as SAPIV3 api.