### PR TITLE
Whitebit parse ticker

### DIFF
--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -484,31 +484,32 @@ module.exports = class whitebit extends Exchange {
     }
 
     parseTicker (ticker, market = undefined) {
+        //
         //  FetchTicker (v1)
         //
-        //      {
-        //          "bid":"0.021979",
-        //          "ask":"0.021996",
-        //          "open":"0.02182",
-        //          "high":"0.022039",
-        //          "low":"0.02161",
-        //          "last":"0.021987",
-        //          "volume":"2810.267",
-        //          "deal":"61.383565474",
-        //          "change":"0.76",
-        //      }
+        //    {
+        //        "bid": "0.021979",
+        //        "ask": "0.021996",
+        //        "open": "0.02182",
+        //        "high": "0.022039",
+        //        "low": "0.02161",
+        //        "last": "0.021987",
+        //        "volume": "2810.267",
+        //        "deal": "61.383565474",
+        //        "change": "0.76",
+        //    }
         //
         // FetchTickers (v4)
         //
-        //      "BCH_RUB":{
-        //          "base_id":1831,
-        //          "quote_id":0,
-        //          "last_price":"32830.21",
-        //          "quote_volume":"1494659.8024096",
-        //          "base_volume":"46.1083",
-        //          "isFrozen":false,
-        //          "change":"2.12" // in percent
-        //      },
+        //    "BCH_RUB": {
+        //        "base_id": 1831,
+        //        "quote_id": 0,
+        //        "last_price": "32830.21",
+        //        "quote_volume": "1494659.8024096",
+        //        "base_volume": "46.1083",
+        //        "isFrozen": false,
+        //        "change": "2.12" // in percent
+        //    }
         //
         market = this.safeMarket (undefined, market);
         const last = this.safeString (ticker, 'last_price');

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -512,8 +512,6 @@ module.exports = class whitebit extends Exchange {
         //
         market = this.safeMarket (undefined, market);
         const last = this.safeString (ticker, 'last_price');
-        const change = this.safeString (ticker, 'change');
-        const percentage = Precise.stringMul (change, '0.01');
         return this.safeTicker ({
             'symbol': market['symbol'],
             'timestamp': undefined,
@@ -530,7 +528,7 @@ module.exports = class whitebit extends Exchange {
             'last': last,
             'previousClose': undefined,
             'change': undefined,
-            'percentage': percentage,
+            'percentage': this.safeString (ticker, 'change'),
             'average': undefined,
             'baseVolume': this.safeString2 (ticker, 'base_volume', 'volume'),
             'quoteVolume': this.safeString2 (ticker, 'quote_volume', 'deal'),


### PR DESCRIPTION
```
% whitebit fetchTicker ADA/USDT                     
2022-05-04T10:38:55.391Z
Node.js: v14.17.0
CCXT v1.81.40
whitebit.fetchTicker (ADA/USDT)
2022-05-04T10:38:57.264Z iteration 0 passed in 724 ms

{
  symbol: 'ADA/USDT',
  timestamp: undefined,
  datetime: undefined,
  high: 0.818393,
  low: 0.760428,
  bid: 0.815325,
  bidVolume: undefined,
  ask: 0.81557,
  askVolume: undefined,
  vwap: 0.7841435973871996,
  open: 0.7848,
  close: undefined,
  last: undefined,
  previousClose: undefined,
  change: undefined,
  percentage: 3.91,
  average: undefined,
  baseVolume: 6644206.14,
  quoteVolume: 5210011.70440172,
  info: {
    open: '0.7848',
    bid: '0.815325',
    ask: '0.81557',
    low: '0.760428',
    high: '0.818393',
    last: '0.815447',
    volume: '6644206.14',
    deal: '5210011.70440172',
    change: '3.91'
  }
}
```