### PR TITLE
Fetch borrow interest new fields

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2228,4 +2228,13 @@ module.exports = class Exchange {
         }
 
     }
+
+    parseBorrowInterests (response, market = undefined) {
+        const interest = [];
+        for (let i = 0; i < response.length; i++) {
+            const row = response[i];
+            interest.push (this.parseBorrowInterest (row, market));
+        }
+        return interest;
+    }
 }

--- a/js/binance.js
+++ b/js/binance.js
@@ -5563,22 +5563,24 @@ module.exports = class binance extends Exchange {
         //     }
         //
         const rows = this.safeValue (response, 'rows');
-        const interest = [];
-        for (let i = 0; i < rows.length; i++) {
-            const row = rows[i];
-            const timestamp = this.safeNumber (row, 'interestAccuredTime');
-            const account = (symbol === undefined) ? 'cross' : symbol;
-            interest.push ({
-                'account': account,
-                'currency': this.safeCurrencyCode (this.safeString (row, 'asset')),
-                'interest': this.safeNumber (row, 'interest'),
-                'interestRate': this.safeNumber (row, 'interestRate'),
-                'amountBorrowed': this.safeNumber (row, 'principal'),
-                'timestamp': timestamp,
-                'datetime': this.iso8601 (timestamp),
-                'info': row,
-            });
-        }
+        const interest = this.parseBorrowInterests (rows, market);
         return this.filterByCurrencySinceLimit (interest, code, since, limit);
+    }
+
+    parseBorrowInterest (info, market) {
+        const symbol = this.safeString (info, 'isolatedSymbol');
+        const timestamp = this.safeNumber (info, 'interestAccuredTime');
+        return {
+            'account': (symbol === undefined) ? 'cross' : symbol,
+            'symbol': symbol,
+            'marginType': (symbol === undefined) ? 'cross' : 'isolated',
+            'currency': this.safeCurrencyCode (this.safeString (info, 'asset')),
+            'interest': this.safeNumber (info, 'interest'),
+            'interestRate': this.safeNumber (info, 'interestRate'),
+            'amountBorrowed': this.safeNumber (info, 'principal'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': info,
+        };
     }
 };

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2687,22 +2687,24 @@ module.exports = class ftx extends Exchange {
         //     }
         //
         const result = this.safeValue (response, 'result');
-        const interest = [];
-        for (let i = 0; i < result.length; i++) {
-            const payment = result[i];
-            const coin = this.safeString (payment, 'coin');
-            const datetime = this.safeString (payment, 'time');
-            interest.push ({
-                'account': undefined,
-                'currency': this.safeCurrencyCode (coin),
-                'interest': this.safeNumber (payment, 'cost'),
-                'interestRate': this.safeNumber (payment, 'rate'),
-                'amountBorrowed': this.safeNumber (payment, 'size'),
-                'timestamp': this.parse8601 (datetime),
-                'datetime': datetime,
-                'info': payment,
-            });
-        }
+        const interest = this.parseBorrowInterests (result);
         return this.filterByCurrencySinceLimit (interest, code, since, limit);
+    }
+
+    parseBorrowInterest (info, market = undefined) {
+        const coin = this.safeString (info, 'coin');
+        const datetime = this.safeString (info, 'time');
+        return {
+            'account': 'cross',
+            'symbol': undefined,
+            'marginType': 'cross',
+            'currency': this.safeCurrencyCode (coin),
+            'interest': this.safeNumber (info, 'cost'),
+            'interestRate': this.safeNumber (info, 'rate'),
+            'amountBorrowed': this.safeNumber (info, 'size'),
+            'timestamp': this.parse8601 (datetime),
+            'datetime': datetime,
+            'info': info,
+        }
     }
 };

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2705,6 +2705,6 @@ module.exports = class ftx extends Exchange {
             'timestamp': this.parse8601 (datetime),
             'datetime': datetime,
             'info': info,
-        }
+        };
     }
 };

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4670,11 +4670,11 @@ module.exports = class huobi extends Exchange {
         //    }
         //
         const data = this.safeValue (response, 'data');
-        const interest = this.parseBorrowInterests (data, marginType, market);
+        const interest = this.parseBorrowInterests (data, market);
         return this.filterByCurrencySinceLimit (interest, code, since, limit);
     }
 
