### PR TITLE
Remove DRK as common currency for DASH #13157

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -221,7 +221,6 @@ module.exports = class Exchange {
             'commonCurrencies': { // gets extended/overwritten in subclasses
                 'XBT': 'BTC',
                 'BCC': 'BCH',
-                'DRK': 'DASH',
                 'BCHABC': 'BCH',
                 'BCHSV': 'BSV',
             },

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1319,7 +1319,6 @@ class Exchange {
         $this->commonCurrencies = array(
             'XBT' => 'BTC',
             'BCC' => 'BCH',
-            'DRK' => 'DASH',
             'BCHABC' => 'BCH',
             'BCHSV' => 'BSV',
         );

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -359,7 +359,6 @@ class Exchange(object):
     commonCurrencies = {
         'XBT': 'BTC',
         'BCC': 'BCH',
-        'DRK': 'DASH',
         'BCHABC': 'BCH',
         'BCHSV': 'BSV',
     }


### PR DESCRIPTION
This PR is to fix #13157 where Draken (DRK) was getting mixed up with DASH

Dash (DASH) used to be called Darkcoin(DRK), however in 2015 they rebranded to Dash. But as not all exchanges made this change DRK was added as a common currency to dash in the base class.

This PR removes DRK as a common currency to Dash.

Another option could be to add `'DRK': 'DRK'` to the commonCurrency of just bibox. However as the rebrand was done 7 years ago. I felt it was better to remove from it from the global class as there may be more exchanges that have the same issue.


