### PR TITLE
CCXT Pro buildOHLCVC/build_ohlcvc example

### DIFF
--- a/examples/ccxt.pro/js/build-ohlcv-many-symbols.js
+++ b/examples/ccxt.pro/js/build-ohlcv-many-symbols.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const ccxtpro = require ('ccxt.pro');
+const asTable  = require ('as-table').configure ({ delimiter: ' | ' })
+
+console.log ('CCXT Pro Version:', ccxtpro.version)
+
+
+async function loop (exchange, symbol, timeframe) {
+    while (true) {
+        try {
+            const trades = await exchange.watchTrades (symbol)
+            if (trades.length >0) {
+                const ohlcvc = exchange.buildOHLCVC(trades, timeframe)
+                console.log("Symbol:", symbol, "timeframe", timeframe);
+                console.log ('-----------------------------------------------------------')
+                console.log (asTable (ohlcvc))
+                console.log ('-----------------------------------------------------------')
+            }
+        } catch (e) {
+            console.log (symbol, e)
+            // do nothing and retry on next loop iteration
+            // throw e // uncomment to break all loops in case of an error in any one of them
+            // break // you can also break just this one loop if it fails
+        }
+    }
+}
+
+async function main () {
+
+    const exchange = new ccxtpro.ftx ()
+
+    if (exchange.has['watchTrades']) {
+        await exchange.loadMarkets ()
+        // Change this value accordingly
+        const timeframe = '15m'
+
+        const allSymbols = exchange.symbols;
+
+        // arbitrary n symbols
+        const limit = 5;
+        const selectedSymbols = allSymbols.slice(0, limit);
+        // you can also specify the symbols
+        // example:
+        // const selectedSymbols = ['BTC/USDT', 'LTC/USDT']
+
+        console.log(selectedSymbols);
+
+        await Promise.all (selectedSymbols.map (symbol => loop (exchange, symbol, timeframe)))
+
+    } else {
+        console.log (exchange.id, 'does not support watchTrades yet')
+    }
+}
+
+main ()

--- a/examples/ccxt.pro/js/build-ohlcv-many-symbols.js
+++ b/examples/ccxt.pro/js/build-ohlcv-many-symbols.js
@@ -12,7 +12,7 @@ async function loop (exchange, symbol, timeframe) {
             const trades = await exchange.watchTrades (symbol)
             if (trades.length >0) {
                 const ohlcvc = exchange.buildOHLCVC(trades, timeframe)
-                console.log("Symbol:", symbol, "timeframe", timeframe);
+                console.log("Symbol:", symbol, "timeframe:", timeframe);
                 console.log ('-----------------------------------------------------------')
                 console.log (asTable (ohlcvc))
                 console.log ('-----------------------------------------------------------')
@@ -27,7 +27,7 @@ async function loop (exchange, symbol, timeframe) {
 }
 
 async function main () {
-
+    // select the exchange
     const exchange = new ccxtpro.ftx ()
 
     if (exchange.has['watchTrades']) {
@@ -40,7 +40,7 @@ async function main () {
         // arbitrary n symbols
         const limit = 5;
         const selectedSymbols = allSymbols.slice(0, limit);
-        // you can also specify the symbols
+        // you can also specify the symbols manually
         // example:
         // const selectedSymbols = ['BTC/USDT', 'LTC/USDT']
 

--- a/examples/ccxt.pro/py/build-ohlcv-many-symbols.py
+++ b/examples/ccxt.pro/py/build-ohlcv-many-symbols.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import ccxtpro
+
+async def loop(exchange, symbol, timeframe):
+    while True:
+        try:
+            trades = await exchange.watch_trades(symbol)
+            if len(trades) > 0:
+                ohlcvc = exchange.build_ohlcvc(trades, timeframe)
+                print("Symbol:", symbol, "timeframe:", timeframe)
+                print ('-----------------------------------------------------------')
+                print (ohlcvc)
+                print ('-----------------------------------------------------------')
+
+        except Exception as e:
+            print(str(e))
+            # raise e  # uncomment to break all loops in case of an error in any one of them
+            # break  # you can also break just this one loop if it fails
+
+async def main():
+    # select the exchange
+    exchange = ccxtpro.ftx()
+    if exchange.has['watchTrades']:
+        markets = await exchange.load_markets()
+        # Change this value accordingly
+        timeframe = '15m'
+        limit = 5
+        marketList = [*markets]
+        selected_symbols = marketList[:limit]
+        # you can also specify the symbols manually
+        # example:
+        # selected_symbols = ['BTC/USDT', 'LTC/USDT']
+        await asyncio.gather(*[loop(exchange, symbol, timeframe) for symbol in selected_symbols])
+        await exchange.close()
+    else:
+        print(exchange.id, 'does not support watchTrades yet')
+
+
+asyncio.run(main())


### PR DESCRIPTION
fixes https://github.com/ccxt/ccxt/issues/12630

Result JS example:

```
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
1649253600000 | 1.6676 | 1.6676 | 1.6675 | 1.6675 | 950 | 5
-----------------------------------------------------------
Symbol: 1INCH/USD timeframe: 15m
-----------------------------------------------------------
1649253600000 | 1.6693 | 1.6693 | 1.6693 | 1.6693 | 44 | 1
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
1649253600000 | 1.6676 | 1.6676 | 1.6675 | 1.6675 | 1412 | 7
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
1649253600000 | 1.6676 | 1.6686 | 1.6675 | 1.6686 | 1479 | 9
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
1649253600000 | 1.6676 | 1.6686 | 1.6675 | 1.6686 | 1745 | 10
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
1649253600000 | 1.6676 | 1.6686 | 1.6674 | 1.6674 | 1825 | 13
-----------------------------------------------------------
```

Result Python example:

```
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.6697, 1.6697, 1.6697, 1.0, 1]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.6697, 1.6693, 1.6693, 2.0, 2]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.6697, 1.6693, 1.6693, 475.0, 3]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.6697, 1.6689, 1.6689, 478.0, 4]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.671, 1.6689, 1.671, 963.0, 6]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.671, 1.6689, 1.671, 1436.0, 9]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.671, 1.6689, 1.671, 1909.0, 10]]
-----------------------------------------------------------
Symbol: 1INCH/USD:USD timeframe: 15m
-----------------------------------------------------------
[[1649253600000, 1.6697, 1.6713, 1.6689, 1.6713, 2228.0, 11]]
```
