### PR TITLE
Okx: fetchMarketLeverageTiers unify marginMode

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -5098,6 +5098,7 @@ module.exports = class okx extends Exchange {
          * @method
          * @name okx#fetchMarketLeverageTiers
          * @description retrieve information on the maximum leverage, and maintenance margin for trades of varying trade sizes for a single market
+         * @see https://www.okx.com/docs-v5/en/#rest-api-public-data-get-position-tiers
          * @param {str} symbol unified market symbol
          * @param {dict} params extra parameters specific to the okx api endpoint
          * @returns {dict} a [leverage tiers structure]{@link https://docs.ccxt.com/en/latest/manual.html#leverage-tiers-structure}
@@ -5107,11 +5108,16 @@ module.exports = class okx extends Exchange {
         const type = market['spot'] ? 'MARGIN' : this.convertToInstrumentType (market['type']);
         const uly = this.safeString (market['info'], 'uly');
         if (!uly) {
-            throw new BadRequest (this.id + ' fetchMarketLeverageTiers() cannot fetch leverage tiers for ' + symbol);
+            if (type !== 'MARGIN') {
+                throw new BadRequest (this.id + ' fetchMarketLeverageTiers() cannot fetch leverage tiers for ' + symbol);
+            }
         }
+        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
+        const marginMode = this.safeString2 (params, 'marginMode', 'tdMode', defaultMarginMode);
+        params = this.omit (params, 'marginMode');
         const request = {
             'instType': type,
-            'tdMode': this.safeString (params, 'tdMode', 'isolated'),
+            'tdMode': marginMode,
             'uly': uly,
         };
         if (type === 'MARGIN') {


### PR DESCRIPTION
Added marginMode to fetchMarketLeverageTiers:

### Cross:
```
node examples/js/cli okx fetchMarketLeverageTiers BTC/USDT '{"marginMode":"cross"}' --verbose

okx.fetchMarketLeverageTiers (BTC/USDT, [object Object])
fetch Request:
 okx GET https://www.okx.com/api/v5/public/position-tiers?instType=MARGIN&tdMode=cross&instId=BTC-USDT

2022-07-08T17:45:44.180Z iteration 0 passed in 375 ms

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |     USDT |           0 |          25 |                  0.03 |          10
   2 |     USDT |          25 |          50 |                  0.04 |        9.09
   3 |     USDT |          50 |          75 |                  0.05 |        8.33
...
91 objects
2022-07-08T17:45:44.180Z iteration 1 passed in 375 ms
```

### Isolated:
```
node examples/js/cli okx fetchMarketLeverageTiers BTC/USDT '{"marginMode":"isolated"}' --verbose

okx.fetchMarketLeverageTiers (BTC/USDT, [object Object])
fetch Request:
 okx GET https://www.okx.com/api/v5/public/position-tiers?instType=MARGIN&tdMode=isolated&instId=BTC-USDT

2022-07-08T17:46:53.513Z iteration 0 passed in 419 ms

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |     USDT |           0 |          25 |                  0.03 |          10
   2 |     USDT |          25 |          50 |                  0.04 |        9.09
   3 |     USDT |          50 |          75 |                  0.05 |        8.33
...
91 objects
2022-07-08T17:46:53.513Z iteration 1 passed in 419 ms
```