### PR TITLE
Huobi :: fix fetchBalance

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2427,7 +2427,11 @@ module.exports = class huobi extends Exchange {
             request['account-id'] = accountId;
             method = 'spotPrivateGetV1AccountAccountsAccountIdBalance';
         } else if (linear) {
-            method = 'contractPrivatePostLinearSwapApiV1SwapCrossAccountInfo';
+            if (marginType === 'isolated') {
+                method = 'contractPrivatePostLinearSwapApiV1SwapAccountInfo';
+            } else {
+                method = 'contractPrivatePostLinearSwapApiV1SwapCrossAccountInfo';
+            }
         } else if (inverse) {
             if (future) {
                 method = 'contractPrivatePostApiV1ContractAccountInfo';
@@ -2570,10 +2574,8 @@ module.exports = class huobi extends Exchange {
                 const code = this.safeCurrencyCode (currencyId);
                 result[code] = account;
             } else if (isolated) {
-                const fieldName = future ? 'futures_contract_detail' : 'contract_detail';
-                const balances = this.safeValue (first, fieldName, []);
-                for (let i = 0; i < balances.length; i++) {
-                    const balance = balances[i];
+                for (let i = 0; i < data.length; i++) {
+                    const balance = data[i];
                     const marketId = this.safeString2 (balance, 'contract_code', 'margin_account');
                     const market = this.safeMarket (marketId);
                     const account = this.account ();


### PR DESCRIPTION
Fixes #12670

- Added the isolated margin endpoint and fixed the balance parsing

Cross output
```
{
    "info":{
       "status":"ok",
       "data":[
          (...)
       ],
       "ts":"1649415601244"
    },
    "USDT":{
       "free":20.920440895,
       "used":2,
       "total":22.920440895
    },
    "free":{
       "USDT":20.920440895
    },
    "used":{
       "USDT":2
    },
    "total":{
       "USDT":22.920440895
    }
 }

```
Isolated output
```
{
   "info":{
      "status":"ok",
        "data": [
         {
            "symbol":"GMT",
            "margin_balance":"0",
            "margin_position":"0",
            "margin_frozen":"0",
            "margin_available":"0",
            "profit_real":"0",
            "profit_unreal":"0",
            "risk_rate":null,
            "withdraw_available":"0",
            "liquidation_price":null,
            "lever_rate":"5",
            "adjust_factor":"0.100000000000000000",
            "margin_static":"0",
            "contract_code":"GMT-USDT",
            "margin_asset":"USDT",
            "margin_mode":"isolated",
            "margin_account":"GMT-USDT",
            "trade_partition":"USDT",
            "position_mode":"dual_side"
         }
         (...)
      ],
      "ts":"1649415422720"
   },
   "BTC/USDT:USDT":{
      "USDT":{
         "free":0,
         "used":0,
         "total":0
      },
      "free":{
         "USDT":0
      },
      "used":{
         "USDT":0
      },
      "total":{
         "USDT":0
      }
   }
   (...)
}
```