### PR TITLE
public/private api removals from implementations

### DIFF
--- a/examples/js/exchange-capabilities.js
+++ b/examples/js/exchange-capabilities.js
@@ -55,8 +55,6 @@ async function main () {
     const table = asTable (exchanges.map (exchange => {
         let result = {};
         const basics = [
-            'publicAPI',
-            'privateAPI',
             'CORS',
             'spot',
             'margin',

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -49,6 +49,7 @@ module.exports = class Exchange {
             'pro': false, // if it is integrated with CCXT Pro for WebSocket support
             'alias': false, // whether this exchange is an alias to another exchange
             'has': {
+                // stubs
                 'publicAPI': true,
                 'privateAPI': true,
                 'CORS': undefined,
@@ -57,6 +58,7 @@ module.exports = class Exchange {
                 'swap': undefined,
                 'future': undefined,
                 'option': undefined,
+                // methods
                 'addMargin': undefined,
                 'cancelAllOrders': undefined,
                 'cancelOrder': true,

--- a/js/bitpanda.js
+++ b/js/bitpanda.js
@@ -81,8 +81,6 @@ module.exports = class bitpanda extends Exchange {
                 'fetchTransfers': false,
                 'fetchWithdrawal': false,
                 'fetchWithdrawals': true,
-                'privateAPI': true,
-                'publicAPI': true,
                 'reduceMargin': false,
                 'setLeverage': false,
                 'setMargin': false,

--- a/js/bkex.js
+++ b/js/bkex.js
@@ -91,8 +91,6 @@ module.exports = class bkex extends Exchange {
                 'fetchTransfers': false,
                 'fetchWithdrawal': false,
                 'fetchWithdrawals': true,
-                'privateAPI': true,
-                'publicAPI': true,
                 'reduceMargin': undefined,
                 'setLeverage': undefined,
                 'setMarginMode': undefined,

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -92,8 +92,6 @@ module.exports = class mexc3 extends Exchange {
                 'fetchTransfers': true,
                 'fetchWithdrawal': undefined,
                 'fetchWithdrawals': true,
-                'privateAPI': true,
-                'publicAPI': true,
                 'reduceMargin': true,
                 'setLeverage': true,
                 'setMarginMode': undefined,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1259,6 +1259,7 @@ class Exchange {
 
         // API methods metainfo
         $this->has = array(
+            // stubs
             'publicAPI' => true,
             'privateAPI' => true,
             'CORS' => null,
@@ -1267,6 +1268,7 @@ class Exchange {
             'swap' => null,
             'future' => null,
             'option' => null,
+            // methods
             'addMargin' => null,
             'cancelAllOrders' => null,
             'cancelOrder' => true,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -242,7 +242,8 @@ class Exchange(object):
 
     # API method metainfo
     has = {
-        'publxicAPI': True,
+        # stubs
+        'publicAPI': True,
         'privateAPI': True,
         'CORS': None,
         'spot': None,
@@ -250,6 +251,7 @@ class Exchange(object):
         'swap': None,
         'future': None,
         'option': None,
+        # methods
         'addMargin': None,
         'cancelAllOrders': None,
         'cancelOrder': True,

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -367,8 +367,6 @@ Here's an overview of generic exchange properties with values added for example:
     'api':             { ... },          // dictionary of api endpoints
     'has': {                             // exchange capabilities
         'CORS': false,
-        'publicAPI': true,
-        'privateAPI': true,
         'cancelOrder': true,
         'createDepositAddress': false,
         'createOrder': true,
@@ -492,9 +490,6 @@ See this section on [Overriding exchange properties](#overriding-exchange-proper
     'has': {
 
         'CORS': false,  // has Cross-Origin Resource Sharing enabled (works from browser) or not
-
-        'publicAPI': true,  // has public API available and implemented, true/false
-        'privateAPI': true, // has private API available and implemented, true/false
 
         // unified methods availability flags (can be true, false, or 'emulated'):
 


### PR DESCRIPTION
public/private api removals from implementations, and marking them under stab, to avoid accidentally copy/paste during into new-exchange implementations