### PR TITLE
gateio getMarginType

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -413,7 +413,6 @@ module.exports = class gateio extends Exchange {
                     'delivery': 'delivery',
                 },
                 'defaultType': 'spot',
-                'defaultMarginType': 'isolated',
                 'swap': {
                     'fetchMarkets': {
                         'settlementCurrencies': [ 'usdt', 'btc' ],


### PR DESCRIPTION
Will make it possible to split https://github.com/ccxt/ccxt/pull/12908 into smaller PRs. The value `spot` (normal for stop), `margin` and `cross_margin` correspond the `account` property in  gateio's api

![](https://i.imgur.com/N6U7J4c.png)
![](https://i.imgur.com/XsxdV3u.png)