### PR TITLE
CLI :: add market option

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -92,9 +92,9 @@ try {
     })
 
     if (swap) {
-        exchange['options']['defaultType'] = 'swap'
+        exchange.options['defaultType'] = 'swap'
     } else if (future) {
-        exchange['options']['defaultType'] = 'future'
+        exchange.options['defaultType'] = 'future'
     }
 
     // check auth keys in env var

--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -19,6 +19,8 @@ let [processPath, , exchangeId, methodName, ... params] = process.argv.filter (x
         process.argv.includes ('--testnet') ||
         process.argv.includes ('--sandbox')
     , signIn = process.argv.includes ('--sign-in') || process.argv.includes ('--signIn')
+    , swap = process.argv.includes ('--swap')
+    , future = process.argv.includes ('--future')
 
 //-----------------------------------------------------------------------------
 
@@ -88,6 +90,12 @@ try {
         httpsAgent,
         ... settings,
     })
+
+    if (swap) {
+        exchange['options']['defaultType'] = 'swap'
+    } else if (future) {
+        exchange['options']['defaultType'] = 'future'
+    }
 
     // check auth keys in env var
     const requiredCredentials = exchange.requiredCredentials;

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -21,6 +21,12 @@ if (count($argv) > 2) {
     $debug = count(array_filter($args, function ($option) { return strstr($option, '--debug') !== false; })) > 0;
     $args = array_values(array_filter($args, function ($option) { return strstr($option, '--debug') === false; }));
 
+    $swap = count(array_filter($args, function ($option) { return strstr($option, '--swap') !== false; })) > 0;
+    $args = array_values(array_filter($args, function ($option) { return strstr($option, '--swap') === false; }));
+
+    $future = count(array_filter($args, function ($option) { return strstr($option, '--future') !== false; })) > 0;
+    $args = array_values(array_filter($args, function ($option) { return strstr($option, '--future') === false; }));
+
     $id = $args[1];
     $member = $args[2];
     $args = array_slice($args, 3);
@@ -41,6 +47,12 @@ if (count($argv) > 2) {
         // instantiate the exchange by id
         $exchange = '\\ccxt\\' . $id;
         $exchange = new $exchange($config);
+
+        if ($swap) {
+            $exchange->options['defaultType'] = 'swap';
+        } else if ($future) {
+            $exchange->options['defaultType'] = 'future';
+        }
 
         if ($test) {
             $exchange->set_sandbox_mode(true);

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -123,14 +123,10 @@ if argv.exchange_id in keys:
 
 exchange = getattr(ccxt, argv.exchange_id)(config)
 
-options = getattr(exchange, 'options', None)
 if argv.swap:
-    options['defaultType'] = 'swap' 
-    setattr(exchange, 'options', options)
-    print(options)
+    exchange.options['defaultType'] = 'swap' 
 elif argv.future:
-    options['defaultType'] = 'future' 
-    setattr(exchange, 'options', options)
+    exchange.options['defaultType'] = 'future' 
 
 # check auth keys in env var
 requiredCredentials = exchange.requiredCredentials

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -36,6 +36,8 @@ class Argv(object):
     exchange_id = None
     method = None
     symbol = None
+    swap = False,
+    future = False
 
 
 argv = Argv()
@@ -49,6 +51,8 @@ parser.add_argument('--debug', action='store_true', help='enable debug output')
 parser.add_argument('--sandbox', action='store_true', help='enable sandbox/testnet')
 parser.add_argument('--testnet', action='store_true', help='enable sandbox/testnet')
 parser.add_argument('--test', action='store_true', help='enable sandbox/testnet')
+parser.add_argument('--swap', action='store_true', help='enable swap markets')
+parser.add_argument('--future', action='store_true', help='enable future markets')
 parser.add_argument('exchange_id', type=str, help='exchange id in lowercase', nargs='?')
 parser.add_argument('method', type=str, help='method or property', nargs='?')
 parser.add_argument('args', type=str, help='arguments', nargs='*')
@@ -118,6 +122,15 @@ if argv.exchange_id in keys:
     config.update(keys[argv.exchange_id])
 
 exchange = getattr(ccxt, argv.exchange_id)(config)
+
+options = getattr(exchange, 'options', None)
+if argv.swap:
+    options['defaultType'] = 'swap' 
+    setattr(exchange, 'options', options)
+    print(options)
+elif argv.future:
+    options['defaultType'] = 'future' 
+    setattr(exchange, 'options', options)
 
 # check auth keys in env var
 requiredCredentials = exchange.requiredCredentials


### PR DESCRIPTION
As you know some exchanges don't load all markets due to incompatible ids, so they usually default to spot. However upon using the CLI currently we don't have an easy way to define the market type we want to load so I add those options, making it very easy to switch between them.

Example JS:
```
node cli.js gateio fetchTrades "BTC/USDT:USDT" --verbose --swap
```

Example Python:
```
python cli.py gateio fetchTrades "BTC/USDT:USDT" --verbose --swap
```

Example PHP:
```
 php cli.php gateio fetchTrades "BTC/USDT:USDT" --swap
```