### PR TITLE
Flip sign for OKX fees

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -1731,8 +1731,9 @@ module.exports = class okx extends Exchange {
         return {
             'info': fee,
             'symbol': this.safeSymbol (undefined, market),
-            'maker': this.safeNumber (fee, 'maker'),
-            'taker': this.safeNumber (fee, 'taker'),
+            // OKX returns the fees as negative values opposed to other exchanges, so the sign needs to be flipped
+            'maker': this.safeNumber (fee, 'maker') * -1,
+            'taker': this.safeNumber (fee, 'taker') * -1,
         };
     }
 

--- a/js/okx.js
+++ b/js/okx.js
@@ -1732,8 +1732,8 @@ module.exports = class okx extends Exchange {
             'info': fee,
             'symbol': this.safeSymbol (undefined, market),
             // OKX returns the fees as negative values opposed to other exchanges, so the sign needs to be flipped
-            'maker': this.safeNumber (fee, 'maker') * -1,
-            'taker': this.safeNumber (fee, 'taker') * -1,
+            'maker': this.parseNumber (Precise.stringNeg (this.safeString (fee, 'maker'))),
+            'taker': this.parseNumber (Precise.stringNeg (this.safeString (fee, 'taker'))),
         };
     }
 


### PR DESCRIPTION
As opposed to other exchanges, OKX returns the fees in a flipped way (e.g. -0.0008 means a fee of 0.08%). This breaks the CCXT fee structure unification & explanation (https://docs.ccxt.com/en/latest/manual.html#fee-structure).