### PR TITLE
bitget - transfer

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -53,9 +53,12 @@ module.exports = class bitget extends Exchange {
                 'fetchTrades': true,
                 'fetchTradingFee': true,
                 'fetchTradingFees': true,
+                'fetchTransfer': false,
+                'fetchTransfers': undefined,
                 'fetchWithdrawals': false,
                 'setLeverage': true,
                 'setMarginMode': true,
+                'transfer': false,
             },
             'timeframes': {
                 'spot': {


### PR DESCRIPTION
No endpoint to transfer or do an individual transfer.

For `fetchTransfers` I believe we could use either the endpoint `/api/spot/v1/account/transferRecords` or `/api/mix/v1/account/accountBill` however leaving it for a future PR.