### PR TITLE
ZB fetchOpenOrders 'stop'

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -2134,7 +2134,7 @@ module.exports = class zb extends Exchange {
             method = 'contractV2PrivateGetTradeGetOrderAlgos';
             const orderType = this.safeInteger (params, 'orderType');
             if (orderType === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOrders() requires an orderType parameter for stop orders');
+                throw new ArgumentsRequired (this.id + ' fetchClosedOrders() requires an orderType parameter for stop orders');
             }
             const side = this.safeInteger (params, 'side');
             const bizType = this.safeInteger (params, 'bizType');
@@ -2272,7 +2272,7 @@ module.exports = class zb extends Exchange {
             method = 'contractV2PrivateGetTradeGetOrderAlgos';
             const orderType = this.safeInteger (params, 'orderType');
             if (orderType === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOrders() requires an orderType parameter for stop orders');
+                throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires an orderType parameter for stop orders');
             }
             const side = this.safeInteger (params, 'side');
             const bizType = this.safeInteger (params, 'bizType');

--- a/js/zb.js
+++ b/js/zb.js
@@ -2236,16 +2236,23 @@ module.exports = class zb extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        const stop = this.safeValue (params, 'stop');
         const swap = market['swap'];
         const request = {
             // 'pageSize': limit, // default pageSize is 10 for spot, 30 for swap
-            // 'currency': market['id'], // spot only
-            // 'pageIndex': 1, // spot only
-            // 'symbol': market['id'], // swap only
-            // 'pageNum': 1, // swap only
+            // 'currency': market['id'], // SPOT
+            // 'pageIndex': 1, // SPOT
+            // 'symbol': market['id'], // SWAP and STOP
+            // 'pageNum': 1, // SWAP and STOP, default 1
             // 'type': params['type'], // swap only
-            // 'side': params['side'], // swap only
-            // 'action': params['action'], // swap only
+            // 'side': params['side'], // SWAP and STOP, for stop orders: 1 Open long (buy), 2 Open short (sell), 3 Close long (sell), 4 Close Short (Buy). One-Way Positions: 5 Buy, 6 Sell, 0 Close Only
+            // 'action': params['action'], // SWAP
+            // 'orderType': 1, // STOP, 1: Plan order, 2: SP/SL
+            // 'bizType': 1, // Plan order, 1: TP, 2: SL
+            // 'status': 1, // STOP, 1: untriggered, 2: cancelled, 3:triggered, 4:failed, 5:completed
+            // 'startTime': since, // SWAP and STOP
+            // 'endTime': params['endTime'], // STOP
         };
         if (limit !== undefined) {
             request['pageSize'] = limit; // default pageSize is 10 for spot, 30 for swap
@@ -2261,13 +2268,45 @@ module.exports = class zb extends Exchange {
             'spot': 'spotV1PrivateGetGetUnfinishedOrdersIgnoreTradeType',
             'swap': 'contractV2PrivateGetTradeGetUndoneOrders',
         });
+        if (stop) {
+            method = 'contractV2PrivateGetTradeGetOrderAlgos';
+            const orderType = this.safeInteger (params, 'orderType');
+            if (orderType === undefined) {
+                throw new ArgumentsRequired (this.id + ' fetchOrders() requires an orderType parameter for stop orders');
+            }
+            const side = this.safeInteger (params, 'side');
+            const bizType = this.safeInteger (params, 'bizType');
+            if (side === 'sell' && reduceOnly) {
+                request['side'] = 3; // close long
+            } else if (side === 'buy' && reduceOnly) {
+                request['side'] = 4; // close short
+            } else if (side === 'buy') {
+                request['side'] = 1; // open long
+            } else if (side === 'sell') {
+                request['side'] = 2; // open short
+            } else if (side === 5) {
+                request['side'] = 5; // one way position buy
+            } else if (side === 6) {
+                request['side'] = 6; // one way position sell
+            } else if (side === 0) {
+                request['side'] = 0; // one way position close only
+            }
+            if (orderType === 1) {
+                request['orderType'] = 1;
+            } else if (orderType === 2 || bizType) {
+                request['orderType'] = 2;
+                request['bizType'] = bizType;
+            }
+            request['status'] = 1;
+        }
+        const query = this.omit (params, [ 'reduceOnly', 'stop', 'side', 'orderType', 'bizType' ]);
         // tradeType 交易类型1/0[buy/sell]
         if ('tradeType' in params) {
             method = 'spotV1PrivateGetGetOrdersNew';
         }
         let response = undefined;
         try {
-            response = await this[method] (this.extend (request, params));
+            response = await this[method] (this.extend (request, query));
         } catch (e) {
             if (e instanceof OrderNotFound) {
                 return [];
@@ -2333,6 +2372,45 @@ module.exports = class zb extends Exchange {
         //         "desc": "操作成功"
         //     }
         //
+        // Algo order
+        //
+        //     {
+        //         "code": 10000,
+        //         "data": {
+        //             "list": [
+        //                 {
+        //                     "action": 1,
+        //                     "algoPrice": "30000",
+        //                     "amount": "0.003",
+        //                     "bizType": 0,
+        //                     "canCancel": true,
+        //                     "createTime": "1649913941109",
+        //                     "errorCode": 0,
+        //                     "id": "6920240642849449984",
+        //                     "isLong": false,
+        //                     "leverage": 10,
+        //                     "marketId": "100",
+        //                     "modifyTime": "1649913941109",
+        //                     "orderType": 1,
+        //                     "priceType": 2,
+        //                     "side": 5,
+        //                     "sourceType": 4,
+        //                     "status": 1,
+        //                     "submitPrice": "41270.53",
+        //                     "symbol": "BTC_USDT",
+        //                     "tradedAmount": "0",
+        //                     "triggerCondition": "<=",
+        //                     "triggerPrice": "31000",
+        //                     "triggerTime": "0",
+        //                     "userId": "6896693805014120448"
+        //                 },
+        //             ],
+        //             "pageNum": 1,
+        //             "pageSize": 10
+        //         },
+        //         "desc": "操作成功"
+        //     }
+        //
         if (swap) {
             const data = this.safeValue (response, 'data', {});
             response = this.safeValue (data, 'list', []);
@@ -2389,7 +2467,7 @@ module.exports = class zb extends Exchange {
         //         "value": "60"
         //     },
         //
-        // Algo fetchOrders, fetchClosedOrders
+        // Algo fetchOrders, fetchOpenOrders, fetchClosedOrders
         //
         //     {
         //         "action": 1,


### PR DESCRIPTION
Added stop functionality to fetchOpenOrders:
```
node examples/js/cli zb fetchOpenOrders BTC/USDT:USDT undefined undefined '{"stop":"true","orderType":"1"}'

zb.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2022-04-14T23:22:28.305Z iteration 0 passed in 349 ms

                 id |       clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | cost | amount | filled | remaining | status | fee | trades | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6920511551971731456 | 6896693805014120448 | 1649978530877 | 2022-04-14T23:22:10.877Z |                    | BTC/USDT:USDT | limit |             |    false |    1 | 33333 |     33333 |         |      |  0.001 |        |           |   open |     |     [] |   []
1 objects
```