### PR TITLE
Coinex fetchTicker

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -441,6 +441,46 @@ module.exports = class coinex extends Exchange {
     }
 
     parseTicker (ticker, market = undefined) {
+        //
+        // Spot fetchTicker
+        //
+        //     {
+        //         "vol": "293.19415130",
+        //         "low": "38200.00",
+        //         "open": "39514.99",
+        //         "high": "39530.00",
+        //         "last": "38649.57",
+        //         "buy": "38640.20",
+        //         "buy_amount": "0.22800000",
+        //         "sell": "38640.21",
+        //         "sell_amount": "0.02828439"
+        //     }
+        //
+        // Swap fetchTicker
+        //
+        //     {
+        //         "vol": "7714.2175",
+        //         "low": "38200.00",
+        //         "open": "39569.23",
+        //         "high": "39569.23",
+        //         "last": "38681.37",
+        //         "buy": "38681.36",
+        //         "period": 86400,
+        //         "funding_time": 462,
+        //         "position_amount": "296.7552",
+        //         "funding_rate_last": "0.00009395",
+        //         "funding_rate_next": "0.00000649",
+        //         "funding_rate_predict": "-0.00007176",
+        //         "insurance": "16464465.09431942163278132918",
+        //         "sign_price": "38681.93",
+        //         "index_price": "38681.69500000",
+        //         "sell_total": "16.6039",
+        //         "buy_total": "19.8481",
+        //         "buy_amount": "4.6315",
+        //         "sell": "38681.37",
+        //         "sell_amount": "11.4044"
+        //     }
+        //
         const timestamp = this.safeInteger (ticker, 'date');
         const symbol = this.safeSymbol (undefined, market);
         ticker = this.safeValue (ticker, 'ticker', {});
@@ -456,7 +496,7 @@ module.exports = class coinex extends Exchange {
             'ask': this.safeString (ticker, 'sell'),
             'askVolume': undefined,
             'vwap': undefined,
-            'open': undefined,
+            'open': this.safeString (ticker, 'open'),
             'close': last,
             'last': last,
             'previousClose': undefined,
@@ -475,7 +515,62 @@ module.exports = class coinex extends Exchange {
         const request = {
             'market': market['id'],
         };
-        const response = await this.publicGetMarketTicker (this.extend (request, params));
+        const method = market['swap'] ? 'perpetualPublicGetMarketTicker' : 'publicGetMarketTicker';
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Spot
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "date": 1651306913414,
+        //             "ticker": {
+        //                 "vol": "293.19415130",
+        //                 "low": "38200.00",
+        //                 "open": "39514.99",
+        //                 "high": "39530.00",
+        //                 "last": "38649.57",
+        //                 "buy": "38640.20",
+        //                 "buy_amount": "0.22800000",
+        //                 "sell": "38640.21",
+        //                 "sell_amount": "0.02828439"
+        //             }
+        //         },
+        //         "message": "OK"
+        //     }
+        //
+        // Swap
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "date": 1651306641500,
+        //             "ticker": {
+        //                 "vol": "7714.2175",
+        //                 "low": "38200.00",
+        //                 "open": "39569.23",
+        //                 "high": "39569.23",
+        //                 "last": "38681.37",
+        //                 "buy": "38681.36",
+        //                 "period": 86400,
+        //                 "funding_time": 462,
+        //                 "position_amount": "296.7552",
+        //                 "funding_rate_last": "0.00009395",
+        //                 "funding_rate_next": "0.00000649",
+        //                 "funding_rate_predict": "-0.00007176",
+        //                 "insurance": "16464465.09431942163278132918",
+        //                 "sign_price": "38681.93",
+        //                 "index_price": "38681.69500000",
+        //                 "sell_total": "16.6039",
+        //                 "buy_total": "19.8481",
+        //                 "buy_amount": "4.6315",
+        //                 "sell": "38681.37",
+        //                 "sell_amount": "11.4044"
+        //             }
+        //         },
+        //         "message": "OK"
+        //     }
+        //
         return this.parseTicker (response['data'], market);
     }
 


### PR DESCRIPTION
Added swap functionality to fetchTicker:
```
coinex.fetchTicker (BTC/USDT:USDT)
2022-04-30T09:03:27.096Z iteration 0 passed in 280 ms

{
  symbol: 'BTC/USDT:USDT',
  timestamp: 1651309406512,
  datetime: '2022-04-30T09:03:26.512Z',
  high: 39395.35,
  low: 38200,
  bid: 38579.24,
  bidVolume: undefined,
  ask: 38579.25,
  askVolume: undefined,
  vwap: undefined,
  open: 39320.91,
  close: 38575.06,
  last: 38575.06,
  previousClose: undefined,
  change: -745.85,
  percentage: -1.89682792183599,
  average: 38947.985,
  baseVolume: 7642.6591,
  quoteVolume: undefined,
  info: {
    vol: '7642.6591',
    low: '38200.00',
    open: '39320.91',
    high: '39395.35',
    last: '38575.06',
    buy: '38579.24',
    period: 86400,
    funding_time: 416,
    position_amount: '298.6264',
    funding_rate_last: '0.00009395',
    funding_rate_next: '0.00000649',
    funding_rate_predict: '-0.00001398',
    insurance: '16467826.95340521641917856732',
    sign_price: '38580.68',
    index_price: '38580.47250000',
    sell_total: '15.3452',
    buy_total: '23.2325',
    buy_amount: '0.2027',
    sell: '38579.25',
    sell_amount: '5.0173'
  }
}
```