### PR TITLE
bitfinex2 - `parseTransfer` for `transfer`

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -740,7 +740,7 @@ module.exports = class bitfinex2 extends bitfinex {
             'ERROR': 'fail',
             'FAILURE': 'fail',
         };
-        return this.safeString (statuses, status, 'canceled');
+        return this.safeString (statuses, status, status);
     }
 
     convertDerivativesId (currency, type) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1916,7 +1916,7 @@ module.exports = class bitfinex2 extends bitfinex {
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 
-    handleErrors (statusCode, statusText, url, method, responseHeaders, body, response, requestHeaders, requestBody) {
+    handleErrors (statusCode, statusText, url, method, headers, body, response, requestHeaders, requestBody) {
         if (response !== undefined) {
             if (!Array.isArray (response)) {
                 const message = this.safeString2 (response, 'message', 'error');

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -711,6 +711,13 @@ module.exports = class bitfinex2 extends bitfinex {
         //         "1.0 Tether USDt transfered from Exchange to Margin"
         //     ]
         //
+        const error = this.safeString (response, 0);
+        if (error === 'error') {
+            const message = this.safeString (response, 2, '');
+            // same message as in v1
+            this.throwExactlyMatchedException (this.exceptions['exact'], message, this.id + ' ' + message);
+            throw new ExchangeError (this.id + ' ' + message);
+        }
         return this.parseTransfer (response, currency);
     }
 


### PR DESCRIPTION
this is breaking change :  there was `code` field, while `currency` is the unified field-name for that purpose.