### PR TITLE
[ftx, okx] Correctly classify server errors

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -345,6 +345,7 @@ module.exports = class ftx extends Exchange {
                     'Account does not have enough balances': InsufficientFunds, // {"success":false,"error":"Account does not have enough balances"}
                     'Not authorized for subaccount-specific access': PermissionDenied, // {"success":false,"error":"Not authorized for subaccount-specific access"}
                     'Not approved to trade this product': PermissionDenied, // {"success":false,"error":"Not approved to trade this product"}
+                    'Internal Error': ExchangeNotAvailable, // {"success":false,"error":"Internal Error"}
                 },
                 'broad': {
                     // {"error":"Not logged in","success":false}

--- a/js/okx.js
+++ b/js/okx.js
@@ -347,7 +347,7 @@ module.exports = class okx extends Exchange {
                     '50023': ExchangeError, // Funding fee frozen. Operation restricted
                     '50024': BadRequest, // Parameter {0} and {1} can not exist at the same time
                     '50025': ExchangeError, // Parameter {0} count exceeds the limit {1}
-                    '50026': ExchangeError, // System error
+                    '50026': ExchangeNotAvailable, // System error, please try again later.
                     '50027': PermissionDenied, // The account is restricted from trading
                     '50028': ExchangeError, // Unable to take the order, please reach out to support center for details
                     // API Class
@@ -593,6 +593,7 @@ module.exports = class okx extends Exchange {
                     '63999': ExchangeError, // Internal system error
                 },
                 'broad': {
+                    'server error': ExchangeNotAvailable, // {"code":500,"data":{},"detailMsg":"","error_code":"500","error_message":"server error 1236805249","msg":"server error 1236805249"}
                 },
             },
             'httpExceptions': {


### PR DESCRIPTION
Raise `ExchangeNotAvailable` instead of `ExchangeError` for temporary server-side errors on FTX and OKX so that they can be retried in userspace.

I observed these exceptions in production.