### PR TITLE
`safeFundingRate`  for `fetchFundingRates`

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1544,6 +1544,28 @@ module.exports = class Exchange {
         throw new NotSupported (this.id + ' parseFundingRate() not supported yet')
     }
 
+    safeFundingRate (fundingRate) {
+        return this.extend({
+            'timestamp': undefined,
+            'datetime': undefined,
+            'symbol': undefined,
+            'markPrice': undefined,
+            'indexPrice': undefined,
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'fundingRate': undefined,
+            'fundingTimestamp': undefined,
+            'fundingDatetime': undefined,
+            'nextFundingRate': undefined,
+            'nextFundingTimestamp': undefined,
+            'nextFundingDatetime': undefined,
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
+            'info': {},
+        }, fundingRate);
+    }
+
     parseFundingRates (response, market = undefined) {
         const result = {};
         for (let i = 0; i < response.length; i++) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1545,7 +1545,7 @@ module.exports = class Exchange {
     }
 
     safeFundingRate (fundingRate, market = undefined) {
-        return this.extend({
+        return this.extend ({
             'timestamp': undefined,
             'datetime': undefined,
             'symbol': this.safeSymbol (undefined, market),

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1544,11 +1544,11 @@ module.exports = class Exchange {
         throw new NotSupported (this.id + ' parseFundingRate() not supported yet')
     }
 
-    safeFundingRate (fundingRate) {
+    safeFundingRate (fundingRate, market = undefined) {
         return this.extend({
             'timestamp': undefined,
             'datetime': undefined,
-            'symbol': undefined,
+            'symbol': this.safeSymbol (undefined, market),
             'markPrice': undefined,
             'indexPrice': undefined,
             'interestRate': undefined,
@@ -1562,7 +1562,7 @@ module.exports = class Exchange {
             'previousFundingRate': undefined,
             'previousFundingTimestamp': undefined,
             'previousFundingDatetime': undefined,
-            'info': {},
+            'info': undefined,
         }, fundingRate);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1934,6 +1934,28 @@ class Exchange {
         throw new NotSupported($this->id . ' parse_funding_rate() not supported yet');
     }
 
+    public function safe_funding_rate($funding_rate) {
+        return $this->extend([
+            'timestamp'=> null,
+            'datetime'=> null,
+            'symbol'=> null,
+            'markPrice'=> null,
+            'indexPrice'=> null,
+            'interestRate'=> null,
+            'estimatedSettlePrice'=> null,
+            'fundingRate'=> null,
+            'fundingTimestamp'=> null,
+            'fundingDatetime'=> null,
+            'nextFundingRate'=> null,
+            'nextFundingTimestamp'=> null,
+            'nextFundingDatetime'=> null,
+            'previousFundingRate'=> null,
+            'previousFundingTimestamp'=> null,
+            'previousFundingDatetime'=> null,
+            'info'=> [],
+        ], $funding_rate);
+    }
+
     public function parse_funding_rates($response, $market = null) {
         $response = is_array($response) ? array_values($response) : array();
         $result = array();

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1934,11 +1934,11 @@ class Exchange {
         throw new NotSupported($this->id . ' parse_funding_rate() not supported yet');
     }
 
-    public function safe_funding_rate($funding_rate) {
+    public function safe_funding_rate($funding_rate, $market = null) {
         return $this->extend([
             'timestamp'=> null,
             'datetime'=> null,
-            'symbol'=> null,
+            'symbol'=> $this->safe_symbol (null, $market),
             'markPrice'=> null,
             'indexPrice'=> null,
             'interestRate'=> null,
@@ -1952,7 +1952,7 @@ class Exchange {
             'previousFundingRate'=> null,
             'previousFundingTimestamp'=> null,
             'previousFundingDatetime'=> null,
-            'info'=> [],
+            'info'=> null,
         ], $funding_rate);
     }
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1638,6 +1638,27 @@ class Exchange(object):
     def parse_funding_rate(self, contract, market=None):
         raise NotSupported(self.id + ' parse_funding_rate() not supported yet')
 
+    def safe_funding_rate(self, funding_rate):
+        return self.extend({
+            'timestamp': None,
+            'datetime': None,
+            'symbol': None,
+            'markPrice': None,
+            'indexPrice': None,
+            'interestRate': None,
+            'estimatedSettlePrice': None,
+            'fundingRate': None,
+            'fundingTimestamp': None,
+            'fundingDatetime': None,
+            'nextFundingRate': None,
+            'nextFundingTimestamp': None,
+            'nextFundingDatetime': None,
+            'previousFundingRate': None,
+            'previousFundingTimestamp': None,
+            'previousFundingDatetime': None,
+            'info': {},
+        }, funding_rate)
+
     def parse_funding_rates(self, response, market=None):
         result = {}
         for entry in response:

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1638,11 +1638,11 @@ class Exchange(object):
     def parse_funding_rate(self, contract, market=None):
         raise NotSupported(self.id + ' parse_funding_rate() not supported yet')
 
-    def safe_funding_rate(self, funding_rate):
+    def safe_funding_rate(self, funding_rate, market=None):
         return self.extend({
             'timestamp': None,
             'datetime': None,
-            'symbol': None,
+            'symbol': self.safe_symbol(None, market),
             'markPrice': None,
             'indexPrice': None,
             'interestRate': None,
@@ -1656,7 +1656,7 @@ class Exchange(object):
             'previousFundingRate': None,
             'previousFundingTimestamp': None,
             'previousFundingDatetime': None,
-            'info': {},
+            'info': None,
         }, funding_rate)
 
     def parse_funding_rates(self, response, market=None):


### PR DESCRIPTION
`safeFundingRate` to be used in `fetchFundingRates`.
open for further improvements.