### PR TITLE
gateio.prepareRequest accepts type and params as parameters, gateio.multiOrderSpotPrepareRequest

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1102,19 +1102,14 @@ module.exports = class gateio extends Exchange {
          * @param {dict} params request parameters
          * @returns the api request object, and the new params object with non-needed parameters removed
          */
-        let request = {};
+        const request = {};
         if (market !== undefined) {
             if (market['contract']) {
-                request = {
-                    'contract': market['id'],
-                    'settle': market['settleId'],
-                };
+                request['contract'] = market['id'];
+                request['settle'] = market['settleId'];
             } else {
-                request = {
-                    'currency_pair': market['id'],
-                };
+                request['currency_pair'] = market['id'];
             }
-            type = market['type'];
         } else {
             const swap = type === 'swap';
             const future = type === 'future';
@@ -1122,21 +1117,17 @@ module.exports = class gateio extends Exchange {
                 const defaultSettle = swap ? 'usdt' : 'btc';
                 const settle = this.safeStringLower (params, 'settle', defaultSettle);
                 params = this.omit (params, 'settle');
-                request = {
-                    'settle': settle,
-                };
-            } else {
-                request = {};
+                request['settle'] = settle;
             }
         }
         return [ request, params ];
     }
 
-    multiOrderSpotSetMarginType (market = undefined, stop = false, params = {}) {
+    multiOrderSpotPrepareRequest (market = undefined, stop = false, params = {}) {
         /**
          * @ignore
          * @method
-         * @name gateio#multiOrderSpotSetMarginType
+         * @name gateio#multiOrderSpotPrepareRequest
          * @description Fills request params currency_pair, market and account where applicable for spot order methods like fetchOpenOrders, cancelAllOrders
          * @param {dict} market CCXT market
          * @param {bool} stop true if for a stop order

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1134,7 +1134,6 @@ module.exports = class gateio extends Exchange {
          * @param {dict} params request parameters
          * @returns the api request object, and the new params object with non-needed parameters removed
          */
-
         const [ marginType, query ] = this.getMarginType (stop, params);
         const request = {
             'account': marginType,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1091,7 +1091,7 @@ module.exports = class gateio extends Exchange {
         return underlyings;
     }
 
-    prepareRequest (market = undefined, type = undefined, setMarginType = false, stop = false, multiOrder = false, params = {}) {
+    prepareRequest (market = undefined, type = undefined, params = {}) {
         /**
          * @ignore
          * @method
@@ -1099,9 +1099,6 @@ module.exports = class gateio extends Exchange {
          * @description Fills request params contract, settle, currency_pair, market and account where applicable
          * @param {dict} market CCXT market, required when type is undefined
          * @param {str} type 'spot', 'swap', or 'future', required when market is undefined
-         * @param {bool} setMarginType true if setting 'account' param for margin trading
-         * @param {bool} stop true if for a stop order
-         * @param {bool} multiOrder methods like fetchOpenOrders, cancelAllOrders, etc. Only needed for stop orders
          * @param {dict} params request parameters
          * @returns the api request object, and the new params object with non-needed parameters removed
          */
@@ -1132,24 +1129,34 @@ module.exports = class gateio extends Exchange {
                 request = {};
             }
         }
-        if (setMarginType && (type === 'spot' || type === 'margin')) {
-            let marginType = undefined;
-            [ marginType, params ] = this.getMarginType (stop, params);
+        return [ request, params ];
+    }
+
+    multiOrderSpotSetMarginType (market = undefined, stop = false, params = {}) {
+        /**
+         * @ignore
+         * @method
+         * @name gateio#multiOrderSpotSetMarginType
+         * @description Fills request params currency_pair, market and account where applicable for spot order methods like fetchOpenOrders, cancelAllOrders
+         * @param {dict} market CCXT market
+         * @param {bool} stop true if for a stop order
+         * @param {dict} params request parameters
+         * @returns the api request object, and the new params object with non-needed parameters removed
+         */
+
+        const [ marginType, query ] = this.getMarginType (stop, params);
+        const request = {
+            'account': marginType,
+        };
+        if (market !== undefined) {
             if (stop) {
                 // gateio spot and margin stop orders use the term market instead of currency_pair, and normal instead of spot. Neither parameter is used when fetching/cancelling a single order. They are used for creating a single stop order, but createOrder does not call this method
-                if (multiOrder) {
-                    if (market !== undefined) {
-                        request = {
-                            'market': market['id'],
-                        };
-                    }
-                    request['account'] = marginType;
-                }
+                request['market'] = market['id'];
             } else {
-                request['account'] = marginType;
+                request['currency_pair'] = market['id'];
             }
         }
-        return [ request, params ];
+        return [ request, query ];
     }
 
     getMarginType (stop, params) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1247,7 +1247,7 @@ module.exports = class gateio extends Exchange {
         if (!market['swap']) {
             throw new BadRequest ('Funding rates only exist for swap contracts');
         }
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const response = await this.publicFuturesGetSettleContractsContract (this.extend (request, query));
         //
         //    [
@@ -1639,7 +1639,7 @@ module.exports = class gateio extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
             symbol = market['symbol'];
-            [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+            [ request, params ] = this.prepareRequest (market, undefined, params);
         }
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchFundingHistory', market, params);
@@ -1722,7 +1722,7 @@ module.exports = class gateio extends Exchange {
         //         'with_id': true, // return order book ID
         //     };
         //
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const spotOrMargin = market['spot'] || market['margin'];
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'publicSpotGetOrderBook',
@@ -1814,7 +1814,7 @@ module.exports = class gateio extends Exchange {
     async fetchTicker (symbol, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'publicSpotGetTickers',
             'margin': 'publicSpotGetTickers',
@@ -2130,7 +2130,7 @@ module.exports = class gateio extends Exchange {
         const market = this.market (symbol);
         const price = this.safeString (params, 'price');
         let request = {};
-        [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+        [ request, params ] = this.prepareRequest (market, undefined, params);
         request['interval'] = this.timeframes[timeframe];
         let method = 'publicSpotGetCandlesticks';
         if (market['contract']) {
@@ -2286,7 +2286,7 @@ module.exports = class gateio extends Exchange {
         //         'to': this.seconds (), // end time in seconds, default to current time
         //     };
         //
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'publicSpotGetTrades',
             'margin': 'publicSpotGetTrades',
@@ -2339,7 +2339,7 @@ module.exports = class gateio extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchMyTrades', undefined, params);
         if (symbol) {
             market = this.market (symbol);
-            [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+            [ request, params ] = this.prepareRequest (market, undefined, params);
             type = market['type'];
         } else {
             if (type === 'swap' || type === 'future') {
@@ -3380,7 +3380,7 @@ module.exports = class gateio extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         request['status'] = status;
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -3576,7 +3576,7 @@ module.exports = class gateio extends Exchange {
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+            [ request, params ] = this.prepareRequest (market, undefined, params);
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         const swap = type === 'swap';
@@ -3719,7 +3719,7 @@ module.exports = class gateio extends Exchange {
             'swap': 'privateFuturesPostSettlePositionsContractLeverage',
             'future': 'privateDeliveryPostSettlePositionsContractLeverage',
         });
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const defaultMarginType = this.safeString2 (this.options, 'marginType', 'defaultMarginType');
         const crossLeverageLimit = this.safeString (query, 'cross_leverage_limit');
         let marginType = this.safeString (query, 'marginType', defaultMarginType);


### PR DESCRIPTION
More verbose checks within prepare request. This PR just updates the prepare request method and calls so that the code doesn't break. I'll update each method individually to look how they do in https://github.com/ccxt/ccxt/pull/12908

-------------------------

```
gateio.fetchFundingRate (ADA/USDT:USDT)
2022-05-04T01:47:39.859Z iteration 0 passed in 189 ms

{
  info: {
    funding_rate_indicative: '0.0001',
    mark_price_round: '0.00001',
    funding_offset: '0',
    in_delisting: false,
    risk_limit_base: '500000',
    interest_rate: '0.0003',
    index_price: '0.778',
    order_price_round: '0.00001',
    order_size_min: '1',
    ref_rebate_rate: '0.2',
    name: 'ADA_USDT',
    ref_discount_rate: '0',
    order_price_deviate: '0.5',
    maintenance_rate: '0.025',
    mark_type: 'index',
    funding_interval: '28800',
    type: 'direct',
    risk_limit_step: '500000',
    enable_bonus: true,
    leverage_min: '1',
    funding_rate: '-0.000239',
    last_price: '0.77735',
    mark_price: '0.77786',
    order_size_max: '1000000',
    funding_next_apply: '1651651200',
    short_users: '167',
    config_change_time: '1651460585',
    trade_size: '181068158',
    position_size: '303781',
    long_users: '391',
    quanto_multiplier: '10',
    funding_impact_value: '5000',
    leverage_max: '20',
    risk_limit_max: '5000000',
    maker_fee_rate: '-0.00025',
    taker_fee_rate: '0.00075',
    orders_limit: '50',
    trade_id: '4861027',
    orderbook_id: '4851745986'
  },
  symbol: 'ADA/USDT:USDT',
  markPrice: 0.77786,
  indexPrice: 0.778,
  interestRate: 0.0003,
  estimatedSettlePrice: undefined,
  timestamp: undefined,
  datetime: undefined,
  fundingRate: -0.000239,
  fundingTimestamp: 1651651200000,
  fundingDatetime: '2022-05-04T08:00:00.000Z',
  nextFundingRate: 0.0001,
  nextFundingTimestamp: undefined,
  nextFundingDatetime: undefined,
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
```

```
gateio.fetchFundingHistory (ADA/USDT:USDT)                                              gateio.fetchFundingHistory ()
2022-05-04T01:48:25.998Z iteration 0 passed in 530 ms                                   2022-05-04T01:48:50.529Z iteration 0 passed in 594 ms
                                                                                        
       symbol | code |     timestamp |                 datetime | id |       amount            symbol | code |     timestamp |                 datetime | id |       amount
-----------------------------------------------------------------------------------     -----------------------------------------------------------------------------------
ADA/USDT:USDT | USDT | 1651161600000 | 2022-04-28T16:00:00.000Z |    |  -0.00058317     ADA/USDT:USDT | USDT | 1651161600000 | 2022-04-28T16:00:00.000Z |    |  -0.00058317
ADA/USDT:USDT | USDT | 1651190400000 | 2022-04-29T00:00:00.000Z |    |  -0.00054821     ADA/USDT:USDT | USDT | 1651190400000 | 2022-04-29T00:00:00.000Z |    |  -0.00054821
ADA/USDT:USDT | USDT | 1651219200000 | 2022-04-29T08:00:00.000Z |    |   -0.0008372     ADA/USDT:USDT | USDT | 1651219200000 | 2022-04-29T08:00:00.000Z |    |   -0.0008372
ADA/USDT:USDT | USDT | 1651248000000 | 2022-04-29T16:00:00.000Z |    |   -0.0008181     ADA/USDT:USDT | USDT | 1651248000000 | 2022-04-29T16:00:00.000Z |    |   -0.0008181
ADA/USDT:USDT | USDT | 1651276800000 | 2022-04-30T00:00:00.000Z |    | -0.000217215     ADA/USDT:USDT | USDT | 1651276800000 | 2022-04-30T00:00:00.000Z |    | -0.000217215
ADA/USDT:USDT | USDT | 1651305600000 | 2022-04-30T08:00:00.000Z |    | -0.000415242     ADA/USDT:USDT | USDT | 1651305600000 | 2022-04-30T08:00:00.000Z |    | -0.000415242
ADA/USDT:USDT | USDT | 1651334400000 | 2022-04-30T16:00:00.000Z |    |   -0.0007939     ADA/USDT:USDT | USDT | 1651334400000 | 2022-04-30T16:00:00.000Z |    |   -0.0007939
ADA/USDT:USDT | USDT | 1651363200000 | 2022-05-01T00:00:00.000Z |    | -0.000665456     ADA/USDT:USDT | USDT | 1651363200000 | 2022-05-01T00:00:00.000Z |    | -0.000665456
ADA/USDT:USDT | USDT | 1651392000000 | 2022-05-01T08:00:00.000Z |    |    0.0005526     ADA/USDT:USDT | USDT | 1651392000000 | 2022-05-01T08:00:00.000Z |    |    0.0005526
ADA/USDT:USDT | USDT | 1651420800000 | 2022-05-01T16:00:00.000Z |    |  0.000687822     ADA/USDT:USDT | USDT | 1651420800000 | 2022-05-01T16:00:00.000Z |    |  0.000687822
ADA/USDT:USDT | USDT | 1651449600000 | 2022-05-02T00:00:00.000Z |    | -0.000142092     ADA/USDT:USDT | USDT | 1651449600000 | 2022-05-02T00:00:00.000Z |    | -0.000142092
ADA/USDT:USDT | USDT | 1651478400000 | 2022-05-02T08:00:00.000Z |    | -0.000267614     ADA/USDT:USDT | USDT | 1651478400000 | 2022-05-02T08:00:00.000Z |    | -0.000267614
ADA/USDT:USDT | USDT | 1651507200000 | 2022-05-02T16:00:00.000Z |    | -0.000651504     ADA/USDT:USDT | USDT | 1651507200000 | 2022-05-02T16:00:00.000Z |    | -0.000651504
ADA/USDT:USDT | USDT | 1651536000000 | 2022-05-03T00:00:00.000Z |    |  0.000742045     ADA/USDT:USDT | USDT | 1651536000000 | 2022-05-03T00:00:00.000Z |    |  0.000742045
ADA/USDT:USDT | USDT | 1651564800000 | 2022-05-03T08:00:00.000Z |    |   -0.0007856     ADA/USDT:USDT | USDT | 1651564800000 | 2022-05-03T08:00:00.000Z |    |   -0.0007856
ADA/USDT:USDT | USDT | 1651593600000 | 2022-05-03T16:00:00.000Z |    |   -0.0007904     ADA/USDT:USDT | USDT | 1651593600000 | 2022-05-03T16:00:00.000Z |    |   -0.0007904
ADA/USDT:USDT | USDT | 1651622400000 | 2022-05-04T00:00:00.000Z |    |   -0.0007708     ADA/USDT:USDT | USDT | 1651622400000 | 2022-05-04T00:00:00.000Z |    |   -0.0007708
17 objects                                                                              17 objects
```

```
gateio.fetchOrderBook (ADA/USDT:USDT)                     gateio.fetchOrderBook (ADA/USDT)
2022-05-04T01:50:06.789Z iteration 0 passed in 198 ms     2022-05-04T01:50:47.212Z iteration 0 passed in 195 ms
                                                          
{                                                         {
  symbol: 'ADA/USDT:USDT',                                  symbol: 'ADA/USDT',
  bids: [                                                   bids: [
    [ 0.77744, 203 ],                                         [ 0.7777, 1241.708 ],
    [ 0.77742, 130 ],                                         [ 0.7775, 2951.126 ],
    [ 0.77735, 65 ],                                          [ 0.7774, 1855.583 ],
    [ 0.77732, 157 ],                                         [ 0.7773, 6050.494 ],
    [ 0.77722, 77 ],                                          [ 0.7772, 18915.768 ],
    [ 0.77717, 185 ],                                         [ 0.777, 1959.782 ],
    [ 0.77716, 65 ],                                          [ 0.7767, 12666.749 ],
    [ 0.77713, 190 ],                                         [ 0.7765, 83472.066 ],
    [ 0.77709, 334 ],                                         [ 0.7763, 14037.004 ],
    [ 0.77708, 17378 ]                                        [ 0.7762, 8308.842 ]
  ],                                                        ],
  asks: [                                                   asks: [
    [ 0.77758, 65 ],                                          [ 0.7779, 1600.54 ],
    [ 0.77759, 131 ],                                         [ 0.778, 323.808 ],
    [ 0.77761, 65 ],                                          [ 0.7781, 2383.508 ],
    [ 0.77774, 229 ],                                         [ 0.7783, 1450.415 ],
    [ 0.77777, 643 ],                                         [ 0.7784, 25104.982 ],
    [ 0.77778, 207 ],                                         [ 0.7786, 4225.93 ],
    [ 0.77779, 238 ],                                         [ 0.7787, 37081.118 ],
    [ 0.7778, 194 ],                                          [ 0.7789, 17013.737 ],
    [ 0.77781, 103 ],                                         [ 0.7791, 1928.643 ],
    [ 0.77782, 34 ]                                           [ 0.7792, 80334.439 ]
  ],                                                        ],
  timestamp: 1651629006000,                                 timestamp: 1651629047365,
  datetime: '2022-05-04T01:50:06.000Z',                     datetime: '2022-05-04T01:50:47.365Z',
  nonce: 4851747800                                         nonce: 2008381589
}                                                         }
```

```
gateio.fetchTicker (ADA/USDT)                            gateio.fetchTicker (ADA/USDT:USDT)
2022-05-04T01:53:13.017Z iteration 0 passed in 208 ms    2022-05-04T01:53:42.589Z iteration 0 passed in 202 ms
                                                         
{                                                        {
  symbol: 'ADA/USDT',                                      symbol: 'ADA/USDT:USDT',
  timestamp: undefined,                                    timestamp: undefined,
  datetime: undefined,                                     datetime: undefined,
  high: 0.7994,                                            high: 0.79859,
  low: 0.7606,                                             low: 0.75989,
  bid: 0.7778,                                             bid: undefined,
  bidVolume: undefined,                                    bidVolume: undefined,
  ask: 0.7779,                                             ask: undefined,
  askVolume: undefined,                                    askVolume: undefined,
  vwap: 0.7809104143680704,                                vwap: 0.777249945821738,
  open: 0.78342309,                                        open: 0.78269075,
  close: 0.7779,                                           close: 0.77725,
  last: 0.7779,                                            last: 0.77725,
  previousClose: undefined,                                previousClose: undefined,
  change: -0.00552309,                                     change: -0.00544075,
  percentage: -0.71,                                       percentage: -0.7,
  average: undefined,                                      average: undefined,
  baseVolume: 11241174.087214,                             baseVolume: 2907070,
  quoteVolume: 8778349.9144299,                            quoteVolume: 2259520,
  info: {                                                  info: {
    currency_pair: 'ADA_USDT',                               total_size: '303781',
    last: '0.7779',                                          volume_24h_quote: '2259520',
    lowest_ask: '0.7779',                                    volume_24h_settle: '2259520',
    highest_bid: '0.7778',                                   high_24h: '0.79859',
    change_percentage: '-0.71',                              change_percentage: '-0.70',
    base_volume: '11241174.087214',                          volume_24h_base: '2907070',
    quote_volume: '8778349.9144299',                         last: '0.77725',
    high_24h: '0.7994',                                      index_price: '0.7779',
    low_24h: '0.7606'                                        mark_price: '0.77776',
  }                                                          funding_rate_indicative: '0.0001',
}                                                            funding_rate: '-0.000239',
                                                             contract: 'ADA_USDT',
                                                             low_24h: '0.75989',
                                                             volume_24h: '290707'
                                                           }
                                                         }
```

```
gateio.fetchOHLCV (ADA/USDT:USDT, , , 5)                     gateio.fetchOHLCV (ADA/USDT, , , 5)
2022-05-04T01:56:00.703Z iteration 0 passed in 198 ms        2022-05-04T01:56:55.187Z iteration 0 passed in 208 ms
                                                             
1651629120000 | 0.77725 | 0.77725 | 0.77725 | 0.77725 | 0    1651629120000 | 0.7779 | 0.7779 | 0.7779 | 0.7779 |    354.636831
1651629180000 | 0.77725 | 0.77725 | 0.77725 | 0.77725 | 0    1651629180000 | 0.7779 | 0.7779 | 0.7779 | 0.7779 |             0
1651629240000 | 0.77725 | 0.77725 | 0.77725 | 0.77725 | 0    1651629240000 |  0.778 |  0.778 |  0.778 |  0.778 | 1.33758566095
1651629300000 | 0.77725 | 0.77725 | 0.77725 | 0.77725 | 0    1651629300000 | 0.7779 | 0.7779 | 0.7779 | 0.7779 |   344.1709644
1651629360000 | 0.77725 | 0.77725 | 0.77725 | 0.77725 | 0    1651629360000 | 0.7778 | 0.7778 | 0.7769 | 0.7769 |  2222.3510438
5 objects                                                    5 objects
```

```
gateio.fetchTrades (ADA/USDT, , 5)                                                                                                                                                   gateio.fetchTrades (ADA/USDT:USDT, , 5)
2022-05-04T01:58:47.098Z iteration 0 passed in 198 ms                                                                                                                                2022-05-04T01:59:17.792Z iteration 0 passed in 194 ms
                                                                                                                                                                                     
        id |     timestamp |                 datetime |   symbol | order | type | side | takerOrMaker |  price |  amount |        cost |               fee |                fees          id |  timestamp |                 datetime |        symbol | order | type | side | takerOrMaker |   price | amount |      cost |               fee |                fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3395022450 | 1651629401492 | 2022-05-04T01:56:41.492Z | ADA/USDT |       |      |  buy |              | 0.7769 | 465.198 | 361.4123262 | {"currency":"GT"} | [{"currency":"GT"}]     4861026 | 1651628737 | 1970-01-20T02:47:08.737Z | ADA/USDT:USDT |       |      |  buy |              | 0.77755 |      1 |    7.7755 | {"currency":"GT"} | [{"currency":"GT"}]
3395025423 | 1651629442234 | 2022-05-04T01:57:22.234Z | ADA/USDT |       |      | sell |              | 0.7768 | 671.648 | 521.7361664 | {"currency":"GT"} | [{"currency":"GT"}]     4861027 | 1651628813 | 1970-01-20T02:47:08.813Z | ADA/USDT:USDT |       |      |  buy |              | 0.77735 |     15 |  116.6025 | {"currency":"GT"} | [{"currency":"GT"}]
3395026808 | 1651629466565 | 2022-05-04T01:57:46.565Z | ADA/USDT |       |      | sell |              | 0.7768 | 278.352 | 216.2238336 | {"currency":"GT"} | [{"currency":"GT"}]     4861028 | 1651629065 | 1970-01-20T02:47:09.065Z | ADA/USDT:USDT |       |      |  buy |              | 0.77725 |     65 |  505.2125 | {"currency":"GT"} | [{"currency":"GT"}]
3395026809 | 1651629466565 | 2022-05-04T01:57:46.565Z | ADA/USDT |       |      | sell |              | 0.7768 |     300 |      233.04 | {"currency":"GT"} | [{"currency":"GT"}]     4861029 | 1651629374 | 1970-01-20T02:47:09.374Z | ADA/USDT:USDT |       |      | sell |              | 0.77711 |    204 | 1585.3044 | {"currency":"GT"} | [{"currency":"GT"}]
3395027048 | 1651629468560 | 2022-05-04T01:57:48.560Z | ADA/USDT |       |      |  buy |              | 0.7767 |   1.288 |   1.0003896 | {"currency":"GT"} | [{"currency":"GT"}]     4861030 | 1651629391 | 1970-01-20T02:47:09.391Z | ADA/USDT:USDT |       |      | sell |              | 0.77698 |      1 |    7.7698 | {"currency":"GT"} | [{"currency":"GT"}]
5 objects                                                                                                                                                                            5 objects
```

```
gateio.fetchMyTrades (ADA/USDT:USDT, , 5)                                                                                                                                               gateio.fetchMyTrades (ADA/USDT, , 1)
2022-05-04T02:05:47.487Z iteration 0 passed in 204 ms                                                                                                                                   2022-05-04T02:06:42.977Z iteration 0 passed in 203 ms
                                                                                                                                                                                        
     id |     timestamp |                 datetime |        symbol |        order | type | side | takerOrMaker |   price | amount |   cost |               fee |                fees            id |     timestamp |                 datetime |   symbol |        order | type | side | takerOrMaker | price | amount |   cost |                                  fee |                                   fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
...     | 1651132800193 | 2022-04-28T08:00:00.193Z | ADA/USDT:USDT | 153103904704 |      |  buy |        taker | 0.83953 |      1 | 8.3953 | {"currency":"GT"} | [{"currency":"GT"}]    3394630217 | 1651624231898 | 2022-05-04T00:30:31.898Z | ADA/USDT | 150914352356 |      | sell |        maker | 0.771 |    5.8 | 4.4718 | {"cost":0.0089436,"currency":"USDT"} | [{"currency":"USDT","cost":0.0089436}]
1 objects                                                                                                                                                                               1 objects
```

```
gateio.fetchClosedOrders (ADA/USDT, , 3)                                                                                                                                                                                                                                                                                 gateio.fetchClosedOrders (ADA/USDT:USDT, , 3)
2022-05-04T02:09:30.454Z iteration 0 passed in 209 ms                                                                                                                                                                                                                                                                    2022-05-04T02:13:41.093Z iteration 0 passed in 207 ms
                                                                                                                                                                                                                                                                                                                         
          id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | amount |   cost | filled | remaining | fee |                                                                  fees | trades               id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | amount |   cost | filled | remaining | fee | fees | trades
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------     --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
...          |         apiv4 | 1651624218793 | 2022-05-04T00:30:18.793Z |      1651624231898 | closed | ADA/USDT | limit |         GTC |    false | sell | 0.771 |           |   0.771 |    5.8 | 4.4718 |    5.8 |         0 |     | [{"currency":"GT","cost":"0"},{"currency":"USDT","cost":"0.0089436"}] |     []     153103904704 |           api | 1651132800192 | 2022-04-28T08:00:00.192Z |      1651132800193 | closed | ADA/USDT:USDT | limit |         GTC |    false |  buy |  0.85 |           | 0.83953 |      1 | 8.3953 |      1 |         0 |     |   [] |     []
3 objects                                                                                                                                                                                                                                                                                                                1 objects
```

```
gateio.cancelAllOrders ()                                                                                                                                                                                                                                      gateio.cancelAllOrders ()
2022-05-04T02:15:40.212Z iteration 0 passed in 199 ms                                                                                                                                                                                                          2022-05-04T02:16:00.049Z iteration 0 passed in 269 ms
                                                                                                                                                                                                                                                               
          id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | amount | cost | filled | remaining | fee | fees | trades                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | amount | cost | filled | remaining | fee |                                                                                        fees | trades
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------       ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
...          |           api | 1651626265635 | 2022-05-04T01:04:25.635Z |      1651630540373 | canceled | ADA/USDT:USDT | limit |         GTC |    false |  buy |  0.74 |           |         |      2 |    0 |      0 |         2 |     |   [] |     []       150918632324 |         apiv4 | 1651625275923 | 2022-05-04T00:47:55.923Z |      1651630560202 | canceled | ADA/USDT | limit |         GTC |    false |  buy |  0.74 |           |         |      2 |    0 |      0 |         2 |     | [{"currency":"GT","cost":"0"},{"currency":"ADA","cost":"0"},{"currency":"USDT","cost":"0"}] |     []
...          |           api | 1651630529263 | 2022-05-04T02:15:29.263Z |      1651630540373 | canceled | ADA/USDT:USDT | limit |         GTC |    false |  buy |  0.74 |           |         |      2 |    0 |      0 |         2 |     |   [] |     []       150918975017 |         apiv4 | 1651625368661 | 2022-05-04T00:49:28.661Z |      1651630560207 | canceled | ADA/USDT | limit |         GTC |    false |  buy |  0.74 |           |         |      2 |    0 |      0 |         2 |     | [{"currency":"GT","cost":"0"},{"currency":"ADA","cost":"0"},{"currency":"USDT","cost":"0"}] |     []
                                                                                                                                                                                                                                                               150919174688 |         apiv4 | 1651625424102 | 2022-05-04T00:50:24.102Z |      1651630560202 | canceled | ADA/USDT | limit |         GTC |    false |  buy |  0.74 |           |         |      2 |    0 |      0 |         2 |     | [{"currency":"GT","cost":"0"},{"currency":"ADA","cost":"0"},{"currency":"USDT","cost":"0"}] |     []
                                                                                                                                                                                                                                                               150919478050 |         apiv4 | 1651625492002 | 2022-05-04T00:51:32.002Z |      1651630560202 | canceled | ADA/USDT | limit |         GTC |    false |  buy |  0.74 |           |         |      2 |    0 |      0 |         2 |     | [{"currency":"GT","cost":"0"},{"currency":"ADA","cost":"0"},{"currency":"USDT","cost":"0"}] |     []
2 objects                                                                                                                                                                                                                                                      4 objects
```

```
gateio.setLeverage (20, ADA/USDT:USDT)
2022-05-04T02:17:34.294Z iteration 0 passed in 198 ms

{
  value: '7.7887',
  leverage: '20',
  mode: 'single',
  realised_point: '0',
  contract: 'ADA_USDT',
  entry_price: '0.83953',
  mark_price: '0.77887',
  history_point: '0',
  realised_pnl: '-0.010501686',
  close_order: null,
  size: '1',
  cross_leverage_limit: '5',
  pending_orders: '0',
  adl_ranking: '5',
  maintenance_rate: '0.025',
  unrealised_pnl: '-0.6066',
  user: '10406147',
  leverage_max: '20',
  history_pnl: '0',
  risk_limit: '500000',
  margin: '1.001876525',
  last_close_pnl: '0',
  liq_price: '0.75889'
}
```