### PR TITLE
@see transpile to python

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -387,6 +387,7 @@ class Transpiler {
             [ /\s+\* @method/g, '' ], // docstring @method
             [ /(\s+) \* @description (.*)/g, '$1$2' ], // docstring description
             [ /\s+\* @name .*/g, '' ], // docstring @name
+            [ /(\s+) \* @see( .*)/g, '$1see$2' ], // docstring @see
             [ /(\s+) \* @returns ([^\{])/g, '$1:returns: $2' ], // docstring return
             [ /(\s+) \* @returns \{(.+)\}/g, '$1:returns $2:' ], // docstring return
             [ /(\s+ \* @param \{[\]\[\|a-zA-Z]+\} )([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+) (.*)/g, '$1$2[\'$3\'] $4' ], // docstring params.anything


### PR DESCRIPTION
So that we can use the `@see` tag in docstrings, python doesn't have this tag so when transpiled the `@` is removed making it just `see`, making the see tag part of the description

```
* @see https://binance-docs.github.io/apidocs/futures/en/#new-future-account-transfer
```
transpiled to
```
see https://binance-docs.github.io/apidocs/futures/en/#new-future-account-transfer
```

for python