### PR TITLE
Bitmex :: add contract quantity

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -2149,6 +2149,7 @@ module.exports = class bitmex extends Exchange {
         }
         const maintenanceMargin = this.safeNumber (position, 'maintMargin');
         const unrealisedPnl = this.safeNumber (position, 'unrealisedPnl');
+        const contracts = this.omitZero (this.safeNumber (position, 'currentQty'));
         return {
             'info': position,
             'id': this.safeString (position, 'account'),
@@ -2157,7 +2158,7 @@ module.exports = class bitmex extends Exchange {
             'datetime': datetime,
             'hedged': undefined,
             'side': undefined,
-            'contracts': undefined,
+            'contracts': this.convertValue (contracts, market),
             'contractSize': undefined,
             'entryPrice': this.safeNumber (position, 'avgEntryPrice'),
             'markPrice': this.safeNumber (position, 'markPrice'),


### PR DESCRIPTION
- fixes #13931

Demo

```
CCXT v1.88.15
bitmex.fetchPositions (BTC/USDT:USDT)
2022-06-20T13:37:15.478Z iteration 0 passed in 2094 ms

    id |        symbol |     timestamp |                 datetime | hedged | side | contracts | contractSize | entryPrice | markPrice | notional | leverage | collateral | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | unrealizedPnl | liquidationPrice | marginMode | marginRatio | percentage
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
395724 | BTC/USDT:USDT | 1655732231348 | 2022-06-20T13:37:11.348Z |        |      |     0.001 |              |      20879 |  20490.49 | 20.49049 |        1 |            |               |                       1 |         20.449215 |                             |      -0.38851 |              177 |   isolated |             |    -0.0186
1 objects
```