### PR TITLE
fix fetchOrderBook

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1048,7 +1048,7 @@ module.exports = class kucoin extends Exchange {
         let method = 'publicGetMarketOrderbookLevelLevelLimit';
         const isAuthenticated = this.checkRequiredCredentials (false);
         let response = undefined;
-        if (!isAuthenticated) {
+        if (!isAuthenticated || limit !== undefined) {
             if (level === 2) {
                 request['level'] = level;
                 if (limit !== undefined) {
@@ -1059,13 +1059,11 @@ module.exports = class kucoin extends Exchange {
                     }
                 }
                 request['limit'] = limit ? limit : 100;
-                method = 'publicGetMarketOrderbookLevelLevelLimit';
-                response = await this[method] (this.extend (request, params));
             }
         } else {
             method = 'privateGetMarketOrderbookLevel2'; // recommended (v3)
-            response = await this[method] (this.extend (request, params));
         }
+        response = await this[method] (this.extend (request, params));
         //
         // public (v1) market/orderbook/level2_20 and market/orderbook/level2_100
         //


### PR DESCRIPTION
when called with limit 20 or 100 and authenticated use publicGetMarketOrderbookLevelLevelLimit
when called with limit 20 or 100 and not authenticated use publicGetMarketOrderbookLevelLevelLimit
when called with no limit and not authenticated use publicGetMarketOrderbookLevelLevelLimit with limit of 100
when called with no limit and authenticated use privateGetMarketOrderbookLevel2

The private method is more rate-limited than the public one, we should avoid it unless it's completely necessary.

fix #11933