### PR TITLE
BITBNS accept exchange code 204 - empty response as valid

### DIFF
--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -1193,7 +1193,7 @@ module.exports = class bitbns extends Exchange {
         //
         const code = this.safeString (response, 'code');
         const message = this.safeString (response, 'msg');
-        const error = (code !== undefined) && (code !== '200');
+        const error = (code !== undefined) && (code !== '200') && (code !== '204');
         if (error || (message !== undefined)) {
             const feedback = this.id + ' ' + body;
             this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);

--- a/python/ccxt/bitbns.py
+++ b/python/ccxt/bitbns.py
@@ -1118,7 +1118,7 @@ class bitbns(Exchange):
         #
         code = self.safe_string(response, 'code')
         message = self.safe_string(response, 'msg')
-        error = (code is not None) and (code != '200')
+        error = (code is not None) and (code not in ['200','204'])
         if error or (message is not None):
             feedback = self.id + ' ' + body
             self.throw_exactly_matched_exception(self.exceptions['exact'], code, feedback)


### PR DESCRIPTION
bitbns returns code 204 with empty response, which is correct response, currently ccxt throws exception
```
ccxt.base.errors.ExchangeError: bitbns {"data":[],"status":1,"error":null,"code":204}
```