### PR TITLE
coinmate - transfer

### DIFF
--- a/js/coinmate.js
+++ b/js/coinmate.js
@@ -59,6 +59,7 @@ module.exports = class coinmate extends Exchange {
                 'setLeverage': false,
                 'setMarginMode': false,
                 'setPositionMode': false,
+                'transfer': false,
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87460806-1c9f3f00-c616-11ea-8c46-a77018a8f3f4.jpg',


### PR DESCRIPTION
Even though the UI allows for sub accounts. There is no endpoint in the docs to do transfers between account types or sub accounts. 

Note: there is a `privatePostTransfer` endpoint but it's to fetch a withdrawal or deposit transaction