### PR TITLE
zb-fetchDepositAddresses removed

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -1182,40 +1182,6 @@ module.exports = class zb extends Exchange {
         };
     }
 
-    async fetchDepositAddresses (codes = undefined, params = {}) {
-        await this.loadMarkets ();
-        const response = await this.spotV1PrivateGetGetPayinAddress (params);
-        //
-        //     {
-        //         "code": 1000,
-        //         "message": {
-        //             "des": "success",
-        //             "isSuc": true,
-        //             "datas": [
-        //                 {
-        //                     "blockChain": "btc",
-        //                     "isUseMemo": false,
-        //                     "address": "1LL5ati6pXHZnTGzHSA3rWdqi4mGGXudwM",
-        //                     "canWithdraw": true,
-        //                     "canDeposit": true
-        //                 },
-        //                 {
-        //                     "blockChain": "bts",
-        //                     "isUseMemo": true,
-        //                     "account": "btstest",
-        //                     "memo": "123",
-        //                     "canWithdraw": true,
-        //                     "canDeposit": true
-        //                 },
-        //             ]
-        //         }
-        //     }
-        //
-        const message = this.safeValue (response, 'message', {});
-        const datas = this.safeValue (message, 'datas', []);
-        return this.parseDepositAddresses (datas, codes);
-    }
-
     async fetchDepositAddress (code, params = {}) {
         /**
          * @method


### PR DESCRIPTION
`zb` `fetchDepositAddresses` isn't the same as other `fetchDepositAddresses` methods, `zb` will return multiple addresses, but they all have to be for the same currency, and other exchanges will return multiple currencies, `zb.fetchDepositAddresses` currrently doesn't work also, because it requires a single code argument, which isn't passed to it, it has an arguments codes but the api endpoint can't take multiple codes, it can only take a single code