### PR TITLE
[ftx] Don't crash on expiring delivery future in `fetch_markets`

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -4,7 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { TICK_SIZE } = require ('./base/functions/number');
-const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId } = require ('./base/errors');
+const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId, BadResponse } = require ('./base/errors');
 const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------
@@ -594,7 +594,7 @@ module.exports = class ftx extends Exchange {
                     const options = this.safeValue (this.options, 'fetchMarkets', {});
                     const throwOnUndefinedExpiry = this.safeValue (options, 'throwOnUndefinedExpiry', false);
                     if (throwOnUndefinedExpiry) {
-                        throw new BadSymbol (this.id + " symbol '" + id + "' is a future contract with an invalid expiry datetime.");
+                        throw new BadResponse (this.id + " symbol '" + id + "' is a future contract with an invalid expiry datetime.");
                     } else {
                         continue;
                     }

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -587,7 +587,7 @@ module.exports = class ftx extends Exchange {
                 expiry = this.parse8601 (expiryDatetime);
                 if (expiry === undefined) {
                     // It is likely a future that is expiring in this moment
-                    self.log (this.id + " symbol '" + id + "' is a future contract but with an invalid expiry datetime.");
+                    self.log (this.id + " symbol '" + id + "' is a future contract with an invalid expiry datetime.");
                     continue;
                 }
                 const parsedId = id.split ('-');

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -4,7 +4,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { TICK_SIZE } = require ('./base/functions/number');
-const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId, BadResponse } = require ('./base/errors');
+const { ExchangeError, InvalidOrder, BadRequest, InsufficientFunds, OrderNotFound, AuthenticationError, RateLimitExceeded, ExchangeNotAvailable, CancelPending, ArgumentsRequired, PermissionDenied, BadSymbol, DuplicateOrderId } = require ('./base/errors');
 const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -586,7 +586,9 @@ module.exports = class ftx extends Exchange {
                 type = 'future';
                 expiry = this.parse8601 (expiryDatetime);
                 if (expiry === undefined) {
-                    throw new BadResponse (this.id + " symbol '" + id + "' is a future contract but with an invalid expiry datetime.");
+                    // It is likely a future that is expiring in this moment
+                    self.log (this.id + " symbol '" + id + "' is a future contract but with an invalid expiry datetime.");
+                    continue;
                 }
                 const parsedId = id.split ('-');
                 const length = parsedId.length;


### PR DESCRIPTION
At the end of the day (00:00 UTC), we are observing crashes in `fetch_markets()` because of delivery futures that are apparently with `undefined` expiry (#12104).

The problem seems to be caused by the fact that the results of two API calls of FTX are not coherent: no expiry is reported for a delivery future that is expiring just now.

This PR logs the error and ignores the invalid symbol (which is expired anyways).

See also: #12017 #11544

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202098466023809