### PR TITLE
Update fetchMyTrades to get information from trades

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -1707,14 +1707,7 @@ module.exports = class bittrex extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
             symbol = market['symbol'];
-            // because of this line we will have to rethink the entire v3
-            // in other words, markets define all the rest of the API
-            // and v3 market ids are reversed in comparison to v1
-            // v3 has to be a completely separate implementation
-            // otherwise we will have to shuffle symbols and currencies everywhere
-            // which is prone to errors, as was shown here
-            // https://github.com/ccxt/ccxt/pull/5219#issuecomment-499646209
-            request['marketSymbol'] = market['base'] + '-' + market['quote'];
+            request['marketSymbol'] = market['id'];
         }
         const response = await this.privateGetExecutions (this.extend (request, params));
         const trades = this.parseTrades (response, market);

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -55,7 +55,7 @@ module.exports = class bittrex extends Exchange {
                 'fetchLeverageTiers': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
-                'fetchMyTrades': 'emulated',
+                'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
@@ -1702,15 +1702,6 @@ module.exports = class bittrex extends Exchange {
             'info': order,
             'takerOrMaker': undefined,
         };
-    }
-
-    ordersToTrades (orders) {
-        // this entire method should be moved to the base class
-        const result = [];
-        for (let i = 0; i < orders.length; i++) {
-            result.push (this.orderToTrade (orders[i]));
-        }
-        return result;
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -140,6 +140,7 @@ module.exports = class bittrex extends Exchange {
                         'deposits/closed',
                         'deposits/ByTxId/{txId}',
                         'deposits/{depositId}',
+                        'executions',
                         'orders/closed',
                         'orders/open',
                         'orders/{orderId}',
@@ -1744,9 +1745,8 @@ module.exports = class bittrex extends Exchange {
             // https://github.com/ccxt/ccxt/pull/5219#issuecomment-499646209
             request['marketSymbol'] = market['base'] + '-' + market['quote'];
         }
-        const response = await this.privateGetOrdersClosed (this.extend (request, params));
-        const orders = this.parseOrders (response, market);
-        const trades = this.ordersToTrades (orders);
+        const response = await this.privateGetExecutions (this.extend (request, params));
+        const trades = this.parseTrades (response, market);
         return this.filterBySymbolSinceLimit (trades, symbol, since, limit);
     }
 

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -1684,26 +1684,6 @@ module.exports = class bittrex extends Exchange {
         return this.parseOrder (response, market);
     }
 
-    orderToTrade (order) {
-        // this entire method should be moved to the base class
-        const timestamp = this.safeInteger2 (order, 'lastTradeTimestamp', 'timestamp');
-        return {
-            'id': this.safeString (order, 'id'),
-            'side': this.safeString (order, 'side'),
-            'order': this.safeString (order, 'id'),
-            'type': this.safeString (order, 'type'),
-            'price': this.safeNumber (order, 'average'),
-            'amount': this.safeNumber (order, 'filled'),
-            'cost': this.safeNumber (order, 'cost'),
-            'symbol': this.safeString (order, 'symbol'),
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
-            'fee': this.safeValue (order, 'fee'),
-            'info': order,
-            'takerOrMaker': undefined,
-        };
-    }
-
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         /**
          * @method


### PR DESCRIPTION
Currently the method fetchMyTrades is getting information from closed orders instead from trades, which is wrong.

Also, the IDs that is returning fetchMyTrades are order IDs, but I would expect to get trade IDs. And the number of orders is not the same as the number of trades.

I've updated the method so it is working in the same way that works the method **watchMyTrades** of CCXT.PRO.

The problem is that Bittrex API returns this information:

`{
      id: 'd4f56a73-838f-4771-a80b-060a3690f998',
      marketSymbol: 'B2M-USDT',
      executedAt: '2022-06-08T11:10:23.56Z',
      quantity: '100.00000000',
      rate: '0.014040000000',
      orderId: '1805cbfd-9963-48fe-8eb6-8f3d2ee8519d',
      commission: '0.00042120',
      isTaker: true
}`

From this information is not possible to get the properties **type** and **side**. This is the information the returns the new implementation of fetchMyTrades:

`
  {
    info: {
      id: 'd4f56a73-838f-4771-a80b-060a3690f998',
      marketSymbol: 'B2M-USDT',
      executedAt: '2022-06-08T11:10:23.56Z',
      quantity: '100.00000000',
      rate: '0.014040000000',
      orderId: '1805cbfd-9963-48fe-8eb6-8f3d2ee8519d',
      commission: '0.00042120',
      isTaker: true
    },
    timestamp: 1654686623560,
    datetime: '2022-06-08T11:10:23.560Z',
    symbol: 'B2M/USDT',
    id: 'd4f56a73-838f-4771-a80b-060a3690f998',
    order: '1805cbfd-9963-48fe-8eb6-8f3d2ee8519d',
    takerOrMaker: 'taker',
    type: undefined,
    side: undefined,
    price: 0.01404,
    amount: 100,
    cost: 1.404,
    fee: { cost: 0.0004212, currency: 'USDT' },
    fees: [ [Object] ]
  }
`
In any case, I think that is better this information because they are trades, and the current implementation is returning orders.
