### PR TITLE
Wazrix rate limit 1000

### DIFF
--- a/js/wazirx.js
+++ b/js/wazirx.js
@@ -11,7 +11,7 @@ module.exports = class wazirx extends Exchange {
             'name': 'WazirX',
             'countries': [ 'IN' ],
             'version': 'v2',
-            'rateLimit': 100,
+            'rateLimit': 1000,
             'has': {
                 'CORS': false,
                 'spot': true,


### PR DESCRIPTION
From https://docs.wazirx.com/#limits:
"Ping api will have a limit of 1 request/sec"
Also, in `fetch_order_book` I got a lot of 429s.
