### PR TITLE
Cryptocom :: fix fetchTickers

### DIFF
--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -497,7 +497,14 @@ module.exports = class cryptocom extends Exchange {
             const symbol = market['symbol'];
             result[symbol] = this.parseTicker (ticker, market);
         }
-        return this.filterByArray (result, 'symbol', symbols);
+        const unifiedSymbols = [];
+        for (let i = 0; i < symbols.length; i++) {
+            const market = this.market (symbols[i]);
+            if (market !== undefined) {
+                unifiedSymbols.push (market['symbol']);
+            }
+        }
+        return this.filterByArray (result, 'symbol', unifiedSymbols);
     }
 
     async fetchTicker (symbol, params = {}) {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -497,7 +497,7 @@ module.exports = class cryptocom extends Exchange {
             const symbol = market['symbol'];
             result[symbol] = this.parseTicker (ticker, market);
         }
-        return result;
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     async fetchTicker (symbol, params = {}) {


### PR DESCRIPTION
- fixes #13321

Demo

```
node cli.js cryptocom fetchTickers '["BTC/USDT", "BCH/USDT"]' --spot          
Debugger attached.
2022-05-18T10:41:53.092Z
Node.js: v16.13.2
CCXT v1.82.94
cryptocom.fetchTickers (BTC/USDT,BCH/USDT)
2022-05-18T10:41:56.026Z iteration 0 passed in 2192 ms

{
  'BCH/USDT': {
    symbol: 'BCH/USDT',
    timestamp: 1652870513760,
    datetime: '2022-05-18T10:41:53.760Z',
    high: 215.37,
    low: 196.91,
    bid: 202.24,
    bidVolume: undefined,
    ask: 202.38,
    askVolume: undefined,
    vwap: undefined,
    open: 207.16,
    close: 202.28,
    last: 202.28,
    previousClose: undefined,
    change: -4.88,
    percentage: undefined,
    average: undefined,
    baseVolume: 9702.45576,
    quoteVolume: undefined,
    info: {
      i: 'BCH_USDT',
      b: '202.24',
      k: '202.38',
      a: '202.28',
      t: '1652870513760',
      v: '9702.45576',
      h: '215.37',
      l: '196.91',
      c: '-4.88'
    }
  },
  'BTC/USDT': {
    symbol: 'BTC/USDT',
    timestamp: 1652870514126,
    datetime: '2022-05-18T10:41:54.126Z',
    high: 30751.41,
    low: 29446.38,
    bid: 29935.3,
    bidVolume: undefined,
    ask: 29936.65,
    askVolume: undefined,
    vwap: undefined,
    open: 30478.9,
    close: 29936.69,
    last: 29936.69,
    previousClose: undefined,
    change: -542.21,
    percentage: undefined,
    average: undefined,
    baseVolume: 13236.715332,
    quoteVolume: undefined,
    info: {
      i: 'BTC_USDT',
      b: '29935.30',
      k: '29936.65',
      a: '29936.69',
      t: '1652870514126',
      v: '13236.715332',
      h: '30751.41',
      l: '29446.38',
      c: '-542.21'
    }
  }
}
```
