### PR TITLE
Bitmex :: fix balance parsing

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -493,9 +493,12 @@ module.exports = class bitmex extends Exchange {
             const account = this.account ();
             let free = this.safeString (balance, 'availableMargin');
             let total = this.safeString (balance, 'marginBalance');
-            if (code === 'BTC') {
+            if (code !== 'USDT') {
                 free = Precise.stringDiv (free, '1e8');
                 total = Precise.stringDiv (total, '1e8');
+            } else {
+                free = Precise.stringDiv (free, '1e6');
+                total = Precise.stringDiv (total, '1e6');
             }
             account['free'] = free;
             account['total'] = total;


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/11147

Demo:
```
  BTC: { free: 0.00739468, used: 0, total: 0.00739468 },
  USDT: { free: 3.89471, used: 20.382479, total: 24.277189 },
  GWEI: { free: 0.02, used: 0, total: 0.02 },
  free: { BTC: 0.00739468, USDT: 3.89471, GWEI: 0.02 },
  used: { BTC: 0, USDT: 20.382479, GWEI: 0 },
  total: { BTC: 0.00739468, USDT: 24.277189, GWEI: 0.02 }

2022-07-05T09:10:49.300Z iteration 1 passed in 2097 ms
```

My account:
![image](https://user-images.githubusercontent.com/43336371/177293642-573d1089-0bde-4e4a-9d86-72b20db57cbe.png)
