### PR TITLE
aax.fetchMarkets parse numbers in limits, add leverage min/max for swap

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -493,10 +493,15 @@ module.exports = class aax extends Exchange {
             let symbol = base + '/' + quote;
             let type = 'spot';
             let contractSize = undefined;
+            let minLeverage = undefined;
+            let maxLeverage = undefined;
             if (swap) {
                 symbol = symbol + ':' + settle;
                 type = 'swap';
                 contractSize = this.safeNumber (market, 'multiplier');
+                minLeverage = '1';
+                const imRate = this.safeString (market, 'imRate');
+                maxLeverage = Precise.stringDiv ('1', imRate);
             }
             result.push ({
                 'id': id,
@@ -517,6 +522,7 @@ module.exports = class aax extends Exchange {
                 'contract': swap,
                 'linear': linear,
                 'inverse': inverse,
+                'quanto': quanto,
                 'taker': this.safeNumber (market, 'takerFee'),
                 'maker': this.safeNumber (market, 'makerFee'),
                 'contractSize': contractSize,
@@ -524,23 +530,22 @@ module.exports = class aax extends Exchange {
                 'expiryDatetime': undefined,
                 'strike': undefined,
                 'optionType': undefined,
-                'quanto': quanto,
                 'precision': {
                     'amount': this.safeNumber (market, 'lotSize'),
                     'price': this.safeNumber (market, 'tickSize'),
                 },
                 'limits': {
                     'leverage': {
-                        'min': undefined,
-                        'max': undefined,
+                        'min': this.parseNumber (minLeverage),
+                        'max': this.parseNumber (maxLeverage),
                     },
                     'amount': {
-                        'min': this.safeString (market, 'minQuantity'),
-                        'max': this.safeString (market, 'maxQuantity'),
+                        'min': this.safeNumber (market, 'minQuantity'),
+                        'max': this.safeNumber (market, 'maxQuantity'),
                     },
                     'price': {
-                        'min': this.safeString (market, 'minPrice'),
-                        'max': this.safeString (market, 'maxPrice'),
+                        'min': this.safeNumber (market, 'minPrice'),
+                        'max': this.safeNumber (market, 'maxPrice'),
                     },
                     'cost': {
                         'min': undefined,


### PR DESCRIPTION
```
2022-05-13T03:57:48.694Z
Node.js: v14.17.0
CCXT v1.82.28
aax.market (ADA/USDT:USDT)
2022-05-13T03:57:51.808Z iteration 0 passed in 0 ms

{
  id: 'ADAUSDTFP',
  symbol: 'ADA/USDT:USDT',
  base: 'ADA',
  quote: 'USDT',
  baseId: 'ADA',
  quoteId: 'USDT',
  active: true,
  type: 'swap',
  linear: true,
  inverse: false,
  spot: false,
  swap: true,
  future: false,
  option: false,
  margin: false,
  contract: true,
  contractSize: 1,
  expiry: undefined,
  expiryDatetime: undefined,
  optionType: undefined,
  strike: undefined,
  settle: 'USDT',
  settleId: 'USDT',
  precision: { amount: 1, price: 0.000001 },
  limits: {
    leverage: { min: 1, max: 25 },
    amount: { min: 1, max: 570000 },
    price: { min: 0.2068084, max: 999999 },
    cost: { min: undefined, max: undefined }
  },
  info: {
    tickSize: '0.000001',
    lotSize: '1',
    base: 'ADA',
    quote: 'USDT',
    minQuantity: '1',
    maxQuantity: '570000',
    minPrice: '0.2068084',
    maxPrice: '999999',
    status: 'enable',
    symbol: 'ADAUSDTFP',
    code: 'FP',
    takerFee: '0.0006',
    makerFee: '0.0004',
    multiplier: '1',
    mmRate: '0.01',
    imRate: '0.04',
    type: 'futures',
    settleType: 'Vanilla',
    settleCurrency: 'USDT'
  },
  tierBased: false,
  percentage: true,
  taker: 0.0006,
  maker: 0.0004,
  quanto: false
}
```