### PR TITLE
Huobi fetchSettlementHistory

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -6368,7 +6368,8 @@ module.exports = class huobi extends Exchange {
         //
         const data = this.safeValue (response, 'data');
         const settlementRecord = this.safeValue (data, 'settlement_record');
-        return this.parseSettlements (settlementRecord, market);
+        const settlements = this.parseSettlements (settlementRecord, market);
+        return this.sortBy (settlements, 'timestamp');
     }
 
     parseSettlements (settlements, market) {

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -87,6 +87,7 @@ module.exports = class huobi extends Exchange {
                 'fetchPositions': true,
                 'fetchPositionsRisk': false,
                 'fetchPremiumIndexOHLCV': true,
+                'fetchSettlementHistory': true,
                 'fetchStatus': true,
                 'fetchTicker': true,
                 'fetchTickers': true,
@@ -6261,6 +6262,206 @@ module.exports = class huobi extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,
+        };
+    }
+
+    async fetchSettlementHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name huobi#fetchSettlementHistory
+         * @description Fetches historical settlement records
+         * @param {str} symbol unified symbol of the market to fetch the settlement history for
+         * @param {int} since timestamp in ms, value range = current time - 90 days，default = current time - 90 days
+         * @param {int} limit page items, default 20, shall not exceed 50
+         * @param {dict} params exchange specific params
+         * @param {int} params.till timestamp in ms, value range = start_time -> current time，default = current time
+         * @param {int} params.page_index page index, default page 1 if not filled
+         * @returns A list of settlement history objects
+         */
+        const code = this.safeString (params, 'code');
+        const till = this.safeInteger (params, 'till');
+        params = this.omit (params, 'till');
+        const market = (symbol === undefined) ? undefined : this.market (symbol);
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchSettlementHistory', market, params);
+        if (type === 'future') {
+            if (symbol === undefined && code === undefined) {
+                throw new ArgumentsRequired (this.id + ' requires a symbol argument or params["code"] for fetchSettlementHistory future');
+            }
+        } else if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' requires a symbol argument for fetchSettlementHistory swap');
+        }
+        const request = {};
+        if (market['future']) {
+            request['symbol'] = market['baseId'];
+        } else {
+            request['contract_code'] = market['id'];
+        }
+        if (since !== undefined) {
+            request['start_at'] = since;
+        }
+        if (limit !== undefined) {
+            request['page_size'] = limit;
+        }
+        if (till !== undefined) {
+            request['end_at'] = till;
+        }
+        let method = 'contractPublicGetApiV1ContractSettlementRecords';
+        if (market['swap']) {
+            if (market['linear']) {
+                method = 'contractPublicGetLinearSwapApiV1SwapSettlementRecords';
+            } else {
+                method = 'contractPublicGetSwapApiV1SwapSettlementRecords';
+            }
+        }
+        const response = await this[method] (this.extend (request, query));
+        //
+        // linear swap, coin-m swap
+        //
+        //    {
+        //        "status": "ok",
+        //        "data": {
+        //        "total_page": 14,
+        //        "current_page": 1,
+        //        "total_size": 270,
+        //        "settlement_record": [
+        //            {
+        //                "symbol": "ADA",
+        //                "contract_code": "ADA-USDT",
+        //                "settlement_time": 1652313600000,
+        //                "clawback_ratio": 0E-18,
+        //                "settlement_price": 0.512303000000000000,
+        //                "settlement_type": "settlement",
+        //                "business_type": "swap",
+        //                "pair": "ADA-USDT",
+        //                "trade_partition": "USDT"
+        //            },
+        //            ...
+        //        ],
+        //        "ts": 1652338693256
+        //    }
+        //
+        // coin-m future
+        //
+        //    {
+        //        "status": "ok",
+        //        "data": {
+        //            "total_page": 5,
+        //            "current_page": 1,
+        //            "total_size": 90,
+        //            "settlement_record": [
+        //                {
+        //                    "symbol": "FIL",
+        //                    "settlement_time": 1652342400000,
+        //                    "clawback_ratio": 0E-18,
+        //                    "list": [
+        //                        {
+        //                            "contract_code": "FIL220513",
+        //                            "settlement_price": 7.016000000000000000,
+        //                            "settlement_type": "settlement"
+        //                        },
+        //                        ...
+        //                    ]
+        //                },
+        //            ]
+        //        }
+        //    }
+        //
+        const data = this.safeValue (response, 'data');
+        const settlementRecord = this.safeValue (data, 'settlement_record');
+        return this.parseSettlements (settlementRecord, market);
+    }
+
+    parseSettlements (settlements, market) {
+        //
+        // linear swap, coin-m swap, fetchSettlementHistory
+        //
+        //    [
+        //        {
+        //            "symbol": "ADA",
+        //            "contract_code": "ADA-USDT",
+        //            "settlement_time": 1652313600000,
+        //            "clawback_ratio": 0E-18,
+        //            "settlement_price": 0.512303000000000000,
+        //            "settlement_type": "settlement",
+        //            "business_type": "swap",
+        //            "pair": "ADA-USDT",
+        //            "trade_partition": "USDT"
+        //        },
+        //        ...
+        //    ]
+        //
+        // coin-m future, fetchSettlementHistory
+        //
+        //    [
+        //        {
+        //            "symbol": "FIL",
+        //            "settlement_time": 1652342400000,
+        //            "clawback_ratio": 0E-18,
+        //            "list": [
+        //                {
+        //                    "contract_code": "FIL220513",
+        //                    "settlement_price": 7.016000000000000000,
+        //                    "settlement_type": "settlement"
+        //                },
+        //                ...
+        //            ]
+        //        },
+        //    ]
+        //
+        const result = [];
+        for (let i = 0; i < settlements.length; i++) {
+            const settlement = settlements[i];
+            const list = this.safeValue (settlement, 'list');
+            if (list !== undefined) {
+                const timestamp = this.safeInteger (settlement, 'settlement_time');
+                const timestampDetails = {
+                    'timestamp': timestamp,
+                    'datetime': this.iso8601 (timestamp),
+                };
+                for (let j = 0; j < list.length; j++) {
+                    const item = list[j];
+                    const parsedSettlement = this.parseSettlement (item, market);
+                    result.push (this.extend (parsedSettlement, timestampDetails));
+                }
+            } else {
+                result.push (this.parseSettlement (settlements[i], market));
+            }
+        }
+        return result;
+    }
+
+    parseSettlement (settlement, market) {
+        //
+        // linear swap, coin-m swap, fetchSettlementHistory
+        //
+        //    {
+        //        "symbol": "ADA",
+        //        "contract_code": "ADA-USDT",
+        //        "settlement_time": 1652313600000,
+        //        "clawback_ratio": 0E-18,
+        //        "settlement_price": 0.512303000000000000,
+        //        "settlement_type": "settlement",
+        //        "business_type": "swap",
+        //        "pair": "ADA-USDT",
+        //        "trade_partition": "USDT"
+        //    }
+        //
+        // coin-m future, fetchSettlementHistory
+        //
+        //    {
+        //        "contract_code": "FIL220513",
+        //        "settlement_price": 7.016000000000000000,
+        //        "settlement_type": "settlement"
+        //    }
+        //
+        const timestamp = this.safeInteger (settlement, 'settlement_time');
+        const marketId = this.safeString (settlement, 'contract_code');
+        return {
+            'info': settlement,
+            'symbol': this.safeSymbol (marketId, market),
+            'price': this.safeNumber (settlement, 'settlement_price'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
         };
     }
 };


