### PR TITLE
Coinex addMargin, reduceMargin

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -663,7 +663,7 @@ class Transpiler {
         const libraries = []
 
         for (let library in pythonStandardLibraries) {
-            const regex = new RegExp ("[^\\'a-zA-Z]" + library + "[^\\'a-zA-Z]")
+            const regex = new RegExp ("[^\\'\\\"a-zA-Z]" + library + "[^\\'\\\"a-zA-Z]")
             if (bodyAsString.match (regex))
                 libraries.push ('import ' + pythonStandardLibraries[library])
         }

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -24,7 +24,6 @@ module.exports = class coinex extends Exchange {
                 'future': false,
                 'option': false,
                 'addMargin': true,
-                'reduceMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,
@@ -46,6 +45,7 @@ module.exports = class coinex extends Exchange {
                 'fetchTradingFee': true,
                 'fetchTradingFees': true,
                 'fetchWithdrawals': true,
+                'reduceMargin': true,
                 'withdraw': true,
             },
             'timeframes': {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -23,6 +23,8 @@ module.exports = class coinex extends Exchange {
                 'swap': undefined, // has but unimplemented
                 'future': false,
                 'option': false,
+                'addMargin': true,
+                'reduceMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,
@@ -1820,6 +1822,100 @@ module.exports = class coinex extends Exchange {
         const data = this.safeValue (response, 'data');
         const trades = this.safeValue (data, tradeRequest, []);
         return this.parseTrades (trades, market, since, limit);
+    }
+
+    async modifyMarginHelper (symbol, amount, addOrReduce, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'market': market['id'],
+            'amount': this.amountToPrecision (symbol, amount),
+            'type': addOrReduce,
+        };
+        const response = await this.perpetualPrivatePostPositionAdjustMargin (this.extend (request, params));
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "adl_sort": 1,
+        //             "adl_sort_val": "0.00004320",
+        //             "amount": "0.0005",
+        //             "amount_max": "0.0005",
+        //             "amount_max_margin": "6.57352000000000000000",
+        //             "bkr_price": "16294.08000000000000011090",
+        //             "bkr_price_imply": "0.00000000000000000000",
+        //             "close_left": "0.0005",
+        //             "create_time": 1651202571.320778,
+        //             "deal_all": "19.72000000000000000000",
+        //             "deal_asset_fee": "0.00000000000000000000",
+        //             "fee_asset": "",
+        //             "finish_type": 1,
+        //             "first_price": "39441.12",
+        //             "insurance": "0.00000000000000000000",
+        //             "latest_price": "39441.12",
+        //             "leverage": "3",
+        //             "liq_amount": "0.00000000000000000000",
+        //             "liq_order_price": "0",
+        //             "liq_order_time": 0,
+        //             "liq_price": "16491.28560000000000011090",
+        //             "liq_price_imply": "0.00000000000000000000",
+        //             "liq_profit": "0.00000000000000000000",
+        //             "liq_time": 0,
+        //             "mainten_margin": "0.005",
+        //             "mainten_margin_amount": "0.09860280000000000000",
+        //             "maker_fee": "0.00000000000000000000",
+        //             "margin_amount": "11.57352000000000000000",
+        //             "market": "BTCUSDT",
+        //             "open_margin": "0.58687582908396110455",
+        //             "open_margin_imply": "0.00000000000000000000",
+        //             "open_price": "39441.12000000000000000000",
+        //             "open_val": "19.72056000000000000000",
+        //             "open_val_max": "19.72056000000000000000",
+        //             "position_id": 65171206,
+        //             "profit_clearing": "-0.00986028000000000000",
+        //             "profit_real": "-0.00986028000000000000",
+        //             "profit_unreal": "0.00",
+        //             "side": 2,
+        //             "stop_loss_price": "0.00000000000000000000",
+        //             "stop_loss_type": 0,
+        //             "sys": 0,
+        //             "take_profit_price": "0.00000000000000000000",
+        //             "take_profit_type": 0,
+        //             "taker_fee": "0.00000000000000000000",
+        //             "total": 3464,
+        //             "type": 1,
+        //             "update_time": 1651202638.911212,
+        //             "user_id": 3620173
+        //         },
+        //         "message":"OK"
+        //     }
+        //
+        const status = this.safeString (response, 'message');
+        const type = (addOrReduce === 1) ? 'add' : 'reduce';
+        return this.extend (this.parseModifyMargin (response, market), {
+            'amount': this.parseNumber (amount),
+            'type': type,
+            'status': status,
+        });
+    }
+
+    parseModifyMargin (data, market = undefined) {
+        return {
+            'info': data,
+            'type': undefined,
+            'amount': undefined,
+            'code': market['quote'],
+            'symbol': this.safeSymbol (undefined, market),
+            'status': undefined,
+        };
+    }
+
+    async addMargin (symbol, amount, params = {}) {
+        return await this.modifyMarginHelper (symbol, amount, 1, params);
+    }
+
+    async reduceMargin (symbol, amount, params = {}) {
+        return await this.modifyMarginHelper (symbol, amount, 2, params);
     }
 
     async fetchFundingHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Created addMargin and reduceMargin for Coinex:

addMargin:
```
coinex.addMargin (BTC/USDT:USDT, 1)
2022-04-29T04:19:58.474Z iteration 0 passed in 303 ms

{
  info: {
    code: '0',
    data: {
      adl_sort: '1',
      adl_sort_val: '0.00004320',
      amount: '0.0005',
      amount_max: '0.0005',
      amount_max_margin: '6.57352000000000000000',
      bkr_price: '16294.08000000000000011090',
      bkr_price_imply: '0.00000000000000000000',
      close_left: '0.0005',
      create_time: '1651202571.320778',
      deal_all: '19.72000000000000000000',
      deal_asset_fee: '0.00000000000000000000',
      fee_asset: '',
      finish_type: '1',
      first_price: '39441.12',
      insurance: '0.00000000000000000000',
      latest_price: '39441.12',
      leverage: '3',
      liq_amount: '0.00000000000000000000',
      liq_order_price: '0',
      liq_order_time: '0',
      liq_price: '16491.28560000000000011090',
      liq_price_imply: '0.00000000000000000000',
      liq_profit: '0.00000000000000000000',
      liq_time: '0',
      mainten_margin: '0.005',
      mainten_margin_amount: '0.09860280000000000000',
      maker_fee: '0.00000000000000000000',
      margin_amount: '11.57352000000000000000',
      market: 'BTCUSDT',
      open_margin: '0.58687582908396110455',
      open_margin_imply: '0.00000000000000000000',
      open_price: '39441.12000000000000000000',
      open_val: '19.72056000000000000000',
      open_val_max: '19.72056000000000000000',
      position_id: '65171206',
      profit_clearing: '-0.00986028000000000000',
      profit_real: '-0.00986028000000000000',
      profit_unreal: '-0.03',
      side: '2',
      stop_loss_price: '0.00000000000000000000',
      stop_loss_type: '0',
      sys: '0',
      take_profit_price: '0.00000000000000000000',
      take_profit_type: '0',
      taker_fee: '0.00000000000000000000',
      total: '3502',
      type: '1',
      update_time: '1651205997.787416',
      user_id: '3620173'
    },
    message: 'OK'
  },
  type: 'add',
  amount: 1,
  code: 'USDT',
  symbol: 'BTC/USDT:USDT',
  status: 'OK'
}
```

reduceMargin:
```
coinex.reduceMargin (BTC/USDT:USDT, 1)
2022-04-29T04:21:35.242Z iteration 0 passed in 325 ms

{
  info: {
    code: '0',
    data: {
      adl_sort: '1',
      adl_sort_val: '0.00004728',
      amount: '0.0005',
      amount_max: '0.0005',
      amount_max_margin: '6.57352000000000000000',
      bkr_price: '18294.08000000000000035166',
      bkr_price_imply: '0.00000000000000000000',
      close_left: '0.0005',
      create_time: '1651202571.320778',
      deal_all: '19.72000000000000000000',
      deal_asset_fee: '0.00000000000000000000',
      fee_asset: '',
      finish_type: '1',
      first_price: '39441.12',
      insurance: '0.00000000000000000000',
      latest_price: '39441.12',
      leverage: '3',
      liq_amount: '0.00000000000000000000',
      liq_order_price: '0',
      liq_order_time: '0',
      liq_price: '18491.28560000000000035166',
      liq_price_imply: '0.00000000000000000000',
      liq_profit: '0.00000000000000000000',
      liq_time: '0',
      mainten_margin: '0.005',
      mainten_margin_amount: '0.09860280000000000000',
      maker_fee: '0.00000000000000000000',
      margin_amount: '10.57352000000000000000',
      market: 'BTCUSDT',
      open_margin: '0.53616732993383555030',
      open_margin_imply: '0.00000000000000000000',
      open_price: '39441.12000000000000000000',
      open_val: '19.72056000000000000000',
      open_val_max: '19.72056000000000000000',
      position_id: '65171206',
      profit_clearing: '-0.00986028000000000000',
      profit_real: '-0.00986028000000000000',
      profit_unreal: '-0.02',
      side: '2',
      stop_loss_price: '0.00000000000000000000',
      stop_loss_type: '0',
      sys: '0',
      take_profit_price: '0.00000000000000000000',
      take_profit_type: '0',
      taker_fee: '0.00000000000000000000',
      total: '3540',
      type: '1',
      update_time: '1651206094.559186',
      user_id: '3620173'
    },
    message: 'OK'
  },
  type: 'reduce',
  amount: 1,
  code: 'USDT',
  symbol: 'BTC/USDT:USDT',
  status: 'OK'
}
```