### PR TITLE
bitfinex - refactor transfer

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -379,7 +379,6 @@ module.exports = class bitfinex extends Exchange {
                     'spot': 'exchange',
                     'margin': 'trading',
                     'funding': 'deposit',
-                    'future': 'exchange',
                     'swap': 'trading',
                 },
             },

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -379,10 +379,13 @@ module.exports = class bitfinex extends Exchange {
                     'spot': 'exchange',
                     'margin': 'trading',
                     'funding': 'deposit',
-                    'exchange': 'exchange',
-                    'trading': 'trading',
-                    'deposit': 'deposit',
-                    'derivatives': 'trading',
+                    'future': 'exchange',
+                    'contract': 'trading',
+                },
+                'accountsById': {
+                    'exchange': 'spot',
+                    'trading': 'margin',
+                    'deposit': 'funding',
                 },
             },
         });
@@ -647,15 +650,17 @@ module.exports = class bitfinex extends Exchange {
         // however we support it in CCXT (from just looking at web inspector)
         await this.loadMarkets ();
         const accountsByType = this.safeValue (this.options, 'accountsByType', {});
-        const fromId = this.safeString (accountsByType, fromAccount);
-        if (fromId === undefined) {
+        const accountsById = this.safeValue (this.options, 'accountsById', {});
+        const accountIds = Object.keys (accountsById);
+        const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
+        if (!(fromId in accountIds)) {
             const keys = Object.keys (accountsByType);
-            throw new ExchangeError (this.id + ' transfer fromAccount must be one of ' + keys.join (', '));
+            throw new ExchangeError (this.id + ' transfer() fromAccount must be one of ' + keys.join (', '));
         }
-        const toId = this.safeString (accountsByType, toAccount);
-        if (toId === undefined) {
+        const toId = this.safeString (accountsByType, toAccount, toAccount);
+        if (!(toId in accountIds)) {
             const keys = Object.keys (accountsByType);
-            throw new ExchangeError (this.id + ' transfer toAccount must be one of ' + keys.join (', '));
+            throw new ExchangeError (this.id + ' transfer() toAccount must be one of ' + keys.join (', '));
         }
         const currency = this.currency (code);
         const fromCurrencyId = this.convertDerivativesId (currency['id'], fromAccount);

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -380,7 +380,7 @@ module.exports = class bitfinex extends Exchange {
                     'margin': 'trading',
                     'funding': 'deposit',
                     'future': 'exchange',
-                    'contract': 'trading',
+                    'swap': 'trading',
                 },
                 'accountsById': {
                     'exchange': 'spot',

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4542,9 +4542,11 @@ Parameters
 Unified values for `fromAccount` and `toAccount` include
 
 - `funding` *For some exchanges `funding` and `spot` are the same account*
+- `main` *For some exchanges that allow for subaccounts
 - `spot`
 - `margin`
 - `future`
+- `contract`
 
 You can retrieve all the account types by selecting the keys from `exchange.options['accountsByType']
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4541,8 +4541,8 @@ Parameters
 
 Unified values for `fromAccount` and `toAccount` include
 
-- `funding` *For some exchanges `funding` and `spot` are the same account*
-- `main` *For some exchanges that allow for subaccounts
+- `funding` *for some exchanges `funding` and `spot` are the same account*
+- `main` *for some exchanges that allow for subaccounts*
 - `spot`
 - `margin`
 - `future`

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4534,19 +4534,19 @@ Parameters
 - **code** (String) Unified CCXT currency code (e.g. `"USDT"`)
 - **amount** (Float) The amount of currency to transfer (e.g. `10.5`)
 - **fromAccount** (String) The account to transfer funds from.
-- **toAccount** (String) The account to transfer funds to
+- **toAccount** (String) The account to transfer funds to.
 - **params** (Dictionary) Parameters specific to the exchange API endpoint (e.g. `{"endTime": 1645807945000}`)
 
 **Account Types**
 
-Unified values for `fromAccount` and `toAccount` include
+`fromAccount` and `toAccount` can accept the exchange account id or one of the following unified values:
 
 - `funding` *for some exchanges `funding` and `spot` are the same account*
 - `main` *for some exchanges that allow for subaccounts*
 - `spot`
 - `margin`
 - `future`
-- `contract`
+- `swap`
 
 You can retrieve all the account types by selecting the keys from `exchange.options['accountsByType']
 


### PR DESCRIPTION
Update Manual
Refactor transfer per other PR comments:
- Use common error message format.
- Accept both unified account and account Id from exchange