### PR TITLE
Class docstrings

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -394,7 +394,7 @@ class Transpiler {
             [ /\/\*\*/, '\"\"\"' ], // Doc strings
             [ / \*\//, '\"\"\"' ], // Doc strings
             [ /\[([^\[\]]*)\]\{@link (.*)\}/g, '`$1 <$2>`' ], // docstring item with link
-            [ /\s+\* @method/g, '' ], // docstring @method
+            [ /\s+\* @(class|method)/g, '' ], // docstring @class and @method
             [ /(\s+) \* @description (.*)/g, '$1$2' ], // docstring description
             [ /\s+\* @name .*/g, '' ], // docstring @name
             [ /(\s+) \* @see( .*)/g, '$1see$2' ], // docstring @see
@@ -445,7 +445,7 @@ class Transpiler {
             //
             [ /\{([\]\[\|a-zA-Z0-9_-]+?)\}/g, '~$1~' ], // resolve the "arrays vs url params" conflict (both are in {}-brackets)
             [ /\[([^\]\[]*)\]\{(@link .*)\}/g, '~$2 $1~' ], // docstring item with link
-            [ /\s+\* @method/g, '' ], // docstring @method
+            [ /\s+\* @(class|method)/g, '' ], // docstring @class and @method
             [ /(\s+)\* @description (.*)/g, '$1\* $2' ], // docstring description
             [ /\s+\* @name .*/g, '' ], // docstring @name
             [ /(\s+)\* @returns/g, '$1\* @return' ], // docstring return

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1102,8 +1102,10 @@ class Transpiler {
 
     // ------------------------------------------------------------------------
 
+
     getClassDeclarationMatches (contents) {
         return contents.match (/^module\.exports\s*=\s*class\s+([\S]+)(?:\s+extends\s+([\S]+))?\s+{([\s\S]+?)^};*/m)
+        // /^module\.exports\s*=\s*class\s+([\S]+)\s+extends\s+([\S]+)\s+{([\s\S]+?)^};*/m
     }
 
     // ------------------------------------------------------------------------
@@ -1121,6 +1123,7 @@ class Transpiler {
         // altogether in PHP, async PHP, Python sync and async
         const sync = false
         const async = true
+        // const docstringPattern = /^\s*\/\*\*[^\/]*\*\//m;   // Cannot have / character in class docstring
         return {
             python2:      this.createPythonClass (className, baseClass, python2,  methodNames, sync),
             python3:      this.createPythonClass (className, baseClass, python3,  methodNames, async),

--- a/js/aax.js
+++ b/js/aax.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ----------------------------------------------------------------------------
 
 module.exports = class aax extends Exchange {
+    /**
+     * @class
+     * @name aax
+     * @description exchange class for aax api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'aax',

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class ascendex extends Exchange {
+    /**
+     * @class
+     * @name ascendex
+     * @description exchange class for ascendex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'ascendex',

--- a/js/bequant.js
+++ b/js/bequant.js
@@ -6,6 +6,11 @@ const hitbtc = require ('./hitbtc');
 // ---------------------------------------------------------------------------
 
 module.exports = class bequant extends hitbtc {
+    /**
+     * @class
+     * @name bequant
+     * @description exchange class for bequant api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bequant',

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bibox extends Exchange {
+    /**
+     * @class
+     * @name bibox
+     * @description exchange class for bibox api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bibox',

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bigone extends Exchange {
+    /**
+     * @class
+     * @name bigone
+     * @description exchange class for bigone api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bigone',

--- a/js/binance.js
+++ b/js/binance.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class binance extends Exchange {
+    /**
+     * @class
+     * @name binance
+     * @description exchange class for binance api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'binance',

--- a/js/binancecoinm.js
+++ b/js/binancecoinm.js
@@ -7,6 +7,11 @@ const binance = require ('./binance.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class binancecoinm extends binance {
+    /**
+     * @class
+     * @name binancecoinm
+     * @description exchange class for binancecoinm api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'binancecoinm',

--- a/js/binanceus.js
+++ b/js/binanceus.js
@@ -7,6 +7,11 @@ const binance = require ('./binance.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class binanceus extends binance {
+    /**
+     * @class
+     * @name binanceus
+     * @description exchange class for binanceus api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'binanceus',

--- a/js/binanceusdm.js
+++ b/js/binanceusdm.js
@@ -7,6 +7,11 @@ const binance = require ('./binance.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class binanceusdm extends binance {
+    /**
+     * @class
+     * @name binanceusdm
+     * @description exchange class for binanceusdm api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'binanceusdm',

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bit2c extends Exchange {
+    /**
+     * @class
+     * @name bit2c
+     * @description exchange class for bit2c api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bit2c',

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitbank extends Exchange {
+    /**
+     * @class
+     * @name bitbank
+     * @description exchange class for bitbank api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitbank',

--- a/js/bitbay.js
+++ b/js/bitbay.js
@@ -7,6 +7,11 @@ const zonda = require ('./zonda.js');
 // ---------------------------------------------------------------------------
 
 module.exports = class bitbay extends zonda {
+    /**
+     * @class
+     * @name bitbay
+     * @description exchange class for bitbay api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitbay',

--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitbns extends Exchange {
+    /**
+     * @class
+     * @name bitbns
+     * @description exchange class for bitbns api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitbns',

--- a/js/bitcoincom.js
+++ b/js/bitcoincom.js
@@ -7,6 +7,11 @@ const fmfwio = require ('./fmfwio.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitcoincom extends fmfwio {
+    /**
+     * @class
+     * @name bitcoincom
+     * @description exchange class for bitcoincom api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitcoincom',

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitfinex extends Exchange {
+    /**
+     * @class
+     * @name bitfinex
+     * @description exchange class for bitfinex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitfinex',

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -10,6 +10,11 @@ const { SIGNIFICANT_DIGITS, DECIMAL_PLACES, TRUNCATE, ROUND } = require ('./base
 // ---------------------------------------------------------------------------
 
 module.exports = class bitfinex2 extends Exchange {
+    /**
+     * @class
+     * @name bitfinex2
+     * @description exchange class for bitfinex2 api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitfinex2',

--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitflyer extends Exchange {
+    /**
+     * @class
+     * @name bitflyer
+     * @description exchange class for bitflyer api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitflyer',

--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitforex extends Exchange {
+    /**
+     * @class
+     * @name bitforex
+     * @description exchange class for bitforex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitforex',

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitget extends Exchange {
+    /**
+     * @class
+     * @name bitget
+     * @description exchange class for bitget api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitget',

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bithumb extends Exchange {
+    /**
+     * @class
+     * @name bithumb
+     * @description exchange class for bithumb api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bithumb',

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitmart extends Exchange {
+    /**
+     * @class
+     * @name bitmart
+     * @description exchange class for bitmart api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitmart',

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitmex extends Exchange {
+    /**
+     * @class
+     * @name bitmex
+     * @description exchange class for bitmex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitmex',

--- a/js/bitopro.js
+++ b/js/bitopro.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitopro extends Exchange {
+    /**
+     * @class
+     * @name bitopro
+     * @description exchange class for bitopro api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitopro',

--- a/js/bitpanda.js
+++ b/js/bitpanda.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitpanda extends Exchange {
+    /**
+     * @class
+     * @name bitpanda
+     * @description exchange class for bitpanda api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitpanda',

--- a/js/bitrue.js
+++ b/js/bitrue.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitrue extends Exchange {
+    /**
+     * @class
+     * @name bitrue
+     * @description exchange class for bitrue api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitrue',

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitso extends Exchange {
+    /**
+     * @class
+     * @name bitso
+     * @description exchange class for bitso api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitso',

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitstamp extends Exchange {
+    /**
+     * @class
+     * @name bitstamp
+     * @description exchange class for bitstamp api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitstamp',

--- a/js/bitstamp1.js
+++ b/js/bitstamp1.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bitstamp1 extends Exchange {
+    /**
+     * @class
+     * @name bitstamp1
+     * @description exchange class for bitstamp1 api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitstamp1',

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -9,6 +9,11 @@ const { TRUNCATE, TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bittrex extends Exchange {
+    /**
+     * @class
+     * @name bittrex
+     * @description exchange class for bittrex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bittrex',

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -9,6 +9,11 @@ const { SIGNIFICANT_DIGITS, DECIMAL_PLACES, TRUNCATE, ROUND } = require ('./base
 // ----------------------------------------------------------------------------
 
 module.exports = class bitvavo extends Exchange {
+    /**
+     * @class
+     * @name bitvavo
+     * @description exchange class for bitvavo api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bitvavo',

--- a/js/bkex.js
+++ b/js/bkex.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 // ---------------------------------------------------------------------------
 
 module.exports = class bkex extends Exchange {
+    /**
+     * @class
+     * @name bkex
+     * @description exchange class for bkex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bkex',

--- a/js/bl3p.js
+++ b/js/bl3p.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class bl3p extends Exchange {
+    /**
+     * @class
+     * @name bl3p
+     * @description exchange class for bl3p api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bl3p',

--- a/js/blockchaincom.js
+++ b/js/blockchaincom.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class blockchaincom extends Exchange {
+    /**
+     * @class
+     * @name blockchaincom
+     * @description exchange class for blockchaincom api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'blockchaincom',

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class btcalpha extends Exchange {
+    /**
+     * @class
+     * @name btcalpha
+     * @description exchange class for btcalpha api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'btcalpha',

--- a/js/btcbox.js
+++ b/js/btcbox.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class btcbox extends Exchange {
+    /**
+     * @class
+     * @name btcbox
+     * @description exchange class for btcbox api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'btcbox',

--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class btcmarkets extends Exchange {
+    /**
+     * @class
+     * @name btcmarkets
+     * @description exchange class for btcmarkets api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'btcmarkets',

--- a/js/btctradeua.js
+++ b/js/btctradeua.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class btctradeua extends Exchange {
+    /**
+     * @class
+     * @name btctradeua
+     * @description exchange class for btctradeua api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'btctradeua',

--- a/js/btcturk.js
+++ b/js/btcturk.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class btcturk extends Exchange {
+    /**
+     * @class
+     * @name btcturk
+     * @description exchange class for btcturk api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'btcturk',

--- a/js/buda.js
+++ b/js/buda.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class buda extends Exchange {
+    /**
+     * @class
+     * @name buda
+     * @description exchange class for buda api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'buda',

--- a/js/bw.js
+++ b/js/bw.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bw extends Exchange {
+    /**
+     * @class
+     * @name bw
+     * @description exchange class for bw api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bw',

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bybit extends Exchange {
+    /**
+     * @class
+     * @name bybit
+     * @description exchange class for bybit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bybit',

--- a/js/bytetrade.js
+++ b/js/bytetrade.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class bytetrade extends Exchange {
+    /**
+     * @class
+     * @name bytetrade
+     * @description exchange class for bytetrade api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'bytetrade',

--- a/js/cdax.js
+++ b/js/cdax.js
@@ -9,6 +9,11 @@ const { TRUNCATE, TICK_SIZE } = require ('./base/functions/number');
 // ---------------------------------------------------------------------------
 
 module.exports = class cdax extends Exchange {
+    /**
+     * @class
+     * @name cdax
+     * @description exchange class for cdax api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'cdax',

--- a/js/cex.js
+++ b/js/cex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class cex extends Exchange {
+    /**
+     * @class
+     * @name cex
+     * @description exchange class for cex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'cex',

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ----------------------------------------------------------------------------
 
 module.exports = class coinbase extends Exchange {
+    /**
+     * @class
+     * @name coinbase
+     * @description exchange class for coinbase api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinbase',

--- a/js/coinbaseprime.js
+++ b/js/coinbaseprime.js
@@ -7,6 +7,11 @@ const coinbasepro = require ('./coinbasepro.js');
 // ---------------------------------------------------------------------------
 
 module.exports = class coinbaseprime extends coinbasepro {
+    /**
+     * @class
+     * @name coinbaseprime
+     * @description exchange class for coinbaseprime api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinbaseprime',

--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ----------------------------------------------------------------------------
 
 module.exports = class coinbasepro extends Exchange {
+    /**
+     * @class
+     * @name coinbasepro
+     * @description exchange class for coinbasepro api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinbasepro',

--- a/js/coincheck.js
+++ b/js/coincheck.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class coincheck extends Exchange {
+    /**
+     * @class
+     * @name coincheck
+     * @description exchange class for coincheck api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coincheck',

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class coinex extends Exchange {
+    /**
+     * @class
+     * @name coinex
+     * @description exchange class for coinex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinex',

--- a/js/coinfalcon.js
+++ b/js/coinfalcon.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class coinfalcon extends Exchange {
+    /**
+     * @class
+     * @name coinfalcon
+     * @description exchange class for coinfalcon api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinfalcon',

--- a/js/coinmate.js
+++ b/js/coinmate.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class coinmate extends Exchange {
+    /**
+     * @class
+     * @name coinmate
+     * @description exchange class for coinmate api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinmate',

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class coinone extends Exchange {
+    /**
+     * @class
+     * @name coinone
+     * @description exchange class for coinone api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinone',

--- a/js/coinspot.js
+++ b/js/coinspot.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class coinspot extends Exchange {
+    /**
+     * @class
+     * @name coinspot
+     * @description exchange class for coinspot api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'coinspot',

--- a/js/crex24.js
+++ b/js/crex24.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class crex24 extends Exchange {
+    /**
+     * @class
+     * @name crex24
+     * @description exchange class for crex24 api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'crex24',

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -8,6 +8,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
 module.exports = class cryptocom extends Exchange {
+    /**
+     * @class
+     * @name cryptocom
+     * @description exchange class for cryptocom api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'cryptocom',

--- a/js/currencycom.js
+++ b/js/currencycom.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class currencycom extends Exchange {
+    /**
+     * @class
+     * @name currencycom
+     * @description exchange class for currencycom api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'currencycom',

--- a/js/delta.js
+++ b/js/delta.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class delta extends Exchange {
+    /**
+     * @class
+     * @name delta
+     * @description exchange class for delta api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'delta',

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class deribit extends Exchange {
+    /**
+     * @class
+     * @name deribit
+     * @description exchange class for deribit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'deribit',

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class digifinex extends Exchange {
+    /**
+     * @class
+     * @name digifinex
+     * @description exchange class for digifinex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'digifinex',

--- a/js/eqonex.js
+++ b/js/eqonex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ----------------------------------------------------------------------------
 
 module.exports = class eqonex extends Exchange {
+    /**
+     * @class
+     * @name eqonex
+     * @description exchange class for eqonex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'eqonex',

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class exmo extends Exchange {
+    /**
+     * @class
+     * @name exmo
+     * @description exchange class for exmo api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'exmo',

--- a/js/flowbtc.js
+++ b/js/flowbtc.js
@@ -7,6 +7,11 @@ const ndax = require ('./ndax.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class flowbtc extends ndax {
+    /**
+     * @class
+     * @name flowbtc
+     * @description exchange class for flowbtc api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'flowbtc',

--- a/js/fmfwio.js
+++ b/js/fmfwio.js
@@ -7,6 +7,11 @@ const hitbtc = require ('./hitbtc.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class fmfwio extends hitbtc {
+    /**
+     * @class
+     * @name fmfwio
+     * @description exchange class for fmfwio api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'fmfwio',

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class ftx extends Exchange {
+    /**
+     * @class
+     * @name ftx
+     * @description exchange class for ftx api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'ftx',

--- a/js/ftxus.js
+++ b/js/ftxus.js
@@ -5,6 +5,11 @@
 const ftx = require ('./ftx.js');
 
 module.exports = class ftxus extends ftx {
+    /**
+     * @class
+     * @name ftxus
+     * @description exchange class for ftxus api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'ftxus',

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -8,6 +8,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 const { ExchangeError, BadRequest, ArgumentsRequired, AuthenticationError, PermissionDenied, AccountSuspended, InsufficientFunds, RateLimitExceeded, ExchangeNotAvailable, BadSymbol, InvalidOrder, OrderNotFound, NotSupported, AccountNotEnabled, OrderImmediatelyFillable } = require ('./base/errors');
 
 module.exports = class gateio extends Exchange {
+    /**
+     * @class
+     * @name gateio
+     * @description exchange class for gate.io api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'gateio',

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class gemini extends Exchange {
+    /**
+     * @class
+     * @name gemini
+     * @description exchange class for gemini api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'gemini',

--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class hitbtc extends Exchange {
+    /**
+     * @class
+     * @name hitbtc
+     * @description exchange class for hitbtc api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'hitbtc',

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -4,6 +4,11 @@ const Precise = require ('./base/Precise');
 const { BadSymbol, BadRequest, OnMaintenance, AccountSuspended, PermissionDenied, ExchangeError, RateLimitExceeded, ExchangeNotAvailable, OrderNotFound, InsufficientFunds, InvalidOrder, AuthenticationError, ArgumentsRequired } = require ('./base/errors');
 
 module.exports = class hitbtc3 extends Exchange {
+    /**
+     * @class
+     * @name hitbtc3
+     * @description exchange class for hitbtc3 api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'hitbtc3',

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class hollaex extends Exchange {
+    /**
+     * @class
+     * @name hollaex
+     * @description exchange class for hollaex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'hollaex',

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class huobi extends Exchange {
+    /**
+     * @class
+     * @name huobi
+     * @description exchange class for huobi api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'huobi',

--- a/js/huobijp.js
+++ b/js/huobijp.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class huobijp extends Exchange {
+    /**
+     * @class
+     * @name huobijp
+     * @description exchange class for huobijp api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'huobijp',

--- a/js/huobipro.js
+++ b/js/huobipro.js
@@ -7,6 +7,11 @@ const huobi = require ('./huobi.js');
 // ---------------------------------------------------------------------------
 
 module.exports = class huobipro extends huobi {
+    /**
+     * @class
+     * @name huobipro
+     * @description exchange class for huobipro api
+     */
     describe () {
         // this is an alias for backward-compatibility
         // to be removed soon

--- a/js/idex.js
+++ b/js/idex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class idex extends Exchange {
+    /**
+     * @class
+     * @name idex
+     * @description exchange class for idex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'idex',

--- a/js/independentreserve.js
+++ b/js/independentreserve.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class independentreserve extends Exchange {
+    /**
+     * @class
+     * @name independentreserve
+     * @description exchange class for independentreserve api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'independentreserve',

--- a/js/indodax.js
+++ b/js/indodax.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class indodax extends Exchange {
+    /**
+     * @class
+     * @name indodax
+     * @description exchange class for indodax api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'indodax',

--- a/js/itbit.js
+++ b/js/itbit.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class itbit extends Exchange {
+    /**
+     * @class
+     * @name itbit
+     * @description exchange class for itbit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'itbit',

--- a/js/kraken.js
+++ b/js/kraken.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class kraken extends Exchange {
+    /**
+     * @class
+     * @name kraken
+     * @description exchange class for kraken api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'kraken',

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class kucoin extends Exchange {
+    /**
+     * @class
+     * @name kucoin
+     * @description exchange class for kucoin api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'kucoin',

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -10,6 +10,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class kucoinfutures extends kucoin {
+    /**
+     * @class
+     * @name kucoinfutures
+     * @description exchange class for kucoinfutures api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'kucoinfutures',

--- a/js/kuna.js
+++ b/js/kuna.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 // ---------------------------------------------------------------------------
 
 module.exports = class kuna extends Exchange {
+    /**
+     * @class
+     * @name kuna
+     * @description exchange class for kuna api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'kuna',

--- a/js/latoken.js
+++ b/js/latoken.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class latoken extends Exchange {
+    /**
+     * @class
+     * @name latoken
+     * @description exchange class for latoken api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'latoken',

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class lbank extends Exchange {
+    /**
+     * @class
+     * @name lbank
+     * @description exchange class for lbank api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'lbank',

--- a/js/liquid.js
+++ b/js/liquid.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class liquid extends Exchange {
+    /**
+     * @class
+     * @name liquid
+     * @description exchange class for liquid api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'liquid',

--- a/js/luno.js
+++ b/js/luno.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class luno extends Exchange {
+    /**
+     * @class
+     * @name luno
+     * @description exchange class for luno api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'luno',

--- a/js/lykke.js
+++ b/js/lykke.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class lykke extends Exchange {
+    /**
+     * @class
+     * @name lykke
+     * @description exchange class for lykke api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'lykke',

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class mercado extends Exchange {
+    /**
+     * @class
+     * @name mercado
+     * @description exchange class for mercado api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'mercado',

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class mexc extends Exchange {
+    /**
+     * @class
+     * @name mexc
+     * @description exchange class for mexc api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'mexc',

--- a/js/ndax.js
+++ b/js/ndax.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 // ---------------------------------------------------------------------------
 
 module.exports = class ndax extends Exchange {
+    /**
+     * @class
+     * @name ndax
+     * @description exchange class for ndax api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'ndax',

--- a/js/novadax.js
+++ b/js/novadax.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class novadax extends Exchange {
+    /**
+     * @class
+     * @name novadax
+     * @description exchange class for novadax api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'novadax',

--- a/js/oceanex.js
+++ b/js/oceanex.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class oceanex extends Exchange {
+    /**
+     * @class
+     * @name oceanex
+     * @description exchange class for oceanex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'oceanex',

--- a/js/okcoin.js
+++ b/js/okcoin.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class okcoin extends Exchange {
+    /**
+     * @class
+     * @name okcoin
+     * @description exchange class for okcoin api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'okcoin',

--- a/js/okex.js
+++ b/js/okex.js
@@ -7,6 +7,11 @@ const okx = require ('./okx.js');
 // ---------------------------------------------------------------------------
 
 module.exports = class okex extends okx {
+    /**
+     * @class
+     * @name okex
+     * @description exchange class for okex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'okex',

--- a/js/okex5.js
+++ b/js/okex5.js
@@ -7,6 +7,11 @@ const okex = require ('./okex.js');
 // ---------------------------------------------------------------------------
 
 module.exports = class okex5 extends okex {
+    /**
+     * @class
+     * @name okex5
+     * @description exchange class for okex5 api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'okex5',

--- a/js/okx.js
+++ b/js/okx.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class okx extends Exchange {
+    /**
+     * @class
+     * @name okx
+     * @description exchange class for okx api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'okx',

--- a/js/paymium.js
+++ b/js/paymium.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class paymium extends Exchange {
+    /**
+     * @class
+     * @name paymium
+     * @description exchange class for paymium api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'paymium',

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ----------------------------------------------------------------------------
 
 module.exports = class phemex extends Exchange {
+    /**
+     * @class
+     * @name phemex
+     * @description exchange class for phemex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'phemex',

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class poloniex extends Exchange {
+    /**
+     * @class
+     * @name poloniex
+     * @description exchange class for poloniex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'poloniex',

--- a/js/probit.js
+++ b/js/probit.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class probit extends Exchange {
+    /**
+     * @class
+     * @name probit
+     * @description exchange class for probit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'probit',

--- a/js/qtrade.js
+++ b/js/qtrade.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class qtrade extends Exchange {
+    /**
+     * @class
+     * @name qtrade
+     * @description exchange class for qtrade api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'qtrade',

--- a/js/ripio.js
+++ b/js/ripio.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class ripio extends Exchange {
+    /**
+     * @class
+     * @name ripio
+     * @description exchange class for ripio api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'ripio',

--- a/js/stex.js
+++ b/js/stex.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class stex extends Exchange {
+    /**
+     * @class
+     * @name stex
+     * @description exchange class for stex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'stex',

--- a/js/therock.js
+++ b/js/therock.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class therock extends Exchange {
+    /**
+     * @class
+     * @name therock
+     * @description exchange class for therock api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'therock',

--- a/js/tidebit.js
+++ b/js/tidebit.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class tidebit extends Exchange {
+    /**
+     * @class
+     * @name tidebit
+     * @description exchange class for tidebit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'tidebit',

--- a/js/tidex.js
+++ b/js/tidex.js
@@ -6,6 +6,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
 module.exports = class tidex extends Exchange {
+    /**
+     * @class
+     * @name tidex
+     * @description exchange class for tidex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'tidex',

--- a/js/timex.js
+++ b/js/timex.js
@@ -6,6 +6,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
 module.exports = class timex extends Exchange {
+    /**
+     * @class
+     * @name timex
+     * @description exchange class for timex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'timex',

--- a/js/upbit.js
+++ b/js/upbit.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class upbit extends Exchange {
+    /**
+     * @class
+     * @name upbit
+     * @description exchange class for upbit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'upbit',

--- a/js/vcc.js
+++ b/js/vcc.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class vcc extends Exchange {
+    /**
+     * @class
+     * @name vcc
+     * @description exchange class for vcc api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'vcc',

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -9,6 +9,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class wavesexchange extends Exchange {
+    /**
+     * @class
+     * @name wavesexchange
+     * @description exchange class for wavesexchange api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'wavesexchange',

--- a/js/wazirx.js
+++ b/js/wazirx.js
@@ -6,6 +6,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
 module.exports = class wazirx extends Exchange {
+    /**
+     * @class
+     * @name wazirx
+     * @description exchange class for wazirx api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'wazirx',

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class whitebit extends Exchange {
+    /**
+     * @class
+     * @name whitebit
+     * @description exchange class for whitebit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'whitebit',

--- a/js/woo.js
+++ b/js/woo.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class woo extends Exchange {
+    /**
+     * @class
+     * @name woo
+     * @description exchange class for woo api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'woo',

--- a/js/xena.js
+++ b/js/xena.js
@@ -6,6 +6,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
 module.exports = class xena extends Exchange {
+    /**
+     * @class
+     * @name xena
+     * @description exchange class for xena api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'xena',

--- a/js/yobit.js
+++ b/js/yobit.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 // ---------------------------------------------------------------------------
 
 module.exports = class yobit extends Exchange {
+    /**
+     * @class
+     * @name yobit
+     * @description exchange class for yobit api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'yobit',

--- a/js/zaif.js
+++ b/js/zaif.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class zaif extends Exchange {
+    /**
+     * @class
+     * @name zaif
+     * @description exchange class for zaif api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'zaif',

--- a/js/zb.js
+++ b/js/zb.js
@@ -10,6 +10,11 @@ const Precise = require ('./base/Precise');
 //  ---------------------------------------------------------------------------
 
 module.exports = class zb extends Exchange {
+    /**
+     * @class
+     * @name zb
+     * @description exchange class for zb api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'zb',

--- a/js/zipmex.js
+++ b/js/zipmex.js
@@ -7,6 +7,11 @@ const ndax = require ('./ndax.js');
 //  ---------------------------------------------------------------------------
 
 module.exports = class zipmex extends ndax {
+    /**
+     * @class
+     * @name zipmex
+     * @description exchange class for zipmex api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'zipmex',

--- a/js/zonda.js
+++ b/js/zonda.js
@@ -9,6 +9,11 @@ const { TICK_SIZE } = require ('./base/functions/number');
 //  ---------------------------------------------------------------------------
 
 module.exports = class zonda extends Exchange {
+    /**
+     * @class
+     * @name zonda
+     * @description exchange class for zonda api
+     */
     describe () {
         return this.deepExtend (super.describe (), {
             'id': 'zonda',


### PR DESCRIPTION
These are needed to autogenerate exchange specific documentation files like

```
@@ -0,0 +1,7 @@
!!! These are auto-generated documentation created for details about specific exchanges. If you would like to read human created in depth documentation, please visit [docs.ccxt.com][https://docs.ccxt.com/en/latest/]

<a name="binanceusdm"></a>

## binanceusdm
**Kind**: global class  

```

-------------

I injected all these with a python script, so I can change the docstring easily if you would like to change something for seo purposes. Having a documentation file for each exchange will be really good for SEO. I plan to link them all in [this table](https://docs.ccxt.com/en/latest/exchange-markets.html). With a warning like 

```
!!! These are auto-generated documentation created for details about specific exchanges. If you would like to read human created in depth documentation, please visit [docs.ccxt.com][https://docs.ccxt.com/en/latest/]
```

it will be clear that each doc page is just for differences in that exchange, and that there is a more verbose documentation on all the methods in the main CCXT docs