### PR TITLE
[FTX] Remove redundant information in fetchTradingFees response

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1234,12 +1234,8 @@ module.exports = class ftx extends Exchange {
         for (let i = 0; i < this.symbols.length; i++) {
             const symbol = this.symbols[i];
             tradingFees[symbol] = {
-                'info': response,
-                'symbol': symbol,
                 'maker': maker,
                 'taker': taker,
-                'percentage': true,
-                'tierBased': true,
             };
         }
         return tradingFees;


### PR DESCRIPTION
The fetchTradingFees response contains a list of markets in which you append the privateGetAccount response for each market; this can cause the response to be really heavy (more than 2M lines in my case).

This PR only keeps maker and taker fees for each market in the response.