### PR TITLE
Mexc cancelAllOrders

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2249,7 +2249,18 @@ module.exports = class mexc extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const response = await this.spotPrivateDeleteOrderCancelBySymbol (this.extend (request, params));
+        let method = this.getSupportedMapping (market['type'], {
+            'spot': 'spotPrivateDeleteOrderCancelBySymbol',
+            'swap': 'contractPrivatePostOrderCancelAll',
+        });
+        const stop = this.safeValue (params, 'stop');
+        if (stop) {
+            method = 'contractPrivatePostPlanorderCancelAll';
+        }
+        const query = this.omit (params, [ 'method', 'stop' ]);
+        const response = await this[method] (this.extend (request, query));
+        //
+        // Spot
         //
         //     {
         //         "code": 200,
@@ -2268,6 +2279,13 @@ module.exports = class mexc extends Exchange {
         //                 "order_id": "b58ef34c570e4917981f276d44091484"
         //             }
         //         ]
+        //     }
+        //
+        // Swap and Trigger
+        //
+        //     {
+        //         "success": true,
+        //         "code": 0
         //     }
         //
         return response;


### PR DESCRIPTION
Added swap and trigger order functionality to cancelAllOrders:

Trigger:
```
node examples/js/cli mexc cancelAllOrders BTC/USDT:USDT '{"stop":"true"}'

mexc.cancelAllOrders (BTC/USDT:USDT, [object Object])
2022-04-08T03:04:19.375Z iteration 0 passed in 295 ms

{ success: true, code: '0' }
```

Swap:
```
node examples/js/cli mexc cancelAllOrders BTC/USDT:USDT

mexc.cancelAllOrders (BTC/USDT:USDT)
2022-04-08T03:05:25.766Z iteration 0 passed in 532 ms

{ success: true, code: '0' }
```