### PR TITLE
[DOCS] typo on javascripts' load markets function

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2566,7 +2566,7 @@ In order to load markets manually beforehand call the ``loadMarkets ()`` / ``loa
    // JavaScript
    (async () => {
        let kraken = new ccxt.kraken ()
-       let markets = await kraken.load_markets ()
+       let markets = await kraken.loadMarkets ()
        console.log (kraken.id, markets)
    }) ()
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1039,7 +1039,7 @@ In order to load markets manually beforehand call the `loadMarkets ()` / `load_m
 // JavaScript
 (async () => {
     let kraken = new ccxt.kraken ()
-    let markets = await kraken.load_markets ()
+    let markets = await kraken.loadMarkets ()
     console.log (kraken.id, markets)
 }) ()
 ```
@@ -1304,12 +1304,12 @@ When exchange markets are loaded, you can then access market information any tim
 // JavaScript
 (async () => {
     let kraken = new ccxt.kraken ({ verbose: true }) // log HTTP requests
-    await kraken.load_markets () // request markets
+    await kraken.loadMarkets () // request markets
     console.log (kraken.id, kraken.markets)    // output a full list of all loaded markets
     console.log (Object.keys (kraken.markets)) // output a short list of market symbols
     console.log (kraken.markets['BTC/USD'])    // output single market details
-    await kraken.load_markets () // return a locally cached version, no reload
-    let reloadedMarkets = await kraken.load_markets (true) // force HTTP reload = true
+    await kraken.loadMarkets () // return a locally cached version, no reload
+    let reloadedMarkets = await kraken.loadMarkets (true) // force HTTP reload = true
     console.log (reloadedMarkets['ETH/BTC'])
 }) ()
 ```


### PR DESCRIPTION
small one: `load_markets` --> `loadMarkets`