### PR TITLE
Phemex fetchFundingRate

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -2774,7 +2774,7 @@ module.exports = class phemex extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadRequest ('Funding rates only exist for swap contracts');
+            throw new BadSymbol (this.id + ' fetchFundingRate() supports swap contracts only');
         }
         const request = {
             'symbol': market['id'],


### PR DESCRIPTION
Added fetchFundingRate to Phemex:
```
phemex.fetchFundingRate (BTC/USD:BTC)
2022-05-06T23:04:50.816Z iteration 0 passed in 391 ms

{
  info: {
    askEp: '360270000',
    bidEp: '360265000',
    fundingRateEr: '10000',
    highEp: '366675000',
    indexEp: '360302245',
    lastEp: '360270000',
    lowEp: '351900000',
    markEp: '360306389',
    openEp: '362705000',
    openInterest: '136242227',
    predFundingRateEr: '10000',
    symbol: 'BTCUSD',
    timestamp: '1651878287354938589',
    turnoverEv: '4386533279049',
    volume: '1582949074'
  },
  symbol: 'BTC/USD:BTC',
  markPrice: '36030.6389',
  indexPrice: '36030.2245',
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: 1651878287354,
  datetime: '2022-05-06T23:04:47.354Z',
  fundingRate: '0.0001',
  fundingTimestamp: undefined,
  fundingDatetime: undefined,
  nextFundingRate: '0.0001',
  nextFundingTimestamp: undefined,
  nextFundingDatetime: undefined,
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
```