### PR TITLE
Bitfinex upgrade to v2 and detach v1

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -699,8 +699,8 @@ module.exports = class bitfinex2 extends Exchange {
             const networks = {};
             const currencyNetworks = this.safeValue (response, 8, []);
             const cleanId = id.replace ('F0', '');
-            for (let i = 0; i < currencyNetworks.length; i++) {
-                const pair = currencyNetworks[i];
+            for (let j = 0; j < currencyNetworks.length; j++) {
+                const pair = currencyNetworks[j];
                 const networkId = this.safeString (pair, 0);
                 const currencyId = this.safeString (this.safeValue (pair, 1, []), 0);
                 if (currencyId === cleanId) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -90,12 +90,6 @@ module.exports = class bitfinex2 extends Exchange {
                 'fees': 'https://www.bitfinex.com/fees',
             },
             'api': {
-                'v1': {
-                    'get': [
-                        'symbols',
-                        'symbols_details',
-                    ],
-                },
                 'public': {
                     'get': {
                         'conf/{config}': 2.66, // 90 requests a minute

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -329,45 +329,6 @@ module.exports = class bitfinex2 extends Exchange {
                 },
                 'currencyNames': {
                 },
-                'commonCurrencies': {
-                    'ALG': 'ALGO', // https://github.com/ccxt/ccxt/issues/6034
-                    'AMP': 'AMPL',
-                    'ATO': 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
-                    'BCHABC': 'XEC',
-                    'BCHN': 'BCH',
-                    'DAT': 'DATA',
-                    'DOG': 'MDOGE',
-                    'DSH': 'DASH',
-                    // https://github.com/ccxt/ccxt/issues/7399
-                    // https://coinmarketcap.com/currencies/pnetwork/
-                    // https://en.cryptonomist.ch/blog/eidoo/the-edo-to-pnt-upgrade-what-you-need-to-know-updated/
-                    'EDO': 'PNT',
-                    'EUS': 'EURS',
-                    'EUT': 'EURT',
-                    'IDX': 'ID',
-                    'IOT': 'IOTA',
-                    'IQX': 'IQ',
-                    'LUNA': 'LUNC',
-                    'LUNA2': 'LUNA',
-                    'MNA': 'MANA',
-                    'ORS': 'ORS Group', // conflict with Origin Sport #3230
-                    'PAS': 'PASS',
-                    'QSH': 'QASH',
-                    'QTM': 'QTUM',
-                    'RBT': 'RBTC',
-                    'SNG': 'SNGLS',
-                    'STJ': 'STORJ',
-                    'TERRAUST': 'USTC',
-                    'TSD': 'TUSD',
-                    'YGG': 'YEED', // conflict with Yield Guild Games
-                    'YYW': 'YOYOW',
-                    'UDC': 'USDC',
-                    'UST': 'USDT',
-                    'VSY': 'VSYS',
-                    'WAX': 'WAXP',
-                    'XCH': 'XCHF',
-                    'ZBT': 'ZB',
-                },
             },
             'exceptions': {
                 'exact': {
@@ -389,8 +350,42 @@ module.exports = class bitfinex2 extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'UST': 'USDT',
                 'EUTF0': 'EURT',
                 'USTF0': 'USDT',
+                'ALG': 'ALGO', // https://github.com/ccxt/ccxt/issues/6034
+                'AMP': 'AMPL',
+                'ATO': 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
+                'BCHABC': 'XEC',
+                'BCHN': 'BCH',
+                'DAT': 'DATA',
+                'DOG': 'MDOGE',
+                'DSH': 'DASH',
+                'EDO': 'PNT',
+                'EUS': 'EURS',
+                'EUT': 'EURT',
+                'IDX': 'ID',
+                'IOT': 'IOTA',
+                'IQX': 'IQ',
+                'LUNA': 'LUNC',
+                'LUNA2': 'LUNA',
+                'MNA': 'MANA',
+                'ORS': 'ORS Group', // conflict with Origin Sport #3230
+                'PAS': 'PASS',
+                'QSH': 'QASH',
+                'QTM': 'QTUM',
+                'RBT': 'RBTC',
+                'SNG': 'SNGLS',
+                'STJ': 'STORJ',
+                'TERRAUST': 'USTC',
+                'TSD': 'TUSD',
+                'YGG': 'YEED', // conflict with Yield Guild Games
+                'YYW': 'YOYOW',
+                'UDC': 'USDC',
+                'VSY': 'VSYS',
+                'WAX': 'WAXP',
+                'XCH': 'XCHF',
+                'ZBT': 'ZB',
             },
         });
     }
@@ -675,6 +670,10 @@ module.exports = class bitfinex2 extends Exchange {
         const result = {};
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i];
+            if (id.indexOf ('F0') >= 0) {
+                // we get a lot of F0 currencies, skip those
+                // continue;
+            }
             const code = this.safeCurrencyCode (id);
             const label = this.safeValue (indexed['label'], id, []);
             const name = this.safeString (label, 1);

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -469,7 +469,10 @@ module.exports = class bitfinex2 extends Exchange {
             }
             const minOrderSizeString = this.safeString (market, 3);
             const maxOrderSizeString = this.safeString (market, 4);
-            const margin = (marginIds.indexOf (id) >= 0) ? true : false;
+            let margin = false;
+            if (marginIds.indexOf (id) >= 0) {
+                margin = true;
+            }
             result.push ({
                 'id': 't' + id,
                 'symbol': symbol,

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1330,6 +1330,27 @@ module.exports = class bitfinex2 extends Exchange {
         return this.parseOHLCVs (response, market, timeframe, since, limit);
     }
 
+    parseOHLCV (ohlcv, market = undefined) {
+        //
+        //     [
+        //         1457539800000,
+        //         0.02594,
+        //         0.02594,
+        //         0.02594,
+        //         0.02594,
+        //         0.1
+        //     ]
+        //
+        return [
+            this.safeInteger (ohlcv, 0),
+            this.safeNumber (ohlcv, 1),
+            this.safeNumber (ohlcv, 3),
+            this.safeNumber (ohlcv, 4),
+            this.safeNumber (ohlcv, 2),
+            this.safeNumber (ohlcv, 5),
+        ];
+    }
+
     parseOrderStatus (status) {
         if (status === undefined) {
             return status;

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -2191,9 +2191,11 @@ module.exports = class bitfinex2 extends Exchange {
         if (networkId === undefined) {
             throw new ArgumentsRequired (this.id + " fetchDepositAddress() could not find a network for '" + code + "'. You can specify it by providing the 'network' value inside params");
         }
+        const wallet = this.safeString (params, 'wallet', 'exchange');  // 'exchange', 'margin', 'funding' and also old labels 'exchange', 'trading', 'deposit', respectively
+        params = this.omit (params, 'network', 'wallet');
         const request = {
             'method': networkId,
-            'wallet': 'exchange', // 'exchange', 'margin', 'funding' and also old labels 'exchange', 'trading', 'deposit', respectively
+            'wallet': wallet,
             'amount': this.numberToString (amount),
             'address': address,
         };

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -485,11 +485,8 @@ module.exports = class bitfinex2 extends Exchange {
             const minOrderSizeString = this.safeString (market, 3);
             const maxOrderSizeString = this.safeString (market, 4);
             let margin = false;
-            for (let i = 0; i < marginIds.length; i++) {
-                if (marginIds[i] === id) {
-                    margin = true;
-                    break;
-                }
+            if (this.inArray (id, marginIds)) {
+                margin = true;
             }
             result.push ({
                 'id': 't' + id,

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -327,6 +327,47 @@ module.exports = class bitfinex2 extends Exchange {
                         'settlementCurrencies': [ 'BTC', 'USDT', 'EURT' ],
                     },
                 },
+                'currencyNames': {
+                },
+                'commonCurrencies': {
+                    'ALG': 'ALGO', // https://github.com/ccxt/ccxt/issues/6034
+                    'AMP': 'AMPL',
+                    'ATO': 'ATOM', // https://github.com/ccxt/ccxt/issues/5118
+                    'BCHABC': 'XEC',
+                    'BCHN': 'BCH',
+                    'DAT': 'DATA',
+                    'DOG': 'MDOGE',
+                    'DSH': 'DASH',
+                    // https://github.com/ccxt/ccxt/issues/7399
+                    // https://coinmarketcap.com/currencies/pnetwork/
+                    // https://en.cryptonomist.ch/blog/eidoo/the-edo-to-pnt-upgrade-what-you-need-to-know-updated/
+                    'EDO': 'PNT',
+                    'EUS': 'EURS',
+                    'EUT': 'EURT',
+                    'IDX': 'ID',
+                    'IOT': 'IOTA',
+                    'IQX': 'IQ',
+                    'LUNA': 'LUNC',
+                    'LUNA2': 'LUNA',
+                    'MNA': 'MANA',
+                    'ORS': 'ORS Group', // conflict with Origin Sport #3230
+                    'PAS': 'PASS',
+                    'QSH': 'QASH',
+                    'QTM': 'QTUM',
+                    'RBT': 'RBTC',
+                    'SNG': 'SNGLS',
+                    'STJ': 'STORJ',
+                    'TERRAUST': 'USTC',
+                    'TSD': 'TUSD',
+                    'YGG': 'YEED', // conflict with Yield Guild Games
+                    'YYW': 'YOYOW',
+                    'UDC': 'USDC',
+                    'UST': 'USDT',
+                    'VSY': 'VSYS',
+                    'WAX': 'WAXP',
+                    'XCH': 'XCHF',
+                    'ZBT': 'ZB',
+                },
             },
             'exceptions': {
                 'exact': {
@@ -535,7 +576,8 @@ module.exports = class bitfinex2 extends Exchange {
             'pub:map:currency:undl', // maps derivatives symbols to their underlying currency
             'pub:map:currency:pool', // maps symbols to underlying network/protocol they operate on
             'pub:map:currency:explorer', // maps symbols to their recognised block explorer URLs
-            'pub:map:currency:tx:fee', // maps currencies to their withdrawal fees https://github.com/ccxt/ccxt/issues/7745
+            'pub:map:currency:tx:fee', // maps currencies to their withdrawal fees https://github.com/ccxt/ccxt/issues/7745,
+            'pub:map:tx:method', // maps withdrawal/deposit methods to their API symbols
         ];
         const config = labels.join (',');
         const request = {
@@ -667,6 +709,34 @@ module.exports = class bitfinex2 extends Exchange {
                     },
                 },
             };
+            const networks = {};
+            const currencyNetworks = this.safeValue (response, 8, []);
+            for (let i = 0; i < currencyNetworks.length; i++) {
+                const pair = currencyNetworks[i];
+                const networkId = this.safeString (pair, 0);
+                const currencyId = this.safeString (this.safeValue (pair, 1, []), 0);
+                if (currencyId === id) {
+                    networks[networkId] = {
+                        'info': currencyId,
+                        'id': currencyId,
+                        'network': undefined,
+                        'active': undefined,
+                        'deposit': undefined,
+                        'withdraw': undefined,
+                        'fee': undefined,
+                        'precision': undefined,
+                        'limits': {
+                            'withdraw': {
+                                'min': undefined,
+                                'max': undefined,
+                            },
+                        },
+                    };
+                }
+            }
+            if (Object.keys (networks).length > 0) {
+                result['networks'] = networks;
+            }
         }
         return result;
     }

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -485,8 +485,11 @@ module.exports = class bitfinex2 extends Exchange {
             const minOrderSizeString = this.safeString (market, 3);
             const maxOrderSizeString = this.safeString (market, 4);
             let margin = false;
-            if (marginIds.indexOf (id) >= 0) {
-                margin = true;
+            for (let i = 0; i < marginIds.length; i++) {
+                if (marginIds[i] === id) {
+                    margin = true;
+                    break;
+                }
             }
             result.push ({
                 'id': 't' + id,
@@ -720,7 +723,9 @@ module.exports = class bitfinex2 extends Exchange {
                     };
                 }
             }
-            if (Object.keys (networks).length > 0) {
+            const keysNetworks = Object.keys (networks);
+            const networksLength = keysNetworks.length;
+            if (networksLength > 0) {
                 result[code]['networks'] = networks;
             }
         }

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1836,16 +1836,17 @@ module.exports = class bitfinex2 extends Exchange {
         const currency = this.currency (code);
         // if not provided explicitly we will try to match using the currency name
         const network = this.safeString (params, 'network', code);
-        params = this.omit (params, 'network');
         const currencyNetworks = this.safeValue (currency, 'networks', {});
         const currencyNetwork = this.safeValue (currencyNetworks, network);
         const networkId = this.safeString (currencyNetwork, 'id');
         if (networkId === undefined) {
             throw new ArgumentsRequired (this.id + " fetchDepositAddress() could not find a network for '" + code + "'. You can specify it by providing the 'network' value inside params");
         }
+        const wallet = this.safeString (params, 'wallet', 'exchange');  // 'exchange', 'margin', 'funding' and also old labels 'exchange', 'trading', 'deposit', respectively
+        params = this.omit (params, 'network', 'wallet');
         const request = {
             'method': networkId,
-            'wallet': 'exchange', // 'exchange', 'margin', 'funding' and also old labels 'exchange', 'trading', 'deposit', respectively
+            'wallet': wallet,
             'op_renew': 0, // a value of 1 will generate a new address
         };
         const response = await this.privatePostAuthWDepositAddress (this.extend (request, params));

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -2084,7 +2084,7 @@ module.exports = class bitfinex2 extends Exchange {
         //              vol_BFX: '0',
         //              vol_BFX_safe: '0',
         //              vol_BFX_maker: '0'
-        //              } g
+        //              }
         //          ],
         //          {},
         //          0

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -711,14 +711,16 @@ module.exports = class bitfinex2 extends Exchange {
             };
             const networks = {};
             const currencyNetworks = this.safeValue (response, 8, []);
+            const cleanId = id.replace ('F0', '');
             for (let i = 0; i < currencyNetworks.length; i++) {
                 const pair = currencyNetworks[i];
                 const networkId = this.safeString (pair, 0);
                 const currencyId = this.safeString (this.safeValue (pair, 1, []), 0);
-                if (currencyId === id) {
-                    networks[networkId] = {
-                        'info': currencyId,
-                        'id': currencyId,
+                if (currencyId === cleanId) {
+                    const network = this.safeNetwork (networkId);
+                    networks[network] = {
+                        'info': networkId,
+                        'id': networkId,
                         'network': undefined,
                         'active': undefined,
                         'deposit': undefined,
@@ -735,10 +737,31 @@ module.exports = class bitfinex2 extends Exchange {
                 }
             }
             if (Object.keys (networks).length > 0) {
-                result['networks'] = networks;
+                result[code]['networks'] = networks;
             }
         }
         return result;
+    }
+
+    safeNetwork (networkId) {
+        const networksById = {
+            'BITCOIN': 'BTC',
+            'LITECOIN': 'LTC',
+            'ETHEREUM': 'ERC20',
+            'TETHERUSE': 'ERC20',
+            'TETHERUSO': 'OMNI',
+            'TETHERUSL': 'LIQUID',
+            'TETHERUSX': 'TRC20',
+            'TETHERUSS': 'EOS',
+            'TETHERUSDTAVAX': 'AVAX',
+            'TETHERUSDTSOL': 'SOL',
+            'TETHERUSDTALG': 'ALGO',
+            'TETHERUSDTBCH': 'BCH',
+            'TETHERUSDTKSM': 'KSM',
+            'TETHERUSDTDVF': 'DVF',
+            'TETHERUSDTOMG': 'OMG',
+        };
+        return this.safeString (networksById, networkId, networkId);
     }
 
     async fetchBalance (params = {}) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -941,7 +941,7 @@ module.exports = class bitfinex2 extends Exchange {
          * @param {dict} params extra parameters specific to the bitfinex2 api endpoint
          * @returns {dict} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
-        throw new NotSupported (this.id + ' fetchOrder() is not supported yet');
+        throw new NotSupported (this.id + ' fetchOrder() is not supported yet. Consider using fetchOpenOrder() or fetchClosedOrder() instead.');
     }
 
     async fetchOrderBook (symbol, limit = undefined, params = {}) {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -322,13 +322,6 @@ module.exports = class bitfinex2 extends Exchange {
                     'derivatives': 'margin',
                     'future': 'margin',
                 },
-                'swap': {
-                    'fetchMarkets': {
-                        'settlementCurrencies': [ 'BTC', 'USDT', 'EURT' ],
-                    },
-                },
-                'currencyNames': {
-                },
             },
             'exceptions': {
                 'exact': {


### PR DESCRIPTION
- Removed Bitfinex v1 inheritance
- Upgraded remaining v1 functionality to v2
- Fixed a bug in swap symbols (we were using an exchange specific settle)
- Added networks to currencies

- Note: fetchDepositAddress/withdraw only work for stablecoins if your account level is intermediate or higher.