### PR TITLE
Gateio fetch tickers

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1102,19 +1102,14 @@ module.exports = class gateio extends Exchange {
          * @param {dict} params request parameters
          * @returns the api request object, and the new params object with non-needed parameters removed
          */
-        let request = {};
+        const request = {};
         if (market !== undefined) {
             if (market['contract']) {
-                request = {
-                    'contract': market['id'],
-                    'settle': market['settleId'],
-                };
+                request['contract'] = market['id'];
+                request['settle'] = market['settleId'];
             } else {
-                request = {
-                    'currency_pair': market['id'],
-                };
+                request['currency_pair'] = market['id'];
             }
-            type = market['type'];
         } else {
             const swap = type === 'swap';
             const future = type === 'future';
@@ -1122,21 +1117,17 @@ module.exports = class gateio extends Exchange {
                 const defaultSettle = swap ? 'usdt' : 'btc';
                 const settle = this.safeStringLower (params, 'settle', defaultSettle);
                 params = this.omit (params, 'settle');
-                request = {
-                    'settle': settle,
-                };
-            } else {
-                request = {};
+                request['settle'] = settle;
             }
         }
         return [ request, params ];
     }
 
-    multiOrderSpotSetMarginType (market = undefined, stop = false, params = {}) {
+    multiOrderSpotPrepareRequest (market = undefined, stop = false, params = {}) {
         /**
          * @ignore
          * @method
-         * @name gateio#multiOrderSpotSetMarginType
+         * @name gateio#multiOrderSpotPrepareRequest
          * @description Fills request params currency_pair, market and account where applicable for spot order methods like fetchOpenOrders, cancelAllOrders
          * @param {dict} market CCXT market
          * @param {bool} stop true if for a stop order

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1134,7 +1134,6 @@ module.exports = class gateio extends Exchange {
          * @param {dict} params request parameters
          * @returns the api request object, and the new params object with non-needed parameters removed
          */
-
         const [ marginType, query ] = this.getMarginType (stop, params);
         const request = {
             'account': marginType,

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1091,7 +1091,7 @@ module.exports = class gateio extends Exchange {
         return underlyings;
     }
 
-    prepareRequest (market = undefined, type = undefined, setMarginType = false, stop = false, multiOrder = false, params = {}) {
+    prepareRequest (market = undefined, type = undefined, params = {}) {
         /**
          * @ignore
          * @method
@@ -1099,9 +1099,6 @@ module.exports = class gateio extends Exchange {
          * @description Fills request params contract, settle, currency_pair, market and account where applicable
          * @param {dict} market CCXT market, required when type is undefined
          * @param {str} type 'spot', 'swap', or 'future', required when market is undefined
-         * @param {bool} setMarginType true if setting 'account' param for margin trading
-         * @param {bool} stop true if for a stop order
-         * @param {bool} multiOrder methods like fetchOpenOrders, cancelAllOrders, etc. Only needed for stop orders
          * @param {dict} params request parameters
          * @returns the api request object, and the new params object with non-needed parameters removed
          */
@@ -1132,24 +1129,34 @@ module.exports = class gateio extends Exchange {
                 request = {};
             }
         }
-        if (setMarginType && (type === 'spot' || type === 'margin')) {
-            let marginType = undefined;
-            [ marginType, params ] = this.getMarginType (stop, params);
+        return [ request, params ];
+    }
+
+    multiOrderSpotSetMarginType (market = undefined, stop = false, params = {}) {
+        /**
+         * @ignore
+         * @method
+         * @name gateio#multiOrderSpotSetMarginType
+         * @description Fills request params currency_pair, market and account where applicable for spot order methods like fetchOpenOrders, cancelAllOrders
+         * @param {dict} market CCXT market
+         * @param {bool} stop true if for a stop order
+         * @param {dict} params request parameters
+         * @returns the api request object, and the new params object with non-needed parameters removed
+         */
+
+        const [ marginType, query ] = this.getMarginType (stop, params);
+        const request = {
+            'account': marginType,
+        };
+        if (market !== undefined) {
             if (stop) {
                 // gateio spot and margin stop orders use the term market instead of currency_pair, and normal instead of spot. Neither parameter is used when fetching/cancelling a single order. They are used for creating a single stop order, but createOrder does not call this method
-                if (multiOrder) {
-                    if (market !== undefined) {
-                        request = {
-                            'market': market['id'],
-                        };
-                    }
-                    request['account'] = marginType;
-                }
+                request['market'] = market['id'];
             } else {
-                request['account'] = marginType;
+                request['currency_pair'] = market['id'];
             }
         }
-        return [ request, params ];
+        return [ request, query ];
     }
 
     getMarginType (stop, params) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1898,23 +1898,15 @@ module.exports = class gateio extends Exchange {
 
     async fetchTickers (symbols = undefined, params = {}) {
         await this.loadMarkets ();
-        let type = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        const [ request, requestParams ] = this.prepareRequest (undefined, type, query);
         const method = this.getSupportedMapping (type, {
             'spot': 'publicSpotGetTickers',
             'margin': 'publicSpotGetTickers',
             'swap': 'publicFuturesGetSettleTickers',
             'future': 'publicDeliveryGetSettleTickers',
         });
-        const request = {};
-        const future = type === 'future';
-        const swap = type === 'swap';
-        const defaultSettle = swap ? 'usdt' : 'btc';
-        const settle = this.safeStringLower (params, 'settle', defaultSettle);
-        if (swap || future) {
-            request['settle'] = settle;
-        }
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, requestParams));
         return this.parseTickers (response, symbols);
     }
 

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1247,7 +1247,7 @@ module.exports = class gateio extends Exchange {
         if (!market['swap']) {
             throw new BadRequest ('Funding rates only exist for swap contracts');
         }
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const response = await this.publicFuturesGetSettleContractsContract (this.extend (request, query));
         //
         //    [
@@ -1639,7 +1639,7 @@ module.exports = class gateio extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
             symbol = market['symbol'];
-            [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+            [ request, params ] = this.prepareRequest (market, undefined, params);
         }
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchFundingHistory', market, params);
@@ -1722,7 +1722,7 @@ module.exports = class gateio extends Exchange {
         //         'with_id': true, // return order book ID
         //     };
         //
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const spotOrMargin = market['spot'] || market['margin'];
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'publicSpotGetOrderBook',
@@ -1814,7 +1814,7 @@ module.exports = class gateio extends Exchange {
     async fetchTicker (symbol, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'publicSpotGetTickers',
             'margin': 'publicSpotGetTickers',
@@ -2130,7 +2130,7 @@ module.exports = class gateio extends Exchange {
         const market = this.market (symbol);
         const price = this.safeString (params, 'price');
         let request = {};
-        [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+        [ request, params ] = this.prepareRequest (market, undefined, params);
         request['interval'] = this.timeframes[timeframe];
         let method = 'publicSpotGetCandlesticks';
         if (market['contract']) {
@@ -2286,7 +2286,7 @@ module.exports = class gateio extends Exchange {
         //         'to': this.seconds (), // end time in seconds, default to current time
         //     };
         //
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const method = this.getSupportedMapping (market['type'], {
             'spot': 'publicSpotGetTrades',
             'margin': 'publicSpotGetTrades',
@@ -2339,7 +2339,7 @@ module.exports = class gateio extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchMyTrades', undefined, params);
         if (symbol) {
             market = this.market (symbol);
-            [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+            [ request, params ] = this.prepareRequest (market, undefined, params);
             type = market['type'];
         } else {
             if (type === 'swap' || type === 'future') {
@@ -3380,7 +3380,7 @@ module.exports = class gateio extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         request['status'] = status;
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -3576,7 +3576,7 @@ module.exports = class gateio extends Exchange {
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            [ request, params ] = this.prepareRequest (market, undefined, false, false, false, params);
+            [ request, params ] = this.prepareRequest (market, undefined, params);
         }
         const [ type, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         const swap = type === 'swap';
@@ -3719,7 +3719,7 @@ module.exports = class gateio extends Exchange {
             'swap': 'privateFuturesPostSettlePositionsContractLeverage',
             'future': 'privateDeliveryPostSettlePositionsContractLeverage',
         });
-        const [ request, query ] = this.prepareRequest (market, undefined, false, false, false, params);
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         const defaultMarginType = this.safeString2 (this.options, 'marginType', 'defaultMarginType');
         const crossLeverageLimit = this.safeString (query, 'cross_leverage_limit');
         let marginType = this.safeString (query, 'marginType', defaultMarginType);


### PR DESCRIPTION
```
2022-05-04T11:40:25.762Z                                   2022-05-04T11:40:14.433Z
Node.js: v14.17.0                                          Node.js: v14.17.0
CCXT v1.81.40                                              CCXT v1.81.40
gateio.fetchTickers ()                                     gateio.fetchTickers ()
2022-05-04T11:40:28.767Z iteration 0 passed in 1218 ms     2022-05-04T11:40:17.568Z iteration 0 passed in 1264 ms
                                                           
{                                                          {
  'SRK/ETH': {                                               'HOT/USDT:USDT': {
    symbol: 'SRK/ETH',                                         symbol: 'HOT/USDT:USDT',
    timestamp: undefined,                                      timestamp: undefined,
    datetime: undefined,                                       datetime: undefined,
    high: 3.26e-7,                                             high: 0.0042316,
    low: 3.04e-7,                                              low: 0.0039399,
    bid: 3.01e-7,                                              bid: undefined,
    bidVolume: undefined,                                      bidVolume: undefined,
    ask: 3.15e-7,                                              ask: undefined,
    askVolume: undefined,                                      askVolume: undefined,
    vwap: 3.21509501081e-7,                                    vwap: 0.004177172685368906,
    open: 3.285128e-7,                                         open: 0.00411746604,
    close: 3.08e-7,                                            close: 0.0041772,
    last: 3.08e-7,                                             last: 0.0041772,
    previousClose: undefined,                                  previousClose: undefined,
    change: -2.05128e-8,                                       change: 0.00005973396,
    percentage: -6.66,                                         percentage: 1.43,
    average: undefined,                                        average: undefined,
    baseVolume: 16564695.7,                                    baseVolume: 32759000,
    quoteVolume: 5.32570705007,                                quoteVolume: 136840,
    info: {                                                    info: {
      currency_pair: 'SRK_ETH',                                  total_size: '9334',
      last: '0.000000308',                                       volume_24h_quote: '136840',
      lowest_ask: '0.000000315',                                 volume_24h_settle: '136840',
      highest_bid: '0.000000301',                                high_24h: '0.0042316',
      change_percentage: '-6.66',                                change_percentage: '1.43',
      base_volume: '16564695.7',                                 volume_24h_base: '32759000',
      quote_volume: '5.32570705007',                             last: '0.0041772',
      high_24h: '0.000000326',                                   index_price: '0.00417737',
      low_24h: '0.000000304'                                     mark_price: '0.0041776',
    }                                                            funding_rate_indicative: '0.0001',
  },                                                             funding_rate: '0.0001',
  ...                                                            contract: 'HOT_USDT',
}                                                                low_24h: '0.0039399',
                                                                 volume_24h: '32759'
                                                               }
                                                             },
                                                             ...
                                                           }
```