### PR TITLE
methodGuard class added to base exchange

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2223,9 +2223,7 @@ module.exports = class Exchange {
 
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
-        if (!this.has['fetchBorrowRates']) {
-            throw new NotSupported (this.id + ' fetchBorrowRate() is not supported yet')
-        }
+        this.methodGuard ('fetchBorrowRates', 'fetchBorrowRate');
         const borrowRates = await this.fetchBorrowRates (params);
         const rate = this.safeValue (borrowRates, code);
         if (rate === undefined) {
@@ -2279,16 +2277,13 @@ module.exports = class Exchange {
     }
 
     async fetchMarketLeverageTiers (symbol, params = {}) {
-        if (this.has['fetchLeverageTiers']) {
-            const market = await this.market (symbol);
-            if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() supports contract markets only');
-            }
-            const tiers = await this.fetchLeverageTiers ([ symbol ]);
-            return this.safeValue (tiers, symbol);
-        } else {
-            throw new NotSupported (this.id + ' fetchMarketLeverageTiers() is not supported yet');
+        this.methodGuard ('fetchLeverageTiers', 'fetchMarketLeverageTiers');
+        const market = await this.market (symbol);
+        if (!market['contract']) {
+            throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() supports contract markets only');
         }
+        const tiers = await this.fetchLeverageTiers ([ symbol ]);
+        return this.safeValue (tiers, symbol);
     }
 
     parseOpenInterests (response, market = undefined, since = undefined, limit = undefined) {
@@ -2333,43 +2328,39 @@ module.exports = class Exchange {
     }
 
     async createPostOnlyOrder (symbol, type, side, amount, price, params = {}) {
-        if (!this.has['createPostOnlyOrder']) {
-            throw new NotSupported (this.id + 'createPostOnlyOrder() is not supported yet');
-        }
+        this.methodGuard ('createPostOnlyOrder');
         const query = this.extend (params, { 'postOnly': true });
         return await this.createOrder (symbol, type, side, amount, price, query);
     }
 
     async createReduceOnlyOrder (symbol, type, side, amount, price, params = {}) {
-        if (!this.has['createReduceOnlyOrder']) {
-            throw new NotSupported (this.id + 'createReduceOnlyOrder() is not supported yet');
-        }
+        this.methodGuard ('createReduceOnlyOrder');
         const query = this.extend (params, { 'reduceOnly': true });
         return await this.createOrder (symbol, type, side, amount, price, query);
     }
 
     async createStopOrder (symbol, type, side, amount, price = undefined, stopPrice = undefined, params = {}) {
-        if (!this.has['createStopOrder']) {
-            throw new NotSupported (this.id + ' createStopOrder() is not supported yet');
-        }
+        this.methodGuard ('createStopOrder');
         if (stopPrice === undefined) {
-            throw new ArgumentsRequired(this.id + ' create_stop_order() requires a stopPrice argument');
+            throw new ArgumentsRequired(this.id + ' createStopOrder() requires a stopPrice argument');
         }
         const query = this.extend (params, { 'stopPrice': stopPrice });
         return await this.createOrder (symbol, type, side, amount, price, query);
     }
 
     async createStopLimitOrder(symbol, side, amount, price, stopPrice, params = {}) {
-        if (!this.has['createStopLimitOrder']) {
-            throw new NotSupported(this.id + ' createStopLimitOrder() is not supported yet');
+        this.methodGuard ('createStopLimitOrder');
+        if (stopPrice === undefined) {
+            throw new ArgumentsRequired(this.id + ' createStopLimitOrder() requires a stopPrice argument');
         }
         const query = this.extend(params, {'stopPrice': stopPrice});
         return this.createOrder(symbol, 'limit', side, amount, price, query);
     }
 
     async createStopMarketOrder(symbol, side, amount, stopPrice, params = {}) {
-        if (!this.has['createStopMarketOrder']) {
-            throw new NotSupported(this.id + ' createStopMarketOrder() is not supported yet');
+        this.methodGuard ('createStopMarketOrder');
+        if (stopPrice === undefined) {
+            throw new ArgumentsRequired(this.id + ' createStopMarketOrder() requires a stopPrice argument');
         }
         const query = this.extend(params, {'stopPrice': stopPrice});
         return this.createOrder(symbol, 'market', side, amount, undefined, query);
@@ -2413,20 +2404,24 @@ module.exports = class Exchange {
     }
 
     async fetchFundingRate (symbol, params = {}) {
-        if (this.has['fetchFundingRates']) {
-            const market = await this.market (symbol);
-            if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchFundingRate() supports contract markets only');
-            }
-            const rates = await this.fetchFundingRates ([ symbol ], params);
-            const rate = this.safeValue (rates, symbol);
-            if (rate === undefined) {
-                throw new NullResponse (this.id + ' fetchFundingRate () returned no data for ' + symbol);
-            } else {
-                return rate;
-            }
+        this.methodGuard ('fetchFundingRates', 'fetchFundingRate');
+        const market = await this.market (symbol);
+        if (!market['contract']) {
+            throw new BadSymbol (this.id + ' fetchFundingRate() supports contract markets only');
+        }
+        const rates = await this.fetchFundingRates ([ symbol ], params);
+        const rate = this.safeValue (rates, symbol);
+        if (rate === undefined) {
+            throw new NullResponse (this.id + ' fetchFundingRate () returned no data for ' + symbol);
         } else {
-            throw new NotSupported (this.id + ' fetchFundingRate () is not supported yet');
+            return rate;
+        }
+    }
+
+    methodGuard (hasMethod, unsupportedMethod = undefined) {
+        if (!this.has[hasMethod]) {
+            unsupportedMethod = unsupportedMethod ? unsupportedMethod : hasMethod;
+            throw new NotSupported (this.id + ' ' + unsupportedMethod + ' () is not supported yet');
         }
     }
 
@@ -2442,14 +2437,11 @@ module.exports = class Exchange {
          * @param {dict} params extra parameters specific to the exchange api endpoint
          * @returns {[[int|float]]} A list of candles ordered as timestamp, open, high, low, close, undefined
          */
-        if (this.has['fetchMarkOHLCV']) {
-            const request = {
-                'price': 'mark',
-            };
-            return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
-        } else {
-            throw new NotSupported (this.id + ' fetchMarkOHLCV () is not supported yet');
-        }
+        this.methodGuard ('fetchMarkOHLCV');
+        const request = {
+            'price': 'mark',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
@@ -2464,14 +2456,11 @@ module.exports = class Exchange {
          * @param {dict} params extra parameters specific to the exchange api endpoint
          * @returns {[[int|float]]} A list of candles ordered as timestamp, open, high, low, close, undefined
          */
-        if (this.has['fetchIndexOHLCV']) {
-            const request = {
-                'price': 'index',
-            };
-            return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
-        } else {
-            throw new NotSupported (this.id + ' fetchIndexOHLCV () is not supported yet');
-        }
+        this.methodGuard ('fetchIndexOHLCV');
+        const request = {
+            'price': 'index',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 
     async fetchPremiumIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
@@ -2486,13 +2475,10 @@ module.exports = class Exchange {
          * @param {dict} params extra parameters specific to the exchange api endpoint
          * @returns {[[int|float]]} A list of candles ordered as timestamp, open, high, low, close, undefined
          */
-        if (this.has['fetchPremiumIndexOHLCV']) {
-            const request = {
-                'price': 'premiumIndex',
-            };
-            return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
-        } else {
-            throw new NotSupported (this.id + ' fetchPremiumIndexOHLCV () is not supported yet');
-        }
+        this.methodGuard ('fetchPremiumIndexOHLCV');
+        const request = {
+            'price': 'premiumIndex',
+        };
+        return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
     }
 }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2900,8 +2900,7 @@ class Exchange(object):
 
     def fetch_borrow_rate(self, code, params={}):
         self.load_markets()
-        if not self.has['fetchBorrowRates']:
-            raise NotSupported(self.id + 'fetchBorrowRate() is not supported yet')
+        self.method_guard('fetchBorrowRates', 'fetch_borrow_rate')
         borrow_rates = self.fetch_borrow_rates(params)
         rate = self.safe_value(borrow_rates, code)
         if rate is None:
@@ -2943,14 +2942,12 @@ class Exchange(object):
         return tiers
 
     def fetch_market_leverage_tiers(self, symbol, params={}):
-        if self.has['fetchLeverageTiers']:
-            market = self.market(symbol)
-            if (not market['contract']):
-                raise BadRequest(self.id + ' fetch_market_leverage_tiers() supports contract markets only')
-            tiers = self.fetch_leverage_tiers([symbol])
-            return self.safe_value(tiers, symbol)
-        else:
-            raise NotSupported(self.id + 'fetch_market_leverage_tiers() is not supported yet')
+        self.method_guard('fetchLeverageTiers', 'fetch_market_leverage_tiers')
+        market = self.market(symbol)
+        if (not market['contract']):
+            raise BadRequest(self.id + ' fetch_market_leverage_tiers() supports contract markets only')
+        tiers = self.fetch_leverage_tiers([symbol])
+        return self.safe_value(tiers, symbol)
 
     def is_post_only(self, isMarketOrder, exchangeSpecificParam, params={}):
         """
@@ -2978,34 +2975,29 @@ class Exchange(object):
             return False
 
     def create_post_only_order(self, symbol, type, side, amount, price, params={}):
-        if not self.has['createPostOnlyOrder']:
-            raise NotSupported(self.id + ' create_post_only_order() is not supported yet')
+        self.method_guard('createPostOnlyOrder', 'create_post_only_order')
         query = self.extend(params, {'postOnly': True})
         return self.create_order(symbol, type, side, amount, price, query)
 
     def create_reduce_only_order(self, symbol, type, side, amount, price, params={}):
-        if not self.has['createReduceOnlyOrder']:
-            raise NotSupported(self.id + ' create_reduce_only_order() is not supported yet')
+        self.method_guard('createReduceOnlyOrder', 'create_reduce_only_order')
         query = self.extend(params, {'reduceOnly': True})
         return self.create_order(symbol, type, side, amount, price, query)
 
     def create_stop_order(self, symbol, type, side, amount, price=None, stopPrice=None, params={}):
-        if not self.has['createStopOrder']:
-            raise NotSupported(self.id + 'create_stop_order() is not supported yet')
+        self.method_guard('createStopOrder', 'create_stop_order')
         if stopPrice is None:
             raise ArgumentsRequired(self.id + ' create_stop_order() requires a stopPrice argument')
         query = self.extend(params, {'stopPrice': stopPrice})
         return self.create_order(symbol, type, side, amount, price, query)
 
     def create_stop_limit_order(self, symbol, side, amount, price, stopPrice, params={}):
-        if not self.has['createStopLimitOrder']:
-            raise NotSupported(self.id + ' create_stop_limit_order() is not supported yet')
+        self.method_guard('createStopLimitOrder', 'create_stop_limit_order')
         query = self.extend(params, {'stopPrice': stopPrice})
         return self.create_order(symbol, 'limit', side, amount, price, query)
 
     def create_stop_market_order(self, symbol, side, amount, stopPrice, params={}):
-        if not self.has['createStopMarketOrder']:
-            raise NotSupported(self.id + ' create_stop_market_order() is not supported yet')
+        self.method_guard('createStopMarketOrder', 'create_stop_market_order')
         query = self.extend(params, {'stopPrice': stopPrice})
         return self.create_order(symbol, 'market', side, amount, None, query)
 
@@ -3045,22 +3037,20 @@ class Exchange(object):
             interest = self.parseOpenInterest(entry, market)
             interests.append(interest)
         sorted = self.sortBy(interests, 'timestamp')
-        symbol = this.safeString(market, 'symbol')
+        symbol = self.safeString(market, 'symbol')
         return self.filterBySymbolSinceLimit(sorted, symbol, since, limit)
 
     def fetch_funding_rate(self, symbol, params={}):
-        if self.has['fetchFundingRates']:
-            market = self.market(symbol)
-            if not market['contract']:
-                raise BadSymbol(self.id + ' fetch_funding_rate() supports contract markets only')
-            rates = self.fetchFundingRates([symbol], params)
-            rate = self.safe_value(rates, symbol)
-            if rate is None:
-                raise NullResponse(self.id + ' fetch_funding_rate() returned no data for ' + symbol)
-            else:
-                return rate
+        self.method_guard('fetchFundingRates', 'fetch_funding_rate')
+        market = self.market(symbol)
+        if not market['contract']:
+            raise BadSymbol(self.id + ' fetch_funding_rate() supports contract markets only')
+        rates = self.fetchFundingRates([symbol], params)
+        rate = self.safe_value(rates, symbol)
+        if rate is None:
+            raise NullResponse(self.id + ' fetch_funding_rate() returned no data for ' + symbol)
         else:
-            raise NotSupported(self.id + ' fetch_funding_rate() is not supported yet')
+            return rate
 
     def fetch_mark_ohlcv(self, symbol, timeframe='1m', since=None, limit=None, params={}):
         """
@@ -3072,13 +3062,11 @@ class Exchange(object):
         :param dict params: extra parameters specific to the exchange api endpoint
         :returns [[int|float]] A: list of candles ordered as timestamp, open, high, low, close, None
         """
-        if self.has['fetchMarkOHLCV']:
-            request = {
-                'price': 'mark',
-            }
-            return self.fetch_ohlcv(symbol, timeframe, since, limit, self.extend(request, params))
-        else:
-            raise NotSupported(self.id + ' fetchMarkOHLCV() is not supported yet')
+        self.method_guard('fetchMarkOHLCV', 'fetch_mark_ohlcv')
+        request = {
+            'price': 'mark',
+        }
+        return self.fetch_ohlcv(symbol, timeframe, since, limit, self.extend(request, params))
 
     def fetch_index_ohlcv(self, symbol, timeframe='1m', since=None, limit=None, params={}):
         """
@@ -3090,13 +3078,11 @@ class Exchange(object):
         :param dict params: extra parameters specific to the exchange api endpoint
         :returns [[int|float]] A: list of candles ordered as timestamp, open, high, low, close, None
         """
-        if self.has['fetchIndexOHLCV']:
-            request = {
-                'price': 'index',
-            }
-            return self.fetch_ohlcv(symbol, timeframe, since, limit, self.extend(request, params))
-        else:
-            raise NotSupported(self.id + ' fetchIndexOHLCV() is not supported yet')
+        self.method_guard('fetchIndexOHLCV', 'fetch_index_ohlcv')
+        request = {
+            'price': 'index',
+        }
+        return self.fetch_ohlcv(symbol, timeframe, since, limit, self.extend(request, params))
 
     def fetch_premium_index_ohlcv(self, symbol, timeframe='1m', since=None, limit=None, params={}):
         """
@@ -3108,10 +3094,13 @@ class Exchange(object):
         :param dict params: extra parameters specific to the exchange api endpoint
         :returns [[int|float]] A: list of candles ordered as timestamp, open, high, low, close, None
         """
-        if self.has['fetchPremiumIndexOHLCV']:
-            request = {
-                'price': 'premiumIndex',
-            }
-            return self.fetch_ohlcv(symbol, timeframe, since, limit, self.extend(request, params))
-        else:
-            raise NotSupported(self.id + ' fetchPremiumIndexOHLCV() is not supported yet')
+        self.method_guard('fetchPremiumIndexOHLCV', 'fetch_premium_index_ohlcv')
+        request = {
+            'price': 'premiumIndex',
+        }
+        return self.fetch_ohlcv(symbol, timeframe, since, limit, self.extend(request, params))
+
+    def method_guard(self, hasMethod, unsupportedMethod=None):
+        if not self.has[hasMethod]:
+            unsupportedMethod = unsupportedMethod if unsupportedMethod else hasMethod
+            raise NotSupported(self.id + ' ' + unsupportedMethod + '() is not supported yet')


### PR DESCRIPTION
# fetchBorrowRate

```
Node.js: v14.17.0                                                    PHP v8.1.6                  Python v3.10.4
CCXT v1.84.42                                                        CCXT v1.84.42               CCXT v1.84.42
ftx.fetchBorrowRate (USDT)                                           ftx->fetchBorrowRate(USDT)  ftx.fetchBorrowRate(USDT)
{                                                                    (                           {'currency': 'USDT',
 currency: 'USDT',                                                    [currency] => USDT          'datetime': None,
 rate: 0.00000567,                                                    [rate] => 5.67E-6           'info': {'coin': 'USDT', 'estimate': '5.4135e-6', 'previous': '5.67e-6'},
 period: 3600000,                                                     [period] => 3600000         'period': 3600000,
 timestamp: undefined,                                                [timestamp] =>              'rate': 5.67e-06,
 datetime: undefined,                                                 [datetime] =>               'timestamp': None}
 info: { coin: 'USDT', previous: '5.67e-6', estimate: '5.4135e-6' }   [info] => Array            
}                                                                      (                         
                                                                        [coin] => USDT           
                                                                        [previous] => 5.67e-6    
                                                                        [estimate] => 5.4135e-6  
                                                                       )                         
                                                                     ) 
```

# fetchMarketLeverageTiers

```
Node.js: v14.17.0                                  PHP v8.1.6                                         Python v3.10.4
CCXT v1.84.42                                      CCXT v1.84.42                                      CCXT v1.84.42
ascendex.fetchMarketLeverageTiers (ADA/USDT:USDT)  ascendex->fetchMarketLeverageTiers(ADA/USDT:USDT)  ascendex.fetchMarketLeverageTiers(ADA/USDT:USDT)
[                                                  (                                                  [{'currency': 'USDT',
 {                                                  [0] => Array                                       'info': {'initialMarginRate': '0.01',
 tier: 1,                                            (                                                   'maintenanceMarginRate': '0.006',
 currency: 'USDT',                                    [tier] => 1                                        'positionNotionalLowerBound': '0',
 minNotional: 0,                                      [currency] => USDT                                 'positionNotionalUpperBound': '5000'},
 maxNotional: 5000,                                   [minNotional] => 0                               'maintenanceMarginRate': 0.006,
 maintenanceMarginRate: 0.006,                        [maxNotional] => 5000                            'maxLeverage': 100.0,
 maxLeverage: 100,                                    [maintenanceMarginRate] => 0.006                 'maxNotional': 5000.0,
 info: {                                              [maxLeverage] => 100                             'minNotional': 0.0,
  positionNotionalLowerBound: '0',                    [info] => Array                                  'tier': 1},
  positionNotionalUpperBound: '5000',                  (                                               {'currency': 'USDT',
  initialMarginRate: '0.01',                            [positionNotionalLowerBound] => 0              'info': {'initialMarginRate': '0.02',
  maintenanceMarginRate: '0.006'                        [positionNotionalUpperBound] => 5000             'maintenanceMarginRate': '0.012',
 }                                                      [initialMarginRate] => 0.01                      'positionNotionalLowerBound': '5000',
 },                                                     [maintenanceMarginRate] => 0.006                 'positionNotionalUpperBound': '20000'},
 {                                                     )                                               'maintenanceMarginRate': 0.012,
 tier: 2,                                            )                                                 'maxLeverage': 50.0,
 currency: 'USDT',                                  [1] => Array                                       'maxNotional': 20000.0,
 minNotional: 5000,                                  (                                                 'minNotional': 5000.0,
 maxNotional: 20000,                                  [tier] => 2                                      'tier': 2},
 maintenanceMarginRate: 0.012,                        [currency] => USDT                               {'currency': 'USDT',
 maxLeverage: 50,                                     [minNotional] => 5000                            'info': {'initialMarginRate': '0.04',
 info: {                                              [maxNotional] => 20000                             'maintenanceMarginRate': '0.024',
  positionNotionalLowerBound: '5000',                 [maintenanceMarginRate] => 0.012                   'positionNotionalLowerBound': '20000',
  positionNotionalUpperBound: '20000',                [maxLeverage] => 50                                'positionNotionalUpperBound': '200000'},
  initialMarginRate: '0.02',                          [info] => Array                                  'maintenanceMarginRate': 0.024,
  maintenanceMarginRate: '0.012'                       (                                               'maxLeverage': 25.0,
 }                                                      [positionNotionalLowerBound] => 5000           'maxNotional': 200000.0,
 },                                                     [positionNotionalUpperBound] => 20000          'minNotional': 20000.0,
 {                                                      [initialMarginRate] => 0.02                    'tier': 3},
 tier: 3,                                               [maintenanceMarginRate] => 0.012               {'currency': 'USDT',
 currency: 'USDT',                                     )                                               'info': {'initialMarginRate': '0.1',
 minNotional: 20000,                                 )                   
```

# fetchFundingRate

```
Node.js: v14.17.0                                 PHP v8.1.6                                          Python v3.10.4
CCXT v1.84.42                                     CCXT v1.84.42                                       CCXT v1.84.42
ascendex.fetchFundingRate (ADA/USDT:USDT)         ascendex->fetchFundingRate(ADA/USDT:USDT)           ascendex.fetchFundingRate(ADA/USDT:USDT)
{                                                 (                                                   {'datetime': '2022-05-31T04:49:08.190Z',
 info: {                                           [info] => Array                                     'estimatedSettlePrice': None,
 time: '1653972548190',                             (                                                  'indexPrice': 0.6039955,
 symbol: 'ADA-PERP',                                 [time] => 1653972548190                           'info': {'fundingRate': '0.001078874',
 markPrice: '0.604680824',                           [symbol] => ADA-PERP                                'indexPrice': '0.6039955',
 indexPrice: '0.6039455',                            [markPrice] => 0.604709373                          'markPrice': '0.604658201',
 openInterest: '498190',                             [indexPrice] => 0.604101                            'nextFundingTime': '1653984000000',
 fundingRate: '0.001078874',                         [openInterest] => 498190                            'openInterest': '498190',
 nextFundingTime: '1653984000000'                    [fundingRate] => 0.001078874                        'symbol': 'ADA-PERP',
 },                                                  [nextFundingTime] => 1653984000000                  'time': '1653972548190'},
 symbol: 'ADA/USDT:USDT',                           )                                                  'interestRate': 0.0,
 markPrice: 0.604680824,                           [symbol] => ADA/USDT:USDT                           'markPrice': 0.604658201,
 indexPrice: 0.6039455,                            [markPrice] => 0.604709373                          'nextFundingDatetime': '2022-05-31T08:00:00.000Z',
 interestRate: 0,                                  [indexPrice] => 0.604101                            'nextFundingRate': 0.001078874,
 estimatedSettlePrice: undefined,                  [interestRate] => 0                                 'nextFundingTimestamp': 1653984000000,
 timestamp: 1653972548190,                         [estimatedSettlePrice] =>                           'previousFundingDatetime': None,
 datetime: '2022-05-31T04:49:08.190Z',             [timestamp] => 1653972548190                        'previousFundingRate': None,
 previousFundingRate: undefined,                   [datetime] => 2022-05-31T04:49:08.190Z              'previousFundingTimestamp': None,
 nextFundingRate: 0.001078874,                     [previousFundingRate] =>                            'symbol': 'ADA/USDT:USDT',
 previousFundingTimestamp: undefined,              [nextFundingRate] => 0.001078874                    'timestamp': 1653972548190}
 nextFundingTimestamp: 1653984000000,              [previousFundingTimestamp] =>                      
 previousFundingDatetime: undefined,               [nextFundingTimestamp] => 1653984000000            
 nextFundingDatetime: '2022-05-31T08:00:00.000Z'   [previousFundingDatetime] =>                       
}                                                  [nextFundingDatetime] => 2022-05-31T08:00:00.000Z  
                                                  )  
```

## fetchPremiumIndexOHLCV

```
Node.js: v14.17.0                                                       PHP v8.1.6                                    Python v3.10.4
CCXT v1.84.42                                                           CCXT v1.84.42                                 CCXT v1.84.42
huobi.fetchPremiumIndexOHLCV (ADA/USDT:USDT)                            huobi->fetchPremiumIndexOHLCV(ADA/USDT:USDT)  huobi.fetchPremiumIndexOHLCV(ADA/USDT:USDT)
[                                                                       (                                             [[1653852840000,
 [                                                                       [0] => Array                                  -0.0005446300867349,
 1653852840000,                                                           (                                            -0.0005446300867349,
 -0.0005446300867349,                                                      [0] => 1653852840000                        -0.0005446300867349,
 -0.0005446300867349,                                                      [1] => -0.0005446300867349                  -0.0005446300867349,
 -0.0005446300867349,                                                      [2] => -0.0005446300867349                  0.0],
 -0.0005446300867349,                                                      [3] => -0.0005446300867349                  [1653852900000,
 0                                                                         [4] => -0.0005446300867349                  -0.0005874820152949,
 ],                                                                        [5] => 0                                    -0.0005874820152949,
 [                                                                        )                                            -0.0005874820152949,
 1653852900000,                                                          [1] => Array                                  -0.0005874820152949,
 -0.0005874820152949,                                                     (                                            0.0],
 -0.0005874820152949,                                                      [0] => 1653852900000                        [1653852960000,
 -0.0005874820152949,                                                      [1] => -0.0005874820152949                  -0.0008758637952577,
 -0.0005874820152949,                                                      [2] => -0.0005874820152949                  -0.0008758637952577,
 0                                                                         [3] => -0.0005874820152949                  -0.0008758637952577,
 ],                                                                        [4] => -0.0005874820152949                  -0.0008758637952577,
 [                                                                         [5] => 0                                    0.0],
 1653852960000,                                                           )                                            [1653853020000,
```

## fetchIndexOHLCV

```
Node.js: v14.17.0                                                       PHP v8.1.6                          Python v3.10.4
CCXT v1.84.42                                                           CCXT v1.84.42                       CCXT v1.84.42
binance.fetchIndexOHLCV (ADA/USDT)                                      binance->fetchIndexOHLCV(ADA/USDT)  binance.fetchIndexOHLCV(ADA/USDT)
[                                                                       (                                   [[1653942900000, 0.5434328, 0.5434328, 0.54214549, 0.54240473, 0.0],
 [ 1653942900000, 0.5434328, 0.5434328, 0.54214549, 0.54242337, 0 ],     [0] => Array                        [1653942960000, 0.54250645, 0.54250645, 0.54139408, 0.54178474, 0.0],
 [ 1653942960000, 0.54250645, 0.54250645, 0.54139408, 0.54178474, 0 ],    (                                  [1653943020000, 0.541795, 0.54252899, 0.54143356, 0.54216995, 0.0],
 [ 1653943020000, 0.541795, 0.54252899, 0.54143356, 0.54216995, 0 ],       [0] => 1653942900000              [1653943080000, 0.54216995, 0.54279274, 0.54205915, 0.54223669, 0.0],
 [ 1653943080000, 0.54216995, 0.54279274, 0.54205915, 0.54223669, 0 ],     [1] => 0.5434328                  [1653943140000, 0.54223669, 0.54229242, 0.54182172, 0.5422075, 0.0],
 [ 1653943140000, 0.54223669, 0.54229242, 0.54182172, 0.54221778, 0 ],     [2] => 0.5434328                  [1653943200000, 0.54230149, 0.54239229, 0.54155561, 0.54204068, 0.0],
 [ 1653943200000, 0.54230149, 0.54239229, 0.54155561, 0.54204068, 0 ],     [3] => 0.54214549                 [1653943260000, 0.54203041, 0.54306854, 0.54105289, 0.54263533, 0.0],
 [ 1653943260000, 0.54203041, 0.54306854, 0.54105289, 0.54263533, 0 ],     [4] => 0.54240473                 [1653943320000, 0.54258847, 0.54387189, 0.54242447, 0.54363056, 0.0],
```

## createStopOrder

```
gateio.createStopOrder(ADA/USDT:USDT,limit,sell,3,0.45,0.45)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '21021821',
 'info': {'id': '21021821'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'type': None}
```

```
 Node.js: v14.17.0
CCXT v1.84.42
gateio.createStopOrder (ADA/USDT:USDT, limit, sell, 3, 0.45, 0.45)
2022-05-31T05:03:22.382Z iteration 0 passed in 183 ms

{
  id: '21021768',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: false,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  fees: [],
  trades: [],
  info: { id: '21021768' }
}
```