### PR TITLE
Allow to filter exchange-capabilities by exchange

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -8,6 +8,7 @@ const csv = process.argv.includes ('--csv')
     , log = require ('ololog').noLocate
     , ansi = require ('ansicolor').nice
     , sortCertified = process.argv.includes ('--sort-certified') || process.argv.includes ('--certified')
+    , selectedExchanges = process.argv.includes ('--exchanges') ? process.argv.at(process.argv.findIndex ((val)=> val === '--exchanges') + 1) : []
 
 console.log (ccxt.iso8601 (ccxt.milliseconds ()))
 console.log ('CCXT v' + ccxt.version)
@@ -46,6 +47,9 @@ async function main () {
     }, {})
     const unified = Object.entries (reduced).filter (([ _, count ]) => count > 1)
     const methods = unified.map (([ method, _ ]) => method).sort ()
+    if (selectedExchanges.length > 0) {
+        exchanges = exchanges.filter ((exchange) => (selectedExchanges.includes(exchange.id)))
+    }
     const table = asTable (exchanges.map (exchange => {
         let result = {};
         const basics = [

--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -8,7 +8,9 @@ const csv = process.argv.includes ('--csv')
     , log = require ('ololog').noLocate
     , ansi = require ('ansicolor').nice
     , sortCertified = process.argv.includes ('--sort-certified') || process.argv.includes ('--certified')
-    , selectedExchanges = process.argv.includes ('--exchanges') ? process.argv.at(process.argv.findIndex ((val)=> val === '--exchanges') + 1) : []
+    , exchangesArgument = process.argv.find (arg => arg.startsWith ('--exchanges='))
+    , exchangesArgumentParts = exchangesArgument ? exchangesArgument.split ('=') : []
+    , selectedExchanges = (exchangesArgumentParts.length > 1) ? exchangesArgumentParts[1].split (',') : []
 
 console.log (ccxt.iso8601 (ccxt.milliseconds ()))
 console.log ('CCXT v' + ccxt.version)

--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -48,7 +48,7 @@ async function main () {
     const unified = Object.entries (reduced).filter (([ _, count ]) => count > 1)
     const methods = unified.map (([ method, _ ]) => method).sort ()
     if (selectedExchanges.length > 0) {
-        exchanges = exchanges.filter ((exchange) => (selectedExchanges.includes(exchange.id)))
+        exchanges = exchanges.filter ((exchange) => selectedExchanges.includes(exchange.id))
     }
     const table = asTable (exchanges.map (exchange => {
         let result = {};


### PR DESCRIPTION
Many times I found my self scrolling up and down when running to look at only one exchange `node examples/js/exchange-capabilities.js | less -S -R`

This PR adds a flag `--exchanges` to pass in an array of exchanges to select.

For example: `node examples/js/exchange-capabilities.js --exchanges [aax,binance] | less -S -R` would show only aax and binance
![image](https://user-images.githubusercontent.com/12142844/168683133-70cdbe3d-5267-4362-bcc4-1f20991f4071.png)
