### PR TITLE
Coinex createOrder

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1789,10 +1789,18 @@ module.exports = class coinex extends Exchange {
                 }
             }
         }
-        params = this.omit (params, [ 'reduceOnly', 'position_id', 'positionId', 'timeInForce', 'postOnly', 'stopPrice', 'stop_price', 'stop_type' ]);
+        const accountId = this.safeInteger (params, 'account_id');
+        const defaultType = this.safeString (this.options, 'defaultType');
+        if (defaultType === 'margin') {
+            if (accountId === undefined) {
+                throw new BadRequest (this.id + ' createOrder() requires an account_id parameter for margin orders');
+            }
+            request['account_id'] = accountId;
+        }
+        params = this.omit (params, [ 'account_id', 'reduceOnly', 'position_id', 'positionId', 'timeInForce', 'postOnly', 'stopPrice', 'stop_price', 'stop_type' ]);
         const response = await this[method] (this.extend (request, params));
         //
-        // Spot
+        // Spot and Margin
         //
         //     {
         //         "code": 0,


### PR DESCRIPTION
Added margin functionality to createOrder:
```
node examples/js/cli coinex createOrder BTC/USDT limit sell 0.0008 35000 '{"account_id":"1"}'

coinex.createOrder (BTC/USDT, limit, sell, 0.0008, 35000, [object Object])
2022-05-31T23:23:27.151Z iteration 0 passed in 336 ms

{
  id: '77865943356',
  clientOrderId: undefined,
  datetime: '2022-05-31T23:23:27.000Z',
  timestamp: 1654039407000,
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: 'sell',
  price: 35000,
  stopPrice: undefined,
  cost: 0,
  average: undefined,
  amount: 0.0008,
  filled: 0,
  remaining: 0.0008,
  trades: [],
  fee: { currency: 'USDT', cost: 0 },
  info: {
    amount: '0.0008',
    asset_fee: '0',
    avg_price: '0.00',
    client_id: '',
    create_time: '1654039407',
    deal_amount: '0',
    deal_fee: '0',
    deal_money: '0',
    fee_asset: null,
    fee_discount: '1',
    finished_time: null,
    id: '77865943356',
    left: '0.0008',
    maker_fee_rate: '0.002',
    market: 'BTCUSDT',
    money_fee: '0',
    order_type: 'limit',
    price: '35000',
    status: 'not_deal',
    stock_fee: '0',
    taker_fee_rate: '0.002',
    type: 'sell'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```