### PR TITLE
Bitvavo: adding stop-orders

### DIFF
--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -931,6 +931,36 @@ module.exports = class bitvavo extends Exchange {
         };
     }
 
+    async createOrder2 (symbol, type, side, amount, price = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitvavo#createOrder
+         * @description create a trade order
+         * @param {str} symbol unified symbol of the market to create an order in
+         * @param {str} type 'market' or 'limit'
+         * @param {str} side 'buy' or 'sell'
+         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {dict} params extra parameters specific to the bitvavo api endpoint
+         * @returns {dict} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'market': market['id'],
+            'side': side,
+            'orderType': type, // 'market', 'limit', 'stopLoss', 'stopLossLimit', 'takeProfit', 'takeProfitLimit'
+            // 'amount': this.amountToPrecision (symbol, amount),
+            // 'price': this.priceToPrecision (symbol, price),
+            // 'amountQuote': this.costToPrecision (symbol, cost),
+            // 'timeInForce': 'GTC', // 'GTC', 'IOC', 'FOK'
+            // 'selfTradePrevention': 'decrementAndCancel', // 'decrementAndCancel', 'cancelOldest', 'cancelNewest', 'cancelBoth'
+            // 'postOnly': false,
+            // 'disableMarketProtection': false, // don't cancel if the next fill price is 10% worse than the best fill price
+            // 'responseRequired': true, // false is faster
+        };
+    }
+
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         /**
          * @method

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -1035,7 +1035,18 @@ module.exports = class bitvavo extends Exchange {
         //          "filledAmountQuote":"0",
         //          "feePaid":"0",
         //          "feeCurrency":"EUR",
-        //          "fills":[],
+        //          "fills":[
+        //             {
+        //                 "id":"b0c86aa5-6ed3-4a2d-ba3a-be9a964220f4",
+        //                 "timestamp":1590505649245,
+        //                 "amount":"0.249825",
+        //                 "price":"183.49",
+        //                 "taker":true,
+        //                 "fee":"0.12038925",
+        //                 "feeCurrency":"EUR",
+        //                 "settled":true
+        //             }
+        //          ],
         //          "selfTradePrevention":"decrementAndCancel",
         //          "visible":true,
         //          "timeInForce":"GTC",

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -1006,18 +1006,43 @@ module.exports = class bitvavo extends Exchange {
             request['triggerType'] = 'price';
             request['triggerReference'] = 'lastTrade'; // 'bestBid', 'bestAsk', 'midPrice'
         }
-        if (timeInForce !== undefined) {
+        if ((timeInForce !== undefined) && (timeInForce !== 'PO')) {
             request['timeInForce'] = timeInForce;
         }
         if (postOnly) {
             request['postOnly'] = true;
         }
-        return this.extend (request, params);
-        // const response = await this.privatePostOrder (this.extend (request, params));
+        const response = await this.privatePostOrder (this.extend (request, params));
         //
+        //      {
+        //          "orderId":"dec6a640-5b4c-45bc-8d22-3b41c6716630",
+        //          "market":"DOGE-EUR",
+        //          "created":1654789135146,
+        //          "updated":1654789135153,
+        //          "status":"new",
+        //          "side":"buy",
+        //          "orderType":"stopLossLimit",
+        //          "amount":"200",
+        //          "amountRemaining":"200",
+        //          "price":"0.07471",
+        //          "triggerPrice":"0.0747",
+        //          "triggerAmount":"0.0747",
+        //          "triggerType":"price",
+        //          "triggerReference":"lastTrade",
+        //          "onHold":"14.98",
+        //          "onHoldCurrency":"EUR",
+        //          "filledAmount":"0",
+        //          "filledAmountQuote":"0",
+        //          "feePaid":"0",
+        //          "feeCurrency":"EUR",
+        //          "fills":[],
+        //          "selfTradePrevention":"decrementAndCancel",
+        //          "visible":true,
+        //          "timeInForce":"GTC",
+        //          "postOnly":false
+        //      }
         //
-        //
-        // return this.parseOrder (response, market);
+        return this.parseOrder (response, market);
     }
 
     async editOrder (id, symbol, type, side, amount = undefined, price = undefined, params = {}) {

--- a/js/bitvavo.js
+++ b/js/bitvavo.js
@@ -1035,7 +1035,7 @@ module.exports = class bitvavo extends Exchange {
         //          "filledAmountQuote":"0",
         //          "feePaid":"0",
         //          "feeCurrency":"EUR",
-        //          "fills":[
+        //          "fills":[ // filled with market orders only
         //             {
         //                 "id":"b0c86aa5-6ed3-4a2d-ba3a-be9a964220f4",
         //                 "timestamp":1590505649245,


### PR DESCRIPTION
note: discussed with Igor, the usage is not quite the same as `takeProfitPrice` and `stopLossPrice` is in other exchanges (in this case it specifies direction), see discord stop-order thread. 

(all combinations of types and params supported and default with only `triggerPrice` or `stopPrice` given is to `stopLoss` type)