### PR TITLE
gateio.fetchFundingRateHistory new prepareRequest

### DIFF
--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2160,15 +2160,12 @@ module.exports = class gateio extends Exchange {
         if (!market['swap']) {
             throw new BadRequest ('Funding rates only exist for swap contracts');
         }
-        const request = {
-            'contract': market['id'],
-            'settle': market['settleId'],
-        };
+        const [ request, query ] = this.prepareRequest (market, undefined, params);
         if (limit !== undefined) {
             request['limit'] = limit;
         }
         const method = 'publicFuturesGetSettleFundingRate';
-        const response = await this[method] (this.extend (request, params));
+        const response = await this[method] (this.extend (request, query));
         //
         //     {
         //         "r": "0.00063521",

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -2158,7 +2158,7 @@ module.exports = class gateio extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadRequest ('Funding rates only exist for swap contracts');
+            throw new BadRequest (this.id + ' fetchFundingRateHistory() supports swap contracts only');
         }
         const [ request, query ] = this.prepareRequest (market, undefined, params);
         if (limit !== undefined) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -1244,7 +1244,7 @@ module.exports = class gateio extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadRequest ('Funding rates only exist for swap contracts');
+            throw new BadSymbol (this.id + ' fetchFundingRate() supports swap contracts only');
         }
         const [ request, query ] = this.prepareRequest (market, undefined, params);
         const response = await this.publicFuturesGetSettleContractsContract (this.extend (request, query));
@@ -2158,7 +2158,7 @@ module.exports = class gateio extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadRequest (this.id + ' fetchFundingRateHistory() supports swap contracts only');
+            throw new BadSymbol (this.id + ' fetchFundingRateHistory() supports swap contracts only');
         }
         const [ request, query ] = this.prepareRequest (market, undefined, params);
         if (limit !== undefined) {


### PR DESCRIPTION
```
2022-05-06T01:50:56.867Z
Node.js: v14.17.0
CCXT v1.81.56
gateio.fetchFundingRateHistory (ADA/USDT:USDT)
2022-05-06T01:50:58.887Z iteration 0 passed in 199 ms
       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
ADA/USDT:USDT |      0.0001 | 1648944000000 | 2022-04-03T00:00:00.000Z
...
ADA/USDT:USDT |      0.0001 | 1651766400000 | 2022-05-05T16:00:00.000Z
ADA/USDT:USDT |      0.0001 | 1651795200000 | 2022-05-06T00:00:00.000Z
100 objects
```