### PR TITLE
Coinex fetchLeverageTiers, fetchMarketLeverageTiers

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2261,7 +2261,8 @@ module.exports = class Exchange {
         return this.options['timeDifference'];
     }
 
-    parseLeverageTiers (response, symbols, marketIdKey) {
+    parseLeverageTiers (response, symbols = undefined, marketIdKey = undefined) {
+        // * marketIdKey should only be undefined when response is a dictionary
         const tiers = {};
         for (let i = 0; i < response.length; i++) {
             const item = response[i];

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2292,7 +2292,6 @@ module.exports = class Exchange {
         } else {
             throw new NotSupported (this.id + ' fetchMarketLeverageTiers() is not supported yet');
         }
-
     }
 
     isPostOnly (type, timeInForce, exchangeSpecificOption, params = {}) {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -2687,7 +2687,7 @@ module.exports = class coinex extends Exchange {
             if (symbols !== undefined) {
                 symbolsLength = symbols.length;
             }
-            if (symbol !== undefined && (symbolsLength === 0 || symbols.includes (symbol))) {
+            if (symbol !== undefined && (symbolsLength === 0 || this.inArray (symbols, symbol))) {
                 tiers[symbol] = this.parseMarketLeverageTiers (response[marketId], market);
             }
         }

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -2699,16 +2699,14 @@ module.exports = class coinex extends Exchange {
         let minNotional = 0;
         for (let j = 0; j < item.length; j++) {
             const bracket = item[j];
-            const leverage = this.safeInteger (bracket, 1);
             const maxNotional = this.safeNumber (bracket, 0);
-            const currency = (market['linear']) ? market['base'] : market['quote'];
             tiers.push ({
                 'tier': j + 1,
-                'currency': currency,
+                'currency': market['linear'] ? market['base'] : market['quote'],
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
                 'maintenanceMarginRate': this.safeNumber (bracket, 2),
-                'maxLeverage': leverage,
+                'maxLeverage': this.safeInteger (bracket, 1),
                 'info': bracket,
             });
             minNotional = maxNotional;

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -38,7 +38,7 @@ module.exports = class coinex extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchLeverage': false,
                 'fetchLeverageTiers': true,
-                'fetchMarketLeverageTiers': true,
+                'fetchMarketLeverageTiers': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
@@ -2661,35 +2661,6 @@ module.exports = class coinex extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         return this.parseLeverageTiers (data, symbols, undefined);
-    }
-
-    async fetchMarketLeverageTiers (symbol, params = {}) {
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        if (!market['contract']) {
-            throw new BadRequest (this.id + ' fetchMarketLeverageTiers() symbol supports contract markets only');
-        }
-        const response = await this.perpetualPublicGetMarketLimitConfig (params);
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "BTCUSD": [
-        //                 ["500001", "100", "0.005"],
-        //                 ["1000001", "50", "0.01"],
-        //                 ["2000001", "30", "0.015"],
-        //                 ["5000001", "20", "0.02"],
-        //                 ["10000001", "15", "0.025"],
-        //                 ["20000001", "10", "0.03"]
-        //             ],
-        //             ...
-        //         },
-        //         "message": "OK"
-        //     }
-        //
-        const data = this.safeValue (response, 'data', {});
-        const tiers = this.parseLeverageTiers (data, [ symbol ], market['id']);
-        return this.safeValue (tiers, symbol);
     }
 
     parseLeverageTiers (response, symbols = undefined, marketIdKey = undefined) {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -38,7 +38,7 @@ module.exports = class coinex extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchLeverage': false,
                 'fetchLeverageTiers': true,
-                'fetchMarketLeverageTiers': false,
+                'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
@@ -2688,7 +2688,7 @@ module.exports = class coinex extends Exchange {
                 symbolsLength = symbols.length;
             }
             if (symbol !== undefined && (symbolsLength === 0 || symbols.includes (symbol))) {
-                tiers[marketId] = this.parseMarketLeverageTiers (response[marketId], market);
+                tiers[symbol] = this.parseMarketLeverageTiers (response[marketId], market);
             }
         }
         return tiers;

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -2730,9 +2730,10 @@ module.exports = class coinex extends Exchange {
             const bracket = item[j];
             const leverage = this.safeInteger (bracket, 1);
             const maxNotional = this.safeNumber (bracket, 0);
+            const currency = (market['linear']) ? market['base'] : market['quote'];
             tiers.push ({
                 'tier': j + 1,
-                'currency': undefined,
+                'currency': currency,
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
                 'maintenanceMarginRate': this.safeNumber (bracket, 2),


### PR DESCRIPTION
Added fetchLeverageTiers and fetchMarketLeverageTiers to Coinex:

fetchLeverageTiers:
```
{
...
  'ZRX/USDT:USDT': [
    {
      tier: 1,
      currency: undefined,
      minNotional: 0,
      maxNotional: 10001,
      maintenanceMarginRate: 0.01,
      maxLeverage: 50,
      info: [ '10001', '50', '0.01' ]
    },
    {
      tier: 2,
      currency: undefined,
      minNotional: 10001,
      maxNotional: 20001,
      maintenanceMarginRate: 0.02,
      maxLeverage: 20,
      info: [ '20001', '20', '0.02' ]
    },
    {
      tier: 3,
      currency: undefined,
      minNotional: 20001,
      maxNotional: 50001,
      maintenanceMarginRate: 0.03,
      maxLeverage: 15,
      info: [ '50001', '15', '0.03' ]
    },
    {
      tier: 4,
      currency: undefined,
      minNotional: 50001,
      maxNotional: 100001,
      maintenanceMarginRate: 0.04,
      maxLeverage: 10,
      info: [ '100001', '10', '0.04' ]
    },
    {
      tier: 5,
      currency: undefined,
      minNotional: 100001,
      maxNotional: 200001,
      maintenanceMarginRate: 0.05,
      maxLeverage: 5,
      info: [ '200001', '5', '0.05' ]
    }
  ]
}
```
fetchMarketLeverageTiers BTC/USDT:USDT
```
coinex.fetchMarketLeverageTiers (BTC/USDT:USDT)
2022-05-05T19:07:55.515Z iteration 0 passed in 296 ms

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |          |           0 |     20.0001 |                 0.005 |         100
   2 |          |     20.0001 |     50.0001 |                  0.01 |          50
   3 |          |     50.0001 |    100.0001 |                 0.015 |          30
   4 |          |    100.0001 |    200.0001 |                  0.02 |          20
   5 |          |    200.0001 |    500.0001 |                 0.025 |          15
   6 |          |    500.0001 |   1000.0001 |                  0.03 |          10
6 objects
```

fetchMarketLeverageTiers BTC/USD:BTC
```
coinex.fetchMarketLeverageTiers (BTC/USD:BTC)
2022-05-05T19:08:31.013Z iteration 0 passed in 831 ms

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |          |           0 |      500001 |                 0.005 |         100
   2 |          |      500001 |     1000001 |                  0.01 |          50
   3 |          |     1000001 |     2000001 |                 0.015 |          30
   4 |          |     2000001 |     5000001 |                  0.02 |          20
   5 |          |     5000001 |    10000001 |                 0.025 |          15
   6 |          |    10000001 |    20000001 |                  0.03 |          10
6 objects
```