### PR TITLE
isPostOnly fixes

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2333,17 +2333,19 @@ module.exports = class Exchange {
 
     }
 
-    isPostOnly (type, timeInForce, exchangeSpecificOption, params = {}) {
+    isPostOnly (type, timeInForce = undefined, exchangeSpecificOption = undefined, params = {}) {
         /**
-         * @param {string} type: Order type
+         * @ignore
+         * @method
+         * @param {string} type Order type
          * @param {string} timeInForce
-         * @param {boolean} exchangeSpecificOption: True if the exchange specific post only setting is set
-         * @param {dict} params: Exchange specific params
-         * @returns {boolean}: true if a post only order, false otherwise
+         * @param {boolean} exchangeSpecificOption True if the exchange specific post only setting is set
+         * @param {dict} params Exchange specific params
+         * @returns {boolean} true if a post only order, false otherwise
          */
         let postOnly = this.safeValue2 (params, 'postOnly', 'post_only', false);
         params = this.omit (params, [ 'post_only', 'postOnly' ]);
-        const timeInForceUpper = timeInForce.toUpperCase ();
+        const timeInForceUpper = (timeInForce !== undefined) ? timeInForce.toUpperCase () : undefined;
         const typeLower = type.toLowerCase ();
         const ioc = timeInForceUpper === 'IOC';
         const fok = timeInForceUpper === 'FOK';

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -104,6 +104,7 @@ class Exchange {
         'bw',
         'bybit',
         'bytetrade',
+        'bytex',
         'cdax',
         'cex',
         'coinbase',
@@ -3944,7 +3945,7 @@ class Exchange {
         if ($post_only) {
             if ($ioc || $fok) {
                 throw new InvalidOrder($this->id . ' postOnly orders cannot have $timeInForce equal to ' . $time_in_force);
-            } else if ($isMarket) {
+            } else if ($is_market) {
                 throw new InvalidOrder($this->id . ' postOnly orders cannot have $type ' . $type);
             } else {
                 $time_in_force = $time_in_force_post_only ? null : $time_in_force;

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -104,7 +104,6 @@ class Exchange {
         'bw',
         'bybit',
         'bytetrade',
-        'bytex',
         'cdax',
         'cex',
         'coinbase',
@@ -3942,7 +3941,7 @@ class Exchange {
         $time_in_force_post_only = $time_in_force_upper === 'PO';
         $is_market = $type_lower === 'market';
         $post_only = $post_only || ($type_lower === 'postonly') || $time_in_force_post_only || $exchange_specific_option;
-        if ($postOnly) {
+        if ($post_only) {
             if ($ioc || $fok) {
                 throw new InvalidOrder($this->id . ' postOnly orders cannot have $timeInForce equal to ' . $time_in_force);
             } else if ($isMarket) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -104,6 +104,7 @@ class Exchange {
         'bw',
         'bybit',
         'bytetrade',
+        'bytex',
         'cdax',
         'cex',
         'coinbase',
@@ -3924,26 +3925,34 @@ class Exchange {
         sleep($milliseconds / 1000);
     }
 
-    public function is_post_only($type, $time_in_force, $exchange_specific_option, $params = array()){
+    public function is_post_only($type, $time_in_force = null, $exchange_specific_option = null, $params = array ()) {
+        /**
+         * @param {string} $type Order type
+         * @param {string} $time_in_force
+         * @param {boolean} $exchange_specific_option True if the exchange specific post only setting is set
+         * @param {dict} $params Exchange specific $params
+         * @return {boolean} true if a post only order, false otherwise
+         */
         $post_only = $this->safe_value_2($params, 'postOnly', 'post_only', false);
-        $params = $this->omit($params, array('post_only', 'postOnly'));
-        $time_in_force_upper = strtoupper($time_in_force);
+        $params = $this->omit($params, array( 'post_only', 'postOnly' ));
+        $time_in_force_upper = ($time_in_force !== null) ? strtoupper($time_in_force) : null;
         $type_lower = strtolower($type);
         $ioc = $time_in_force_upper === 'IOC';
+        $fok = $time_in_force_upper === 'FOK';
         $time_in_force_post_only = $time_in_force_upper === 'PO';
         $is_market = $type_lower === 'market';
-        $post_only = $post_only || $type_lower === 'postonly' || $time_in_force_post_only || $exchange_specific_option;
-        if ($post_only) {
-            if ($ioc) {
-                throw new InvalidOrder($this->id . ' postOnly orders cannot have timeInForce equal to ' . $time_in_force);
-            } else if ($is_market) {
-                throw new InvalidOrder($this->id . ' postOnly orders cannot have type ' . $type);
+        $post_only = $post_only || ($type_lower === 'postonly') || $time_in_force_post_only || $exchange_specific_option;
+        if ($postOnly) {
+            if ($ioc || $fok) {
+                throw new InvalidOrder($this->id . ' postOnly orders cannot have $timeInForce equal to ' . $time_in_force);
+            } else if ($isMarket) {
+                throw new InvalidOrder($this->id . ' postOnly orders cannot have $type ' . $type);
             } else {
                 $time_in_force = $time_in_force_post_only ? null : $time_in_force;
-                return array('limit', true, $time_in_force, $params);
+                return array( 'limit', true, $time_in_force, $params );
             }
         } else {
-            return array($type, false, $time_in_force, $params);
+            return array( $type, false, $time_in_force, $params );
         }
     }
 


### PR DESCRIPTION
```
PHP v8.1.6                                                                % ccxt bytex createOrder ADA/USDT limit buy 1 0.4 '{"postOnly": true};'      % python3 examples/py/cli.py bytex createOrder ADA/USDT limit buy 1 0.4 '{"postOnly": true}'
CCXT v1.82.87                                                            2022-05-18T09:39:23.486Z                                                      Python v3.10.4
bytex->createOrder(ADA/USDT, limit, buy, 1, 0.4, Array)                  Node.js: v14.17.0                                                             CCXT v1.82.87
Array                                                                    CCXT v1.82.87                                                                 bytex.createOrder(ADA/USDT,limit,buy,1,0.4,{'postOnly': True})
(                                                                        bytex.createOrder (ADA/USDT, limit, buy, 1, 0.4, {"postOnly": true};)         {'amount': 1.0,
    [id] => 2530d39d-34e2-489a-97bc-6975e392cdfe                         2022-05-18T09:39:26.051Z iteration 0 passed in 713 ms                          'average': None,
    [clientOrderId] =>                                                                                                                                  'clientOrderId': None,
    [timestamp] => 1652866739660                                         {                                                                              'cost': 0.0,
    [datetime] => 2022-05-18T09:38:59.660Z                                 id: '543e9c5d-15de-4d6d-948f-c479acae61c1',                                  'datetime': '2022-05-18T09:39:09.749Z',
    [lastTradeTimestamp] =>                                                clientOrderId: undefined,                                                    'fee': None,
    [status] => open                                                       timestamp: 1652866766060,                                                    'fees': [],
    [symbol] => ADA/USDT                                                   datetime: '2022-05-18T09:39:26.060Z',                                        'filled': 0.0,
    [type] => limit                                                        lastTradeTimestamp: undefined,                                               'id': 'e53e84d8-669b-49df-a752-745520bc35b8',
    [timeInForce] => PO                                                    status: 'open',                                                              'info': {'created_at': '2022-05-18T09:39:09.749Z',
    [postOnly] => 1                                                        symbol: 'ADA/USDT',                                                                   'created_by': '159372',
    [side] => buy                                                          type: 'limit',                                                                        'fee': '0',
    [price] => 0.4                                                         timeInForce: undefined,                                                               'fee_coin': 'ada',
    [stopPrice] =>                                                         postOnly: undefined,                                                                  'fee_structure': {'maker': '0.05', 'taker': '0.1'},
    [amount] => 1                                                          side: 'buy',                                                                          'filled': '0',
    [filled] => 0                                                          price: 0.4,                                                                           'id': 'e53e84d8-669b-49df-a752-745520bc35b8',
    [remaining] => 1                                                       stopPrice: undefined,                                                                 'meta': {'post_only': True},
    [cost] => 0                                                            amount: 1,                                                                            'price': '0.4',
    [trades] => Array                                                      filled: 0,                                                                            'side': 'buy',
        (                                                                  remaining: 1,                                                                         'size': '1',
        )                                                                  cost: 0,                                                                              'status': 'new',
                                                                           trades: [],                                                                           'stop': None,
    [fee] =>                                                               fee: undefined,                                                                       'symbol': 'ada-usdt',
    [average] =>                                                           average: undefined,                                                                   'type': 'limit',
    [info] => Array                                                        info: {                                                                               'updated_at': '2022-05-18T09:39:09.749Z'},
        (                                                                    fee: '0',                                                                  'lastTradeTimestamp': None,
            [fee] => 0                                                       meta: {},                                                                  'postOnly': True,
            [symbol] => ada-usdt                                             symbol: 'ada-usdt',                                                        'price': 0.4,
            [side] => buy                                                    side: 'buy',                                                               'remaining': 1.0,
            [size] => 1                                                      size: '1',                                                                 'side': 'buy',
            [type] => limit                                                  type: 'limit',                                                             'status': 'open',
            [price] => 0.4                                                   price: '0.4',                                                              'stopPrice': None,
            [fee_structure] => Array                                         fee_structure: { maker: '0.05', taker: '0.1' },                            'symbol': 'ADA/USDT',
                (                                                            fee_coin: 'ada',                                                           'timeInForce': 'PO',
                    [maker] => 0.05                                          id: '543e9c5d-15de-4d6d-948f-c479acae61c1',                                'timestamp': 1652866749749,
                    [taker] => 0.1                                           created_by: '159372',                                                      'trades': [],
                )                                                            filled: '0',                                                               'type': 'limit'}
                                                                             status: 'new',
            [meta] => Array                                                  updated_at: '2022-05-18T09:39:26.060Z',
                (                                                            created_at: '2022-05-18T09:39:26.060Z',
                    [post_only] => 1                                         stop: null
                )                                                          },
                                                                           fees: []
            [fee_coin] => ada                                            }
            [id] => 2530d39d-34e2-489a-97bc-6975e392cdfe
            [created_by] => 159372
            [filled] => 0
            [status] => new
            [updated_at] => 2022-05-18T09:38:59.660Z
            [created_at] => 2022-05-18T09:38:59.660Z
            [stop] => 
        )

    [fees] => Array
        (
        )

)
```
