### PR TITLE
python sort-swap-markets-by-hourly-price-change example asyncio.run_until_complete -> asyncio.run

### DIFF
--- a/examples/py/sort-swap-markets-by-hourly-price-change.py
+++ b/examples/py/sort-swap-markets-by-hourly-price-change.py
@@ -65,7 +65,4 @@ async def main():
     priceChanges.sort()
     pprint(priceChanges)
 
-
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
-loop.close()
+asyncio.run(main())


### PR DESCRIPTION
Removes this deprecation warning

```
/path/to/ccxt/examples/py/sort-swap-markets-by-hourly-price-change.py:69: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
  ```