### PR TITLE
fix `fetchStatus` - removal of `extend` and conditionals

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -2062,15 +2062,27 @@ module.exports = class binance extends Exchange {
 
     async fetchStatus (params = {}) {
         const response = await this.sapiGetSystemStatus (params);
-        let status = this.safeString (response, 'status');
-        if (status !== undefined) {
-            status = (status === '0') ? 'ok' : 'maintenance';
-            this.status = this.extend (this.status, {
-                'status': status,
-                'updated': this.milliseconds (),
-                'info': response,
-            });
+        //
+        //     {
+        //         "status": 0,              // 0: normal，1：system maintenance
+        //         "msg": "normal"           // "normal", "system_maintenance"
+        //     }
+        //
+        const statusData = {
+            'status': undefined,
+            'updated': this.milliseconds (),
+            'eta': undefined,
+            'info': response,
+        };
+        const statusRaw = this.safeInteger (response, 'status');
+        if (statusRaw === undefined) {
+            statusData['status'] = undefined;
+        } else if (statusRaw === 0) {
+            statusData['status'] = 'ok';
+        } else {
+            statusData['status'] = 'maintenance';
         }
+        this.status = statusData;
         return this.status;
     }
 

--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -159,15 +159,19 @@ module.exports = class bitbns extends Exchange {
         //         "code":200
         //     }
         //
-        let status = this.safeString (response, 'status');
-        if (status !== undefined) {
-            status = (status === '1') ? 'ok' : 'maintenance';
-            this.status = this.extend (this.status, {
-                'status': status,
-                'updated': this.milliseconds (),
-                'info': response,
-            });
+        const statusData = {
+            'status': undefined,
+            'updated': this.milliseconds (),
+            'eta': undefined,
+            'info': response,
+        };
+        const statusRaw = this.safeString (response, 'status');
+        if (statusRaw === undefined) {
+            statusData['status'] = undefined;
+        } else {
+            statusData['status'] = (statusRaw === '1') ? 'ok' : 'maintenance';
         }
+        this.status = statusData;
         return this.status;
     }
 

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -378,13 +378,21 @@ module.exports = class bitfinex2 extends bitfinex {
         //    [0] // maintenance
         //
         const response = await this.publicGetPlatformStatus (params);
-        const status = this.safeInteger (response, 0);
-        const formattedStatus = (status === 1) ? 'ok' : 'maintenance';
-        this.status = this.extend (this.status, {
-            'status': formattedStatus,
+        const statusRaw = this.safeInteger (response, 0);
+        let status = undefined;
+        if (statusRaw === undefined) {
+            status = undefined;
+        } else if (statusRaw === 1) {
+            status = 'ok';
+        } else {
+            status = 'maintenance';
+        }
+        this.status = {
+            'status': status,
             'updated': this.milliseconds (),
+            'eta': undefined,
             'info': response,
-        });
+        };
         return this.status;
     }
 

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -364,27 +364,28 @@ module.exports = class bitmart extends Exchange {
         params = this.omit (params, 'type');
         const response = await this.publicSystemGetService (params);
         //
+        //
         //     {
-        //         "code": 1000,
-        //         "trace":"886fb6ae-456b-4654-b4e0-d681ac05cea1",
         //         "message": "OK",
+        //         "code": 1000,
+        //         "trace": "1d3f28b0-763e-4f78-90c4-5e3ad19dc595",
         //         "data": {
-        //             "serivce":[
-        //                 {
-        //                     "title": "Spot API Stop",
-        //                     "service_type": "spot",
-        //                     "status": "2",
-        //                     "start_time": 1527777538000,
-        //                     "end_time": 1527777538000
-        //                 },
-        //                 {
-        //                     "title": "Contract API Stop",
-        //                     "service_type": "contract",
-        //                     "status": "2",
-        //                     "start_time": 1527777538000,
-        //                     "end_time": 1527777538000
-        //                 }
-        //             ]
+        //           "service": [
+        //             {
+        //               "title": "Spot API Stop",
+        //               "service_type": "spot",
+        //               "status": 2,
+        //               "start_time": 1648639069125,
+        //               "end_time": 1648639069125
+        //             },
+        //             {
+        //               "title": "Contract API Stop",
+        //               "service_type": "contract",
+        //               "status": 2,
+        //               "start_time": 1648639069125,
+        //               "end_time": 1648639069125
+        //             }
+        //           ]
         //         }
         //     }
         //
@@ -406,12 +407,12 @@ module.exports = class bitmart extends Exchange {
                 eta = this.safeInteger (service, 'end_time');
             }
         }
-        this.status = this.extend (this.status, {
+        this.status = {
             'status': status,
             'updated': this.milliseconds (),
             'eta': eta,
             'info': response,
-        });
+        };
         return this.status;
     }
 


### PR DESCRIPTION
1) there should be no `if (status !== undefined) { ..set fields..}.`. for every request, the response should be set accordingly, be it realistic response or even fully undefined - that expresses the real answer to user about the last status call.

2) every time user makes `fetchStatus` it should return the new object from ground. I don't think there should be any 'extend' of previous status (if I am wrong, please mention argument/reason for extending the last response?)
