### PR TITLE
safeTicker - use safeString for Precise values

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1299,15 +1299,15 @@ module.exports = class Exchange {
     }
 
     safeTicker (ticker, market = undefined) {
-        let open = this.safeValue (ticker, 'open');
-        let close = this.safeValue (ticker, 'close');
-        let last = this.safeValue (ticker, 'last');
-        let change = this.safeValue (ticker, 'change');
-        let percentage = this.safeValue (ticker, 'percentage');
-        let average = this.safeValue (ticker, 'average');
-        let vwap = this.safeValue (ticker, 'vwap');
-        const baseVolume = this.safeValue (ticker, 'baseVolume');
-        const quoteVolume = this.safeValue (ticker, 'quoteVolume');
+        let open = this.safeString (ticker, 'open');
+        let close = this.safeString (ticker, 'close');
+        let last = this.safeString (ticker, 'last');
+        let change = this.safeString (ticker, 'change');
+        let percentage = this.safeString (ticker, 'percentage');
+        let average = this.safeString (ticker, 'average');
+        let vwap = this.safeString (ticker, 'vwap');
+        const baseVolume = this.safeString (ticker, 'baseVolume');
+        const quoteVolume = this.safeString (ticker, 'quoteVolume');
         if (vwap === undefined) {
             vwap = Precise.stringDiv (quoteVolume, baseVolume);
         }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2243,15 +2243,15 @@ class Exchange {
     }
 
     public function safe_ticker($ticker, $market = null) {
-        $open = $this->safe_value($ticker, 'open');
-        $close = $this->safe_value($ticker, 'close');
-        $last = $this->safe_value($ticker, 'last');
-        $change = $this->safe_value($ticker, 'change');
-        $percentage = $this->safe_value($ticker, 'percentage');
-        $average = $this->safe_value($ticker, 'average');
-        $vwap = $this->safe_value($ticker, 'vwap');
-        $baseVolume = $this->safe_value($ticker, 'baseVolume');
-        $quoteVolume = $this->safe_value($ticker, 'quoteVolume');
+        $open = $this->safe_string($ticker, 'open');
+        $close = $this->safe_string($ticker, 'close');
+        $last = $this->safe_string($ticker, 'last');
+        $change = $this->safe_string($ticker, 'change');
+        $percentage = $this->safe_string($ticker, 'percentage');
+        $average = $this->safe_string($ticker, 'average');
+        $vwap = $this->safe_string($ticker, 'vwap');
+        $baseVolume = $this->safe_string($ticker, 'baseVolume');
+        $quoteVolume = $this->safe_string($ticker, 'quoteVolume');
         if ($vwap === null) {
             $vwap = Precise::string_div($quoteVolume, $baseVolume);
         }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2007,15 +2007,15 @@ class Exchange(object):
         return timestamp - offset + (ms if direction == ROUND_UP else 0)
 
     def safe_ticker(self, ticker, market=None):
-        open = self.safe_value(ticker, 'open')
-        close = self.safe_value(ticker, 'close')
-        last = self.safe_value(ticker, 'last')
-        change = self.safe_value(ticker, 'change')
-        percentage = self.safe_value(ticker, 'percentage')
-        average = self.safe_value(ticker, 'average')
-        vwap = self.safe_value(ticker, 'vwap')
-        baseVolume = self.safe_value(ticker, 'baseVolume')
-        quoteVolume = self.safe_value(ticker, 'quoteVolume')
+        open = self.safe_string(ticker, 'open')
+        close = self.safe_string(ticker, 'close')
+        last = self.safe_string(ticker, 'last')
+        change = self.safe_string(ticker, 'change')
+        percentage = self.safe_string(ticker, 'percentage')
+        average = self.safe_string(ticker, 'average')
+        vwap = self.safe_string(ticker, 'vwap')
+        baseVolume = self.safe_string(ticker, 'baseVolume')
+        quoteVolume = self.safe_string(ticker, 'quoteVolume')
         if vwap is None:
             vwap = Precise.string_div(quoteVolume, baseVolume)
         if (last is not None) and (close is None):


### PR DESCRIPTION
This is to fix an error that appeared when using safeTicker because the Precise library requires strings