### PR TITLE
`handleOptionAndParams` in base

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2058,7 +2058,7 @@ module.exports = class Exchange {
 
     handleOptionAndParams (methodName, params, optionName, defaultValue = undefined) {
         // This method can be used to obtain method specific properties, like:
-        //    .methodOptions ('fetchPosition', 'marginMode'), .methodOptions ('fetchBalance', 'type')`,  etc
+        //    .handleOptionAndParams ('fetchPosition', 'marginMode'), .handleOptionAndParams ('fetchBalance', 'type')`,  etc
         const defaultOptionName = 'default' + this.capitalize (optionName); // we also need to check the 'defaultXyzWhatever'
         // check if params contain the key
         let value = this.safeString2 (params, optionName, defaultOptionName);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2056,6 +2056,30 @@ module.exports = class Exchange {
         return rate;
     }
 
+    handleOptionAndParams (methodName, params, optionName, defaultValue = undefined) {
+        // This method can be used to obtain method specific properties, like:
+        //    .methodOptions ('fetchPosition', 'marginMode'), .methodOptions ('fetchBalance', 'type')`,  etc
+        const defaultOptionName = 'default' + this.capitalize (optionName); // we also need to check the 'defaultXyzWhatever'
+        // check if params contain the key
+        let value = this.safeString2 (params, optionName, defaultOptionName);
+        if (value !== undefined) {
+            params = this.omit (params, [ optionName, defaultOptionName ]);
+        }
+        if (value === undefined) {
+            // check if exchange-wide method options contain the key
+            const exchangeWideMethodOptions = this.safeValue (this.options, methodName);
+            if (exchangeWideMethodOptions !== undefined) {
+                value = this.safeString2 (exchangeWideMethodOptions, optionName, defaultOptionName);
+            }
+        }
+        if (value === undefined) {
+            // check if exchange-wide options contain the key
+            value = this.safeString2 (this.options, optionName, defaultOptionName);
+        }
+        value = (value !== undefined) ? value : defaultValue;
+        return [ value, params ];
+    }
+
     handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
         const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
         const methodOptions = this.safeValue (this.options, methodName);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2056,9 +2056,8 @@ module.exports = class Exchange {
         return rate;
     }
 
-    handleOptionAndParams (methodName, params, optionName, defaultValue = undefined) {
-        // This method can be used to obtain method specific properties, like:
-        //    .handleOptionAndParams ('fetchPosition', 'marginMode'), .handleOptionAndParams ('fetchBalance', 'type')`,  etc
+    handleOptionAndParams (params, methodName, optionName, defaultValue = undefined) {
+        // This method can be used to obtain method specific properties, i.e: this.handleOptionAndParams (params, 'fetchPosition', 'marginMode', 'isolated')
         const defaultOptionName = 'default' + this.capitalize (optionName); // we also need to check the 'defaultXyzWhatever'
         // check if params contain the key
         let value = this.safeString2 (params, optionName, defaultOptionName);


### PR DESCRIPTION
This method can be used in implementations as a shorthand to get any exchange-wide, exchange-method-wide or params-wide options.
This method/PR might effectively depreciate all other individual `handleXXXAndParams`  methods, as this will be able to perform:
```
[marketType, params] = this.handleOptionAndParams (params, 'fetchXXX', 'type', 'swap' );
[subType, params] = this.handleOptionAndParams (params, 'fetchXXX', 'subType', 'linear');
[marginMode, params] = this.handleOptionAndParams (params, 'fetchXXX',  'marginMode', 'isolated');
[methodEndpoint, params] = this.handleOptionAndParams (params, 'fetchXXX', 'method', 'privateGetV1Whatever');
```