### PR TITLE
Bybit fetch open interest history

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4564,7 +4564,7 @@ module.exports = class bybit extends Exchange {
         market = this.safeMarket (id, market);
         const timestamp = this.safeTimestamp (interest, 'timestamp');
         const numContracts = this.safeString (interest, 'open_interest');
-        const contractSize = this.safeNumber (market, 'contractSize');
+        const contractSize = this.safeString (market, 'contractSize');
         return {
             'symbol': this.safeSymbol (id),
             'baseVolume': Precise.stringMul (numContracts, contractSize),

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4553,6 +4553,13 @@ module.exports = class bybit extends Exchange {
     }
 
     parseOpenInterest (interest, market = undefined) {
+        //
+        //    {
+        //        "open_interest": 805604444,
+        //        "timestamp": 1645056000,
+        //        "symbol": "BTCUSD"
+        //    }
+        //
         const id = this.safeString (interest, 'symbol');
         market = this.safeMarket (id, market);
         const timestamp = this.safeTimestamp (interest, 'timestamp');

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -863,7 +863,7 @@ module.exports = class bybit extends Exchange {
                 symbol = symbol + '-' + this.yymmdd (expiry);
             }
             const inverse = !linear;
-            const contractSize = inverse ? this.safeNumber (lotSizeFilter, 'min_trading_qty') : undefined;
+            const contractSize = inverse ? this.safeNumber (lotSizeFilter, 'min_trading_qty') : this.parseNumber ('1');
             result.push ({
                 'id': id,
                 'symbol': symbol,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4506,7 +4506,7 @@ module.exports = class bybit extends Exchange {
         return await this[method] (this.extend (request, params));
     }
 
-    async fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOpenInterestHistory (symbol, timeframe = '1h', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name bybit#fetchOpenInterestHistory
@@ -4549,7 +4549,7 @@ module.exports = class bybit extends Exchange {
         //    }
         //
         const result = this.safeValue (response, 'result');
-        return this.parseOpenInterests (result);
+        return this.parseOpenInterests (result, market, since, limit);
     }
 
     parseOpenInterest (interest, market = undefined) {
@@ -4564,11 +4564,11 @@ module.exports = class bybit extends Exchange {
         market = this.safeMarket (id, market);
         const timestamp = this.safeTimestamp (interest, 'timestamp');
         const numContracts = this.safeString (interest, 'open_interest');
-        const contractSize = market['contractSize'];
+        const contractSize = this.safeNumber (market, 'contractSize');
         return {
             'symbol': this.safeSymbol (id),
-            'baseVolume': this.parseNumber (numContracts),
-            'quoteVolume': Precise.stringMul (numContracts, contractSize),
+            'baseVolume': Precise.stringMul (numContracts, contractSize),
+            'quoteVolume': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4567,9 +4567,8 @@ module.exports = class bybit extends Exchange {
         const contractSize = market['contractSize'];
         return {
             'symbol': this.safeSymbol (id),
-            'volume': this.parseNumber (numContracts),
-            'value': Precise.stringMul (numContracts, contractSize),
-            'valueCurrency': market['base'],
+            'baseVolume': this.parseNumber (numContracts),
+            'quoteVolume': Precise.stringMul (numContracts, contractSize),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4507,6 +4507,17 @@ module.exports = class bybit extends Exchange {
     }
 
     async fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name bybit#fetchOpenInterestHistory
+         * @description Gets the total amount of unsettled contracts. In other words, the total number of contracts held in open positions
+         * @param {str} symbol Unified market symbol
+         * @param {str} timeframe "5m", 15m, 30m, 1h, 4h, 1d
+         * @param {int} since Not used by Bybit
+         * @param {int} limit The number of open interest structures to return. Max 200, default 50
+         * @param {dict} params Exchange specific parameters
+         * @returns An array of open interest structures
+         */
         if (timeframe === '1m') {
             throw new BadRequest (this.id + 'fetchOpenInterestHistory cannot use the 1m timeframe');
         }

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4530,7 +4530,7 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.v2PublicGetOpenInterest (this.extend (request, params));
+        const response = await this.publicGetV2PublicOpenInterest (this.extend (request, params));
         //
         //    {
         //        "ret_code": 0,


### PR DESCRIPTION
```
2022-06-01T08:15:49.558Z
Node.js: v14.17.0
CCXT v1.83.85
bybit.fetchOpenInterestHistory (BTC/USDT:USDT)
2022-06-01T08:15:52.640Z iteration 0 passed in 253 ms
       symbol |     baseVolume | quoteVolume |     timestamp |                 datetime
---------------------------------------------------------------------------------------
BTC/USDT:USDT |      32027.327 |             | 1653894000000 | 2022-05-30T07:00:00.000Z
...
BTC/USDT:USDT |       28652.28 |             | 1654066800000 | 2022-06-01T07:00:00.000Z
BTC/USDT:USDT |      29112.655 |             | 1654070400000 | 2022-06-01T08:00:00.000Z
50 objects
```

```
bybit.fetchOpenInterestHistory (BTC/USDT:USDT, 1h, 1654066800000)
2022-06-01T08:17:54.342Z iteration 0 passed in 824 ms

       symbol | baseVolume | quoteVolume |     timestamp |                 datetime
-----------------------------------------------------------------------------------
BTC/USDT:USDT |   28652.28 |             | 1654066800000 | 2022-06-01T07:00:00.000Z
BTC/USDT:USDT |  29112.655 |             | 1654070400000 | 2022-06-01T08:00:00.000Z
2 objects
```

```
bybit.fetchOpenInterestHistory (BTC/USDT:USDT, 1h, , 3)
2022-06-01T08:18:16.780Z iteration 0 passed in 241 ms

       symbol | baseVolume | quoteVolume |     timestamp |                 datetime
-----------------------------------------------------------------------------------
BTC/USDT:USDT |   28796.41 |             | 1654063200000 | 2022-06-01T06:00:00.000Z
BTC/USDT:USDT |   28652.28 |             | 1654066800000 | 2022-06-01T07:00:00.000Z
BTC/USDT:USDT |  29112.655 |             | 1654070400000 | 2022-06-01T08:00:00.000Z
3 objects
```