### PR TITLE
Gateio :: add nonce to orderBook

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1646,11 +1646,13 @@ module.exports = class gateio extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 10, max 100
         }
+        request['with_id'] = true;
         const response = await this[method] (this.extend (request, params));
         //
         // SPOT
         //
         //     {
+        //         "id":6358770031
         //         "current": 1634345973275,
         //         "update": 1634345973271,
         //         "asks": [
@@ -1681,6 +1683,7 @@ module.exports = class gateio extends Exchange {
         // Perpetual Swap
         //
         //     {
+        //         "id":6358770031
         //         "current": 1634350208.745,
         //         "asks": [
         //             {"s":24909,"p": "61264.8"},
@@ -1715,7 +1718,10 @@ module.exports = class gateio extends Exchange {
         }
         const priceKey = spotOrMargin ? 0 : 'p';
         const amountKey = spotOrMargin ? 1 : 's';
-        return this.parseOrderBook (response, symbol, timestamp, 'bids', 'asks', priceKey, amountKey);
+        const nonce = this.safeInteger (response, 'id');
+        const result = this.parseOrderBook (response, symbol, timestamp, 'bids', 'asks', priceKey, amountKey);
+        result['nonce'] = nonce;
+        return result;
     }
 
     async fetchTicker (symbol, params = {}) {


### PR DESCRIPTION
- Nonce is required to synchronize deltas on the pro end

Output:

```
 node cli.js gateio fetchOrderBook "BTC/USDT" 10  --verbose
2022-04-12T13:23:07.435Z
Node.js: v16.13.2
CCXT v1.78.73
gateio.fetchOrderBook (BTC/USDT, 10)
fetch Request:
 gateio GET https://api.gateio.ws/api/v4/spot/order_book?currency_pair=BTC_USDT&limit=10&with_id=true 
RequestHeaders:
 { 'X-Gate-Channel-Id': 'ccxt' } 
RequestBody:
 undefined 

handleRestResponse:
 gateio GET https://api.gateio.ws/api/v4/spot/order_book?currency_pair=BTC_USDT&limit=10&with_id=true 200 OK 
ResponseHeaders:
 {} 
ResponseBody:
 {"id":6358826658,"current":1649769789574,"update":1649769789566,"asks":[["40486.86","0.1661"],["40487.09","0.016"],["40487.89","0.6676"],["40489.54","0.8333"],["40489.7","0.525"],["40493.45","0.005"],["40497.29","0.2937"],["40498.6","0.1761"],["40498.61","2.971"],["40503.4","0.0016"]],"bids":[["40486.85","0.0578"],["40486.28","0.525"],["40486.12","0.0115"],["40484.34","0.096"],["40483.84","0.0466"],["40483","0.0002"],["40481.42","0.2788"],["40481.41","0.8381"],["40480.6","0.005"],["40476.47","0.0015"]]} 

2022-04-12T13:23:09.655Z iteration 0 passed in 252 ms

{
  symbol: 'BTC/USDT',
  bids: [
    [ 40486.85, 0.0578 ],
    [ 40486.28, 0.525 ],
    [ 40486.12, 0.0115 ],
    [ 40484.34, 0.096 ],
    [ 40483.84, 0.0466 ],
    [ 40483, 0.0002 ],
    [ 40481.42, 0.2788 ],
    [ 40481.41, 0.8381 ],
    [ 40480.6, 0.005 ],
    [ 40476.47, 0.0015 ]
  ],
  asks: [
    [ 40486.86, 0.1661 ],
    [ 40487.09, 0.016 ],
    [ 40487.89, 0.6676 ],
    [ 40489.54, 0.8333 ],
    [ 40489.7, 0.525 ],
    [ 40493.45, 0.005 ],
    [ 40497.29, 0.2937 ],
    [ 40498.6, 0.1761 ],
    [ 40498.61, 2.971 ],
    [ 40503.4, 0.0016 ]
  ],
  timestamp: 1649769789574,
  datetime: '2022-04-12T13:23:09.574Z',
  nonce: 6358826658
}
```