### PR TITLE
php&python docstring transpiler regexes

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -348,6 +348,11 @@ class Transpiler {
     getPHPRegexes () {
         return [
             [ /\{([a-zA-Z0-9_-]+?)\}/g, '~$1~' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)
+            [ /\[(.*)\]\{(@link .*)\}/g, '~$2 $1~' ], // docstring item with link
+            [ /\s+\* @method/g, '' ], // docstring @method
+            [ /(\s+)\* @description (.*)/g, '$1\* $2' ], // docstring description
+            [ /\s+\* @name .*/g, '' ], // docstring @name
+            [ /(\s+)\* @returns/g, '$1\* @return' ], // docstring return
             [ /\!Array\.isArray\s*\(([^\)]+)\)/g, "gettype($1) === 'array' && count(array_filter(array_keys($1), 'is_string')) != 0" ],
             [ /Array\.isArray\s*\(([^\)]+)\)/g, "gettype($1) === 'array' && count(array_filter(array_keys($1), 'is_string')) == 0" ],
             [ /([^\(\s]+)\s+instanceof\s+String/g, 'is_string($1)' ],
@@ -488,7 +493,7 @@ class Transpiler {
             [ /process\.exit/g, 'exit'],
             [ /super\./g, 'parent::'],
             [ /\sdelete\s([^\n]+)\;/g, ' unset($1);' ],
-            [ /\~([a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)
+            [ /\~([@\.\s+\:\/#\-a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)
         ])
     }
 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -493,7 +493,8 @@ class Transpiler {
             [ /process\.exit/g, 'exit'],
             [ /super\./g, 'parent::'],
             [ /\sdelete\s([^\n]+)\;/g, ' unset($1);' ],
-            [ /\~([@\.\s+\:\/#\-a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)
+            [ /\~([a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)        ])
+            [ /\~(@link.*)\~/g, '{$1}' ],
         ])
     }
 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -326,8 +326,14 @@ class Transpiler {
             [ /\=\=\sTrue/g, 'is True' ], // a correction for PEP8 E712, it likes "is True", not "== True"
             [ /\sdelete\s/g, ' del ' ],
             [ /(?<!#.+)null/, 'None' ],
-            [ /\/\*\*/, '\'\'\'' ], // Doc strings
-            [ / \*\//, '\'\'\'' ], // Doc strings
+            [ /\/\*\*/, '\"\"\"' ], // Doc strings
+            [ / \*\//, '\"\"\"' ], // Doc strings
+            [ /\[(.*)\]\{@link (.*)\}/g, '`$1 <$2>`' ], // docstring item with link
+            [ /\s+\* @method/g, '' ], // docstring @method
+            [ /(\s+) \* @description (.*)/g, '$1$2' ], // docstring description
+            [ /\s+\* @name .*/g, '' ], // docstring @name
+            [ /(\s+) \* @returns/g, '$1:returns:' ], // docstring return
+            [ /(\s+) \* @([a-z]+) \{([a-z]+)\} ([a-zA-Z0-9_\-\.]+)/g, '$1:$2 $3 $4:' ], // docstring param
         ])
     }
 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -493,8 +493,7 @@ class Transpiler {
             [ /process\.exit/g, 'exit'],
             [ /super\./g, 'parent::'],
             [ /\sdelete\s([^\n]+)\;/g, ' unset($1);' ],
-            [ /\~([a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)        ])
-            [ /\~(@link.*)\~/g, '{$1}' ],
+            [ /\~([@\.\s+\:\/#\-a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)
         ])
     }
 

--- a/examples/js/delta-maintenance-margin-rate-max-leverage.js
+++ b/examples/js/delta-maintenance-margin-rate-max-leverage.js
@@ -4,10 +4,10 @@ console.log ('CCXT Version:', ccxt.version);
 
 function getMaxLeverage (market, positionSize) {
     /**
-     * Equation taken from https://www.delta.exchange/contracts/
-     * @param market: CCXT market
-     * @param positionSize: The value of the position in quote currency
-     * @return: The maximum leverage available for the market for the given position size
+     * @description Equation taken from https://www.delta.exchange/contracts/
+     * @param {dict} market CCXT market
+     * @param {float} positionSize The value of the position in quote currency
+     * @returns The maximum leverage available for the market for the given position size
      */
     const info = market['info'];
     const maxLeverageNotional = Number (info['max_leverage_notional']);
@@ -26,10 +26,10 @@ function getMaxLeverage (market, positionSize) {
 
 function getMaintenanceMarginRate (market, positionSize) {
     /**
-     * Equation taken from https://www.delta.exchange/contracts/
-     * @param market: CCXT market
-     * @param positionSize: The value of the position in quote currency
-     * @return: The maintenance margin rate as a percentage for the market with the given position size
+     * @description Equation taken from https://www.delta.exchange/contracts/
+     * @param {dict} market CCXT market
+     * @param {float} positionSize The value of the position in quote currency
+     * @returns The maintenance margin rate as a percentage for the market with the given position size
      */
     const info = market['info'];
     const maxLeverageNotional = Number (info['max_leverage_notional']);

--- a/js/aax.js
+++ b/js/aax.js
@@ -2357,30 +2357,32 @@ module.exports = class aax extends Exchange {
 
     parseMarketLeverageTiers (info, market) {
         /**
-            @param info: Exchange market response
-            {
-                "tickSize":"0.01",
-                "lotSize":"1",
-                "base":"BTC",
-                "quote":"USDT",
-                "minQuantity":"1.0000000000",
-                "maxQuantity":"30000",
-                "minPrice":"0.0100000000",
-                "maxPrice":"999999.0000000000",
-                "status":"readOnly",
-                "symbol":"BTCUSDTFP",
-                "code":"FP",
-                "takerFee":"0.00040",
-                "makerFee":"0.00020",
-                "multiplier":"0.001000000000",
-                "mmRate":"0.00500",
-                "imRate":"0.01000",
-                "type":"futures",
-                "settleType":"Vanilla",
-                "settleCurrency":"USDT"
-            }
-            @param market: CCXT Market
-        */
+         * @param {dict} info Exchange market response
+         * @param {dict} market CCXT Market
+         */
+        //
+        //    {
+        //        "tickSize":"0.01",
+        //        "lotSize":"1",
+        //        "base":"BTC",
+        //        "quote":"USDT",
+        //        "minQuantity":"1.0000000000",
+        //        "maxQuantity":"30000",
+        //        "minPrice":"0.0100000000",
+        //        "maxPrice":"999999.0000000000",
+        //        "status":"readOnly",
+        //        "symbol":"BTCUSDTFP",
+        //        "code":"FP",
+        //        "takerFee":"0.00040",
+        //        "makerFee":"0.00020",
+        //        "multiplier":"0.001000000000",
+        //        "mmRate":"0.00500",
+        //        "imRate":"0.01000",
+        //        "type":"futures",
+        //        "settleType":"Vanilla",
+        //        "settleCurrency":"USDT"
+        //    }
+        //
         let maintenanceMarginRate = this.safeString (info, 'mmRate');
         let initialMarginRate = this.safeString (info, 'imRate');
         const maxVol = this.safeString (info, 'maxQuantity');

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2362,30 +2362,32 @@ module.exports = class ascendex extends Exchange {
 
     parseMarketLeverageTiers (info, market = undefined) {
         /**
-            @param info: Exchange market response for 1 market
-            {
-                "symbol":"BTC-PERP",
-                "status":"Normal",
-                "displayName":"BTCUSDT",
-                "settlementAsset":"USDT",
-                "underlying":"BTC/USDT",
-                "tradingStartTime":1579701600000,
-                "priceFilter":{"minPrice":"1","maxPrice":"1000000","tickSize":"1"},
-                "lotSizeFilter":{"minQty":"0.0001","maxQty":"1000000000","lotSize":"0.0001"},
-                "commissionType":"Quote",
-                "commissionReserveRate":"0.001",
-                "marketOrderPriceMarkup":"0.03",
-                "marginRequirements":[
-                    {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"50000","initialMarginRate":"0.01","maintenanceMarginRate":"0.006"},
-                    {"positionNotionalLowerBound":"50000","positionNotionalUpperBound":"200000","initialMarginRate":"0.02","maintenanceMarginRate":"0.012"},
-                    {"positionNotionalLowerBound":"200000","positionNotionalUpperBound":"2000000","initialMarginRate":"0.04","maintenanceMarginRate":"0.024"},
-                    {"positionNotionalLowerBound":"2000000","positionNotionalUpperBound":"20000000","initialMarginRate":"0.1","maintenanceMarginRate":"0.06"},
-                    {"positionNotionalLowerBound":"20000000","positionNotionalUpperBound":"40000000","initialMarginRate":"0.2","maintenanceMarginRate":"0.12"},
-                    {"positionNotionalLowerBound":"40000000","positionNotionalUpperBound":"1000000000","initialMarginRate":"0.333333","maintenanceMarginRate":"0.2"}
-                ]
-            }
-            @param market: CCXT market
-        */
+         * @param {dict} info Exchange market response for 1 market
+         * @param {dict} market CCXT market
+         */
+        //
+        //    {
+        //        "symbol":"BTC-PERP",
+        //        "status":"Normal",
+        //        "displayName":"BTCUSDT",
+        //        "settlementAsset":"USDT",
+        //        "underlying":"BTC/USDT",
+        //        "tradingStartTime":1579701600000,
+        //        "priceFilter":{"minPrice":"1","maxPrice":"1000000","tickSize":"1"},
+        //        "lotSizeFilter":{"minQty":"0.0001","maxQty":"1000000000","lotSize":"0.0001"},
+        //        "commissionType":"Quote",
+        //        "commissionReserveRate":"0.001",
+        //        "marketOrderPriceMarkup":"0.03",
+        //        "marginRequirements":[
+        //            {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"50000","initialMarginRate":"0.01","maintenanceMarginRate":"0.006"},
+        //            {"positionNotionalLowerBound":"50000","positionNotionalUpperBound":"200000","initialMarginRate":"0.02","maintenanceMarginRate":"0.012"},
+        //            {"positionNotionalLowerBound":"200000","positionNotionalUpperBound":"2000000","initialMarginRate":"0.04","maintenanceMarginRate":"0.024"},
+        //            {"positionNotionalLowerBound":"2000000","positionNotionalUpperBound":"20000000","initialMarginRate":"0.1","maintenanceMarginRate":"0.06"},
+        //            {"positionNotionalLowerBound":"20000000","positionNotionalUpperBound":"40000000","initialMarginRate":"0.2","maintenanceMarginRate":"0.12"},
+        //            {"positionNotionalLowerBound":"40000000","positionNotionalUpperBound":"1000000000","initialMarginRate":"0.333333","maintenanceMarginRate":"0.2"}
+        //        ]
+        //    }
+        //
         const marginRequirements = this.safeValue (info, 'marginRequirements');
         const id = this.safeString (info, 'symbol');
         market = this.safeMarket (id, market);

--- a/js/binance.js
+++ b/js/binance.js
@@ -4833,23 +4833,27 @@ module.exports = class binance extends Exchange {
 
     parseMarketLeverageTiers (info, market) {
         /**
-            @param info: Exchange response for 1 market
-            {
-                "symbol": "SUSHIUSDT",
-                "brackets": [
-                    {
-                        "bracket": 1,
-                        "initialLeverage": 50,
-                        "notionalCap": 50000,
-                        "notionalFloor": 0,
-                        "maintMarginRatio": 0.01,
-                        "cum": 0.0
-                    },
-                    ...
-                ]
-            }
-            @param market: CCXT market
-        */
+         * @ignore
+         * @method
+         * @param {dict} info Exchange response for 1 market
+         * @param {dict} market CCXT market
+         */
+        //
+        //    {
+        //        "symbol": "SUSHIUSDT",
+        //        "brackets": [
+        //            {
+        //                "bracket": 1,
+        //                "initialLeverage": 50,
+        //                "notionalCap": 50000,
+        //                "notionalFloor": 0,
+        //                "maintMarginRatio": 0.01,
+        //                "cum": 0.0
+        //            },
+        //            ...
+        //        ]
+        //    }
+        //
         const marketId = this.safeString (info, 'symbol');
         const safeSymbol = this.safeSymbol (marketId);
         market = this.safeMarket (safeSymbol, market);

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1073,10 +1073,10 @@ module.exports = class coinbasepro extends Exchange {
          * @method
          * @name coinbasepro#deposit
          * @description Creates a new deposit address, as required by coinbasepro
-         * @param {string} code Unified CCXT currency code (e.g. `"USDT"`)
+         * @param {str} code Unified CCXT currency code (e.g. `"USDT"`)
          * @param {float} amount The amount of currency to send in the deposit (e.g. `20`)
-         * @param {string} address Not used by coinbasepro
-         * @param {dictionary} params Parameters specific to the exchange API endpoint (e.g. `{"network": "TRX"}`)
+         * @param {str} address Not used by coinbasepro
+         * @param {dict} params Parameters specific to the exchange API endpoint (e.g. `{"network": "TRX"}`)
          * @returns a [transaction structure]{@link https://docs.ccxt.com/en/latest/manual.html#transaction-structure}
          */
         await this.loadMarkets ();

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2593,22 +2593,22 @@ module.exports = class gateio extends Exchange {
          * @method
          * @name gateio#createOrder
          * @description Create an order on the exchange
-         * @param {string} symbol Unified CCXT market symbol
-         * @param {string} type "limit" or "market" *"market" is contract only*
-         * @param {string} side "buy" or "sell"
+         * @param {str} symbol Unified CCXT market symbol
+         * @param {str} type "limit" or "market" *"market" is contract only*
+         * @param {str} side "buy" or "sell"
          * @param {float} amount the amount of currency to trade
          * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
          * @param {dict} params  Extra parameters specific to the exchange API endpoint
          * @param {float} params.stopPrice The price at which a trigger order is triggered at
-         * @param {string} params.timeInForce "gtc" for GoodTillCancelled, "ioc" for ImmediateOrCancelled or poc for PendingOrCancelled
-         * @param {integer} params.iceberg Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
-         * @param {string} params.text User defined information
-         * @param {string} params.account *spot and margin only* "spot", "margin" or "cross_margin"
-         * @param {boolean} params.auto_borrow *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient amount if balance is not enough
-         * @param {string} params.settle *contract only* Unified Currency Code for settle currency
-         * @param {boolean} params.reduceOnly *contract only* Indicates if this order is to reduce the size of a position
-         * @param {boolean} params.close *contract only* Set as true to close the position, with size set to 0
-         * @param {boolean} params.auto_size *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
+         * @param {str} params.timeInForce "gtc" for GoodTillCancelled, "ioc" for ImmediateOrCancelled or poc for PendingOrCancelled
+         * @param {int} params.iceberg Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
+         * @param {str} params.text User defined information
+         * @param {str} params.account *spot and margin only* "spot", "margin" or "cross_margin"
+         * @param {bool} params.auto_borrow *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient amount if balance is not enough
+         * @param {str} params.settle *contract only* Unified Currency Code for settle currency
+         * @param {bool} params.reduceOnly *contract only* Indicates if this order is to reduce the size of a position
+         * @param {bool} params.close *contract only* Set as true to close the position, with size set to 0
+         * @param {bool} params.auto_size *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
          * @returns [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -3083,11 +3083,13 @@ module.exports = class gateio extends Exchange {
 
     async fetchOrder (id, symbol = undefined, params = {}) {
         /**
-         * Retrieves information on an order
-         * @param {string} id: Order id
-         * @param {string} symbol: Unified market symbol
-         * @param {boolean} params.stop: True if the order being fetched is a trigger order
-         * @param {dictionary} params: Parameters specified by the exchange api
+         * @method
+         * @name gateio#fetchOrder
+         * @description Retrieves information on an order
+         * @param {str} id Order id
+         * @param {str} symbol Unified market symbol
+         * @param {bool} params.stop True if the order being fetched is a trigger order
+         * @param {dict} params Parameters specified by the exchange api
          * @returns Order structure
          */
         if (symbol === undefined) {
@@ -3264,11 +3266,13 @@ module.exports = class gateio extends Exchange {
 
     async cancelOrder (id, symbol = undefined, params = {}) {
         /**
-         * Cancels an open order
-         * @param {string} id: Order id
-         * @param {string} symbol: Unified market symbol
-         * @param {boolean} params.stop: True if the order to be cancelled is a trigger order
-         * @param {dictionary} params: Parameters specified by the exchange api
+         * @method
+         * @name gateio#cancelOrder
+         * @description Cancels an open order
+         * @param {str} id Order id
+         * @param {str} symbol Unified market symbol
+         * @param {bool} params.stop True if the order to be cancelled is a trigger order
+         * @param {dict} params Parameters specified by the exchange api
          * @returns Order structure
          */
         if (symbol === undefined) {
@@ -3799,93 +3803,97 @@ module.exports = class gateio extends Exchange {
 
     parseMarketLeverageTiers (info, market = undefined) {
         /**
-            https://www.gate.io/help/futures/perpetual/22162/instrctions-of-risk-limit
-            @param info: Exchange market response for 1 market
-            Perpetual swap
-            {
-                "name": "BTC_USDT",
-                "type": "direct",
-                "quanto_multiplier": "0.0001",
-                "ref_discount_rate": "0",
-                "order_price_deviate": "0.5",
-                "maintenance_rate": "0.005",
-                "mark_type": "index",
-                "last_price": "38026",
-                "mark_price": "37985.6",
-                "index_price": "37954.92",
-                "funding_rate_indicative": "0.000219",
-                "mark_price_round": "0.01",
-                "funding_offset": 0,
-                "in_delisting": false,
-                "risk_limit_base": "1000000",
-                "interest_rate": "0.0003",
-                "order_price_round": "0.1",
-                "order_size_min": 1,
-                "ref_rebate_rate": "0.2",
-                "funding_interval": 28800,
-                "risk_limit_step": "1000000",
-                "leverage_min": "1",
-                "leverage_max": "100",
-                "risk_limit_max": "8000000",
-                "maker_fee_rate": "-0.00025",
-                "taker_fee_rate": "0.00075",
-                "funding_rate": "0.002053",
-                "order_size_max": 1000000,
-                "funding_next_apply": 1610035200,
-                "short_users": 977,
-                "config_change_time": 1609899548,
-                "trade_size": 28530850594,
-                "position_size": 5223816,
-                "long_users": 455,
-                "funding_impact_value": "60000",
-                "orders_limit": 50,
-                "trade_id": 10851092,
-                "orderbook_id": 2129638396
-            }
-            Delivery Futures
-            {
-                "name": "BTC_USDT_20200814",
-                "underlying": "BTC_USDT",
-                "cycle": "WEEKLY",
-                "type": "direct",
-                "quanto_multiplier": "0.0001",
-                "mark_type": "index",
-                "last_price": "9017",
-                "mark_price": "9019",
-                "index_price": "9005.3",
-                "basis_rate": "0.185095",
-                "basis_value": "13.7",
-                "basis_impact_value": "100000",
-                "settle_price": "0",
-                "settle_price_interval": 60,
-                "settle_price_duration": 1800,
-                "settle_fee_rate": "0.0015",
-                "expire_time": 1593763200,
-                "order_price_round": "0.1",
-                "mark_price_round": "0.1",
-                "leverage_min": "1",
-                "leverage_max": "100",
-                "maintenance_rate": "1000000",
-                "risk_limit_base": "140.726652109199",
-                "risk_limit_step": "1000000",
-                "risk_limit_max": "8000000",
-                "maker_fee_rate": "-0.00025",
-                "taker_fee_rate": "0.00075",
-                "ref_discount_rate": "0",
-                "ref_rebate_rate": "0.2",
-                "order_price_deviate": "0.5",
-                "order_size_min": 1,
-                "order_size_max": 1000000,
-                "orders_limit": 50,
-                "orderbook_id": 63,
-                "trade_id": 26,
-                "trade_size": 435,
-                "position_size": 130,
-                "config_change_time": 1593158867,
-                "in_delisting": false
-            }
-            @param market: CCXT market
-        */
+         * @ignore
+         * @method
+         * @description https://www.gate.io/help/futures/perpetual/22162/instrctions-of-risk-limit
+         * @param {dict} info Exchange market response for 1 market
+         * @param {dict} market CCXT market
+         */
+        //
+        //    Perpetual swap
+        //    {
+        //        "name": "BTC_USDT",
+        //        "type": "direct",
+        //        "quanto_multiplier": "0.0001",
+        //        "ref_discount_rate": "0",
+        //        "order_price_deviate": "0.5",
+        //        "maintenance_rate": "0.005",
+        //        "mark_type": "index",
+        //        "last_price": "38026",
+        //        "mark_price": "37985.6",
+        //        "index_price": "37954.92",
+        //        "funding_rate_indicative": "0.000219",
+        //        "mark_price_round": "0.01",
+        //        "funding_offset": 0,
+        //        "in_delisting": false,
+        //        "risk_limit_base": "1000000",
+        //        "interest_rate": "0.0003",
+        //        "order_price_round": "0.1",
+        //        "order_size_min": 1,
+        //        "ref_rebate_rate": "0.2",
+        //        "funding_interval": 28800,
+        //        "risk_limit_step": "1000000",
+        //        "leverage_min": "1",
+        //        "leverage_max": "100",
+        //        "risk_limit_max": "8000000",
+        //        "maker_fee_rate": "-0.00025",
+        //        "taker_fee_rate": "0.00075",
+        //        "funding_rate": "0.002053",
+        //        "order_size_max": 1000000,
+        //        "funding_next_apply": 1610035200,
+        //        "short_users": 977,
+        //        "config_change_time": 1609899548,
+        //        "trade_size": 28530850594,
+        //        "position_size": 5223816,
+        //        "long_users": 455,
+        //        "funding_impact_value": "60000",
+        //        "orders_limit": 50,
+        //        "trade_id": 10851092,
+        //        "orderbook_id": 2129638396
+        //    }
+        //    Delivery Futures
+        //    {
+        //        "name": "BTC_USDT_20200814",
+        //        "underlying": "BTC_USDT",
+        //        "cycle": "WEEKLY",
+        //        "type": "direct",
+        //        "quanto_multiplier": "0.0001",
+        //        "mark_type": "index",
+        //        "last_price": "9017",
+        //        "mark_price": "9019",
+        //        "index_price": "9005.3",
+        //        "basis_rate": "0.185095",
+        //        "basis_value": "13.7",
+        //        "basis_impact_value": "100000",
+        //        "settle_price": "0",
+        //        "settle_price_interval": 60,
+        //        "settle_price_duration": 1800,
+        //        "settle_fee_rate": "0.0015",
+        //        "expire_time": 1593763200,
+        //        "order_price_round": "0.1",
+        //        "mark_price_round": "0.1",
+        //        "leverage_min": "1",
+        //        "leverage_max": "100",
+        //        "maintenance_rate": "1000000",
+        //        "risk_limit_base": "140.726652109199",
+        //        "risk_limit_step": "1000000",
+        //        "risk_limit_max": "8000000",
+        //        "maker_fee_rate": "-0.00025",
+        //        "taker_fee_rate": "0.00075",
+        //        "ref_discount_rate": "0",
+        //        "ref_rebate_rate": "0.2",
+        //        "order_price_deviate": "0.5",
+        //        "order_size_min": 1,
+        //        "order_size_max": 1000000,
+        //        "orders_limit": 50,
+        //        "orderbook_id": 63,
+        //        "trade_id": 26,
+        //        "trade_size": 435,
+        //        "position_size": 130,
+        //        "config_change_time": 1593158867,
+        //        "in_delisting": false
+        //    }
+        //
         const maintenanceMarginUnit = this.safeString (info, 'maintenance_rate'); // '0.005',
         const leverageMax = this.safeString (info, 'leverage_max'); // '100',
         const riskLimitStep = this.safeString (info, 'risk_limit_step'); // '1000000',

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1659,18 +1659,22 @@ module.exports = class kucoinfutures extends kucoin {
 
     parseMarketLeverageTiers (info, market) {
         /**
-            @param info: Exchange market response for 1 market
-            {
-                "symbol": "ETHUSDTM",
-                "level": 1,
-                "maxRiskLimit": 300000,
-                "minRiskLimit": 0,
-                "maxLeverage": 100,
-                "initialMargin": 0.0100000000,
-                "maintainMargin": 0.0050000000
-            }
-            @param market: CCXT market
-        */
+         * @ignore
+         * @method
+         * @param {dict} info Exchange market response for 1 market
+         * @param {dict} market CCXT market
+         */
+        //
+        //    {
+        //        "symbol": "ETHUSDTM",
+        //        "level": 1,
+        //        "maxRiskLimit": 300000,
+        //        "minRiskLimit": 0,
+        //        "maxLeverage": 100,
+        //        "initialMargin": 0.0100000000,
+        //        "maintainMargin": 0.0050000000
+        //    }
+        //
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2968,45 +2968,49 @@ module.exports = class mexc extends Exchange {
 
     parseMarketLeverageTiers (info, market) {
         /**
-            @param info: Exchange response for 1 market
-            {
-                "symbol": "BTC_USDT",
-                "displayName": "BTC_USDT永续",
-                "displayNameEn": "BTC_USDT SWAP",
-                "positionOpenType": 3,
-                "baseCoin": "BTC",
-                "quoteCoin": "USDT",
-                "settleCoin": "USDT",
-                "contractSize": 0.0001,
-                "minLeverage": 1,
-                "maxLeverage": 125,
-                "priceScale": 2,
-                "volScale": 0,
-                "amountScale": 4,
-                "priceUnit": 0.5,
-                "volUnit": 1,
-                "minVol": 1,
-                "maxVol": 1000000,
-                "bidLimitPriceRate": 0.1,
-                "askLimitPriceRate": 0.1,
-                "takerFeeRate": 0.0006,
-                "makerFeeRate": 0.0002,
-                "maintenanceMarginRate": 0.004,
-                "initialMarginRate": 0.008,
-                "riskBaseVol": 10000,
-                "riskIncrVol": 200000,
-                "riskIncrMmr": 0.004,
-                "riskIncrImr": 0.004,
-                "riskLevelLimit": 5,
-                "priceCoefficientVariation": 0.1,
-                "indexOrigin": ["BINANCE","GATEIO","HUOBI","MXC"],
-                "state": 0, // 0 enabled, 1 delivery, 2 completed, 3 offline, 4 pause
-                "isNew": false,
-                "isHot": true,
-                "isHidden": false
-            }
-            @param market: CCXT market
+         * @ignore
+         * @method
+         * @param {dict} info Exchange response for 1 market
+         * @param {dict} market CCXT market
          */
+        //
+        //    {
+        //        "symbol": "BTC_USDT",
+        //        "displayName": "BTC_USDT永续",
+        //        "displayNameEn": "BTC_USDT SWAP",
+        //        "positionOpenType": 3,
+        //        "baseCoin": "BTC",
+        //        "quoteCoin": "USDT",
+        //        "settleCoin": "USDT",
+        //        "contractSize": 0.0001,
+        //        "minLeverage": 1,
+        //        "maxLeverage": 125,
+        //        "priceScale": 2,
+        //        "volScale": 0,
+        //        "amountScale": 4,
+        //        "priceUnit": 0.5,
+        //        "volUnit": 1,
+        //        "minVol": 1,
+        //        "maxVol": 1000000,
+        //        "bidLimitPriceRate": 0.1,
+        //        "askLimitPriceRate": 0.1,
+        //        "takerFeeRate": 0.0006,
+        //        "makerFeeRate": 0.0002,
+        //        "maintenanceMarginRate": 0.004,
+        //        "initialMarginRate": 0.008,
+        //        "riskBaseVol": 10000,
+        //        "riskIncrVol": 200000,
+        //        "riskIncrMmr": 0.004,
+        //        "riskIncrImr": 0.004,
+        //        "riskLevelLimit": 5,
+        //        "priceCoefficientVariation": 0.1,
+        //        "indexOrigin": ["BINANCE","GATEIO","HUOBI","MXC"],
+        //        "state": 0, // 0 enabled, 1 delivery, 2 completed, 3 offline, 4 pause
+        //        "isNew": false,
+        //        "isHot": true,
+        //        "isHidden": false
+        //    }
+        //
         let maintenanceMarginRate = this.safeString (info, 'maintenanceMarginRate');
         let initialMarginRate = this.safeString (info, 'initialMarginRate');
         const maxVol = this.safeString (info, 'maxVol');

--- a/js/okx.js
+++ b/js/okx.js
@@ -2339,16 +2339,16 @@ module.exports = class okx extends Exchange {
          * @method
          * @name okx#fetchOpenOrders
          * @description Fetch orders that are still open
-         * @param {string} symbol Unified market symbol
-         * @param {integer} since Timestamp in ms of the earliest time to retrieve orders for
-         * @param {integer} limit Number of results per request. The maximum is 100; The default is 100
+         * @param {str} symbol Unified market symbol
+         * @param {int} since Timestamp in ms of the earliest time to retrieve orders for
+         * @param {int} limit Number of results per request. The maximum is 100; The default is 100
          * @param {dict} params Extra and exchange specific parameters
-         * @param {integer} params.till Timestamp in ms of the latest time to retrieve orders for
-         * @param {boolean} params.stop True if fetching trigger orders
-         * @param {string} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
-         * @param {string} params.algoId Algo ID
+         * @param {int} params.till Timestamp in ms of the latest time to retrieve orders for
+         * @param {bool} params.stop True if fetching trigger orders
+         * @param {str} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
+         * @param {str} params.algoId Algo ID
          * @returns [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-        */
+         */
         await this.loadMarkets ();
         const request = {
             // 'instType': 'SPOT', // SPOT, MARGIN, SWAP, FUTURES, OPTION
@@ -4404,9 +4404,9 @@ module.exports = class okx extends Exchange {
         /**
          * @ignore
          * @method
-         * @param info: Exchange response for 1 market
-         * @param market: CCXT market
-        */
+         * @param {dict} info Exchange response for 1 market
+         * @param {dict} market CCXT market
+         */
         //
         //    [
         //        {
@@ -4446,12 +4446,12 @@ module.exports = class okx extends Exchange {
          * @method
          * @name okx#fetchBorrowInterest
          * @description Obtain the amount of interest that has accrued for margin trading
-         * @param {string} code The unified currency code for the currency of the interest
-         * @param {string} symbol The market symbol of an isolated margin market, if undefined, the interest for cross margin markets is returned
-         * @param {integer} since Timestamp in ms of the earliest time to receive interest records for
-         * @param {integer} limit The number of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure} to retrieve
+         * @param {str} code The unified currency code for the currency of the interest
+         * @param {str} symbol The market symbol of an isolated margin market, if undefined, the interest for cross margin markets is returned
+         * @param {int} since Timestamp in ms of the earliest time to receive interest records for
+         * @param {int} limit The number of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure} to retrieve
          * @param {dict} params Exchange specific parameters
-         * @param {integer} params.type Loan type 1 - VIP loans 2 - Market loans *Default is Market loans*
+         * @param {int} params.type Loan type 1 - VIP loans 2 - Market loans *Default is Market loans*
          * @returns An array of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure}
          */
         await this.loadMarkets ();

--- a/js/xena.js
+++ b/js/xena.js
@@ -1771,76 +1771,81 @@ module.exports = class xena extends Exchange {
 
     parseMarketLeverageTiers (info, market) {
         /**
-            @param info: Exchange market response for 1 market
-            {
-                "id": "XBTUSD_3M_240622",
-                "type": "Margin",
-                "marginType": "XenaFuture",
-                "symbol": "XBTUSD_3M_240622",
-                "baseCurrency": "BTC",
-                "quoteCurrency": "USD",
-                "settlCurrency": "USDC",
-                "tickSize": 0,
-                "minOrderQuantity": "0.0001",
-                "orderQtyStep": "0.0001",
-                "limitOrderMaxDistance": "10",
-                "priceInputMask": "00000.0",
-                "enabled": true,
-                "liquidationMaxDistance": "0.01",
-                "contractValue": "1",
-                "contractCurrency": "BTC",
-                "lotSize": "1",
-                "maxOrderQty": "10",
-                "maxPosVolume": "200",
-                "mark": ".XBTUSD_3M_240622",
-                "underlying": ".BTC3_TWAP",
-                "openInterest": ".XBTUSD_3M_240622_OpenInterest",
-                "addUvmToFreeMargin": "ProfitAndLoss",
-                "margin": {
-                    "netting": "PositionsAndOrders",
-                    "rates": [
-                        { "maxVolume": "10", "initialRate": "0.05", "maintenanceRate": "0.025" },
-                        { "maxVolume": "20", "initialRate": "0.1", "maintenanceRate": "0.05" },
-                        { "maxVolume": "30", "initialRate": "0.2", "maintenanceRate": "0.1" },
-                        { "maxVolume": "40", "initialRate": "0.3", "maintenanceRate": "0.15" },
-                        { "maxVolume": "60", "initialRate": "0.4", "maintenanceRate": "0.2" },
-                        { "maxVolume": "150", "initialRate": "0.5", "maintenanceRate": "0.25" },
-                        { "maxVolume": "200", "initialRate": "1", "maintenanceRate": "0.5" }
-                    ],
-                    "rateMultipliers": {
-                        "LimitBuy": "1",
-                        "LimitSell": "1",
-                        "Long": "1",
-                        "MarketBuy": "1",
-                        "MarketSell": "1",
-                        "Short": "1",
-                        "StopBuy": "0",
-                        "StopSell": "0"
-                    }
-                },
-                "clearing": { "enabled": true, "index": ".XBTUSD_3M_240622" },
-                "riskAdjustment": { "enabled": true, "index": ".RiskAdjustment_IR" },
-                "expiration": { "enabled": true, "index": ".BTC3_TWAP" },
-                "pricePrecision": 1,
-                "priceRange": {
-                    "enabled": true,
-                    "distance": "0.2",
-                    "movingBoundary": "0",
-                    "lowIndex": ".XBTUSD_3M_240622_LOWRANGE",
-                    "highIndex": ".XBTUSD_3M_240622_HIGHRANGE"
-                },
-                "priceLimits": {
-                    "enabled": true,
-                    "distance": "0.5",
-                    "movingBoundary": "0",
-                    "lowIndex": ".XBTUSD_3M_240622_LOWLIMIT",
-                    "highIndex": ".XBTUSD_3M_240622_HIGHLIMIT"
-                },
-                "serie": "XBTUSD",
-                "tradingStartDate": "2021-12-31 07:00:00",
-                "expiryDate": "2022-06-24 08:00:00"
-            }
-        */
+         * @ignore
+         * @method
+         * @param {dict} info Exchange market response for 1 market
+         * @param {dict} market CCXT market
+         */
+        //
+        //    {
+        //        "id": "XBTUSD_3M_240622",
+        //        "type": "Margin",
+        //        "marginType": "XenaFuture",
+        //        "symbol": "XBTUSD_3M_240622",
+        //        "baseCurrency": "BTC",
+        //        "quoteCurrency": "USD",
+        //        "settlCurrency": "USDC",
+        //        "tickSize": 0,
+        //        "minOrderQuantity": "0.0001",
+        //        "orderQtyStep": "0.0001",
+        //        "limitOrderMaxDistance": "10",
+        //        "priceInputMask": "00000.0",
+        //        "enabled": true,
+        //        "liquidationMaxDistance": "0.01",
+        //        "contractValue": "1",
+        //        "contractCurrency": "BTC",
+        //        "lotSize": "1",
+        //        "maxOrderQty": "10",
+        //        "maxPosVolume": "200",
+        //        "mark": ".XBTUSD_3M_240622",
+        //        "underlying": ".BTC3_TWAP",
+        //        "openInterest": ".XBTUSD_3M_240622_OpenInterest",
+        //        "addUvmToFreeMargin": "ProfitAndLoss",
+        //        "margin": {
+        //            "netting": "PositionsAndOrders",
+        //            "rates": [
+        //                { "maxVolume": "10", "initialRate": "0.05", "maintenanceRate": "0.025" },
+        //                { "maxVolume": "20", "initialRate": "0.1", "maintenanceRate": "0.05" },
+        //                { "maxVolume": "30", "initialRate": "0.2", "maintenanceRate": "0.1" },
+        //                { "maxVolume": "40", "initialRate": "0.3", "maintenanceRate": "0.15" },
+        //                { "maxVolume": "60", "initialRate": "0.4", "maintenanceRate": "0.2" },
+        //                { "maxVolume": "150", "initialRate": "0.5", "maintenanceRate": "0.25" },
+        //                { "maxVolume": "200", "initialRate": "1", "maintenanceRate": "0.5" }
+        //            ],
+        //            "rateMultipliers": {
+        //                "LimitBuy": "1",
+        //                "LimitSell": "1",
+        //                "Long": "1",
+        //                "MarketBuy": "1",
+        //                "MarketSell": "1",
+        //                "Short": "1",
+        //                "StopBuy": "0",
+        //                "StopSell": "0"
+        //            }
+        //        },
+        //        "clearing": { "enabled": true, "index": ".XBTUSD_3M_240622" },
+        //        "riskAdjustment": { "enabled": true, "index": ".RiskAdjustment_IR" },
+        //        "expiration": { "enabled": true, "index": ".BTC3_TWAP" },
+        //        "pricePrecision": 1,
+        //        "priceRange": {
+        //            "enabled": true,
+        //            "distance": "0.2",
+        //            "movingBoundary": "0",
+        //            "lowIndex": ".XBTUSD_3M_240622_LOWRANGE",
+        //            "highIndex": ".XBTUSD_3M_240622_HIGHRANGE"
+        //        },
+        //        "priceLimits": {
+        //            "enabled": true,
+        //            "distance": "0.5",
+        //            "movingBoundary": "0",
+        //            "lowIndex": ".XBTUSD_3M_240622_LOWLIMIT",
+        //            "highIndex": ".XBTUSD_3M_240622_HIGHLIMIT"
+        //        },
+        //        "serie": "XBTUSD",
+        //        "tradingStartDate": "2021-12-31 07:00:00",
+        //        "expiryDate": "2022-06-24 08:00:00"
+        //    }
+        //
         const margin = this.safeValue (info, 'margin');
         const rates = this.safeValue (margin, 'rates');
         let floor = 0;


### PR DESCRIPTION
For proper PHP docstrings

- removes `@method`
- removes `@name exchange#method`
- replaces `@description _______` with `_______`
- replaces `[Example]{@link https://example.com}` with `{@link https://example.com Example}`

---------------------

The last point isn't true yet, it actually gets replaced with `array(@link https://example.com Example)` but I noticed this inside transpile.js 

`[ /\~([a-zA-Z0-9_-]+?)\~/g, '{$1}' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)` 

which looks like it's something that solves the same problem, but it's not being solved in this case, how can I make use of this?

--------------

```
        /**
         * @method
         * @name gateio#createOrder
         * @description Create an order on the exchange
         * @description Create an order on the exchange [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure} some more text
         * @description Create an order on the exchange [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
         * @param {string} symbol Unified CCXT market symbol
         * @param {string} type "limit" or "market" *"market" is contract only*
         * @param {string} side "buy" or "sell" [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure} some more text
         * @param {float} amount the amount of currency to trade [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
         * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
         * @param {dict} params  Extra parameters specific to the exchange API endpoint
         * @param {float} params.stopPrice The price at which a trigger order is triggered at
         * @param {string} params.timeInForce "gtc" for GoodTillCancelled, "ioc" for ImmediateOrCancelled or poc for PendingOrCancelled
         * @param {integer} params.iceberg Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
         * @param {string} params.text User defined information
         * @param {string} params.account *spot and margin only* "spot", "margin" or "cross_margin"
         * @param {boolean} params.auto_borrow *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient amount if balance is not enough
         * @param {string} params.settle *contract only* Unified Currency Code for settle currency
         * @param {boolean} params.reduceOnly *contract only* Indicates if this order is to reduce the size of a position
         * @param {boolean} params.close *contract only* Set as true to close the position, with size set to 0
         * @param {boolean} params.auto_size *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
         * @returns [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
         * @returns [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure} some more text
         * @returns An order structure
         */
```

gets transpiled to php as

```
        /**
         * Create an order on the exchange
         * Create an order on the exchange {@link https://docs.ccxt.com/en/latest/manual.html#order-structure An order structure} some more text
         * Create an order on the exchange {@link https://docs.ccxt.com/en/latest/manual.html#order-structure An order structure}
         * @param {string} $symbol Unified CCXT $market $symbol
         * @param {string} $type "limit" or "market" *"market" is $contract only*
         * @param {string} $side "buy" or "sell" {@link https://docs.ccxt.com/en/latest/manual.html#order-structure An order structure} some more text
         * @param {float} $amount the $amount of currency to trade {@link https://docs.ccxt.com/en/latest/manual.html#order-structure An order structure}
         * @param {float} $price *ignored in "market" orders* the $price at which the order is to be fullfilled at in units of the quote currency
         * @param {dict} $params  Extra parameters specific to the exchange API endpoint
         * @param {float} $params->stopPrice The $price at which a $trigger order is triggered at
         * @param {string} $params->timeInForce "gtc" for GoodTillCancelled, "ioc" for ImmediateOrCancelled or poc for PendingOrCancelled
         * @param {integer} $params->iceberg Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
         * @param {string} $params->text User defined information
         * @param {string} $params->account *spot and margin only* "spot", "margin" or "cross_margin"
         * @param {boolean} $params->auto_borrow *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient $amount if balance is not enough
         * @param {string} $params->settle *$contract only* Unified Currency Code for settle currency
         * @param {boolean} $params->reduceOnly *$contract only* Indicates if this order is to reduce the size of a position
         * @param {boolean} $params->close *$contract only* Set as true to close the position, with size set to 0
         * @param {boolean} $params->auto_size *$contract only* Set $side to close dual-mode position, close_long closes the long $side, while close_short the short one, size also needs to be set to 0
         * @return {@link https://docs.ccxt.com/en/latest/manual.html#order-structure An order structure}
         * @return {@link https://docs.ccxt.com/en/latest/manual.html#order-structure An order structure} some more text
         * @return An order structure
         */
```

which is proper PHP docstring syntax

--------------------

Python

```
        """
        Create an order on the exchange
        :param string symbol: Unified CCXT market symbol
        :param string type: "limit" or "market" *"market" is contract only*
        :param string side: "buy" or "sell"
        :param float amount: the amount of currency to trade
        :param float price: *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
        :param dict params:  Extra parameters specific to the exchange API endpoint
        :param float params.stopPrice: The price at which a trigger order is triggered at
        :param string params.timeInForce: "gtc" for GoodTillCancelled, "ioc" for ImmediateOrCancelled or poc for PendingOrCancelled
        :param integer params.iceberg: Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
        :param string params.text: User defined information
        :param string params.account: *spot and margin only* "spot", "margin" or "cross_margin"
        :param boolean params.auto_borrow: *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient amount if balance is not enough
        :param string params.settle: *contract only* Unified Currency Code for settle currency
        :param boolean params.reduceOnly: *contract only* Indicates if self order is to reduce the size of a position
        :param boolean params.close: *contract only* Set as True to close the position, with size set to 0
        :param boolean params.auto_size: *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
        :returns: `An order structure <https://docs.ccxt.com/en/latest/manual.html#order-structure>`
        """
```