### PR TITLE
Adding EUROC

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -292,6 +292,8 @@ module.exports = class bitstamp extends Exchange {
                         'ape_address/': 1,
                         'mpl_withdrawal/': 1,
                         'mpl_address/': 1,
+                        'euroc_withdrawal/': 1,
+                        'euroc_address/': 1,
                     },
                 },
             },


### PR DESCRIPTION
Bitstamp is adding EUROC to their platform: https://blog.bitstamp.net/post/soon-on-bitstamp-euro-coin-euroc/