### PR TITLE
`safeBalanceEntry` for `fetchBalance`

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1145,6 +1145,14 @@ module.exports = class Exchange {
         return balance
     }
 
+    safeBalanceEntry (balanceEntry) {
+        return this.extend({
+            'free': undefined,
+            'used': undefined,
+            'total': undefined,
+        }, balanceEntry);
+    }
+
     async fetchBalance (params = {}) {
         throw new NotSupported (this.id + ' fetchBalance not supported yet')
     }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2036,6 +2036,14 @@ class Exchange {
         return $balance;
     }
 
+    public function safe_balance_entry($balance_entry) {
+        return $this->extend([
+            'free'=> null,
+            'used'=> null,
+            'total'=> null,
+        ], $balance_entry);
+    }
+
     public function fetch_partial_balance($part, $params = array()) {
         $balance = $this->fetch_balance($params);
         return $balance[$part];

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1722,6 +1722,13 @@ class Exchange(object):
             balance['total'][currency] = balance[currency]['total']
         return balance
 
+    def safe_balance_entry(self, balance_entry):
+        return self.extend({
+            'free': None,
+            'used': None,
+            'total': None,
+        }, balance_entry)
+
     def fetch_partial_balance(self, part, params={}):
         balance = self.fetch_balance(params)
         return balance[part]


### PR DESCRIPTION
`safeBalanceEntry` to be used in `fetchBalance`.
open for further improvements.

so this code (used in [`fetchBalance`->parseBalance](https://github.com/ccxt/ccxt/blob/master/js/ascendex.js#L653)):
```
...
const account = this.account ();
account['free'] = this.safeString (balance, 'available');
account['used'] = this.safeString (balance, 'unavailable');
result[code] = account;
...
```
becomes:
```
result[code] = this.safeBalanceAccount ({
    'free': this.safeString (balance, 'available'),
    'used': this.safeString (balance, 'unavailable')
});
```