### PR TITLE
Exchange.php.safeValue: array_key_exists swapped for isset. fixes:#13986

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -468,7 +468,7 @@ class Exchange {
     }
 
     public static function safe_value($object, $key, $default_value = null) {
-        return (is_array($object) && array_key_exists($key, $object)) ? $object[$key] : $default_value;
+        return (is_array($object) && isset($object[$key])) ? $object[$key] : $default_value;
     }
 
     // we're not using safe_floats with a list argument as we're trying to save some cycles here


### PR DESCRIPTION
```
% php ./examples/php/cli.php ndax fetchOpenOrders
PHP v8.1.7
CCXT v1.88.24
ndax->fetchOpenOrders()
Array
(
    [0] => Array
        (
            [id] => 18932135960
            [clientOrderId] => 0
            [info] => Array
                (
                    [Side] => Sell
                    [OrderId] => 18932135960
                    [Price] => 1.499
                    [Quantity] => 10.7
                    [DisplayQuantity] => 10.7
                    [Instrument] => 80
                    [Account] => ...
                    [AccountName] => ...
                    [OrderType] => Limit
                    [ClientOrderId] => 0
                    [OrderState] => Working
                    [ReceiveTime] => 1655868888376
                    [ReceiveTimeTicks] => 637914656883758815
                    [LastUpdatedTime] => 1655868888376
                    [LastUpdatedTimeTicks] => 637914656883761818
                    [OrigQuantity] => 10.7
                    [QuantityExecuted] => 0
                    [GrossValueExecuted] => 0
                    [ExecutableValue] => 0
                    [AvgPrice] => 0
                    [CounterPartyId] => 0
                    [ChangeReason] => NewInputAccepted
                    [OrigOrderId] => 18932135960
                    [OrigClOrdId] => 0
                    [EnteredBy] => ...
                    [UserName] => ...
                    [IsQuote] => 
                    [InsideAsk] => 1.3027
                    [InsideAskSize] => 4893.21
                    [InsideBid] => 1.296
                    [InsideBidSize] => 0
                    [LastTradePrice] => 1.3022
                    [RejectReason] => 
                    [IsLockedIn] => 
                    [CancelReason] => 
                    [OrderFlag] => AddedToBook
                    [UseMargin] => 
                    [StopPrice] => 0
                    [PegPriceType] => Last
                    [PegOffset] => 0
                    [PegLimitOffset] => 0
                    [IpAddress] => 
                    [ClientOrderIdUuid] => 
                    [OMSId] => 1
                )

            [timestamp] => 1655868888376
            [datetime] => 2022-06-22T03:34:48.376Z
            [lastTradeTimestamp] => 1655868888376
            [status] => open
            [symbol] => USDT/CAD
            [type] => limit
            [timeInForce] => 
            [postOnly] => 
            [side] => sell
            [price] => 1.499
            [stopPrice] => 
            [cost] => 0
            [amount] => 10.7
            [filled] => 0
            [average] => 
            [remaining] => 10.7
            [fee] => 
            [trades] => Array
                (
                )

            [fees] => Array
                (
                )

        )

)
```

----------------------------------

fixes #13986