### PR TITLE
zb: cant make swap orders in python

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -1825,11 +1825,18 @@ module.exports = class zb extends Exchange {
                     request['action'] = type;
                 }
                 request['symbol'] = market['id'];
-                request['clientOrderId'] = params['clientOrderId']; // OPTIONAL '^[a-zA-Z0-9-_]{1,36}$', // The user-defined order number
-                request['extend'] = params['extend']; // OPTIONAL {"orderAlgos":[{"bizType":1,"priceType":1,"triggerPrice":"70000"},{"bizType":2,"priceType":1,"triggerPrice":"40000"}]}
+                const clientOrderId = this.safeString (params, 'clientOrderId'); // OPTIONAL '^[a-zA-Z0-9-_]{1,36}$', // The user-defined order number
+                if (clientOrderId !== undefined) {
+                    request['clientOrderId'] = clientOrderId;
+                }
+                // using extend as const name causes issues in python
+                const extendOrderAlgos = this.safeValue (params, 'extend', undefined); // OPTIONAL {"orderAlgos":[{"bizType":1,"priceType":1,"triggerPrice":"70000"},{"bizType":2,"priceType":1,"triggerPrice":"40000"}]}
+                if (extendOrderAlgos !== undefined) {
+                    request['extend'] = extendOrderAlgos;
+                }
             }
         }
-        const query = this.omit (params, [ 'reduceOnly', 'stop', 'stopPrice', 'orderType', 'triggerPrice', 'algoPrice', 'priceType', 'bizType' ]);
+        const query = this.omit (params, [ 'reduceOnly', 'stop', 'stopPrice', 'orderType', 'triggerPrice', 'algoPrice', 'priceType', 'bizType', 'clientOrderId', 'extend' ]);
         let response = await this[method] (this.extend (request, query));
         //
         // Spot
@@ -1859,10 +1866,13 @@ module.exports = class zb extends Exchange {
         //         "desc": "操作成功"
         //     }
         //
-        if (swap && stop === undefined && stopPrice === undefined) {
+        if ((swap) && (stop === undefined) && (stopPrice === undefined)) {
             response = this.safeValue (response, 'data');
             response['timeInForce'] = timeInForce;
-            response['type'] = request['tradeType'];
+            const tradeType = this.safeString (response, 'tradeType');
+            if (tradeType === undefined) {
+                response['type'] = tradeType;
+            }
             response['total_amount'] = amount;
             response['price'] = price;
         }

--- a/js/zb.js
+++ b/js/zb.js
@@ -1866,7 +1866,7 @@ module.exports = class zb extends Exchange {
         //         "desc": "操作成功"
         //     }
         //
-        if ((swap) && (stop === undefined) && (stopPrice === undefined)) {
+        if ((swap) && (!stop) && (stopPrice === undefined)) {
             response = this.safeValue (response, 'data');
             response['timeInForce'] = timeInForce;
             const tradeType = this.safeString (response, 'tradeType');


### PR DESCRIPTION
as it stands, trying to make swap order in python throws the follow errors:
https://github.com/ZBFuture/docs/blob/main/API%20V2%20_en.md#5-futures-trading

`zb.createOrder(DOGE/USDT:USDT,limit,buy,1,0.1)
Traceback (most recent call last):
  File "/Users/drslimm/work/ccxt0/ccxt/examples/py/cli.py", line 193, in <module>
    result = method(*args)
  File "/Users/drslimm/work/ccxt0/ccxt/python/ccxt/zb.py", line 1781, in create_order
    request['clientOrderId'] = params['clientOrderId']  # OPTIONAL '^[a-zA-Z0-9-_]{1,36}$',  # The user-defined order number
KeyError: 'clientOrderId'`

(even though clientOrderId is an optional parameter)

and another error for another weird optional parameter:
`zb.createOrder(DOGE/USDT:USDT,limit,buy,1,0.1,{'clientOrderId': '007'})
Traceback (most recent call last):
  File "/Users/drslimm/work/ccxt0/ccxt/examples/py/cli.py", line 193, in <module>
    result = method(*args)
  File "/Users/drslimm/work/ccxt0/ccxt/python/ccxt/zb.py", line 1782, in create_order
    request['extend'] = params['extend']  # OPTIONAL {"orderAlgos":[{"bizType":1,"priceType":1,"triggerPrice":"70000"},{"bizType":2,"priceType":1,"triggerPrice":"40000"}]}
KeyError: 'extend'`