### PR TITLE
`fetchLeverageTiers` to `fetchMarketLeverageTiers`  and few things

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2326,7 +2326,7 @@ module.exports = class Exchange {
         if (this.has['fetchLeverageTiers']) {
             const market = await this.market (symbol);
             if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchLeverageTiers() supports contract markets only');
+                throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() can not be emulated, because fetchLeverageTiers() supports contract markets only');
             }
             const tiers = await this.fetchLeverageTiers ([ symbol ]);
             return this.safeValue (tiers, symbol);
@@ -2446,7 +2446,7 @@ module.exports = class Exchange {
         if (this.has['fetchFundingRates']) {
             const market = await this.market (symbol);
             if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchFundingRate () supports contract markets only');
+                throw new BadSymbol (this.id + ' fetchFundingRate() can not be emulated, because fetchFundingRates() supports contract markets only');
             }
             const rates = await this.fetchFundingRates ([ symbol ], params);
             const rate = this.safeValue (rates, symbol);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2326,7 +2326,7 @@ module.exports = class Exchange {
         if (this.has['fetchLeverageTiers']) {
             const market = await this.market (symbol);
             if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() can not be emulated, because fetchLeverageTiers() supports contract markets only');
+                throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() supports contract markets only');
             }
             const tiers = await this.fetchLeverageTiers ([ symbol ]);
             return this.safeValue (tiers, symbol);
@@ -2446,7 +2446,7 @@ module.exports = class Exchange {
         if (this.has['fetchFundingRates']) {
             const market = await this.market (symbol);
             if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchFundingRate() can not be emulated, because fetchFundingRates() supports contract markets only');
+                throw new BadSymbol (this.id + ' fetchFundingRate() supports contract markets only');
             }
             const rates = await this.fetchFundingRates ([ symbol ], params);
             const rate = this.safeValue (rates, symbol);

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4339,7 +4339,7 @@ module.exports = class bybit extends Exchange {
         let market = undefined;
         market = this.market (symbol);
         if (market['spot'] || market['option']) {
-            throw new BadRequest (this.id + ' fetchLeverageTiers() symbol does not support market ' + symbol);
+            throw new BadRequest (this.id + ' fetchMarketLeverageTiers() symbol does not support market ' + symbol);
         }
         request['symbol'] = market['id'];
         const isUsdcSettled = market['settle'] === 'USDC';

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -5670,7 +5670,7 @@ module.exports = class huobi extends Exchange {
         if (symbol !== undefined) {
             const market = this.market (symbol);
             if (!market['contract']) {
-                throw new BadRequest (this.id + ' fetchLeverageTiers() symbol supports contract markets only');
+                throw new BadRequest (this.id + ' fetchMarketLeverageTiers() symbol supports contract markets only');
             }
             request['contract_code'] = market['id'];
         }

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1854,7 +1854,7 @@ module.exports = class kucoinfutures extends kucoin {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['contract']) {
-            throw new BadRequest (this.id + ' fetchLeverageTiers() supports contract markets only');
+            throw new BadRequest (this.id + ' fetchMarketLeverageTiers() supports contract markets only');
         }
         const request = {
             'symbol': market['id'],

--- a/js/okx.js
+++ b/js/okx.js
@@ -4660,7 +4660,7 @@ module.exports = class okx extends Exchange {
         const type = market['spot'] ? 'MARGIN' : this.convertToInstrumentType (market['type']);
         const uly = this.safeString (market['info'], 'uly');
         if (!uly) {
-            throw new BadRequest (this.id + ' fetchLeverageTiers() cannot fetch leverage tiers for ' + symbol);
+            throw new BadRequest (this.id + ' fetchMarketLeverageTiers() cannot fetch leverage tiers for ' + symbol);
         }
         const request = {
             'instType': type,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3915,7 +3915,7 @@ class Exchange {
         if ($this->has['fetchLeverageTiers']) {
             $market = $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadRequest($this->id . ' fetchMarketLeverageTiers() can not be emulated, because fetchLeverageTiers() supports contract markets only');
+                throw new BadRequest($this->id . ' fetch_market_leverage_tiers() supports contract markets only');
             }
             $tiers = $this->fetch_leverage_tiers(array($symbol));
             return $this->safe_value($tiers, $symbol);
@@ -4042,17 +4042,17 @@ class Exchange {
         if ($this->has['fetchFundingRates']) {
             $market = $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadSymbol($this->id . ' fetchFundingRate () supports contract markets only');
+                throw new BadSymbol($this->id . ' fetch_funding_rate () supports contract markets only');
             }
-            $rates = $this->fetchFundingRates (array( $symbol ), $params);
+            $rates = $this->fetch_funding_rates (array( $symbol ), $params);
             $rate = $this->safe_value($rates, $symbol);
             if ($rate === null) {
-                throw new NullResponse($this->id . ' fetchFundingRate () returned no data for ' . $symbol);
+                throw new NullResponse($this->id . ' fetch_funding_rate () returned no data for ' . $symbol);
             } else {
                 return $rate;
             }
         } else {
-            throw new NotSupported($this->id . ' fetchFundingRate () is not supported yet');
+            throw new NotSupported($this->id . ' fetch_funding_rate () is not supported yet');
         }
     }
 }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3915,7 +3915,7 @@ class Exchange {
         if ($this->has['fetchLeverageTiers']) {
             $market = $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadRequest($this->id . ' fetchLeverageTiers() supports contract markets only');
+                throw new BadRequest($this->id . ' fetchMarketLeverageTiers() can not be emulated, because fetchLeverageTiers() supports contract markets only');
             }
             $tiers = $this->fetch_leverage_tiers(array($symbol));
             return $this->safe_value($tiers, $symbol);

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -364,7 +364,7 @@ class Exchange extends \ccxt\Exchange {
         if ($this->has['fetchLeverageTiers']) {
             $market = yield $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadRequest($this->id . ' fetchMarketLeverageTiers() can not be emulated, because fetchLeverageTiers() supports contract markets only');
+                throw new BadRequest($this->id . ' fetch_market_leverage_tiers() supports contract markets only');
             }
             $tiers = yield $this->fetch_leverage_tiers(array($symbol));
             return $this->safe_value($tiers, $symbol);
@@ -427,17 +427,17 @@ class Exchange extends \ccxt\Exchange {
         if ($this->has['fetchFundingRates']) {
             $market = $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadSymbol($this->id . ' fetch_funding_rate() can not be emulated, because fetch_funding_rates() supports contract markets only');
+                throw new BadSymbol($this->id . ' fetch_funding_rate() supports contract markets only');
             }
             $rates = yield $this->fetchFundingRates (array( $symbol ), $params);
             $rate = $this->safe_value($rates, $symbol);
             if ($rate === null) {
-                throw new NullResponse($this->id . ' fetchFundingRate () returned no data for ' . $symbol);
+                throw new NullResponse($this->id . ' fetch_funding_rate () returned no data for ' . $symbol);
             } else {
                 return $rate;
             }
         } else {
-            throw new NotSupported($this->id . ' fetchFundingRate () is not supported yet');
+            throw new NotSupported($this->id . ' fetch_funding_rate () is not supported yet');
         }
     }
 }

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -364,7 +364,7 @@ class Exchange extends \ccxt\Exchange {
         if ($this->has['fetchLeverageTiers']) {
             $market = yield $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadRequest($this->id . ' fetchLeverageTiers() supports contract markets only');
+                throw new BadRequest($this->id . ' fetchMarketLeverageTiers() can not be emulated, because fetchLeverageTiers() supports contract markets only');
             }
             $tiers = yield $this->fetch_leverage_tiers(array($symbol));
             return $this->safe_value($tiers, $symbol);
@@ -427,7 +427,7 @@ class Exchange extends \ccxt\Exchange {
         if ($this->has['fetchFundingRates']) {
             $market = $this->market($symbol);
             if (!$market['contract']) {
-                throw new BadSymbol($this->id . ' fetchFundingRate () supports contract markets only');
+                throw new BadSymbol($this->id . ' fetch_funding_rate() can not be emulated, because fetch_funding_rates() supports contract markets only');
             }
             $rates = yield $this->fetchFundingRates (array( $symbol ), $params);
             $rate = $this->safe_value($rates, $symbol);

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -393,7 +393,7 @@ class Exchange(BaseExchange):
         if self.has['fetchLeverageTiers']:
             market = await self.market(symbol)
             if (not market['contract']):
-                raise BadRequest(self.id + ' fetch_leverage_tiers() supports contract markets only')
+                raise BadRequest(self.id + ' fetch_market_leverage_tiers() can not be emulated, because fetch_leverage_tiers() supports contract markets only')
             tiers = await self.fetch_leverage_tiers([symbol])
             return self.safe_value(tiers, symbol)
         else:

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -393,7 +393,7 @@ class Exchange(BaseExchange):
         if self.has['fetchLeverageTiers']:
             market = await self.market(symbol)
             if (not market['contract']):
-                raise BadRequest(self.id + ' fetch_market_leverage_tiers() can not be emulated, because fetch_leverage_tiers() supports contract markets only')
+                raise BadRequest(self.id + ' fetch_market_leverage_tiers() supports contract markets only')
             tiers = await self.fetch_leverage_tiers([symbol])
             return self.safe_value(tiers, symbol)
         else:
@@ -429,12 +429,12 @@ class Exchange(BaseExchange):
         if self.has['fetchFundingRates']:
             market = self.market(symbol)
             if not market['contract']:
-                raise BadSymbol(self.id + ' fetchFundingRate() supports contract markets only')
+                raise BadSymbol(self.id + ' fetch_funding_rate() supports contract markets only')
             rates = await self.fetchFundingRates([symbol], params)
             rate = self.safe_value(rates, symbol)
             if rate is None:
-                raise NullResponse(self.id + ' fetchFundingRate() returned no data for ' + symbol)
+                raise NullResponse(self.id + ' fetch_funding_rate() returned no data for ' + symbol)
             else:
                 return rate
         else:
-            raise NotSupported(self.id + ' fetchFundingRate() is not supported yet')
+            raise NotSupported(self.id + ' fetch_funding_rate() is not supported yet')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2978,7 +2978,7 @@ class Exchange(object):
         if self.has['fetchLeverageTiers']:
             market = self.market(symbol)
             if (not market['contract']):
-                raise BadRequest(self.id + ' fetch_market_leverage_tiers() can not be emulated, because fetch_leverage_tiers() supports contract markets only')
+                raise BadRequest(self.id + ' fetch_market_leverage_tiers() supports contract markets only')
             tiers = self.fetch_leverage_tiers([symbol])
             return self.safe_value(tiers, symbol)
         else:
@@ -3071,12 +3071,12 @@ class Exchange(object):
         if self.has['fetchFundingRates']:
             market = self.market(symbol)
             if not market['contract']:
-                raise BadSymbol(self.id + ' fetchFundingRate() supports contract markets only')
+                raise BadSymbol(self.id + ' fetch_funding_rate() supports contract markets only')
             rates = self.fetchFundingRates([symbol], params)
             rate = self.safe_value(rates, symbol)
             if rate is None:
-                raise NullResponse(self.id + ' fetchFundingRate() returned no data for ' + symbol)
+                raise NullResponse(self.id + ' fetch_funding_rate() returned no data for ' + symbol)
             else:
                 return rate
         else:
-            raise NotSupported(self.id + ' fetchFundingRate() is not supported yet')
+            raise NotSupported(self.id + ' fetch_funding_rate() is not supported yet')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2978,7 +2978,7 @@ class Exchange(object):
         if self.has['fetchLeverageTiers']:
             market = self.market(symbol)
             if (not market['contract']):
-                raise BadRequest(self.id + ' fetch_leverage_tiers() supports contract markets only')
+                raise BadRequest(self.id + ' fetch_market_leverage_tiers() can not be emulated, because fetch_leverage_tiers() supports contract markets only')
             tiers = self.fetch_leverage_tiers([symbol])
             return self.safe_value(tiers, symbol)
         else:


### PR DESCRIPTION
`fetchMarketLeverageTiers` seems unified method, so the exception should mention itself, not other method.