### PR TITLE
Ascendex parsePosition

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2282,7 +2282,7 @@ module.exports = class ascendex extends Exchange {
             'contracts': undefined,
             'contractSize': this.safeNumber (position, 'position'),
             'markPrice': this.safeNumber (position, 'markPrice'),
-            'side': this.safeString (position, 'side'),
+            'side': this.safeStringLower (position, 'side'),
             'hedged': undefined,
             'timestamp': undefined,
             'datetime': undefined,

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2185,7 +2185,115 @@ module.exports = class ascendex extends Exchange {
         const request = {
             'account-group': accountGroup,
         };
-        return await this.v2PrivateAccountGroupGetFuturesPosition (this.extend (request, params));
+        const response = await this.v2PrivateAccountGroupGetFuturesPosition (this.extend (request, params));
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "accountId": "fut2ODPhGiY71Pl4vtXnOZ00ssgD7QGn",
+        //             "ac": "FUTURES",
+        //             "collaterals": [
+        //                 {
+        //                     "asset": "USDT",
+        //                     "balance": "44.570287262",
+        //                     "referencePrice": "1",
+        //                     "discountFactor": "1"
+        //                 }
+        //             ],
+        //             "contracts": [
+        //                 {
+        //                     "symbol": "BTC-PERP",
+        //                     "side": "LONG",
+        //                     "position": "0.0001",
+        //                     "referenceCost": "-3.12277254",
+        //                     "unrealizedPnl": "-0.001700233",
+        //                     "realizedPnl": "0",
+        //                     "avgOpenPrice": "31209",
+        //                     "marginType": "isolated",
+        //                     "isolatedMargin": "1.654972977",
+        //                     "leverage": "2",
+        //                     "takeProfitPrice": "0",
+        //                     "takeProfitTrigger": "market",
+        //                     "stopLossPrice": "0",
+        //                     "stopLossTrigger": "market",
+        //                     "buyOpenOrderNotional": "0",
+        //                     "sellOpenOrderNotional": "0",
+        //                     "markPrice": "31210.723063672",
+        //                     "indexPrice": "31223.148857925"
+        //                 },
+        //             ]
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const position = this.safeValue (data, 'contracts', []);
+        const result = [];
+        for (let i = 0; i < position.length; i++) {
+            result.push (this.parsePosition (position[i]));
+        }
+        return this.filterByArray (result, 'symbol', symbols, false);
+    }
+
+    parsePosition (position, market = undefined) {
+        //
+        //     {
+        //         "symbol": "BTC-PERP",
+        //         "side": "LONG",
+        //         "position": "0.0001",
+        //         "referenceCost": "-3.12277254",
+        //         "unrealizedPnl": "-0.001700233",
+        //         "realizedPnl": "0",
+        //         "avgOpenPrice": "31209",
+        //         "marginType": "isolated",
+        //         "isolatedMargin": "1.654972977",
+        //         "leverage": "2",
+        //         "takeProfitPrice": "0",
+        //         "takeProfitTrigger": "market",
+        //         "stopLossPrice": "0",
+        //         "stopLossTrigger": "market",
+        //         "buyOpenOrderNotional": "0",
+        //         "sellOpenOrderNotional": "0",
+        //         "markPrice": "31210.723063672",
+        //         "indexPrice": "31223.148857925"
+        //     },
+        //
+        const marketId = this.safeString (position, 'symbol');
+        market = this.safeMarket (marketId, market);
+        let notional = this.safeNumber (position, 'buyOpenOrderNotional');
+        if (notional === 0) {
+            notional = this.safeNumber (position, 'sellOpenOrderNotional');
+        }
+        const marginMode = this.safeString (position, 'marginType');
+        let collateral = undefined;
+        if (marginMode === 'isolated') {
+            collateral = this.safeNumber (position, 'isolatedMargin');
+        }
+        return {
+            'info': position,
+            'id': undefined,
+            'symbol': market['symbol'],
+            'notional': notional,
+            'marginMode': marginMode,
+            'marginType': undefined, // deprecated
+            'liquidationPrice': undefined,
+            'entryPrice': this.safeNumber (position, 'avgOpenPrice'),
+            'unrealizedPnl': this.safeNumber (position, 'unrealizedPnl'),
+            'percentage': undefined,
+            'contracts': undefined,
+            'contractSize': this.safeNumber (position, 'position'),
+            'markPrice': this.safeNumber (position, 'markPrice'),
+            'side': this.safeString (position, 'side'),
+            'hedged': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'maintenanceMargin': undefined,
+            'maintenanceMarginPercentage': undefined,
+            'collateral': collateral,
+            'initialMargin': undefined,
+            'initialMarginPercentage': undefined,
+            'leverage': this.safeInteger (position, 'leverage'),
+            'marginRatio': undefined,
+        };
     }
 
     parseFundingRate (fundingRate, market = undefined) {

--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -2274,7 +2274,7 @@ module.exports = class ascendex extends Exchange {
             'symbol': market['symbol'],
             'notional': notional,
             'marginMode': marginMode,
-            'marginType': undefined, // deprecated
+            'marginType': marginMode, // deprecated
             'liquidationPrice': undefined,
             'entryPrice': this.safeNumber (position, 'avgOpenPrice'),
             'unrealizedPnl': this.safeNumber (position, 'unrealizedPnl'),


### PR DESCRIPTION
Added unified structure to fetchPositions with parsePosition:
Fix #13166
```
ascendex.fetchPositions (BTC/USDT:USDT,ETH/USDT:USDT)
2022-05-11T04:33:22.854Z iteration 0 passed in 1261 ms

id |        symbol | notional | marginMode | marginType | liquidationPrice | entryPrice | unrealizedPnl | percentage | contracts | contractSize |       markPrice | side | hedged | timestamp | datetime | maintenanceMargin | maintenanceMarginPercentage |   collateral | initialMargin | initialMarginPercentage | leverage | marginRatio
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | ETH/USDT:USDT |        0 |   isolated |            |                  |     2371.8 |  -0.077283524 |            |           |         0.01 |  2365.494727504 | LONG |        |           |          |                   |                             | 12.584823462 |               |                         |        2 |
   | BTC/USDT:USDT |        0 |   isolated |            |                  |      31226 |   0.006351892 |            |           |       0.0001 | 31308.254529029 | LONG |        |           |          |                   |                             |  1.655924418 |               |                         |        2 |
2 objects
```