### PR TITLE
bybit: add new api endpoints

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -240,6 +240,7 @@ module.exports = class bybit extends Exchange {
                         'asset/v1/private/coin-info/query': 25,
                         'asset/v1/private/asset-info/query': 50,
                         'asset/v1/private/deposit/address': 100,
+                        'asset/v1/private/universal/transfer/list': 50,
                         'contract/v3/private/copytrading/order/list': 1,
                         'contract/v3/private/copytrading/position/list': 1,
                         'contract/v3/private/copytrading/wallet/balance': 1,
@@ -303,6 +304,8 @@ module.exports = class bybit extends Exchange {
                         'asset/v1/private/sub-member/transfer': 150,
                         'asset/v1/private/withdraw': 50,
                         'asset/v1/private/withdraw/cancel': 50,
+                        'asset/v1/private/transferable-subs/save': 3000,
+                        'asset/v1/private/universal/transfer': 1500,
                         // USDC endpoints
                         // option USDC
                         'option/usdc/openapi/private/v1/place-order': 2.5,
@@ -331,6 +334,7 @@ module.exports = class bybit extends Exchange {
                         'perpetual/usdc/openapi/private/v1/cancel-all': 2.5,
                         'perpetual/usdc/openapi/private/v1/position/leverage/save': 2.5,
                         'option/usdc/openapi/private/v1/session-settlement': 2.5,
+                        'option/usdc/private/asset/account/setMarginMode': 2.5,
                         'perpetual/usdc/openapi/public/v1/risk-limit/list': 2.5,
                         'perpetual/usdc/openapi/private/v1/position/set-risk-limit': 2.5,
                         // 'perpetual/usdc/openapi/private/v1/predicted-funding': 2.5,


### PR DESCRIPTION
Bybit had added endpoints in these two section:

* https://bybit-exchange.github.io/docs/account_asset/#t-introduction
* https://bybit-exchange.github.io/docs/usdc/option/#t-introduction

In this PR, I added these api endpoints. Since they added setMarginMode for USDC PERP, we need to update `setMarginMode` as well.

TODO:

- [ ] update setMarginMode

```
Margin Mode (marginMode)
REGULAR_MARGIN
PORTFOLIO_MARGIN
```