### PR TITLE
Coinex fetchFundingHistory

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1286,10 +1286,11 @@ module.exports = class coinex extends Exchange {
         return this.parseTrades (trades, market, since, limit);
     }
 
-    async fetchFundingHistory (symbol = undefined, since = undefined, limit = 100, params = {}) {
+    async fetchFundingHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingHistory() requires a symbol argument');
         }
+        limit = (limit === undefined) ? 100 : limit;
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -28,6 +28,7 @@ module.exports = class coinex extends Exchange {
                 'fetchBalance': true,
                 'fetchClosedOrders': true,
                 'fetchDeposits': true,
+                'fetchFundingHistory': true,
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
                 'fetchMarkets': true,
@@ -1283,6 +1284,71 @@ module.exports = class coinex extends Exchange {
         const data = this.safeValue (response, 'data');
         const trades = this.safeValue (data, tradeRequest, []);
         return this.parseTrades (trades, market, since, limit);
+    }
+
+    async fetchFundingHistory (symbol = undefined, since = undefined, limit = 100, params = {}) {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingHistory() requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'market': market['id'],
+            'limit': limit,
+            // 'offset': 0,
+            // 'end_time': 1638990636000,
+            // 'windowtime': 1638990636000,
+        };
+        if (since !== undefined) {
+            request['start_time'] = since;
+        }
+        const response = await this.perpetualPrivateGetPositionFunding (this.extend (request, params));
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "limit": 100,
+        //             "offset": 0,
+        //             "records": [
+        //                 {
+        //                     "amount": "0.0012",
+        //                     "asset": "USDT",
+        //                     "funding": "-0.0095688273996",
+        //                     "funding_rate": "0.00020034",
+        //                     "market": "BTCUSDT",
+        //                     "position_id": 62052321,
+        //                     "price": "39802.45",
+        //                     "real_funding_rate": "0.00020034",
+        //                     "side": 2,
+        //                     "time": 1650729623.933885,
+        //                     "type": 1,
+        //                     "user_id": 3620173,
+        //                     "value": "47.76294"
+        //                 },
+        //             ]
+        //         },
+        //         "message": "OK"
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const resultList = this.safeValue (data, 'records', []);
+        const result = [];
+        for (let i = 0; i < resultList.length; i++) {
+            const entry = resultList[i];
+            const timestamp = this.safeTimestamp (entry, 'time');
+            const currencyId = this.safeString (entry, 'asset');
+            const code = this.safeCurrencyCode (currencyId);
+            result.push ({
+                'info': entry,
+                'symbol': symbol,
+                'code': code,
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+                'id': this.safeNumber (entry, 'position_id'),
+                'amount': this.safeNumber (entry, 'funding'),
+            });
+        }
+        return result;
     }
 
     async fetchFundingRate (symbol, params = {}) {


### PR DESCRIPTION
Added the fetchFundingHistory method to Coinex:
```
coinex.fetchFundingHistory (BTC/USDT:USDT)
2022-04-23T16:46:37.381Z iteration 0 passed in 284 ms

       symbol | code |     timestamp |                 datetime |       id |            amount
----------------------------------------------------------------------------------------------
BTC/USDT:USDT | USDT | 1650729623933 | 2022-04-23T16:00:23.933Z | 62052321 |  -0.0095688273996
BTC/USDT:USDT | USDT | 1650700822278 | 2022-04-23T08:00:22.278Z | 62052321 | -0.00625367476584
2 objects
```