### PR TITLE
`safeFundingRateHistoryEntry` for `fetchFundingRateHistory`.

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1845,7 +1845,7 @@ module.exports = class Exchange {
         return result;
     }
 
-    safeFundingRateHistoryEntry (fundingRateHistoryEntry, market = undeifned) {
+    safeFundingRateHistoryEntry (fundingRateHistoryEntry, market = undefined) {
         return this.extend({
             'symbol': this.safeSymbol (undefined, market),
             'timestamp': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1845,13 +1845,13 @@ module.exports = class Exchange {
         return result;
     }
 
-    safeFundingRateHistoryEntry (fundingRateHistoryEntry) {
+    safeFundingRateHistoryEntry (fundingRateHistoryEntry, market = undeifned) {
         return this.extend({
-            'symbol': undefined,
+            'symbol': this.safeSymbol (undefined, market),
             'timestamp': undefined,
             'datetime': undefined,
             'fundingRate': undefined,
-            'info': {},
+            'info': undefined,
         }, fundingRateHistoryEntry);
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1845,6 +1845,16 @@ module.exports = class Exchange {
         return result;
     }
 
+    safeFundingRateHistoryEntry (fundingRateHistoryEntry) {
+        return this.extend({
+            'symbol': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'fundingRate': undefined,
+            'info': {},
+        }, fundingRateHistoryEntry);
+    }
+
     safeTrade (trade, market = undefined) {
         const amount = this.safeString (trade, 'amount');
         const price = this.safeString (trade, 'price');

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1846,7 +1846,7 @@ module.exports = class Exchange {
     }
 
     safeFundingRateHistoryEntry (fundingRateHistoryEntry, market = undefined) {
-        return this.extend({
+        return this.extend ({
             'symbol': this.safeSymbol (undefined, market),
             'timestamp': undefined,
             'datetime': undefined,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3343,6 +3343,16 @@ class Exchange {
         return $result;
     }
 
+    public function safe_funding_rate_history_entry($funding_rate_history_entry) {
+        return $this->extend([
+            'symbol'=> null,
+            'timestamp'=> null,
+            'datetime'=> null,
+            'fundingRate'=> null,
+            'info'=> [],
+        ], $funding_rate_history_entry);
+    }
+
     public function safe_trade($trade, $market = null) {
         $amount = $this->safe_string($trade, 'amount');
         $price = $this->safe_string($trade, 'price');

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3343,13 +3343,13 @@ class Exchange {
         return $result;
     }
 
-    public function safe_funding_rate_history_entry($funding_rate_history_entry) {
+    public function safe_funding_rate_history_entry($funding_rate_history_entry, $market = null) {
         return $this->extend([
-            'symbol'=> null,
+            'symbol'=> $this->safe_symbol (null, $market),
             'timestamp'=> null,
             'datetime'=> null,
             'fundingRate'=> null,
-            'info'=> [],
+            'info'=> null,
         ], $funding_rate_history_entry);
     }
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2500,6 +2500,15 @@ class Exchange(object):
             result = self.array_concat(result, reducedFeeValues)
         return result
 
+    def safe_funding_rate_history_entry(self, funding_rate_history_entry):
+        return self.extend({
+            'symbol': None,
+            'timestamp': None,
+            'datetime': None,
+            'fundingRate': None,
+            'info': {},
+        }, funding_rate_history_entry)
+
     def safe_trade(self, trade, market=None):
         amount = self.safe_string(trade, 'amount')
         price = self.safe_string(trade, 'price')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2500,13 +2500,13 @@ class Exchange(object):
             result = self.array_concat(result, reducedFeeValues)
         return result
 
-    def safe_funding_rate_history_entry(self, funding_rate_history_entry):
+    def safe_funding_rate_history_entry(self, funding_rate_history_entry, market=None):
         return self.extend({
-            'symbol': None,
+            'symbol': self.safe_symbol (None, market),
             'timestamp': None,
             'datetime': None,
             'fundingRate': None,
-            'info': {},
+            'info': None,
         }, funding_rate_history_entry)
 
     def safe_trade(self, trade, market=None):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2502,7 +2502,7 @@ class Exchange(object):
 
     def safe_funding_rate_history_entry(self, funding_rate_history_entry, market=None):
         return self.extend({
-            'symbol': self.safe_symbol (None, market),
+            'symbol': self.safe_symbol(None, market),
             'timestamp': None,
             'datetime': None,
             'fundingRate': None,


### PR DESCRIPTION
`safeFundingRateHistoryEntry` to be used in `fetchFundingRateHistory`.
open for further improvements.