### PR TITLE
Coinex createOrder

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1203,7 +1203,7 @@ module.exports = class coinex extends Exchange {
         const stopPrice = this.safeString2 (params, 'stopPrice', 'stop_price');
         const postOnly = this.safeValue (params, 'postOnly', false);
         const reduceOnly = this.safeValue (params, 'reduceOnly');
-        const positionId = this.safeInteger (params, 'position_id'); // Required for closing swap positions
+        const positionId = this.safeInteger2 (params, 'position_id', 'positionId'); // Required for closing swap positions
         let timeInForce = this.safeString (params, 'timeInForce'); // Spot: IOC, FOK, PO, GTC, ... NORMAL (default), MAKER_ONLY
         let method = undefined;
         const request = {
@@ -1320,7 +1320,7 @@ module.exports = class coinex extends Exchange {
                 }
             }
         }
-        params = this.omit (params, [ 'reduceOnly', 'position_id', 'timeInForce', 'postOnly', 'stopPrice', 'stop_price', 'stop_type' ]);
+        params = this.omit (params, [ 'reduceOnly', 'position_id', 'positionId', 'timeInForce', 'postOnly', 'stopPrice', 'stop_price', 'stop_type' ]);
         const response = await this[method] (this.extend (request, params));
         //
         // Spot


### PR DESCRIPTION
Added market_close and limit_close endpoints to createOrder that are needed for closing swap positions:

Market Close:
```
node examples/js/cli coinex createOrder BTC/USDT:USDT market undefined undefined undefined '{"reduceOnly":"true","position_id":"65816724"}'

coinex.createOrder (BTC/USDT:USDT, market, , , , [object Object])
2022-04-30T02:34:54.562Z iteration 0 passed in 303 ms

{
  id: '18605225098',
  clientOrderId: undefined,
  datetime: '2022-04-30T02:34:54.000Z',
  timestamp: 1651286094000,
  lastTradeTimestamp: 1651286094000,
  status: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: undefined,
  side: 'sell',
  price: undefined,
  stopPrice: undefined,
  cost: undefined,
  average: undefined,
  amount: 0.0005,
  filled: 0.0005,
  remaining: 0,
  trades: [],
  fee: { currency: '', cost: 0.0096718 },
  info: {
    amount: '0.0005',
    client_id: '',
    create_time: '1651286094.000066',
    deal_asset_fee: '0.00000000000000000000',
    deal_fee: '0.00967180000000000000',
    deal_profit: '0.00457000000000000000',
    deal_stock: '19.34360000000000000000',
    effect_type: '0',
    fee_asset: '',
    fee_discount: '0.00000000000000000000',
    last_deal_amount: '0.0005',
    last_deal_id: '389734032',
    last_deal_price: '38687.20',
    last_deal_role: '2',
    last_deal_time: '1651286094.000113',
    last_deal_type: '4',
    left: '0.0000',
    leverage: '3',
    maker_fee: '0.00000000000000000000',
    market: 'BTCUSDT',
    order_id: '18605225098',
    position_id: '0',
    position_type: '1',
    price: '0.00000000000000000000',
    side: '1',
    source: 'api.v1',
    stop_id: '0',
    taker_fee: '0.00050',
    target: '0',
    type: '2',
    update_time: '1651286094.000113',
    user_id: '3620173'
  },
  fees: [ { currency: '', cost: 0.0096718 } ]
}
```

Limit Close:
```
node examples/js/cli coinex createOrder BTC/USDT:USDT limit sell 0.0005 45000 '{"reduceOnly":"true","position_id":"65817478"}'

coinex.createOrder (BTC/USDT:USDT, limit, sell, 0.0005, 45000, [object Object])
2022-04-30T02:37:46.778Z iteration 0 passed in 317 ms

{
  id: '18605450318',
  clientOrderId: undefined,
  datetime: '2022-04-30T02:37:46.223Z',
  timestamp: 1651286266223,
  lastTradeTimestamp: 1651286266223,
  status: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'sell',
  price: 45000,
  stopPrice: undefined,
  cost: 0,
  average: undefined,
  amount: 0.0005,
  filled: 0,
  remaining: 0.0005,
  trades: [],
  fee: { currency: '', cost: 0 },
  info: {
    amount: '0.0005',
    client_id: '',
    create_time: '1651286266.223734',
    deal_asset_fee: '0.00000000000000000000',
    deal_fee: '0.00000000000000000000',
    deal_profit: '0.00000000000000000000',
    deal_stock: '0.00000000000000000000',
    effect_type: '1',
    fee_asset: '',
    fee_discount: '0.00000000000000000000',
    last_deal_amount: '0.00000000000000000000',
    last_deal_id: '0',
    last_deal_price: '0.00000000000000000000',
    last_deal_role: '0',
    last_deal_time: '0',
    last_deal_type: '0',
    left: '0.0005',
    leverage: '3',
    maker_fee: '0.00030',
    market: 'BTCUSDT',
    order_id: '18605450318',
    position_id: '0',
    position_type: '1',
    price: '45000.00',
    side: '1',
    source: 'api.v1',
    stop_id: '0',
    taker_fee: '0.00050',
    target: '0',
    type: '1',
    update_time: '1651286266.223734',
    user_id: '3620173'
  },
  fees: [ { currency: '', cost: 0 } ]
}
```