### PR TITLE
`safeTradingLimit` for `fetchTradingLimits`

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1201,6 +1201,18 @@ module.exports = class Exchange {
         return this.markets;
     }
 
+    safeTradingLimit (tradingLimit) {
+        return this.extend({
+            'limit': {
+                'amount': {
+                    'min': undefined,
+                    'max': undefined,
+                }
+            },
+            'info': {},
+        }, tradingLimit);
+    }
+
     filterBySinceLimit (array, since = undefined, limit = undefined, key = 'timestamp', tail = false) {
         const sinceIsDefined = (since !== undefined && since !== null)
         if (sinceIsDefined) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1201,15 +1201,16 @@ module.exports = class Exchange {
         return this.markets;
     }
 
-    safeTradingLimit (tradingLimit) {
+    safeTradingLimit (tradingLimit, market = undefined) {
         return this.extend({
+            'symbol': this.safeSymbol (undefined, market),
             'limit': {
                 'amount': {
                     'min': undefined,
                     'max': undefined,
                 }
             },
-            'info': {},
+            'info': undefined,
         }, tradingLimit);
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1202,7 +1202,7 @@ module.exports = class Exchange {
     }
 
     safeTradingLimit (tradingLimit, market = undefined) {
-        return this.extend({
+        return this.extend ({
             'symbol': this.safeSymbol (undefined, market),
             'limit': {
                 'amount': {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2080,15 +2080,16 @@ class Exchange {
         return $this->markets;
     }
 
-    public function safe_trading_limit($trading_limit) {
+    public function safe_trading_limit($trading_limit, $market = null) {
         return $this->deep_extend([
+            'symbol'=> $this->safe_symbol (null, $market),
             'limits'=> [
                 'amount'=> [
                     'min'=> null,
                     'max'=> null,
                 ],
             ],
-            'info'=> [],
+            'info'=> null,
         ], $trading_limit);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2080,6 +2080,18 @@ class Exchange {
         return $this->markets;
     }
 
+    public function safe_trading_limit($trading_limit) {
+        return $this->deep_extend([
+            'limits'=> [
+                'amount'=> [
+                    'min'=> null,
+                    'max'=> null,
+                ],
+            ],
+            'info'=> [],
+        ], $trading_limit);
+    }
+
     public function filter_by_since_limit($array, $since = null, $limit = null, $key = 'timestamp', $tail = false) {
         $result = array();
         $since_is_set = isset($since);

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1761,15 +1761,16 @@ class Exchange(object):
                 self.options['limitsLoaded'] = self.milliseconds()
         return self.markets
 
-    def safe_trading_limit(self, trading_limit):
+    def safe_trading_limit(self, trading_limit, market):
         return self.extend({
+            'symbol': self.safe_symbol (None, market),
             'limit': {
                 'amount': {
                     'min': None,
                     'max': None,
                 }
             },
-            'info': {},
+            'info': None,
         }, trading_limit)
 
     def fetch_ohlcvc(self, symbol, timeframe='1m', since=None, limit=None, params={}):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1763,7 +1763,7 @@ class Exchange(object):
 
     def safe_trading_limit(self, trading_limit, market):
         return self.extend({
-            'symbol': self.safe_symbol (None, market),
+            'symbol': self.safe_symbol(None, market),
             'limit': {
                 'amount': {
                     'min': None,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1761,6 +1761,17 @@ class Exchange(object):
                 self.options['limitsLoaded'] = self.milliseconds()
         return self.markets
 
+    def safe_trading_limit(self, trading_limit):
+        return self.extend({
+            'limit': {
+                'amount': {
+                    'min': None,
+                    'max': None,
+                }
+            },
+            'info': {},
+        }, trading_limit)
+
     def fetch_ohlcvc(self, symbol, timeframe='1m', since=None, limit=None, params={}):
         if not self.has['fetchTrades']:
             raise NotSupported('fetch_ohlcv() not supported yet')


### PR DESCRIPTION
`safeTradingLimit` to be used in `fetchTradingLimits` (through `parseTradingLimits`).
open for further improvements.