### PR TITLE
binance: add giftcard cryptography rsa-public-key

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -328,6 +328,7 @@ module.exports = class binance extends Exchange {
                         'nft/user/getAsset': 20.001,
                         'pay/transactions': 20.001, // Weight(UID): 3000 => cost = 0.006667 * 3000 = 20.001
                         'giftcard/verify': 0.1,
+                        'giftcard/cryptography/rsa-public-key': 0.1,
                         'algo/futures/openOrders': 0.1,
                         'algo/futures/historicalOrders': 0.1,
                         'algo/futures/subOrders': 0.1,


### PR DESCRIPTION
Add binance new endpoint: `giftcard/cryptography/rsa-public-key`

Doc: https://binance-docs.github.io/apidocs/spot/en/#fetch-rsa-public-key-user_data

Result: 
```
{
  code: '000000',
  message: 'success',
  data: 'RSA PUBLIC KEY',
  success: true
}

```