### PR TITLE
ftx.fetchBorrowRateHistory fix with limit being set as {}

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2601,7 +2601,7 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchBorrowRateHistory (code, since = undefined, limit = undefined, params = {}) {
-        const histories = await this.fetchBorrowRateHistories (since, limit, params);
+        const histories = await this.fetchBorrowRateHistories ([ code ], since, limit, params);
         const borrowRateHistory = this.safeValue (histories, code);
         if (borrowRateHistory === undefined) {
             throw new BadRequest (this.id + ' fetchBorrowRateHistory() returned no data for ' + code);


### PR DESCRIPTION
Fixes this issue https://github.com/ccxt/ccxt/commit/50f69b7faabda692ece559756af8ad6cb211b7b4#commitcomment-71811378