### PR TITLE
leverageTiers.notionalCap renamed to maxNotional and leverageTiers.notionalFloor renamed to minNotional

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -2397,8 +2397,8 @@ module.exports = class aax extends Exchange {
             tiers.push ({
                 'tier': this.parseNumber (Precise.stringDiv (cap, riskIncrVol)),
                 'currency': market['base'],
-                'notionalFloor': this.parseNumber (floor),
-                'notionalCap': this.parseNumber (cap),
+                'minNotional': this.parseNumber (floor),
+                'maxNotional': this.parseNumber (cap),
                 'maintenanceMarginRate': this.parseNumber (maintenanceMarginRate),
                 'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialMarginRate)),
                 'info': info,

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2398,8 +2398,8 @@ module.exports = class ascendex extends Exchange {
             tiers.push ({
                 'tier': this.sum (i, 1),
                 'currency': market['quote'],
-                'notionalFloor': this.safeNumber (tier, 'positionNotionalLowerBound'),
-                'notionalCap': this.safeNumber (tier, 'positionNotionalUpperBound'),
+                'minNotional': this.safeNumber (tier, 'positionNotionalLowerBound'),
+                'maxNotional': this.safeNumber (tier, 'positionNotionalUpperBound'),
                 'maintenanceMarginRate': this.safeNumber (tier, 'maintenanceMarginRate'),
                 'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialMarginRate)),
                 'info': tier,

--- a/js/binance.js
+++ b/js/binance.js
@@ -4894,8 +4894,8 @@ module.exports = class binance extends Exchange {
             tiers.push ({
                 'tier': this.safeNumber (bracket, 'bracket'),
                 'currency': market['quote'],
-                'notionalFloor': this.safeNumber2 (bracket, 'notionalFloor', 'qtyFloor'),
-                'notionalCap': this.safeNumber (bracket, 'notionalCap', 'qtyCap'),
+                'minNotional': this.safeNumber2 (bracket, 'notionalFloor', 'qtyFloor'),
+                'maxNotional': this.safeNumber (bracket, 'notionalCap', 'qtyCap'),
                 'maintenanceMarginRate': this.safeNumber (bracket, 'maintMarginRatio'),
                 'maxLeverage': this.safeNumber (bracket, 'initialLeverage'),
                 'info': bracket,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3234,21 +3234,21 @@ module.exports = class bybit extends Exchange {
         //        ...
         //    ]
         //
-        let notionalFloor = 0;
+        let minNotional = 0;
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const item = info[i];
-            const notionalCap = this.safeNumber (item, 'limit');
+            const maxNotional = this.safeNumber (item, 'limit');
             tiers.push ({
                 'tier': this.sum (i, 1),
                 'currency': market['base'],
-                'notionalFloor': notionalFloor,
-                'notionalCap': notionalCap,
+                'minNotional': minNotional,
+                'maxNotional': maxNotional,
                 'maintenanceMarginRate': this.safeNumber (item, 'maintain_margin'),
                 'maxLeverage': this.safeNumber (item, 'max_leverage'),
                 'info': item,
             });
-            notionalFloor = notionalCap;
+            minNotional = maxNotional;
         }
         return tiers;
     }

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -3925,8 +3925,8 @@ module.exports = class gateio extends Exchange {
             tiers.push ({
                 'tier': this.parseNumber (Precise.stringDiv (cap, riskLimitStep)),
                 'currency': this.safeString (market, 'settle'),
-                'notionalFloor': this.parseNumber (floor),
-                'notionalCap': this.parseNumber (cap),
+                'minNotional': this.parseNumber (floor),
+                'maxNotional': this.parseNumber (cap),
                 'maintenanceMarginRate': this.parseNumber (maintenanceMarginRate),
                 'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialMarginRatio)),
                 'info': info,

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -5685,8 +5685,8 @@ module.exports = class huobi extends Exchange {
                         tiers.push ({
                             'tier': this.safeInteger (bracket, 'ladder'),
                             'currency': this.safeCurrencyCode (currency),
-                            'notionalFloor': this.safeNumber (bracket, 'min_size'),
-                            'notionalCap': this.safeNumber (bracket, 'max_size'),
+                            'minNotional': this.safeNumber (bracket, 'min_size'),
+                            'maxNotional': this.safeNumber (bracket, 'max_size'),
                             'maintenanceMarginRate': this.parseNumber (Precise.stringDiv (adjustFactor, leverage)),
                             'maxLeverage': this.parseNumber (leverage),
                             'info': bracket,

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -3122,8 +3122,8 @@ module.exports = class mexc extends Exchange {
             tiers.push ({
                 'tier': this.parseNumber (Precise.stringDiv (cap, riskIncrVol)),
                 'currency': this.safeCurrencyCode (quoteId),
-                'notionalFloor': this.parseNumber (floor),
-                'notionalCap': this.parseNumber (cap),
+                'minNotional': this.parseNumber (floor),
+                'maxNotional': this.parseNumber (cap),
                 'maintenanceMarginRate': this.parseNumber (maintenanceMarginRate),
                 'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialMarginRate)),
                 'info': info,

--- a/js/okx.js
+++ b/js/okx.js
@@ -4647,8 +4647,8 @@ module.exports = class okx extends Exchange {
             tiers.push ({
                 'tier': this.safeInteger (tier, 'tier'),
                 'currency': market['quote'],
-                'notionalFloor': this.safeNumber (tier, 'minSz'),
-                'notionalCap': this.safeNumber (tier, 'maxSz'),
+                'minNotional': this.safeNumber (tier, 'minSz'),
+                'maxNotional': this.safeNumber (tier, 'maxSz'),
                 'maintenanceMarginRate': this.safeNumber (tier, 'mmr'),
                 'maxLeverage': this.safeNumber (tier, 'maxLever'),
                 'info': tier,

--- a/js/xena.js
+++ b/js/xena.js
@@ -1869,8 +1869,8 @@ module.exports = class xena extends Exchange {
                 tiers.push ({
                     'tier': this.sum (j, 1),
                     'currency': market['base'],
-                    'notionalFloor': floor,
-                    'notionalCap': cap,
+                    'minNotional': floor,
+                    'maxNotional': cap,
                     'maintenanceMarginRate': this.safeNumber (tier, 'maintenanceRate'),
                     'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialRate)),
                     'info': tier,

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2564,18 +2564,18 @@ Returns
 [
     {
         "tier": 1,                       // tier index
-        "notionalCurrency": "USDT",      // the currency that notionalFloor and notionalCap are in
-        "notionalFloor": 0,              // the lowest amount of this tier // stake = 0.0
-        "notionalCap": 10000,            // the highest amount of this tier // max stake amount at 75x leverage = 133.33333333333334
+        "notionalCurrency": "USDT",      // the currency that minNotional and maxNotional are in
+        "minNotional": 0,                // the lowest amount of this tier // stake = 0.0
+        "maxNotional": 10000,            // the highest amount of this tier // max stake amount at 75x leverage = 133.33333333333334
         "maintenanceMarginRate": 0.0065, // maintenance margin rate
-        "maxLeverage": 75,               // max available leverage for this market when the value of the trade is > notionalFloor and < notionalCap
+        "maxLeverage": 75,               // max available leverage for this market when the value of the trade is > minNotional and < maxNotional
         "info": { ... }                  // Response from exchange
     },
     {
         "tier": 2,
         "notionalCurrency": "USDT",
-        "notionalFloor": 10000,          // min stake amount at 50x leverage = 200.0
-        "notionalCap": 50000,            // max stake amount at 50x leverage = 1000.0
+        "minNotional": 10000,            // min stake amount at 50x leverage = 200.0
+        "maxNotional": 50000,            // max stake amount at 50x leverage = 1000.0
         "maintenanceMarginRate": 0.01,
         "maxLeverage": 50,
         "info": { ... },
@@ -2584,8 +2584,8 @@ Returns
     {
         "tier": 9,
         "notionalCurrency": "USDT",
-        "notionalFloor": 20000000,
-        "notionalCap": 50000000,
+        "minNotional": 20000000,
+        "maxNotional": 50000000,
         "maintenanceMarginRate": 0.5,
         "maxLeverage": 1,
         "info": { ... },


### PR DESCRIPTION
2022-04-17T03:32:32.821Z
Node.js: v14.17.0
CCXT v1.79.62

```
bybit.fetchMarketLeverageTiers (BTC/USDT)
2022-04-17T03:32:33.695Z iteration 0 passed in 267 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |      BTC |           0 |     2000000 |                 0.005 |         100
...
  29 |      BTC |    56000000 |    58000000 |                 0.145 |        4.55
  30 |      BTC |    58000000 |    60000000 |                  0.15 |         4.4
30 objects
```

```
binanceusdm.fetchMarketLeverageTiers (BTC/USDT)
2022-04-17T03:33:37.826Z iteration 0 passed in 211 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |     USDT |           0 |       50000 |                 0.004 |         125
...
   9 |     USDT |   400000000 |   600000000 |                  0.25 |           2
  10 |     USDT |   600000000 |  1000000000 |                   0.5 |           1
10 objects
```

```
aax.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:34:08.158Z iteration 0 passed in 792 ms

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |      BTC |           0 |       30000 |                 0.005 |         100
1 objects
```

```
gateio.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:35:14.648Z iteration 0 passed in 203 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate |        maxLeverage
----------------------------------------------------------------------------------------
   1 |     USDT |           0 |     1000000 |                 0.005 |                100
...
  15 |     USDT |    14000000 |    15000000 |                 0.075 |  6.666666666666667
  16 |     USDT |    15000000 |    16000000 |                  0.08 |               6.25
16 objects
```

```
kucoinfutures.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:35:42.704Z iteration 0 passed in 249 ms
tier | currency | notionalFloor | notionalCap | maintenanceMarginRate | maxLeverage
-----------------------------------------------------------------------------------
   1 |      BTC |             0 |      500000 |                 0.005 |         100
...
   4 |      BTC |       2000000 |     3000000 |                  0.02 |          25
   5 |      BTC |       3000000 |     4000000 |                  0.05 |          10
5 objects
```

```
ascendex.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:36:34.042Z iteration 0 passed in 673 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate |    maxLeverage
------------------------------------------------------------------------------------
   1 |     USDT |           0 |       50000 |                 0.006 |            100
...
   5 |     USDT |    20000000 |    40000000 |                  0.12 |              5
   6 |     USDT |    40000000 |  1000000000 |                   0.2 | 3.000003000003
6 objects
```

```
xena.fetchMarketLeverageTiers (BTC/USD:USDC)
2022-04-17T03:38:02.702Z iteration 0 passed in 804 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate |        maxLeverage
----------------------------------------------------------------------------------------
   1 |      BTC |           0 |          10 |                 0.025 |                 20
...
   6 |      BTC |          60 |         150 |                  0.25 |                  2
   7 |      BTC |         150 |         200 |                   0.5 |                  1
7 objects
```

```
huobi.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:38:36.527Z iteration 0 passed in 678 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   0 |     USDT |           0 |        3999 |               0.00375 |         200
...
   3 |     USDT |       80000 |      119999 |                  0.02 |           1
   4 |     USDT |      120000 |             |                 0.025 |           1
52 objects
```

```
mexc.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:39:00.529Z iteration 0 passed in 476 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate |        maxLeverage
----------------------------------------------------------------------------------------
   1 |     USDT |           0 |      200000 |                 0.004 |                125
...
   4 |     USDT |      600000 |      800000 |                 0.016 |                 50
   5 |     USDT |      800000 |     1000000 |                  0.02 | 41.666666666666664
5 objects
```

```
okx.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-04-17T03:39:31.369Z iteration 0 passed in 314 ms
tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |     USDT |           0 |         500 |                 0.004 |         125
...
 199 |     USDT |     1962001 |     1972000 |                  0.99 |           1
 200 |     USDT |     1972001 |     1982000 |                 0.995 |           1
200 objects
```