### PR TITLE
Coinex fetchTrades

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -561,7 +561,7 @@ module.exports = class coinex extends Exchange {
 
     parseTrade (trade, market = undefined) {
         //
-        // Spot fetchTrades (public)
+        // Spot and Swap fetchTrades (public)
         //
         //      {
         //          "id":  2611511379,
@@ -657,6 +657,9 @@ module.exports = class coinex extends Exchange {
             } else if (side === 2) {
                 side = 'buy';
             }
+            if (side === undefined) {
+                side = this.safeString (trade, 'type');
+            }
         } else {
             side = this.safeString (trade, 'type');
         }
@@ -682,8 +685,15 @@ module.exports = class coinex extends Exchange {
         const market = this.market (symbol);
         const request = {
             'market': market['id'],
+            // 'last_id': 0,
         };
-        const response = await this.publicGetMarketDeals (this.extend (request, params));
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const method = market['swap'] ? 'perpetualPublicGetMarketDeals' : 'publicGetMarketDeals';
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Spot and Swap
         //
         //      {
         //          "code":    0,


### PR DESCRIPTION
Added swap functionality to fetchTrades:
```
coinex.fetchTrades (BTC/USDT:USDT)
2022-04-25T20:35:04.840Z iteration 0 passed in 294 ms

    timestamp |                 datetime |        symbol |        id | order | type | side | takerOrMaker |    price | amount |        cost | fee | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------
1650918885557 | 2022-04-25T20:34:45.557Z | BTC/USDT:USDT | 382747754 |       |      | sell |              | 40122.27 | 0.0594 | 2383.262838 |     |   []
1650918893592 | 2022-04-25T20:34:53.592Z | BTC/USDT:USDT | 382747919 |       |      |  buy |              | 40122.28 | 0.0074 |  296.904872 |     |   []
1650918898610 | 2022-04-25T20:34:58.610Z | BTC/USDT:USDT | 382747965 |       |      |  buy |              | 40122.28 | 0.0469 | 1881.734932 |     |   []
...
```