### PR TITLE
Kucoin stop price

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1112,20 +1112,24 @@ module.exports = class kucoin extends Exchange {
          * @param {float} amount the amount of currency to trade
          * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
          * @param {dict} params  Extra parameters specific to the exchange API endpoint
-         * @param {float} params.leverage Leverage size of the order
-         * @param {float} params.stopPrice The price at which a trigger order is triggered at
-         * @param {str} params.timeInForce GTC, GTT, IOC, or FOK, default is GTC, limit orders only
-         * @param {str} params.postOnly Post only flag, invalid when timeInForce is IOC or FOK
          * @param {str} params.clientOid client order id, defaults to uuid if not passed
          * @param {str} params.remark remark for the order, length cannot exceed 100 utf8 characters
-         * @param {str} params.stop  Either loss or entry, the default is loss. Requires stopPrice to be defined
-         * @param {str} params.stp '', // self trade prevention, CN, CO, CB or DC
          * @param {str} params.tradeType 'TRADE', // TRADE, MARGIN_TRADE // not used with margin orders
+         * limit orders ---------------------------------------------------
+         * @param {str} params.timeInForce GTC, GTT, IOC, or FOK, default is GTC, limit orders only
          * @param {float} params.cancelAfter long, // cancel after n seconds, requires timeInForce to be GTT
+         * @param {str} params.postOnly Post only flag, invalid when timeInForce is IOC or FOK
          * @param {bool} params.hidden false, // Order will not be displayed in the order book
          * @param {bool} params.iceberg false, // Only a portion of the order is displayed in the order book
          * @param {str} params.visibleSize this.amountToPrecision (symbol, visibleSize), // The maximum visible size of an iceberg order
+         * market orders --------------------------------------------------
          * @param {str} params.funds // Amount of quote currency to use
+         * stop orders ----------------------------------------------------
+         * @param {str} params.stop  Either loss or entry, the default is loss. Requires stopPrice to be defined
+         * @param {float} params.stopPrice The price at which a trigger order is triggered at
+         * margin orders --------------------------------------------------
+         * @param {float} params.leverage Leverage size of the order
+         * @param {str} params.stp '', // self trade prevention, CN, CO, CB or DC
          * @param {str} params.marginMode 'cross', // cross (cross mode) and isolated (isolated mode), set to cross by default, the isolated mode will be released soon, stay tuned
          * @param {bool} params.autoBorrow false, // The system will first borrow you funds at the optimal interest rate and then place an order for you
          * @returns an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1429,11 +1429,11 @@ module.exports = class kucoin extends Exchange {
             request['clientOid'] = clientOrderId;
             if (stop) {
                 method = 'privateGetStopOrderQueryOrderByClientOid';
-                if (symbol) {
+                if (symbol !== undefined) {
                     request['symbol'] = market['id'];
                 }
             } else {
-                method = 'privateGetOrdersClientOrderClientOid';
+                method = 'privateGetOrderClientOrderClientOid';
             }
         } else {
             // a special case for undefined ids
@@ -1489,6 +1489,39 @@ module.exports = class kucoin extends Exchange {
         //         "createdAt": 1547026471000  // time
         //     }
         //
+        //    {
+        //        id: 'vs86koip04qlmsrn000h4ncq',
+        //        symbol: 'ADA-USDT',
+        //        userId: '613a896885d8660006151f01',
+        //        status: 'NEW',
+        //        type: 'limit',
+        //        side: 'sell',
+        //        price: '0.92000000000000000000',
+        //        size: '10.00000000000000000000',
+        //        funds: null,
+        //        stp: null,
+        //        timeInForce: 'GTC',
+        //        cancelAfter: -1,
+        //        postOnly: false,
+        //        hidden: false,
+        //        iceberg: false,
+        //        visibleSize: null,
+        //        channel: 'API',
+        //        clientOid: 'e5bc0f1e-dd22-4e4c-b3a6-eff3b2ae254a',
+        //        remark: null,
+        //        tags: null,
+        //        orderTime: 1650000181132000000,
+        //        domainId: 'kucoin',
+        //        tradeSource: 'USER',
+        //        tradeType: 'TRADE',
+        //        feeCurrency: 'USDT',
+        //        takerFeeRate: '0.00100000000000000000',
+        //        makerFeeRate: '0.00100000000000000000',
+        //        createdAt: 1650000181132,
+        //        stop: 'loss',
+        //        stopTriggerTime: null,
+        //        stopPrice: '0.92000000000000000000'
+        //    }
         const marketId = this.safeString (order, 'symbol');
         const symbol = this.safeSymbol (marketId, market, '-');
         const orderId = this.safeString (order, 'id');

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1449,7 +1449,10 @@ module.exports = class kucoin extends Exchange {
         }
         params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
         const response = await this[method] (this.extend (request, params));
-        const responseData = this.safeValue (response, 'data');
+        let responseData = this.safeValue (response, 'data');
+        if (method === 'privateGetStopOrderQueryOrderByClientOid') {
+            responseData = this.safeValue (responseData, 0);
+        }
         return this.parseOrder (responseData, market);
     }
 
@@ -1489,39 +1492,6 @@ module.exports = class kucoin extends Exchange {
         //         "createdAt": 1547026471000  // time
         //     }
         //
-        //    {
-        //        id: 'vs86koip04qlmsrn000h4ncq',
-        //        symbol: 'ADA-USDT',
-        //        userId: '613a896885d8660006151f01',
-        //        status: 'NEW',
-        //        type: 'limit',
-        //        side: 'sell',
-        //        price: '0.92000000000000000000',
-        //        size: '10.00000000000000000000',
-        //        funds: null,
-        //        stp: null,
-        //        timeInForce: 'GTC',
-        //        cancelAfter: -1,
-        //        postOnly: false,
-        //        hidden: false,
-        //        iceberg: false,
-        //        visibleSize: null,
-        //        channel: 'API',
-        //        clientOid: 'e5bc0f1e-dd22-4e4c-b3a6-eff3b2ae254a',
-        //        remark: null,
-        //        tags: null,
-        //        orderTime: 1650000181132000000,
-        //        domainId: 'kucoin',
-        //        tradeSource: 'USER',
-        //        tradeType: 'TRADE',
-        //        feeCurrency: 'USDT',
-        //        takerFeeRate: '0.00100000000000000000',
-        //        makerFeeRate: '0.00100000000000000000',
-        //        createdAt: 1650000181132,
-        //        stop: 'loss',
-        //        stopTriggerTime: null,
-        //        stopPrice: '0.92000000000000000000'
-        //    }
         const marketId = this.safeString (order, 'symbol');
         const symbol = this.safeSymbol (marketId, market, '-');
         const orderId = this.safeString (order, 'id');

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -934,7 +934,7 @@ module.exports = class kucoinfutures extends kucoin {
          * @name kucoinfutures#createOrder
          * @description Create an order on the exchange
          * @param {str} symbol Unified CCXT market symbol
-         * @param {str} type "limit" or "market" *"market" is contract only*
+         * @param {str} type "limit" or "market"
          * @param {str} side "buy" or "sell"
          * @param {float} amount the amount of currency to trade
          * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency


### PR DESCRIPTION
```
% kucoin createOrder ADA/USDT limit sell 10 0.92 '{"stopPrice": 0.92}'
2022-04-15T05:22:59.395Z
Node.js: v14.17.0
CCXT v1.79.17
kucoin.createOrder (ADA/USDT, limit, sell, 10, 0.92, [object Object])
2022-04-15T05:23:00.992Z iteration 0 passed in 262 ms

{
  id: 'vs86koip04qlmsrn000h4ncq',
  clientOrderId: '...',
  info: { orderId: 'vs86koip04qlmsrn000h4ncq' },
  timestamp: 1650000180992,
  datetime: '2022-04-15T05:23:00.992Z',
  lastTradeTimestamp: undefined,
  symbol: 'ADA/USDT',
  type: 'limit',
  side: 'sell',
  price: 0.92,
  amount: 10,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: undefined
}

% kucoin fetchOrder vs86koip05b4tii0000novl5 undefined '{"stop": true}'
2022-04-15T06:13:05.187Z
Node.js: v14.17.0
CCXT v1.79.17
kucoin.fetchOrder (vs86koip05b4tii0000novl5, , [object Object])
2022-04-15T06:13:07.164Z iteration 0 passed in 252 ms

{
  id: 'vs86koip05b4tii0000novl5',
  clientOrderId: '...',
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  amount: 10,
  price: 0.92,
  stopPrice: 0.92,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  timestamp: 1650000214239,
  datetime: '2022-04-15T05:23:34.239Z',
  fee: { currency: 'USDT', cost: undefined },
  status: 'canceled',
  info: {
    id: 'vs86koip05b4tii0000novl5',
    symbol: 'ADA-USDT',
    userId: '...',
    status: 'NEW',
    type: 'limit',
    side: 'sell',
    price: '0.92000000000000000000',
    size: '10.00000000000000000000',
    funds: null,
    stp: null,
    timeInForce: 'GTC',
    cancelAfter: -1,
    postOnly: false,
    hidden: false,
    iceberg: false,
    visibleSize: null,
    channel: 'API',
    clientOid: '...',
    remark: null,
    tags: null,
    orderTime: 1650000214238000000,
    domainId: 'kucoin',
    tradeSource: 'USER',
    tradeType: 'TRADE',
    feeCurrency: 'USDT',
    takerFeeRate: '0.00100000000000000000',
    makerFeeRate: '0.00100000000000000000',
    createdAt: 1650000214239,
    stop: 'loss',
    stopTriggerTime: null,
    stopPrice: '0.92000000000000000000'
  },
  lastTradeTimestamp: undefined,
  average: undefined,
  trades: [],
  fees: [ { currency: 'USDT', cost: undefined } ]
}

% kucoin fetchOrder undefined undefined '{"stop": true, "clientOid": "..."}'
kucoin.fetchOrder (, , [object Object])
2022-04-15T06:14:35.485Z iteration 0 passed in 230 ms

{
  id: undefined,
  clientOrderId: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  amount: undefined,
  price: undefined,
  stopPrice: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  timestamp: undefined,
  datetime: undefined,
  fee: { currency: undefined, cost: undefined },
  status: 'closed',
  info: [
    {
      id: 'vs86koip04qlmsrn000h4ncq',
      symbol: 'ADA-USDT',
      userId: '...',
      status: 'NEW',
      type: 'limit',
      side: 'sell',
      price: '0.92000000000000000000',
      size: '10.00000000000000000000',
      funds: null,
      stp: null,
      timeInForce: 'GTC',
      cancelAfter: -1,
      postOnly: false,
      hidden: false,
      iceberg: false,
      visibleSize: null,
      channel: 'API',
      clientOid: '...',
      remark: null,
      tags: null,
      orderTime: 1650000181132000000,
      domainId: 'kucoin',
      tradeSource: 'USER',
      tradeType: 'TRADE',
      feeCurrency: 'USDT',
      takerFeeRate: '0.00100000000000000000',
      makerFeeRate: '0.00100000000000000000',
      createdAt: 1650000181132,
      stop: 'loss',
      stopTriggerTime: null,
      stopPrice: '0.92000000000000000000'
    }
  ],
  lastTradeTimestamp: undefined,
  average: undefined,
  trades: [],
  fees: [ { currency: undefined, cost: undefined } ]
}

% kucoin cancelOrder undefined undefined '{"clientOid": "...", "stop": true}'
kucoin.cancelOrder (, , [object Object])
2022-04-15T06:18:51.715Z iteration 0 passed in 244 ms

{
  code: '200000',
  data: {
    cancelledOrderId: 'vs86koip04qlmsrn000h4ncq',
    clientOid: '...'
  }
}

% kucoin fetchOpenOrders undefined undefined undefined '{"stop": true}'
2022-04-15T06:20:05.597Z
Node.js: v14.17.0
CCXT v1.79.17
kucoin.fetchOpenOrders (, , , [object Object])
2022-04-15T06:20:07.650Z iteration 0 passed in 244 ms

                      id |                        clientOrderId |   symbol |  type | timeInForce | postOnly | side | amount | price | stopPrice | cost | filled | remaining |     timestamp |                 datetime |                 fee |   status | lastTradeTimestamp | average | trades |                  fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
vs86koip05b4tii0000novl5 | ... | ADA/USDT | limit |         GTC |    false | sell |     10 |  0.92 |      0.92 |      |        |           | 1650000214239 | 2022-04-15T05:23:34.239Z | {"currency":"USDT"} | canceled |                    |         |     [] | [{"currency":"USDT"}]
1 objects

% kucoin cancelOrder vs86koip05b4tii0000novl5 undefined '{"stop": true}'
2022-04-15T06:21:05.190Z
Node.js: v14.17.0
CCXT v1.79.17
kucoin.cancelOrder (vs86koip05b4tii0000novl5, , [object Object])
2022-04-15T06:21:06.600Z iteration 0 passed in 247 ms

{
  code: '200000',
  data: { cancelledOrderIds: [ 'vs86koip05b4tii0000novl5' ] }
}

% kucoin cancelAllOrders undefined '{"stop": true}'
2022-04-15T06:22:45.868Z
Node.js: v14.17.0
CCXT v1.79.17
kucoin.cancelAllOrders (, [object Object])
2022-04-15T06:22:47.040Z iteration 0 passed in 245 ms

{
  code: '200000',
  data: {
    cancelledOrderIds: [ 'vs86koip1s1sci4e000tb3op', 'vs86koip1s7uve3f000jml1r' ]
  }
}
```