### PR TITLE
fix(typing): remove marketsById which doesn't exist anymore

### DIFF
--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -308,7 +308,6 @@ declare module 'ccxt' {
         countries: string[];
         // set by loadMarkets
         markets: Dictionary<Market>;
-        marketsById: Dictionary<Market>;
         currencies: Dictionary<Currency>;
         ids: string[];
         symbols: string[];


### PR DESCRIPTION
Hi :)

I found `marketsById` doesn't exist anymore in the source code so it should be removed from the typing