### PR TITLE
check credentials for only private calls

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -3870,9 +3870,9 @@ module.exports = class coinex extends Exchange {
         path = this.implodeParams (path, params);
         let url = this.urls['api'][api] + '/' + this.version + '/' + path;
         let query = this.omit (params, this.extractParams (path));
-        this.checkRequiredCredentials ();
         const nonce = this.nonce ().toString ();
         if (api === 'perpetualPrivate' || url === 'https://api.coinex.com/perpetual/v1/market/user_deals') {
+            this.checkRequiredCredentials ();
             query = this.extend ({
                 'access_id': this.apiKey,
                 'timestamp': nonce,
@@ -3895,6 +3895,7 @@ module.exports = class coinex extends Exchange {
                 url += '?' + this.urlencode (query);
             }
         } else {
+            this.checkRequiredCredentials ();
             query = this.extend ({
                 'access_id': this.apiKey,
                 'tonce': nonce,


### PR DESCRIPTION
- Solves issue where `checkRequiredCredentials()` was called for public endpoints