### PR TITLE
`safeFundingHistoryEntry` for `fetchFundingHistory`.

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1553,6 +1553,18 @@ module.exports = class Exchange {
         return result;
     }
 
+    safeFundingHistoryEntry (fundingHistoryEntry) {
+        return this.extend({
+            'id': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'code': undefined,
+            'symbol': undefined,
+            'amount': undefined,
+            'info': {},
+        }, fundingHistoryEntry);
+    }
+
     parseOHLCV (ohlcv, market = undefined) {
         return Array.isArray (ohlcv) ? ohlcv.slice (0, 6) : ohlcv
     }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1553,13 +1553,13 @@ module.exports = class Exchange {
         return result;
     }
 
-    safeFundingHistoryEntry (fundingHistoryEntry) {
-        return this.extend({
+    safeFundingHistoryEntry (fundingHistoryEntry, market = undefined) {
+        return this.extend ({
             'id': undefined,
             'timestamp': undefined,
             'datetime': undefined,
             'code': undefined,
-            'symbol': undefined,
+            'symbol': this.safeSymbol (undefined, market),
             'amount': undefined,
             'info': {},
         }, fundingHistoryEntry);

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1944,13 +1944,13 @@ class Exchange {
         return $result;
     }
 
-    public function safe_funding_history_entry($funding_history_entry) {
+    public function safe_funding_history_entry($funding_history_entry, $market = null) {
         return $this->extend([
             'id'=> null,
             'timestamp'=> null,
             'datetime'=> null,
             'code'=> null,
-            'symbol'=> null,
+            'symbol'=> $this->safe_symbol(null, $market),
             'amount'=> null,
             'info'=> [],
         ], $funding_history_entry);

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1944,6 +1944,18 @@ class Exchange {
         return $result;
     }
 
+    public function safe_funding_history_entry($funding_history_entry) {
+        return $this->extend([
+            'id'=> null,
+            'timestamp'=> null,
+            'datetime'=> null,
+            'code'=> null,
+            'symbol'=> null,
+            'amount'=> null,
+            'info'=> [],
+        ], $funding_history_entry);
+    }
+
     public function parse_ohlcv($ohlcv, $market = null) {
         return ('array' === gettype($ohlcv) && !static::is_associative($ohlcv)) ? array_slice($ohlcv, 0, 6) : $ohlcv;
     }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1645,6 +1645,17 @@ class Exchange(object):
             result[parsed['symbol']] = parsed
         return result
 
+    def safe_funding_history_entry(self, funding_history_entry):
+        return self.extend({
+            'id': None,
+            'timestamp': None,
+            'datetime': None,
+            'code': None,
+            'symbol': None,
+            'amount': None,
+            'info': None,
+        }, funding_history_entry)
+
     def parse_ohlcv(self, ohlcv, market=None):
         if isinstance(ohlcv, list):
             return [

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1645,13 +1645,13 @@ class Exchange(object):
             result[parsed['symbol']] = parsed
         return result
 
-    def safe_funding_history_entry(self, funding_history_entry):
+    def safe_funding_history_entry(self, funding_history_entry, market=None):
         return self.extend({
             'id': None,
             'timestamp': None,
             'datetime': None,
             'code': None,
-            'symbol': None,
+            'symbol': self.safe_symbol(None, market),
             'amount': None,
             'info': None,
         }, funding_history_entry)


### PR DESCRIPTION
`safeFundingHistoryEntry` to be used in `fetchFundingHistory`.
open for further improvements.