### PR TITLE
`safeDepositAddress` for `fetchDepositAddresses` 

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1400,7 +1400,7 @@ module.exports = class Exchange {
             'address': undefined,
             'tag': undefined,
             'network': undefined,
-            'info': null,
+            'info': undefined,
         }, depositAddress);
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1394,13 +1394,13 @@ module.exports = class Exchange {
         return indexed ? this.indexBy (result, 'currency') : result;
     }
 
-    safeDepositAddress (depositAddress) {
-        return this.extend({
-            'currency': undefined,
+    safeDepositAddress (depositAddress, currency = undefined) {
+        return this.extend ({
+            'currency': this.safeCurrencyCode (undefined, currency),
             'address': undefined,
             'tag': undefined,
             'network': undefined,
-            'info': {},
+            'info': null,
         }, depositAddress);
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1394,6 +1394,16 @@ module.exports = class Exchange {
         return indexed ? this.indexBy (result, 'currency') : result;
     }
 
+    safeDepositAddress (depositAddress) {
+        return this.extend({
+            'currency': undefined,
+            'address': undefined,
+            'tag': undefined,
+            'network': undefined,
+            'info': {},
+        }, depositAddress);
+    }
+
     parseTrades (trades, market = undefined, since = undefined, limit = undefined, params = {}) {
         let result = Object.values (trades || []).map ((trade) => this.merge (this.parseTrade (trade, market), params))
         result = sortBy2 (result, 'timestamp', 'id')

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2250,7 +2250,7 @@ class Exchange {
     }
 
     public function safe_deposit_address($deposit_address) {
-        return $this->deep_extend([
+        return $this->extend([
             'currency'=> null,
             'address'=> null,
             'tag'=> null,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2249,13 +2249,13 @@ class Exchange {
         return $indexed ? $this->index_by($result, 'currency') : $result;
     }
 
-    public function safe_deposit_address($deposit_address) {
+    public function safe_deposit_address($deposit_address, $currency = null) {
         return $this->extend([
-            'currency'=> null,
+            'currency'=> $this->safe_currency_code(null, $currency),
             'address'=> null,
             'tag'=> null,
             'network'=> null,
-            'info'=> [],
+            'info'=> null,
         ], $deposit_address);
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2249,6 +2249,16 @@ class Exchange {
         return $indexed ? $this->index_by($result, 'currency') : $result;
     }
 
+    public function safe_deposit_address($deposit_address) {
+        return $this->deep_extend([
+            'currency'=> null,
+            'address'=> null,
+            'tag'=> null,
+            'network'=> null,
+            'info'=> [],
+        ], $deposit_address);
+    }
+
     public function parse_trades($trades, $market = null, $since = null, $limit = null, $params = array()) {
         $array = is_array($trades) ? array_values($trades) : array();
         $result = array();

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1989,6 +1989,15 @@ class Exchange(object):
             result = self.filter_by_array(result, 'currency', codes, False)
         return self.index_by(result, 'currency') if indexed else result
 
+    def safe_deposit_address(self, deposit_address):
+        return self.extend({
+            'currency': None,
+            'address': None,
+            'tag': None,
+            'network': None,
+            'info': {},
+        }, deposit_address)
+
     def parse_trades(self, trades, market=None, since=None, limit=None, params={}):
         array = self.to_array(trades)
         array = [self.merge(self.parse_trade(trade, market), params) for trade in array]

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1989,13 +1989,13 @@ class Exchange(object):
             result = self.filter_by_array(result, 'currency', codes, False)
         return self.index_by(result, 'currency') if indexed else result
 
-    def safe_deposit_address(self, deposit_address):
+    def safe_deposit_address(self, deposit_address, currency=None):
         return self.extend({
-            'currency': None,
+            'currency': self.safe_currency_code(None, currency),
             'address': None,
             'tag': None,
             'network': None,
-            'info': {},
+            'info': None,
         }, deposit_address)
 
     def parse_trades(self, trades, market=None, since=None, limit=None, params={}):


### PR DESCRIPTION
`safeDepositAddress` to be used in `fetchDepositAddresses` (through `parseDepositAddress`).
open for further improvements.