### PR TITLE
Coinex cancelOrder

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1407,7 +1407,7 @@ module.exports = class coinex extends Exchange {
         //         "type": "sell",
         //     }
         //
-        // Spot createOrder, cancelOrder, fetchOrder
+        // Spot and Margin createOrder, cancelOrder, fetchOrder
         //
         //      {
         //          "amount":"1.5",
@@ -1904,10 +1904,18 @@ module.exports = class coinex extends Exchange {
                 method = 'privateDeleteOrderStopPendingId';
             }
         }
-        const query = this.omit (params, 'stop');
+        const accountId = this.safeInteger (params, 'account_id');
+        const defaultType = this.safeString (this.options, 'defaultType');
+        if (defaultType === 'margin') {
+            if (accountId === undefined) {
+                throw new BadRequest (this.id + ' cancelOrder() requires an account_id parameter for margin orders');
+            }
+            request['account_id'] = accountId;
+        }
+        const query = this.omit (params, [ 'stop', 'account_id' ]);
         const response = await this[method] (this.extend (request, query));
         //
-        // Spot
+        // Spot and Margin
         //
         //     {
         //         "code": 0,
@@ -2008,7 +2016,7 @@ module.exports = class coinex extends Exchange {
         //         "message":"OK"
         //     }
         //
-        // Spot Stop
+        // Spot and Margin Stop
         //
         //     {"code":0,"data":{},"message":"Success"}
         //


### PR DESCRIPTION
Added margin functionality to cancelOrder:
```
node examples/js/cli coinex cancelOrder 77968983162 BTC/USDT '{"account_id":"1"}'

coinex.cancelOrder (77968983162, BTC/USDT, [object Object])
2022-06-02T02:17:02.034Z iteration 0 passed in 330 ms

{
  id: '77968983162',
  clientOrderId: undefined,
  datetime: '2022-06-02T02:12:30.000Z',
  timestamp: 1654135950000,
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: 'sell',
  price: 35000,
  stopPrice: undefined,
  cost: 0,
  average: undefined,
  amount: 0.0005,
  filled: 0,
  remaining: 0.0005,
  trades: [],
  fee: { currency: 'USDT', cost: 0 },
  info: {
    amount: '0.0005',
    asset_fee: '0',
    avg_price: '0.00',
    client_id: '',
    create_time: '1654135950',
    deal_amount: '0',
    deal_fee: '0',
    deal_money: '0',
    fee_asset: null,
    fee_discount: '1',
    finished_time: '0',
    id: '77968983162',
    left: '0.0005',
    maker_fee_rate: '0.002',
    market: 'BTCUSDT',
    money_fee: '0',
    order_type: 'limit',
    price: '35000.00',
    status: 'not_deal',
    stock_fee: '0',
    taker_fee_rate: '0.002',
    type: 'sell'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```