### PR TITLE
Bit2c nonce = milliseconds()

### DIFF
--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -636,6 +636,10 @@ module.exports = class bit2c extends Exchange {
         };
     }
 
+    nonce () {
+        return this.milliseconds ();
+    }
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = this.urls['api'] + '/' + this.implodeParams (path, params);
         if (api === 'public') {


### PR DESCRIPTION
The default is seconds, but according to bit2c API docs, its ok to use milliseconds.
