### PR TITLE
ftx funding history - fix start_time and end_time

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2824,7 +2824,13 @@ module.exports = class ftx extends Exchange {
             request['future'] = market['id'];
         }
         if (since !== undefined) {
-            request['startTime'] = since;
+            request['start_time'] = parseInt (since / 1000);
+            request['end_time'] = this.seconds ();
+        }
+        const till = this.safeInteger (params, 'till');
+        if (till !== undefined) {
+            request['end_time'] = parseInt (till / 1000);
+            params = this.omit (params, 'till');
         }
         const response = await this.privateGetFundingPayments (this.extend (request, params));
         const result = this.safeValue (response, 'result', []);


### PR DESCRIPTION
Time filters currently do not work for ftx fetchFundingHistory. **startTime** should be snake_case. Fixed to work the same way as the other methods eg. fetchMyTrades. **since** and **till** as params in milliseconds. 