### PR TITLE
Kucoinfutures fetchClosedOrders & fetchOrderByStatus params.till

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1367,7 +1367,7 @@ module.exports = class kucoin extends Exchange {
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         /**
          * @method
-         * @name kucoin#fetchOrdersByStatus
+         * @name kucoin#fetchClosedOrders
          * @description fetch a list of orders
          * @param {str} symbol unified market symbol
          * @param {int} since timestamp in ms of the earliest order
@@ -1375,8 +1375,8 @@ module.exports = class kucoin extends Exchange {
          * @param {dict} params exchange specific params
          * @param {int} params.till end time in ms
          * @param {str} params.side buy or sell
-         * @param {str} params.type limit, market, limit_stop or market_stop
-         * @param {str} params.tradeType TRADE for spot trading, MARGIN_TRADE for Margin Trading
+         * @param {str} params.type limit, market, limit_stop or market_stop. Futures types include limit and market only
+         * @param {str} params.tradeType TRADE for spot trading, MARGIN_TRADE for Margin Trading. Not used for futures
          * @returns An [array of order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         return await this.fetchOrdersByStatus ('done', symbol, since, limit, params);

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1375,8 +1375,8 @@ module.exports = class kucoin extends Exchange {
          * @param {dict} params exchange specific params
          * @param {int} params.till end time in ms
          * @param {str} params.side buy or sell
-         * @param {str} params.type limit, market, limit_stop or market_stop. Futures types include limit and market only
-         * @param {str} params.tradeType TRADE for spot trading, MARGIN_TRADE for Margin Trading. Not used for futures
+         * @param {str} params.type limit, market, limit_stop or market_stop
+         * @param {str} params.tradeType TRADE for spot trading, MARGIN_TRADE for Margin Trading
          * @returns An [array of order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         return await this.fetchOrdersByStatus ('done', symbol, since, limit, params);

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1147,6 +1147,23 @@ module.exports = class kucoinfutures extends kucoin {
         return this.parseOrders (orders, market, since, limit);
     }
 
+    async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name kucoinfutures#fetchClosedOrders
+         * @description fetch a list of orders
+         * @param {str} symbol unified market symbol
+         * @param {int} since timestamp in ms of the earliest order
+         * @param {int} limit max number of orders to return
+         * @param {dict} params exchange specific params
+         * @param {int} params.till end time in ms
+         * @param {str} params.side buy or sell
+         * @param {str} params.type limit, or market
+         * @returns An [array of order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        return await this.fetchOrdersByStatus ('done', symbol, since, limit, params);
+    }
+
     async fetchOrder (id = undefined, symbol = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {};

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1109,15 +1109,19 @@ module.exports = class kucoinfutures extends kucoin {
          * @param {int} limit The maximum number of orders to retrieve
          * @param {dict} params exchange specific parameters
          * @param {bool} params.stop set to true to retrieve untriggered stop orders
+         * @param {int} params.till End time in ms
          * @param {str} params.side buy or sell
          * @param {str} params.type limit or market
-         * @param {int} params.endAt End time in ms
          * @returns An [array of order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
         const stop = this.safeValue (params, 'stop');
         params = this.omit (params, 'stop');
-        status = (status === 'closed') ? 'done' : status;
+        if (status === 'closed') {
+            status = 'done';
+        } else if (status === 'open') {
+            status = 'active';
+        }
         const request = {};
         if (!stop) {
             request['status'] = status;
@@ -1131,6 +1135,10 @@ module.exports = class kucoinfutures extends kucoin {
         }
         if (since !== undefined) {
             request['startAt'] = since;
+        }
+        const till = this.safeInteger (params, 'till', 'endAt');
+        if (till !== undefined) {
+            request['endAt'] = till;
         }
         const method = stop ? 'futuresPrivateGetStopOrders' : 'futuresPrivateGetOrders';
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
```
 % kucoinfutures fetchClosedOrders undefined 1633046400000 undefined '{"till": 1633651200000}'
2022-05-02T20:06:18.852Z
Node.js: v14.17.0
CCXT v1.81.11
kucoinfutures.fetchClosedOrders (, 1633046400000, , [object Object])
2022-05-02T20:06:20.014Z iteration 0 passed in 672 ms

                      id | clientOrderId |        symbol |  type | timeInForce | postOnly | side | amount |   price | stopPrice |   cost | filled | remaining |     timestamp |                 datetime | fee |   status | lastTradeTimestamp | average | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
...                      |               | ETH/USDT:USDT | limit |         GTC |    false |  buy |      1 | 3403.75 |           |      0 |      0 |         1 | 1633396606000 | 2021-10-05T01:16:46.000Z |  {} | canceled |                    |         |     [] | [{}]
...                      |               | ETH/USDT:USDT | limit |         GTC |    false |  buy |      1 | 3406.65 |           | 6.8106 |      1 |         0 | 1633396639000 | 2021-10-05T01:17:19.000Z |  {} |   closed |                    |  3405.3 |     [] | [{}]
2 objects
```