### PR TITLE
changed params.till -> params.until

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -2588,6 +2588,7 @@ module.exports = class aax extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest funding rate to fetch
          * @param {int|undefined} limit the maximum amount of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure} to fetch
          * @param {dict} params extra parameters specific to the aax api endpoint
+         * @param {int|undefined} params.until timestamp in ms of the latest funding rate to fetch
          * @returns {[dict]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
          */
         if (symbol === undefined) {
@@ -2601,13 +2602,10 @@ module.exports = class aax extends Exchange {
         if (since !== undefined) {
             request['startTime'] = parseInt (since / 1000);
         }
-        const till = this.safeInteger (params, 'till'); // unified in milliseconds
-        const endTime = this.safeString (params, 'endTime'); // exchange-specific in seconds
-        params = this.omit (params, [ 'endTime', 'till' ]);
+        const till = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
+        params = this.omit (params, [ 'till', 'until' ]);
         if (till !== undefined) {
             request['endTime'] = parseInt (till / 1000);
-        } else if (endTime !== undefined) {
-            request['endTime'] = endTime;
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/js/binance.js
+++ b/js/binance.js
@@ -4560,7 +4560,7 @@ module.exports = class binance extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest funding rate to fetch
          * @param {int|undefined} limit the maximum amount of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure} to fetch
          * @param {dict} params extra parameters specific to the binance api endpoint
-         * @param {int|undefined} params.till timestamp in ms of the earliest funding rate
+         * @param {int|undefined} params.until timestamp in ms of the latest funding rate
          * @returns {[dict]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
          */
         await this.loadMarkets ();
@@ -4590,9 +4590,9 @@ module.exports = class binance extends Exchange {
         if (since !== undefined) {
             request['startTime'] = since;
         }
-        const till = this.safeInteger (params, 'till'); // unified in milliseconds
-        const endTime = this.safeString (params, 'endTime', till); // exchange-specific in milliseconds
-        params = this.omit (params, [ 'endTime', 'till' ]);
+        const until = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
+        const endTime = this.safeString (params, 'endTime', until); // exchange-specific in milliseconds
+        params = this.omit (params, [ 'endTime', 'till', 'until' ]);
         if (endTime !== undefined) {
             request['endTime'] = endTime;
         }
@@ -6094,7 +6094,7 @@ module.exports = class binance extends Exchange {
          * @param {int|undefined} since the time(ms) of the earliest record to retrieve as a unix timestamp
          * @param {int|undefined} limit default 30, max 500
          * @param {dict} params exchange specific parameters
-         * @param {int|undefined} params.till the time(ms) of the latest record to retrieve as a unix timestamp
+         * @param {int|undefined} params.until the time(ms) of the latest record to retrieve as a unix timestamp
          * @returns {dict} an array of [open interest history structure]{@link https://docs.ccxt.com/en/latest/manual.html#interest-history-structure}
          */
         if (timeframe === '1m') {
@@ -6116,9 +6116,9 @@ module.exports = class binance extends Exchange {
         if (since !== undefined) {
             request['startTime'] = since;
         }
-        const till = this.safeInteger (params, 'till'); // unified in milliseconds
-        const endTime = this.safeString (params, 'endTime', till); // exchange-specific in milliseconds
-        params = this.omit (params, [ 'endTime', 'till' ]);
+        const until = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
+        const endTime = this.safeString (params, 'endTime', until); // exchange-specific in milliseconds
+        params = this.omit (params, [ 'endTime', 'until', 'till' ]);
         if (endTime) {
             request['endTime'] = endTime;
         } else if (since) {

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1608,7 +1608,7 @@ module.exports = class bitget extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest candle to fetch
          * @param {int|undefined} limit the maximum amount of candles to fetch
          * @param {dict} params extra parameters specific to the bitget api endpoint
-         * @param {dict} params.till timestamp in ms of the latest candle to fetch
+         * @param {int|undefined} params.until timestamp in ms of the latest candle to fetch
          * @returns {[[int]]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         await this.loadMarkets ();
@@ -1621,7 +1621,8 @@ module.exports = class bitget extends Exchange {
             'spot': 'publicSpotGetMarketCandles',
             'swap': 'publicMixGetMarketCandles',
         });
-        const till = this.safeInteger (params, 'till');
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
         if (limit === undefined) {
             limit = 100;
         }
@@ -1630,13 +1631,13 @@ module.exports = class bitget extends Exchange {
             request['limit'] = limit;
             if (since !== undefined) {
                 request['after'] = since;
-                if (till === undefined) {
+                if (until === undefined) {
                     const millisecondsPerTimeframe = this.timeframes['swap'][timeframe] * 1000;
                     request['before'] = this.sum (since, millisecondsPerTimeframe * limit);
                 }
             }
-            if (till !== undefined) {
-                request['before'] = till;
+            if (until !== undefined) {
+                request['before'] = until;
             }
         } else if (market['type'] === 'swap') {
             request['granularity'] = this.timeframes['swap'][timeframe];
@@ -1647,8 +1648,8 @@ module.exports = class bitget extends Exchange {
                 request['endTime'] = now;
             } else {
                 request['startTime'] = this.sum (since, duration * 1000);
-                if (till !== undefined) {
-                    request['endTime'] = till;
+                if (until !== undefined) {
+                    request['endTime'] = until;
                 } else {
                     request['endTime'] = this.sum (since, limit * duration * 1000);
                 }

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -2510,7 +2510,7 @@ module.exports = class bitmex extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest funding rate to fetch
          * @param {int|undefined} limit the maximum amount of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure} to fetch
          * @param {dict} params extra parameters specific to the bitmex api endpoint
-         * @param {int|undefined} params.till timestamp in ms for ending date filter
+         * @param {int|undefined} params.until timestamp in ms for ending date filter
          * @param {bool|undefined} params.reverse if true, will sort results newest first
          * @param {int|undefined} params.start starting point for results
          * @param {str|undefined} params.columns array of column names to fetch in info, if omitted, will return all columns
@@ -2542,10 +2542,10 @@ module.exports = class bitmex extends Exchange {
         if (limit !== undefined) {
             request['count'] = limit;
         }
-        const till = this.safeInteger (params, 'till');
-        params = this.omit (params, [ 'till' ]);
-        if (till !== undefined) {
-            request['endTime'] = this.iso8601 (till);
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
+        if (until !== undefined) {
+            request['endTime'] = this.iso8601 (until);
         }
         const response = await this.publicGetFunding (this.extend (request, params));
         //

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1321,7 +1321,7 @@ module.exports = class ftx extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest funding rate to fetch
          * @param {int|undefined} limit the maximum amount of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure} to fetch
          * @param {dict} params extra parameters specific to the ftx api endpoint
-         * @param {int|undefined} params.till extra parameters specific to the ftx api endpoint
+         * @param {int|undefined} params.until timestamp in ms of the latest funding rate to fetch
          * @returns {[dict]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
          */
         await this.loadMarkets ();
@@ -1334,13 +1334,10 @@ module.exports = class ftx extends Exchange {
         if (since !== undefined) {
             request['start_time'] = parseInt (since / 1000);
         }
-        const till = this.safeInteger (params, 'till'); // unified in milliseconds
-        const endTime = this.safeString (params, 'end_time'); // exchange-specific in seconds
-        params = this.omit (params, [ 'end_time', 'till' ]);
-        if (till !== undefined) {
-            request['end_time'] = parseInt (till / 1000);
-        } else if (endTime !== undefined) {
-            request['end_time'] = endTime;
+        const until = this.safeInteger (params, 'until', 'till'); // unified in milliseconds
+        params = this.omit (params, [ 'end_time', 'until', 'till' ]);
+        if (until !== undefined) {
+            request['end_time'] = parseInt (until / 1000);
         }
         const response = await this.publicGetFundingRates (this.extend (request, params));
         //
@@ -2122,7 +2119,7 @@ module.exports = class ftx extends Exchange {
          * @param {int|undefined} since the earliest time in ms to fetch trades for
          * @param {int|undefined} limit the maximum number of trades structures to retrieve
          * @param {dict} params extra parameters specific to the ftx api endpoint
-         * @param {int|undefined} params.till timestamp in ms of the latest trade
+         * @param {int|undefined} params.until timestamp in ms of the latest trade
          * @returns {[dict]} a list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html#trade-structure}
          */
         await this.loadMarkets ();
@@ -2134,14 +2131,14 @@ module.exports = class ftx extends Exchange {
         if (market !== undefined) {
             symbol = market['symbol'];
         }
-        const till = this.safeInteger (params, 'till');
+        const until = this.safeInteger2 (params, 'until', 'till');
         if (since !== undefined) {
             request['start_time'] = parseInt (since / 1000);
             request['end_time'] = this.seconds ();
         }
-        if (till !== undefined) {
-            request['end_time'] = parseInt (till / 1000);
-            params = this.omit (params, 'till');
+        if (until !== undefined) {
+            request['end_time'] = parseInt (until / 1000);
+            params = this.omit (params, [ 'until', 'till' ]);
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/js/gate.js
+++ b/js/gate.js
@@ -2442,7 +2442,7 @@ module.exports = class gate extends Exchange {
          * @param {dict} params extra parameters specific to the gate api endpoint
          * @param {str|undefined} params.marginMode 'cross' or 'isolated' - marginMode for margin trading if not provided this.options['defaultMarginMode'] is used
          * @param {str|undefined} params.type 'spot', 'swap', or 'future', if not provided this.options['defaultMarginMode'] is used
-         * @param {int|undefined} params.till The latest timestamp, in ms, that fetched trades were made
+         * @param {int|undefined} params.until The latest timestamp, in ms, that fetched trades were made
          * @param {int|undefined} params.page *spot only* Page number
          * @param {str|undefined} params.order_id *spot only* Filter trades with specified order ID. symbol is also required if this field is present
          * @param {str|undefined} params.order *contract only* Futures order ID, return related data only if specified
@@ -2456,8 +2456,8 @@ module.exports = class gate extends Exchange {
         let marginMode = undefined;
         let request = {};
         const market = (symbol !== undefined) ? this.market (symbol) : undefined;
-        const till = this.safeNumber (params, 'till');
-        params = this.omit (params, 'till');
+        const until = this.safeNumber2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
         [ type, params ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
         const contract = (type === 'swap') || (type === 'future');
         if (contract) {
@@ -2475,8 +2475,8 @@ module.exports = class gate extends Exchange {
         if (since !== undefined) {
             request['from'] = parseInt (since / 1000);
         }
-        if (till !== undefined) {
-            request['to'] = parseInt (till / 1000);
+        if (until !== undefined) {
+            request['to'] = parseInt (until / 1000);
         }
         const method = this.getSupportedMapping (type, {
             'spot': 'privateSpotGetMyTrades',

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -6546,13 +6546,14 @@ module.exports = class huobi extends Exchange {
          * @param {int} since timestamp in ms, value range = current time - 90 days，default = current time - 90 days
          * @param {int} limit page items, default 20, shall not exceed 50
          * @param {dict} params exchange specific params
-         * @param {int} params.till timestamp in ms, value range = start_time -> current time，default = current time
+         * @param {int} params.until timestamp in ms, value range = start_time -> current time，default = current time
          * @param {int} params.page_index page index, default page 1 if not filled
+         * @param {int} params.code unified currency code, can be used when symbol is undefined
          * @returns A list of settlement history objects
          */
         const code = this.safeString (params, 'code');
-        const till = this.safeInteger (params, 'till');
-        params = this.omit (params, 'till');
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
         const market = (symbol === undefined) ? undefined : this.market (symbol);
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchSettlementHistory', market, params);
         if (type === 'future') {
@@ -6574,8 +6575,8 @@ module.exports = class huobi extends Exchange {
         if (limit !== undefined) {
             request['page_size'] = limit;
         }
-        if (till !== undefined) {
-            request['end_at'] = till;
+        if (until !== undefined) {
+            request['end_at'] = until;
         }
         let method = 'contractPublicGetApiV1ContractSettlementRecords';
         if (market['swap']) {

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1373,17 +1373,17 @@ module.exports = class kucoin extends Exchange {
          * @name kucoin#fetchOrdersByStatus
          * @description fetch a list of orders
          * @param {str} status *not used for stop orders* 'open' or 'closed'
-         * @param {str} symbol unified market symbol
-         * @param {int} since timestamp in ms of the earliest order
-         * @param {int} limit max number of orders to return
+         * @param {str|undefined} symbol unified market symbol
+         * @param {int|undefined} since timestamp in ms of the earliest order
+         * @param {int|undefined} limit max number of orders to return
          * @param {dict} params exchange specific params
-         * @param {int} params.till end time in ms
-         * @param {bool} params.stop true if fetching stop orders
-         * @param {str} params.side buy or sell
-         * @param {str} params.type limit, market, limit_stop or market_stop
-         * @param {str} params.tradeType TRADE for spot trading, MARGIN_TRADE for Margin Trading
-         * @param {int} params.currentPage *stop orders only* current page
-         * @param {str} params.orderIds *stop orders only* comma seperated order ID list
+         * @param {int|undefined} params.until end time in ms
+         * @param {bool|undefined} params.stop true if fetching stop orders
+         * @param {str|undefined} params.side buy or sell
+         * @param {str|undefined} params.type limit, market, limit_stop or market_stop
+         * @param {str|undefined} params.tradeType TRADE for spot trading, MARGIN_TRADE for Margin Trading
+         * @param {int|undefined} params.currentPage *stop orders only* current page
+         * @param {str|undefined} params.orderIds *stop orders only* comma seperated order ID list
          * @returns An [array of order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1407,9 +1407,9 @@ module.exports = class kucoin extends Exchange {
         if (limit !== undefined) {
             request['pageSize'] = limit;
         }
-        const till = this.safeInteger (params, 'till');
-        if (till) {
-            request['endAt'] = till;
+        const until = this.safeInteger2 (params, [ 'until', 'till' ]);
+        if (until) {
+            request['endAt'] = until;
         }
         const stop = this.safeValue (params, 'stop');
         params = this.omit (params, 'stop');

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1316,19 +1316,20 @@ module.exports = class kucoinfutures extends kucoin {
          * @name kucoinfutures#fetchOrdersByStatus
          * @description fetches a list of orders placed on the exchange
          * @param {str} status 'active' or 'closed', only 'active' is valid for stop orders
-         * @param {str} symbol unified symbol for the market to retrieve orders from
-         * @param {int} since timestamp in ms of the earliest order to retrieve
-         * @param {int} limit The maximum number of orders to retrieve
+         * @param {str|undefined} symbol unified symbol for the market to retrieve orders from
+         * @param {int|undefined} since timestamp in ms of the earliest order to retrieve
+         * @param {int|undefined} limit The maximum number of orders to retrieve
          * @param {dict} params exchange specific parameters
-         * @param {bool} params.stop set to true to retrieve untriggered stop orders
-         * @param {int} params.till End time in ms
-         * @param {str} params.side buy or sell
-         * @param {str} params.type limit or market
+         * @param {bool|undefined} params.stop set to true to retrieve untriggered stop orders
+         * @param {int|undefined} params.until End time in ms
+         * @param {str|undefined} params.side buy or sell
+         * @param {str|undefined} params.type limit or market
          * @returns An [array of order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
         const stop = this.safeValue (params, 'stop');
-        params = this.omit (params, 'stop');
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'stop', 'until', 'till' ]);
         if (status === 'closed') {
             status = 'done';
         } else if (status === 'open') {
@@ -1348,9 +1349,8 @@ module.exports = class kucoinfutures extends kucoin {
         if (since !== undefined) {
             request['startAt'] = since;
         }
-        const till = this.safeInteger2 (params, 'till', 'endAt');
-        if (till !== undefined) {
-            request['endAt'] = till;
+        if (until !== undefined) {
+            request['endAt'] = until;
         }
         const method = stop ? 'futuresPrivateGetStopOrders' : 'futuresPrivateGetOrders';
         const response = await this[method] (this.extend (request, params));

--- a/js/okx.js
+++ b/js/okx.js
@@ -5136,7 +5136,7 @@ module.exports = class okx extends Exchange {
          * @param {int|undefined} since The time in ms of the earliest record to retrieve as a unix timestamp
          * @param {int|undefined} limit Not used by okx, but parsed internally by CCXT
          * @param {dict} params Exchange specific parameters
-         * @param {int|undefined} params.till The time in ms of the latest record to retrieve as a unix timestamp
+         * @param {int|undefined} params.until The time in ms of the latest record to retrieve as a unix timestamp
          * @returns An array of [open interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#interest-history-structure}
          */
         const options = this.safeValue (this.options, 'fetchOpenInterestHistory', {});
@@ -5154,9 +5154,10 @@ module.exports = class okx extends Exchange {
         if (since !== undefined) {
             request['begin'] = since;
         }
-        const till = this.safeInteger2 (params, 'till', 'end');
-        if (till !== undefined) {
-            request['end'] = till;
+        const until = this.safeInteger2 (params, 'till', 'until');
+        if (until !== undefined) {
+            request['end'] = until;
+            params = this.omit (params, [ 'until', 'till' ]);
         }
         const response = await this.publicGetRubikStatContractsOpenInterestVolume (this.extend (request, params));
         //

--- a/js/zb.js
+++ b/js/zb.js
@@ -3116,6 +3116,7 @@ module.exports = class zb extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest funding rate to fetch
          * @param {int|undefined} limit the maximum amount of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure} to fetch
          * @param {dict} params extra parameters specific to the zb api endpoint
+         * @param {int|undefined} params.until timestamp in ms of the latest funding rate to fetch
          * @returns {[dict]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
          */
         await this.loadMarkets ();
@@ -3133,13 +3134,10 @@ module.exports = class zb extends Exchange {
         if (since !== undefined) {
             request['startTime'] = since;
         }
-        const till = this.safeInteger (params, 'till');
-        const endTime = this.safeString (params, 'endTime');
+        const until = this.safeInteger2 (params, 'until', 'till');
         params = this.omit (params, [ 'endTime', 'till' ]);
-        if (till !== undefined) {
-            request['endTime'] = till;
-        } else if (endTime !== undefined) {
-            request['endTime'] = endTime;
+        if (until !== undefined) {
+            request['endTime'] = until;
         }
         if (limit !== undefined) {
             request['limit'] = limit;


### PR DESCRIPTION
2022-06-15T08:51:28.498Z
Node.js: v14.17.0
CCXT v1.87.48

```
% node examples/js/cli gateio fetchOHLCV ADA/USDT 1h 1654819200000 undefined '{"till": 1654905600000}' | condense
gateio.fetchOHLCV (ADA/USDT, 1h, 1654819200000, , [object Object])
2022-06-15T08:51:30.243Z iteration 0 passed in 179 ms
1654819200000 |  0.6324 | 0.63446 |  0.6129 | 0.62184 | 1675731.8805822437
1654822800000 | 0.62203 | 0.62567 | 0.62009 | 0.62346 |  765901.4491567174
1654826400000 | 0.62331 | 0.62777 | 0.62274 | 0.62685 | 509300.71869227575
...
1654902000000 | 0.58309 | 0.58326 | 0.57114 | 0.57413 |  835821.6357402832
1654905600000 | 0.57413 |  0.5833 | 0.57233 | 0.58247 |  630851.2299036063
25 objects
```

```
% node examples/js/cli gateio fetchOHLCV ADA/USDT 1h 1654819200000 50 '{"till": 1654905600000}' | condense
gateio.fetchOHLCV (ADA/USDT, 1h, 1654819200000, 50, [object Object])
2022-06-15T08:52:17.235Z iteration 0 passed in 219 ms
1654819200000 |  0.6324 | 0.63446 |  0.6129 | 0.62184 | 1675731.8805822437
1654822800000 | 0.62203 | 0.62567 | 0.62009 | 0.62346 |  765901.4491567174
1654826400000 | 0.62331 | 0.62777 | 0.62274 | 0.62685 | 509300.71869227575
...
1654902000000 | 0.58309 | 0.58326 | 0.57114 | 0.57413 |  835821.6357402832
1654905600000 | 0.57413 |  0.5833 | 0.57233 | 0.58247 |  630851.2299036063
25 objects
```

```
% node examples/js/cli gateio fetchOHLCV ADA/USDT 1h 1654819200000 50 | condense 
gateio.fetchOHLCV (ADA/USDT, 1h, 1654819200000, 50)
2022-06-15T08:29:52.148Z iteration 0 passed in 184 ms
1654819200000 |  0.6324 | 0.63446 |  0.6129 | 0.62184 | 1675731.8805822437
...
1654995600000 | 0.55439 | 0.55477 | 0.53213 | 0.53362 |  1581400.681387841
50 objects
```

```
% node examples/js/cli gateio fetchOHLCV ADA/USDT:USDT 1h 1654819200000 undefined '{"till": 1654905600000}' | condense
gateio.fetchOHLCV (ADA/USDT:USDT, 1h, 1654819200000, , [object Object])
2022-06-15T08:30:41.587Z iteration 0 passed in 213 ms
1654819200000 | 0.63199 |  0.6338 |  0.6119 | 0.62173 |  83391
...
1654909200000 | 0.58206 | 0.58206 | 0.58206 | 0.58206 |      0
26 objects
```

```
% node examples/js/cli gateio fetchOHLCV ADA/USDT:USDT 1h 1654819200000 50 '{"till": 1654905600000}' | condense
gateio.fetchOHLCV (ADA/USDT:USDT, 1h, 1654819200000, 50, [object Object])
2022-06-15T08:31:53.557Z iteration 0 passed in 195 ms
1654819200000 | 0.63199 |  0.6338 |  0.6119 | 0.62173 |  83391
...
1654909200000 | 0.58206 | 0.58206 | 0.58206 | 0.58206 |      0
26 objects
```

```
% node examples/js/cli gateio fetchOHLCV ADA/USDT:USDT 1h 1654819200000 50 | condense                     
gateio.fetchOHLCV (ADA/USDT:USDT, 1h, 1654819200000, 50)
2022-06-15T08:32:05.650Z iteration 0 passed in 176 ms
1654819200000 | 0.63199 |  0.6338 |  0.6119 | 0.62173 |  83391
...
1654995600000 | 0.55399 | 0.55421 | 0.53138 | 0.53307 |  60463
50 objects
```

```
gateio.fetchMyTrades (ADA/USDT:USDT, 1640995200000, , [object Object])
2022-06-15T09:41:34.907Z iteration 0 passed in 200 ms

     id |     timestamp |                 datetime |        symbol |        order | type | side | takerOrMaker |   price | amount |    cost | fee | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------
4821304 | 1651132800193 | 2022-04-28T08:00:00.193Z | ADA/USDT:USDT | 153103904704 |      |  buy |        taker | 0.83953 |      1 |  8.3953 |     |   []
4863694 | 1651662255157 | 2022-05-04T11:04:15.157Z | ADA/USDT:USDT | 155481182089 |      | sell |        taker | 0.82555 |      1 |  8.2555 |     |   []
4894796 | 1651804319867 | 2022-05-06T02:31:59.867Z | ADA/USDT:USDT | 156212802642 |      |  buy |        taker | 0.79271 |      2 | 15.8542 |     |   []
4901023 | 1651844127973 | 2022-05-06T13:35:27.973Z | ADA/USDT:USDT | 156414918527 |      | sell |        taker | 0.76837 |      2 | 15.3674 |     |   []
4 objects
```

```
binanceusdm.fetchOpenInterestHistory (ADA/USDT, 1h, 1654819200000, , [object Object])
2022-06-15T09:42:44.101Z iteration 0 passed in 248 ms
  symbol | baseVolume |        quoteVolume |     timestamp |                 datetime
-------------------------------------------------------------------------------------
ADA/USDT |  193254130 |  122136556.0488436 | 1654819200000 | 2022-06-10T00:00:00.000Z
...
ADA/USDT |  170369155 |      99274106.6185 | 1654902000000 | 2022-06-10T23:00:00.000Z
ADA/USDT |  170572024 |    97884973.408712 | 1654905600000 | 2022-06-11T00:00:00.000Z
25 objects
```

```
ftx.fetchMyTrades (ADA/USD:USD, 1640995200000, , [object Object])
2022-06-15T09:43:17.889Z iteration 0 passed in 694 ms

    timestamp |                 datetime |      symbol |         id |        order | type | takerOrMaker | side |    price | amount |      cost |                                                 fee |                                                  fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1647494359470 | 2022-03-17T05:19:19.470Z | ADA/USD:USD | 7125065647 | 129148268631 |      |        taker | sell | 0.852965 |    200 |   170.593 |   {"cost":0.1194151,"currency":"USD","rate":0.0007} |   [{"currency":"USD","cost":0.1194151,"rate":0.0007}]
1647494365229 | 2022-03-17T05:19:25.229Z | ADA/USD:USD | 7125066021 | 129148277682 |      |        taker | sell | 0.852965 |    200 |   170.593 |   {"cost":0.1194151,"currency":"USD","rate":0.0007} |   [{"currency":"USD","cost":0.1194151,"rate":0.0007}]
1647494398324 | 2022-03-17T05:19:58.324Z | ADA/USD:USD | 7125069209 | 129148347848 |      |        taker | sell | 0.852655 |     50 |  42.63275 | {"cost":0.029842925,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.029842925,"rate":0.0007}]
1647494534749 | 2022-03-17T05:22:14.749Z | ADA/USD:USD | 7125080927 | 129148645050 |      |        taker |  buy | 0.851925 |    450 | 383.36625 | {"cost":0.268356375,"currency":"USD","rate":0.0007} | [{"currency":"USD","cost":0.268356375,"rate":0.0007}]
4 objects
```