### PR TITLE
wavesexchange - precision fixes #13880

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -1211,7 +1211,7 @@ module.exports = class wavesexchange extends Exchange {
     priceFromPrecision (symbol, price) {
         const market = this.markets[symbol];
         const wavesPrecision = this.safeInteger (this.options, 'wavesPrecision', 8);
-        const scale = wavesPrecision - this.sum (market['precision']['amount'], market['precision']['price']);
+        const scale = this.sum (wavesPrecision, market['precision']['price']) - market['precision']['amount'];
         return this.fromPrecision (price, scale);
     }
 


### PR DESCRIPTION
https://docs.waves.exchange/en/waves-matcher/matcher-api#order
From the docs:
`Price for amountAsset denominated in priceAsset and multiplied by 10^(8 + priceAssetDecimals – amountAssetDecimals).
For example, in the ETH/WAVES asset pair the price 12,500,000,000 means that 1 ETH costs 125 WAVES (PriceAssetDecimals and AmountAssetDecimals both equal to 8).`