### PR TITLE
Add parsing of fiat INR in bitbns

### DIFF
--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -432,6 +432,7 @@ module.exports = class bitbns extends Exchange {
             const numParts = parts.length;
             if (numParts > 1) {
                 let currencyId = this.safeString (parts, 1);
+                // note that "Money" stands for INR - the only fiat in bitbns
                 if (currencyId === 'Money') {
                     // bitbns treats INR differently
                     currencyId = 'INR';
@@ -459,10 +460,10 @@ module.exports = class bitbns extends Exchange {
         //
         //     {
         //         "data":{
-        //             "availableorderMoney":12.34,
+        //             "availableorderMoney":12.34, // INR
         //             "availableorderBTC":0,
         //             "availableorderXRP":0,
-        //             "inorderMoney":0,
+        //             "inorderMoney":0, // INR
         //             "inorderBTC":0,
         //             "inorderXRP":0,
         //             "inorderNEO":0,
@@ -472,7 +473,7 @@ module.exports = class bitbns extends Exchange {
         //         "code":200
         //     }
         //
-        // Note: "Money" stands for INR - the only fiat in bitbns.
+        // note that "Money" stands for INR - the only fiat in bitbns
         return this.parseBalance (response);
     }
 

--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -431,14 +431,16 @@ module.exports = class bitbns extends Exchange {
             const parts = key.split ('availableorder');
             const numParts = parts.length;
             if (numParts > 1) {
-                const currencyId = this.safeString (parts, 1);
-                if (currencyId !== 'Money') {
-                    const code = this.safeCurrencyCode (currencyId);
-                    const account = this.account ();
-                    account['free'] = this.safeString (data, key);
-                    account['used'] = this.safeString (data, 'inorder' + currencyId);
-                    result[code] = account;
+                let currencyId = this.safeString (parts, 1);
+                if (currencyId === 'Money') {
+                    // bitbns treats INR differently
+                    currencyId = 'INR';
                 }
+                const code = this.safeCurrencyCode (currencyId);
+                const account = this.account ();
+                account['free'] = this.safeString (data, key);
+                account['used'] = this.safeString (data, 'inorder' + currencyId);
+                result[code] = account;
             }
         }
         return this.safeBalance (result);
@@ -457,7 +459,7 @@ module.exports = class bitbns extends Exchange {
         //
         //     {
         //         "data":{
-        //             "availableorderMoney":0,
+        //             "availableorderMoney":12.34,
         //             "availableorderBTC":0,
         //             "availableorderXRP":0,
         //             "inorderMoney":0,
@@ -470,6 +472,7 @@ module.exports = class bitbns extends Exchange {
         //         "code":200
         //     }
         //
+        // Note: "Money" stands for INR - the only fiat in bitbns.
         return this.parseBalance (response);
     }
 

--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -434,7 +434,6 @@ module.exports = class bitbns extends Exchange {
                 let currencyId = this.safeString (parts, 1);
                 // note that "Money" stands for INR - the only fiat in bitbns
                 if (currencyId === 'Money') {
-                    // bitbns treats INR differently
                     currencyId = 'INR';
                 }
                 const code = this.safeCurrencyCode (currencyId);


### PR DESCRIPTION
bitbns implemented their balance endpoint in a weird way.
INR, the only fiat, has special key in the responses, as you can see in the PR:

Note: I double checked this.
This isn't the "Total worth or so".
The 2nd common quote is USDT, which has its amount with the rest cryptos.