### PR TITLE
okx - transfer

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -3843,8 +3843,11 @@ module.exports = class okx extends Exchange {
             'ccy': currency['id'],
             'amt': this.currencyToPrecision (code, amount),
             'type': '0', // 0 = transfer within account by default, 1 = master account to sub-account, 2 = sub-account to master account
-            'from': fromId,
-            'to': toId,
+            'from': fromId, // remitting account, 1 = SPOT, 3 = FUTURES, 5 = MARGIN, 6 = FUNDING, 9 = SWAP, 12 = OPTION, 18 = Unified account
+            'to': toId, // beneficiary account, 1 = SPOT, 3 = FUTURES, 5 = MARGIN, 6 = FUNDING, 9 = SWAP, 12 = OPTION, 18 = Unified account
+            // 'subAcct': 'sub-account-name', // optional, only required when type is 1 or 2
+            // 'instId': market['id'], // required when from is 3, 5 or 9, margin trading pair like BTC-USDT or contract underlying like BTC-USD to be transferred out
+            // 'toInstId': market['id'], // required when from is 3, 5 or 9, margin trading pair like BTC-USDT or contract underlying like BTC-USD to be transferred in
         };
         if (fromId === 'master') {
             request['type'] = '1';

--- a/js/okx.js
+++ b/js/okx.js
@@ -636,9 +636,14 @@ module.exports = class okx extends Exchange {
                     'twap': true,
                 },
                 'accountsByType': {
+                    'spot': '1',
+                    'future': '3',
+                    'futures': '3',
+                    'margin': '5',
                     'funding': '6',
-                    'spot': '18',
-                    'main': 'master',
+                    'swap': '9',
+                    'option': '12',
+                    'trading': '18', // unified trading account
                 },
                 'accountsById': {
                     '1': 'spot',
@@ -647,8 +652,7 @@ module.exports = class okx extends Exchange {
                     '6': 'funding',
                     '9': 'swap',
                     '12': 'option',
-                    '18': 'spot', // unified trading account
-                    'master': 'main',
+                    '18': 'trading', // unified trading account
                 },
                 'exchangeType': {
                     'spot': 'SPOT',


### PR DESCRIPTION
- Allow transfers between sub accounts
- Allow using exchange account IDs
- Remove account types that weren't working and don't appear on the docs or as transfers un the UI. (I'm not sure if the docs have changed or if these types were grabbed from somewhere else).
- Change name `typesByAccount` to standard `accountsById`