### PR TITLE
`safePosition` for parsePosition

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1682,6 +1682,195 @@ module.exports = class Exchange {
         return this.filterByArray (result, 'symbol', symbols, false);
     }
 
+    safePosition (position, market = undefined) {
+        market = this.market (position['symbol']);
+        const side = position['side'];
+        const realizedPnlString = this.safeString (position, 'realizedPnl');
+        const entryPriceString = this.safeString (position, 'entryPrice');
+        const markPriceString = this.safeString (position, 'markPrice');
+        const lastPriceString = this.safeString (position, 'lastPrice');
+        // support deprecated 'marginType'
+        const marginMode = this.safeString2 (position, 'marginMode', 'marginType');
+        //
+        // CONTRACT SIZE
+        //
+        let contractSizeString = this.safeString (position, 'contractSize');
+        if (contractSizeString === undefined) {
+            contractSizeString = this.safeString (market, 'contractSize');
+        }
+        //
+        // CONTRACT AMOUNT
+        //
+        const contractsAmountString = this.safeString (position, 'contracts');
+        // calculate multiplier - if contractSize is undefined, skip it and use contracts only.
+        const contractsMultipliedSize = (contractSizeString !== undefined) ? Precise.stringMul (contractsAmountString, contractSizeString) : contractsAmountString;
+        //
+        // NOTIONAL SIZE
+        //
+        let notionalString = this.safeString (position, 'notional');
+        if (notionalString === undefined) {
+            // as it was done in: aax
+            // CONFLICT: deribit, ftx - used only contracts, not multiplied by size
+            if (contractsMultipliedSize !== undefined) {
+                // some exchanges, i.e. HUOBI uses lastPrice, as markPrice is not present
+                const markOrLastString = (markPriceString !== undefined) ? markPriceString : lastPriceString;
+                if (markOrLastString !== undefined) {
+                    // divide or multiply - as done in: OKX & HUOBI
+                    if (market['linear']) {
+                        notionalString = Precise.stringMul (contractsMultipliedSize, markOrLastString);
+                    } else if (market['inverse']) {
+                        notionalString = Precise.stringDiv (contractsMultipliedSize, markOrLastString);
+                    }
+                }
+            }
+        }
+        const notional = this.parseNumber (notionalString);
+        //
+        // INITIAL MARGIN AMOUNT & PERCENTAGE
+        //
+        let initialMarginPercentageString = this.safeString (position, 'initialMarginPercentage');
+        let initialMarginString = this.safeString (position, 'initialMargin');
+        // 'initialMargin' from 'initialMarginPercentage'
+        if (initialMarginString === undefined) {
+            if (notionalString !== undefined && initialMarginPercentageString !== undefined) {
+                // as it was done in: okx
+                initialMarginString = Precise.stringMul (initialMarginPercentageString, notionalString);
+            }
+        }
+        const initialMargin = this.parseNumber (initialMarginString);
+        // 'initialMarginPercentage' from 'initialMargin'
+        if (initialMarginPercentageString === undefined) {
+            if (notionalString !== undefined && initialMarginString !== undefined) {
+                // as it was done in: bybit, deribit, gateio, huobi, kucoinfutures, phemex
+                initialMarginPercentageString = Precise.stringDiv (initialMarginString, notionalString);
+            }
+        }
+        const initialMarginPercentage = this.parseNumber (initialMarginPercentageString);
+        //
+        // MAINTENANCE MARGIN AMOUNT & PRECENTAGE
+        //
+        let maintenanceMarginPercentageString = this.safeString (position, 'maintenanceMarginPercentage');
+        let maintenanceMarginString = this.safeString (position, 'maintenanceMargin');
+        // 'maintenanceMargin' from 'maintenanceMarginPercentage'
+        if (maintenanceMarginString === undefined) {
+            if (notionalString !== undefined && maintenanceMarginPercentageString !== undefined) {
+                // as it was done in: deribit, ftx, gateio, huobi, phemex
+                maintenanceMarginString = Precise.stringMul (notionalString, maintenanceMarginPercentageString);
+            }
+        }
+        const maintenanceMargin = this.parseNumber (maintenanceMarginString);
+        // 'maintenanceMarginPercentage' from 'maintenanceMargin'
+        if (maintenanceMarginPercentageString === undefined) {
+            if (notionalString !== undefined && maintenanceMarginString !== undefined) {
+                // as it was done in: okx
+                maintenanceMarginPercentageString = Precise.stringDiv (maintenanceMarginString, notionalString);
+            }
+        }
+        const maintenanceMarginPercentage = this.parseNumber (maintenanceMarginPercentageString);
+        //
+        // LEVERAGE
+        //
+        let leverage = this.safeNumber (position, 'leverage');
+        if (leverage === undefined) {
+            if (maintenanceMarginString !== undefined) {
+                // as it was done in: currencycom
+                leverage = parseInt (Precise.stringDiv ('1', maintenanceMarginString, 0)); // CONFLICT: ftx has initialMarginPercentage
+            }
+        }
+        //
+        // UNREALIZED PROFITS
+        //
+        let unrealizedPnlString = this.safeString (position, 'unrealizedPnl');
+        if (unrealizedPnlString === undefined) {
+            if (entryPriceString !== undefined && markPriceString !== undefined) {
+                // as it was done in: phemex
+                let priceDiff = undefined;
+                if (market['linear']) {
+                    priceDiff = (side === 'long') ? Precise.stringSub (markPriceString, entryPriceString) : Precise.stringSub (entryPriceString, markPriceString);
+                } else if (market['inverse']) {
+                    const ep = Precise.stringDiv ('1', entryPriceString);
+                    const mp = Precise.stringDiv ('1', markPriceString);
+                    priceDiff = (side === 'long') ? Precise.stringSub (ep, mp) : Precise.stringSub (mp, ep);
+                }
+                unrealizedPnlString = Precise.stringMul (Precise.stringMul (priceDiff, contractsAmountString), contractSizeString);
+            }
+        }
+        const unrealizedPnl = this.parseNumber (unrealizedPnlString);
+        //
+        // PERCENTAGE
+        //
+        let percentage = this.safeNumber (position, 'percentage');
+        if (percentage === undefined) {
+            if (unrealizedPnlString !== undefined && initialMarginString !== undefined) {
+                // as it was done in: bybit, deribit, ftx, kucoinfutures, phemex
+                const percentageString = Precise.stringMul (Precise.stringDiv (unrealizedPnlString, initialMarginString, 4), '100');
+                percentage = this.parseNumber (percentageString);
+            }
+        }
+        //
+        // COLLATERAL
+        //
+        const liquidationPriceString = this.safeString (position, 'liquidationPrice');
+        let collateralString = this.safeString (position, 'collateral');
+        if (collateralString === undefined) {
+            // as it was done in: okx
+            if (marginMode === 'cross') {
+                if (initialMarginString !== undefined && unrealizedPnlString !== undefined) {
+                    collateralString = Precise.stringAdd (initialMarginString, unrealizedPnlString);
+                }
+            }
+            // as it was done in: ftx
+            if (collateralString === undefined) {
+                if (side !== undefined && markPriceString !== undefined && contractsAmountString !== undefined && Precise.stringGt (liquidationPriceString, '0')) {
+                    let difference = undefined;
+                    // collateral = maintenanceMargin ± ((markPrice - liquidationPrice) * size)
+                    difference = (side === 'long') ? Precise.stringSub (markPriceString, liquidationPriceString) : Precise.stringSub (liquidationPriceString, markPriceString);
+                    const loss = Precise.stringMul (difference, contractsAmountString);
+                    collateralString = Precise.stringAdd (loss, maintenanceMarginString);
+                }
+            }
+        }
+        const collateral = this.parseNumber (collateralString);
+        //
+        // MARGIN RATIO
+        //
+        let marginRatio = this.safeNumber (position, 'marginRatio');
+        if (marginRatio === undefined) {
+            if (maintenanceMarginString !== undefined && collateralString !== undefined) {
+                // as it was done in: ftx, huobi, okx, phemex
+                marginRatio = this.parseNumber (Precise.stringDiv (maintenanceMarginString, collateralString, 4));
+            }
+        }
+        return {
+            'symbol': position['symbol'],
+            'timestamp': position['timestamp'],
+            'datetime': position['datetime'],
+            'lastTradeTimestamp': this.safeInteger (position, 'lastTradeTimestamp'),
+            'lastUpdateTimestamp': this.safeInteger (position, 'lastUpdateTimestamp'), // like lastTradeTimestamp, but refers to any change in position
+            'notional': notional,
+            'collateral': collateral,
+            'leverage': leverage,
+            'marginMode': marginMode,
+            'marginType': marginMode, // deprecated
+            'marginRatio': marginRatio,
+            'contracts': this.parseNumber (contractsAmountString),
+            'contractSize': this.parseNumber (contractSizeString),
+            'percentage': percentage,
+            'initialMargin': initialMargin,
+            'initialMarginPercentage': initialMarginPercentage,
+            'maintenanceMargin': maintenanceMargin,
+            'maintenanceMarginPercentage': maintenanceMarginPercentage,
+            'side': side,
+            'hedged': position['hedged'],
+            'entryPrice': this.parseNumber (entryPriceString),
+            'markPrice': this.parseNumber (markPriceString),
+            'liquidationPrice': this.parseNumber (liquidationPriceString),
+            'unrealizedPnl': unrealizedPnl,
+            'realizedPnl': this.parseNumber (realizedPnlString),
+            'info': position['info'],
+        };
+    }
+
     parseAccounts (accounts, params = {}) {
         accounts = this.toArray (accounts);
         const result = [];


### PR DESCRIPTION
`safePosition` (to be used in `parsePosition` or elsewhere)
tested and works (without breaking change) for all the exchanges (except binance, which I've not touched). With several rare cases, there has been one or two conflicts in logic, and i've added the word `CONFLICT` aside such occurrences (in `safePosition` body).

Additionally, as you see, I've added the following fields to all parsePosition implementations:
- realizedPln (some exchanges provide it, and users might need it for analyze/whatever. so, it wouldnt hurt to have that field)
- lastPrice (in addition to markPrice, we definitely need to have lastPrice, as in exchange UI's you frequently see when placing an orders, i.e. stoploss/takeprofit, you can choose that based on `last` price or `mark` price. So, lastPrice seems a needed field, and we should have it in unified structure).
- hedged (hedge-mode is also becoming more and more used by exchanges, so we should have it also in structure)
 
