### PR TITLE
ftx.fetchOHLCV since has a default value if not assigned. fixes:#12855

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -967,16 +967,20 @@ module.exports = class ftx extends Exchange {
         const price = this.safeString (params, 'price');
         const until = this.safeInteger (params, 'until');
         params = this.omit (params, [ 'price', 'until' ]);
-        if (since !== undefined) {
+        const duration = this.parseTimeframe (timeframe);
+        const now = this.seconds ();
+        if (since === undefined) { // Issue #12855, inconsistent results if since is not provided
+            request['end_time'] = now;
+            request['start_time'] = this.sum (now, -limit * duration);
+        } else {
             const startTime = parseInt (since / 1000);
             request['start_time'] = startTime;
-            const duration = this.parseTimeframe (timeframe);
             const endTime = this.sum (startTime, limit * duration);
-            request['end_time'] = Math.min (endTime, this.seconds ());
-            if (duration > 86400) {
-                const wholeDaysInTimeframe = parseInt (duration / 86400);
-                request['limit'] = Math.min (limit * wholeDaysInTimeframe, maxLimit);
-            }
+            request['end_time'] = Math.min (endTime, now);
+        }
+        if (duration > 86400) {
+            const wholeDaysInTimeframe = parseInt (duration / 86400);
+            request['limit'] = Math.min (limit * wholeDaysInTimeframe, maxLimit);
         }
         if (until !== undefined) {
             request['end_time'] = parseInt (until / 1000);


### PR DESCRIPTION
fixes: #12855
passing a since parameter every time solves the problem, so this PR creates a default since parameter

```
2022-04-16T05:13:10.860Z
Node.js: v14.17.0
CCXT v1.79.17
ftx.fetchOHLCV (XRP/USDT)
2022-04-16T05:13:11.674Z iteration 0 passed in 408 ms
1649996040000 | 0.789525 | 0.789525 |  0.78665 | 0.786775 |   7157.18945
1649996100000 | 0.786775 |  0.78915 | 0.784875 | 0.788375 | 73017.534675
1649996160000 | 0.788375 | 0.790275 | 0.787225 | 0.788175 | 45141.832675
...
1650085920000 | 0.785075 | 0.785125 | 0.784875 | 0.784875 |            0
1650085980000 | 0.784875 | 0.784875 | 0.784875 | 0.784875 |            0
1500 objects
```

```
ftx.fetchOHLCV (XRP/USDT, 1m, 1650085920000)
2022-04-16T05:17:18.049Z iteration 0 passed in 341 ms

1650085920000 | 0.785075 | 0.785125 | 0.784875 | 0.784875 |           0
1650085980000 | 0.784875 | 0.784875 | 0.784275 | 0.784275 | 1115.289525
1650086040000 | 0.784275 | 0.784275 | 0.784175 | 0.784175 |   26.662425
1650086100000 | 0.784175 |   0.7847 | 0.784175 |   0.7846 |           0
1650086160000 |   0.7846 |   0.7852 |   0.7846 | 0.785025 |   1031.3628
1650086220000 | 0.785025 | 0.785025 | 0.785025 | 0.785025 |           0
6 objects
```

```
ftx.fetchOHLCV (XRP/USDT, 1m, , 5)
2022-04-16T05:18:21.968Z iteration 0 passed in 639 ms

1650086040000 | 0.784275 | 0.784275 | 0.784175 | 0.784175 | 26.662425
1650086100000 | 0.784175 |   0.7847 | 0.784175 |   0.7846 |         0
1650086160000 |   0.7846 |   0.7852 |   0.7846 | 0.785025 | 1031.3628
1650086220000 | 0.785025 | 0.785025 | 0.785025 | 0.785025 | 1020.5325
1650086280000 | 0.785025 | 0.785025 | 0.785025 | 0.785025 |         0
5 objects
```