### PR TITLE
emulateSingleMarketMethod

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -320,8 +320,6 @@ module.exports = class Exchange {
                 this[property] = value
             }
         }
-
-        this.emulateSingleMarketMethod ('fetchPosition', 'fetchPositions');
         
         // http client options
         const agentOptions = {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -320,6 +320,8 @@ module.exports = class Exchange {
                 this[property] = value
             }
         }
+        this.emulateSingleMarketMethod ('fetchPosition');
+        
         // http client options
         const agentOptions = {
             'keepAlive': true,
@@ -609,6 +611,15 @@ module.exports = class Exchange {
 
     onJsonResponse (responseBody) {
         return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
+    }
+
+    emulateSingleMarketMethod (emulatedMethod, multiMarketMethod = undefined) {
+        if (multiMarketMethod === undefined) {
+            multiMarketMethod = emulatedMethod + 's';
+        }
+        if (this.has[multiMarketMethod] && this.has[emulatedMethod] === undefined) {
+            this.has[emulatedMethod] = 'emulated';
+        }
     }
 
     async loadMarketsHelper (reload = false, params = {}) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -320,7 +320,6 @@ module.exports = class Exchange {
                 this[property] = value
             }
         }
-        
         // http client options
         const agentOptions = {
             'keepAlive': true,
@@ -352,6 +351,7 @@ module.exports = class Exchange {
         if (this.markets) {
             this.setMarkets (this.markets)
         }
+        this.addEmulatedMethodsToHas ();
     }
 
     encodeURIComponent (...args) {
@@ -612,12 +612,6 @@ module.exports = class Exchange {
         return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
     }
 
-    emulateSingleMarketMethod (emulatedMethod, multiMarketMethod) {
-        if (this.has[multiMarketMethod] && this.has[emulatedMethod] === undefined) {
-            this.has[emulatedMethod] = 'emulated';
-        }
-    }
-
     async loadMarketsHelper (reload = false, params = {}) {
         if (!reload && this.markets) {
             if (!this.markets_by_id) {
@@ -803,6 +797,18 @@ module.exports = class Exchange {
 
     // ------------------------------------------------------------------------
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
+
+    addEmulatedMethodsToHas () {
+        // Place all emulated methods inside here
+        this.emulateSingleMarketMethod ('fetchFundingRate', 'fetchFundingRates');
+        this.emulateSingleMarketMethod ('fetchMarketLeverageTiers', 'fetchLeverageTiers');
+    }
+
+    emulateSingleMarketMethod (emulatedMethod, multiMarketMethod) {
+        if (this.has[multiMarketMethod] && this.has[emulatedMethod] === undefined) {
+            this.has[emulatedMethod] = 'emulated';
+        }
+    }
 
     setMarkets (markets, currencies = undefined) {
         const values = [];

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -320,7 +320,8 @@ module.exports = class Exchange {
                 this[property] = value
             }
         }
-        this.emulateSingleMarketMethod ('fetchPosition');
+
+        this.emulateSingleMarketMethod ('fetchPosition', 'fetchPositions');
         
         // http client options
         const agentOptions = {
@@ -613,10 +614,7 @@ module.exports = class Exchange {
         return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
     }
 
-    emulateSingleMarketMethod (emulatedMethod, multiMarketMethod = undefined) {
-        if (multiMarketMethod === undefined) {
-            multiMarketMethod = emulatedMethod + 's';
-        }
+    emulateSingleMarketMethod (emulatedMethod, multiMarketMethod) {
         if (this.has[multiMarketMethod] && this.has[emulatedMethod] === undefined) {
             this.has[emulatedMethod] = 'emulated';
         }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1395,7 +1395,7 @@ class Exchange {
                         $value;
             }
         }
-        $this->emulate_single_market_method('fetchPosition');
+        $this->emulate_single_market_method('fetchPosition', 'fetchPositions');
 
         $this->tokenBucket = array(
             'delay' => 0.001,
@@ -1631,10 +1631,7 @@ class Exchange {
         return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)([,}])/', '":"$1"$2', $response_body) : $response_body;
     }
 
-    public function emulate_single_market_method($emulated_method, $multi_market_method=null) {
-        if ($multi_market_method === null) {
-            $multi_market_method = $emulated_method . 's';
-        }
+    public function emulate_single_market_method($emulated_method, $multi_market_method) {
         if ($this->has[$multi_market_method] && $this->has[$emulated_method] === null) {
             $this->has[$emulated_method] = 'emulated';
         }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1421,6 +1421,8 @@ class Exchange {
         if ($this->markets) {
             $this->set_markets($this->markets);
         }
+        
+        $this->add_emulated_methods_to_has();
     }
 
     public function set_sandbox_mode($enabled) {
@@ -1628,12 +1630,6 @@ class Exchange {
 
     public function on_json_response($response_body) {
         return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)([,}])/', '":"$1"$2', $response_body) : $response_body;
-    }
-
-    public function emulate_single_market_method($emulated_method, $multi_market_method) {
-        if ($this->has[$multi_market_method] && $this->has[$emulated_method] === null) {
-            $this->has[$emulated_method] = 'emulated';
-        }
     }
 
     public function fetch($url, $method = 'GET', $headers = null, $body = null) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1395,7 +1395,6 @@ class Exchange {
                         $value;
             }
         }
-        $this->emulate_single_market_method('fetchPosition', 'fetchPositions');
 
         $this->tokenBucket = array(
             'delay' => 0.001,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1395,6 +1395,7 @@ class Exchange {
                         $value;
             }
         }
+        $this->emulate_single_market_method('fetchPosition');
 
         $this->tokenBucket = array(
             'delay' => 0.001,
@@ -1628,6 +1629,15 @@ class Exchange {
 
     public function on_json_response($response_body) {
         return (is_string($response_body) && $this->quoteJsonNumbers) ? preg_replace('/":([+.0-9eE-]+)([,}])/', '":"$1"$2', $response_body) : $response_body;
+    }
+
+    public function emulate_single_market_method($emulated_method, $multi_market_method=null) {
+        if ($multi_market_method === null) {
+            $multi_market_method = $emulated_method . 's';
+        }
+        if ($this->has[$multi_market_method] && $this->has[$emulated_method] === null) {
+            $this->has[$emulated_method] = 'emulated';
+        }
     }
 
     public function fetch($url, $method = 'GET', $headers = null, $body = null) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -393,6 +393,7 @@ class Exchange(object):
         self.userAgent = default_user_agent()
 
         settings = self.deep_extend(self.describe(), config)
+        self.emulate_single_market_method('fetchPosition', 'fetchPositions')
 
         for key in settings:
             if hasattr(self, key) and isinstance(getattr(self, key), dict):
@@ -567,6 +568,12 @@ class Exchange(object):
             return json.loads(response_body, parse_float=str, parse_int=str)
         else:
             return json.loads(response_body)
+
+    def emulate_single_market_method(self, emulated_method, multi_market_method=None):
+        if multi_market_method is None:
+            multi_market_method = emulated_method + 's'
+        if self.has[multi_market_method] and self.has[single_market_method] is None:
+            self.has[emulated_method] = 'emulated'
 
     def fetch(self, url, method='GET', headers=None, body=None):
         """Perform a HTTP request and return decoded JSON data"""

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -393,7 +393,6 @@ class Exchange(object):
         self.userAgent = default_user_agent()
 
         settings = self.deep_extend(self.describe(), config)
-        self.emulate_single_market_method('fetchPosition', 'fetchPositions')
 
         for key in settings:
             if hasattr(self, key) and isinstance(getattr(self, key), dict):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -429,6 +429,7 @@ class Exchange(object):
 
         self.session = self.session if self.session or not self.synchronous else Session()
         self.logger = self.logger if self.logger else logging.getLogger(__name__)
+        self.add_emulated_methods_to_has()
 
     def __del__(self):
         if self.session:
@@ -567,10 +568,6 @@ class Exchange(object):
             return json.loads(response_body, parse_float=str, parse_int=str)
         else:
             return json.loads(response_body)
-
-    def emulate_single_market_method(self, emulated_method, multi_market_method):
-        if self.has[multi_market_method] and self.has[emulated_method] is None:
-            self.has[emulated_method] = 'emulated'
 
     def fetch(self, url, method='GET', headers=None, body=None):
         """Perform a HTTP request and return decoded JSON data"""

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -569,10 +569,8 @@ class Exchange(object):
         else:
             return json.loads(response_body)
 
-    def emulate_single_market_method(self, emulated_method, multi_market_method=None):
-        if multi_market_method is None:
-            multi_market_method = emulated_method + 's'
-        if self.has[multi_market_method] and self.has[single_market_method] is None:
+    def emulate_single_market_method(self, emulated_method, multi_market_method):
+        if self.has[multi_market_method] and self.has[emulated_method] is None:
             self.has[emulated_method] = 'emulated'
 
     def fetch(self, url, method='GET', headers=None, body=None):


### PR DESCRIPTION
Makes it so that you can add `this.emulateSingleMarketMethod ('fetchSingle', 'fetchMulti');` to the method `addEmulatedMethodsToHas` and all exchanges that contain `fetchMulti` will get `has['fetchSingle'] == 'emulated'`