### PR TITLE
Okx: fetchLeverage unify marginMode

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -3936,7 +3936,7 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
         const marginMode = this.safeString2 (params, 'mgnMode', 'marginMode', defaultMarginMode);
-        params = this.omit (params, [ 'mgnMode', 'marginMode' ]);
+        params = this.omit (params, 'marginMode');
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a mgnMode parameter that must be either cross or isolated');
         }

--- a/js/okx.js
+++ b/js/okx.js
@@ -3928,13 +3928,15 @@ module.exports = class okx extends Exchange {
          * @method
          * @name okx#fetchLeverage
          * @description fetch the set leverage for a market
+         * @see https://www.okx.com/docs-v5/en/#rest-api-account-get-leverage
          * @param {str} symbol unified market symbol
          * @param {dict} params extra parameters specific to the okx api endpoint
          * @returns {dict} a [leverage structure]{@link https://docs.ccxt.com/en/latest/manual.html#leverage-structure}
          */
         await this.loadMarkets ();
-        const marginMode = this.safeStringLower (params, 'mgnMode');
-        params = this.omit (params, [ 'mgnMode' ]);
+        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
+        const marginMode = this.safeString2 (params, 'mgnMode', 'marginMode', defaultMarginMode);
+        params = this.omit (params, [ 'mgnMode', 'marginMode' ]);
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a mgnMode parameter that must be either cross or isolated');
         }


### PR DESCRIPTION
Added unified marginMode to fetchLeverage:

### Cross:
```
node examples/js/cli okx fetchLeverage BTC/USDT:USDT '{"marginMode":"cross"}'

okx.fetchLeverage (BTC/USDT:USDT, [object Object])
2022-07-07T06:42:40.482Z iteration 0 passed in 346 ms

{
  code: '0',
  data: [
    {
      instId: 'BTC-USDT-SWAP',
      lever: '11',
      mgnMode: 'cross',
      posSide: 'long'
    },
    {
      instId: 'BTC-USDT-SWAP',
      lever: '11',
      mgnMode: 'cross',
      posSide: 'short'
    }
  ],
  msg: ''
}
2022-07-07T06:42:40.482Z iteration 1 passed in 346 ms
```

### Isolated:
```
node examples/js/cli okx fetchLeverage BTC/USDT:USDT '{"marginMode":"isolated"}'

okx.fetchLeverage (BTC/USDT:USDT, [object Object])
2022-07-07T06:44:06.804Z iteration 0 passed in 359 ms

{
  code: '0',
  data: [
    {
      instId: 'BTC-USDT-SWAP',
      lever: '10',
      mgnMode: 'isolated',
      posSide: 'long'
    },
    {
      instId: 'BTC-USDT-SWAP',
      lever: '3',
      mgnMode: 'isolated',
      posSide: 'short'
    }
  ],
  msg: ''
}
2022-07-07T06:44:06.804Z iteration 1 passed in 359 ms
```