### PR TITLE
Browser bundle :: allow webworker usage

### DIFF
--- a/ccxt.browser.js
+++ b/ccxt.browser.js
@@ -3,4 +3,7 @@
         browserify --debug ./ccxt.browser.js > ./dist/ccxt.browser.js
  */
 
-window.ccxt = require ('./ccxt')
+ccxt = require ('./ccxt')
+if (typeof window !== 'undefined') {
+        window.ccxt = ccxt
+}

--- a/ccxt.browser.js
+++ b/ccxt.browser.js
@@ -3,6 +3,5 @@
         browserify --debug ./ccxt.browser.js > ./dist/ccxt.browser.js
  */
 
-// var adds variables to the global window scope
-// window.ccxt should be defined after this line
-var ccxt = require ('./ccxt')
+// self works in webworkers too
+self.ccxt = require ('./ccxt')

--- a/ccxt.browser.js
+++ b/ccxt.browser.js
@@ -1,9 +1,8 @@
 /*  A entry point for the browser bundle version. This gets compiled by:
-        
+
         browserify --debug ./ccxt.browser.js > ./dist/ccxt.browser.js
  */
 
-ccxt = require ('./ccxt')
-if (typeof window !== 'undefined') {
-        window.ccxt = ccxt
-}
+// var adds variables to the global window scope
+// window.ccxt should be defined after this line
+var ccxt = require ('./ccxt')


### PR DESCRIPTION
Web Workers don't have a window object so as is` ccxt.browser` can't be imported because we're assuming that window is defined. I added that check. Should have no impact on normal browser usage (I've tested ofc).

![image](https://user-images.githubusercontent.com/43336371/162235218-b61f2bac-e702-4958-9c3a-36ecd6437497.png)

More info: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers