### PR TITLE
Gateio create order uses getMarginType

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1127,7 +1127,7 @@ module.exports = class gateio extends Exchange {
                 // gateio spot and margin stop orders use the term normal instead of spot
             }
             if (marginType === 'cross_margin') {
-                throw new BadRequest (this.id + ' createOrder does not support stop orders for cross margin');
+                throw new BadRequest (this.id + ' does not support stop orders for cross margin');
             }
         }
         return [ marginType, params ];

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1127,7 +1127,7 @@ module.exports = class gateio extends Exchange {
                 // gateio spot and margin stop orders use the term normal instead of spot
             }
             if (marginType === 'cross_margin') {
-                throw new BadRequest (this.id + ' does not support stop orders for cross margin');
+                throw new BadRequest (this.id + ' getMarginType() does not support stop orders for cross margin');
             }
         }
         return [ marginType, params ];

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -413,7 +413,6 @@ module.exports = class gateio extends Exchange {
                     'delivery': 'delivery',
                 },
                 'defaultType': 'spot',
-                'defaultMarginType': 'isolated',
                 'swap': {
                     'fetchMarkets': {
                         'settlementCurrencies': [ 'usdt', 'btc' ],

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2651,7 +2651,7 @@ module.exports = class gateio extends Exchange {
          * @param {dict} params  Extra parameters specific to the exchange API endpoint
          * @param {float} params.stopPrice The price at which a trigger order is triggered at
          * @param {str} params.timeInForce "GTC", "IOC", or "PO"
-         * @param {str} params.marginType 'cross' or 'isolated' - marginType for type='margin', if not provided this.options['defaultMarginType'] is used
+         * @param {str} params.marginType 'cross' or 'isolated' - marginType for margin trading if not provided this.options['defaultMarginType'] is used
          * @param {int} params.iceberg Amount to display for the iceberg order, Null or 0 for normal orders, Set to -1 to hide the order completely
          * @param {str} params.text User defined information
          * @param {str} params.account *spot and margin only* "spot", "margin" or "cross_margin"
@@ -2717,16 +2717,15 @@ module.exports = class gateio extends Exchange {
                     request['tif'] = timeInForce;
                 }
             } else {
-                const options = this.safeValue (this.options, 'createOrder', {});
-                const defaultAccount = this.safeString (options, 'account', 'spot');
-                const account = this.safeString (params, 'account', defaultAccount);
+                let marginType = undefined;
+                [ marginType, params ] = this.getMarginType (false, params);
                 params = this.omit (params, 'account');
                 // spot order
                 request = {
                     // 'text': clientOrderId, // 't-abcdef1234567890',
                     'currency_pair': market['id'], // filled in prepareRequest above
                     'type': type,
-                    'account': account, // 'spot', 'margin', 'cross_margin'
+                    'account': marginType, // 'spot', 'margin', 'cross_margin'
                     'side': side,
                     'amount': this.amountToPrecision (symbol, amount),
                     'price': this.priceToPrecision (symbol, price),
@@ -2791,9 +2790,8 @@ module.exports = class gateio extends Exchange {
             } else {
                 // spot conditional order
                 const options = this.safeValue (this.options, 'createOrder', {});
-                const defaultAccount = this.safeString (options, 'account', 'normal');
-                const account = this.safeString (params, 'account', defaultAccount);
-                params = this.omit (params, 'account');
+                let marginType = undefined;
+                [ marginType, params ] = this.getMarginType (true, params);
                 const defaultExpiration = this.safeInteger (options, 'expiration');
                 const expiration = this.safeInteger (params, 'expiration', defaultExpiration);
                 const rule = (side === 'buy') ? '>=' : '<=';
@@ -2809,7 +2807,7 @@ module.exports = class gateio extends Exchange {
                         'side': side,
                         'price': this.priceToPrecision (symbol, price),
                         'amount': this.amountToPrecision (symbol, amount),
-                        'account': account, // normal, margin
+                        'account': marginType,
                         'time_in_force': timeInForce, // gtc, ioc for taker only
                     },
                     'market': market['id'],


### PR DESCRIPTION
# SPOT

```
% gateio createOrder ADA/USDT limit buy 2 0.8
2022-05-02T23:19:11.386Z
Node.js: v14.17.0
CCXT v1.81.10
gateio.createOrder (ADA/USDT, limit, buy, 2, 0.8)
2022-05-02T23:19:13.590Z iteration 0 passed in 210 ms

{
  id: '...',
  clientOrderId: 'apiv4',
  timestamp: 1651533553656,
  datetime: '2022-05-02T23:19:13.656Z',
  lastTradeTimestamp: 1651533553656,
  status: 'closed',
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.8,
  stopPrice: undefined,
  average: 0.7856,
  amount: 2,
  cost: 1.5712,
  filled: 2,
  remaining: 0,
  fee: undefined,
  fees: [
    { currency: 'GT', cost: '0' },
    { currency: 'ADA', cost: '0.004' },
    { currency: 'USDT', cost: '0' }
  ],
  trades: [],
  info: {
    id: '...',
    text: 'apiv4',
    create_time: '1651533553',
    update_time: '1651533553',
    create_time_ms: '1651533553656',
    update_time_ms: '1651533553656',
    status: 'closed',
    currency_pair: 'ADA_USDT',
    type: 'limit',
    account: 'spot',
    side: 'buy',
    amount: '2',
    price: '0.8',
    time_in_force: 'gtc',
    iceberg: '0',
    left: '0',
    fill_price: '1.5712',
    filled_total: '1.5712',
    fee: '0.004',
    fee_currency: 'ADA',
    point_fee: '0',
    gt_fee: '0',
    gt_discount: false,
    rebated_fee: '0',
    rebated_fee_currency: 'USDT'
  }
}
```

# ISOLATED MARGIN

```
% gateio createOrder ADA/USDT limit buy 2 0.8 '{"marginType": "isolated"}'
Debugger listening on ws://127.0.0.1:58936/e82fa7f4-f857-456b-8299-f89c110e7b24
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2022-05-02T23:21:10.753Z
Node.js: v14.17.0
CCXT v1.81.10
gateio.createOrder (ADA/USDT, limit, buy, 2, 0.8, [object Object])
2022-05-02T23:21:13.961Z iteration 0 passed in 215 ms

{
  id: '...',
  clientOrderId: 'apiv4',
  timestamp: 1651533674030,
  datetime: '2022-05-02T23:21:14.030Z',
  lastTradeTimestamp: 1651533674030,
  status: 'closed',
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.8,
  stopPrice: undefined,
  average: 0.786,
  amount: 2,
  cost: 1.572,
  filled: 2,
  remaining: 0,
  fee: undefined,
  fees: [
    { currency: 'GT', cost: '0' },
    { currency: 'ADA', cost: '0.004' },
    { currency: 'USDT', cost: '0' }
  ],
  trades: [],
  info: {
    id: '...',
    text: 'apiv4',
    create_time: '1651533674',
    update_time: '1651533674',
    create_time_ms: '1651533674030',
    update_time_ms: '1651533674030',
    status: 'closed',
    currency_pair: 'ADA_USDT',
    type: 'limit',
    account: 'margin',
    side: 'buy',
    amount: '2',
    price: '0.8',
    time_in_force: 'gtc',
    iceberg: '0',
    left: '0',
    fill_price: '1.572',
    filled_total: '1.572',
    fee: '0.004',
    fee_currency: 'ADA',
    point_fee: '0',
    gt_fee: '0',
    gt_discount: false,
    rebated_fee: '0',
    rebated_fee_currency: 'USDT'
  }
}
```

# Cross Margin

```
 % gateio createOrder ADA/USDT limit buy 2 0.8 '{"marginType": "cross"}'   
2022-05-02T23:21:49.974Z
Node.js: v14.17.0
CCXT v1.81.10
gateio.createOrder (ADA/USDT, limit, buy, 2, 0.8, [object Object])
2022-05-02T23:21:52.024Z iteration 0 passed in 222 ms

{
  id: '150548827536',
  clientOrderId: 'apiv4',
  timestamp: 1651533712093,
  datetime: '2022-05-02T23:21:52.093Z',
  lastTradeTimestamp: 1651533712093,
  status: 'closed',
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.8,
  stopPrice: undefined,
  average: 0.7865,
  amount: 2,
  cost: 1.573,
  filled: 2,
  remaining: 0,
  fee: undefined,
  fees: [
    { currency: 'GT', cost: '0' },
    { currency: 'ADA', cost: '0.004' },
    { currency: 'USDT', cost: '0' }
  ],
  trades: [],
  info: {
    id: '...',
    text: 'apiv4',
    create_time: '1651533712',
    update_time: '1651533712',
    create_time_ms: '1651533712093',
    update_time_ms: '1651533712093',
    status: 'closed',
    currency_pair: 'ADA_USDT',
    type: 'limit',
    account: 'cross_margin',
    side: 'buy',
    amount: '2',
    price: '0.8',
    time_in_force: 'gtc',
    iceberg: '0',
    left: '0',
    fill_price: '1.573',
    filled_total: '1.573',
    fee: '0.004',
    fee_currency: 'ADA',
    point_fee: '0',
    gt_fee: '0',
    gt_discount: false,
    rebated_fee: '0',
    rebated_fee_currency: 'USDT'
  }
}
```

# SPOT STOP

```
% gateio createOrder ADA/USDT limit buy 2 0.8 '{"stopPrice": "0.8"}'      
2022-05-02T23:26:27.213Z
Node.js: v14.17.0
CCXT v1.81.10
gateio.createOrder (ADA/USDT, limit, buy, 2, 0.8, [object Object])
2022-05-02T23:26:29.463Z iteration 0 passed in 225 ms

{
  id: '8391440',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: false,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  fees: [],
  trades: [],
  info: { id: '8391440' }
}
```

# Margin Stop

```
% gateio createOrder ADA/USDT limit buy 2 0.8 '{"stopPrice": "0.8", "marginType": "isolated"}'
2022-05-02T23:27:34.168Z
Node.js: v14.17.0
CCXT v1.81.10
gateio.createOrder (ADA/USDT, limit, buy, 2, 0.8, [object Object])
2022-05-02T23:27:36.138Z iteration 0 passed in 214 ms

{
  id: '8391444',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: false,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  fees: [],
  trades: [],
  info: { id: '8391444' }
}
```

# STOP CROSS_MARGIN

```
% gateio createOrder ADA/USDT limit buy 2 0.8 '{"stopPrice": "0.8", "marginType": "cross_margin"}'
2022-05-02T23:28:26.912Z
Node.js: v14.17.0
CCXT v1.81.10
gateio.createOrder (ADA/USDT, limit, buy, 2, 0.8, [object Object])
BadRequest gateio createOrder does not support stop orders for cross margin
---------------------------------------------------
[BadRequest] gateio createOrder does not support stop orders for cross margin

    at getMarginType              ../../ccxt/ccxt/js/gateio.js:1130       throw new BadRequest (this.id + ' createOrder does not support stop orders for …
    at createOrder                ../../ccxt/ccxt/js/gateio.js:2794       [ marginType, params ] = this.getMarginType (true, params);                     
    at processTicksAndRejections  internal/process/task_queues.js:95                                                                                      
    at async main                 ../../ccxt/ccxt/examples/js/cli.js:280  const result = await exchange[methodName] (... args)                            

gateio createOrder does not support stop orders for cross margin
```