### PR TITLE
handleMarketTypeAndParams "margin" defaultType

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2248,7 +2248,8 @@ module.exports = class Exchange {
                 methodType = this.safeString2 (methodOptions, 'defaultType', 'type', methodType);
             }
         }
-        const marketType = (market === undefined) ? methodType : market['type'];
+        // market type takes priority over methodType except when methodType is "margin" and market type is spot
+        const marketType = (market === undefined || (methodType === 'margin' && market['type'] === 'spot')) ? methodType : market['type'];
         const type = this.safeString2 (params, 'defaultType', 'type', marketType);
         params = this.omit (params, [ 'defaultType', 'type' ]);
         return [ type, params ];

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3771,7 +3771,8 @@ class Exchange {
                 $method_type = $this->safe_string_2($method_options, 'defaultType', 'type', $method_type);
             }
         }
-        $market_type = isset($market) ? $market['type'] : $method_type;
+        // market type takes priority over method_type except when method_type is "margin" and market type is spot
+        $market_type = !isset($market) || ($method_type === 'margin' && $market['type'] === 'spot') ? $method_type : $market['type'];
         $type = $this->safe_string_2($params, 'defaultType', 'type', $market_type);
         $params = $this->omit($params, [ 'defaultType', 'type' ]);
         return array($type, $params);

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2853,7 +2853,8 @@ class Exchange(object):
                 method_type = method_options
             else:
                 method_type = self.safe_string_2(method_options, 'defaultType', 'type', method_type)
-        market_type = method_type if market is None else market['type']
+        # market type takes priority over method_type except when method_type is "margin" and market type is spot
+        market_type = method_type if market is None or (method_type == 'margin' and market['type'] == 'spot') else market['type']
         type = self.safe_string_2(params, 'defaultType', 'type', market_type)
         params = self.omit(params, ['defaultType', 'type'])
         return [type, params]


### PR DESCRIPTION
In base.exchange.handleMarketTypeAndParams `defaultType`/`methodType` takes priority over market type when `defaultType` is "margin" and market type is `spot`

If there is going to be no type `margin`, then this will be needed for margin trading when spot and margin api endpoints differ if we don't want to require the user to specify the type with every method call