### PR TITLE
Transpile docstring @param params.param into python`

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -336,6 +336,7 @@ class Transpiler {
             [ /\s+\* @name .*/g, '' ], // docstring @name
             [ /(\s+) \* @returns/g, '$1:returns:' ], // docstring return
             [ /(\s+) \* @([a-z]+) \{([a-z]+)\} ([a-zA-Z0-9_\-\.]+)/g, '$1:$2 $3 $4:' ], // docstring param
+            [ /(\s+\* @param [a-zA-Z0-9_-])+\.([a-zA-Z0-9_-]) (.*)/g, '$1[\'$2\']$3' ], // docstring params.anything
         ])
     }
 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -177,7 +177,6 @@ class Transpiler {
     getPythonRegexes () {
 
         return [
-
             [ /Array\.isArray\s*\(([^\)]+)\)/g, 'isinstance($1, list)' ],
             [ /([^\(\s]+)\s+instanceof\s+String/g, 'isinstance($1, str)' ],
             [ /([^\(\s]+)\s+instanceof\s+([^\)\s]+)/g, 'isinstance($1, $2)' ],
@@ -335,8 +334,8 @@ class Transpiler {
             [ /(\s+) \* @description (.*)/g, '$1$2' ], // docstring description
             [ /\s+\* @name .*/g, '' ], // docstring @name
             [ /(\s+) \* @returns/g, '$1:returns:' ], // docstring return
-            [ /(\s+) \* @([a-z]+) \{([a-z]+)\} ([a-zA-Z0-9_\-\.]+)/g, '$1:$2 $3 $4:' ], // docstring param
-            [ /(\s+\* @param [a-zA-Z0-9_-])+\.([a-zA-Z0-9_-]) (.*)/g, '$1[\'$2\']$3' ], // docstring params.anything
+            [ /(\s+ \* @param \{[a-z]+\} )([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+) (.*)/g, '$1$2[\'$3\'] $4' ], // docstring params.anything
+            [ /(\s+) \* @([a-z]+) \{([a-z]+)\} ([a-zA-Z0-9_\-\.\[\]\']+)/g, '$1:$2 $3 $4:' ], // docstring param
         ])
     }
 


### PR DESCRIPTION
```
/**
         * @method
         * @name gateio#createOrder
         * @description Create an order on the exchange
         * @param {str} symbol Unified CCXT market symbol
         * @param {str} type "limit" or "market" *"market" is contract only*
         * @param {str} side "buy" or "sell"
         * @param {float} amount the amount of currency to trade
         * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
         * @param {dict} params  Extra parameters specific to the exchange API endpoint
         * @param {float} params.stopPrice The price at which a trigger order is triggered at
         * @param {str} params.timeInForce "GTC", "IOC", or "PO"
         * @param {int} params.iceberg Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
         * @param {str} params.text User defined information
         * @param {str} params.account *spot and margin only* "spot", "margin" or "cross_margin"
         * @param {bool} params.auto_borrow *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient amount if balance is not enough
         * @param {str} params.settle *contract only* Unified Currency Code for settle currency
         * @param {bool} params.reduceOnly *contract only* Indicates if this order is to reduce the size of a position
         * @param {bool} params.close *contract only* Set as true to close the position, with size set to 0
         * @param {bool} params.auto_size *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
         * @returns [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
         */
```

Transpiled to

```
"""
        Create an order on the exchange
        :param str symbol: Unified CCXT market symbol
        :param str type: "limit" or "market" *"market" is contract only*
        :param str side: "buy" or "sell"
        :param float amount: the amount of currency to trade
        :param float price: *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
        :param dict params:  Extra parameters specific to the exchange API endpoint
        :param float params['stopPrice']: The price at which a trigger order is triggered at
        :param str params['timeInForce']: "GTC", "IOC", or "PO"
        :param int params['iceberg']: Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
        :param str params['text']: User defined information
        :param str params['account']: *spot and margin only* "spot", "margin" or "cross_margin"
        :param bool params['auto_borrow']: *margin only* Used in margin or cross margin trading to allow automatic loan of insufficient amount if balance is not enough
        :param str params['settle']: *contract only* Unified Currency Code for settle currency
        :param bool params['reduceOnly']: *contract only* Indicates if self order is to reduce the size of a position
        :param bool params['close']: *contract only* Set as True to close the position, with size set to 0
        :param bool params['auto_size']: *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
        :returns: `An order structure <https://docs.ccxt.com/en/latest/manual.html#order-structure>`
        """
```