### PR TITLE
Fix doc code error

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3020,7 +3020,7 @@ exchange.checkRequiredCredentials() // throw AuthenticationError
 import ccxt
 exchange = ccxt.coinbasepro()
 print(exchange.requiredCredentials)  # prints required credentials
-exchange.checkRequiredCredentials()  # raises AuthenticationError
+exchange.check_required_credentials()  # raises AuthenticationError
 ```
 
 ```PHP


### PR DESCRIPTION
For Python it's `check_required_credentials()` and not `checkRequiredCredentials()`