### PR TITLE
Exchange createReduceOnlyOrder

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -80,6 +80,7 @@ module.exports = class Exchange {
                 'createMarketOrder': true,
                 'createOrder': true,
                 'createPostOnlyOrder': undefined,
+                'createReduceOnlyOrder': undefined,
                 'createStopOrder': undefined,
                 'createStopLimitOrder': undefined,
                 'createStopMarketOrder': undefined,
@@ -2371,6 +2372,14 @@ module.exports = class Exchange {
             throw new NotSupported (this.id + 'createPostOnlyOrder() is not supported yet');
         }
         const query = this.extend (params, { 'postOnly': true });
+        return await this.createOrder (symbol, type, side, amount, price, query);
+    }
+
+    async createReduceOnlyOrder (symbol, type, side, amount, price, params = {}) {
+        if (!this.has['createReduceOnlyOrder']) {
+            throw new NotSupported (this.id + 'createReduceOnlyOrder() is not supported yet');
+        }
+        const query = this.extend (params, { 'reduceOnly': true });
         return await this.createOrder (symbol, type, side, amount, price, query);
     }
 

--- a/js/binance.js
+++ b/js/binance.js
@@ -2678,6 +2678,7 @@ module.exports = class binance extends Exchange {
             'type': type,
             'timeInForce': timeInForce,
             'postOnly': postOnly,
+            'reduceOnly': this.safeValue (order, 'reduceOnly'),
             'side': side,
             'price': price,
             'stopPrice': stopPrice,
@@ -2690,13 +2691,6 @@ module.exports = class binance extends Exchange {
             'fee': undefined,
             'trades': fills,
         }, market);
