### PR TITLE
coinex fetchOrderBook no merging

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -681,7 +681,7 @@ module.exports = class coinex extends Exchange {
         }
         const request = {
             'market': this.marketId (symbol),
-            'merge': '0.0000000001',
+            'merge': '0',
             'limit': limit.toString (),
         };
         const method = market['swap'] ? 'perpetualPublicGetMarketDepth' : 'publicGetMarketDepth';


### PR DESCRIPTION
When `0` is set there is no merging
https://api.coinex.com/v1/market/depth?market=BABYDOGEUSDT&merge=0
And with current setting some pairs, that have precision >10 works not properly
https://api.coinex.com/v1/market/depth?market=BABYDOGEUSDT&merge=0.0000000001