### PR TITLE
test.Orderbook :: fix assertion

### DIFF
--- a/js/test/Exchange/test.orderbook.js
+++ b/js/test/Exchange/test.orderbook.js
@@ -55,7 +55,8 @@ module.exports = (exchange, orderbook, method, symbol) => {
     ].includes (exchange.id)) {
 
         if (bids.length && asks.length) {
-            assert (bids[0][0] <= asks[0][0], 'bids[0][0]:', bids[0][0], 'of', bids.length, 'asks[0][0]:', asks[0][0], 'of', asks.length)
+            const errorMessage = 'bids[0][0]:' +  bids[0][0] + 'of' + bids.length +  'asks[0][0]:' +  asks[0][0] + 'of' + asks.length
+            assert (bids[0][0] <= asks[0][0], errorMessage)
         }
     }
 


### PR DESCRIPTION
- **assert** expects two arguments, `value` and `message` and we were passing 9 😅  probably by mistake it was thought that the multiple strings would get concatenated as in `console.log`