### PR TITLE
Add `parseTradingFee` on FTX

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -83,6 +83,8 @@ class Transpiler {
             [ /\.parseTradesData\s/g, '.parse_trades_data'],
             [ /\.parseTrades\s/g, '.parse_trades'],
             [ /\.parseTrade\s/g, '.parse_trade'],
+            [ /\.parseTradingFees\s/g, '.parse_trading_fees'],
+            [ /\.parseTradingFee\s/g, '.parse_trading_fee'],
             [ /\.parseTradingViewOHLCV\s/g, '.parse_trading_view_ohlcv'],
             [ /\.convertTradingViewToOHLCV\s/g, '.convert_trading_view_to_ohlcv'],
             [ /\.parseTransaction\s/g, '.parse_transaction'],

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -87,7 +87,7 @@ module.exports = class ftx extends Exchange {
                 'fetchTickers': true,
                 'fetchTime': false,
                 'fetchTrades': true,
-                'fetchTradingFee': false,
+                'fetchTradingFee': true,
                 'fetchTradingFees': true,
                 'fetchTransactionFees': undefined,
                 'fetchTransfer': undefined,
@@ -1185,6 +1185,31 @@ module.exports = class ftx extends Exchange {
         //
         const result = this.safeValue (response, 'result', []);
         return this.parseTrades (result, market, since, limit);
+    }
+
+    async fetchTradingFee (symbol, params = {}) {
+        /**
+         * @method
+         * @name ftx#fetchTradingFee
+         * @description fetch the trading fee for a market
+         * @param {str} symbol unified symbol of the market to fetch the fee for
+         * @param {dict} params extra parameters specific to the ftx api endpoint
+         * @returns {dict} a [fee structure]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.privateGetAccount (params);
+        const result = this.safeValue (response, 'result', {});
+        const maker = this.safeNumber (result, 'makerFee');
+        const taker = this.safeNumber (result, 'takerFee');
+        const tradingFee = {
+            'info': response,
+            'symbol': symbol,
+            'maker': maker,
+            'taker': taker,
+            'percentage': true,
+            'tierBased': true,
+        };
+        return tradingFee;
     }
 
     async fetchTradingFees (params = {}) {

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1187,6 +1187,64 @@ module.exports = class ftx extends Exchange {
         return this.parseTrades (result, market, since, limit);
     }
 
+    parseTradingFee (fee, market = undefined) {
+        //
+        //     {
+        //         "backstopProvider": true,
+        //         "collateral": 3568181.02691129,
+        //         "freeCollateral": 1786071.456884368,
+        //         "initialMarginRequirement": 0.12222384240257728,
+        //         "liquidating": false,
+        //         "maintenanceMarginRequirement": 0.07177992558058484,
+        //         "makerFee": 0.0002,
+        //         "marginFraction": 0.5588433331419503,
+        //         "openMarginFraction": 0.2447194090423075,
+        //         "takerFee": 0.0005,
+        //         "totalAccountValue": 3568180.98341129,
+        //         "totalPositionSize": 6384939.6992,
+        //         "username": "user@domain.com",
+        //         "positions": [
+        //             {
+        //                 "cost": -31.7906,
+        //                 "entryPrice": 138.22,
+        //                 "future": "ETH-PERP",
+        //                 "initialMarginRequirement": 0.1,
+        //                 "longOrderSize": 1744.55,
+        //                 "maintenanceMarginRequirement": 0.04,
+        //                 "netSize": -0.23,
+        //                 "openSize": 1744.32,
+        //                 "realizedPnl": 3.39441714,
+        //                 "shortOrderSize": 1732.09,
+        //                 "side": "sell",
+        //                 "size": 0.23,
+        //                 "unrealizedPnl": 0,
+        //             },
+        //         ],
+        //     },
+        //
+        const symbol = this.safeSymbol (undefined, market);
+        const maker = this.safeNumber (fee, 'makerFee');
+        const taker = this.safeNumber (fee, 'takerFee');
+        return {
+            'info': fee,
+            'symbol': symbol,
+            'maker': maker,
+            'taker': taker,
+            'percentage': true,
+            'tierBased': true,
+        };
+    }
+
+    parseTradingFees (response) {
+        const result = {};
+        for (let i = 0; i < this.symbols.length; i++) {
+            const symbol = this.symbols[i];
+            const market = this.market (symbol);
+            result[symbol] = this.parseTradingFee (response, market);
+        }
+        return result;
+    }
+
     async fetchTradingFee (symbol, params = {}) {
         /**
          * @method
@@ -1197,19 +1255,10 @@ module.exports = class ftx extends Exchange {
          * @returns {dict} a [fee structure]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
          */
         await this.loadMarkets ();
+        const market = this.market (symbol);
         const response = await this.privateGetAccount (params);
         const result = this.safeValue (response, 'result', {});
-        const maker = this.safeNumber (result, 'makerFee');
-        const taker = this.safeNumber (result, 'takerFee');
-        const tradingFee = {
-            'info': response,
-            'symbol': symbol,
-            'maker': maker,
-            'taker': taker,
-            'percentage': true,
-            'tierBased': true,
-        };
-        return tradingFee;
+        return this.parseTradingFee (result, market);
     }
 
     async fetchTradingFees (params = {}) {
@@ -1260,21 +1309,7 @@ module.exports = class ftx extends Exchange {
         //     }
         //
         const result = this.safeValue (response, 'result', {});
-        const maker = this.safeNumber (result, 'makerFee');
-        const taker = this.safeNumber (result, 'takerFee');
-        const tradingFees = {};
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
-            tradingFees[symbol] = {
-                'info': response,
-                'symbol': symbol,
-                'maker': maker,
-                'taker': taker,
-                'percentage': true,
-                'tierBased': true,
-            };
-        }
-        return tradingFees;
+        return this.parseTradingFees (result);
     }
 
     async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Since the `parseTradingFees` are just created by iterating through all symbols, the `parseTradingFee` method can easily be supported.

My IDE showed me the following warning on the return statement. I am not too experienced with JS, so please double-check whether I missed something.
```js
Returned expression type {symbol, percentage: boolean, maker: (any | number), tierBased: boolean, taker: (any | number), info: any} is not assignable to type Promise<never>
```