### PR TITLE
Bybit ::  setMarginUpdate update

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3569,6 +3569,15 @@ module.exports = class bybit extends Exchange {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setMarginMode() requires a symbol argument');
         }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (market['settle'] === 'USDC') {
+            throw new NotSupported (this.id + ' setMarginMode() does not support market ' + symbol + '');
+        }
+        marginMode = marginMode.toUpperCase ();
+        if ((marginMode !== 'ISOLATED') && (marginMode !== 'CROSS')) {
+            throw new BadRequest (this.id + ' setMarginMode() marginMode must be either isolated or cross');
+        }
         const leverage = this.safeNumber (params, 'leverage');
         let sellLeverage = undefined;
         let buyLeverage = undefined;
@@ -3584,13 +3593,7 @@ module.exports = class bybit extends Exchange {
             sellLeverage = leverage;
             buyLeverage = leverage;
         }
-        marginMode = marginMode.toUpperCase ();
-        if ((marginMode !== 'ISOLATED') && (marginMode !== 'CROSS')) {
-            throw new BadRequest (this.id + ' setMarginMode() marginMode must be either isolated or cross');
-        }
         const isIsolated = (marginMode === 'ISOLATED');
-        await this.loadMarkets ();
-        const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
             'is_isolated': isIsolated,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3582,8 +3582,8 @@ module.exports = class bybit extends Exchange {
         let sellLeverage = undefined;
         let buyLeverage = undefined;
         if (leverage === undefined) {
-            sellLeverage = this.safeNumber (params, 'sell_leverage', 'sellLeverage');
-            buyLeverage = this.safeNumber (params, 'buy_leverage', 'buyLeverage');
+            sellLeverage = this.safeNumber2 (params, 'sell_leverage', 'sellLeverage');
+            buyLeverage = this.safeNumber2 (params, 'buy_leverage', 'buyLeverage');
             if (sellLeverage === undefined || buyLeverage === undefined) {
                 throw new ArgumentsRequired (this.id + ' setMarginMode() requires a leverage parameter or sell_leverage and buy_leverage parameters');
             }
@@ -3602,7 +3602,7 @@ module.exports = class bybit extends Exchange {
         };
         let method = undefined;
         if (market['future']) {
-            method = 'privateFuturesPostPositionSwitchIsolated';
+            method = 'privatePostFuturesPrivatePositionSwitchIsolated';
         } else if (market['inverse']) {
             method = 'privatePostV2PrivatePositionSwitchIsolated';
         } else {


### PR DESCRIPTION
- setMarginUpdate to comply with the new API structure/market types

Demo:
```
node cli.js bybit setMarginMode "ISOLATED" "ETH/USD:ETH-220624" '{"leverage":2}' --verbose
CCXT v1.82.19
bybit.setMarginMode (ISOLATED, ETH/USD:ETH-220624, [object Object])
fetch Request:
 bybit POST https://api.bybit.com/futures/private/position/switch-isolated 
RequestHeaders:
 { 'Content-Type': 'application/json' } 
RequestBody:
 {"symbol":"ETHUSDM22","is_isolated":true,"buy_leverage":2,"sell_leverage":2,"api_key":"cH4MQfkrFNKYiLfpVB","recv_window":5000,"timestamp":1652440256084,"sign":"6c66bca246a4416099e8ef615e5d705303d256831d396cd61a5fac36c9f28cc0"} 

handleRestResponse:
 bybit POST https://api.bybit.com/futures/private/position/switch-isolated 200 OK 
ResponseBody:
 {"ret_code":0,"ret_msg":"OK","ext_code":"","ext_info":"","result":null,"time_now":"1652440256.250539","rate_limit_status":72,"rate_limit_reset_ms":1652440256248,"rate_limit":75} 

2022-05-13T11:10:56.286Z iteration 0 passed in 222 ms

{
  ret_code: '0',
  ret_msg: 'OK',
  ext_code: '',
  ext_info: '',
  result: null,
  time_now: '1652440256.250539',
  rate_limit_status: '72',
  rate_limit_reset_ms: '1652440256248',
  rate_limit: '75'
}
```
