### PR TITLE
Coinex fetchOHLCV

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -706,7 +706,10 @@ module.exports = class coinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.publicGetMarketKline (this.extend (request, params));
+        const method = market['swap'] ? 'perpetualPublicGetMarketKline' : 'publicGetMarketKline';
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Spot
         //
         //     {
         //         "code": 0,
@@ -714,6 +717,18 @@ module.exports = class coinex extends Exchange {
         //             [1591484400, "0.02505349", "0.02506988", "0.02507000", "0.02505304", "343.19716223", "8.6021323866383196", "ETHBTC"],
         //             [1591484700, "0.02506990", "0.02508109", "0.02508109", "0.02506979", "91.59841581", "2.2972047780447000", "ETHBTC"],
         //             [1591485000, "0.02508106", "0.02507996", "0.02508106", "0.02507500", "65.15307697", "1.6340597822306000", "ETHBTC"],
+        //         ],
+        //         "message": "OK"
+        //     }
+        //
+        // Swap
+        //
+        //     {
+        //         "code": 0,
+        //         "data": [
+        //             [1650569400, "41524.64", "41489.31", "41564.61", "41480.58", "29.7060", "1233907.099562"],
+        //             [1650569700, "41489.31", "41438.29", "41489.31", "41391.87", "42.4115", "1756154.189061"],
+        //             [1650570000, "41438.29", "41482.21", "41485.05", "41427.31", "22.2892", "924000.317861"]
         //         ],
         //         "message": "OK"
         //     }


### PR DESCRIPTION
Added swap functionality to fetchOHLCV:
```
coinex.fetchOHLCV (BTC/USDT:USDT)
2022-04-22T03:49:10.968Z iteration 0 passed in 298 ms

1650569400000 | 41524.64 | 41564.61 | 41480.58 | 41489.31 |   29.706
1650569700000 | 41489.31 | 41489.31 | 41391.87 | 41438.29 |  42.4115
1650570000000 | 41438.29 | 41485.05 | 41427.31 | 41482.21 |  22.2892
...
```