### PR TITLE
bitmex - transfer

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -50,6 +50,9 @@ module.exports = class bitmex extends Exchange {
                 'fetchTickers': true,
                 'fetchTrades': true,
                 'fetchTransactions': 'emulated',
+                'fetchTransfer': false,
+                'fetchTransfers': false,
+                'transfer': false,
                 'withdraw': true,
             },
             'timeframes': {


### PR DESCRIPTION
Bitmex has no endpoint to do transfers between accounts type or subaccounts.

Note: It has an endpoint `position/transferMargin` however it's to add or reduce margin