### PR TITLE
Ftx parse borrow rate history python array includes fix, docstrings

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2553,6 +2553,17 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchBorrowRateHistories (codes = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name ftx#fetchBorrowRateHistory
+         * @description Gets the history of the borrow rate for mutiple currencies
+         * @param {str} code Unified currency code
+         * @param {int} since Timestamp in ms of the earliest time to fetch the borrow rate
+         * @param {int} limit Max number of [borrow rate structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-rate-structure} to return per currency, max=48 for multiple currencies, max=5000 for a single currency
+         * @param {dict} params Exchange specific parameters
+         * @param {dict} params.till Timestamp in ms of the latest time to fetch the borrow rate
+         * @returns A dictionary of [borrow rate structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-rate-structure} with unified currency codes as keys
+         */
         await this.loadMarkets ();
         const request = {};
         let numCodes = 0;
@@ -2620,6 +2631,17 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchBorrowRateHistory (code, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name ftx#fetchBorrowRateHistory
+         * @description Gets the history of the borrow rate for a currency
+         * @param {str} code Unified currency code
+         * @param {int} since Timestamp in ms of the earliest time to fetch the borrow rate
+         * @param {int} limit Max number of [borrow rate structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-rate-structure} to return, max=5000
+         * @param {dict} params Exchange specific parameters
+         * @param {dict} params.till Timestamp in ms of the latest time to fetch the borrow rate
+         * @returns An array of [borrow rate structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-rate-structure}
+         */
         const histories = await this.fetchBorrowRateHistories ([ code ], since, limit, params);
         const borrowRateHistory = this.safeValue (histories, code);
         if (borrowRateHistory === undefined) {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2637,7 +2637,7 @@ module.exports = class ftx extends Exchange {
         for (let i = 0; i < response.length; i++) {
             const item = response[i];
             const code = this.safeCurrencyCode (this.safeString (item, 'coin'));
-            if (codes === undefined || codes.includes (code)) {
+            if (codes === undefined || this.inArray (code, codes)) {
                 if (!(code in borrowRateHistories)) {
                     borrowRateHistories[code] = [];
                 }


### PR DESCRIPTION
```
Node.js: v14.17.0                       PHP v8.1.4                                 Python v3.9.5
CCXT v1.80.68                           CCXT v1.80.68                              CCXT v1.80.68
ftx.fetchBorrowRateHistory (USDT)       ftx->fetchBorrowRateHistory(USDT)          ftx.fetchBorrowRateHistory(USDT)
[                                       (                                          [{'currency': 'USDT',
 {                                       [0] => Array                               'datetime': '2022-04-26T05:00:00.000Z',
 currency: 'USDT',                        (                                         'info': {'coin': 'USDT',
 rate: '0.000003078',                      [currency] => USDT                         'rate': '2.28e-6',
 period: 3600000,                          [rate] => 0.000003078                      'size': '481844290.193978',
 timestamp: 1650949200000,                 [period] => 3600000                        'time': '2022-04-26T05:00:00+00:00'},
 datetime: '2022-04-26T05:00:00.000Z',     [timestamp] => 1650949200000             'period': 3600000,
 info: {                                   [datetime] => 2022-04-26T05:00:00.000Z   'rate': '0.000003078',
  coin: 'USDT',                            [info] => Array                          'timestamp': 1650949200000},
  time: '2022-04-26T05:00:00+00:00',        (                                       {'currency': 'USDT',
  size: '481844290.193978',                  [coin] => USDT                         'datetime': '2022-04-26T04:00:00.000Z',
  rate: '2.28e-6'                            [time] => 2022-04-26T05:00:00+00:00    'info': {'coin': 'USDT',
 }                                           [size] => 481844290.193978               'rate': '2.28e-6',
 },                                          [rate] => 2.28e-6                        'size': '482882626.4446618',

 ```