### PR TITLE
Crypto.com Margin

### DIFF
--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1240,6 +1240,7 @@ module.exports = class cryptocom extends Exchange {
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchMyTrades', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateGetTrades',
+            'margin': 'spotPrivatePostPrivateMarginGetTrades',
             'future': 'derivativesPrivatePostPrivateGetTrades',
             'swap': 'derivativesPrivatePostPrivateGetTrades',
         });

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1684,12 +1684,22 @@ module.exports = class cryptocom extends Exchange {
         let toAccount = undefined;
         if (information !== undefined) {
             const parts = information.split (' ');
-            fromAccount = this.safeStringLower (parts, 1);
+            const direction = this.safeStringLower (parts, 0);
             const method = this.safeString (response, 'method');
-            if (method === 'private/margin/get-transfer-history') {
-                toAccount = (fromAccount === 'spot') ? 'margin' : 'spot';
-            } else {
-                toAccount = (fromAccount === 'spot') ? 'derivative' : 'spot';
+            if (direction === 'from') {
+                fromAccount = this.safeStringLower (parts, 1);
+                if (method === 'private/margin/get-transfer-history') {
+                    toAccount = 'margin';
+                } else {
+                    toAccount = 'derivative';
+                }
+            } else if (direction === 'to') {
+                toAccount = this.safeStringLower (parts, 1);
+                if (method === 'private/margin/get-transfer-history') {
+                    fromAccount = 'margin';
+                } else {
+                    fromAccount = 'derivative';
+                }
             }
         }
         return {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1045,6 +1045,7 @@ module.exports = class cryptocom extends Exchange {
         const [ marketType, query ] = this.handleMarketTypeAndParams ('createOrder', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateCreateOrder',
+            'margin': 'spotPrivatePostPrivateMarginCreateOrder',
             'future': 'derivativesPrivatePostPrivateCreateOrder',
             'swap': 'derivativesPrivatePostPrivateCreateOrder',
         });

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -961,13 +961,14 @@ module.exports = class cryptocom extends Exchange {
         }
         const request = {};
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
-        if (marketType === 'spot') {
+        if ((marketType === 'spot') || (marketType === 'spot')) {
             request['order_id'] = id.toString ();
         } else {
             request['order_id'] = parseInt (id);
         }
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateGetOrderDetail',
+            'margin': 'spotPrivatePostPrivateMarginGetOrderDetail',
             'future': 'derivativesPrivatePostPrivateGetOrderDetail',
             'swap': 'derivativesPrivatePostPrivateGetOrderDetail',
         });

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -23,6 +23,7 @@ module.exports = class cryptocom extends Exchange {
                 'swap': undefined, // has but not fully implemented
                 'future': undefined, // has but not fully implemented
                 'option': undefined,
+                'borrowMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,
@@ -2056,6 +2057,46 @@ module.exports = class cryptocom extends Exchange {
             'updated': updated,
             'internal': undefined,
             'fee': fee,
+        };
+    }
+
+    async borrowMargin (code, amount, symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'currency': currency['id'],
+            'amount': this.currencyToPrecision (code, amount),
+        };
+        const response = await this.spotPrivatePostPrivateMarginBorrow (this.extend (request, params));
+        //
+        //     {
+        //         "id": 1656619578559,
+        //         "method": "private/margin/borrow",
+        //         "code": 0
+        //     }
+        //
+        const transaction = this.parseMarginLoan (response, currency);
+        return this.extend (transaction, {
+            'amount': amount,
+        });
+    }
+
+    parseMarginLoan (info, currency = undefined) {
+        //
+        //     {
+        //         "id": 1656619578559,
+        //         "method": "private/margin/borrow",
+        //         "code": 0
+        //     }
+        //
+        return {
+            'id': this.safeInteger (info, 'id'),
+            'currency': this.safeCurrencyCode (undefined, currency),
+            'amount': undefined,
+            'symbol': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'info': info,
         };
     }
 

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1153,6 +1153,7 @@ module.exports = class cryptocom extends Exchange {
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateGetOpenOrders',
+            'margin': 'spotPrivatePostPrivateMarginGetOpenOrders',
             'future': 'derivativesPrivatePostPrivateGetOpenOrders',
             'swap': 'derivativesPrivatePostPrivateGetOpenOrders',
         });

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -2077,6 +2077,16 @@ module.exports = class cryptocom extends Exchange {
     }
 
     async repayMargin (code, amount, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name cryptocom#repayMargin
+         * @description repay borrowed margin and interest
+         * @param {str} code unified currency code of the currency to repay
+         * @param {float} amount the amount to repay
+         * @param {str|undefined} symbol unified market symbol
+         * @param {dict} params extra parameters specific to the cryptocom api endpoint
+         * @returns {[dict]} a dictionary of a [margin loan structure]
+         */
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {
@@ -2101,6 +2111,16 @@ module.exports = class cryptocom extends Exchange {
     }
 
     async borrowMargin (code, amount, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name cryptocom#borrowMargin
+         * @description create a loan to borrow margin
+         * @param {str} code unified currency code of the currency to borrow
+         * @param {float} amount the amount to borrow
+         * @param {str|undefined} symbol unified market symbol
+         * @param {dict} params extra parameters specific to the cryptocom api endpoint
+         * @returns {[dict]} a dictionary of a [margin loan structure]
+         */
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -2083,7 +2083,7 @@ module.exports = class cryptocom extends Exchange {
          * @description repay borrowed margin and interest
          * @param {str} code unified currency code of the currency to repay
          * @param {float} amount the amount to repay
-         * @param {str|undefined} symbol unified market symbol
+         * @param {str|undefined} symbol unified market symbol, not used by cryptocom.repayMargin ()
          * @param {dict} params extra parameters specific to the cryptocom api endpoint
          * @returns {[dict]} a dictionary of a [margin loan structure]
          */
@@ -2117,7 +2117,7 @@ module.exports = class cryptocom extends Exchange {
          * @description create a loan to borrow margin
          * @param {str} code unified currency code of the currency to borrow
          * @param {float} amount the amount to borrow
-         * @param {str|undefined} symbol unified market symbol
+         * @param {str|undefined} symbol unified market symbol, not used by cryptocom.repayMargin ()
          * @param {dict} params extra parameters specific to the cryptocom api endpoint
          * @returns {[dict]} a dictionary of a [margin loan structure]
          */

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -843,6 +843,7 @@ module.exports = class cryptocom extends Exchange {
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateGetAccountSummary',
+            'margin': 'spotPrivatePostPrivateMarginGetAccountSummary',
             'future': 'derivativesPrivatePostPrivateUserBalance',
             'swap': 'derivativesPrivatePostPrivateUserBalance',
         });
@@ -862,6 +863,42 @@ module.exports = class cryptocom extends Exchange {
         //                     "currency": "CRO"
         //                 }
         //             ]
+        //         }
+        //     }
+        //
+        // margin
+        //     {
+        //         "id": 1656529728178,
+        //         "method": "private/margin/get-account-summary",
+        //         "code": 0,
+        //         "result": {
+        //             "accounts": [
+        //                 {
+        //                     "balance": 0,
+        //                     "available": 0,
+        //                     "order": 0,
+        //                     "borrowed": 0,
+        //                     "position": 0,
+        //                     "positionHomeCurrency": 0,
+        //                     "positionBtc": 0,
+        //                     "lastPriceHomeCurrency": 20111.38,
+        //                     "lastPriceBtc": 1,
+        //                     "currency": "BTC",
+        //                     "accrued_interest": 0,
+        //                     "liquidation_price": 0
+        //                 },
+        //             ],
+        //             "is_liquidating": false,
+        //             "total_balance": 16,
+        //             "total_balance_btc": 0.00079556,
+        //             "equity_value": 16,
+        //             "equity_value_btc": 0.00079556,
+        //             "total_borrowed": 0,
+        //             "total_borrowed_btc": 0,
+        //             "total_accrued_interest": 0,
+        //             "total_accrued_interest_btc": 0,
+        //             "margin_score": "GOOD",
+        //             "currency": "USDT"
         //         }
         //     }
         //
@@ -900,6 +937,7 @@ module.exports = class cryptocom extends Exchange {
         //
         const parser = this.getSupportedMapping (marketType, {
             'spot': 'parseSpotBalance',
+            'margin': 'parseSpotBalance',
             'future': 'parseSwapBalance',
             'swap': 'parseSwapBalance',
         });
@@ -1590,7 +1628,8 @@ module.exports = class cryptocom extends Exchange {
 
     parseTransfer (transfer, currency = undefined) {
         //
-        //     {
+        //   {
+        //     response: {
         //       id: '1641032709328',
         //       method: 'private/deriv/get-transfer-history',
         //       code: '0',
@@ -1607,6 +1646,7 @@ module.exports = class cryptocom extends Exchange {
         //         ]
         //       }
         //     }
+        //   }
         //
         const response = this.safeValue (transfer, 'response', {});
         const result = this.safeValue (response, 'result', {});

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -222,6 +222,7 @@ module.exports = class cryptocom extends Exchange {
                 'accountsById': {
                     'funding': 'SPOT',
                     'spot': 'SPOT',
+                    'margin': 'MARGIN',
                     'derivatives': 'DERIVATIVES',
                     'swap': 'DERIVATIVES',
                     'future': 'DERIVATIVES',
@@ -1503,7 +1504,11 @@ module.exports = class cryptocom extends Exchange {
             'from': fromId,
             'to': toId,
         };
-        const repsonse = await this.spotPrivatePostPrivateDerivTransfer (this.extend (request, params));
+        let method = 'spotPrivatePostPrivateDerivTransfer';
+        if ((fromAccount === 'margin') || (toAccount === 'margin')) {
+            method = 'spotPrivatePostPrivateMarginTransfer';
+        }
+        const response = await this[method] (this.extend (request, params));
         //
         //     {
         //         "id": 11,
@@ -1511,7 +1516,7 @@ module.exports = class cryptocom extends Exchange {
         //         "code": 0
         //     }
         //
-        return this.parseTransfer (repsonse, currency);
+        return this.parseTransfer (response, currency);
     }
 
     async fetchTransfers (code = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1080,7 +1080,7 @@ module.exports = class cryptocom extends Exchange {
         }
         const request = {};
         const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
-        if (marketType === 'spot') {
+        if ((marketType === 'spot') || (marketType === 'margin')) {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol argument for ' + marketType + ' orders');
             }
@@ -1088,6 +1088,7 @@ module.exports = class cryptocom extends Exchange {
         }
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateCancelAllOrders',
+            'margin': 'spotPrivatePostPrivateMarginCancelAllOrders',
             'future': 'derivativesPrivatePostPrivateCancelAllOrders',
             'swap': 'derivativesPrivatePostPrivateCancelAllOrders',
         });

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -2081,6 +2081,7 @@ module.exports = class cryptocom extends Exchange {
          * @method
          * @name cryptocom#repayMargin
          * @description repay borrowed margin and interest
+         * @see https://exchange-docs.crypto.com/spot/index.html#private-margin-repay
          * @param {str} code unified currency code of the currency to repay
          * @param {float} amount the amount to repay
          * @param {str|undefined} symbol unified market symbol, not used by cryptocom.repayMargin ()
@@ -2115,6 +2116,7 @@ module.exports = class cryptocom extends Exchange {
          * @method
          * @name cryptocom#borrowMargin
          * @description create a loan to borrow margin
+         * @see https://exchange-docs.crypto.com/spot/index.html#private-margin-borrow
          * @param {str} code unified currency code of the currency to borrow
          * @param {float} amount the amount to borrow
          * @param {str|undefined} symbol unified market symbol, not used by cryptocom.repayMargin ()

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -2085,7 +2085,7 @@ module.exports = class cryptocom extends Exchange {
          * @param {float} amount the amount to repay
          * @param {str|undefined} symbol unified market symbol, not used by cryptocom.repayMargin ()
          * @param {dict} params extra parameters specific to the cryptocom api endpoint
-         * @returns {[dict]} a dictionary of a [margin loan structure]
+         * @returns {dict} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
@@ -2119,7 +2119,7 @@ module.exports = class cryptocom extends Exchange {
          * @param {float} amount the amount to borrow
          * @param {str|undefined} symbol unified market symbol, not used by cryptocom.repayMargin ()
          * @param {dict} params extra parameters specific to the cryptocom api endpoint
-         * @returns {[dict]} a dictionary of a [margin loan structure]
+         * @returns {dict} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
         await this.loadMarkets ();
         const currency = this.currency (code);

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -1111,7 +1111,7 @@ module.exports = class cryptocom extends Exchange {
         }
         const request = {};
         const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
-        if (marketType === 'spot') {
+        if ((marketType === 'spot') || (marketType === 'margin')) {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument for ' + marketType + ' orders');
             }
@@ -1122,6 +1122,7 @@ module.exports = class cryptocom extends Exchange {
         }
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateCancelOrder',
+            'margin': 'spotPrivatePostPrivateMarginCancelOrder',
             'future': 'derivativesPrivatePostPrivateCancelOrder',
             'swap': 'derivativesPrivatePostPrivateCancelOrder',
         });

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -582,12 +582,13 @@ module.exports = class cryptocom extends Exchange {
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivatePostPrivateGetOrderHistory',
+            'margin': 'spotPrivatePostPrivateMarginGetOrderHistory',
             'future': 'derivativesPrivatePostPrivateGetOrderHistory',
             'swap': 'derivativesPrivatePostPrivateGetOrderHistory',
         });
         const response = await this[method] (this.extend (request, query));
         //
-        // spot
+        // spot and margin
         //     {
         //       id: 1641026542065,
         //       method: 'private/get-order-history',


### PR DESCRIPTION
Adds margin functionality to Crypto.com:
fixes #14042

### Methods to be completed:
- [x] transfer
- [x] fetchTransfers
- [x] fetchBalance
- [x] createOrder
- [x] fetchOrders
- [x] fetchOpenOrders
- [x] fetchOrder
- [x] cancelOrder
- [x] cancelAllOrders
- [x] fetchMyTrades
- [x] borrowMargin
- [x] repayMargin
- [x] fetchBorrowInterest
- [x] fetchBorrowRates
- [ ] ~fetchBorrowRate~
- [ ] ~fetchBorrowHistory~
- [ ] ~fetchBorrowHistories~
- [ ] ~setMarginMode~

### transfer:
```
cryptocom.transfer (USDT, 16, spot, margin)
2022-06-29T06:02:03.453Z iteration 0 passed in 279 ms

{
  info: { id: '1656482523210', method: 'private/margin/transfer', code: '0' },
  id: '1656482523210',
  timestamp: undefined,
  datetime: undefined,
  currency: undefined,
  amount: undefined,
  fromAccount: undefined,
  toAccount: undefined,
  status: undefined
}
2022-06-29T06:02:03.453Z iteration 1 passed in 279 ms
```

### fetchTransfers:
```
node examples/js/cli cryptocom fetchTransfers USDT undefined undefined '{"direction":"OUT"}'

cryptocom.fetchTransfers (USDT, , , [object Object])
2022-06-29T06:46:47.512Z iteration 0 passed in 278 ms

           id |     timestamp |                 datetime | currency | amount | fromAccount | toAccount | status | direction
---------------------------------------------------------------------------------------------------------------------------
1656485207268 | 1656482503867 | 2022-06-29T06:01:43.867Z |     USDT |     16 |        spot |    margin |     ok |       OUT
1 objects
2022-06-29T06:46:47.512Z iteration 1 passed in 278 ms
```

### fetchBalance:
```
cryptocom.fetchBalance ()
2022-06-29T19:39:21.911Z iteration 0 passed in 286 ms

{
    {
        {
          balance: '0',
          available: '0',
          order: '0',
          borrowed: '0',
          position: '0',
          positionHomeCurrency: '0',
          positionBtc: '0',
          lastPriceHomeCurrency: '0.05115',
          lastPriceBtc: '0.00000254',
          currency: 'SKL',
          accrued_interest: '0',
          liquidation_price: '0'
        },
        ...
      ],
      is_liquidating: false,
      total_balance: '16',
      total_balance_btc: '0.00079556',
      equity_value: '16',
      equity_value_btc: '0.00079556',
      total_borrowed: '0',
      total_borrowed_btc: '0',
      total_accrued_interest: '0',
      total_accrued_interest_btc: '0',
      margin_score: 'GOOD',
      currency: 'USDT'
    }
  },
  BTC: { free: 0, used: 0, total: 0 },
  USDT: { free: 16, used: 0, total: 16 },
  CRO: { free: 0, used: 0, total: 0 },
 ...
  free: {
    BTC: 0,
    USDT: 16,
    CRO: 0,
    ...
  },
  used: {
    BTC: 0,
    USDT: 0,
    CRO: 0,
    ...
  },
  total: {
    BTC: 0,
    USDT: 16,
    CRO: 0,
    ...
  }
}
```

### createOrder:
```
cryptocom.createOrder (BTC/USDT, limit, buy, 0.0005, 18000)
2022-06-29T19:39:21.911Z iteration 0 passed in 286 ms

{
  info: { order_id: '2640558065979074241' },
  id: '2640558065979074241',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'BTC/USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  fee: undefined,
  average: undefined,
  trades: [],
  fees: []
}
2022-06-29T19:39:21.911Z iteration 1 passed in 286 ms
```

### fetchOrders:
```
cryptocom.fetchOrders (BTC/USDT)
2022-06-29T19:49:06.807Z iteration 0 passed in 286 ms

                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |   symbol |  type | timeInForce | postOnly | side | price | amount | filled | remaining | cost | fee | average | trades | fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2640558065979074241 |               | 1656531562766 | 2022-06-29T19:39:22.766Z |      1656531562766 | rejected | BTC/USDT | limit |         GTC |          |  buy | 18000 | 0.0005 |      0 |    0.0005 |    0 |     |         |     [] |   []
2640571243535947235 |               | 1656531955488 | 2022-06-29T19:45:55.488Z |      1656531955488 | rejected | BTC/USDT | limit |         GTC |          |  buy | 18000 | 0.0005 |      0 |    0.0005 |    0 |     |         |     [] |   []
2 objects
2022-06-29T19:49:06.807Z iteration 1 passed in 286 ms
```

### fetchOpenOrders:
```
cryptocom.fetchOpenOrders (BTC/USDT)
2022-06-29T20:03:23.498Z iteration 0 passed in 267 ms

                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |   symbol |  type | timeInForce | postOnly | side | price | amount | filled | remaining | cost | fee | average | trades | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2640600951149394145 |               | 1656532840843 | 2022-06-29T20:00:40.843Z |      1656532840843 |   open | BTC/USDT | limit |         GTC |          |  buy | 15000 | 0.0001 |      0 |    0.0001 |    0 |     |         |     [] |   []
1 objects
2022-06-29T20:03:23.498Z iteration 1 passed in 267 ms
```

### fetchOrder:
```
node examples/js/cli cryptocom fetchOrder "'2640600951149394145'" --verbose

cryptocom.fetchOrder (2640600951149394145)
fetch Request:
 cryptocom POST https://api.crypto.com/v2/private/margin/get-order-detail

ResponseBody:
 {"id":1656533261392,"method":"private/margin/get-order-detail","code":0,"result":{}}

2022-06-29T20:07:41.736Z iteration 0 passed in 379 ms

{
  info: {},
  id: undefined,
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  fee: undefined,
  average: undefined,
  trades: [],
  fees: []
}
2022-06-29T20:07:41.736Z iteration 1 passed in 379 ms
```

### cancelOrder:
```
cryptocom.cancelOrder (2640600951149394145, BTC/USDT)
2022-06-29T20:13:09.040Z iteration 0 passed in 287 ms

{
  info: { id: '1656533588785', method: 'private/cancel-order', code: '0' },
  id: undefined,
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  fee: undefined,
  average: undefined,
  trades: [],
  fees: []
}
2022-06-29T20:13:09.040Z iteration 1 passed in 287 ms
```

### cancelAllOrders:
```
cryptocom.cancelAllOrders (BTC/USDT)
2022-06-29T20:16:21.353Z iteration 0 passed in 290 ms

{ id: '1656533781098', method: 'private/cancel-all-orders', code: '0' }
2022-06-29T20:16:21.353Z iteration 1 passed in 290 ms
```

### fetchMyTrades:
```
cryptocom.fetchMyTrades (BTC/USDT)
2022-06-29T20:35:57.195Z iteration 0 passed in 293 ms

                 id |     timestamp |                 datetime |   symbol | side |    price |  amount |      cost |               order | takerOrMaker | type |                            fee |                             fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2640669883735463296 | 1656534895194 | 2022-06-29T20:34:55.194Z | BTC/USDT |  buy | 20200.26 | 0.00001 | 0.2020026 | 2640669883630473091 |        taker |      | {"currency":"BTC","cost":4e-8} | [{"currency":"BTC","cost":4e-8}]
1 objects
2022-06-29T20:35:57.195Z iteration 1 passed in 293 ms
```

### borrowMargin:
```
cryptocom.borrowMargin (USDT, 30)
2022-06-30T20:06:18.892Z iteration 0 passed in 367 ms

{
  id: 1656619578559,
  currency: 'USDT',
  amount: 30,
  symbol: undefined,
  timestamp: undefined,
  datetime: undefined,
  info: { id: '1656619578559', method: 'private/margin/borrow', code: '0' }
}
2022-06-30T20:06:18.892Z iteration 1 passed in 367 ms
```

### repayMargin:
```
cryptocom.repayMargin (USDT, 30)
2022-06-30T20:12:57.803Z iteration 0 passed in 318 ms

{
  id: 1656619977521,
  currency: 'USDT',
  amount: 30,
  symbol: undefined,
  timestamp: undefined,
  datetime: undefined,
  info: {
    id: '1656619977521',
    method: 'private/margin/repay',
    code: '0',
    result: { badDebt: '0' }
  }
}
2022-06-30T20:12:57.803Z iteration 1 passed in 318 ms
```

### fetchBorrowInterest:
```
cryptocom.fetchBorrowInterest ()
2022-07-01T20:31:37.451Z iteration 0 passed in 287 ms

symbol | marginMode | currency | interest | interestRate | amountBorrowed |     timestamp |                 datetime
--------------------------------------------------------------------------------------------------------------------
       |            |     USDT |     4e-8 |     0.000025 |                | 1656706499559 | 2022-07-01T20:14:59.559Z
       |            |     USDT |     4e-8 |     0.000025 |                | 1656702899559 | 2022-07-01T19:14:59.559Z
       |            |     USDT |     4e-8 |     0.000025 |                | 1656699299559 | 2022-07-01T18:14:59.559Z
...
20 objects
2022-07-01T20:31:37.451Z iteration 1 passed in 287 ms
```

### fetchBorrowRates:
```
cryptocom.fetchBorrowRates ()
2022-07-01T20:52:16.864Z iteration 0 passed in 293 ms

currency |       rate |  period |     timestamp |                 datetime
--------------------------------------------------------------------------
    AGLD | 0.00003334 | 3600000 | 1656708736864 | 2022-07-01T20:52:16.864Z
   MATIC | 0.00003334 | 3600000 | 1656708736864 | 2022-07-01T20:52:16.864Z
    IOTX | 0.00003334 | 3600000 | 1656708736864 | 2022-07-01T20:52:16.864Z
...
130 objects
2022-07-01T20:52:16.864Z iteration 1 passed in 293 ms
```