-    }
-
-    async createReduceOnlyOrder (symbol, type, side, amount, price = undefined, params = {}) {
-        const request = {
-            'reduceOnly': true,
-        };
-        return await this.createOrder (symbol, type, side, amount, price, this.extend (request, params));
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1460,6 +1460,7 @@ module.exports = class coinex extends Exchange {
             'type': type,
             'timeInForce': undefined,
             'postOnly': undefined,
+            'reduceOnly': undefined,
             'side': side,
             'price': priceString,
             'stopPrice': this.safeString (order, 'stop_price'),
@@ -1687,13 +1688,6 @@ module.exports = class coinex extends Exchange {
         //
         const data = this.safeValue (response, 'data');
         return this.parseOrder (data, market);
-    }
-
-    async createReduceOnlyOrder (symbol, type, side, amount, price = undefined, params = {}) {
-        const request = {
-            'reduceOnly': true,
-        };
-        return await this.createOrder (symbol, type, side, amount, price, this.extend (request, params));
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1446,6 +1446,7 @@ module.exports = class ftx extends Exchange {
             'type': type,
             'timeInForce': timeInForce,
             'postOnly': postOnly,
+            'reduceOnly': this.safeValue (order, 'reduceOnly'),
             'side': side,
             'price': price,
             'stopPrice': stopPrice,
@@ -1477,6 +1478,10 @@ module.exports = class ftx extends Exchange {
             // 'trailValue': -0.306525, // required for trailingStop orders, negative for "sell"; positive for "buy"
             // 'orderPrice': 0.306525, // optional, for stop and takeProfit orders only (market by default). If not specified, a market order will be submitted
         };
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        if (reduceOnly === true) {
+            request['reduceOnly'] = reduceOnly;
+        }
         const clientOrderId = this.safeString2 (params, 'clientId', 'clientOrderId');
         if (clientOrderId !== undefined) {
             request['clientId'] = clientOrderId;
@@ -1592,13 +1597,6 @@ module.exports = class ftx extends Exchange {
         //
         const result = this.safeValue (response, 'result', []);
         return this.parseOrder (result, market);
-    }
-
-    async createReduceOnlyOrder (symbol, type, side, amount, price = undefined, params = {}) {
-        const request = {
-            'reduceOnly': true,
-        };
-        return await this.createOrder (symbol, type, side, amount, price, this.extend (request, params));
     }
 
     async editOrder (id, symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/gateio.js
+++ b/js/gateio.js
@@ -3168,6 +3168,7 @@ module.exports = class gateio extends Exchange {
             'type': type,
             'timeInForce': timeInForce,
             'postOnly': postOnly,
+            'reduceOnly': this.safeValue (order, 'is_reduce_only'),
             'side': side,
             'price': this.parseNumber (price),
             'stopPrice': this.safeNumber (trigger, 'price'),
@@ -3181,13 +3182,6 @@ module.exports = class gateio extends Exchange {
             'trades': undefined,
             'info': order,
         }, market);
-    }
-
-    async createReduceOnlyOrder (symbol, type, side, amount, price = undefined, params = {}) {
-        const request = {
-            'reduceOnly': true,
-        };
-        return await this.createOrder (symbol, type, side, amount, price, this.extend (request, params));
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1830,6 +1830,11 @@ module.exports = class phemex extends Exchange {
         const timeInForce = this.parseTimeInForce (this.safeString (order, 'timeInForce'));
         const stopPrice = this.safeNumber (order, 'stopPx');
         const postOnly = (timeInForce === 'PO');
+        let reduceOnly = this.safeValue (order, 'reduceOnly');
+        const execInst = this.safeString (order, 'execInst');
+        if (execInst === 'ReduceOnly') {
+            reduceOnly = true;
+        }
         return {
             'info': order,
             'id': id,
@@ -1841,6 +1846,7 @@ module.exports = class phemex extends Exchange {
             'type': type,
             'timeInForce': timeInForce,
             'postOnly': postOnly,
+            'reduceOnly': reduceOnly,
             'side': side,
             'price': price,
             'stopPrice': stopPrice,
@@ -2040,13 +2046,6 @@ module.exports = class phemex extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         return this.parseOrder (data, market);
-    }
-
-    async createReduceOnlyOrder (symbol, type, side, amount, price = undefined, params = {}) {
-        const request = {
-            'reduceOnly': true,
-        };
-        return await this.createOrder (symbol, type, side, amount, price, this.extend (request, params));
     }
 
     async editOrder (id, symbol, type = undefined, side = undefined, amount = undefined, price = undefined, params = {}) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -399,6 +399,7 @@ class Exchange {
         'fetchMarketLeverageTiers' => 'fetch_market_leverage_tiers',
         'isPostOnly' => 'is_post_only',
         'createPostOnlyOrder' => 'create_post_only_order',
+        'createReduceOnlyOrder' => 'create_reduce_only_order',
         'createStopOrder' => 'create_stop_order',
         'createStopLimitOrder' => 'create_stop_limit_order',
         'createStopMarketOrder' => 'create_stop_market_order',
@@ -1292,6 +1293,7 @@ class Exchange {
             'createMarketOrder' => true,
             'createOrder' => true,
             'createPostOnlyOrder' => null,
+            'createReduceOnlyOrder' => null,
             'createStopOrder' => null,
             'editOrder' => 'emulated',
             'fetchAccounts' => null,
@@ -3962,6 +3964,15 @@ class Exchange {
             throw new NotSupported($this->id . ' create_post_only_order() is not supported yet');
         }
         $array = array('postOnly' => true);
+        $query = $this->extend($params, $array);
+        return $this->create_order($symbol, $type, $side, $amount, $price, $params);
+    }
+
+    public function create_reduce_only_order($symbol, $type, $side, $amount, $price, $params = array()) {
+        if (!$this->has['createReduceOnlyOrder']) {
+            throw new NotSupported($this->id . ' create_reduce_only_order() is not supported yet');
+        }
+        $array = array('reduceOnly' => true);
         $query = $this->extend($params, $array);
         return $this->create_order($symbol, $type, $side, $amount, $price, $params);
     }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -257,6 +257,7 @@ class Exchange(object):
         'createMarketOrder': True,
         'createOrder': True,
         'createPostOnlyOrder': None,
+        'createReduceOnlyOrder': None,
         'createStopOrder': None,
         'createStopLimitOrder': None,
         'createStopMarketOrder': None,
@@ -3014,6 +3015,12 @@ class Exchange(object):
         if not self.has['createPostOnlyOrder']:
             raise NotSupported(self.id + ' create_post_only_order() is not supported yet')
         query = self.extend(params, {'postOnly': True})
+        return self.create_order(symbol, type, side, amount, price, query)
+
+    def create_reduce_only_order(self, symbol, type, side, amount, price, params={}):
+        if not self.has['createReduceOnlyOrder']:
+            raise NotSupported(self.id + ' create_reduce_only_order() is not supported yet')
+        query = self.extend(params, {'reduceOnly': True})
         return self.create_order(symbol, type, side, amount, price, query)
 
     def create_stop_order(self, symbol, type, side, amount, price=None, stopPrice=None, params={}):


### PR DESCRIPTION
Added a createReduceOnlyOrder to Exchange.js
Adjusted the handing of reduceOnly in createOrder and parseOrder on exchanges Ascendex, FTX, GateIo, Hitbtc3, Phemex, Coinex and Binance:

Phemex createReduceOnlyOrder:
```
phemex.createReduceOnlyOrder (BTC/USD:USD, limit, sell, 14.67, 32000)
2022-05-18T20:05:37.451Z iteration 0 passed in 547 ms

{
  info: {
    bizError: '0',
    orderID: 'ce80d422-22fb-4721-8af8-87b5d75b015b',
    clOrdID: 'ccxt2022bb847ba4b497b6d4',
    symbol: 'uBTCUSD',
    side: 'Sell',
    actionTimeNs: '1652904337256038045',
    transactTimeNs: '1652904337256038045',
    orderType: 'Limit',
    priceEp: '320000000',
    price: '32000.00000000',
    orderQty: '1',
    displayQty: '0',
    timeInForce: 'GoodTillCancel',
    reduceOnly: false,
    closedPnlEv: '0',
    closedPnl: '0E-8',
    closedSize: '0',
    cumQty: '0',
    cumValueEv: '0',
    cumValue: '0E-8',
    leavesQty: '1',
    leavesValueEv: '320000',
    leavesValue: '32.00000000',
    stopDirection: 'UNSPECIFIED',
    stopPxEp: '0',
    stopPx: '0E-8',
    trigger: 'UNSPECIFIED',
    pegOffsetValueEp: '0',
    execStatus: 'PendingNew',
    pegPriceType: 'UNSPECIFIED',
    ordStatus: 'Created',
    execInst: 'ReduceOnly'
  },
  id: 'ce80d422-22fb-4721-8af8-87b5d75b015b',
  clientOrderId: 'ccxt2022bb847ba4b497b6d4',
  datetime: '2022-05-18T20:05:37.256Z',
  timestamp: 1652904337256,
  lastTradeTimestamp: 1652904337256,
  symbol: 'BTC/USD:USD',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: true,
  side: 'sell',
  price: 32000,
  stopPrice: 0,
  amount: 1,
  filled: 0,
  remaining: 1,
  cost: 0,
  average: undefined,
  status: 'open',
  fee: undefined,
  trades: undefined
}
```