### PR TITLE
Ascendex fetchBalance

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -679,10 +679,11 @@ module.exports = class ascendex extends Exchange {
     }
 
     parseBalance (response) {
+        const timestamp = this.milliseconds ();
         const result = {
             'info': response,
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
         };
         const balances = this.safeValue (response, 'data', []);
         for (let i = 0; i < balances.length; i++) {
@@ -740,7 +741,7 @@ module.exports = class ascendex extends Exchange {
             'margin': defaultMethod,
             'swap': 'v2PrivateAccountGroupGetFuturesPosition',
         });
-        if (accountCategory === 'cash') {
+        if ((accountCategory === 'cash') || (accountCategory === 'margin')) {
             request['account-category'] = accountCategory;
         }
         const response = await this[method] (this.extend (request, query));


### PR DESCRIPTION
Adjusted margin functionality for fetchBalance:
fixes #14004
```
node examples/js/cli ascendex fetchBalance '{"type":"margin"}'
```
```
ascendex.fetchBalance ()
2022-06-22T01:52:00.673Z iteration 0 passed in 1791 ms

{
  info: {
    code: '0',
    data: [
      {
        asset: 'USDT',
        totalBalance: '48.949901399',
        availableBalance: '48.949901399',
        borrowed: '0',
        interest: '0'
      }
    ]
  },
  timestamp: 1655862720672,
  datetime: '2022-06-22T01:52:00.672Z',
  USDT: { free: 48.949901399, used: 0, total: 48.949901399 },
  free: { USDT: 48.949901399 },
  used: { USDT: 0 },
  total: { USDT: 48.949901399 }
}
```