### PR TITLE
add `timestamp === undefined` check in `test.positions.js`

### DIFF
--- a/js/test/Exchange/test.position.js
+++ b/js/test/Exchange/test.position.js
@@ -7,9 +7,9 @@ function testPosition (exchange, position, symbol, now) {
     assert ('id' in position);
     assert (position['id'] === undefined || typeof position['id'] === 'string');
     assert ('timestamp' in position);
-    assert (typeof position['timestamp'] === 'number');
-    assert (position['timestamp'] > 1230940800000); // 03 Jan 2009 - first cryptocurrency block creation time
-    assert (position['timestamp'] < now);
+    assert (position['timestamp'] === undefiend || typeof position['timestamp'] === 'number');
+    assert (position['timestamp'] === undefiend || position['timestamp'] > 1230940800000); // 03 Jan 2009 - first cryptocurrency block creation time
+    assert (position['timestamp'] === undefiend || position['timestamp'] < now);
     assert ('datetime' in position);
     assert (position['datetime'] === exchange.iso8601 (position['timestamp']));
     assert ('symbol' in position);

--- a/js/test/Exchange/test.position.js
+++ b/js/test/Exchange/test.position.js
@@ -7,9 +7,9 @@ function testPosition (exchange, position, symbol, now) {
     assert ('id' in position);
     assert (position['id'] === undefined || typeof position['id'] === 'string');
     assert ('timestamp' in position);
-    assert (position['timestamp'] === undefiend || typeof position['timestamp'] === 'number');
-    assert (position['timestamp'] === undefiend || position['timestamp'] > 1230940800000); // 03 Jan 2009 - first cryptocurrency block creation time
-    assert (position['timestamp'] === undefiend || position['timestamp'] < now);
+    assert (position['timestamp'] === undefined || typeof position['timestamp'] === 'number');
+    assert (position['timestamp'] === undefined || position['timestamp'] > 1230940800000); // 03 Jan 2009 - first cryptocurrency block creation time
+    assert (position['timestamp'] === undefined || position['timestamp'] < now);
     assert ('datetime' in position);
     assert (position['datetime'] === exchange.iso8601 (position['timestamp']));
     assert ('symbol' in position);


### PR DESCRIPTION
sometimes `timestamp` is not available in position/s response from api.