### PR TITLE
Digifinex fetchBorrowRate, fetchBorrowRates

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -28,6 +28,8 @@ module.exports = class digifinex extends Exchange {
                 'createOrder': true,
                 'fetchBalance': true,
                 'fetchBorrowInterest': true,
+                'fetchBorrowRate': true,
+                'fetchBorrowRates': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
@@ -1750,6 +1752,104 @@ module.exports = class digifinex extends Exchange {
             'datetime': undefined,
             'info': info,
         };
+    }
+
+    async fetchBorrowRate (code, params = {}) {
+        await this.loadMarkets ();
+        const request = {};
+        const response = await this.privateGetMarginAssets (this.extend (request, params));
+        //
+        //     {
+        //         "list": [
+        //             {
+        //                 "valuation_rate": 1,
+        //                 "total": 1.92012186174,
+        //                 "free": 1.92012186174,
+        //                 "currency": "USDT"
+        //             },
+        //         ],
+        //         "total": 45.133305540922,
+        //         "code": 0,
+        //         "unrealized_pnl": 0,
+        //         "free": 45.133305540922,
+        //         "equity": 45.133305540922
+        //     }
+        //
+        const data = this.safeValue (response, 'list', []);
+        let result = [];
+        for (let i = 0; i < data.length; i++) {
+            const entry = data[i];
+            if (this.safeString (entry, 'currency') === code) {
+                result = entry;
+            }
+        }
+        const currency = this.safeString (result, 'currency');
+        return this.parseBorrowRate (result, currency);
+    }
+
+    async fetchBorrowRates (params = {}) {
+        await this.loadMarkets ();
+        const response = await this.privateGetMarginAssets (params);
+        //
+        //     {
+        //         "list": [
+        //             {
+        //                 "valuation_rate": 1,
+        //                 "total": 1.92012186174,
+        //                 "free": 1.92012186174,
+        //                 "currency": "USDT"
+        //             },
+        //         ],
+        //         "total": 45.133305540922,
+        //         "code": 0,
+        //         "unrealized_pnl": 0,
+        //         "free": 45.133305540922,
+        //         "equity": 45.133305540922
+        //     }
+        //
+        const result = this.safeValue (response, 'list');
+        return this.parseBorrowRates (result, 'currency');
+    }
+
+    parseBorrowRate (info, currency = undefined) {
+        //
+        //     {
+        //         "valuation_rate": 1,
+        //         "total": 1.92012186174,
+        //         "free": 1.92012186174,
+        //         "currency": "USDT"
+        //     }
+        //
+        const timestamp = this.milliseconds ();
+        const currencyId = this.safeString (info, 'currency');
+        return {
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'rate': 0.001, // all interest rates on digifinex are 0.1%
+            'period': 86400000,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': info,
+        };
+    }
+
+    parseBorrowRates (info, codeKey) {
+        //
+        //     {
+        //         "valuation_rate": 1,
+        //         "total": 1.92012186174,
+        //         "free": 1.92012186174,
+        //         "currency": "USDT"
+        //     },
+        //
+        const result = {};
+        for (let i = 0; i < info.length; i++) {
+            const item = info[i];
+            const currency = this.safeString (item, codeKey);
+            const code = this.safeCurrencyCode (currency);
+            const borrowRate = this.parseBorrowRate (item, currency);
+            result[code] = borrowRate;
+        }
+        return result;
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -19,9 +19,9 @@ module.exports = class digifinex extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined, // has but unimplemented
+                'margin': true,
                 'swap': undefined, // has but unimplemented
-                'future': undefined, // has but unimplemented
+                'future': false,
                 'option': false,
                 'cancelOrder': true,
                 'cancelOrders': true,
@@ -29,6 +29,8 @@ module.exports = class digifinex extends Exchange {
                 'fetchBalance': true,
                 'fetchBorrowInterest': true,
                 'fetchBorrowRate': true,
+                'fetchBorrowRateHistories': false,
+                'fetchBorrowRateHistory': false,
                 'fetchBorrowRates': true,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
@@ -49,6 +51,7 @@ module.exports = class digifinex extends Exchange {
                 'fetchTradingFee': false,
                 'fetchTradingFees': false,
                 'fetchWithdrawals': true,
+                'setMarginMode': false,
                 'transfer': true,
                 'withdraw': true,
             },


### PR DESCRIPTION
Added fetchBorrowRate and fetchBorrowRates to Digifinex:

fetchBorrowRate:
```
digifinex.fetchBorrowRate (BTC)
2022-06-07T20:01:31.345Z iteration 0 passed in 1370 ms

{
  currency: 'BTC',
  rate: 0.001,
  period: 86400000,
  timestamp: 1654632091345,
  datetime: '2022-06-07T20:01:31.345Z',
  info: {
    valuation_rate: '1',
    total: '0.0013930827',
    free: '0.0013930827',
    currency: 'BTC'
  }
}
```

fetchBorrowRates:
```
digifinex.fetchBorrowRates ()
2022-06-07T20:01:13.180Z iteration 0 passed in 1419 ms

{
  USDT: {
    currency: 'USDT',
    rate: 0.001,
    period: 86400000,
    timestamp: 1654632073180,
    datetime: '2022-06-07T20:01:13.180Z',
    info: {
      valuation_rate: '1',
      total: '1.92012186174',
      free: '1.92012186174',
      currency: 'USDT'
    }
  },
  BTC: {
    currency: 'BTC',
    rate: 0.001,
    period: 86400000,
    timestamp: 1654632073180,
    datetime: '2022-06-07T20:01:13.180Z',
    info: {
      valuation_rate: '1',
      total: '0.0013930827',
      free: '0.0013930827',
      currency: 'BTC'
    }
  },
  ETH: {
    currency: 'ETH',
    rate: 0.001,
    period: 86400000,
    timestamp: 1654632073180,
    datetime: '2022-06-07T20:01:13.180Z',
    info: { valuation_rate: '1', total: '0', free: '0', currency: 'ETH' }
  },
...
}
```