### PR TITLE
woo: patch fetchMarkets

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -282,9 +282,9 @@ module.exports = class woo extends Exchange {
             const market = data[i];
             const marketId = this.safeString (market, 'symbol');
             const parts = marketId.split ('_');
-            const marketTypeVal = this.safeStringLower (parts, 0);
-            const isSpot = marketTypeVal === 'spot';
-            const isSwap = marketTypeVal === 'perp';
+            let marketType = this.safeStringLower (parts, 0);
+            const isSpot = marketType === 'spot';
+            const isSwap = marketType === 'perp';
             const baseId = this.safeString (parts, 1);
             const quoteId = this.safeString (parts, 2);
             const base = this.safeCurrencyCode (baseId);
@@ -293,11 +293,14 @@ module.exports = class woo extends Exchange {
             let settle = undefined;
             let symbol = base + '/' + quote;
             let contractSize = undefined;
+            let linear = undefined;
             if (isSwap) {
                 settleId = this.safeString (parts, 2);
                 settle = this.safeCurrencyCode (settleId);
                 symbol = base + '/' + quote + ':' + settle;
                 contractSize = this.parseNumber ('1');
+                marketType = 'swap';
+                linear = true;
             }
             result.push ({
                 'id': marketId,
@@ -308,7 +311,7 @@ module.exports = class woo extends Exchange {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'settleId': settleId,
-                'type': marketTypeVal,
+                'type': marketType,
                 'spot': isSpot,
                 'margin': true,
                 'swap': isSwap,
@@ -316,7 +319,7 @@ module.exports = class woo extends Exchange {
                 'option': false,
                 'active': undefined,
                 'contract': isSwap,
-                'linear': undefined,
+                'linear': linear,
                 'inverse': undefined,
                 'contractSize': contractSize,
                 'expiry': undefined,


### PR DESCRIPTION
```
ccxt % node examples/js/cli woo market SHIB/USDT:USDT 
2022-07-05T10:41:44.777Z
Node.js: v14.17.0
CCXT v1.89.99
woo.market (SHIB/USDT:USDT)
2022-07-05T10:41:45.178Z iteration 0 passed in 0 ms

{
  id: 'PERP_SHIB_USDT',
  symbol: 'SHIB/USDT:USDT',
  base: 'SHIB',
  quote: 'USDT',
  baseId: 'SHIB',
  quoteId: 'USDT',
  active: undefined,
  type: 'swap',
  linear: true,
  inverse: undefined,
  spot: false,
  swap: true,
  future: false,
  option: false,
  margin: true,
  contract: true,
  contractSize: 1,
  expiry: undefined,
  expiryDatetime: undefined,
  optionType: undefined,
  strike: undefined,
  settle: 'USDT',
  settleId: 'USDT',
  precision: { amount: 1, price: 1e-8 },
  limits: {
    amount: { min: 1, max: 20000000000 },
    price: { min: 0, max: 100000 },
    cost: { min: 0, max: undefined },
    leverage: { min: undefined, max: undefined }
  },
  info: {
    symbol: 'PERP_SHIB_USDT',
    quote_min: '0',
    quote_max: '100000',
    quote_tick: '0.00000001',
    base_min: '1',
    base_max: '20000000000',
    base_tick: '1',
    min_notional: '0',
    price_range: '0.02',
    price_scope: '0.4',
    created_time: '1647838758.000',
    updated_time: '1657017663.000',
    is_stable: '0'
  },
  tierBased: true,
  percentage: true,
  taker: 0.0005,
  maker: 0.0002
}
2022-07-05T10:41:45.178Z iteration 1 passed in 0 ms
```