### PR TITLE
Coinex fetchOrderBook

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -237,13 +237,10 @@ module.exports = class coinex extends Exchange {
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
         if (type === 'spot' || type === 'margin') {
             result = await this.fetchSpotMarkets (query);
-        }
-        if (type === 'swap') {
+        } else if (type === 'swap') {
             result = await this.fetchContractMarkets (query);
-        }
-        const resultLength = result.length;
-        if (resultLength === 0) {
-            throw new ExchangeError (this.id + " does not support '" + type + "' type, set exchange.options['defaultType'] to " + "'spot', 'margin' or 'swap'");
+        } else {
+            throw new ExchangeError (this.id + " does not support the '" + type + "' market type, set exchange.options['defaultType'] to 'spot', 'margin' or 'swap'");
         }
         return result;
     }


### PR DESCRIPTION
Added swap functionality to fetchOrderBook:
```
coinex.fetchOrderBook (BTC/USDT:USDT)
2022-04-22T00:41:47.428Z iteration 0 passed in 302 ms

{
  symbol: 'BTC/USDT:USDT',
  bids: [
    [ 40545.02, 0.4015 ], [ 40545.01, 0.2931 ],
    [ 40545, 0.0023 ],    [ 40544.32, 0.8574 ],
    [ 40544.31, 0.5327 ], [ 40544.3, 0.3015 ],
    [ 40540.57, 0.1517 ], [ 40540.08, 0.0493 ],
    [ 40540.01, 0.3053 ], [ 40540, 0.0018 ],
    [ 40537.98, 0.24 ],   [ 40536.45, 0.0005 ],
    [ 40535, 0.0022 ],    [ 40534.58, 0.24 ],
    [ 40534.43, 0.0595 ], [ 40534.1, 0.0247 ],
    [ 40534.08, 0.001 ],  [ 40533.67, 0.0139 ],
    [ 40533.59, 0.0486 ], [ 40532.88, 0.0141 ]
  ],
  asks: [
    [ 40545.03, 9.5115 ], [ 40545.73, 0.0219 ],
    [ 40546.04, 0.0305 ], [ 40546.24, 0.117 ],
    [ 40546.74, 0.1452 ], [ 40546.79, 0.0219 ],
    [ 40548.45, 0.0036 ], [ 40548.46, 0.48 ],
    [ 40550.09, 0.0605 ], [ 40550.61, 0.0219 ],
    [ 40551.84, 0.1452 ], [ 40551.85, 0.0438 ],
    [ 40553.92, 0.2047 ], [ 40553.93, 0.0528 ],
    [ 40554, 0.2472 ],    [ 40554.77, 0.1233 ],
    [ 40555.01, 0.074 ],  [ 40555.11, 0.0589 ],
    [ 40555.57, 0.0535 ], [ 40555.98, 0.052 ]
  ],
  timestamp: 1650588108447,
  datetime: '2022-04-22T00:41:48.447Z',
  nonce: undefined
}
```