### PR TITLE
Add __repr__ to Precise 

### DIFF
--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -183,6 +183,9 @@ class Precise:
         integer_array.insert(index, item)
         return sign + ''.join(integer_array)
 
+    def __repr__(self):
+        return "Precise(" + str(self) + ")"
+
     @staticmethod
     def string_mul(string1, string2):
         if string1 is None or string2 is None:


### PR DESCRIPTION
Visualize precise as "Precise(value)" in `__repr__` cases (like exceptions)

this will avoid output like `<ccxt.base.precise.Precise object at 0x7ff1e2001880>` - but instead render the object appropriately (e.g. `Precise(0.00005)`).
