### PR TITLE
therock - describe, cancelAllOrders, createDepositAddress, margin

### DIFF
--- a/js/therock.js
+++ b/js/therock.js
@@ -897,23 +897,6 @@ module.exports = class therock extends Exchange {
         };
     }
 
-    async fetchWithdrawal (id, code = undefined, params = {}) {
-        /**
-         * @method
-         * @name therock#fetchWithdrawal
-         * @description fetch data on a currency withdrawal via the withdrawal id
-         * @param {str} id withdrawal id
-         * @param {str|undefined} code not used by therock.fetchWithdrawal
-         * @param {dict} params extra parameters specific to the therock api endpoint
-         * @returns {dict} a [transaction structure]{@link https://docs.ccxt.com/en/latest/manual.html#transaction-structure}
-         */
-        const request = {
-            'type': 'withdraw',
-            'transfer_id': id,
-        };
-        return await this.fetchTransactions (code, undefined, undefined, this.extend (request, params));
-    }
-
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
         /**
          * @method


### PR DESCRIPTION
- Update describe
- add `cancelAllOrders`
- add `createDepositAddress`
- For margin: TheRock has a margin api in their docs to `fetchPosition()` and it responds correctly. However there are no endpoints through their api or through their web app to create margin positions. My best guess is that they have supported it in the past but then removed it? So in this case not sure if it's best to set margin as false for the exchange.