### PR TITLE
Mexc fetchOrder

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1923,8 +1923,7 @@ module.exports = class mexc extends Exchange {
         //         "order_type":"LIMIT_ORDER"
         //     }
         //
-        //
-        // fetchOpenOrders swap
+        // swap fetchOrder, fetchOpenOrders
         //
         //     {
         //         "orderId": "266578267438402048",
@@ -1987,35 +1986,6 @@ module.exports = class mexc extends Exchange {
         //         "errorCode": 0,
         //         "createTime": 1649228972000,
         //         "updateTime": 1649230287000
-        //     }
-        //
-        // swap fetchOrder
-        //
-        //     {
-        //         "orderId": "259208506647860224",
-        //         "symbol": "BTC_USDT",
-        //         "positionId": 0,
-        //         "price": 30000,
-        //         "vol": 10,
-        //         "leverage": 20,
-        //         "side": 1,
-        //         "category": 1,
-        //         "orderType": 1,
-        //         "dealAvgPrice": 0,
-        //         "dealVol": 0,
-        //         "orderMargin": 1.536,
-        //         "takerFee": 0,
-        //         "makerFee": 0,
-        //         "profit": 0,
-        //         "feeCurrency": "USDT",
-        //         "openType": 1,
-        //         "state": 4,
-        //         "externalOid": "planorder_279208506303929856_10",
-        //         "errorCode": 0,
-        //         "usedMargin": 0,
-        //         "createTime": 1647470524000,
-        //         "updateTime": 1647470540000,
-        //         "positionMode": 1
         //     }
         //
         // cancelOrder
@@ -2261,7 +2231,7 @@ module.exports = class mexc extends Exchange {
         if (firstOrder === undefined) {
             throw new OrderNotFound (this.id + ' fetchOrder() could not find the order id ' + id);
         }
-        return this.parseOrder (firstOrder);
+        return this.parseOrder (firstOrder, market);
     }
 
     async fetchOrdersByState (state, symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1989,6 +1989,35 @@ module.exports = class mexc extends Exchange {
         //         "updateTime": 1649230287000
         //     }
         //
+        // swap fetchOrder
+        //
+        //     {
+        //         "orderId": "259208506647860224",
+        //         "symbol": "BTC_USDT",
+        //         "positionId": 0,
+        //         "price": 30000,
+        //         "vol": 10,
+        //         "leverage": 20,
+        //         "side": 1,
+        //         "category": 1,
+        //         "orderType": 1,
+        //         "dealAvgPrice": 0,
+        //         "dealVol": 0,
+        //         "orderMargin": 1.536,
+        //         "takerFee": 0,
+        //         "makerFee": 0,
+        //         "profit": 0,
+        //         "feeCurrency": "USDT",
+        //         "openType": 1,
+        //         "state": 4,
+        //         "externalOid": "planorder_279208506303929856_10",
+        //         "errorCode": 0,
+        //         "usedMargin": 0,
+        //         "createTime": 1647470524000,
+        //         "updateTime": 1647470540000,
+        //         "positionMode": 1
+        //     }
+        //
         // cancelOrder
         //
         //     {"965245851c444078a11a7d771323613b":"success"}
@@ -2157,11 +2186,22 @@ module.exports = class mexc extends Exchange {
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchOrder requires a symbol argument');
+        }
         await this.loadMarkets ();
+        const market = this.market (symbol);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         const request = {
             'order_ids': id,
         };
-        const response = await this.spotPrivateGetOrderQuery (this.extend (request, params));
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPrivateGetOrderQuery',
+            'swap': 'contractPrivateGetOrderBatchQuery',
+        });
+        const response = await this[method] (this.extend (request, query));
+        //
+        // Spot
         //
         //     {
         //         "code":200,
@@ -2177,6 +2217,41 @@ module.exports = class mexc extends Exchange {
         //                 "deal_amount":"0",
         //                 "create_time":1633988662000,
         //                 "order_type":"LIMIT_ORDER"
+        //             }
+        //         ]
+        //     }
+        //
+        // Swap
+        //
+        //     {
+        //         "success": true,
+        //         "code": 0,
+        //         "data": [
+        //             {
+        //                 "orderId": "259208506647860224",
+        //                 "symbol": "BTC_USDT",
+        //                 "positionId": 0,
+        //                 "price": 30000,
+        //                 "vol": 10,
+        //                 "leverage": 20,
+        //                 "side": 1,
+        //                 "category": 1,
+        //                 "orderType": 1,
+        //                 "dealAvgPrice": 0,
+        //                 "dealVol": 0,
+        //                 "orderMargin": 1.536,
+        //                 "takerFee": 0,
+        //                 "makerFee": 0,
+        //                 "profit": 0,
+        //                 "feeCurrency": "USDT",
+        //                 "openType": 1,
+        //                 "state": 4,
+        //                 "externalOid": "planorder_279208506303929856_10",
+        //                 "errorCode": 0,
+        //                 "usedMargin": 0,
+        //                 "createTime": 1647470524000,
+        //                 "updateTime": 1647470540000,
+        //                 "positionMode": 1
         //             }
         //         ]
         //     }


### PR DESCRIPTION
Added swap functionality to fetchOrder:
```
node examples/js/cli mexc fetchOrder '"266949776505921026"' BTC/USDT:USDT

mexc.fetchOrder (266949776505921026, BTC/USDT:USDT)
2022-04-07T22:24:00.989Z iteration 0 passed in 301 ms

{
  id: 'orderId',
  clientOrderId: '266949776505921026',
  timestamp: 1649316186000,
  datetime: '2022-04-07T07:23:06.000Z',
  lastTradeTimestamp: 1649316332000,
  status: '4',
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  side: 'open long',
  price: 43541,
  stopPrice: undefined,
  average: undefined,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  fee: undefined,
  trades: [],
  info: {
    orderId: '266949776505921026',
    symbol: 'BTC_USDT',
    positionId: '0',
    price: '43541',
    vol: '1',
    leverage: '20',
    side: '1',
    category: '1',
    orderType: '1',
    dealAvgPrice: '0',
    dealVol: '0',
    orderMargin: '0.22292992',
    takerFee: '0',
    makerFee: '0',
    profit: '0',
    feeCurrency: 'USDT',
    openType: '1',
    state: '4',
    externalOid: 'planorder_266949662181769728_10',
    errorCode: '0',
    usedMargin: '0',
    createTime: '1649316186000',
    updateTime: '1649316332000',
    positionMode: '1'
  },
  fees: []
}
```