### PR TITLE
Okx: setLeverage unify marginMode

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4684,7 +4684,7 @@ module.exports = class okx extends Exchange {
         const market = this.market (symbol);
         const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
         const marginMode = this.safeString2 (params, 'mgnMode', 'marginMode', defaultMarginMode);
-        params = this.omit (params, [ 'mgnMode' ]);
+        params = this.omit (params, [ 'mgnMode', 'marginMode' ]);
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' setLeverage() params["mgnMode"] must be either cross or isolated');
         }

--- a/js/okx.js
+++ b/js/okx.js
@@ -4684,7 +4684,7 @@ module.exports = class okx extends Exchange {
         const market = this.market (symbol);
         const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
         const marginMode = this.safeString2 (params, 'mgnMode', 'marginMode', defaultMarginMode);
-        params = this.omit (params, [ 'mgnMode', 'marginMode' ]);
+        params = this.omit (params, 'marginMode');
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' setLeverage() params["mgnMode"] must be either cross or isolated');
         }


### PR DESCRIPTION
Added unified marginMode to setLeverage:

### Isolated:
```
node examples/js/cli okx setLeverage 10 BTC/USDT:USDT '{"marginMode":"isolated","posSide":"long"}'

okx.setLeverage (10, BTC/USDT:USDT, [object Object])
2022-07-07T06:32:36.943Z iteration 0 passed in 368 ms

{
  code: '0',
  data: [
    {
      instId: 'BTC-USDT-SWAP',
      lever: '10',
      mgnMode: 'isolated',
      posSide: 'long'
    }
  ],
  msg: ''
}
2022-07-07T06:32:36.943Z iteration 1 passed in 368 ms
```

### Cross:
```
node examples/js/cli okx setLeverage 11 BTC/USDT:USDT '{"marginMode":"cross"}'

okx.setLeverage (11, BTC/USDT:USDT, [object Object])
2022-07-07T06:35:08.626Z iteration 0 passed in 350 ms

{
  code: '0',
  data: [
    {
      instId: 'BTC-USDT-SWAP',
      lever: '11',
      mgnMode: 'cross',
      posSide: ''
    }
  ],
  msg: ''
}
2022-07-07T06:35:08.626Z iteration 1 passed in 350 ms
```