### PR TITLE
PHP - exchange decorator for overriding methods

### DIFF
--- a/ccxt.php
+++ b/ccxt.php
@@ -90,6 +90,7 @@ require_once PATH_TO_CCXT . 'RequestTimeout.php';
 require_once PATH_TO_CCXT . 'Precise.php';
 
 require_once PATH_TO_CCXT . 'Exchange.php';
+require_once PATH_TO_CCXT . 'ExchangeDecorator.php';
 require_once PATH_TO_CCXT_ASYNC . 'Exchange.php';
 
 $autoloadFile = __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';

--- a/php/ExchangeDecorator.php
+++ b/php/ExchangeDecorator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ccxt;
+
+use Exception;
+
+class Decorator
+{
+    protected $_instance;
+    private $methods = array();
+
+    public function __construct($instance)
+    {
+        $this->_instance = $instance;
+    }
+
+    public function addMethod ($method, $callback)
+    {
+        $this->methods[$method] = $callback;
+    }
+
+    public function __call($method, $args = array())
+    {
+        if (array_key_exists ( $method, $this->methods )) {
+            return call_user_func_array($this->methods[$method], $args);
+        }
+        return call_user_func_array(array($this->_instance, $method), $args);
+    }
+}


### PR DESCRIPTION
PHP - exchange decorator for overriding methods, without need to create endless derived classes. 
i.e. if user wants to add custom overload of `method1` for binance, then he does:

```
class myBinance extends binance {
    public function method1 () {
       ....
    }
}
```
(situation becomes more complex if same/other user wants to extend that class on the other part of the application).

However, with `Decorator` (you can name it other name if you want) we can create endless overrides for our custom methods without the need to create derived classes, as users are not always comfortable creating additional classes in other files, and sometimes want the compact code inside one method, and now it will be possible with

```
class MyApplication {

    private function whateverUserMethod (){
        ...
        $huobi = new \ccxt\huobi();
        $huobi_override = new \ccxt\Decorator($huobi);
        $huobi_override->addMethod( 'fetch_markets', function() use ($huobi, $huobi_override){
            var_dump($huobi_override->fetch_currencies ());
            var_dump($huobi->fetch_currencies());
        });
        $huobi_override->addMethod( 'fetch_currencies', function() use ($huobi, $huobi_override){
            return [ ];
        });
        $huobi_override->fetch_markets();
        ...
    } 
}
```

So, this PR shouldnt break anything and might be just a benefit and people might use in needed scenarios.
We can also include that in manuals.