### PR DESCRIPTION
I'll need this to enable huobi futures on freqtrade, it doesn't really make sense for other exchanges though because they don't do it for swap contracts, they only have settlement prices for futures and options, so markets would only have one settlement price record

----------------------------

2022-06-01T23:41:01.740Z
Node.js: v14.17.0
CCXT v1.84.63

```
huobi.fetchSettlementHistory (BTC/USDT:USDT-220603)
2022-06-01T23:41:03.685Z iteration 0 passed in 331 ms
              symbol |    price |     timestamp |                 datetime
--------------------------------------------------------------------------
BTC/USDT:USDT-220603 | 30277.51 | 1652428800000 | 2022-05-13T08:00:00.000Z
...
  BTC/USD:BTC-220624 | 31574.67 | 1654070400000 | 2022-06-01T08:00:00.000Z
  BTC/USD:BTC-220930 | 31836.43 | 1654070400000 | 2022-06-01T08:00:00.000Z
80 objects
```
```
% huobi fetchSettlementHistory BTC/USD:BTC
2022-06-01T23:41:10.118Z
Node.js: v14.17.0
CCXT v1.84.63
huobi.fetchSettlementHistory (BTC/USD:BTC)
2022-06-01T23:41:11.611Z iteration 0 passed in 361 ms
     symbol |   price |     timestamp |                 datetime
----------------------------------------------------------------
BTC/USD:BTC | 29673.7 | 1653552000000 | 2022-05-26T08:00:00.000Z
...
BTC/USD:BTC | 31479.7 | 1654070400000 | 2022-06-01T08:00:00.000Z
BTC/USD:BTC |   30742 | 1654099200000 | 2022-06-01T16:00:00.000Z
20 objects
```
```
% huobi fetchSettlementHistory ADA/USDT:USDT
huobi.fetchSettlementHistory (ADA/USDT:USDT)
2022-06-01T23:41:18.025Z iteration 0 passed in 303 ms
       symbol |    price |     timestamp |                 datetime
-------------------------------------------------------------------
ADA/USDT:USDT |  0.50341 | 1653552000000 | 2022-05-26T08:00:00.000Z
...
ADA/USDT:USDT | 0.604565 | 1654070400000 | 2022-06-01T08:00:00.000Z
ADA/USDT:USDT | 0.573262 | 1654099200000 | 2022-06-01T16:00:00.000Z
20 objects
```