### PR TITLE
Mexc fetchOpenOrders

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1988,7 +1988,7 @@ module.exports = class mexc extends Exchange {
         const cost = this.safeString2 (order, 'deal_amount', 'dealAvgPrice');
         const marketId = this.safeString (order, 'symbol');
         const symbol = this.safeSymbol (marketId, market, '_');
-        const sideCheck = this.safeNumber (order, 'side');
+        const sideCheck = this.safeInteger (order, 'side');
         let side = undefined;
         const bidOrAsk = this.safeString (order, 'type');
         if (bidOrAsk === 'BID') {


### PR DESCRIPTION
Added swap functionality to fetchOpenOrders:
```
mexc.fetchOpenOrders (BTC/USDT:USDT)
2022-04-06T07:31:44.775Z iteration 0 passed in 309 ms

     id |      clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |        symbol | type | timeInForce |      side | price | stopPrice | average | amount | cost | filled | remaining | fee | trades | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
orderId | 266585628878134784 | 1649229367000 | 2022-04-06T07:16:07.000Z |      1649229366000 |      2 | BTC/USDT:USDT |      |             | open long | 30000 |           |         |     11 |    0 |      0 |        11 |     |     [] |   []
1 objects
```