### PR TITLE
Filter `fetchPositions` by input symbols

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -3713,7 +3713,7 @@ module.exports = class okx extends Exchange {
                 result.push (this.parsePosition (positions[i]));
             }
         }
-        return result;
+        return this.filterByArray (result, 'symbol', symbols, false);
     }
 
     parsePosition (position, market = undefined) {


### PR DESCRIPTION
Filter `fetchPositions` by input symbols

This aligns okx to how other exchanges (e.g. gateio) behaves.
https://github.com/ccxt/ccxt/blob/426f491ad15aa99930ace8190ea2a5fc140c0c4d/js/gateio.js#L3845


Without this - running `fetchPositions(['DOT/USDT:USDT'])` will return positions for other pairs as well if they're open at that point.