### PR TITLE
`safeTransaction` (for `fetchTransactions`)

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -150,6 +150,7 @@ class Transpiler {
             [ /\.safeMarket\s/g, '.safe_market'],
             [ /\.safeOrder\s/g, '.safe_order'],
             [ /\.safeTicker\s/g, '.safe_ticker'],
+            [ /\.safeTransaction\s/g, '.safe_transaction'],
             [ /\.roundTimeframe\s/g, '.round_timeframe'],
             [ /\.calculateRateLimiterCost\s/g, '.calculate_rate_limiter_cost' ],
             [ /\.parseAccountPosition\s/g, '.parse_account_position' ],

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1410,10 +1410,11 @@ module.exports = class Exchange {
         return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
     }
 
-    safeTransaction (transaction) {
-        return this.extend({
+    safeTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
+        return this.extend ({
             'id': undefined,
-            'currency': undefined,
+            'currency': currency['code'],
             'amount': undefined,
             'network': undefined,
             'address': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1430,7 +1430,7 @@ module.exports = class Exchange {
             'timestamp': undefined,
             'datetime': undefined,
             'fee': undefined,
-            'info': transaction,
+            'info': undefined,
         }, transaction);
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1410,6 +1410,29 @@ module.exports = class Exchange {
         return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
     }
 
+    safeTransaction (transaction) {
+        return this.extend({
+            'id': undefined,
+            'currency': undefined,
+            'amount': undefined,
+            'network': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'addressFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'tagFrom': undefined,
+            'status': undefined,
+            'type': undefined,
+            'updated': undefined,
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'fee': undefined,
+            'info': {},
+        }, transaction);
+    }
+
     parseTransfers (transfers, currency = undefined, since = undefined, limit = undefined, params = {}) {
         let result = Object.values (transfers || []).map ((transfer) => this.extend (this.parseTransfer (transfer, currency), params))
         result = this.sortBy (result, 'timestamp');

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1430,7 +1430,7 @@ module.exports = class Exchange {
             'timestamp': undefined,
             'datetime': undefined,
             'fee': undefined,
-            'info': {},
+            'info': transaction,
         }, transaction);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2273,10 +2273,11 @@ class Exchange {
         return $this->filter_by_currency_since_limit($result, $code, $since, $limit, $tail);
     }
 
-    public function safe_transaction($transaction) {
+    public function safe_transaction($transaction, $currency = null) {
+        $currency = $this->safe_currency(null, $currency);
         return $this->extend(array(
             'id'=> null,
-            'currency'=> null,
+            'currency'=> $currency['code'],
             'amount'=> null,
             'network'=> null,
             'address'=> null,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2293,7 +2293,7 @@ class Exchange {
             'timestamp'=> null,
             'datetime'=> null,
             'fee'=> null,
-            'info'=> [],
+            'info'=> transaction,
         ), $transaction);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2293,7 +2293,7 @@ class Exchange {
             'timestamp'=> null,
             'datetime'=> null,
             'fee'=> null,
-            'info'=> $transaction,
+            'info'=> null,
         ), $transaction);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2274,7 +2274,7 @@ class Exchange {
     }
 
     public function safe_transaction($transaction) {
-        return $this->extend([
+        return $this->extend(array(
             'id'=> null,
             'currency'=> null,
             'amount'=> null,
@@ -2293,7 +2293,7 @@ class Exchange {
             'datetime'=> null,
             'fee'=> null,
             'info'=> [],
-        ], $transaction);
+        ), $transaction);
     }
 
     public function parse_transfers($transfers, $currency = null, $since = null, $limit = null, $params = array()) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2273,6 +2273,29 @@ class Exchange {
         return $this->filter_by_currency_since_limit($result, $code, $since, $limit, $tail);
     }
 
+    public function safe_transaction($transaction) {
+        return $this->extend([
+            'id'=> null,
+            'currency'=> null,
+            'amount'=> null,
+            'network'=> null,
+            'address'=> null,
+            'addressTo'=> null,
+            'addressFrom'=> null,
+            'tag'=> null,
+            'tagTo'=> null,
+            'tagFrom'=> null,
+            'status'=> null,
+            'type'=> null,
+            'updated'=> null,
+            'txid'=> null,
+            'timestamp'=> null,
+            'datetime'=> null,
+            'fee'=> null,
+            'info'=> [],
+        ], $transaction);
+    }
+
     public function parse_transfers($transfers, $currency = null, $since = null, $limit = null, $params = array()) {
         $array = is_array($transfers) ? array_values($transfers) : array();
         $result = array();

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2293,7 +2293,7 @@ class Exchange {
             'timestamp'=> null,
             'datetime'=> null,
             'fee'=> null,
-            'info'=> transaction,
+            'info'=> $transaction,
         ), $transaction);
     }
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1997,6 +1997,28 @@ class Exchange(object):
         tail = since is None
         return self.filter_by_symbol_since_limit(array, symbol, since, limit, tail)
 
+    def safe_transaction(self, transaction):
+        return self.extend({
+            'id': None,
+            'currency': None,
+            'amount': None,
+            'network': None,
+            'address': None,
+            'addressTo': None,
+            'addressFrom': None,
+            'tag': None,
+            'tagTo': None,
+            'tagFrom': None,
+            'status': None,
+            'type': None,
+            'updated': None,
+            'txid': None,
+            'timestamp': None,
+            'datetime': None,
+            'fee': None,
+            'info': [],
+        }, transaction)
+
     def parse_transactions(self, transactions, currency=None, since=None, limit=None, params={}):
         array = self.to_array(transactions)
         array = [self.extend(self.parse_transaction(transaction, currency), params) for transaction in array]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2017,7 +2017,7 @@ class Exchange(object):
             'timestamp': None,
             'datetime': None,
             'fee': None,
-            'info': transaction,
+            'info': None,
         }, transaction)
 
     def parse_transactions(self, transactions, currency=None, since=None, limit=None, params={}):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1997,10 +1997,11 @@ class Exchange(object):
         tail = since is None
         return self.filter_by_symbol_since_limit(array, symbol, since, limit, tail)
 
-    def safe_transaction(self, transaction):
+    def safe_transaction(self, transaction, currency=None):
+        currency = self.safe_currency(None, currency)
         return self.extend({
             'id': None,
-            'currency': None,
+            'currency': currency['code'],
             'amount': None,
             'network': None,
             'address': None,
@@ -2016,7 +2017,7 @@ class Exchange(object):
             'timestamp': None,
             'datetime': None,
             'fee': None,
-            'info': None,
+            'info': transaction,
         }, transaction)
 
     def parse_transactions(self, transactions, currency=None, since=None, limit=None, params={}):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2016,7 +2016,7 @@ class Exchange(object):
             'timestamp': None,
             'datetime': None,
             'fee': None,
-            'info': [],
+            'info': None,
         }, transaction)
 
     def parse_transactions(self, transactions, currency=None, since=None, limit=None, params={}):


### PR DESCRIPTION
`safeTransaction` to be used in `fetchTransactions` (and thus, in parent derived methods of it: `fetchDeposits` & `fetchWithdrawals`)
open for further improvements.