### PR TITLE
Coinex fetchOpenOrders, fetchClosedOrders

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1234,7 +1234,7 @@ module.exports = class coinex extends Exchange {
             type = this.safeInteger (order, 'type');
             if (type === 1) {
                 type = 'limit';
-            } else if (type === 2)
+            } else if (type === 2) {
                 type = 'market';
             }
         }

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1215,23 +1215,28 @@ module.exports = class coinex extends Exchange {
         const remainingString = this.safeString (order, 'left');
         const marketId = this.safeString (order, 'market');
         market = this.safeMarket (marketId, market);
-        const swap = market['swap'];
         const feeCurrencyId = this.safeString (order, 'fee_asset');
         let feeCurrency = this.safeCurrencyCode (feeCurrencyId);
         if (feeCurrency === undefined) {
             feeCurrency = market['quote'];
         }
         const status = this.parseOrderStatus (this.safeString (order, 'status'));
-        let type = undefined;
-        let side = undefined;
-        if (swap) {
-            type = this.safeInteger (order, 'type');
-            type = (type === 1) ? 'limit' : 'market';
-            side = this.safeInteger (order, 'side');
-            side = (side === 1) ? 'sell' : 'buy';
+        let side = this.safeInteger (order, 'side');
+        if (side === 1) {
+            side = 'sell';
+        } else if (side === 2) {
+            side = 'buy';
         } else {
             side = this.safeString (order, 'type');
-            type = this.safeString (order, 'order_type');
+        }
+        let type = this.safeString (order, 'order_type');
+        if (type === undefined) {
+            type = this.safeInteger (order, 'type');
+            if (type === 1) {
+                type = 'limit';
+            } else if (type === 2)
+                type = 'market';
+            }
         }
         return this.safeOrder ({
             'id': this.safeString2 (order, 'id', 'order_id'),

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1206,7 +1206,6 @@ module.exports = class coinex extends Exchange {
         //         "user_id": 3620173
         //     }
         //
-        const swap = market['swap'];
         const timestamp = this.safeTimestamp (order, 'create_time');
         const priceString = this.safeString (order, 'price');
         const costString = this.safeString (order, 'deal_money');
@@ -1216,6 +1215,7 @@ module.exports = class coinex extends Exchange {
         const remainingString = this.safeString (order, 'left');
         const marketId = this.safeString (order, 'market');
         market = this.safeMarket (marketId, market);
+        const swap = market['swap'];
         const feeCurrencyId = this.safeString (order, 'fee_asset');
         let feeCurrency = this.safeCurrencyCode (feeCurrencyId);
         if (feeCurrency === undefined) {
@@ -1833,7 +1833,7 @@ module.exports = class coinex extends Exchange {
         const tradeRequest = (marketType === 'swap') ? 'records' : 'data';
         const data = this.safeValue (response, 'data');
         const orders = this.safeValue (data, tradeRequest, []);
-        return this.parseOrders (orders, marketType, since, limit);
+        return this.parseOrders (orders, market, since, limit);
     }
 
     async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Added swap and stop functionality to fetchClosedOrders and fetchOpenOrders:

Swap fetchOpenOrders:
```
coinex.fetchOpenOrders (BTC/USDT:USDT)
2022-04-27T22:01:49.725Z iteration 0 passed in 290 ms

         id | clientOrderId |                 datetime |     timestamp | lastTradeTimestamp | status |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | cost | average | amount | filled | remaining | trades |                      fee |                       fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
18332128528 |               | 2022-04-27T19:52:16.910Z | 1651089136910 |      1651089136910 |        | BTC/USDT:USDT | limit |             |          |  buy | 31000 |           |    0 |         | 0.0005 |      0 |    0.0005 |     [] | {"currency":"","cost":0} | [{"currency":"","cost":0}]
1 objects
```

Swap fetchClosedOrders:
```
coinex.fetchClosedOrders (BTC/USDT:USDT)
2022-04-27T22:02:45.640Z iteration 0 passed in 297 ms

         id | clientOrderId |                 datetime |     timestamp | lastTradeTimestamp | status |        symbol |   type | timeInForce | postOnly | side |    price | stopPrice |      cost | average | amount | filled | remaining | trades |                                fee |                                  fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
17797092987 |               | 2022-04-23T01:05:36.016Z | 1650675936016 |      1650675936016 |        | BTC/USDT:USDT | market |         IOC |          |  buy |          |           |           |         | 0.0012 | 0.0012 |         0 |     [] |   {"currency":"","cost":0.0237528} |    [{"currency":"","cost":0.0237528}]
...
```

Swap Stop fetchOpenOrders:
```
node examples/js/cli coinex fetchOpenOrders BTC/USDT:USDT undefined undefined '{"stop":"true"}'

coinex.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2022-04-27T22:03:55.064Z iteration 0 passed in 316 ms

         id | clientOrderId |                 datetime |     timestamp | lastTradeTimestamp | status |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | cost | average | amount | filled | remaining | trades |             fee |              fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
18332143848 |               | 2022-04-27T19:52:27.321Z | 1651089147321 |      1651089147321 |        | BTC/USDT:USDT | limit |             |          |  buy | 31000 |  31500.00 |      |         | 0.0005 |        |           |     [] | {"currency":""} | [{"currency":""}]
1 objects
```

Spot Stop fetchOpenOrders:
```
node examples/js/cli coinex fetchOpenOrders BTC/USDT undefined undefined '{"stop":"true"}'

coinex.fetchOpenOrders (BTC/USDT, , , [object Object])
2022-04-27T22:04:49.944Z iteration 0 passed in 323 ms

         id | clientOrderId |                 datetime |     timestamp | lastTradeTimestamp | status |   symbol |   type | timeInForce | postOnly | side | price | stopPrice | cost | average | amount | filled | remaining | trades |                 fee |                  fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
74660111965 |               | 2022-04-27T19:53:02.000Z | 1651089182000 |                    |        | BTC/USDT | market |         IOC |          |  buy |       |     31500 |      |         |    155 |        |           |     [] | {"currency":"USDT"} | [{"currency":"USDT"}]
1 objects
```