### PR TITLE
`safeSignInEntry` for `signIn`.

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -424,6 +424,10 @@ module.exports = class Exchange {
         return true
     }
 
+    safeSignInEntry(signInEntry) {
+        return signInEntry;
+    }
+
     checkAddress (address) {
 
         if (address === undefined) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1021,6 +1021,10 @@ class Exchange {
         return true;
     }
 
+    public function safe_sign_in_entry($sign_in_entry) {
+        return $sign_in_entry;
+    }
+
     public function check_address($address) {
         if (empty($address) || !is_string($address)) {
             throw new InvalidAddress($this->id . ' address is null');

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1384,6 +1384,9 @@ class Exchange(object):
                     return error
         return True
 
+    def safe_sign_in_entry(self, sign_in_entry):
+        return sign_in_entry
+
     def check_address(self, address):
         """Checks an address is not the same character repeated or an empty sequence"""
         if address is None:


### PR DESCRIPTION
`safeSignInEntry` to be used in `signIn`.
open for further improvements.