### PR TITLE
Bybit :: take timeDifference into consideration

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4887,7 +4887,7 @@ module.exports = class bybit extends Exchange {
         } else if (api === 'private') {
             this.checkRequiredCredentials ();
             const isOpenapi = url.indexOf ('openapi') >= 0;
-            const timestamp = this.milliseconds ().toString ();
+            const timestamp = this.nonce ().toString ();
             if (isOpenapi) {
                 if (Object.keys (params).length) {
                     body = this.json (params);


### PR DESCRIPTION
- I'm not sure yet but I think this might be impacting this issue #14104 because if the user provides API keys it will `fetchCurrencies`  using a private endpoint and for these, we need the timestamp