### PR TITLE
Bitmex parse positions

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1746,8 +1746,148 @@ module.exports = class bitmex extends Exchange {
         //         }
         //     ]
         //
-        // todo unify parsePosition/parsePositions
-        return response;
+        const result = this.parsePositions (response);
+        return this.filterByArray (result, 'symbol', symbols, false);
+    }
+
+    parsePosition (position, market = undefined) {
+        //
+        //     {
+        //         "account": 9371654,
+        //         "symbol": "ETHUSDT",
+        //         "currency": "USDt",
+        //         "underlying": "ETH",
+        //         "quoteCurrency": "USDT",
+        //         "commission": 0.00075,
+        //         "initMarginReq": 0.3333333333333333,
+        //         "maintMarginReq": 0.01,
+        //         "riskLimit": 1000000000000,
+        //         "leverage": 3,
+        //         "crossMargin": false,
+        //         "deleveragePercentile": 1,
+        //         "rebalancedPnl": 0,
+        //         "prevRealisedPnl": 0,
+        //         "prevUnrealisedPnl": 0,
+        //         "prevClosePrice": 2053.738,
+        //         "openingTimestamp": "2022-05-21T04:00:00.000Z",
+        //         "openingQty": 0,
+        //         "openingCost": 0,
+        //         "openingComm": 0,
+        //         "openOrderBuyQty": 0,
+        //         "openOrderBuyCost": 0,
+        //         "openOrderBuyPremium": 0,
+        //         "openOrderSellQty": 0,
+        //         "openOrderSellCost": 0,
+        //         "openOrderSellPremium": 0,
+        //         "execBuyQty": 2000,
+        //         "execBuyCost": 39260000,
+        //         "execSellQty": 0,
+        //         "execSellCost": 0,
+        //         "execQty": 2000,
+        //         "execCost": 39260000,
+        //         "execComm": 26500,
+        //         "currentTimestamp": "2022-05-21T04:35:16.397Z",
+        //         "currentQty": 2000,
+        //         "currentCost": 39260000,
+        //         "currentComm": 26500,
+        //         "realisedCost": 0,
+        //         "unrealisedCost": 39260000,
+        //         "grossOpenCost": 0,
+        //         "grossOpenPremium": 0,
+        //         "grossExecCost": 39260000,
+        //         "isOpen": true,
+        //         "markPrice": 1964.195,
+        //         "markValue": 39283900,
+        //         "riskValue": 39283900,
+        //         "homeNotional": 0.02,
+        //         "foreignNotional": -39.2839,
+        //         "posState": "",
+        //         "posCost": 39260000,
+        //         "posCost2": 39260000,
+        //         "posCross": 0,
+        //         "posInit": 13086667,
+        //         "posComm": 39261,
+        //         "posLoss": 0,
+        //         "posMargin": 13125928,
+        //         "posMaint": 435787,
+        //         "posAllowance": 0,
+        //         "taxableMargin": 0,
+        //         "initMargin": 0,
+        //         "maintMargin": 13149828,
+        //         "sessionMargin": 0,
+        //         "targetExcessMargin": 0,
+        //         "varMargin": 0,
+        //         "realisedGrossPnl": 0,
+        //         "realisedTax": 0,
+        //         "realisedPnl": -26500,
+        //         "unrealisedGrossPnl": 23900,
+        //         "longBankrupt": 0,
+        //         "shortBankrupt": 0,
+        //         "taxBase": 0,
+        //         "indicativeTaxRate": null,
+        //         "indicativeTax": 0,
+        //         "unrealisedTax": 0,
+        //         "unrealisedPnl": 23900,
+        //         "unrealisedPnlPcnt": 0.0006,
+        //         "unrealisedRoePcnt": 0.0018,
+        //         "simpleQty": null,
+        //         "simpleCost": null,
+        //         "simpleValue": null,
+        //         "simplePnl": null,
+        //         "simplePnlPcnt": null,
+        //         "avgCostPrice": 1963,
+        //         "avgEntryPrice": 1963,
+        //         "breakEvenPrice": 1964.35,
+        //         "marginCallPrice": 1328.5,
+        //         "liquidationPrice": 1328.5,
+        //         "bankruptPrice": 1308.7,
+        //         "timestamp": "2022-05-21T04:35:16.397Z",
+        //         "lastPrice": 1964.195,
+        //         "lastValue": 39283900
+        //     }
+        //
+        market = this.safeMarket (this.safeString (position, 'symbol'), market);
+        const symbol = market['symbol'];
+        const datetime = this.safeString (position, 'timestamp');
+        const crossMargin = this.safeValue (position, 'crossMargin');
+        const marginMode = (crossMargin === true) ? 'cross' : 'isolated';
+        let notional = undefined;
+        if (market['quote'] === 'USDT') {
+            notional = this.safeNumber (position, 'foreignNotional');
+        }
+        return {
+            'info': position,
+            'id': this.safeString (position, 'account'),
+            'symbol': symbol,
+            'timestamp': this.parse8601 (datetime),
+            'datetime': datetime,
+            'hedged': undefined,
+            'side': undefined,
+            'contracts': undefined,
+            'contractSize': undefined,
+            'entryPrice': this.safeNumber (position, 'avgEntryPrice'),
+            'markPrice': this.safeNumber (position, 'markPrice'),
+            'notional': notional,
+            'leverage': this.safeNumber (position, 'leverage'),
+            'collateral': undefined,
+            'initialMargin': undefined,
+            'initialMarginPercentage': this.safeNumber (position, 'initMarginReq'),
+            'maintenanceMargin': undefined,
+            'maintenanceMarginPercentage': undefined,
+            'unrealizedPnl': undefined,
+            'liquidationPrice': this.safeNumber (position, 'liquidationPrice'),
+            'marginMode': marginMode,
+            'marginRatio': undefined,
+            'percentage': this.safeNumber (position, 'unrealisedPnlPcnt'),
+        };
+    }
+
+    parsePositions (positions) {
+        const result = [];
+        for (let i = 0; i < positions.length; i++) {
+            result.push (this.parsePosition (positions[i]));
+        }
+        return result;
     }
 
     isFiat (currency) {

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1853,7 +1853,7 @@ module.exports = class bitmex extends Exchange {
         const marginMode = (crossMargin === true) ? 'cross' : 'isolated';
         let notional = undefined;
         if (market['quote'] === 'USDT') {
-            notional = this.safeNumber (position, 'foreignNotional');
+            notional = Precise.stringMul (this.safeString (position, 'foreignNotional'), '-1');
         }
         return {
             'info': position,


### PR DESCRIPTION
Added parsePosition and parsePositions to Bitmex:
```
bitmex.fetchPositions (ETH/USDT:USDT)
2022-05-21T05:28:06.879Z iteration 0 passed in 2434 ms

     id |        symbol |     timestamp |                 datetime | hedged | side | contracts | contractSize | entryPrice | markPrice |  notional | leverage | collateral | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | unrealizedPnl | liquidationPrice | marginMode | marginRatio | percentage
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6387821 | ETH/USDT:USDT | 1653110886398 | 2022-05-21T05:28:06.398Z |        |      |           |              |       1963 |  1963.899 |  39.27798 |        3 |            |               |      0.3333333333333333 |                   |                             |               |           1328.5 |   isolated |             |     0.0005
1 objects
```