### PR TITLE
binance.parsePositionRisk check if quotePrecision is undefined

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4710,7 +4710,8 @@ module.exports = class binance extends Exchange {
                 }
                 const inner = Precise.stringMul (liquidationPriceString, onePlusMaintenanceMarginPercentageString);
                 const leftSide = Precise.stringAdd (inner, entryPriceSignString);
-                const quotePrecision = this.safeInteger (precision, 'quote');
+                const pricePrecision = this.safeInteger (precision, 'price');
+                const quotePrecision = this.safeInteger (precision, 'quote', pricePrecision);
                 collateralString = Precise.stringDiv (Precise.stringMul (leftSide, contractsAbs), '1', quotePrecision);
             } else {
                 // walletBalance = (contracts * contractSize) * (±1/entryPrice - (±1 - mmp) / liquidationPrice)

--- a/js/binance.js
+++ b/js/binance.js
@@ -4712,7 +4712,9 @@ module.exports = class binance extends Exchange {
                 const leftSide = Precise.stringAdd (inner, entryPriceSignString);
                 const pricePrecision = this.safeInteger (precision, 'price');
                 const quotePrecision = this.safeInteger (precision, 'quote', pricePrecision);
-                collateralString = Precise.stringDiv (Precise.stringMul (leftSide, contractsAbs), '1', quotePrecision);
+                if (quotePrecision !== undefined) {
+                    collateralString = Precise.stringDiv (Precise.stringMul (leftSide, contractsAbs), '1', quotePrecision);
+                }
             } else {
                 // walletBalance = (contracts * contractSize) * (±1/entryPrice - (±1 - mmp) / liquidationPrice)
                 let onePlusMaintenanceMarginPercentageString = undefined;
@@ -4726,7 +4728,9 @@ module.exports = class binance extends Exchange {
                 const leftSide = Precise.stringMul (contractsAbs, contractSizeString);
                 const rightSide = Precise.stringSub (Precise.stringDiv ('1', entryPriceSignString), Precise.stringDiv (onePlusMaintenanceMarginPercentageString, liquidationPriceString));
                 const basePrecision = this.safeInteger (precision, 'base');
-                collateralString = Precise.stringDiv (Precise.stringMul (leftSide, rightSide), '1', basePrecision);
+                if (basePrecision !== undefined) {
+                    collateralString = Precise.stringDiv (Precise.stringMul (leftSide, rightSide), '1', basePrecision);
+                }
             }
         } else {
             collateralString = this.safeString (position, 'isolatedMargin');


### PR DESCRIPTION
I'm trying to fix this issue

```
  File "/path/python3.9/site-packages/ccxt/binance.py", line 4472, in parse_position_risk
    collateralString = Precise.string_div(Precise.string_mul(leftSide, contractsAbs), '1', quotePrecision)
  File "/path/python3.9/site-packages/ccxt/base/precise.py", line 199, in string_div
    return str(Precise(string1).div(string2_precise, precision))
  File "/home/ubuntu/freq-bots-secret/freqtrade/.env/lib/python3.9/site-packages/ccxt/base/precise.py", line 85, in div
    distance = precision - self.decimals + other.decimals
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

![](https://i.imgur.com/VJSZ3sh.png)

It happens kind of randomly, but @xmatthias is telling me he thinks it's because a new pair is listed - market is not reloaded, and fetch_positions is called (with a previously cached market).

```
[12:16 AM] xmatthias: @Samwow seems it happens if quotePrecision is None ... 
Precise.string_div('22', '1', None) triggers the error - exactly at that line of Precise (edited)
[12:16 AM] Samwow: yeah, i'm pushing a pr that might be a fix, but it might not also
[12:17 AM] xmatthias: which means the problem is: 
new pair is listed - market is not reloaded, and fetch_positions is called (with a previously cached market).
[12:17 AM] xmatthias: so one pair in fetch_positions is not in self.markets ... which makes precision None, quotePrecision None ...
[12:18 AM] xmatthias: this either needs to be handled (market is none) - or ccxt must assume to refresh markets before/after every call - which i think is not the correct way
```

If that's the case, then there are probably better solutions that this one, and using `pricePrecision` as the default wouldn't fix anything