### PR TITLE
Bitmex setMarginMode

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -54,6 +54,7 @@ module.exports = class bitmex extends Exchange {
                 'fetchTransactions': 'emulated',
                 'fetchTransfer': false,
                 'fetchTransfers': false,
+                'setMarginMode': true,
                 'transfer': false,
                 'withdraw': true,
             },
@@ -2401,6 +2402,27 @@ module.exports = class bitmex extends Exchange {
             'timestamp': this.parse8601 (datetime),
             'datetime': datetime,
         };
+    }
+
+    async setMarginMode (marginMode, symbol = undefined, params = {}) {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' setMarginMode() requires a symbol argument');
+        }
+        marginMode = marginMode.toLowerCase ();
+        if (marginMode !== 'isolated' && marginMode !== 'cross') {
+            throw new BadRequest (this.id + ' setMarginMode() marginMode argument should be isolated or cross');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if ((market['type'] !== 'swap') && (market['type'] !== 'future')) {
+            throw new BadSymbol (this.id + ' setMarginMode() supports swap and future contracts only');
+        }
+        const enabled = (marginMode === 'cross') ? false : true;
+        const request = {
+            'symbol': market['id'],
+            'enabled': enabled,
+        };
+        return await this.privatePostPositionIsolate (this.extend (request, params));
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {


### PR DESCRIPTION
Added setMarginMode to Bitmex:
```
bitmex.setMarginMode (isolated, BTC/USDT:USDT)
2022-05-23T23:00:01.823Z iteration 0 passed in 2191 ms

{
  account: '2079371',
  symbol: 'XBTUSDT',
  currency: 'USDt',
  underlying: 'XBT',
  quoteCurrency: 'USDT',
  commission: '0.00075',
  initMarginReq: '0.01',
  maintMarginReq: '0.005',
  riskLimit: '1000000000000',
  leverage: '100',
  crossMargin: false,
  deleveragePercentile: null,
  rebalancedPnl: '0',
  prevRealisedPnl: '0',
  prevUnrealisedPnl: '0',
  prevClosePrice: '30396.69',
  openingTimestamp: '2022-05-23T23:00:00.000Z',
  openingQty: '0',
  openingCost: '0',
  openingComm: '0',
  openOrderBuyQty: '0',
  openOrderBuyCost: '0',
  openOrderBuyPremium: '0',
  openOrderSellQty: '0',
  openOrderSellCost: '0',
  openOrderSellPremium: '0',
  execBuyQty: '0',
  execBuyCost: '0',
  execSellQty: '0',
  execSellCost: '0',
  execQty: '0',
  execCost: '0',
  execComm: '0',
  currentTimestamp: '2022-05-23T23:00:01.993Z',
  currentQty: '0',
  currentCost: '0',
  currentComm: '0',
  realisedCost: '0',
  unrealisedCost: '0',
  grossOpenCost: '0',
  grossOpenPremium: '0',
  grossExecCost: '0',
  isOpen: false,
  markPrice: null,
  markValue: '0',
  riskValue: '0',
  homeNotional: '0',
  foreignNotional: '0',
  posState: '',
  posCost: '0',
  posCost2: '0',
  posCross: '0',
  posInit: '0',
  posComm: '0',
  posLoss: '0',
  posMargin: '0',
  posMaint: '0',
  posAllowance: '0',
  taxableMargin: '0',
  initMargin: '0',
  maintMargin: '0',
  sessionMargin: '0',
  targetExcessMargin: '0',
  varMargin: '0',
  realisedGrossPnl: '0',
  realisedTax: '0',
  realisedPnl: '0',
  unrealisedGrossPnl: '0',
  longBankrupt: '0',
  shortBankrupt: '0',
  taxBase: '0',
  indicativeTaxRate: null,
  indicativeTax: '0',
  unrealisedTax: '0',
  unrealisedPnl: '0',
  unrealisedPnlPcnt: '0',
  unrealisedRoePcnt: '0',
  simpleQty: null,
  simpleCost: null,
  simpleValue: null,
  simplePnl: null,
  simplePnlPcnt: null,
  avgCostPrice: null,
  avgEntryPrice: null,
  breakEvenPrice: null,
  marginCallPrice: null,
  liquidationPrice: null,
  bankruptPrice: null,
  timestamp: '2022-05-23T23:00:01.993Z',
  lastPrice: null,
  lastValue: '0'
}
```