### PR TITLE
Okx fetchOrder 'stop'

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -617,28 +617,20 @@ module.exports = class okx extends Exchange {
                 // 1 = SPOT, 3 = FUTURES, 5 = MARGIN, 6 = FUNDING, 9 = SWAP, 12 = OPTION, 18 = Unified account
                 'fetchOrder': {
                     'method': 'privateGetTradeOrder', // privateGetTradeOrdersAlgoHistory
-                    'algoOrderTypes': {
-                        'conditional': true,
-                        'trigger': true,
-                        'oco': true,
-                        'move_order_stop': true,
-                        'iceberg': true,
-                        'twap': true,
-                    },
                 },
                 'fetchOpenOrders': {
                     'method': 'privateGetTradeOrdersPending', // privateGetTradeOrdersAlgoPending
-                    'algoOrderTypes': {
-                        'conditional': true,
-                        'trigger': true,
-                        'oco': true,
-                        'move_order_stop': true,
-                        'iceberg': true,
-                        'twap': true,
-                    },
                 },
                 'cancelOrders': {
                     'method': 'privatePostTradeCancelBatchOrders', // privatePostTradeCancelAlgos
+                },
+                'algoOrderTypes': {
+                    'conditional': true,
+                    'trigger': true,
+                    'oco': true,
+                    'move_order_stop': true,
+                    'iceberg': true,
+                    'twap': true,
                 },
                 'accountsByType': {
                     'spot': '1',
@@ -2312,7 +2304,7 @@ module.exports = class okx extends Exchange {
         };
         const clientOrderId = this.safeString2 (params, 'clOrdId', 'clientOrderId');
         const options = this.safeValue (this.options, 'fetchOrder', {});
-        const algoOrderTypes = this.safeValue (options, 'algoOrderTypes', {});
+        const algoOrderTypes = this.safeValue (this.options, 'algoOrderTypes', {});
         const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrder');
         let method = this.safeString (params, 'method', defaultMethod);
         const ordType = this.safeString (params, 'ordType');
@@ -2469,7 +2461,7 @@ module.exports = class okx extends Exchange {
             request['limit'] = limit; // default 100, max 100
         }
         const options = this.safeValue (this.options, 'fetchOpenOrders', {});
-        const algoOrderTypes = this.safeValue (options, 'algoOrderTypes', {});
+        const algoOrderTypes = this.safeValue (this.options, 'algoOrderTypes', {});
         const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrdersPending');
         let method = this.safeString (params, 'method', defaultMethod);
         const ordType = this.safeString (params, 'ordType');

--- a/js/okx.js
+++ b/js/okx.js
@@ -615,6 +615,17 @@ module.exports = class okx extends Exchange {
                     'method': 'privateGetAccountBills', // privateGetAccountBillsArchive, privateGetAssetBills
                 },
                 // 1 = SPOT, 3 = FUTURES, 5 = MARGIN, 6 = FUNDING, 9 = SWAP, 12 = OPTION, 18 = Unified account
+                'fetchOrder': {
+                    'method': 'privateGetTradeOrder', // privateGetTradeOrdersAlgoHistory
+                    'algoOrderTypes': {
+                        'conditional': true,
+                        'trigger': true,
+                        'oco': true,
+                        'move_order_stop': true,
+                        'iceberg': true,
+                        'twap': true,
+                    },
+                },
                 'fetchOpenOrders': {
                     'method': 'privateGetTradeOrdersPending', // privateGetTradeOrdersAlgoPending
                     'algoOrderTypes': {
@@ -2106,7 +2117,7 @@ module.exports = class okx extends Exchange {
         //         "sMsg": ""
         //     }
         //
-        // fetchOrder, fetchOpenOrders
+        // Spot and Swap fetchOrder, fetchOpenOrders
         //
         //     {
         //         "accFillSz": "0",
@@ -2143,7 +2154,7 @@ module.exports = class okx extends Exchange {
         //         "uTime": "1621910749815"
         //     }
         //
-        // fetchOpenOrders Algo order
+        // Algo Order fetchOrder fetchOpenOrders
         //
         //     {
         //         "activePx": "",
@@ -2269,6 +2280,19 @@ module.exports = class okx extends Exchange {
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name okx#fetchOrder
+         * @description Fetch an order by the id
+         * @param {string} id The order id
+         * @param {string} symbol Unified market symbol
+         * @param {dict} params Extra and exchange specific parameters
+         * @param {integer} params.till Timestamp in ms of the latest time to retrieve orders for
+         * @param {boolean} params.stop True if fetching trigger orders
+         * @param {string} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
+         * @param {string} params.algoId Algo ID
+         * @returns [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+        */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
@@ -2278,15 +2302,38 @@ module.exports = class okx extends Exchange {
             'instId': market['id'],
             // 'clOrdId': 'abcdef12345', // optional, [a-z0-9]{1,32}
             // 'ordId': id,
+            // 'ordType': 'limit', // stop orders: conditional, oco, trigger, move_order_stop, iceberg, or twap
+            // 'state': 'live', // stop orders: effective, canceled, order_failed
+            // 'alogId': orderId, // stop orders
+            // 'instType': // spot, swap, futures, margin
+            // 'after': orderId, // stop orders
+            // 'before': orderId, // stop orders
+            // 'limit': limit, // stop orders, default 100, max 100
         };
         const clientOrderId = this.safeString2 (params, 'clOrdId', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clOrdId'] = clientOrderId;
+        const options = this.safeValue (this.options, 'fetchOrder', {});
+        const algoOrderTypes = this.safeValue (options, 'algoOrderTypes', {});
+        const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrder');
+        let method = this.safeString (params, 'method', defaultMethod);
+        const ordType = this.safeString (params, 'ordType');
+        const stop = this.safeValue (params, 'stop');
+        if (stop || (ordType in algoOrderTypes)) {
+            if (ordType === undefined) {
+                throw new ArgumentsRequired (this.id + ' fetchOrder() requires an ordType parameter');
+            }
+            method = 'privateGetTradeOrdersAlgoHistory';
+            request['algoId'] = id;
         } else {
-            request['ordId'] = id;
+            if (clientOrderId !== undefined) {
+                request['clOrdId'] = clientOrderId;
+            } else {
+                request['ordId'] = id;
+            }
         }
-        const query = this.omit (params, [ 'clOrdId', 'clientOrderId' ]);
-        const response = await this.privateGetTradeOrder (this.extend (request, query));
+        const query = this.omit (params, [ 'method', 'stop', 'clOrdId', 'clientOrderId' ]);
+        const response = await this[method] (this.extend (request, query));
+        //
+        // Spot and Swap
         //
         //     {
         //         "code": "0",
@@ -2324,6 +2371,59 @@ module.exports = class okx extends Exchange {
         //                 "tpTriggerPx": "",
         //                 "tradeId": "",
         //                 "uTime": "1621910749815"
+        //             }
+        //         ],
+        //         "msg": ""
+        //     }
+        //
+        // Algo order
+        //
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             {
+        //                 "activePx": "",
+        //                 "activePxType": "",
+        //                 "actualPx": "",
+        //                 "actualSide": "buy",
+        //                 "actualSz": "0",
+        //                 "algoId": "432912085631369216",
+        //                 "cTime": "1649486284333",
+        //                 "callbackRatio": "",
+        //                 "callbackSpread": "",
+        //                 "ccy": "",
+        //                 "ctVal": "0.01",
+        //                 "instId": "BTC-USDT-SWAP",
+        //                 "instType": "SWAP",
+        //                 "last": "42458.6",
+        //                 "lever": "125",
+        //                 "moveTriggerPx": "",
+        //                 "notionalUsd": "1699.856",
+        //                 "ordId": "",
+        //                 "ordPx": "30000",
+        //                 "ordType": "trigger",
+        //                 "posSide": "long",
+        //                 "pxLimit": "",
+        //                 "pxSpread": "",
+        //                 "pxVar": "",
+        //                 "side": "buy",
+        //                 "slOrdPx": "",
+        //                 "slTriggerPx": "",
+        //                 "slTriggerPxType": "",
+        //                 "state": "live",
+        //                 "sz": "4",
+        //                 "szLimit": "",
+        //                 "tag": "",
+        //                 "tdMode": "isolated",
+        //                 "tgtCcy": "",
+        //                 "timeInterval": "",
+        //                 "tpOrdPx": "",
+        //                 "tpTriggerPx": "",
+        //                 "tpTriggerPxType": "",
+        //                 "triggerPx": "31000",
+        //                 "triggerPxType": "last",
+        //                 "triggerTime": "",
+        //                 "uly": "BTC-USDT"
         //             }
         //         ],
         //         "msg": ""


### PR DESCRIPTION
Added functionality for stop orders to fetchOrder. The algo history endpoint I'm using is returning an empty data array when the order is still open but returns the correct data if the order is closed.

The endpoint I'm using:
https://www.okx.com/docs-v5/en/#rest-api-trade-get-algo-order-history

When the order is canceled:
```
node examples/js/cli okx fetchOrder "'432912085631369216'" BTC/USDT:USDT '{"ordType":"trigger"}' --verbose

okx GET https://www.okx.com/api/v5/trade/orders-algo-history?instId=BTC-USDT-SWAP&algoId=432912085631369216&ordType=trigger

ResponseBody:
 {"code":"0","data":[{"activePx":"","activePxType":"","actualPx":"","actualSide":"buy","actualSz":"0","algoId":"432912085631369216","cTime":"1649486284333","callbackRatio":"","callbackSpread":"","ccy":"","ctVal":"0.01","instId":"BTC-USDT-SWAP","instType":"SWAP","last":"42458.6","lever":"125","moveTriggerPx":"","notionalUsd":"1699.3960000000002","ordId":"","ordPx":"30000","ordType":"trigger","posSide":"long","pxLimit":"","pxSpread":"","pxVar":"","side":"buy","slOrdPx":"","slTriggerPx":"","slTriggerPxType":"","state":"canceled","sz":"4","szLimit":"","tag":"","tdMode":"isolated","tgtCcy":"","timeInterval":"","tpOrdPx":"","tpTriggerPx":"","tpTriggerPxType":"","triggerPx":"31000","triggerPxType":"last","triggerTime":"","uly":"BTC-USDT"}],"msg":""}

2022-04-09T18:56:50.572Z iteration 0 passed in 424 ms

{
  info: {
    activePx: '',
    activePxType: '',
    actualPx: '',
    actualSide: 'buy',
    actualSz: '0',
    algoId: '432912085631369216',
    cTime: '1649486284333',
    callbackRatio: '',
    callbackSpread: '',
    ccy: '',
    ctVal: '0.01',
    instId: 'BTC-USDT-SWAP',
    instType: 'SWAP',
    last: '42458.6',
    lever: '125',
    moveTriggerPx: '',
    notionalUsd: '1699.3960000000002',
    ordId: '',
    ordPx: '30000',
    ordType: 'trigger',
    posSide: 'long',
    pxLimit: '',
    pxSpread: '',
    pxVar: '',
    side: 'buy',
    slOrdPx: '',
    slTriggerPx: '',
    slTriggerPxType: '',
    state: 'canceled',
    sz: '4',
    szLimit: '',
    tag: '',
    tdMode: 'isolated',
    tgtCcy: '',
    timeInterval: '',
    tpOrdPx: '',
    tpTriggerPx: '',
    tpTriggerPxType: '',
    triggerPx: '31000',
    triggerPxType: 'last',
    triggerTime: '',
    uly: 'BTC-USDT'
  },
  id: '',
  clientOrderId: undefined,
  timestamp: 1649486284333,
  datetime: '2022-04-09T06:38:04.333Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'trigger',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 30000,
  stopPrice: 0,
  average: undefined,
  cost: undefined,
  amount: 4,
  filled: undefined,
  remaining: undefined,
  status: 'canceled',
  fee: undefined,
  trades: [],
  fees: []
}
```

When the order is still open:
```
node examples/js/cli okx fetchOrder "'432912085631369216'" BTC/USDT:USDT '{"ordType":"trigger"}' --verbose

okx GET https://www.okx.com/api/v5/trade/orders-algo-history?instId=BTC-USDT-SWAP&algoId=432912085631369216&ordType=trigger

ResponseBody:
 {"code":"0","data":[],"msg":""}

2022-04-09T18:42:52.625Z iteration 0 passed in 421 ms

{
  info: undefined,
  id: undefined,
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```
