### PR TITLE
update examples to use unified symbols. Fixes: #12666

### DIFF
--- a/examples/ccxt.pro/js/okex-create-futures-order.js
+++ b/examples/ccxt.pro/js/okex-create-futures-order.js
@@ -8,7 +8,7 @@ const ccxtpro = require ('ccxt.pro')
         enableRateLimit: true,
         options: { defaultType: 'futures' },
     })
-    , symbol = 'BTC-USD-201225'
+    , symbol = 'BTC/USDT:USDT-201225'
     , amount = 1 // how may contracts
     , price = undefined // or your limit price
     , side = 'buy' // or 'sell'

--- a/examples/ccxt.pro/py/okex-create-swap-order.py
+++ b/examples/ccxt.pro/py/okex-create-swap-order.py
@@ -22,7 +22,7 @@ async def main():
     # https://github.com/ccxt/ccxt/wiki/Manual#overriding-unified-params
     # https://www.okex.com/docs/en/#swap-swap---orders
 
-    symbol = 'BTC-USD-SWAP'
+    symbol = 'BTC/USDT:USDT'
     amount = 1  # how may contracts
     price = None  # or your limit price
     side = 'buy'  # or 'sell'

--- a/examples/php/bitmex-create-order.php
+++ b/examples/php/bitmex-create-order.php
@@ -12,7 +12,7 @@ $exchange = new \ccxt\bitmex (array (
     'enableRateLimit' => true,
 ));
 
-$symbol = 'XBTM18'; // bitcoin contract according to bitmex futures coding
+$symbol = 'BTC/USD:BTC-220624';
 $type = 'StopLimit'; // # or 'market', or 'Stop' or 'StopLimit'
 $side = 'sell'; // or 'buy'
 $amount = 1.0;

--- a/examples/py/async-okex-positional-orders.py
+++ b/examples/py/async-okex-positional-orders.py
@@ -25,7 +25,7 @@ async def main(exchange):
         print('Futures symbols:')
         print([market['symbol'] for market in markets.values() if market['futures']])
         print('---------------------------------------------------------------')
-        symbol = 'BTC-USDT-201225'  # a futures symbol
+        symbol = 'BTC/USDT:USDT-201225'  # a futures symbol
         market = exchange.market(symbol)
         pprint(market)
         print('---------------------------------------------------------------')

--- a/examples/py/bitmex-create-order.py
+++ b/examples/py/bitmex-create-order.py
@@ -15,7 +15,7 @@ exchange = ccxt.bitmex({
     'enableRateLimit': True,
 })
 
-symbol = 'XBTM18'  # bitcoin contract according to https://github.com/ccxt/ccxt/wiki/Manual#symbols-and-market-ids
+symbol = 'BTC/USD:BTC-220624'  # bitcoin contract according to https://github.com/ccxt/ccxt/wiki/Manual#symbols-and-market-ids
 type = 'StopLimit'  # or 'Market', or 'Stop' or 'StopLimit'
 side = 'sell'  # or 'buy'
 amount = 1.0

--- a/examples/py/ftx-close-position-reduceOnly.py
+++ b/examples/py/ftx-close-position-reduceOnly.py
@@ -22,7 +22,7 @@ exchange.load_markets()
 
 # exchange.verbose = True  # uncomment for debugging purposes if necessary
 
-symbol = 'BTC-PERP'  # change for your symbol
+symbol = 'BTC/USD:USD'  # change for your symbol
 positions = exchange.fetch_positions()
 positions_by_symbol = exchange.index_by(positions, 'symbol')
 if symbol in positions_by_symbol:

--- a/examples/py/ftx-conditional-orders.py
+++ b/examples/py/ftx-conditional-orders.py
@@ -22,7 +22,7 @@ exchange.load_markets()
 
 # exchange.verbose = True  # uncomment for debugging purposes if necessary
 
-symbol = 'BTC-PERP'
+symbol = 'BTC/USD:USD'
 type = 'stop'
 side = 'sell'
 amount = 1


### PR DESCRIPTION
Changes symbols in examples to unified symbols