### PR TITLE
Wavesexchange :: add fetchTickers

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -765,15 +765,7 @@ module.exports = class wavesexchange extends Exchange {
         let symbol = undefined;
         if ((baseId !== undefined) && (quoteId !== undefined)) {
             const marketId = baseId + '/' + quoteId;
-            if (marketId in this.markets_by_id) {
-                market = this.markets_by_id[marketId];
-            } else {
-                const base = this.safeCurrencyCode (baseId);
-                const quote = this.safeCurrencyCode (quoteId);
-                symbol = base + '/' + quote;
-            }
-        }
-        if ((symbol === undefined) && (market !== undefined)) {
+            market = this.safeMarket (marketId);
             symbol = market['symbol'];
         }
         const data = this.safeValue (ticker, 'data', {});
@@ -849,6 +841,44 @@ module.exports = class wavesexchange extends Exchange {
         const data = this.safeValue (response, 'data', []);
         const ticker = this.safeValue (data, 0, {});
         return this.parseTicker (ticker, market);
+    }
+
+    async fetchTickers (symbols = undefined, params = {}) {
+        /**
+         * @method
+         * @name wavesexchange#fetchTickers
+         * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @param {[str]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
+         * @param {dict} params extra parameters specific to the aax api endpoint
+         * @returns {dict} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.publicGetPairs (params);
+        //
+        //     {
+        //         "__type":"list",
+        //         "data":[
+        //             {
+        //                 "__type":"pair",
+        //                 "data":{
+        //                     "firstPrice":0.00012512,
+        //                     "lastPrice":0.00012441,
+        //                     "low":0.00012167,
+        //                     "high":0.00012768,
+        //                     "weightedAveragePrice":0.000124710697407246,
+        //                     "volume":209554.26356614,
+        //                     "quoteVolume":26.1336583539951,
+        //                     "volumeWaves":209554.26356614,
+        //                     "txsCount":6655
+        //                 },
+        //                 "amountAsset":"WAVES",
+        //                 "priceAsset":"8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS"
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        return this.parseTickers (data, symbols);
     }
 
     async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/13820

Demo
```
wavesexchange.fetchTickers ("["WAVES/USDT"]")
fetch Request:
 wavesexchange GET https://api.wavesplatform.com/v0/pairs 
RequestHeaders:
 { 'content-type': 'application/x-www-form-urlencoded' } 
RequestBody:
 undefined 

handleRestResponse:
 wavesexchange GET https://api.wavesplatform.com/v0/pairs 200 OK 
ResponseHeaders:

ResponseBody:

2022-06-13T13:46:19.103Z iteration 0 passed in 12300 ms

{
  'WAVES/USDT': {
    symbol: 'WAVES/USDT',
    timestamp: undefined,
    datetime: undefined,
    high: 6.05,
    low: 4.55,
    bid: undefined,
    bidVolume: undefined,
    ask: undefined,
    askVolume: undefined,
    vwap: 4.924992,
    open: 5.58,
    close: 4.68,
    last: 4.68,
    previousClose: undefined,
    change: -0.9,
    percentage: -16.129032258064516,
    average: 5.13,
    baseVolume: 29384.22770937,
    quoteVolume: 144717.1022582574,
    info: {
      __type: 'pair',
      data: {
        firstPrice: '5.58',
        lastPrice: '4.68',
        volume: '29384.22770937',
        quoteVolume: '144717.10225825737948',
        high: '6.05',
        low: '4.55',
        weightedAveragePrice: '4.924992',
        txsCount: '437',
        volumeWaves: '29384.22770937'
      },
      amountAsset: 'WAVES',
      priceAsset: '34N9YcEETLWn93qYQ64EsP1x89tSruJU44RrEMSXXEPJ'
    }
  }
}
```