### PR TITLE
ftx.cancelOrder params.stop for stop orders. fixes:#13922

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -1872,6 +1872,7 @@ module.exports = class ftx extends Exchange {
          * @param {str} id order id
          * @param {str|undefined} symbol not used by ftx cancelOrder ()
          * @param {dict} params extra parameters specific to the ftx api endpoint
+         * @param {bool} params.stop true if cancelling a stop/trigger order
          * @returns {dict} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1881,18 +1882,19 @@ module.exports = class ftx extends Exchange {
         const options = this.safeValue (this.options, 'cancelOrder', {});
         const defaultMethod = this.safeString (options, 'method', 'privateDeleteOrdersOrderId');
         let method = this.safeString (params, 'method', defaultMethod);
-        const type = this.safeValue (params, 'type');
+        const type = this.safeValue (params, 'type');  // Deprecated: use params.stop instead
+        const stop = this.safeValue (params, 'stop');
         const clientOrderId = this.safeValue2 (params, 'client_order_id', 'clientOrderId');
         if (clientOrderId === undefined) {
             request['order_id'] = parseInt (id);
-            if ((type === 'stop') || (type === 'trailingStop') || (type === 'takeProfit')) {
+            if (stop || (type === 'stop') || (type === 'trailingStop') || (type === 'takeProfit')) {
                 method = 'privateDeleteConditionalOrdersOrderId';
             }
         } else {
             request['client_order_id'] = clientOrderId;
             method = 'privateDeleteOrdersByClientIdClientOrderId';
         }
-        const query = this.omit (params, [ 'method', 'type', 'client_order_id', 'clientOrderId' ]);
+        const query = this.omit (params, [ 'method', 'type', 'client_order_id', 'clientOrderId', 'stop' ]);
         const response = await this[method] (this.extend (request, query));
         //
         //     {


### PR DESCRIPTION
```
% ftx cancelOrder 219226181 undefined '{"stop": true}' 
2022-06-18T01:53:03.398Z
Node.js: v14.17.0
CCXT v1.87.88
ftx.cancelOrder (219226181, , [object Object])
2022-06-18T01:53:04.060Z iteration 0 passed in 266 ms

'Order cancelled'
```