### PR TITLE
Bitget fetchFundingRateHistory

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2355,7 +2355,7 @@ module.exports = class bitget extends Exchange {
         };
     }
 
-    async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = 100, params = {}) {
+    async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
         }


### PR DESCRIPTION
Added fetchFundingRateHistory to Bitget:
```
bitget.fetchFundingRateHistory (BTC/USDT:USDT)
2022-05-13T01:58:59.377Z iteration 0 passed in 306 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
BTC/USDT:USDT |      0.0001 | 1649545200000 | 2022-04-09T23:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1649574000000 | 2022-04-10T07:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1649602800000 | 2022-04-10T15:00:00.000Z
...
```