### PR TITLE
Fix Exchange.calculate_fee not to returning quote currency when feeSide=base

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1634,35 +1634,27 @@ module.exports = class Exchange {
     calculateFee (symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {
         const market = this.markets[symbol];
         const feeSide = this.safeString (market, 'feeSide', 'quote');
-        let key = 'quote';
-        let cost = undefined;
-        if (feeSide === 'quote') {
-            // the fee is always in quote currency
-            cost = amount * price;
-        } else if (feeSide === 'base') {
-            // the fee is always in base currency
-            cost = amount;
-        } else if (feeSide === 'get') {
+        
+        let useQuote = undefined;
+        if (feeSide === 'get') {
             // the fee is always in the currency you get
-            cost = amount;
-            if (side === 'sell') {
-                cost *= price;
-            } else {
-                key = 'base';
-            }
+            useQuote = side === 'sell';
         } else if (feeSide === 'give') {
             // the fee is always in the currency you give
+            useQuote = side === 'buy';
+        }
+
+        let cost = undefined;
+        let key = undefined;
+        if (useQuote) {
+            cost = amount * price;
+            key = 'quote';
+        } else {
             cost = amount;
-            if (side === 'buy') {
-                cost *= price;
-            } else {
-                key = 'base';
-            }
+            key = 'base';
         }
         const rate = market[takerOrMaker];
-        if (cost !== undefined) {
-            cost *= rate;
-        }
+        cost *= rate;
         return {
             'type': takerOrMaker,
             'currency': market[key],

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2166,31 +2166,26 @@ class Exchange(object):
     def calculate_fee(self, symbol, type, side, amount, price, takerOrMaker='taker', params={}):
         market = self.markets[symbol]
         feeSide = self.safe_string(market, 'feeSide', 'quote')
-        key = 'quote'
-        cost = None
-        if feeSide == 'quote':
-            # the fee is always in quote currency
-            cost = amount * price
-        elif feeSide == 'base':
-            # the fee is always in base currency
-            cost = amount
-        elif feeSide == 'get':
+
+        if feeSide == 'get':
             # the fee is always in the currency you get
-            cost = amount
-            if side == 'sell':
-                cost *= price
-            else:
-                key = 'base'
+            useQuote = side == 'sell'
         elif feeSide == 'give':
             # the fee is always in the currency you give
+            useQuote = side == 'buy'
+        else:
+            # the fee is always in feeSide currency
+            useQuote = feeSide == 'quote'
+
+        if useQuote:
+            cost = amount * price
+            key = 'quote'
+        else:
             cost = amount
-            if side == 'buy':
-                cost *= price
-            else:
-                key = 'base'
+            key = 'base'
+
         rate = market[takerOrMaker]
-        if cost is not None:
-            cost *= rate
+        cost *= rate
         return {
             'type': takerOrMaker,
             'currency': market[key],


### PR DESCRIPTION
For original code, one conditional block chain was deciding both currency and cost by its combination.
I changed it to 2 phases to make each step more clear.