### PR TITLE
`withdraw ()` -> `parseTransaction ()`

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -813,6 +813,14 @@ module.exports = class bibox extends Exchange {
         //         'status': 3
         //     }
         //
+        //
+        // withdraw
+        //
+        //     {
+        //       'info': {},
+        //       'id': '12345678...',
+        //     }
+        //
         const id = this.safeString (transaction, 'id');
         const address = this.safeString (transaction, 'to_address');
         const currencyId = this.safeString (transaction, 'coin_symbol');

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1291,10 +1291,10 @@ module.exports = class bibox extends Exchange {
         const outerResults = this.safeValue (response, 'result');
         const firstResult = this.safeValue (outerResults, 0, {});
         const id = this.safeValue (firstResult, 'result');
-        return {
+        return this.parseTransaction ({
             'info': response,
             'id': id,
-        };
+        }, currency);
     }
 
     async fetchFundingFees (codes = undefined, params = {}) {

--- a/js/binance.js
+++ b/js/binance.js
@@ -3987,10 +3987,7 @@ module.exports = class binance extends Exchange {
         }
         const response = await this.sapiPostCapitalWithdrawApply (this.extend (request, params));
         //     { id: '9a67628b16ba4988ae20d329333f16bc' }
-        return {
-            'info': response,
-            'id': this.safeString (response, 'id'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     parseTradingFee (fee, market = undefined) {

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -658,15 +658,15 @@ module.exports = class bitbank extends Exchange {
             'amount': amount,
         };
         const response = await this.privatePostUserRequestWithdrawal (this.extend (request, params));
-        const data = this.safeValue (response, 'data', {});
-        return this.parseTransaction (data, currency); // todo
+        const transactionData = this.safeValue (response, 'data', {});
+        return this.parseTransaction (transactionData, currency); // todo
     }
 
     parseTransaction (transaction, currency = undefined) {
         const txid = this.safeString (transaction, 'txid');
         currency = this.safeCurrency (undefined, currency);
         return {
-            'id': undefined,
+            'id': txid,
             'txid': txid,
             'timestamp': undefined,
             'datetime': undefined,

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -659,10 +659,31 @@ module.exports = class bitbank extends Exchange {
         };
         const response = await this.privatePostUserRequestWithdrawal (this.extend (request, params));
         const data = this.safeValue (response, 'data', {});
-        const txid = this.safeString (data, 'txid');
+        return this.parseTransaction (data, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        const txid = this.safeString (transaction, 'txid');
         return {
-            'info': response,
-            'id': txid,
+            'id': undefined,
+            'txid': txid,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': undefined,
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -659,11 +659,12 @@ module.exports = class bitbank extends Exchange {
         };
         const response = await this.privatePostUserRequestWithdrawal (this.extend (request, params));
         const data = this.safeValue (response, 'data', {});
-        return this.parseTransaction (data, currency);
+        return this.parseTransaction (data, currency); // todo
     }
 
     parseTransaction (transaction, currency = undefined) {
         const txid = this.safeString (transaction, 'txid');
+        currency = this.safeCurrency (undefined, currency);
         return {
             'id': undefined,
             'txid': txid,
@@ -675,7 +676,7 @@ module.exports = class bitbank extends Exchange {
             'addressTo': undefined,
             'amount': undefined,
             'type': undefined,
-            'currency': undefined,
+            'currency': currency['code'],
             'status': undefined,
             'updated': undefined,
             'tagFrom': undefined,

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -1238,6 +1238,13 @@ module.exports = class bitfinex extends Exchange {
         //         "timestamp_created": "1561716066.0"
         //     }
         //
+        // withdraw
+        //
+        //     {
+        //       'info': {},
+        //       'id': '12345678...',
+        //     }
+        //
         const timestamp = this.safeTimestamp (transaction, 'timestamp_created');
         const updated = this.safeTimestamp (transaction, 'timestamp');
         const currencyId = this.safeString (transaction, 'currency');

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -1312,10 +1312,10 @@ module.exports = class bitfinex extends Exchange {
             }
             throw new ExchangeError (this.id + ' withdraw returned an id of zero: ' + this.json (response));
         }
-        return {
+        return this.parseTransaction ({
             'info': response,
             'id': id,
-        };
+        });
     }
 
     async fetchPositions (symbols = undefined, params = {}) {

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -885,9 +885,34 @@ module.exports = class bithumb extends Exchange {
             }
         }
         const response = await this.privatePostTradeBtcWithdrawal (this.extend (request, params));
-        return {
+        return this.parseTransaction ({
             'info': response,
             'id': undefined,
+        }, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
+        return {
+            'id': undefined,
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -885,10 +885,7 @@ module.exports = class bithumb extends Exchange {
             }
         }
         const response = await this.privatePostTradeBtcWithdrawal (this.extend (request, params));
-        return this.parseTransaction ({
-            'info': response,
-            'id': undefined,
-        }, currency);
+        return this.parseTransaction (response, currency);
     }
 
     parseTransaction (transaction, currency = undefined) {

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1742,10 +1742,7 @@ module.exports = class bitmex extends Exchange {
             // 'fee': 0.001, // bitcoin network fee
         };
         const response = await this.privatePostUserRequestWithdrawal (this.extend (request, params));
-        return {
-            'info': response,
-            'id': this.safeString (response, 'transactID'),
-        };
+        return this.parseTransaction (response, undefined);
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1742,7 +1742,7 @@ module.exports = class bitmex extends Exchange {
             // 'fee': 0.001, // bitcoin network fee
         };
         const response = await this.privatePostUserRequestWithdrawal (this.extend (request, params));
-        return this.parseTransaction (response, undefined);
+        return this.parseTransaction (response);
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/js/bitrue.js
+++ b/js/bitrue.js
@@ -1619,10 +1619,7 @@ module.exports = class bitrue extends Exchange {
         }
         const response = await this.v1PrivatePostWithdrawCommit (this.extend (request, params));
         //     { id: '9a67628b16ba4988ae20d329333f16bc' }
-        return {
-            'info': response,
-            'id': this.safeString (response, 'id'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -936,9 +936,32 @@ module.exports = class bitso extends Exchange {
         };
         const classMethod = 'privatePost' + method + 'Withdrawal';
         const response = await this[classMethod] (this.extend (request, params));
+        const payload = this.safeValue (response, 'payload');
+        return this.parseTransaction (payload);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': response,
-            'id': this.safeString (response['payload'], 'wid'),
+            'id': this.safeString (transaction, 'wid'),
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -1627,6 +1627,7 @@ module.exports = class bitstamp extends Exchange {
             'amount': amount,
         };
         let method = undefined;
+        let currency = undefined;
         if (!this.isFiat (code)) {
             const name = this.getCurrencyName (code);
             method = 'privatePost' + this.capitalize (name) + 'Withdrawal';
@@ -1642,15 +1643,12 @@ module.exports = class bitstamp extends Exchange {
             request['address'] = address;
         } else {
             method = 'privatePostWithdrawalOpen';
-            const currency = this.currency (code);
+            currency = this.currency (code);
             request['iban'] = address;
             request['account_currency'] = currency['id'];
         }
         const response = await this[method] (this.extend (request, params));
-        return {
-            'info': response,
-            'id': this.safeString (response, 'id'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     nonce () {

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -1384,11 +1384,7 @@ module.exports = class bittrex extends Exchange {
             request['cryptoAddressTag'] = tag;
         }
         const response = await this.privatePostWithdrawals (this.extend (request, params));
-        const id = this.safeString (response, 'id');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (response, currency);
     }
 
     sign (path, api = 'v3', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/blockchaincom.js
+++ b/js/blockchaincom.js
@@ -783,10 +783,10 @@ module.exports = class blockchaincom extends Exchange {
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {
         await this.loadMarkets ();
-        const currencyid = this.currencyId (code);
+        const currency = this.currency (code);
         const request = {
             'amount': amount,
-            'currency': currencyid,
+            'currency': currency['id'],
             // 'beneficiary': address/id,
             'sendMax': false,
         };
@@ -802,12 +802,7 @@ module.exports = class blockchaincom extends Exchange {
         //         timestamp: "1634218452595"
         //     },
         //
-        const withdrawalId = this.safeString (response, 'withdrawalId');
-        const result = {
-            'info': response,
-            'id': withdrawalId,
-        };
-        return result;
+        return this.parseTransaction (response, currency);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/cdax.js
+++ b/js/cdax.js
@@ -1490,7 +1490,7 @@ module.exports = class cdax extends Exchange {
         const network = this.safeStringUpper (transaction, 'chain');
         return {
             'info': transaction,
-            'id': this.safeString (transaction, 'id'),
+            'id': this.safeString2 (transaction, 'id', 'data'),
             'txid': this.safeString (transaction, 'tx-hash'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -1564,11 +1564,7 @@ module.exports = class cdax extends Exchange {
             params = this.omit (params, 'network');
         }
         const response = await this.privatePostDwWithdrawApiCreate (this.extend (request, params));
-        const id = this.safeString (response, 'data');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (response, currency);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1133,10 +1133,7 @@ module.exports = class coinbasepro extends Exchange {
         if (!response) {
             throw new ExchangeError (this.id + ' withdraw() error: ' + this.json (response));
         }
-        return {
-            'info': response,
-            'id': response['id'],
-        };
+        return this.parseTransaction (response, currency);
     }
 
     parseLedgerEntryType (type) {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1135,11 +1135,7 @@ module.exports = class cryptocom extends Exchange {
         //     }
         //
         const result = this.safeValue (response, 'result');
-        const id = this.safeString (result, 'id');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (result, currency);
     }
 
     async fetchDepositAddressesByNetwork (code, params = {}) {

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -2079,10 +2079,7 @@ module.exports = class deribit extends Exchange {
             request['tfa'] = this.oath ();
         }
         const response = await this.privateGetWithdraw (this.extend (request, params));
-        return {
-            'info': response,
-            'id': this.safeString (response, 'id'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     nonce () {

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -1373,10 +1373,7 @@ module.exports = class exmo extends Exchange {
             params = this.omit (params, 'network');
         }
         const response = await this.privatePostWithdrawCrypt (this.extend (request, params));
-        return {
-            'info': response,
-            'id': response['task_id'],
-        };
+        return this.parseTransaction (response, currency);
     }
 
     parseTransactionStatus (status) {
@@ -1434,7 +1431,7 @@ module.exports = class exmo extends Exchange {
         //             "error": ""
         //          },
         //
-        const id = this.safeString (transaction, 'order_id');
+        const id = this.safeString2 (transaction, 'order_id', 'task_id');
         const timestamp = this.safeTimestamp2 (transaction, 'dt', 'created');
         const updated = this.safeTimestamp (transaction, 'updated');
         let amount = this.safeNumber (transaction, 'amount');

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2502,16 +2502,7 @@ module.exports = class gateio extends Exchange {
         //       "memo": null
         //     }
         //
-        const currencyId = this.safeString (response, 'currency');
-        const id = this.safeString (response, 'id');
-        return {
-            'info': response,
-            'id': id,
-            'code': this.safeCurrencyCode (currencyId),
-            'amount': this.safeNumber (response, 'amount'),
-            'address': this.safeString (response, 'address'),
-            'tag': this.safeString (response, 'memo'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     parseTransactionStatus (status) {
@@ -2550,6 +2541,18 @@ module.exports = class gateio extends Exchange {
         //     }
         //
         // withdrawals
+        //
+        //
+        // withdraw
+        //
+        //     {
+        //       "id": "w13389675",
+        //       "currency": "USDT",
+        //       "amount": "50",
+        //       "address": "TUu2rLFrmzUodiWfYki7QCNtv1akL682p1",
+        //       "memo": null
+        //     }
+        //
         const id = this.safeString (transaction, 'id');
         let type = undefined;
         let amount = this.safeString (transaction, 'amount');
@@ -2561,7 +2564,7 @@ module.exports = class gateio extends Exchange {
             type = this.parseTransactionType (id[0]);
         }
         const currencyId = this.safeString (transaction, 'currency');
-        const code = this.safeCurrencyCode (currencyId);
+        currency = this.safeCurrency (currencyId, currency);
         const txid = this.safeString (transaction, 'txid');
         const rawStatus = this.safeString (transaction, 'status');
         const status = this.parseTransactionStatus (rawStatus);
@@ -2576,7 +2579,7 @@ module.exports = class gateio extends Exchange {
             'info': transaction,
             'id': id,
             'txid': txid,
-            'currency': code,
+            'currency': currency['code'],
             'amount': this.parseNumber (amount),
             'network': undefined,
             'address': address,

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -905,10 +905,7 @@ module.exports = class gemini extends Exchange {
             'address': address,
         };
         const response = await this.privatePostV1WithdrawCurrency (this.extend (request, params));
-        return {
-            'info': response,
-            'id': this.safeString (response, 'txHash'),
-        };
+        return this.parseTransaction (response, code);
     }
 
     nonce () {

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -1288,10 +1288,7 @@ module.exports = class hitbtc extends Exchange {
             params = this.omit (params, 'network');
         }
         const response = await this.privatePostAccountCryptoWithdraw (this.extend (request, params));
-        return {
-            'info': response,
-            'id': response['id'],
-        };
+        return this.parseTransaction (response, currency);
     }
 
     nonce () {

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1794,11 +1794,7 @@ module.exports = class hitbtc3 extends Exchange {
         }
         const response = await this.privatePostWalletCryptoWithdraw (this.extend (request, params));
         // {"id":"084cfcd5-06b9-4826-882e-fdb75ec3625d"}
-        const id = this.safeString (response, 'id');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (response, currency);
     }
 
     async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4181,7 +4181,7 @@ module.exports = class huobi extends Exchange {
         const network = this.safeStringUpper (transaction, 'chain');
         return {
             'info': transaction,
-            'id': this.safeString (transaction, 'id'),
+            'id': this.safeString2 (transaction, 'id', 'data'),
             'txid': this.safeString (transaction, 'tx-hash'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -4255,11 +4255,7 @@ module.exports = class huobi extends Exchange {
             params = this.omit (params, 'network');
         }
         const response = await this.spotPrivatePostV1DwWithdrawApiCreate (this.extend (request, params));
-        const id = this.safeString (response, 'data');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (response, currency);
     }
 
     parseTransfer (transfer, currency = undefined) {

--- a/js/huobijp.js
+++ b/js/huobijp.js
@@ -1538,7 +1538,7 @@ module.exports = class huobijp extends Exchange {
         const network = this.safeStringUpper (transaction, 'chain');
         return {
             'info': transaction,
-            'id': this.safeString (transaction, 'id'),
+            'id': this.safeString2 (transaction, 'id', 'data'),
             'txid': this.safeString (transaction, 'tx-hash'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -1612,11 +1612,7 @@ module.exports = class huobijp extends Exchange {
             params = this.omit (params, 'network');
         }
         const response = await this.privatePostDwWithdrawApiCreate (this.extend (request, params));
-        const id = this.safeString (response, 'data');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (response, currency);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/idex.js
+++ b/js/idex.js
@@ -1205,11 +1205,7 @@ module.exports = class idex extends Exchange {
         //   txId: null
         // }
         const response = await this.privatePostWithdrawals (request);
-        const id = this.safeString (response, 'withdrawalId');
-        return {
-            'info': response,
-            'id': id,
-        };
+        return this.parseTransaction (response, currency);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
@@ -1331,13 +1327,27 @@ module.exports = class idex extends Exchange {
         //   txId: '0x305e9cdbaa85ad029f50578d13d31d777c085de573ed5334d95c19116d8c03ce',
         //   txStatus: 'mined'
         //  }
+        //
+        // withdraw
+        //     {
+        //        withdrawalId: 'a61dcff0-ec4d-11ea-8b83-c78a6ecb3180',
+        //        asset: 'ETH',
+        //        assetContractAddress: '0x0000000000000000000000000000000000000000',
+        //        quantity: '0.20000000',
+        //        time: 1598962883190,
+        //        fee: '0.00024000',
+        //        txStatus: 'pending',
+        //        txId: null
+        //     }
+        //
         let type = undefined;
         if ('depositId' in transaction) {
             type = 'deposit';
         } else if ('withdrawalId' in transaction) {
             type = 'withdrawal';
         }
-        const id = this.safeString2 (transaction, 'depositId', 'withdrawId');
+        let id = this.safeString2 (transaction, 'depositId', 'withdrawId');
+        id = this.safeString (transaction, 'withdrawalId', id);
         const code = this.safeCurrencyCode (this.safeString (transaction, 'asset'), currency);
         const amount = this.safeNumber (transaction, 'quantity');
         const txid = this.safeString (transaction, 'txId');

--- a/js/indodax.js
+++ b/js/indodax.js
@@ -647,13 +647,31 @@ module.exports = class indodax extends Exchange {
         //         "withdraw_memo": "123123"
         //     }
         //
-        let id = undefined;
-        if (('txid' in response) && (response['txid'].length > 0)) {
-            id = response['txid'];
-        }
+        return this.parseTransaction (response, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': response,
-            'id': id,
+            'id': this.safeString (transaction, 'txid'),
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -2006,11 +2006,7 @@ module.exports = class kraken extends Exchange {
             };
             const response = await this.privatePostWithdraw (this.extend (request, params));
             const result = this.safeValue (response, 'result', {});
-            const id = this.safeString (result, 'refid');
-            return {
-                'info': result,
-                'id': id,
-            };
+            return this.parseTransaction (result, currency);
         }
         throw new ExchangeError (this.id + " withdraw() requires a 'key' parameter (withdrawal key name, as set up on your account)");
     }

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1730,10 +1730,7 @@ module.exports = class kucoin extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', {});
-        return {
-            'id': this.safeString (data, 'withdrawalId'),
-            'info': response,
-        };
+        return this.parseTransaction (data, currency);
     }
 
     parseTransactionStatus (status) {
@@ -1778,6 +1775,15 @@ module.exports = class kucoin extends Exchange {
         //         "createdAt": 1546503758000,
         //         "updatedAt": 1546504603000
         //         "remark":"foobar"
+        //     }
+        //
+        // withdraw
+        //
+        //     {
+        //         "code":  200000,
+        //         "data": {
+        //             "withdrawalId":  "abcdefghijklmnopqrstuvwxyz"
+        //         }
         //     }
         //
         const currencyId = this.safeString (transaction, 'currency');

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -614,9 +614,31 @@ module.exports = class lbank extends Exchange {
             request['memo'] = tag;
         }
         const response = this.privatePostWithdraw (this.extend (request, params));
+        return this.parseTransaction (response, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'id': this.safeString (response, 'id'),
-            'info': response,
+            'id': this.safeString (transaction, 'id'),
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -573,9 +573,33 @@ module.exports = class mercado extends Exchange {
             }
         }
         const response = await this.privatePostWithdrawCoin (this.extend (request, params));
+        const data = this.safeValue (response, 'response_data');
+        const withdrawalData = this.safeValue (data, 'withdrawal');
+        return this.parseTransaction (withdrawalData, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': response,
-            'id': response['response_data']['withdrawal']['id'],
+            'id': this.safeString (transaction, 'id'),
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/ndax.js
+++ b/js/ndax.js
@@ -2016,7 +2016,7 @@ module.exports = class ndax extends Exchange {
         //         "NotionalProductId": 0
         //     }
         //
-        const id = this.safeString (transaction, 'DepositId');
+        const id = this.safeString2 (transaction, 'DepositId', 'id');
         let txid = undefined;
         const currencyId = this.safeString (transaction, 'ProductId');
         const code = this.safeCurrencyCode (currencyId, currency);
@@ -2148,10 +2148,7 @@ module.exports = class ndax extends Exchange {
             'Payload': this.json (withdrawPayload),
         };
         const response = await this.privatePostCreateWithdrawTicket (this.deepExtend (withdrawRequest, params));
-        return {
-            'info': response,
-            'id': this.safeString (response, 'Id'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     nonce () {

--- a/js/okcoin.js
+++ b/js/okcoin.js
@@ -2614,10 +2614,7 @@ module.exports = class okcoin extends Exchange {
         //         "result":true
         //     }
         //
-        return {
-            'info': response,
-            'id': this.safeString (response, 'withdrawal_id'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1392,10 +1392,7 @@ module.exports = class poloniex extends Exchange {
         //         withdrawalNumber: 13449869
         //     }
         //
-        return {
-            'info': response,
-            'id': this.safeString (response, 'withdrawalNumber'),
-        };
+        return this.parseTransaction (response, currency);
     }
 
     async fetchTransactionsHelper (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -1564,6 +1561,14 @@ module.exports = class poloniex extends Exchange {
         //         "timestamp": 1523834337,
         //         "canResendEmail": 0,
         //         "withdrawalNumber": 11162900
+        //     }
+        //
+        // withdraw
+        //
+        //     {
+        //         response: 'Withdrew 1.00000000 USDT.',
+        //         email2FA: false,
+        //         withdrawalNumber: 13449869
         //     }
         //
         const timestamp = this.safeTimestamp (transaction, 'timestamp');

--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -552,9 +552,31 @@ module.exports = class tidebit extends Exchange {
             request['memo'] = tag;
         }
         const result = await this.privatePostWithdrawsApply (this.extend (request, params));
+        return this.parseTransaction (result, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': result,
             'id': undefined,
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/tidex.js
+++ b/js/tidex.js
@@ -800,9 +800,31 @@ module.exports = class tidex extends Exchange {
         //     }
         //
         const result = this.safeValue (response, 'return', {});
+        return this.parseTransaction (result, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': response,
-            'id': this.safeString (result, 'withdraw_id'),
+            'id': this.safeString (transaction, 'withdraw_id'),
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -2124,6 +2124,33 @@ module.exports = class wavesexchange extends Exchange {
             'timestamp': timestamp,
             'signature': signature,
         };
-        return await this.nodePostTransactionsBroadcast (request);
+        const result = await this.nodePostTransactionsBroadcast (request);
+        return this.parseTransaction (result, currency); // breaking change
     }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
+        return {
+            'id': undefined,
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
+        };
+    }
+
 };

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -1180,9 +1180,31 @@ module.exports = class whitebit extends Exchange {
         //
         //     []
         //
+        return this.extend ({ 'id': uniqueId }, this.parseTransaction (response, currency));
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'id': uniqueId,
-            'info': response,
+            'id': undefined,
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 

--- a/js/zaif.js
+++ b/js/zaif.js
@@ -525,10 +525,32 @@ module.exports = class zaif extends Exchange {
             request['message'] = tag;
         }
         const result = await this.privatePostWithdraw (this.extend (request, params));
+        const returnData = this.safeValue (result, 'return');
+        return this.parseTransaction (returnData, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': result,
-            'id': result['return']['txid'],
-            'fee': result['return']['fee'],
+            'id': this.safeString (transaction, 'txid'),
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': this.safeValue (transaction, 'fee'),
+            'info': transaction,
         };
     }
 

--- a/js/zonda.js
+++ b/js/zonda.js
@@ -1242,9 +1242,31 @@ module.exports = class zonda extends Exchange {
             request['address'] = address;
         }
         const response = await this[method] (this.extend (request, params));
+        return this.parseTransaction (response, currency);
+    }
+
+    parseTransaction (transaction, currency = undefined) {
+        currency = this.safeCurrency (undefined, currency);
         return {
-            'info': response,
             'id': undefined,
+            'txid': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'network': undefined,
+            'addressFrom': undefined,
+            'address': undefined,
+            'addressTo': undefined,
+            'amount': undefined,
+            'type': undefined,
+            'currency': currency['code'],
+            'status': undefined,
+            'updated': undefined,
+            'tagFrom': undefined,
+            'tag': undefined,
+            'tagTo': undefined,
+            'comment': undefined,
+            'fee': undefined,
+            'info': transaction,
         };
     }
 


### PR DESCRIPTION
This PR was needed (on top of #12757 ) .
I have not functionally tested the withdraw functions across these exchanges (it would have taken untold time to sign-up and withdraw from all of them to test), however, i've only structurally wrapped the existing implementations & data through `parseTransaction` and almost in all cases the responses will not be degraded, in opposite - they will be enhanced. (there is only several cases of slight change, like 'txhash' were being assigned to `id` directly in `withdraw()`'s returned response, and inside `parseTransaction` I've assigned that value to `txhash` instead `id` property).

I thought it was better these to be in one PR (as changes are practically same) instead of having 30 separate PRs.
lmk if something is wrong here.