### PR TITLE
Bybit cancelAllOrders

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2244,7 +2244,20 @@ module.exports = class bybit extends Exchange {
         } else if (market['future']) {
             defaultMethod = 'futuresPrivatePostOrderCancelAll';
         }
+        const stop = this.safeValue (params, 'stop');
+        if (stop) {
+            if (market['swap']) {
+                if (market['linear']) {
+                    defaultMethod = 'privateLinearPostStopOrderCancelAll';
+                } else if (market['inverse']) {
+                    defaultMethod = 'v2PrivatePostStopOrderCancelAll';
+                }
+            } else if (market['future']) {
+                defaultMethod = 'futuresPrivatePostStopOrderCancelAll';
+            }
+        }
         const method = this.safeString (options, 'method', defaultMethod);
+        params = this.omit (params, 'stop');
         const response = await this[method] (this.extend (request, params));
         const result = this.safeValue (response, 'result', []);
         return this.parseOrders (result, market);


### PR DESCRIPTION
Added stop functionality to CancelAllOrders:

Fixes #13075
Part of #12044

Futures Inverse:
https://bybit-exchange.github.io/docs/inverse_futures/#t-cancelallcond
```
node examples/js/cli bybit cancelAllOrders BTC/USD:BTC-220624 '{"stop":"true"}'

2022-05-05T02:16:02.191Z iteration 0 passed in 362 ms

id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |             symbol |  type | timeInForce | postOnly | side | price | stopPrice | amount | cost | average | filled | remaining | status | fee | trades | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   |               | 1651716654288 | 2022-05-05T02:10:54.288Z |                    | BTC/USD:BTC-220624 | limit |         GTC |    false |  buy | 30000 |           |     32 |      |         |        |           |        |     |     [] |   []
1 objects
```

Swap Inverse:
https://bybit-exchange.github.io/docs/inverse/#t-cancelallcond
```
node examples/js/cli bybit cancelAllOrders BTC/USD:BTC '{"stop":"true"}'

2022-05-05T02:18:23.743Z iteration 0 passed in 321 ms

id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |      symbol |  type | timeInForce | postOnly | side | price | stopPrice | amount | cost | average | filled | remaining | status | fee | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   |               | 1651716434497 | 2022-05-05T02:07:14.497Z |                    | BTC/USD:BTC | limit |         GTC |    false |  buy | 30000 |           |    157 |      |         |        |           |        |     |     [] |   []
1 objects
```

Swap Linear:
https://bybit-exchange.github.io/docs/linear/#t-cancelallcond
```
node examples/js/cli bybit cancelAllOrders BTC/USDT:USDT '{"stop":"true"}'

2022-05-05T02:34:41.715Z iteration 0 passed in 323 ms

id | clientOrderId | timestamp | datetime | lastTradeTimestamp |        symbol | type | timeInForce | postOnly | side | price | stopPrice | amount | cost | average | filled | remaining | status | fee | trades | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   |               |           |          |                    | BTC/USDT:USDT |      |             |    false |      |       |           |        |      |         |        |           |        |     |     [] |   []
1 objects
```