### PR TITLE
major sync throttle bug

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3441,8 +3441,9 @@ class Exchange {
             $cost = $this->calculate_rate_limiter_cost($api, $method, $path, $params, $config, $context);
             $this->throttle ($cost);
         }
-        $request = $this->sign ($path, $api, $method, $params, $headers, $body);
-        return $this->fetch ($request['url'], $request['method'], $request['headers'], $request['body']);
+        $this->lastRestRequestTimestamp = static::milliseconds();
+        $request = $this->sign($path, $api, $method, $params, $headers, $body);
+        return $this->fetch($request['url'], $request['method'], $request['headers'], $request['body']);
     }
 
     public function request($path, $api = 'public', $method = 'GET', $params = array (), $headers = null, $body = null, $config = array (), $context = array ()) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2609,6 +2609,7 @@ class Exchange(object):
         if self.enableRateLimit:
             cost = self.calculate_rate_limiter_cost(api, method, path, params, config, context)
             self.throttle(cost)
+        self.lastRestRequestTimestamp = self.milliseconds()
         request = self.sign(path, api, method, params, headers, body)
         return self.fetch(request['url'], request['method'], request['headers'], request['body'])
 


### PR DESCRIPTION
looks like this line got deleted somehow causing sync implementations not to be throttled at all. credits to @DoctorSlimm for helping to find this bug