### PR TITLE
safeBalance :: small improvement

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -933,13 +933,13 @@ module.exports = class Exchange {
             let total = this.safeString (balance[code], 'total');
             let free = this.safeString (balance[code], 'free');
             let used = this.safeString (balance[code], 'used');
-            if (total === undefined) {
+            if (total === undefined && free !== undefined && used !== undefined) {
                 total = Precise.stringAdd (free, used);
             }
-            if (free === undefined) {
+            if (free === undefined && total !== undefined && used !== undefined) {
                 free = Precise.stringSub (total, used);
             }
-            if (used === undefined) {
+            if (used === undefined && total !== undefined && free !== undefined) {
                 used = Precise.stringSub (total, free);
             }
             balance[code]['free'] = this.parseNumber (free);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -933,13 +933,13 @@ module.exports = class Exchange {
             let total = this.safeString (balance[code], 'total');
             let free = this.safeString (balance[code], 'free');
             let used = this.safeString (balance[code], 'used');
-            if (total === undefined && free !== undefined && used !== undefined) {
+            if ((total === undefined) && (free !== undefined) && (used !== undefined)) {
                 total = Precise.stringAdd (free, used);
             }
-            if (free === undefined && total !== undefined && used !== undefined) {
+            if ((free === undefined) && (total !== undefined) && (used !== undefined)) {
                 free = Precise.stringSub (total, used);
             }
-            if (used === undefined && total !== undefined && free !== undefined) {
+            if ((used === undefined) && (total !== undefined) && (free !== undefined)) {
                 used = Precise.stringSub (total, free);
             }
             balance[code]['free'] = this.parseNumber (free);


### PR DESCRIPTION
- We're using precise for string arithmetics but **stringAdd** behaves in a way I don't consider correct for this use case, by ignoring undefined values and returning the other.

Example
```Javascript
// First example
let used = undefined;
let free = 5;
total = Precise.stringAdd (free, used); // total = 5, ignores used = undefined

// since total !== undefined and free !== undefined we're setting
used = total - free // 5-5 = 0

// Second example
let used = 6; 
let free = undefined;
total = Precise.stringAdd (free, used); // total = 6, ignores free = undefined

// since total !== undefined and used !== undefined we're setting
free = total - used // 6-6 = 0


```
- When dealing with balances I don't think we can infer values like this, just because free/used is undefined does not mean they're zero.
- Technically **stringSub** (correctly returns undefined if one of the values is undefined) does not need these extra checks but I've added them as well just for the sake of consistency

