### PR TITLE
Bitmex createReduceOnlyOrder

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -23,21 +23,27 @@ module.exports = class bitmex extends Exchange {
                 'CORS': undefined,
                 'spot': false,
                 'margin': false,
-                'swap': undefined, // has but not fully implemented
-                'future': undefined, // has but not fully implemented
-                'option': undefined, // has but not fully implemented
+                'swap': true,
+                'future': true,
+                'option': false,
+                'addMargin': undefined,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': true,
                 'createOrder': true,
+                'createReduceOnlyOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
                 'fetchClosedOrders': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRateHistory': true,
+                'fetchFundingRate': false,
+                'fetchFundingRates': true,
                 'fetchIndexOHLCV': false,
                 'fetchLedger': true,
+                'fetchLeverage': false,
                 'fetchLeverageTiers': false,
+                'fetchMarketLeverageTiers': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
@@ -46,7 +52,9 @@ module.exports = class bitmex extends Exchange {
                 'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchOrders': true,
+                'fetchPosition': false,
                 'fetchPositions': true,
+                'fetchPositionsRisk': false,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
@@ -54,8 +62,11 @@ module.exports = class bitmex extends Exchange {
                 'fetchTransactions': 'emulated',
                 'fetchTransfer': false,
                 'fetchTransfers': false,
+                'reduceMargin': undefined,
                 'setLeverage': true,
+                'setMargin': undefined,
                 'setMarginMode': true,
+                'setPositionMode': false,
                 'transfer': false,
                 'withdraw': true,
             },
@@ -1661,12 +1672,21 @@ module.exports = class bitmex extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const orderType = this.capitalize (type);
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        if (reduceOnly !== undefined) {
+            if ((market['type'] !== 'swap') && (market['type'] !== 'future')) {
+                throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + market['type'] + ' orders, reduceOnly orders are supported for swap and future markets only');
+            }
+        }
         const request = {
             'symbol': market['id'],
             'side': this.capitalize (side),
-            'orderQty': parseFloat (this.amountToPrecision (symbol, amount)),
+            'orderQty': parseFloat (this.amountToPrecision (symbol, amount)), // lot size 1000 for 1 contract
             'ordType': orderType,
         };
+        if (reduceOnly) {
+            request['execInst'] = 'ReduceOnly';
+        }
         if ((orderType === 'Stop') || (orderType === 'StopLimit') || (orderType === 'MarketIfTouched') || (orderType === 'LimitIfTouched')) {
             const stopPrice = this.safeNumber2 (params, 'stopPx', 'stopPrice');
             if (stopPrice === undefined) {

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1681,7 +1681,7 @@ module.exports = class bitmex extends Exchange {
         const request = {
             'symbol': market['id'],
             'side': this.capitalize (side),
-            'orderQty': parseFloat (this.amountToPrecision (symbol, amount)), // lot size 1000 for 1 contract
+            'orderQty': parseFloat (this.amountToPrecision (symbol, amount)), // lot size multiplied by the number of contracts
             'ordType': orderType,
         };
         if (reduceOnly) {


### PR DESCRIPTION
Added createReduceOnlyOrder functionality to Bitmex:

Set the rest of the swap and futures related methods in 'has' to true, false or undefined.

```
bitmex.createReduceOnlyOrder (BTC/USDT:USDT, market, sell, 1000)
2022-05-26T19:21:56.085Z iteration 0 passed in 2168 ms

{
  info: {
    orderID: '64b5454f-0a2a-4c6a-9e2c-df4e462e6dba',
    clOrdID: '',
    clOrdLinkID: '',
    account: '2079371',
    symbol: 'XBTUSDT',
    side: 'Sell',
    simpleOrderQty: null,
    orderQty: '1000',
    price: '29375.5',
    displayQty: null,
    stopPx: null,
    pegOffsetValue: null,
    pegPriceType: '',
    currency: 'USDT',
    settlCurrency: 'USDt',
    ordType: 'Market',
    timeInForce: 'ImmediateOrCancel',
    execInst: 'ReduceOnly',
    contingencyType: '',
    exDestination: 'XBME',
    ordStatus: 'Filled',
    triggered: '',
    workingIndicator: false,
    ordRejReason: '',
    simpleLeavesQty: null,
    leavesQty: '0',
    simpleCumQty: null,
    cumQty: '1000',
    avgPx: '29375.5',
    multiLegReportingType: 'SingleSecurity',
    text: 'Submitted via API.',
    transactTime: '2022-05-26T19:21:56.464Z',
    timestamp: '2022-05-26T19:21:56.464Z'
  },
  id: '64b5454f-0a2a-4c6a-9e2c-df4e462e6dba',
  clientOrderId: '',
  timestamp: 1653592916464,
  datetime: '2022-05-26T19:21:56.464Z',
  lastTradeTimestamp: 1653592916464,
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: false,
  side: 'sell',
  price: 29375.5,
  stopPrice: undefined,
  amount: 1000,
  cost: 29375500,
  average: 29375.5,
  filled: 1000,
  remaining: 0,
  status: 'closed',
  fee: undefined,
  trades: [],
  fees: []
}
```