### PR TITLE
Digifinex fetchMarkets

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -380,6 +380,9 @@ module.exports = class digifinex extends Exchange {
             // const active = (status === 'TRADING');
             //
             const isAllowed = this.safeInteger (market, 'is_allow', 1);
+            const type = (defaultType === 'margin') ? 'margin' : 'spot';
+            const spot = (defaultType === 'spot') ? true : undefined;
+            const margin = (defaultType === 'margin') ? true : undefined;
             result.push ({
                 'id': id,
                 'symbol': base + '/' + quote,
@@ -389,9 +392,9 @@ module.exports = class digifinex extends Exchange {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'settleId': undefined,
-                'type': (defaultType === 'margin') ? 'margin' : 'spot',
-                'spot': (defaultType === 'spot') ? true : undefined,
-                'margin': (defaultType === 'margin') ? true : undefined,
+                'type': type,
+                'spot': spot,
+                'margin': margin,
                 'swap': false,
                 'future': false,
                 'option': false,

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -314,7 +314,11 @@ module.exports = class digifinex extends Exchange {
     }
 
     async fetchMarketsV2 (params = {}) {
-        const response = await this.publicGetTradesSymbols (params);
+        const defaultType = this.safeString (this.options, 'defaultType');
+        const method = (defaultType === 'margin') ? 'publicGetMarginSymbols' : 'publicGetTradesSymbols';
+        const response = await this[method] (params);
+        //
+        // Spot
         //
         //     {
         //         "symbol_list":[
@@ -331,6 +335,27 @@ module.exports = class digifinex extends Exchange {
         //                 "base_asset":"BTC",
         //                 "price_precision":2
         //             }
+        //         ],
+        //         "code":0
+        //     }
+        //
+        // Margin
+        //
+        //     {
+        //         "symbol_list":[
+        //             {
+        //                     "order_types":["LIMIT"],
+        //                     "quote_asset":"USDT",
+        //                     "minimum_value":0,
+        //                     "amount_precision":2,
+        //                     "status":"TRADING",
+        //                     "minimum_amount":22,
+        //                     "liquidation_rate":0.3,
+        //                     "symbol":"TRX_USDT",
+        //                     "zone":"MAIN",
+        //                     "base_asset":"TRX",
+        //                     "price_precision":6
+        //             },
         //         ],
         //         "code":0
         //     }
@@ -364,13 +389,13 @@ module.exports = class digifinex extends Exchange {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'settleId': undefined,
-                'type': 'spot',
-                'spot': true,
-                'margin': undefined,
+                'type': (defaultType === 'margin') ? 'margin' : 'spot',
+                'spot': (defaultType === 'spot') ? true : undefined,
+                'margin': (defaultType === 'margin') ? true : undefined,
                 'swap': false,
                 'future': false,
                 'option': false,
-                'active': isAllowed ? true : false,
+                'active': isAllowed ? true : undefined,
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,


### PR DESCRIPTION
Added margin functionality to fetchMarkets:
```
digifinex.fetchMarkets ()
2022-06-03T19:38:24.593Z iteration 0 passed in 1188 ms

        id |     symbol |  base | quote | settle | baseId | quoteId | settleId |   type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |              precision |                                    limits
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRX_USDT |   TRX/USDT |   TRX |  USDT |        |    TRX |    USDT |          | margin |      |   true | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"amount":2,"price":6} |      {"leverage":{},"amount":{"min":22},"price":{},"cost":{"min":0}}
  ETH_USDT |   ETH/USDT |   ETH |  USDT |        |    ETH |    USDT |          | margin |      |   true | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"amount":4,"price":2} |  {"leverage":{},"amount":{"min":0.0006},"price":{},"cost":{"min":2}}
  OMG_USDT |   OMG/USDT |   OMG |  USDT |        |    OMG |    USDT |          | margin |      |   true | false |  false |  false |   true |    false |        |         |              |        |                |        |            | {"amount":4,"price":4} |     {"leverage":{},"amount":{"min":0.3},"price":{},"cost":{"min":2}}
...
28 objects
```