### PR TITLE
Bitget cancelOrder

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1760,18 +1760,18 @@ module.exports = class bitget extends Exchange {
             'orderId': id,
         };
         const stop = this.safeValue (params, 'stop');
-        const planType = this.safeString (params, 'planType');
         if (stop) {
-            method = 'privateMixPostPlanCancelPlan';
+            const planType = this.safeString (params, 'planType');
             if (planType === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
             }
             request['planType'] = planType;
+            method = 'privateMixPostPlanCancelPlan';
+            params = this.omit (params, [ 'stop', 'planType' ]);
         }
         if (marketType === 'swap') {
             request['marginCoin'] = market['settleId'];
         }
-        params = this.omit (params, [ 'stop', 'planType' ]);
         const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1763,9 +1763,9 @@ module.exports = class bitget extends Exchange {
         const planType = this.safeString (params, 'planType');
         if (stop) {
             method = 'privateMixPostPlanCancelPlan';
-            // if (planType === undefined) {
-            //     throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
-            // }
+            if (planType === undefined) {
+                throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
+            }
             request['planType'] = planType;
         }
         if (marketType === 'swap') {


### PR DESCRIPTION
Added stop functionality to cancelOrder:
```
node examples/js/cli bitget cancelOrder '"910185209527255040"' BTC/USDT:USDT '{"stop":"true","planType":"normal_plan"}'

bitget.cancelOrder (910185209527255040, BTC/USDT:USDT, [object Object])
2022-05-16T19:59:48.579Z iteration 0 passed in 311 ms

{
  info: {
    code: '00000',
    msg: 'success',
    requestTime: '1652731188747',
    data: {
      clientOid: 'iauIBf#ecee212182fd4100b197c1',
      orderId: '910185209527255040'
    }
  },
  id: undefined,
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```