### PR TITLE
`fetchStatus` added `info`

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -360,6 +360,7 @@ module.exports = class aax extends Exchange {
         const endTime = this.parse8601 (this.safeString (data, 'endTime'));
         const update = {
             'updated': this.safeInteger (response, 'ts', timestamp),
+            'info': response,
         };
         if (endTime !== undefined) {
             const startTimeIsOk = (startTime === undefined) ? true : (timestamp < startTime);

--- a/js/binance.js
+++ b/js/binance.js
@@ -2068,6 +2068,7 @@ module.exports = class binance extends Exchange {
             this.status = this.extend (this.status, {
                 'status': status,
                 'updated': this.milliseconds (),
+                'info': response,
             });
         }
         return this.status;

--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -165,6 +165,7 @@ module.exports = class bitbns extends Exchange {
             this.status = this.extend (this.status, {
                 'status': status,
                 'updated': this.milliseconds (),
+                'info': response,
             });
         }
         return this.status;

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -374,6 +374,7 @@ module.exports = class bitfinex2 extends bitfinex {
         this.status = this.extend (this.status, {
             'status': formattedStatus,
             'updated': this.milliseconds (),
+            'info': response,
         });
         return this.status;
     }

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -400,6 +400,7 @@ module.exports = class bitmart extends Exchange {
             'status': status,
             'updated': this.milliseconds (),
             'eta': eta,
+            'info': response,
         });
         return this.status;
     }

--- a/js/bitrue.js
+++ b/js/bitrue.js
@@ -339,6 +339,7 @@ module.exports = class bitrue extends Exchange {
         this.status = this.extend (this.status, {
             'status': formattedStatus,
             'updated': this.milliseconds (),
+            'info': response,
         });
         return this.status;
     }

--- a/js/delta.js
+++ b/js/delta.js
@@ -212,6 +212,7 @@ module.exports = class delta extends Exchange {
         this.status = this.extend (this.status, {
             'status': status,
             'updated': updated,
+            'info': response,
         });
         return this.status;
     }

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -391,7 +391,7 @@ module.exports = class deribit extends Exchange {
         const request = {
             // 'expected_result': false, // true will trigger an error for testing purposes
         };
-        await this.publicGetTest (this.extend (request, params));
+        const response = await this.publicGetTest (this.extend (request, params));
         //
         //     {
         //         jsonrpc: '2.0',
@@ -405,6 +405,7 @@ module.exports = class deribit extends Exchange {
         this.status = this.extend (this.status, {
             'status': 'ok',
             'updated': this.milliseconds (),
+            'info': response,
         });
         return this.status;
     }

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -719,7 +719,7 @@ module.exports = class digifinex extends Exchange {
     }
 
     async fetchStatus (params = {}) {
-        await this.publicGetPing (params);
+        const response = await this.publicGetPing (params);
         //
         //     {
         //         "msg": "pong",
@@ -729,6 +729,7 @@ module.exports = class digifinex extends Exchange {
         this.status = this.extend (this.status, {
             'status': 'ok',
             'updated': this.milliseconds (),
+            'info': response,
         });
         return this.status;
     }

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -474,6 +474,7 @@ module.exports = class kucoin extends Exchange {
             this.status = this.extend (this.status, {
                 'status': status,
                 'updated': this.milliseconds (),
+                'info': response,
             });
         }
         return this.status;

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -318,6 +318,7 @@ module.exports = class kucoinfutures extends kucoin {
             this.status = this.extend (this.status, {
                 'status': status,
                 'updated': this.milliseconds (),
+                'info': response,
             });
         }
         return this.status;

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -366,6 +366,7 @@ module.exports = class mexc extends Exchange {
             this.status = this.extend (this.status, {
                 'status': status,
                 'updated': this.milliseconds (),
+                'info': response,
             });
         }
         return this.status;

--- a/js/okx.js
+++ b/js/okx.js
@@ -723,10 +723,10 @@ module.exports = class okx extends Exchange {
         const data = this.safeValue (response, 'data', []);
         const timestamp = this.milliseconds ();
         const update = {
-            'info': response,
             'updated': timestamp,
             'status': 'ok',
             'eta': undefined,
+            'info': response,
         };
         for (let i = 0; i < data.length; i++) {
             const event = data[i];

--- a/js/wazirx.js
+++ b/js/wazirx.js
@@ -383,6 +383,7 @@ module.exports = class wazirx extends Exchange {
         this.status = this.extend (this.status, {
             'status': status,
             'updated': this.milliseconds (),
+            'info': response,
         });
         return this.status;
     }

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -743,6 +743,7 @@ module.exports = class whitebit extends Exchange {
         this.status = this.extend (this.status, {
             'status': status,
             'updated': this.milliseconds (),
+            'info': response,
         });
         return this.status;
     }


### PR DESCRIPTION
after looking into all the occasions, i think it's still best to set:
` 'info': response`
instead of
` 'info': this.safeValue (response, 'XYZ');` //'XYZ' or whatever keyword, be it `data`, `status` or whatever, which holds the actual bool/integer value about status

because, somehow 'fetching the status' is relative to the concept to get the whole 'response' , because many exchanges have non-standard data (in addition of `XYZ` key, there are other sibling keys which also hold important data about status, i.e. see [this ](https://github.com/ccxt/ccxt/blob/master/js/wazirx.js#L379) or [this](https://github.com/ccxt/ccxt/blob/master/js/deribit.js#L396) or [this](https://github.com/ccxt/ccxt/blob/master/js/bitbns.js#L157)). so, that's why I suggest to set whole `response` to `info` inside fetchstatus, so users will have all provided raw info from exchange.