### PR TITLE
Bybit fetchFundingRate

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1657,7 +1657,7 @@ module.exports = class bybit extends Exchange {
             method = 'publicGetPerpetualUsdcOpenapiPublicV1PrevFundingRate';
             fundingRateFromTickerMethod = 'publicGetPerpetualUsdcOpenapiPublicV1Tick';
         } else {
-            method = market['linear'] ? 'publicLinearGetFundingPrevFundingRate' : 'publicGetV2PublicFundingPrevFundingRate';
+            method = market['linear'] ? 'publicGetPublicLinearFundingPrevFundingRate' : 'publicGetV2PublicFundingPrevFundingRate';
             fundingRateFromTickerMethod = 'publicGetV2PublicTickers';
         }
         const fetchFundingRateFromTicker = await this[fundingRateFromTickerMethod] (this.extend (request, params));


### PR DESCRIPTION
Fixed a bug in fetchFundingRate API path for linear swaps:
fixes #14031
```
bybit.fetchFundingRate (BTC/USDT:USDT)
2022-06-24T04:20:36.569Z iteration 0 passed in 548 ms

{
  info: {
    symbol: 'BTCUSDT',
    funding_rate: '0.0001',
    funding_rate_timestamp: '2022-06-24T00:00:00.000Z'
  },
  symbol: 'BTC/USDT:USDT',
  markPrice: 21149.62,
  indexPrice: 21148.49,
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: 1656044436569,
  datetime: '2022-06-24T04:20:36.569Z',
  fundingRate: 0.0001,
  fundingTimestamp: 1656028800000,
  fundingDatetime: '2022-06-24T00:00:00.000Z',
  nextFundingRate: 0.000049,
  nextFundingTimestamp: 1656057600000,
  nextFundingDatetime: '2022-06-24T08:00:00Z',
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
```