-    parseBorrowInterest (info, marginType, market = undefined) {
+    parseBorrowInterest (info, market = undefined) {
         // isolated
         //    {
         //        "interest-rate":"0.000040830000000000",
@@ -4717,12 +4717,14 @@ module.exports = class huobi extends Exchange {
         //   }
         //
         const marketId = this.safeString (info, 'symbol');
-        market = this.safeMarket (marketId, market);
-        const symbol = market['symbol'];
-        const account = (marginType === 'cross') ? marginType : symbol;
+        const marginType = (marketId === undefined) ? 'cross' : 'isolated';
+        market = this.safeMarket (marketId);
+        const symbol = this.safeString (market, 'symbol');
         const timestamp = this.safeNumber (info, 'accrued-at');
         return {
-            'account': account,  // isolated symbol, will not be returned for crossed margin
+            'account': (marginType === 'isolated') ? symbol : 'cross',  // deprecated
+            'symbol': symbol,
+            'marginType': marginType,
             'currency': this.safeCurrencyCode (this.safeString (info, 'currency')),
             'interest': this.safeNumber (info, 'interest-amount'),
             'interestRate': this.safeNumber (info, 'interest-rate'),

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4674,15 +4674,6 @@ module.exports = class huobi extends Exchange {
         return this.filterByCurrencySinceLimit (interest, code, since, limit);
     }
 
-    parseBorrowInterests (response, marginType, market = undefined) {
-        const interest = [];
-        for (let i = 0; i < response.length; i++) {
-            const row = response[i];
-            interest.push (this.parseBorrowInterest (row, marginType, market));
-        }
-        return interest;
-    }
-
     parseBorrowInterest (info, marginType, market = undefined) {
         // isolated
         //    {

--- a/js/okx.js
+++ b/js/okx.js
@@ -4565,7 +4565,9 @@ module.exports = class okx extends Exchange {
         }
         const timestamp = this.safeNumber (info, 'ts');
         return {
-            'account': account, // isolated symbol, will not be returned for cross margin
+            'account': account, // deprecated
+            'symbol': this.safeString (market, 'symbol'),
+            'marginType': (instId === undefined) ? 'cross' : 'isolated',
             'currency': this.safeCurrencyCode (this.safeString (info, 'ccy')),
             'interest': this.safeNumber (info, 'interest'),
             'interestRate': this.safeNumber (info, 'interestRate'),

--- a/js/okx.js
+++ b/js/okx.js
@@ -4556,15 +4556,6 @@ module.exports = class okx extends Exchange {
         return this.filterByCurrencySinceLimit (interest, code, since, limit);
     }
 
-    parseBorrowInterests (response, market = undefined) {
-        const interest = [];
-        for (let i = 0; i < response.length; i++) {
-            const row = response[i];
-            interest.push (this.parseBorrowInterest (row, market));
-        }
-        return interest;
-    }
-
     parseBorrowInterest (info, market = undefined) {
         const instId = this.safeString (info, 'instId');
         let account = 'cross'; // todo rename it to margin/marginType and separate it from the symbol

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3737,4 +3737,13 @@ class Exchange {
     public function sleep($milliseconds) {
         sleep($milliseconds / 1000);
     }
+    
+    public function parse_borrow_interests($response, $market = null) {
+        $interest = array();
+        for ($i = 0; $i < count($response); $i++){
+            $row = $response[$i];
+            array_push($interest, $this->parseBorrowInterest ($row, $market));
+        }
+        return $interest;
+    }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2804,3 +2804,10 @@ class Exchange(object):
             return self.safe_value(tiers, symbol)
         else:
             raise NotSupported(self.id + 'fetch_market_leverage_tiers() is not supported yet')
+
+    def parse_borrow_interests(self, response, market=None):
+        interest = []
+        for i in range(len(response)):
+            row = response[i]
+            interest.append(self.parse_borrow_interest(row, market))
+        return interest


### PR DESCRIPTION
I cannot test huobi

---------------------

```
2022-04-11T09:31:22.008Z
Node.js: v14.17.0
CCXT v1.78.62
ftx.fetchBorrowInterest ()
2022-04-11T09:31:22.851Z iteration 0 passed in 267 ms
account | symbol | marginType | currency |           interest | interestRate | amountBorrowed |     timestamp |                  datetime
-----------------------------------------------------------------------------------------------------------------------------------------
  cross |        |      cross |      USD | 0.0000122677095499 |  0.000004617 |     2.65707376 | 1649667600000 | 2022-04-11T09:00:00+00:00
...
  cross |        |      cross |      USD | 0.0000122650035724 |  0.000004617 |     2.65648767 | 1649480400000 | 2022-04-09T05:00:00+00:00
  cross |        |      cross |      USD | 0.0000122649469218 |  0.000004617 |      2.6564754 | 1649476800000 | 2022-04-09T04:00:00+00:00
50 objects
```

```
okx.fetchBorrowInterest ()
2022-04-11T09:32:27.995Z iteration 0 passed in 291 ms

 account |   symbol | marginType | currency |           interest | interestRate |   amountBorrowed |     timestamp |                 datetime
---------------------------------------------------------------------------------------------------------------------------------------------
ZIL/USDT | ZIL/USDT |   isolated |      ZIL | 0.0004214393367048 |   0.00000115 | 366.468988438852 | 1649181600000 | 2022-04-05T18:00:00.000Z
ZIL/USDT | ZIL/USDT |   isolated |      ZIL | 0.0004214388520501 |   0.00000115 |       366.468567 | 1649178000000 | 2022-04-05T17:00:00.000Z
2 objects
```

```
okx.fetchBorrowInterest (, DOGE/USDT)
2022-04-11T09:37:10.868Z iteration 0 passed in 314 ms

  account |    symbol | marginType | currency |           interest | interestRate | amountBorrowed |     timestamp |                 datetime
---------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | DOGE/USDT |   isolated |     DOGE | 0.0003598323308501 |   0.00000115 |     312.897679 | 1649178000000 | 2022-04-05T17:00:00.000Z
1 objects
```
```
account |   symbol | marginType | currency |           interest | interestRate |   amountBorrowed |     timestamp |                 datetime
--------------------------------------------------------------------------------------------------------------------------------------------
  cross | ZIL/USDT |      cross |      ZIL | 0.0004214393367048 |   0.00000115 | 366.468988438852 | 1649181600000 | 2022-04-05T18:00:00.000Z
  cross | ZIL/USDT |      cross |      ZIL | 0.0004214388520501 |   0.00000115 |       366.468567 | 1649178000000 | 2022-04-05T17:00:00.000Z
2 objects
```

```
binance.fetchBorrowInterest ()
2022-04-11T09:40:09.740Z iteration 0 passed in 675 ms

account | symbol | marginType | currency |   interest | interestRate | amountBorrowed |     timestamp |                 datetime
--------------------------------------------------------------------------------------------------------------------------------
  cross |        |      cross |     USDT | 0.00010217 |       0.0002 |          12.26 | 1649667600000 | 2022-04-11T09:00:00.000Z
1 objects
```

```
binance.fetchBorrowInterest (, BTC/USDT)
2022-04-11T09:41:59.732Z iteration 0 passed in 685 ms

account |  symbol | marginType | currency |   interest | interestRate | amountBorrowed |     timestamp |                 datetime
---------------------------------------------------------------------------------------------------------------------------------
BTCUSDT | BTCUSDT |   isolated |     USDT | 0.00046879 |       0.0002 |     56.2541274 | 1649667600000 | 2022-04-11T09:00:00.000Z
1 objects
```
