### PR TITLE
zonda - describe, fetchTickers, fetchDepositAddress, fetchDepositAddresses 

### DIFF
--- a/js/zonda.js
+++ b/js/zonda.js
@@ -1388,9 +1388,11 @@ module.exports = class zonda extends Exchange {
         //     }
         //
         const currencyId = this.safeString (depositAddress, 'currency');
+        const address = this.safeString (depositAddress, 'address');
+        this.checkAddress (address);
         return {
             'currency': this.safeCurrencyCode (currencyId, currency),
-            'address': this.safeString (depositAddress, 'address'),
+            'address': address,
             'tag': this.safeString (depositAddress, 'tag'),
             'network': undefined,
             'info': depositAddress,
@@ -1456,7 +1458,7 @@ module.exports = class zonda extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data');
-        return this.parseDepositAddresses (data, codes, undefined, params);
+        return this.parseDepositAddresses (data, codes);
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {

--- a/js/zonda.js
+++ b/js/zonda.js
@@ -24,6 +24,9 @@ module.exports = class zonda extends Exchange {
                 'option': false,
                 'addMargin': false,
                 'cancelOrder': true,
+                'cancelOrders': false,
+                'cancelAllOrders': false,
+                'createDepositAddress': false,
                 'createOrder': true,
                 'createReduceOnlyOrder': false,
                 'fetchBalance': true,
@@ -32,6 +35,10 @@ module.exports = class zonda extends Exchange {
                 'fetchBorrowRateHistory': false,
                 'fetchBorrowRates': false,
                 'fetchBorrowRatesPerSymbol': false,
+                'fetchDeposit': false,
+                'fetchDeposits': undefined,
+                'fetchDepositAddress': true,
+                'fetchDepositAddresses': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
                 'fetchFundingRateHistory': false,
@@ -45,18 +52,29 @@ module.exports = class zonda extends Exchange {
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenInterestHistory': false,
+                'fetchOpenOrder': false,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
+                'fetchOrderBooks': false,
                 'fetchPosition': false,
                 'fetchPositions': false,
                 'fetchPositionsRisk': false,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTicker': true,
+                'fetchTickers': true,
+                'fetchTime': false,
                 'fetchTrades': true,
                 'fetchTradingFee': false,
                 'fetchTradingFees': false,
+                'fetchTransactionFee': false,
+                'fetchTransactionFees': false,
+                'fetchTransactions': undefined,
+                'fetchTransfer': false,
+                'fetchWithdrawal': false,
+                'fetchWithdrawals': undefined,
                 'reduceMargin': false,
                 'setLeverage': false,
+                'setMargin': false,
                 'setMarginMode': false,
                 'setPositionMode': false,
                 'transfer': true,
@@ -131,6 +149,7 @@ module.exports = class zonda extends Exchange {
                 },
                 'v1_01Private': {
                     'get': [
+                        'api_payments/deposits/crypto/addresses',
                         'payments/withdrawal/{detailId}',
                         'payments/deposit/{detailId}',
                         'trading/offer',
@@ -621,6 +640,35 @@ module.exports = class zonda extends Exchange {
         //
         const stats = this.safeValue (response, 'stats');
         return this.parseTicker (stats, market);
+    }
+
+    async fetchTickers (symbols = undefined, params = {}) {
+        /**
+         * @method
+         * @name zonda#fetchTickers
+         * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @param {[str]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
+         * @param {dict} params extra parameters specific to the zonda api endpoint
+         * @returns {dict} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.v1_01PublicGetTradingStats (params);
+        //
+        //     {
+        //         status: 'Ok',
+        //         items: {
+        //             'DAI-PLN': {
+        //                 m: 'DAI-PLN',
+        //                 h: '4.41',
+        //                 l: '4.37',
+        //                 v: '8.71068087',
+        //                 r24h: '4.36'
+        //             }
+        //         }
+        //     }
+        //
+        const items = this.safeValue (response, 'items');
+        return this.parseTickers (items, symbols);
     }
 
     async fetchLedger (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -1327,6 +1375,88 @@ module.exports = class zonda extends Exchange {
             'PLN': true,
         };
         return this.safeValue (fiatCurrencies, currency, false);
+    }
+
+    parseDepositAddress (depositAddress, currency = undefined) {
+        //
+        //     {
+        //         "address": "33u5YAEhQbYfjHHPsfMfCoSdEjfwYjVcBE",
+        //         "currency": "BTC",
+        //         "balanceId": "5d5d19e7-2265-49c7-af9a-047bcf384f21",
+        //         "balanceEngine": "BITBAY",
+        //         "tag": null
+        //     }
+        //
+        const currencyId = this.safeString (depositAddress, 'currency');
+        return {
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'address': this.safeString (depositAddress, 'address'),
+            'tag': this.safeString (depositAddress, 'tag'),
+            'network': undefined,
+            'info': depositAddress,
+        };
+    }
+
+    async fetchDepositAddress (code, params = {}) {
+        /**
+         * @method
+         * @name zonda#fetchDepositAddress
+         * @description fetch the deposit address for a currency associated with this account
+         * @param {str} code unified currency code
+         * @param {dict} params extra parameters specific to the zonda api endpoint
+         * @param {str|undefined} params.walletId Wallet id to filter deposit adresses.
+         * @returns {dict} an [address structure]{@link https://docs.ccxt.com/en/latest/manual.html#address-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'currency': currency['id'],
+        };
+        const response = await this.v1_01PrivateGetApiPaymentsDepositsCryptoAddresses (this.extend (request, params));
+        //
+        //     {
+        //         "status": "Ok",
+        //         "data": [{
+        //                 "address": "33u5YAEhQbYfjHHPsfMfCoSdEjfwYjVcBE",
+        //                 "currency": "BTC",
+        //                 "balanceId": "5d5d19e7-2265-49c7-af9a-047bcf384f21",
+        //                 "balanceEngine": "BITBAY",
+        //                 "tag": null
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data');
+        const first = this.safeValue (data, 0);
+        return this.parseDepositAddress (first, currency);
+    }
+
+    async fetchDepositAddresses (codes = undefined, params = {}) {
+        /**
+         * @method
+         * @name zonda#fetchDepositAddresses
+         * @description fetch deposit addresses for multiple currencies and chain types
+         * @param {[str]|undefined} codes zonda does not support filtering filtering by multiple codes and will ignore this parameter.
+         * @param {dict} params extra parameters specific to the zonda api endpoint
+         * @returns {dict} a list of [address structures]{@link https://docs.ccxt.com/en/latest/manual.html#address-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.v1_01PrivateGetApiPaymentsDepositsCryptoAddresses (params);
+        //
+        //     {
+        //         "status": "Ok",
+        //         "data": [{
+        //                 "address": "33u5YAEhQbYfjHHPsfMfCoSdEjfwYjVcBE",
+        //                 "currency": "BTC",
+        //                 "balanceId": "5d5d19e7-2265-49c7-af9a-047bcf384f21",
+        //                 "balanceEngine": "BITBAY",
+        //                 "tag": null
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data');
+        return this.parseDepositAddresses (data, codes, undefined, params);
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {


### PR DESCRIPTION
Note:  For `fetchTickers` I used the same endpoint that was being used in `fetchTicker`. (v1_01PublicGetTradingStats) (https://docs.zonda.exchange/v1.0.4-en/reference/market-statistics) which uses the last 24 hour values.
However the api also has an endpoint to get the values from the latest transaction (https://docs.zonda.exchange/v1.0.4-en/reference/ticker-1)

Waiting for KYC to test fetchDepositAddress