### PR TITLE
Fixed Coinbase Pro's `fetchDeposits()` and `fetchWithdrawals()`

### DIFF
--- a/js/coinbasepro.js
+++ b/js/coinbasepro.js
@@ -1402,11 +1402,11 @@ module.exports = class coinbasepro extends Exchange {
     }
 
     async fetchDeposits (code = undefined, since = undefined, limit = undefined, params = {}) {
-        return this.fetchTransactions (code, since, limit, this.extend ({ 'type': 'deposit' }, params));
+        return await this.fetchTransactions (code, since, limit, this.extend ({ 'type': 'deposit' }, params));
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
-        return this.fetchTransactions (code, since, limit, this.extend ({ 'type': 'withdraw' }, params));
+        return await this.fetchTransactions (code, since, limit, this.extend ({ 'type': 'withdraw' }, params));
     }
 
     parseTransactionStatus (transaction) {


### PR DESCRIPTION
Hello, folks :wave:

I created a small fix for Coinbase Pro's `fetchDeposits()` and `fetchWithdrawals()` in the Python library. Due to a missing `await` I was hitting the following error:

```
TypeError: 'coroutine' object is not iterable
```