### PR TITLE
Export ROUND_UP and ROUND_DOWN constants

### DIFF
--- a/python/ccxt/__init__.py
+++ b/python/ccxt/__init__.py
@@ -32,6 +32,8 @@ from ccxt.base.precise import Precise                       # noqa: F401
 from ccxt.base.decimal_to_precision import decimal_to_precision  # noqa: F401
 from ccxt.base.decimal_to_precision import TRUNCATE              # noqa: F401
 from ccxt.base.decimal_to_precision import ROUND                 # noqa: F401
+from ccxt.base.decimal_to_precision import ROUND_UP              # noqa: F401
+from ccxt.base.decimal_to_precision import ROUND_DOWN            # noqa: F401
 from ccxt.base.decimal_to_precision import DECIMAL_PLACES        # noqa: F401
 from ccxt.base.decimal_to_precision import SIGNIFICANT_DIGITS    # noqa: F401
 from ccxt.base.decimal_to_precision import TICK_SIZE             # noqa: F401


### PR DESCRIPTION
Export ROUND_UP and ROUND_DOWN constants

There's little reason to not export these alongside `ROUND` and `TRUNCATE`.