### PR TITLE
`safeMarginEntry` for `addMargin` & `reduceMargin`

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2316,6 +2316,18 @@ module.exports = class Exchange {
         return await this.createOrder (symbol, type, side, amount, price, query);
     }
 
+    safeMarginEntry (entry, market = undefined) {
+        return this.extend({
+            'type': undefined,
+            'amount': undefined,
+            'code': undefined,
+            'symbol': this.safeSymbol (undefined, market),
+            'status': undefined,
+            'marginType': undefined,
+            'info': undefined,
+        }, entry);
+    }
+    
     parseBorrowInterests (response, market = undefined) {
         const interest = [];
         for (let i = 0; i < response.length; i++) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2317,7 +2317,7 @@ module.exports = class Exchange {
     }
 
     safeMarginEntry (entry, market = undefined) {
-        return this.extend({
+        return this.extend ({
             'type': undefined,
             'amount': undefined,
             'code': undefined,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3827,6 +3827,18 @@ class Exchange {
         return $this->create_order($symbol, $type, $side, $amount, $price, $params);
     }
 
+    public function safe_margin_entry($entry, $market = null) {
+        return $this->extend([
+            'type'=> null,
+            'amount'=> null,
+            'code'=> null,
+            'symbol'=> $this->safe_symbol(null, $market),
+            'status'=> null,
+            'marginType'=> null,
+            'info'=> null,
+        ], $entry);
+    }
+    
     public function parse_borrow_interests($response, $market = null) {
         $interest = array();
         for ($i = 0; $i < count($response); $i++){

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2878,6 +2878,17 @@ class Exchange(object):
         query = self.extend(params, {'postOnly': True})
         return self.create_order(symbol, type, side, amount, price, query)
 
+    def safe_margin_entry(self, entry, market=None):
+        return self.extend({
+            'type': None,
+            'amount': None,
+            'code': None,
+            'symbol': self.safe_symbol(None, market),
+            'status': None,
+            'marginType': None,
+            'info': None,
+        }, entry)
+
     def parse_borrow_interests(self, response, market=None):
         interest = []
         for i in range(len(response)):


### PR DESCRIPTION
`safeMarginEntry` to be used in `addMargin` & `reduceMargin` (through `modifyMarginHelper`).
open for further improvements.