### PR TITLE
Bibox v4 fetch ohlcv

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -56,17 +56,19 @@ module.exports = class bibox extends Exchange {
                 'withdraw': true,
             },
             'timeframes': {
-                '1m': '1min',
-                '5m': '5min',
-                '15m': '15min',
-                '30m': '30min',
-                '1h': '1hour',
-                '2h': '2hour',
-                '4h': '4hour',
-                '6h': '6hour',
-                '12h': '12hour',
-                '1d': 'day',
-                '1w': 'week',
+                '1m': '1m',
+                '3m': '3m',
+                '5m': '5m',
+                '15m': '15m',
+                '30m': '30m',
+                '1h': '1h',
+                '2h': '2h',
+                '4h': '4h',
+                '6h': '6h',
+                '12h': '12h',
+                '1d': '1d',
+                '1w': '1w',
+                '1M': '1M',
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/51840849/77257418-3262b000-6c85-11ea-8fb8-20bdf20b3592.jpg',
@@ -626,22 +628,25 @@ module.exports = class bibox extends Exchange {
 
     parseOHLCV (ohlcv, market = undefined) {
         //
-        //     {
-        //         "time":1591448220000,
-        //         "open":"0.02507029",
-        //         "high":"0.02507029",
-        //         "low":"0.02506349",
-        //         "close":"0.02506349",
-        //         "vol":"5.92000000"
-        //     }
+        //    [
+        //        '1656702000000',      // start time
+        //        '19449.4',            // opening price
+        //        '19451.7',            // maximum price
+        //        '19290.6',            // minimum price
+        //        '19401.5',            // closing price
+        //        '73.328833',          // transaction volume
+        //        '1419466.3805812',    // transaction value
+        //        '45740585',           // first transaction id
+        //        2899                  // The total number of transactions in the range
+        //    ]
         //
         return [
-            this.safeInteger (ohlcv, 'time'),
-            this.safeNumber (ohlcv, 'open'),
-            this.safeNumber (ohlcv, 'high'),
-            this.safeNumber (ohlcv, 'low'),
-            this.safeNumber (ohlcv, 'close'),
-            this.safeNumber (ohlcv, 'vol'),
+            this.safeInteger (ohlcv, 0),
+            this.safeNumber (ohlcv, 1),
+            this.safeNumber (ohlcv, 2),
+            this.safeNumber (ohlcv, 3),
+            this.safeNumber (ohlcv, 4),
+            this.safeNumber (ohlcv, 5),
         ];
     }
 
@@ -660,24 +665,30 @@ module.exports = class bibox extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'cmd': 'kline',
-            'pair': market['id'],
-            'period': this.timeframes[timeframe],
-            'size': limit,
+            'symbol': market['id'],
+            'time_frame': this.timeframes[timeframe],
+            'limit': limit,
         };
-        const response = await this.v1PublicGetMdata (this.extend (request, params));
+        const response = await this.v4PublicGetMarketdataCandles (this.extend (request, params));
         //
-        //     {
-        //         "result":[
-        //             {"time":1591448220000,"open":"0.02507029","high":"0.02507029","low":"0.02506349","close":"0.02506349","vol":"5.92000000"},
-        //             {"time":1591448280000,"open":"0.02506449","high":"0.02506975","low":"0.02506108","close":"0.02506843","vol":"5.72000000"},
-        //             {"time":1591448340000,"open":"0.02506698","high":"0.02506698","low":"0.02506452","close":"0.02506519","vol":"4.86000000"},
-        //         ],
-        //         "cmd":"kline",
-        //         "ver":"1.1"
-        //     }
+        //    {
+        //        t: '3600000',
+        //        e: [
+        //            [
+        //                '1656702000000',      // start time
+        //                '19449.4',            // opening price
+        //                '19451.7',            // maximum price
+        //                '19290.6',            // minimum price
+        //                '19401.5',            // closing price
+        //                '73.328833',          // transaction volume
+        //                '1419466.3805812',    // transaction value
+        //                '45740585',           // first transaction id
+        //                2899                  // The total number of transactions in the range
+        //            ],
+        //            ...
+        //    }
         //
-        const result = this.safeValue (response, 'result', []);
+        const result = this.safeValue (response, 'e', []);
         return this.parseOHLCVs (result, market, timeframe, since, limit);
     }
 


### PR DESCRIPTION
builds on #14281 

------------------------------

# Testing


