### PR TITLE
binance: add voption openAccount api

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -25,7 +25,7 @@ module.exports = class binance extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': true,
-                'option': undefined,
+                'option': true,
                 'addMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
@@ -640,6 +640,7 @@ module.exports = class binance extends Exchange {
                         'order',
                         'batchOrders',
                         'userDataStream',
+                        'openAccount',
                     ],
                     'put': [
                         'userDataStream',

--- a/js/binance.js
+++ b/js/binance.js
@@ -25,7 +25,7 @@ module.exports = class binance extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': true,
-                'option': true,
+                'option': undefined,
                 'addMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,


### PR DESCRIPTION
Binance added openAccount api on Mar. 10: https://binance-docs.github.io/apidocs/voptions/en/#2022-03-10

In this PR, I added this api and set `has.'option': true`