### PR TITLE
Bitmex fetchMarkets (positionCurrency)

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -374,7 +374,7 @@ module.exports = class bitmex extends Exchange {
                 symbol = id;
                 active = false;
             }
-            const positionId = this.safeString2 (market, 'positionCurrency', 'settlCurrency');
+            const positionId = this.safeString2 (market, 'positionCurrency', 'underlying');
             const position = this.safeCurrencyCode (positionId);
             const positionIsQuote = (position === quote);
             const maxOrderQty = this.safeNumber (market, 'maxOrderQty');

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -347,7 +347,7 @@ module.exports = class bitmex extends Exchange {
             const basequote = baseId + quoteId;
             const swap = (id === basequote);
             // 'positionCurrency' may be empty ("", as Bitmex currently returns for ETHUSD)
-            // so let's take the quote currency first and then adjust if needed
+            // so let's take the settlCurrency first and then adjust if needed
             let type = undefined;
             let future = false;
             let prediction = false;
@@ -374,7 +374,7 @@ module.exports = class bitmex extends Exchange {
                 symbol = id;
                 active = false;
             }
-            const positionId = this.safeString2 (market, 'positionCurrency', 'quoteCurrency');
+            const positionId = this.safeString2 (market, 'positionCurrency', 'settlCurrency');
             const position = this.safeCurrencyCode (positionId);
             const positionIsQuote = (position === quote);
             const maxOrderQty = this.safeNumber (market, 'maxOrderQty');


### PR DESCRIPTION
Adjusted positionId in fetchMarkets to use the base currency instead of quote currency if positionCurrency is undefined.

fixes #11151