### PR TITLE
ftx.fetchBorrowRateHistories can fetch up to 5000 when fetching a single currency

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2555,10 +2555,22 @@ module.exports = class ftx extends Exchange {
     async fetchBorrowRateHistories (codes = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {};
-        let endTime = this.safeNumber2 (params, 'till', 'end_time');
-        if (limit > 48) {
-            throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 48');
+        let numCodes = 0;
+        if (codes !== undefined) {
+            numCodes = codes.length;
         }
+        if (numCodes === 1) {
+            if (limit > 5000) {
+                throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 5000 for a single currency');
+            }
+            const currency = this.currency (codes[0]);
+            request['coin'] = currency['id'];
+        } else {
+            if (limit > 48) {
+                throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 48 for multiple currencies');
+            }
+        }
+        let endTime = this.safeNumber2 (params, 'till', 'end_time');
         const millisecondsPerHour = 3600000;
         const millisecondsPer2Days = 172800000;
         if ((endTime - since) > millisecondsPer2Days) {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2557,21 +2557,25 @@ module.exports = class ftx extends Exchange {
         const request = {};
         let numCodes = 0;
         let endTime = this.safeNumber2 (params, 'till', 'end_time');
-        const millisecondsPer2Days = 172800000;
         if (codes !== undefined) {
             numCodes = codes.length;
         }
         if (numCodes === 1) {
-            if (limit > 5000) {
+            const millisecondsPer5000Hours = 18000000000;
+            if ((limit !== undefined) && (limit > 5000)) {
                 throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 5000 for a single currency');
+            }
+            if ((endTime !== undefined) && (since !== undefined) && ((endTime - since) > millisecondsPer5000Hours)) {
+                throw new BadRequest (this.id + ' fetchBorrowRateHistories() requires the time range between the since time and the end time to be less than 5000 hours for a single currency');
             }
             const currency = this.currency (codes[0]);
             request['coin'] = currency['id'];
         } else {
-            if (limit > 48) {
+            const millisecondsPer2Days = 172800000;
+            if ((limit !== undefined) && (limit > 48)) {
                 throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 48 for multiple currencies');
             }
-            if ((endTime - since) > millisecondsPer2Days) {
+            if ((endTime !== undefined) && (since !== undefined) && ((endTime - since) > millisecondsPer2Days)) {
                 throw new BadRequest (this.id + ' fetchBorrowRateHistories() requires the time range between the since time and the end time to be less than 48 hours for multiple currencies');
             }
         }

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2556,6 +2556,8 @@ module.exports = class ftx extends Exchange {
         await this.loadMarkets ();
         const request = {};
         let numCodes = 0;
+        let endTime = this.safeNumber2 (params, 'till', 'end_time');
+        const millisecondsPer2Days = 172800000;
         if (codes !== undefined) {
             numCodes = codes.length;
         }
@@ -2569,13 +2571,11 @@ module.exports = class ftx extends Exchange {
             if (limit > 48) {
                 throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot exceed 48 for multiple currencies');
             }
+            if ((endTime - since) > millisecondsPer2Days) {
+                throw new BadRequest (this.id + ' fetchBorrowRateHistories() requires the time range between the since time and the end time to be less than 48 hours for multiple currencies');
+            }
         }
-        let endTime = this.safeNumber2 (params, 'till', 'end_time');
         const millisecondsPerHour = 3600000;
-        const millisecondsPer2Days = 172800000;
-        if ((endTime - since) > millisecondsPer2Days) {
-            throw new BadRequest (this.id + ' fetchBorrowRateHistories() requires the time range between the since time and the end time to be less than 48 hours');
-        }
         if (since !== undefined) {
             request['start_time'] = parseInt (since / 1000);
             if (endTime === undefined) {


### PR DESCRIPTION
```
ftx.fetchBorrowRateHistory (USDT, , 5000)
2022-04-26T05:11:36.344Z iteration 0 passed in 865 ms
currency |         rate |  period |     timestamp |                 datetime
----------------------------------------------------------------------------
    USDT |  0.000003078 | 3600000 | 1650949200000 | 2022-04-26T05:00:00.000Z
...
    USDT | 0.0000077085 | 3600000 | 1632956400000 | 2021-09-29T23:00:00.000Z
    USDT | 0.0000077085 | 3600000 | 1632952800000 | 2021-09-29T22:00:00.000Z
5000 objects
```

```
ftx.fetchBorrowRateHistories (, , 5000)
BadRequest ftx fetchBorrowRateHistories() limit cannot exceed 48 for multiple currencies
---------------------------------------------------
[BadRequest] ftx fetchBorrowRateHistories() limit cannot exceed 48 for multiple currencies

    at fetchBorrowRateHistories   ../../ccxt/ccxt/js/ftx.js:2570          throw new BadRequest (this.id + ' fetchBorrowRateHistories() limit cannot excee…
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:269  const result = await exchange[methodName] (... args)                            

ftx fetchBorrowRateHistories() limit cannot exceed 48 for multiple currencies
```

```
ftx.fetchBorrowRateHistories (, , 48)
2022-04-26T05:13:06.357Z iteration 0 passed in 3097 ms

{
  MSOL: [
    {
      currency: 'MSOL',
      rate: '0.00000135',
      period: 3600000,
      timestamp: 1650949200000,
      datetime: '2022-04-26T05:00:00.000Z',
      info: {
        coin: 'MSOL',
        time: '2022-04-26T05:00:00+00:00',
        size: '1662.0092812',
        rate: '1e-6'
      }
    },
    ...
    {
      currency: 'BTC',
      rate: '0.00000135',
      period: 3600000,
      timestamp: 1650783600000,
      datetime: '2022-04-24T07:00:00.000Z',
      info: {
        coin: 'BTC',
        time: '2022-04-24T07:00:00+00:00',
        size: '32145.24482399',
        rate: '1e-6'
      }
    }
  ]
}
```