```
% bibox fetchOHLCV ADA/USDT
2022-07-05T22:23:43.785Z
Node.js: v18.4.0
CCXT v1.90.22
bibox.fetchOHLCV (ADA/USDT)
2022-07-05T22:23:45.606Z iteration 0 passed in 364 ms
1657041840000 | 0.451118 | 0.451218 | 0.450618 | 0.450718 |   747.21
1657041900000 | 0.450818 | 0.451118 | 0.450818 | 0.451118 |  2599.94
1657041960000 | 0.451018 | 0.451718 | 0.451018 | 0.451473 |  5325.45
...
1657059780000 | 0.457844 | 0.458244 | 0.457844 | 0.458144 |  2217.87
300 objects
2022-07-05T22:23:45.606Z iteration 1 passed in 364 ms
```

```
% bibox fetchOHLCV ADA/USDT 15m
2022-07-05T22:24:16.506Z
Node.js: v18.4.0
CCXT v1.90.22
bibox.fetchOHLCV (ADA/USDT, 15m)
2022-07-05T22:24:18.536Z iteration 0 passed in 382 ms
1656790200000 | 0.453353 | 0.462122 | 0.453353 | 0.461565 | 163459.55
1656791100000 | 0.461665 | 0.461966 | 0.457559 | 0.458361 |  75429.91
1656792000000 | 0.458461 | 0.458762 | 0.457159 | 0.458061 |  28910.82
...
1657059300000 | 0.458945 | 0.459245 | 0.457144 | 0.457944 |  20823.75
300 objects
2022-07-05T22:24:18.536Z iteration 1 passed in 382 ms
```

```
% bibox fetchOHLCV ADA/USDT 15m 1657052100000          
2022-07-05T22:49:05.183Z
Node.js: v18.4.0
CCXT v1.90.22
bibox.fetchOHLCV (ADA/USDT, 15m, 1657052100000)
2022-07-05T22:49:07.125Z iteration 0 passed in 390 ms

1657053000000 | 0.459854 | 0.461655 | 0.458353 | 0.458853 |  37395.6
1657053900000 | 0.459153 | 0.459253 | 0.458004 | 0.458553 | 29382.77
1657054800000 | 0.459053 | 0.460054 | 0.456443 | 0.456643 | 63405.07
1657055700000 | 0.456543 | 0.457544 | 0.456243 | 0.457444 |  22645.2
1657056600000 | 0.457544 | 0.459746 | 0.457444 | 0.459445 | 29851.33
1657057500000 | 0.459545 | 0.460446 | 0.457844 | 0.458545 | 39504.39
1657058400000 | 0.458545 | 0.460746 | 0.457944 | 0.459145 | 88166.47
1657059300000 | 0.458945 | 0.459245 | 0.456243 | 0.456543 | 35075.46
1657060200000 | 0.456743 | 0.458945 | 0.456643 | 0.458144 | 35507.35
9 objects
2022-07-05T22:49:07.125Z iteration 1 passed in 390 ms
```

```
% bibox fetchOHLCV ADA/USDT 15m 1657052100000 3        
2022-07-05T22:49:53.597Z
Node.js: v18.4.0
CCXT v1.90.22
bibox.fetchOHLCV (ADA/USDT, 15m, 1657052100000, 3)
2022-07-05T22:49:55.588Z iteration 0 passed in 373 ms

1657053000000 | 0.459854 | 0.461655 | 0.458353 | 0.458853 |  37395.6
1657053900000 | 0.459153 | 0.459253 | 0.458004 | 0.458553 | 29382.77
1657054800000 | 0.459053 | 0.460054 | 0.456443 | 0.456643 | 63405.07
3 objects
2022-07-05T22:49:55.588Z iteration 1 passed in 373 ms
```

```
% bibox fetchOHLCV ADA/USDT 15m undefined 3 '{"until": 1657057500000}'
2022-07-05T22:50:55.221Z
Node.js: v18.4.0
CCXT v1.90.22
bibox.fetchOHLCV (ADA/USDT, 15m, , 3, [object Object])
2022-07-05T22:50:57.183Z iteration 0 passed in 373 ms

1657054800000 | 0.459053 | 0.460054 | 0.456443 | 0.456643 | 63405.07
1657055700000 | 0.456543 | 0.457544 | 0.456243 | 0.457444 |  22645.2
1657056600000 | 0.457544 | 0.459746 | 0.457444 | 0.459445 | 29851.33
3 objects
2022-07-05T22:50:57.183Z iteration 1 passed in 373 ms
```