### PR TITLE
`safeAccount` (for `fetchAccounts`)

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1110,6 +1110,15 @@ module.exports = class Exchange {
         }
     }
 
+    safeAccount (account) {
+        return this.extend({
+            'id': undefined,
+            'type': undefined,
+            'currency': undefined,
+            'info': {},
+        }, account);
+    }
+
     safeBalance (balance) {
 
         const codes = Object.keys (this.omit (balance, [ 'info', 'timestamp', 'datetime', 'free', 'used', 'total' ]));

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1111,11 +1111,11 @@ module.exports = class Exchange {
     }
 
     safeAccount (account) {
-        return this.extend({
+        return this.extend ({
             'id': undefined,
             'type': undefined,
             'currency': undefined,
-            'info': {},
+            'info': undefined,
         }, account);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2008,7 +2008,7 @@ class Exchange {
             'id'=> null,
             'type'=> null,
             'currency'=> null,
-            'info'=> [],
+            'info'=> null,
         ], $account);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2003,6 +2003,15 @@ class Exchange {
         );
     }
 
+    public function safe_account($account) {
+        return $this->extend([
+            'id'=> null,
+            'type'=> null,
+            'currency'=> null,
+            'info'=> [],
+        ], $account);
+    }
+
     public function safe_balance($balance) {
         $currencies = $this->omit($balance, array('info', 'timestamp', 'datetime', 'free', 'used', 'total'));
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1704,7 +1704,7 @@ class Exchange(object):
             'id': None,
             'type': None,
             'currency': None,
-            'info': [],
+            'info': None,
         }, account)
 
     def safe_balance(self, balance):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1699,6 +1699,14 @@ class Exchange(object):
             'nonce': None,
         }
 
+    def safe_account(self, account):
+        return self.extend({
+            'id': None,
+            'type': None,
+            'currency': None,
+            'info': [],
+        }, account)
+
     def safe_balance(self, balance):
         currencies = self.omit(balance, ['info', 'timestamp', 'datetime', 'free', 'used', 'total']).keys()
         balance['free'] = {}


### PR DESCRIPTION
`safeAccount` to be used in `fetchAccounts`, so instead of :
```
        result.push ({
            'id': accountId,
            'type': undefined,
            'currency': code,
            'info': account,
        })
```
should be:
```
        result.push ( this.safeAccount({
            'id': accountId,
            'type': undefined,
            'currency': code,
            'info': account,
        }))
```
open for future improvement.

