### PR TITLE
huobi - fetchPosition removal

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -83,7 +83,7 @@ module.exports = class huobi extends Exchange {
                 'fetchOrderBooks': undefined,
                 'fetchOrders': true,
                 'fetchOrderTrades': true,
-                'fetchPosition': true,
+                'fetchPosition': false,
                 'fetchPositions': true,
                 'fetchPositionsRisk': false,
                 'fetchPremiumIndexOHLCV': true,
@@ -5713,95 +5713,50 @@ module.exports = class huobi extends Exchange {
                 'future': 'contractPrivatePostApiV1ContractAccountPositionInfo',
                 'swap': 'contractPrivatePostSwapApiV1SwapAccountPositionInfo',
             });
-            // future
+            //
+            // future & swap has almost same structure
+            //
             //     {
-            //       status: 'ok',
-            //       data: [
+            //       "status": "ok",
+            //       "data": [
             //         {
-            //           symbol: 'BTC',
-            //           contract_code: 'BTC-USD',
-            //           margin_balance: 0.000752347253890835,
-            //           margin_position: 0.000705870726835087,
-            //           margin_frozen: 0,
-            //           margin_available: 0.000046476527055748,
-            //           profit_real: 0,
-            //           profit_unreal: -0.000004546248622,
-            //           risk_rate: 1.0508428311146076,
-            //           withdraw_available: 0.000046476527055748,
-            //           liquidation_price: 35017.91655851386,
-            //           lever_rate: 3,
-            //           adjust_factor: 0.015,
-            //           margin_static: 0.000756893502512835,
-            //           positions: [
-            //             {
-            //               symbol: 'BTC',
-            //               contract_code: 'BTC-USD',
-            //               volume: 1,
-            //               available: 1,
-            //               frozen: 0,
-            //               cost_open: 47150.000000000015,
-            //               cost_hold: 47324.6,
-            //               profit_unreal: -0.000004546248622,
-            //               profit_rate: 0.00463757067530574,
-            //               lever_rate: 3,
-            //               position_margin: 0.000705870726835087,
-            //               direction: 'buy',
-            //               profit: 0.0000032785936199,
-            //               last_price: 47223
-            //             }
-            //           ]
+            //             "symbol": "XRP",
+            //             "contract_code": "XRP-USD", // only present in swap
+            //             "margin_balance": 12.186361450698276582,
+            //             "margin_position": 5.036261079774375503,
+            //             "margin_frozen": 0E-18,
+            //             "margin_available": 7.150100370923901079,
+            //             "profit_real": -0.012672343876723438,
+            //             "profit_unreal": 0.163382354575000020,
+            //             "risk_rate": 2.344723929650649798,
+            //             "withdraw_available": 6.986718016348901059,
+            //             "liquidation_price": 0.271625200493799547,
+            //             "lever_rate": 5,
+            //             "adjust_factor": 0.075000000000000000,
+            //             "margin_static": 12.022979096123276562,
+            //             "positions": [{
+            //                     "symbol": "XRP",
+            //                     "contract_code": "XRP-USD",
+            //                     // "contract_type": "this_week", // only present in future
+            //                     "volume": 1.0,
+            //                     "available": 1.0,
+            //                     "frozen": 0E-18,
+            //                     "cost_open": 0.394560000000000000,
+            //                     "cost_hold": 0.394560000000000000,
+            //                     "profit_unreal": 0.163382354575000020,
+            //                     "profit_rate": 0.032232070910556005,
+            //                     "lever_rate": 5,
+            //                     "position_margin": 5.036261079774375503,
+            //                     "direction": "buy",
+            //                     "profit": 0.163382354575000020,
+            //                     "last_price": 0.39712
+            //                 }
+            //             ]
             //         }
             //       ],
-            //       ts: 1641162795228
+            //       "ts": 1653600470199
             //     }
             //
-            // swap
-            //     {
-            //       status: 'ok',
-            //       data: [
-            //         {
-            //           positions: [
-            //             {
-            //               symbol: 'BTC',
-            //               contract_code: 'BTC-USDT',
-            //               volume: 1,
-            //               available: 1,
-            //               frozen: 0,
-            //               cost_open: 47027.1,
-            //               cost_hold: 47324.4,
-            //               profit_unreal: 0.1705,
-            //               profit_rate: -0.269631765513927,
-            //               lever_rate: 100,
-            //               position_margin: 0.471539,
-            //               direction: 'sell',
-            //               profit: -0.1268,
-            //               last_price: 47153.9,
-            //               margin_asset: 'USDT',
-            //               margin_mode: 'isolated',
-            //               margin_account: 'BTC-USDT'
-            //             }
-            //           ],
-            //           symbol: 'BTC',
-            //           margin_balance: 8.01274699,
-            //           margin_position: 0.471539,
-            //           margin_frozen: 0,
-            //           margin_available: 7.54120799,
-            //           profit_real: 0,
-            //           profit_unreal: 0.1705,
-            //           risk_rate: 16.442755615124092,
-            //           withdraw_available: 7.37070799,
-            //           liquidation_price: 54864.89009448036,
-            //           lever_rate: 100,
-            //           adjust_factor: 0.55,
-            //           margin_static: 7.84224699,
-            //           contract_code: 'BTC-USDT',
-            //           margin_asset: 'USDT',
-            //           margin_mode: 'isolated',
-            //           margin_account: 'BTC-USDT'
-            //         }
-            //       ],
-            //       ts: 1641162539767
-            //     }
             // cross usdt swap
             // {
             //     "status":"ok",


### PR DESCRIPTION
this might be merged or not, depending your discretion.
but we might wait until we redefine the `fetchPosition` and thus, the existing users will not have unexpected removal of `fP`, instead they will need a quick transition to new unified `fP` signature.

(the response sample was updated with better version).