### PR TITLE
Ftx fetchMyTrades till param, default till removed

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1901,15 +1901,29 @@ module.exports = class ftx extends Exchange {
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name ftx#fetchMyTrades
+         * @description fetch trades specific to you account
+         * @param {str} symbol unified market symbol
+         * @param {int} since timestamp in ms of the earliest trade
+         * @param {int} limit not sent to exchange but filtered internally by CCXT
+         * @param {dict} params exchange specific parameters
+         * @param {int} params.till timestamp in ms of the latest trade
+         * @returns A list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html#trade-structure}
+         */
         await this.loadMarkets ();
         const [ market, marketId ] = this.getMarketParams (symbol, 'market', params);
         const request = {};
         if (marketId !== undefined) {
             request['market'] = marketId;
         }
+        const till = this.safeInteger (params, 'till');
         if (since !== undefined) {
             request['start_time'] = parseInt (since / 1000);
-            request['end_time'] = this.seconds ();
+        }
+        if (till !== undefined) {
+            request['end_time'] = parseInt (till / 1000);
         }
         const response = await this.privateGetFills (this.extend (request, params));
         //

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1924,6 +1924,7 @@ module.exports = class ftx extends Exchange {
         }
         if (till !== undefined) {
             request['end_time'] = parseInt (till / 1000);
+            params = this.omit (params, 'till');
         }
         const response = await this.privateGetFills (this.extend (request, params));
         //


### PR DESCRIPTION
```
%  ftx fetchMyTrades undefined 1652504274379                                                                                                                                                                                                                               2022-05-18T06:10:58.717Z
2022-05-18T06:11:08.531Z                                                                                                                                                                                                                                                   Node.js: v14.17.0
Node.js: v14.17.0                                                                                                                                                                                                                                                          CCXT v1.82.87
CCXT v1.82.87                                                                                                                                                                                                                                                              ftx.fetchMyTrades (, 1652504274379, , [object Object])
ftx.fetchMyTrades (, 1652504274379)                                                                                                                                                                                                                                        2022-05-18T06:10:59.705Z iteration 0 passed in 357 ms
2022-05-18T06:11:09.516Z iteration 0 passed in 421 ms                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                               timestamp |                 datetime |      symbol |         id |        order | type | takerOrMaker | side |  price |     amount |           cost |                                                  fee |                                                   fees
    timestamp |                 datetime |      symbol |         id |        order | type | takerOrMaker | side |  price |     amount |           cost |                                                  fee |                                                   fees     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------     1652504274379 | 2022-05-14T04:57:54.379Z | XEM/USD:USD | 8097924971 | 146184126879 |      |        taker | sell | 0.0565 |       1234 |         69.721 |    {"cost":0.0488047,"currency":"USD","rate":0.0007} |    [{"currency":"USD","cost":0.0488047,"rate":0.0007}]
1652504274379 | 2022-05-14T04:57:54.379Z | XEM/USD:USD | 8097924971 | 146184126879 |      |        taker | sell | 0.0565 |       1234 |         69.721 |    {"cost":0.0488047,"currency":"USD","rate":0.0007} |    [{"currency":"USD","cost":0.0488047,"rate":0.0007}]     1652504810377 | 2022-05-14T05:06:50.377Z |    USDT/USD | 8098071719 | 146186441749 |      |        taker | sell | 0.9981 |       4.86 |       4.850766 | {"cost":0.0033955362,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0033955362,"rate":0.0007}]
1652504810377 | 2022-05-14T05:06:50.377Z |    USDT/USD | 8098071719 | 146186441749 |      |        taker | sell | 0.9981 |       4.86 |       4.850766 | {"cost":0.0033955362,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0033955362,"rate":0.0007}]     1652504811271 | 2022-05-14T05:06:51.271Z |    USDT/USD | 8098082151 |              |      |        taker | sell | 0.9981 | 0.00324318 | 0.003237017958 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]
1652504811271 | 2022-05-14T05:06:51.271Z |    USDT/USD | 8098082151 |              |      |        taker | sell | 0.9981 | 0.00324318 | 0.003237017958 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]     1652504835390 | 2022-05-14T05:07:15.390Z |    USDT/USD | 8098076101 | 146186520753 |      |        taker | sell | 0.9981 |       0.06 |       0.059886 | {"cost":0.0000419202,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0000419202,"rate":0.0007}]
1652504835390 | 2022-05-14T05:07:15.390Z |    USDT/USD | 8098076101 | 146186520753 |      |        taker | sell | 0.9981 |       0.06 |       0.059886 | {"cost":0.0000419202,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0000419202,"rate":0.0007}]     4 objects
1652504839532 | 2022-05-14T05:07:19.532Z |    USDT/USD | 8098087190 |              |      |        taker | sell | 0.9981 | 0.00185935 | 0.001855817235 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]
1652504864741 | 2022-05-14T05:07:44.741Z |    USDT/USD | 8098080637 | 146186611754 |      |        taker | sell | 0.9981 |       0.24 |       0.239544 | {"cost":0.0001676808,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0001676808,"rate":0.0007}]
1652504865911 | 2022-05-14T05:07:45.911Z |    USDT/USD | 8098091236 |              |      |        taker | sell | 0.9981 | 0.00743834 | 0.007424207154 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]
1652504895336 | 2022-05-14T05:08:15.336Z |    USDT/USD | 8098086727 | 146186714757 |      |        taker | sell | 0.9981 |       0.18 |       0.179658 | {"cost":0.0001257606,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0001257606,"rate":0.0007}]
1652504897514 | 2022-05-14T05:08:17.514Z |    USDT/USD | 8098098291 |              |      |        taker | sell | 0.9981 | 0.00557791 | 0.005567311971 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]
1652505013668 | 2022-05-14T05:10:13.668Z |    USDT/USD | 8098112464 | 146187169792 |      |        taker | sell | 0.9981 |       0.37 |       0.369297 | {"cost":0.0002585079,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.0002585079,"rate":0.0007}]
1652505018013 | 2022-05-14T05:10:18.013Z |    USDT/USD | 8098124454 |              |      |        taker | sell | 0.9981 | 0.00117041 | 0.001168186221 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]
1652505069892 | 2022-05-14T05:11:09.892Z | XEM/USD:USD | 8098134519 |              |      |        taker |  buy | 0.0596 |       1234 |        73.5464 |                 {"cost":0,"currency":"USD","rate":0} |                 [{"currency":"USD","cost":0,"rate":0}]
12 objects
```

fixes #13301 