### PR TITLE
ftx.fetchOHLCV params.until

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -928,6 +928,8 @@ module.exports = class ftx extends Exchange {
          * @param {int|undefined} since timestamp in ms of the earliest candle to fetch
          * @param {int|undefined} limit the maximum amount of candles to fetch
          * @param {dict} params extra parameters specific to the ftx api endpoint
+         * @param {str|undefined} params.price "index" for index price candles
+         * @param {int|undefined} params.until timestamp in ms of the latest candle to fetch
          * @returns {[[int]]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         await this.loadMarkets ();
@@ -944,7 +946,8 @@ module.exports = class ftx extends Exchange {
             'limit': limit,
         };
         const price = this.safeString (params, 'price');
-        params = this.omit (params, 'price');
+        const until = this.safeInteger (params, 'until');
+        params = this.omit (params, [ 'price', 'until' ]);
         if (since !== undefined) {
             const startTime = parseInt (since / 1000);
             request['start_time'] = startTime;
@@ -955,6 +958,9 @@ module.exports = class ftx extends Exchange {
                 const wholeDaysInTimeframe = parseInt (duration / 86400);
                 request['limit'] = Math.min (limit * wholeDaysInTimeframe, maxLimit);
             }
+        }
+        if (until !== undefined) {
+            request['end_time'] = parseInt (until / 1000);
         }
         let method = 'publicGetMarketsMarketNameCandles';
         if (price === 'index') {


### PR DESCRIPTION
```
% ftx fetchOHLCV ADA/USD:USD 1h 1654819200000 undefined '{"until": 1654905600000}'
ftx.fetchOHLCV (ADA/USD:USD, 1h, 1654819200000, , [object Object])
2022-06-15T10:15:40.512Z iteration 0 passed in 71 ms
1654819200000 |  0.63184 |  0.63406 |  0.61227 |  0.62119 |  10784277.27345
1654822800000 |  0.62119 | 0.625145 | 0.619445 |  0.62288 |    3073012.1864
1654826400000 |  0.62283 |  0.62703 | 0.622045 | 0.626125 |   2360216.98321
...
1654902000000 | 0.582145 | 0.582275 |     0.57 |  0.57304 |   4706176.45887
1654905600000 |  0.57304 | 0.582395 | 0.570965 | 0.581375 |  6579502.341035
25 objects
```

```
% ftx fetchOHLCV ADA/USD:USD 1h 1654819200000 undefined '{"until": 1654905600000}'
ftx.fetchOHLCV (ADA/USD:USD, 1h, 1654819200000, , [object Object])
2022-06-15T10:15:48.427Z iteration 0 passed in 239 ms
1654819200000 |  0.63184 |  0.63406 |  0.61227 |  0.62119 |  10784277.27345
1654822800000 |  0.62119 | 0.625145 | 0.619445 |  0.62288 |    3073012.1864
1654826400000 |  0.62283 |  0.62703 | 0.622045 | 0.626125 |   2360216.98321
...
1654902000000 | 0.582145 | 0.582275 |     0.57 |  0.57304 |   4706176.45887
1654905600000 |  0.57304 | 0.582395 | 0.570965 | 0.581375 |  6579502.341035
25 objects
```

```
% ftx fetchOHLCV ADA/USD:USD 1h 1654819200000 50 '{"until": 1654905600000}'
ftx.fetchOHLCV (ADA/USD:USD, 1h, 1654819200000, 50, [object Object])
2022-06-15T10:15:55.503Z iteration 0 passed in 227 ms
1654819200000 |  0.63184 |  0.63406 |  0.61227 |  0.62119 |  10784277.27345
1654822800000 |  0.62119 | 0.625145 | 0.619445 |  0.62288 |    3073012.1864
1654826400000 |  0.62283 |  0.62703 | 0.622045 | 0.626125 |   2360216.98321
...
1654902000000 | 0.582145 | 0.582275 |     0.57 |  0.57304 |   4706176.45887
1654905600000 |  0.57304 | 0.582395 | 0.570965 | 0.581375 |  6579502.341035
25 objects
```

```
% ftx fetchOHLCV ADA/USD:USD 1h 1654819200000 50
ftx.fetchOHLCV (ADA/USD:USD, 1h, 1654819200000, 50)
2022-06-15T10:16:03.064Z iteration 0 passed in 314 ms
1654819200000 |  0.63184 |  0.63406 |  0.61227 |  0.62119 |  10784277.27345
1654822800000 |  0.62119 | 0.625145 | 0.619445 |  0.62288 |    3073012.1864
1654826400000 |  0.62283 |  0.62703 | 0.622045 | 0.626125 |   2360216.98321
...
1654992000000 | 0.553045 |  0.56003 | 0.550965 | 0.553565 |  3538346.716705
1654995600000 | 0.553565 | 0.554055 | 0.530925 |  0.53297 |  6361627.661565
50 objects
```