### PR TITLE
Bitget fetchOpenOrders

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1939,8 +1939,8 @@ module.exports = class bitget extends Exchange {
         const stop = this.safeValue (params, 'stop');
         if (stop) {
             method = 'privateMixGetPlanCurrentPlan';
+            params = this.omit (params, 'stop');
         }
-        params = this.omit (params, 'stop');
         const response = await this[method] (this.extend (request, query));
         //
         //  spot

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -179,6 +179,8 @@ module.exports = class bitget extends Exchange {
                             'order/history': 2,
                             'order/detail': 2,
                             'order/fills': 2,
+                            'plan/currentPlan': 2,
+                            'plan/historyPlan': 2,
                             'position/singlePosition': 2,
                             'position/allPosition': 2,
                             'trace/currentTrack': 2,
@@ -205,8 +207,6 @@ module.exports = class bitget extends Exchange {
                             'plan/placeTPSL': 2,
                             'plan/modifyTPSLPlan': 2,
                             'plan/cancelPlan': 2,
-                            'plan/currentPlan': 2,
-                            'plan/historyPlan': 2,
                             'trace/closeTrackOrder': 2,
                             'trace/setUpCopySymbols': 2,
                         },
@@ -1628,11 +1628,30 @@ module.exports = class bitget extends Exchange {
         //       uTime: '1645925450746'
         //     }
         //
+        // stop
+        //
+        //     {
+        //         "orderId": "910246821491617792",
+        //         "symbol": "BTCUSDT_UMCBL",
+        //         "marginCoin": "USDT",
+        //         "size": "16",
+        //         "executePrice": "20000",
+        //         "triggerPrice": "24000",
+        //         "status": "not_trigger",
+        //         "orderType": "limit",
+        //         "planType": "normal_plan",
+        //         "side": "open_long",
+        //         "triggerType": "market_price",
+        //         "presetTakeProfitPrice": "0",
+        //         "presetTakeLossPrice": "0",
+        //         "cTime": "1652745674488"
+        //     }
+        //
         const marketId = this.safeString (order, 'symbol');
         market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const id = this.safeString (order, 'orderId');
-        const price = this.safeString (order, 'price');
+        const price = this.safeString2 (order, 'price', 'executePrice');
         const amount = this.safeString2 (order, 'quantity', 'size');
         const filled = this.safeString2 (order, 'fillQuantity', 'filledQty');
         const cost = this.safeString2 (order, 'fillTotalAmount', 'filledAmount');
@@ -1663,7 +1682,7 @@ module.exports = class bitget extends Exchange {
             'postOnly': undefined,
             'side': side,
             'price': price,
-            'stopPrice': undefined,
+            'stopPrice': this.safeNumber (order, 'triggerPrice'),
             'average': average,
             'cost': cost,
             'amount': amount,
@@ -1913,10 +1932,15 @@ module.exports = class bitget extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const method = this.getSupportedMapping (marketType, {
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeOpenOrders',
             'swap': 'privateMixGetOrderCurrent',
         });
+        const stop = this.safeValue (params, 'stop');
+        if (stop) {
+            method = 'privateMixGetPlanCurrentPlan';
+        }
+        params = this.omit (params, 'stop');
         const response = await this[method] (this.extend (request, query));
         //
         //  spot
@@ -1969,6 +1993,32 @@ module.exports = class bitget extends Exchange {
         //           uTime: '1645922194995'
         //         }
         //       ]
+        //     }
+        //
+        // stop
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1652745815697,
+        //         "data": [
+        //             {
+        //                 "orderId": "910246821491617792",
+        //                 "symbol": "BTCUSDT_UMCBL",
+        //                 "marginCoin": "USDT",
+        //                 "size": "16",
+        //                 "executePrice": "20000",
+        //                 "triggerPrice": "24000",
+        //                 "status": "not_trigger",
+        //                 "orderType": "limit",
+        //                 "planType": "normal_plan",
+        //                 "side": "open_long",
+        //                 "triggerType": "market_price",
+        //                 "presetTakeProfitPrice": "0",
+        //                 "presetTakeLossPrice": "0",
+        //                 "cTime": "1652745674488"
+        //             }
+        //         ]
         //     }
         //
         const data = this.safeValue (response, 'data', []);


### PR DESCRIPTION
Added stop functionality to fetchOpenOrders:
```
node examples/js/cli bitget fetchOpenOrders BTC/USDT:USDT undefined undefined '{"stop":"true"}'

bitget.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2022-05-17T00:11:11.334Z iteration 0 passed in 348 ms

                id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | cost | amount | filled | remaining |      status | fee | trades | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
910246821491617792 |               | 1652745674488 | 2022-05-17T00:01:14.488Z |                    | BTC/USDT:USDT | limit |             |          |  buy | 20000 |     24000 |         |      |     16 |        |           | not_trigger |     |     [] |   []
1 objects
```