### PR TITLE
Bybit : filtering fetchMyTrades for keeping Trades only

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3881,12 +3881,11 @@ module.exports = class bybit extends Exchange {
         //
         let result = this.safeValue (response, 'result', {});
         const tradesData = [];
-
         if (!Array.isArray (result)) {
             result = this.safeValue2 (result, 'trade_list', 'data', []);
             for (let i = 0; i < result.length; i++) {
                 if (result[i]['exec_type'] === 'Trade') {
-                    tradesData.push(result[i]);
+                    tradesData.push (result[i]);
                 }
             }
         }


### PR DESCRIPTION
Hi,

I updated Bybit.js fetchMyTrades so that it behaves like other exchanges

Bybit API returns all kind of trades https://bybit-exchange.github.io/docs/linear/#exec-type-exec_type and fetchMyTrades in other exchanges only returns trades.

For this to happen we need to filter the result with :

`exec_type === 'Trade' AND closed_size === '0'.`

Without this last condition (closed_size === '0') Bybit returns when a Trade has been partially closed with an order, which in other exchanges languages is not a real trade.

With this update fetchMyTrades I think behaves exactly like fetchMyTrades of Binance or FTX.

I also read the commit manual and it seems .filter is not allowed for the transpiler to generate correclty. If so then I will update without .filter method.

