### PR TITLE
ascendex - refactor transfer

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -238,11 +238,6 @@ module.exports = class ascendex extends Exchange {
                     'future': 'futures',
                     'margin': 'margin',
                 },
-                'accountsById': {
-                    'cash': 'spot',
-                    'futures': 'future',
-                    'margin': 'margin',
-                },
                 'transfer': {
                     'fillResponseFromRequest': true,
                 },
@@ -2421,18 +2416,8 @@ module.exports = class ascendex extends Exchange {
         const currency = this.currency (code);
         amount = this.currencyToPrecision (code, amount);
         const accountsByType = this.safeValue (this.options, 'accountsByType', {});
-        const accountsById = this.safeValue (this.options, 'accountsById', {});
-        const accountIds = Object.keys (accountsById);
         const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
         const toId = this.safeString (accountsByType, toAccount, toAccount);
-        if (!(fromId in accountIds)) {
-            const keys = Object.keys (accountsByType);
-            throw new ExchangeError (this.id + ' trasfer() fromAccount must be one of ' + keys.join (', '));
-        }
-        if (!(toId in accountIds)) {
-            const keys = Object.keys (accountsByType);
-            throw new ExchangeError (this.id + ' transfer() toAccount must be one of ' + keys.join (', '));
-        }
         if (fromId !== 'cash' && toId !== 'cash') {
             throw new ExchangeError (this.id + ' transfer() only supports direct balance transfer between spot and future, spot and margin');
         }

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -233,9 +233,14 @@ module.exports = class ascendex extends Exchange {
                     'method': 'v1PrivateAccountGroupGetOrderHist', // 'v1PrivateAccountGroupGetAccountCategoryOrderHistCurrent'
                 },
                 'defaultType': 'spot', // 'spot', 'margin', 'swap'
-                'accountCategories': {
+                'accountsByType': {
                     'spot': 'cash',
-                    'swap': 'futures',
+                    'future': 'futures',
+                    'margin': 'margin',
+                },
+                'accountsById': {
+                    'cash': 'spot',
+                    'futures': 'future',
                     'margin': 'margin',
                 },
                 'transfer': {
@@ -682,8 +687,8 @@ module.exports = class ascendex extends Exchange {
         await this.loadAccounts ();
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
         const options = this.safeValue (this.options, 'fetchBalance', {});
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, marketType, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, marketType, 'cash');
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeString (account, 'id');
         const request = {
@@ -1232,8 +1237,8 @@ module.exports = class ascendex extends Exchange {
         const market = this.market (symbol);
         const [ style, query ] = this.handleMarketTypeAndParams ('createOrder', market, params);
         const options = this.safeValue (this.options, 'createOrder', {});
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, style, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, style, 'cash');
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const clientOrderId = this.safeString2 (params, 'clientOrderId', 'id');
@@ -1371,8 +1376,8 @@ module.exports = class ascendex extends Exchange {
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         const options = this.safeValue (this.options, 'fetchOrder', {});
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, type, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, type, 'cash');
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const request = {
@@ -1476,8 +1481,8 @@ module.exports = class ascendex extends Exchange {
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, type, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, type, 'cash');
         const request = {
             'account-group': accountGroup,
             'account-category': accountCategory,
@@ -1607,8 +1612,8 @@ module.exports = class ascendex extends Exchange {
             'margin': defaultMethod,
             'swap': 'v2PrivateAccountGroupGetFuturesOrderHistCurrent',
         });
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, type, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, type, 'cash');
         if (method === 'v1PrivateAccountGroupGetOrderHist') {
             if (accountCategory !== undefined) {
                 request['category'] = accountCategory;
@@ -1742,8 +1747,8 @@ module.exports = class ascendex extends Exchange {
         const market = this.market (symbol);
         const [ type, query ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
         const options = this.safeValue (this.options, 'cancelOrder', {});
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, type, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, type, 'cash');
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const request = {
@@ -1851,8 +1856,8 @@ module.exports = class ascendex extends Exchange {
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         const options = this.safeValue (this.options, 'cancelAllOrders', {});
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const accountCategory = this.safeString (accountCategories, type, 'cash');
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountCategory = this.safeString (accountsByType, type, 'cash');
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const request = {
@@ -2415,19 +2420,21 @@ module.exports = class ascendex extends Exchange {
         const accountGroup = this.safeString (account, 'id');
         const currency = this.currency (code);
         amount = this.currencyToPrecision (code, amount);
-        const accountCategories = this.safeValue (this.options, 'accountCategories', {});
-        const fromId = this.safeString (accountCategories, fromAccount);
-        const toId = this.safeString (accountCategories, toAccount);
-        if (fromId === undefined) {
-            const keys = Object.keys (accountCategories);
-            throw new ExchangeError (this.id + ' fromAccount must be one of ' + keys.join (', '));
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountsById = this.safeValue (this.options, 'accountsById', {});
+        const accountIds = Object.keys (accountsById);
+        const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
+        const toId = this.safeString (accountsByType, toAccount, toAccount);
+        if (!(fromId in accountIds)) {
+            const keys = Object.keys (accountsByType);
+            throw new ExchangeError (this.id + ' trasfer() fromAccount must be one of ' + keys.join (', '));
         }
-        if (toId === undefined) {
-            const keys = Object.keys (accountCategories);
-            throw new ExchangeError (this.id + ' toAccount must be one of ' + keys.join (', '));
+        if (!(toId in accountIds)) {
+            const keys = Object.keys (accountsByType);
+            throw new ExchangeError (this.id + ' transfer() toAccount must be one of ' + keys.join (', '));
         }
-        if (fromAccount !== 'spot' && toAccount !== 'spot') {
-            throw new ExchangeError ('This exchange only supports direct balance transfer between spot and swap, spot and margin');
+        if (fromId !== 'cash' && toId !== 'cash') {
+            throw new ExchangeError (this.id + ' transfer() only supports direct balance transfer between spot and future, spot and margin');
         }
         const request = {
             'account-group': accountGroup,


### PR DESCRIPTION
- Use unified `accountsByType` and `accountsById`
- Use standard error
- Accept both unified account types and account ids.