### PR TITLE
Rate limiter

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -455,9 +455,9 @@ module.exports = class Exchange {
         this.tokenBucket = this.extend ({
             delay:       0.001,
             capacity:    1,
-            cost: 1,
+            cost:        1,
             maxCapacity: 1000,
-            refillRate: (this.rateLimit > 0) ? 1 / this.rateLimit : Number.MAX_VALUE
+            refillRate:  (this.rateLimit > 0) ? 1 / this.rateLimit : Number.MAX_VALUE,
         }, this.tokenBucket)
 
         this.throttle = throttle (this.tokenBucket)

--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -15,6 +15,7 @@ class Throttle {
             maxCapacity: 2000,
             tokens: 0,
             cost: 1.0,
+            throttleLimit: false, // set to true to use the maximum available rate limit from the beginning
         };
         Object.assign (this.config, config);
         this.queue = [];  // requests to be sent
@@ -31,10 +32,14 @@ class Throttle {
             const { resolver, cost } = this.queue[0];
             if (this.config['tokens'] >= 0) { // if rate limit hasn't been reached
                 this.config['tokens'] -= cost;
-                this.resolve (resolver)
+                if (this.config[throttleLimit]) {
+                    this.resolve (resolver);
+                } else {
+                    resolver ();
+                    await Promise.resolve (); // what does this do?
+                }
                 this.queue.shift ();
                 // contextswitch
-                await Promise.resolve (); // what does this do?
                 if (this.queue.length === 0) {
                     this.running = false;
                 }

--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -15,31 +15,31 @@ class Throttle {
             maxCapacity: 2000,
             tokens: 0,
             cost: 1.0,
-        }
-        Object.assign (this.config, config)
-        this.queue = []
-        this.running = false
+        };
+        Object.assign (this.config, config);
+        this.queue = [];  // requests to be sent
+        this.running = false;
     }
 
     async loop () {
-        let lastTimestamp = now ()
-        while (this.running) {
-            const { resolver, cost } = this.queue[0]
-            if (this.config['tokens'] >= 0) {
-                this.config['tokens'] -= cost
-                resolver ()
-                this.queue.shift ()
+        let lastTimestamp = now ();
+        while (this.running) { // loops through method calls in the queue, executing them if tokens available, and waiting if tokens not available
+            const { resolver, cost } = this.queue[0];
+            if (this.config['tokens'] >= 0) { // if rate limit hasn't been reached
+                this.config['tokens'] -= cost;
+                resolver (); // method for api endpoint
+                this.queue.shift ();
                 // contextswitch
-                await Promise.resolve ()
+                await Promise.resolve (); // what does this do?
                 if (this.queue.length === 0) {
-                    this.running = false
+                    this.running = false;
                 }
             } else {
                 await sleep (this.config['delay'] * 1000);
-                const current = now ()
-                const elapsed = current - lastTimestamp
-                lastTimestamp = current
-                this.config['tokens'] = Math.min (this.config['tokens'] + (this.config['refillRate'] * elapsed), this.config['capacity'])
+                const current = now ();
+                const elapsed = current - lastTimestamp;
+                lastTimestamp = current;
+                this.config['tokens'] = Math.min (this.config['tokens'] + (this.config['refillRate'] * elapsed), this.config['capacity']);
             }
         }
     }
@@ -47,29 +47,28 @@ class Throttle {
 
 function throttle (config) {
     function inner (cost = undefined) {
-        let resolver
+        let resolver;
         const promise = new Promise ((resolve, reject) => {
-            resolver = resolve
+            resolver = resolve;
         })
         if (this.queue.length > this.config['maxCapacity']) {
-            throw new Error ('throttle queue is over maxCapacity')
+            throw new Error ('throttle queue is over maxCapacity');
         }
-        cost = (cost === undefined) ? this.config['cost'] : cost
-        this.queue.push ({
-            resolver,
-            cost,
-        })
-        if (!this.running) {
-            this.running = true
-            this.loop ()
+        if (cost === undefined) {
+            cost = this.config['cost'];
         }
-        return promise
+        this.queue.push ({ resolver, cost });
+        if (!this.running) { // start the throttle loop if it's not running
+            this.running = true;
+            this.loop ();
+        }
+        return promise;
     }
-    const instance = new Throttle (config)
-    const bound = inner.bind (instance)
+    const instance = new Throttle (config);
+    const bound = inner.bind (instance);
     // useful for inspecting the tokenBucket
-    bound.config = instance.config
-    return bound
+    bound.config = instance.config;
+    return bound;
 }
 
 module.exports = {

--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -21,13 +21,17 @@ class Throttle {
         this.running = false;
     }
 
+    async resolve (resolver) {
+        resolver (); // method for api endpoint
+    }
+
     async loop () {
         let lastTimestamp = now ();
         while (this.running) { // loops through method calls in the queue, executing them if tokens available, and waiting if tokens not available
             const { resolver, cost } = this.queue[0];
             if (this.config['tokens'] >= 0) { // if rate limit hasn't been reached
                 this.config['tokens'] -= cost;
-                resolver (); // method for api endpoint
+                this.resolve (resolver)
                 this.queue.shift ();
                 // contextswitch
                 await Promise.resolve (); // what does this do?

--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -36,11 +36,14 @@ class Throttle {
                 }
             } else {
                 await sleep (this.config['delay'] * 1000);
-                const current = now ();
-                const elapsed = current - lastTimestamp;
-                lastTimestamp = current;
-                this.config['tokens'] = Math.min (this.config['tokens'] + (this.config['refillRate'] * elapsed), this.config['capacity']);
             }
+            const current = now ();
+            const elapsed = current - lastTimestamp;
+            lastTimestamp = current;
+            this.config['tokens'] = Math.min (
+                this.config['tokens'] + (this.config['refillRate'] * elapsed),
+                this.config['capacity']
+            );
         }
     }
 }


### PR DESCRIPTION
@kroitor @frosty00 @DoctorSlimm 

So I'm trying to edit the rate limiter so that the max amount of your available limit is used before your requests start being slowed down, this would make 60 1 weight requests all executed asynchronously at the same time if 60 is not above the rate limit.

Besides the code in throttle.js and Exchange.initRestRateLimiter, I'm not sure what other code would need to be edited, I'm not sure exactly what should be done.