### PR TITLE
Bybit editOrder (stopLossPrice, takeProfitPrice)

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3022,12 +3022,12 @@ module.exports = class bybit extends Exchange {
             const takeProfitPrice = this.safeValue2 (params, 'takeProfit', 'takeProfitPrice');
             const isTakeProfitOrder = takeProfitPrice !== undefined;
             if (isStopLossOrder) {
-                request['stopLoss'] = stopLossPrice;
+                request['stopLoss'] = this.priceToPrecision (symbol, stopLossPrice);
                 const slTriggerBy = this.safeString2 (params, 'slTriggerBy', 'MarkPrice');
                 request['slTriggerBy'] = slTriggerBy;
             }
             if (isTakeProfitOrder) {
-                request['takeProfit'] = takeProfitPrice;
+                request['takeProfit'] = this.priceToPrecision (symbol, takeProfitPrice);
                 const tpTriggerBy = this.safeString2 (params, 'tpTriggerBy', 'MarkPrice');
                 request['tpTriggerBy'] = tpTriggerBy;
             }
@@ -3095,12 +3095,12 @@ module.exports = class bybit extends Exchange {
         const takeProfitPrice = this.safeValue2 (params, 'take_profit', 'takeProfitPrice');
         const isTakeProfitOrder = takeProfitPrice !== undefined;
         if (isStopLossOrder) {
-            request['stop_loss'] = stopLossPrice;
+            request['stop_loss'] = this.priceToPrecision (symbol, stopLossPrice);
             const slTriggerBy = this.safeString2 (params, 'sl_trigger_by', 'LastPrice');
             request['sl_trigger_by'] = slTriggerBy;
         }
         if (isTakeProfitOrder) {
-            request['take_profit'] = takeProfitPrice;
+            request['take_profit'] = this.priceToPrecision (symbol, takeProfitPrice);
             const tpTriggerBy = this.safeString2 (params, 'tp_trigger_by', 'LastPrice');
             request['tp_trigger_by'] = tpTriggerBy;
         }

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3016,7 +3016,24 @@ module.exports = class bybit extends Exchange {
         if (price !== undefined) {
             request['orderPrice'] = this.priceToPrecision (symbol, price);
         }
-        const method = market['option'] ? 'privatePostOptionUsdcOpenApiPrivateV1ReplaceOrder' : 'privatePostPerpetualUsdcOpenApiPrivateV1ReplaceOrder';
+        if (market['swap']) {
+            const stopLossPrice = this.safeValue2 (params, 'stopLoss', 'stopLossPrice');
+            const isStopLossOrder = stopLossPrice !== undefined;
+            const takeProfitPrice = this.safeValue2 (params, 'takeProfit', 'takeProfitPrice');
+            const isTakeProfitOrder = takeProfitPrice !== undefined;
+            if (isStopLossOrder) {
+                request['stopLoss'] = stopLossPrice;
+                const slTriggerBy = this.safeString2 (params, 'slTriggerBy', 'MarkPrice');
+                request['slTriggerBy'] = slTriggerBy;
+            }
+            if (isTakeProfitOrder) {
+                request['takeProfit'] = takeProfitPrice;
+                const tpTriggerBy = this.safeString2 (params, 'tpTriggerBy', 'MarkPrice');
+                request['tpTriggerBy'] = tpTriggerBy;
+            }
+            params = this.omit (params, [ 'stopLoss', 'stopLossPrice', 'takeProfit', 'takeProfitPrice', 'tpTriggerby', 'slTriggerBy' ]);
+        }
+        const method = market['option'] ? 'privatePostOptionUsdcOpenapiPrivateV1ReplaceOrder' : 'privatePostPerpetualUsdcOpenapiPrivateV1ReplaceOrder';
         const response = await this[method] (this.extend (request, params));
         //
         //    {

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3056,7 +3056,6 @@ module.exports = class bybit extends Exchange {
         const orderType = this.safeString (params, 'orderType');
         const isStop = this.safeValue (params, 'stop', false);
         const isConditionalOrder = isStop || (orderType === 'stop' || orderType === 'conditional');
-        params = this.omit (params, [ 'orderType', 'stop' ]);
         const idKey = isConditionalOrder ? 'stop_order_id' : 'order_id';
         request[idKey] = id;
         if (amount !== undefined) {
@@ -3074,6 +3073,21 @@ module.exports = class bybit extends Exchange {
             // inverse swaps
             method = isConditionalOrder ? 'privatePostV2PrivateSpotOrderReplace' : 'privatePostV2PrivateOrderReplace';
         }
+        const stopLossPrice = this.safeValue2 (params, 'stop_loss', 'stopLossPrice');
+        const isStopLossOrder = stopLossPrice !== undefined;
+        const takeProfitPrice = this.safeValue2 (params, 'take_profit', 'takeProfitPrice');
+        const isTakeProfitOrder = takeProfitPrice !== undefined;
+        if (isStopLossOrder) {
+            request['stop_loss'] = stopLossPrice;
+            const slTriggerBy = this.safeString2 (params, 'sl_trigger_by', 'LastPrice');
+            request['sl_trigger_by'] = slTriggerBy;
+        }
+        if (isTakeProfitOrder) {
+            request['take_profit'] = takeProfitPrice;
+            const tpTriggerBy = this.safeString2 (params, 'tp_trigger_by', 'LastPrice');
+            request['tp_trigger_by'] = tpTriggerBy;
+        }
+        params = this.omit (params, [ 'orderType', 'stop', 'stop_loss', 'stopLossPrice', 'take_Profit', 'takeProfitPrice', 'tp_trigger_by', 'sl_trigger_by' ]);
         const response = await this[method] (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
Added 'stopLossPrice' and 'takeProfitPrice' functionality to editOrder:
#13822

editContractOrder:
```
node examples/js/cli bybit editOrder '330160b7-8b71-4d3e-a4ae-ab5eb21e598f' BTC/USDT:USDT limit buy
0.002 20000 '{"takeProfitPrice":"24000","stopLossPrice":"19500"}'

bybit.editOrder (330160b7-8b71-4d3e-a4ae-ab5eb21e598f, BTC/USDT:USDT, limit, buy, 0.002, 20000, [object Object])
2022-06-16T04:33:43.575Z iteration 0 passed in 299 ms

{
  info: {
    ret_code: '0',
    ret_msg: 'OK',
    ext_code: '',
    ext_info: '',
    result: { order_id: '330160b7-8b71-4d3e-a4ae-ab5eb21e598f' },
    time_now: '1655354023.914515',
    rate_limit_status: '99',
    rate_limit_reset_ms: '1655354023911',
    rate_limit: '100'
  },
  id: '330160b7-8b71-4d3e-a4ae-ab5eb21e598f',
  order_id: '330160b7-8b71-4d3e-a4ae-ab5eb21e598f',
  stop_order_id: undefined
}
```

editUsdcOrder:
```
node examples/js/cli bybit editOrder '93570023-3b89-4268-8a5d-91c54acb8862' BTCPERP limit buy 0.011 
20000 '{"takeProfitPrice":"26000","stopLossPrice":"18900"}'

bybit.editOrder (93570023-3b89-4268-8a5d-91c54acb8862, BTCPERP, limit, buy, 0.011, 20000, [object Object])
2022-06-16T04:41:43.920Z iteration 0 passed in 283 ms

{
  info: {
    retCode: '0',
    retMsg: '',
    result: {
      orderId: '93570023-3b89-4268-8a5d-91c54acb8862',
      orderLinkId: '',
      createdAt: '1655354409083459',
      updatedAt: '0',
      symbol: 'BTCPERP',
      orderType: 'UNKNOWN',
      side: 'None',
      qty: '0.01100000',
      price: '20000.00',
      timeInForce: 'UNKNOWN',
      orderStatus: 'UNKNOWN',
      triggerPrice: '0.00'
    }
  },
  id: '93570023-3b89-4268-8a5d-91c54acb8862'
}
```