### PR TITLE
Deribit parse position

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1939,14 +1939,13 @@ module.exports = class deribit extends Exchange {
         //
         const contract = this.safeString (position, 'instrument_name');
         market = this.safeMarket (contract, market);
-        const size = this.safeString (position, 'size');
         let side = this.safeString (position, 'direction');
         side = (side === 'buy') ? 'long' : 'short';
-        const maintenanceRate = this.safeString (position, 'maintenance_margin');
         const markPrice = this.safeString (position, 'mark_price');
-        const notionalString = Precise.stringMul (markPrice, size);
         const unrealisedPnl = this.safeString (position, 'floating_profit_loss');
         const initialMarginString = this.safeString (position, 'initial_margin');
+        const notionalString = this.safeString (position, 'size_currency');
+        const maintenanceMarginString = this.safeString (position, 'maintenance_margin');
         const percentage = Precise.stringMul (Precise.stringDiv (unrealisedPnl, initialMarginString), '100');
         const currentTime = this.milliseconds ();
         return {
@@ -1955,18 +1954,18 @@ module.exports = class deribit extends Exchange {
             'timestamp': currentTime,
             'datetime': this.iso8601 (currentTime),
             'initialMargin': this.parseNumber (initialMarginString),
-            'initialMarginPercentage': this.parseNumber (Precise.stringDiv (initialMarginString, notionalString)),
-            'maintenanceMargin': this.parseNumber (Precise.stringMul (maintenanceRate, notionalString)),
-            'maintenanceMarginPercentage': this.parseNumber (maintenanceRate),
-            'entryPrice': this.safeString (position, 'average_price'),
+            'initialMarginPercentage': this.parseNumber (Precise.stringMul (Precise.stringDiv (initialMarginString, notionalString), '100')),
+            'maintenanceMargin': this.parseNumber (maintenanceMarginString),
+            'maintenanceMarginPercentage': this.parseNumber (Precise.stringMul (Precise.stringDiv (maintenanceMarginString, notionalString), '100')),
+            'entryPrice': this.safeNumber (position, 'average_price'),
             'notional': this.parseNumber (notionalString),
             'leverage': this.safeNumber (position, 'leverage'),
             'unrealizedPnl': this.parseNumber (unrealisedPnl),
             'contracts': undefined,
-            'contractSize': this.parseNumber (size),
+            'contractSize': this.safeNumber (market, 'contractSize'),
             'marginRatio': undefined,
             'liquidationPrice': this.safeNumber (position, 'estimated_liquidation_price'),
-            'markPrice': markPrice,
+            'markPrice': this.parseNumber (markPrice),
             'collateral': undefined,
             'marginMode': undefined,
             'marginType': undefined, // deprecated

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1963,7 +1963,7 @@ module.exports = class deribit extends Exchange {
             'leverage': this.safeNumber (position, 'leverage'),
             'unrealizedPnl': this.parseNumber (unrealisedPnl),
             'contracts': undefined,
-            'contractSize': this.parseNumber (size), // in USD for perpetuals on deribit
+            'contractSize': this.parseNumber (size),
             'marginRatio': undefined,
             'liquidationPrice': this.safeNumber (position, 'estimated_liquidation_price'),
             'markPrice': markPrice,

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1941,12 +1941,11 @@ module.exports = class deribit extends Exchange {
         market = this.safeMarket (contract, market);
         let side = this.safeString (position, 'direction');
         side = (side === 'buy') ? 'long' : 'short';
-        const markPrice = this.safeString (position, 'mark_price');
-        const unrealisedPnl = this.safeString (position, 'floating_profit_loss');
+        const unrealizedPnl = this.safeString (position, 'floating_profit_loss');
         const initialMarginString = this.safeString (position, 'initial_margin');
         const notionalString = this.safeString (position, 'size_currency');
         const maintenanceMarginString = this.safeString (position, 'maintenance_margin');
-        const percentage = Precise.stringMul (Precise.stringDiv (unrealisedPnl, initialMarginString), '100');
+        const percentage = Precise.stringMul (Precise.stringDiv (unrealizedPnl, initialMarginString), '100');
         const currentTime = this.milliseconds ();
         return {
             'info': position,
@@ -1959,13 +1958,13 @@ module.exports = class deribit extends Exchange {
             'maintenanceMarginPercentage': this.parseNumber (Precise.stringMul (Precise.stringDiv (maintenanceMarginString, notionalString), '100')),
             'entryPrice': this.safeNumber (position, 'average_price'),
             'notional': this.parseNumber (notionalString),
-            'leverage': this.safeNumber (position, 'leverage'),
-            'unrealizedPnl': this.parseNumber (unrealisedPnl),
+            'leverage': this.safeInteger (position, 'leverage'),
+            'unrealizedPnl': this.parseNumber (unrealizedPnl),
             'contracts': undefined,
             'contractSize': this.safeNumber (market, 'contractSize'),
             'marginRatio': undefined,
             'liquidationPrice': this.safeNumber (position, 'estimated_liquidation_price'),
-            'markPrice': this.parseNumber (markPrice),
+            'markPrice': this.safeNumber (position, 'mark_price'),
             'collateral': undefined,
             'marginMode': undefined,
             'marginType': undefined, // deprecated

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1962,8 +1962,8 @@ module.exports = class deribit extends Exchange {
             'notional': this.parseNumber (notionalString),
             'leverage': this.safeNumber (position, 'leverage'),
             'unrealizedPnl': this.parseNumber (unrealisedPnl),
-            'contracts': this.parseNumber (size),  // in USD for perpetuals on deribit
-            'contractSize': this.safeValue (market, 'contractSize'),
+            'contracts': undefined,
+            'contractSize': this.parseNumber (size), // in USD for perpetuals on deribit
             'marginRatio': undefined,
             'liquidationPrice': this.safeNumber (position, 'estimated_liquidation_price'),
             'markPrice': markPrice,


### PR DESCRIPTION
Set contracts to undefined and adjusted maintenanceMargin, initialMargin and their percentages of the notional value:
Fixes #13313
```
deribit.fetchPosition (SOL/USD:SOL)
2022-05-21T06:34:06.676Z iteration 0 passed in 178 ms

{
  info: {
    total_profit_loss: '-0.001131489',
    size_currency: '0.603420186',
    size: '30.0',
    settlement_price: '52.09',
    realized_profit_loss: '0.000615087',
    realized_funding: '0.00000443',
    open_orders_margin: '0.0',
    mark_price: '49.72',
    maintenance_margin: '0.012070224',
    leverage: '25',
    kind: 'future',
    instrument_name: 'SOL-PERPETUAL',
    initial_margin: '0.024138628',
    index_price: '49.72',
    floating_profit_loss: '-0.001131489',
    estimated_liquidation_price: '21.98',
    direction: 'buy',
    delta: '0.603420186',
    average_price: '49.81'
  },
  symbol: 'SOL/USD:SOL',
  timestamp: 1653114846676,
  datetime: '2022-05-21T06:34:06.676Z',
  initialMargin: 0.024138628,
  initialMarginPercentage: 4.000301706844126,
  maintenanceMargin: 0.012070224,
  maintenanceMarginPercentage: 2.000301660441966,
  entryPrice: 49.81,
  notional: 0.603420186,
  leverage: 25,
  unrealizedPnl: -0.001131489,
  contracts: undefined,
  contractSize: 10,
  marginRatio: undefined,
  liquidationPrice: 21.98,
  markPrice: 49.72,
  collateral: undefined,
  marginMode: undefined,
  marginType: undefined,
  side: 'long',
  percentage: -4.687461938598996
}
```