### PR TITLE
Coinex fetchMyTrades

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -909,7 +909,7 @@ module.exports = class coinex extends Exchange {
         //          "date_ms":  1638990110518
         //      },
         //
-        // Spot fetchMyTrades (private)
+        // Spot and Margin fetchMyTrades (private)
         //
         //      {
         //          "id": 2611520950,
@@ -2525,9 +2525,18 @@ module.exports = class coinex extends Exchange {
             method = 'privateGetOrderUserDeals';
             request['page'] = 1;
         }
+        const accountId = this.safeInteger (params, 'account_id');
+        const defaultType = this.safeString (this.options, 'defaultType');
+        if (defaultType === 'margin') {
+            if (accountId === undefined) {
+                throw new BadRequest (this.id + ' fetchMyTrades() requires an account_id parameter for margin trades');
+            }
+            request['account_id'] = accountId;
+            params = this.omit (params, 'account_id');
+        }
         const response = await this[method] (this.extend (request, params));
         //
-        // Spot
+        // Spot and Margin
         //
         //      {
         //          "code": 0,


### PR DESCRIPTION
Added margin functionality to fetchMyTrades:
```
node examples/js/cli coinex fetchMyTrades BTC/USDT undefined undefined '{"account_id":"1"}'

coinex.fetchMyTrades (BTC/USDT, , , [object Object])
2022-06-01T21:39:07.136Z iteration 0 passed in 262 ms

    timestamp |                 datetime |   symbol |         id |       order | type | side | takerOrMaker |    price |     amount |          cost |                                        fee |                                         fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1654119386000 | 2022-06-01T21:36:26.000Z | BTC/USDT | 2884209139 | 77951178000 |      | sell |        taker | 29688.08 | 0.00054681 | 16.2337390248 | {"cost":0.0324674780496,"currency":"USDT"} | [{"currency":"USDT","cost":0.0324674780496}]
1654119401000 | 2022-06-01T21:36:41.000Z | BTC/USDT | 2884209615 | 77951191449 |      |  buy |        taker | 29688.09 | 0.00054567 | 16.1999000703 |    {"cost":0.00000109134,"currency":"BTC"} |    [{"currency":"BTC","cost":0.00000109134}]
2 objects
```