### PR TITLE
unified 'addMargin/reduceMargin' responses

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2244,7 +2244,7 @@ module.exports = class ascendex extends Exchange {
         const market = this.market (symbol);
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeString (account, 'id');
-        amount = this.numberToString (amount);
+        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'account-group': accountGroup,
             'symbol': market['id'],
@@ -2263,7 +2263,7 @@ module.exports = class ascendex extends Exchange {
         return {
             'info': response,
             'type': type,
-            'amount': amount,
+            'amount': this.parseNumber (amount),
             'code': market['quote'],
             'symbol': market['symbol'],
             'status': status,

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2268,11 +2268,6 @@ module.exports = class ascendex extends Exchange {
     }
 
     parseModifyMargin (data, market = undefined) {
-        //
-        //     {
-        //          "code": 0
-        //     }
-        //
         const errorCode = this.safeString (data, 'code');
         const status = (errorCode === '0') ? 'ok' : 'failed';
         return {

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2248,7 +2248,7 @@ module.exports = class ascendex extends Exchange {
         const request = {
             'account-group': accountGroup,
             'symbol': market['id'],
-            'amount': amount,
+            'amount': amount, // positive value for adding margin, negative for reducing
         };
         const response = await this.v2PrivateAccountGroupPostFuturesIsolatedPositionMargin (this.extend (request, params));
         //
@@ -2258,12 +2258,27 @@ module.exports = class ascendex extends Exchange {
         //          "code": 0
         //     }
         //
-        const errorCode = this.safeString (response, 'code');
+        if (type === 'reduce') {
+            amount = Precise.stringAbs (amount);
+        }
+        return this.extend (this.parseModifyMargin (response, market), {
+            'amount': this.parseNumber (amount),
+            'type': type,
+        });
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        //
+        //     {
+        //          "code": 0
+        //     }
+        //
+        const errorCode = this.safeString (data, 'code');
         const status = (errorCode === '0') ? 'ok' : 'failed';
         return {
-            'info': response,
-            'type': type,
-            'amount': this.parseNumber (amount),
+            'info': data,
+            'type': undefined,
+            'amount': undefined,
             'code': market['quote'],
             'symbol': market['symbol'],
             'status': status,

--- a/js/binance.js
+++ b/js/binance.js
@@ -5354,7 +5354,7 @@ module.exports = class binance extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        // amount = this.amountToPrecision (symbol, amount);
+        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'type': addOrReduce,
             'symbol': market['id'],

--- a/js/binance.js
+++ b/js/binance.js
@@ -5354,6 +5354,7 @@ module.exports = class binance extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        // amount = this.amountToPrecision (symbol, amount);
         const request = {
             'type': addOrReduce,
             'symbol': market['id'],

--- a/js/binance.js
+++ b/js/binance.js
@@ -5378,16 +5378,22 @@ module.exports = class binance extends Exchange {
         //         "type": 1
         //     }
         //
-        const rawType = this.safeInteger (response, 'type');
+        return this.extend (this.parseModifyMargin (response, market), {
+            'code': code,
+        });
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        const rawType = this.safeInteger (data, 'type');
         const resultType = (rawType === 1) ? 'add' : 'reduce';
-        const resultAmount = this.safeNumber (response, 'amount');
-        const errorCode = this.safeString (response, 'code');
+        const resultAmount = this.safeNumber (data, 'amount');
+        const errorCode = this.safeString (data, 'code');
         const status = (errorCode === '200') ? 'ok' : 'failed';
         return {
-            'info': response,
+            'info': data,
             'type': resultType,
             'amount': resultAmount,
-            'code': code,
+            'code': undefined,
             'symbol': market['symbol'],
             'status': status,
         };

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -2126,12 +2126,12 @@ module.exports = class hitbtc3 extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const leverage = this.safeString (params, 'leverage');
-        amount = this.amountToPrecision (symbol, amount);
         if (market['type'] === 'swap') {
             if (leverage === undefined) {
                 throw new ArgumentsRequired (this.id + ' modifyMarginHelper() requires a leverage parameter for swap markets');
             }
         }
+        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'symbol': market['id'], // swap and margin
             'margin_balance': amount, // swap and margin
@@ -2170,7 +2170,7 @@ module.exports = class hitbtc3 extends Exchange {
         return {
             'info': response,
             'type': type,
-            'amount': amount,
+            'amount': this.safeNumber (amount),
             'code': this.safeString (data, 'code'),
             'symbol': market['symbol'],
             'status': undefined,

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -2165,13 +2165,20 @@ module.exports = class hitbtc3 extends Exchange {
         //         "positions": null
         //     }
         //
-        const currencies = this.safeValue (response, 'currencies', []);
-        const data = this.safeValue (currencies, 0);
-        return {
-            'info': response,
-            'type': type,
+        return this.extend (this.parseModifyMargin (response, market), {
             'amount': this.safeNumber (amount),
-            'code': this.safeString (data, 'code'),
+            'type': type,
+        });
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        const currencies = this.safeValue (data, 'currencies', []);
+        const currencyInfo = this.safeValue (currencies, 0);
+        return {
+            'info': data,
+            'type': undefined,
+            'amount': undefined,
+            'code': this.safeString (currencyInfo, 'code'),
             'symbol': market['symbol'],
             'status': undefined,
         };

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1090,72 +1090,12 @@ module.exports = class kucoinfutures extends kucoin {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const uuid = this.uuid ();
-        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'symbol': market['id'],
             'margin': amount,
             'bizNo': uuid,
         };
-        const response = await this.futuresPrivatePostPositionMarginDepositMargin (this.extend (request, params));
-        //
-        //     {
-        //         "code":"200000",
-        //         "msg":"Position does not exist"
-        //     }
-        //
-        //     {
-        //         "code": "200000",
-        //         "data": {
-        //             "id": "6261bb8e21d8da0001d6cc7c",
-        //             "symbol": "SNXUSDTM",
-        //             "autoDeposit": false,
-        //             "maintMarginReq": 0.025,
-        //             "riskLimit": 70000,
-        //             "realLeverage": 1.7,
-        //             "crossMode": false,
-        //             "delevPercentage": 0.8,
-        //             "openingTimestamp": 1650572174513,
-        //             "currentTimestamp": 1650572194330,
-        //             "currentQty": 42,
-        //             "currentCost": 25.7166,
-        //             "currentComm": 0.01542996,
-        //             "unrealisedCost": 25.7166,
-        //             "realisedGrossCost": 0,
-        //             "realisedCost": 0.01542996,
-        //             "isOpen": true,
-        //             "markPrice": 6.124,
-        //             "markValue": 25.7208,
-        //             "posCost": 25.7166,
-        //             "posCross": 9.994,
-        //             "posInit": 5.14332,
-        //             "posComm": 0.02451595,
-        //             "posLoss": 0,
-        //             "posMargin": 15.16183595,
-        //             "posMaint": 0.67000261,
-        //             "maintMargin": 15.16603595,
-        //             "realisedGrossPnl": 0,
-        //             "realisedPnl": -0.01542996,
-        //             "unrealisedPnl": 0.0042,
-        //             "unrealisedPnlPcnt": 0.0002,
-        //             "unrealisedRoePcnt": 0.0008,
-        //             "avgEntryPrice": 6.123,
-        //             "liquidationPrice": 2.673,
-        //             "bankruptPrice": 2.518,
-        //             "settleCurrency": "USDT"
-        //         }
-        //     }
-        //
-        const data = this.safeValue (response, 'data');
-        const marketId = this.safeString (data, 'symbol');
-        const crossMode = (this.safeValue (data, 'crossMode') === true) ? 'cross' : 'isolated';
-        return {
-            'info': response,
-            'type': crossMode,
-            'amount': this.parseNumber (amount),
-            'code': undefined,
-            'symbol': this.safeSymbol (marketId, market),
-            'status': undefined,
-        };
+        return await this.futuresPrivatePostPositionMarginDepositMargin (this.extend (request, params));
     }
 
     async fetchOrdersByStatus (status, symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1090,12 +1090,72 @@ module.exports = class kucoinfutures extends kucoin {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const uuid = this.uuid ();
+        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'symbol': market['id'],
             'margin': amount,
             'bizNo': uuid,
         };
-        return await this.futuresPrivatePostPositionMarginDepositMargin (this.extend (request, params));
+        const response = await this.futuresPrivatePostPositionMarginDepositMargin (this.extend (request, params));
+        //
+        //     {
+        //         "code":"200000",
+        //         "msg":"Position does not exist"
+        //     }
+        //
+        //     {
+        //         "code": "200000",
+        //         "data": {
+        //             "id": "6261bb8e21d8da0001d6cc7c",
+        //             "symbol": "SNXUSDTM",
+        //             "autoDeposit": false,
+        //             "maintMarginReq": 0.025,
+        //             "riskLimit": 70000,
+        //             "realLeverage": 1.7,
+        //             "crossMode": false,
+        //             "delevPercentage": 0.8,
+        //             "openingTimestamp": 1650572174513,
+        //             "currentTimestamp": 1650572194330,
+        //             "currentQty": 42,
+        //             "currentCost": 25.7166,
+        //             "currentComm": 0.01542996,
+        //             "unrealisedCost": 25.7166,
+        //             "realisedGrossCost": 0,
+        //             "realisedCost": 0.01542996,
+        //             "isOpen": true,
+        //             "markPrice": 6.124,
+        //             "markValue": 25.7208,
+        //             "posCost": 25.7166,
+        //             "posCross": 9.994,
+        //             "posInit": 5.14332,
+        //             "posComm": 0.02451595,
+        //             "posLoss": 0,
+        //             "posMargin": 15.16183595,
+        //             "posMaint": 0.67000261,
+        //             "maintMargin": 15.16603595,
+        //             "realisedGrossPnl": 0,
+        //             "realisedPnl": -0.01542996,
+        //             "unrealisedPnl": 0.0042,
+        //             "unrealisedPnlPcnt": 0.0002,
+        //             "unrealisedRoePcnt": 0.0008,
+        //             "avgEntryPrice": 6.123,
+        //             "liquidationPrice": 2.673,
+        //             "bankruptPrice": 2.518,
+        //             "settleCurrency": "USDT"
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'data');
+        const marketId = this.safeString (data, 'symbol');
+        const crossMode = (this.safeValue (data, 'crossMode') === true) ? 'cross' : 'isolated';
+        return {
+            'info': response,
+            'type': crossMode,
+            'amount': this.parseNumber (amount),
+            'code': undefined,
+            'symbol': this.safeSymbol (marketId, market),
+            'status': undefined,
+        };
     }
 
     async fetchOrdersByStatus (status, symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2565,7 +2565,8 @@ module.exports = class mexc extends Exchange {
     }
 
     parseModifyMargin (data, market = undefined) {
-        const status = (this.safeString (data, 'success') === true) ? 'ok' : 'failed';
+        const statusRaw = this.safeString (data, 'success');
+        const status = (statusRaw === true) ? 'ok' : 'failed';
         return {
             'info': data,
             'type': undefined,

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2543,6 +2543,8 @@ module.exports = class mexc extends Exchange {
             throw new ArgumentsRequired (this.id + ' modifyMarginHelper() requires a positionId parameter');
         }
         await this.loadMarkets ();
+        const market = this.market (symbol);
+        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'positionId': positionId,
             'amount': amount,
@@ -2555,13 +2557,21 @@ module.exports = class mexc extends Exchange {
         //         "code": 0
         //     }
         //
-        const status = (this.safeString (response, 'success') === true) ? 'ok' : 'failed';
+        const type = (addOrReduce === 'ADD') ? 'add' : 'reduce';
+        return this.extend (this.parseModifyMargin (response, market), {
+            'amount': this.safeNumber (amount),
+            'type': type,
+        });
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        const status = (this.safeString (data, 'success') === true) ? 'ok' : 'failed';
         return {
-            'info': response,
+            'info': data,
             'type': undefined,
-            'amount': this.parseNumber (amount),
+            'amount': undefined,
             'code': undefined,
-            'symbol': symbol,
+            'symbol': this.safeSymbol (undefined, market),
             'status': status,
         };
     }

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -2554,7 +2554,16 @@ module.exports = class mexc extends Exchange {
         //         "success": true,
         //         "code": 0
         //     }
-        return response;
+        //
+        const status = (this.safeString (response, 'success') === true) ? 'ok' : 'failed';
+        return {
+            'info': response,
+            'type': undefined,
+            'amount': this.parseNumber (amount),
+            'code': undefined,
+            'symbol': symbol,
+            'status': status,
+        };
     }
 
     async reduceMargin (symbol, amount, params = {}) {

--- a/js/okx.js
+++ b/js/okx.js
@@ -4542,22 +4542,26 @@ module.exports = class okx extends Exchange {
         //       "msg": ""
         //     }
         //
-        const data = this.safeValue (response, 'data', []);
-        const entry = this.safeValue (data, 0, {});
-        const errorCode = this.safeString (response, 'code');
+        return this.parseModifyMargin (response, market);
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        const innerData = this.safeValue (data, 'data', []);
+        const entry = this.safeValue (innerData, 0, {});
+        const errorCode = this.safeString (data, 'code');
         const status = (errorCode === '0') ? 'ok' : 'failed';
-        const responseAmount = this.safeNumber (entry, 'amt');
-        const responseType = this.safeString (entry, 'type');
+        const amountRaw = this.safeNumber (entry, 'amt');
+        const typeRaw = this.safeString (entry, 'type');
+        const type = (typeRaw === 'reduce') ? 'reduce' : 'add';
         const marketId = this.safeString (entry, 'instId');
         const responseMarket = this.safeMarket (marketId, market);
         const code = responseMarket['inverse'] ? responseMarket['base'] : responseMarket['quote'];
-        symbol = responseMarket['symbol'];
         return {
-            'info': response,
-            'type': responseType,
-            'amount': responseAmount,
+            'info': data,
+            'type': type,
+            'amount': amountRaw,
             'code': code,
-            'symbol': symbol,
+            'symbol': responseMarket['symbol'],
             'status': status,
         };
     }

--- a/js/zb.js
+++ b/js/zb.js
@@ -3877,12 +3877,12 @@ module.exports = class zb extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const side = (type === 1) ? 'add' : 'reduce';
-        const errorCode = this.safeInteger (data, 'status');
-        const status = (errorCode === 1) ? 'ok' : 'failed';
+        const statusCode = this.safeInteger (data, 'status');
+        const status = (statusCode === 1) ? 'ok' : 'failed';
         return {
             'info': response,
             'type': side,
-            'amount': amount,
+            'amount': this.parseNumber (amount),
             'code': market['quote'],
             'symbol': market['symbol'],
             'status': status,

--- a/js/zb.js
+++ b/js/zb.js
@@ -3875,25 +3875,25 @@ module.exports = class zb extends Exchange {
         //         "desc":"操作成功"
         //     }
         //
-        const data = this.safeValue (response, 'data', {});
-        const side = (type === 1) ? 'add' : 'reduce';
-        const statusCode = this.safeInteger (data, 'status');
+        return this.extend (this.parseModifyMargin (response, market), {
+            'amount': this.parseNumber (amount),
+        });
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        const innerData = this.safeValue (data, 'data', {});
+        const sideRaw = this.safeInteger (innerData, 'side');
+        const side = (sideRaw === 1) ? 'add' : 'reduce';
+        const statusCode = this.safeInteger (innerData, 'status');
         const status = (statusCode === 1) ? 'ok' : 'failed';
         return {
-            'info': response,
+            'info': data,
             'type': side,
-            'amount': this.parseNumber (amount),
+            'amount': undefined,
             'code': market['quote'],
             'symbol': market['symbol'],
             'status': status,
         };
-    }
-
-    async reduceMargin (symbol, amount, params = {}) {
-        if (params['positionsId'] === undefined) {
-            throw new ArgumentsRequired (this.id + ' reduceMargin() requires a positionsId argument in the params');
-        }
-        return await this.modifyMarginHelper (symbol, amount, 0, params);
     }
 
     async addMargin (symbol, amount, params = {}) {
@@ -3901,6 +3901,13 @@ module.exports = class zb extends Exchange {
             throw new ArgumentsRequired (this.id + ' addMargin() requires a positionsId argument in the params');
         }
         return await this.modifyMarginHelper (symbol, amount, 1, params);
+    }
+
+    async reduceMargin (symbol, amount, params = {}) {
+        if (params['positionsId'] === undefined) {
+            throw new ArgumentsRequired (this.id + ' reduceMargin() requires a positionsId argument in the params');
+        }
+        return await this.modifyMarginHelper (symbol, amount, 0, params);
     }
 
     async fetchBorrowRate (code, params = {}) {


### PR DESCRIPTION
1) about `binance` - i've not dared to modify that without your feedback, so i've only included commented line there.
2) for some exchanges, instead of number (the same argument provided) is returned as `parseNumber`
3) `kucoinfutures & mexc` have breaking change. they returned 'response', instead of unified response.