### PR TITLE
gateio fetchMarkets split spot and margin

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -695,9 +695,7 @@ module.exports = class gateio extends Exchange {
             const amountPrecisionString = this.safeString (market, 'amount_precision');
             const pricePrecisionString = this.safeString (market, 'precision');
             const tradeStatus = this.safeString (market, 'trade_status');
-            const leverage = this.safeNumber (market, 'leverage');
             const defaultMinAmountLimit = this.parseNumber (this.parsePrecision (amountPrecisionString));
-            const margin = leverage !== undefined;
             result.push ({
                 'id': id,
                 'symbol': base + '/' + quote,
@@ -731,8 +729,8 @@ module.exports = class gateio extends Exchange {
                 },
                 'limits': {
                     'leverage': {
-                        'min': this.parseNumber ('1'),
-                        'max': this.safeNumber (market, 'leverage', 1),
+                        'min': margin ? this.parseNumber ('1') : undefined,
+                        'max': this.safeNumber (market, 'leverage'),
                     },
                     'amount': {
                         'min': this.safeNumber (market, 'min_base_amount', defaultMinAmountLimit),


### PR DESCRIPTION
The type was always set as spot before, this messed up some other code that was checking if the type was margin. This only returns the margin markets if type === margin

-------------

# SPOT
```
Node.js: v14.17.0
CCXT v1.80.90
gateio.fetchMarkets ()
2022-04-28T09:50:23.448Z iteration 0 passed in 456 ms
             id |                      symbol |                   base | quote | settle |     baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse |  taker |  maker | contractSize | expiry | expiryDatetime | strike | optionType |                           precision |                                                                    limits
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        IHT_ETH |                     IHT/ETH |                    IHT |   ETH |        |        IHT |     ETH |          | spot | true |  false | false |  false |  false |   true |    false |        |         |  0.002 |  0.002 |              |        |                |        |            |         {"amount":0.1,"price":1e-9} |      {"leverage":{},"amount":{"min":0.1},"price":{},"cost":{"min":0.001}}
...
       DSD_USDT |                    DSD/USDT |                    DSD |  USDT |        |        DSD |    USDT |          | spot | true |  false | false |  false |  false |  false |    false |        |         |  0.002 |  0.002 |              |        |                |        |            |    {"amount":0.001,"price":0.00001} |        {"leverage":{},"amount":{"min":0.001},"price":{},"cost":{"min":1}}
     ALPHR_USDT |                  ALPHR/USDT |                  ALPHR |  USDT |        |      ALPHR |    USDT |          | spot | true |  false | false |  false |  false |   true |    false |        |         |  0.002 |  0.002 |              |        |                |        |            |    {"amount":0.0001,"price":0.0001} |       {"leverage":{},"amount":{"min":0.0001},"price":{},"cost":{"min":1}}
2656 objects
```

# Margin

```
Debugger attached.
2022-04-28T09:49:42.157Z
Node.js: v14.17.0
CCXT v1.80.90
gateio.fetchMarkets ()
2022-04-28T09:49:44.374Z iteration 0 passed in 437 ms
           id |                symbol |             base | quote | settle |   baseId | quoteId | settleId |   type | spot | margin |  swap | future | option | active | contract | linear | inverse | taker | maker | contractSize | expiry | expiryDatetime | strike | optionType |                         precision |                                                                                  limits
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     ERN_USDT |              ERN/USDT |              ERN |  USDT |        |      ERN |    USDT |          | margin | true |   true | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |        |                |        |            |    {"amount":0.001,"price":0.001} |           {"leverage":{"min":1,"max":3},"amount":{"min":5},"price":{},"cost":{"min":1}}
Waiting for the debugger to disconnect...
...
     ZEC_USDT |              ZEC/USDT |              ZEC |  USDT |        |      ZEC |    USDT |          | margin | true |   true | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |        |                |        |            |    {"amount":0.0001,"price":0.01} |           {"leverage":{"min":1,"max":3},"amount":{"min":2},"price":{},"cost":{"min":1}}
   JASMY_USDT |            JASMY/USDT |            JASMY |  USDT |        |    JASMY |    USDT |          | margin | true |   true | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |        |                |        |            | {"amount":0.001,"price":0.000001} |        {"leverage":{"min":1,"max":3},"amount":{"min":2000},"price":{},"cost":{"min":1}}
422 objects
```