### PR TITLE
Kucoin:  new base URL

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -75,8 +75,11 @@ module.exports = class kucoin extends Exchange {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87295558-132aaf80-c50e-11ea-9801-a2fb0c57c799.jpg',
                 'referral': 'https://www.kucoin.com/?rcode=E5wkqe',
                 'api': {
-                    'public': 'https://openapi-v2.kucoin.com',
-                    'private': 'https://openapi-v2.kucoin.com',
+                    // TODO update url https://docs.kucoin.com/#base-url
+                    // 'public': 'https://openapi-v2.kucoin.com',
+                    // 'private': 'https://openapi-v2.kucoin.com',
+                    'public': 'https://api.kucoin.com',
+                    'private': 'https://api.kucoin.com',
                     'futuresPrivate': 'https://api-futures.kucoin.com',
                     'futuresPublic': 'https://api-futures.kucoin.com',
                 },

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -75,9 +75,6 @@ module.exports = class kucoin extends Exchange {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87295558-132aaf80-c50e-11ea-9801-a2fb0c57c799.jpg',
                 'referral': 'https://www.kucoin.com/?rcode=E5wkqe',
                 'api': {
-                    // TODO update url https://docs.kucoin.com/#base-url
-                    // 'public': 'https://openapi-v2.kucoin.com',
-                    // 'private': 'https://openapi-v2.kucoin.com',
                     'public': 'https://api.kucoin.com',
                     'private': 'https://api.kucoin.com',
                     'futuresPrivate': 'https://api-futures.kucoin.com',


### PR DESCRIPTION
browsing kucoin docs for some other reason and noticed they changed their URL

https://docs.kucoin.com/#base-url

ran `node run-tests kucoin --python --js --php --python-async --php-async` and got this: 

`Testing { exchanges: ["kucoin"], symbol: "all", keys: { '--js': true, '--php': true, '--python': true, '--python-async': true, '--php-async': true }, maxConcurrency: 5 } (run-tests.js:255)
[100%] Testing kucoin OK (testExchange @ run-tests.js:172)
All done, 1 succeeded (run-tests.js:276)`

and then made a few orders etc and all was working fine. 