### PR TITLE
okx.fetchOHLCV params.until

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -1551,6 +1551,8 @@ module.exports = class okx extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest candle to fetch
          * @param {int|undefined} limit the maximum amount of candles to fetch
          * @param {dict} params extra parameters specific to the okx api endpoint
+         * @param {str|undefined} params.price "mark" or "index" for mark price and index price candles
+         * @param {int|undefined} params.until timestamp in ms of the latest candle to fetch
          * @returns {[[int]]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         await this.loadMarkets ();
@@ -1578,6 +1580,11 @@ module.exports = class okx extends Exchange {
             const startTime = Math.max (since - 1, 0);
             request['before'] = startTime;
             request['after'] = this.sum (startTime, durationInMilliseconds * limit);
+        }
+        const until = this.safeInteger (params, 'until');
+        if (until !== undefined) {
+            request['after'] = until;
+            params = this.omit (params, 'until');
         }
         const options = this.safeValue (this.options, 'fetchOHLCV', {});
         defaultType = this.safeString (options, 'type', defaultType); // Candles or HistoryCandles


### PR DESCRIPTION
2022-06-15T09:58:26.563Z
Node.js: v14.17.0
CCXT v1.87.48

```
% okx fetchOHLCV ADA/USDT 1h 1654819200000 undefined '{"until": 1654905600000}'
okx.fetchOHLCV (ADA/USDT, 1h, 1654819200000, , [object Object])
2022-06-15T09:57:42.726Z iteration 0 passed in 288 ms
1654819200000 | 0.63249 | 0.63436 |   0.613 | 0.62191 | 2051796.2792
1654822800000 | 0.62202 | 0.62555 | 0.62025 | 0.62316 |  669642.9289
1654826400000 | 0.62307 | 0.62793 | 0.62265 | 0.62687 |  454177.3027
...
1654898400000 | 0.58174 | 0.58782 | 0.58108 |  0.5832 |  468931.7781
1654902000000 |  0.5834 |  0.5834 |  0.5711 |  0.5743 |  536194.2395
24 objects
```
```
% okx fetchOHLCV ADA/USDT 1h 1654819200000 undefined '{"until": 1654905600000}'
okx.fetchOHLCV (ADA/USDT, 1h, 1654819200000, , [object Object])
2022-06-15T09:58:12.543Z iteration 0 passed in 278 ms
1654819200000 | 0.63249 | 0.63436 |   0.613 | 0.62191 | 2051796.2792
1654822800000 | 0.62202 | 0.62555 | 0.62025 | 0.62316 |  669642.9289
1654826400000 | 0.62307 | 0.62793 | 0.62265 | 0.62687 |  454177.3027
...
1654898400000 | 0.58174 | 0.58782 | 0.58108 |  0.5832 |  468931.7781
1654902000000 |  0.5834 |  0.5834 |  0.5711 |  0.5743 |  536194.2395
24 objects
```
```
% okx fetchOHLCV ADA/USDT 1h 1654819200000 50 '{"until": 1654905600000}'
okx.fetchOHLCV (ADA/USDT, 1h, 1654819200000, 50, [object Object])
2022-06-15T09:58:21.915Z iteration 0 passed in 286 ms
1654819200000 | 0.63249 | 0.63436 |   0.613 | 0.62191 | 2051796.2792
1654822800000 | 0.62202 | 0.62555 | 0.62025 | 0.62316 |  669642.9289
1654826400000 | 0.62307 | 0.62793 | 0.62265 | 0.62687 |  454177.3027
...
1654898400000 | 0.58174 | 0.58782 | 0.58108 |  0.5832 |  468931.7781
1654902000000 |  0.5834 |  0.5834 |  0.5711 |  0.5743 |  536194.2395
24 objects
```
```
% okx fetchOHLCV ADA/USDT 1h 1654819200000 50
okx.fetchOHLCV (ADA/USDT, 1h, 1654819200000, 50)
2022-06-15T09:58:27.996Z iteration 0 passed in 277 ms
1654819200000 | 0.63249 | 0.63436 |   0.613 | 0.62191 | 2051796.2792
1654822800000 | 0.62202 | 0.62555 | 0.62025 | 0.62316 |  669642.9289
1654826400000 | 0.62307 | 0.62793 | 0.62265 | 0.62687 |  454177.3027
...
1654992000000 | 0.55419 | 0.56106 | 0.55197 | 0.55461 |  555679.3887
1654995600000 |  0.5546 | 0.55499 | 0.53207 | 0.53347 | 1219417.7969
50 objects
```