### PR TITLE
Coinex fetchOpenOrders, fetchClosedOrders

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -19,7 +19,7 @@ module.exports = class coinex extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined, // has but unimplemented
+                'margin': true,
                 'swap': true,
                 'future': false,
                 'option': false,
@@ -1501,7 +1501,7 @@ module.exports = class coinex extends Exchange {
         //     }
         //
         //
-        // Spot fetchOpenOrders, fetchClosedOrders
+        // Spot and Margin fetchOpenOrders, fetchClosedOrders
         //
         //     {
         //         "account_id": 0,
@@ -1560,7 +1560,7 @@ module.exports = class coinex extends Exchange {
         //         "user_id": 3620173
         //     }
         //
-        // Spot Stop fetchOpenOrders, fetchClosedOrders
+        // Spot and Margin Stop fetchOpenOrders, fetchClosedOrders
         //
         //     {
         //         "account_id": 0,
@@ -2231,9 +2231,18 @@ module.exports = class coinex extends Exchange {
             }
             request['page'] = 1;
         }
-        const response = await this[method] (this.extend (request, query));
+        const accountId = this.safeInteger (params, 'account_id');
+        const defaultType = this.safeString (this.options, 'defaultType');
+        if (defaultType === 'margin') {
+            if (accountId === undefined) {
+                throw new BadRequest (this.id + ' fetchOpenOrders() and fetchClosedOrders() require an account_id parameter for margin orders');
+            }
+            request['account_id'] = accountId;
+        }
+        params = this.omit (query, 'account_id');
+        const response = await this[method] (this.extend (request, params));
         //
-        // Spot
+        // Spot and Margin
         //
         //     {
         //         "code": 0,
@@ -2314,7 +2323,7 @@ module.exports = class coinex extends Exchange {
         //         "message": "OK"
         //     }
         //
-        // Spot Stop
+        // Spot and Margin Stop
         //
         //     {
         //         "code": 0,


### PR DESCRIPTION
Added margin to fetchOpenOrders and fetchClosedOrders:

fetchOpenOrders:
```
node examples/js/cli coinex fetchOpenOrders BTC/USDT undefined undefined '{"account_id":"1"}'

coinex.fetchOpenOrders (BTC/USDT, , , [object Object])
2022-06-02T22:24:10.162Z iteration 0 passed in 283 ms

         id | clientOrderId |                 datetime |     timestamp | lastTradeTimestamp | status |   symbol |  type | timeInForce | postOnly | reduceOnly | side | price | stopPrice | cost | average |    amount | filled | remaining | trades |                          fee |                  fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
78046313828 |               | 2022-06-02T22:23:58.000Z | 1654208638000 |                    |   open | BTC/USDT | limit |             |          |            | sell | 35000 |           |    0 |         | 0.0008512 |      0 | 0.0008512 |     [] | {"currency":"USDT","cost":0} | [{"currency":"USDT","cost":0}]
1 objects
```

fetchClosedOrders:
```
node examples/js/cli coinex fetchClosedOrders BTC/USDT undefined undefined '{"account_id":"1"}'

coinex.fetchClosedOrders (BTC/USDT, , , [object Object])
2022-06-02T22:25:34.111Z iteration 0 passed in 332 ms

         id | clientOrderId |                 datetime |     timestamp | lastTradeTimestamp | status |   symbol |   type | timeInForce | postOnly | reduceOnly | side |    price | stopPrice |          cost |  average |     amount |     filled | remaining | trades |                   fee |                                         fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
77951178000 |               | 2022-06-01T21:36:26.000Z | 1654119386000 |                    | closed | BTC/USDT | market |         IOC |          |            | sell | 29688.08 |           | 16.2337390248 | 29688.08 | 0.00054681 | 0.00054681 |         0 |     [] | {"currency":"USDT","cost":0.0324674780496} | [{"currency":"USDT","cost":0.0324674780496}]
77951191449 |               | 2022-06-01T21:36:41.000Z | 1654119401000 |                    |   open | BTC/USDT | market |         IOC |          |            |  buy | 29688.09 |           | 16.1999000703 | 29688.09 |       16.2 | 0.00054567 |         0 |     [] |   {"currency":"USDT","cost":0.00000109134} |   [{"currency":"USDT","cost":0.00000109134}]
2 objects
```