### PR TITLE
Bitmart: borrowMargin, repayMargin

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -26,6 +26,7 @@ module.exports = class bitmart extends Exchange {
                 'swap': undefined, // has but unimplemented
                 'future': undefined, // has but unimplemented
                 'option': undefined,
+                'borrowMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': false,
@@ -2542,6 +2543,80 @@ module.exports = class bitmart extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'fee': fee,
+        };
+    }
+
+    async borrowMargin (code, amount, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitmart#borrowMargin
+         * @description create a loan to borrow margin
+         * @see https://developer-pro.bitmart.com/en/spot/#margin-borrow-isolated
+         * @param {str} code unified currency code of the currency to borrow
+         * @param {str} amount the amount to borrow
+         * @param {str} symbol unified market symbol
+         * @param {dict} params extra parameters specific to the bitmart api endpoint
+         * @returns {dict} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
+         */
+        await this.loadMarkets ();
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' borrowMargin() requires a symbol argument');
+        }
+        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'isolated');
+        const marginMode = this.safeString (params, 'marginMode', defaultMarginMode);
+        if (marginMode !== 'isolated') {
+            throw new BadRequest (this.id + ' borrowMargin() is only available for isolated margin');
+        }
+        const market = this.market (symbol);
+        const currency = this.currency (code);
+        const request = {
+            'symbol': market['id'],
+            'currency': currency['id'],
+            'amount': this.currencyToPrecision (code, amount),
+        };
+        params = this.omit (params, 'marginMode');
+        const response = await this.privateSpotPostMarginIsolatedBorrow (this.extend (request, params));
+        //
+        //     {
+        //         "message": "OK",
+        //         "code": 1000,
+        //         "trace": "e6fda683-181e-4e78-ac9c-b27c4c8ba035",
+        //         "data": {
+        //             "borrow_id": "629a7177a4ed4cf09869c6a4343b788c"
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const transaction = this.parseMarginLoan (data, currency);
+        return this.extend (transaction, {
+            'amount': amount,
+            'symbol': symbol,
+        });
+    }
+
+    parseMarginLoan (info, currency = undefined) {
+        //
+        // borrowMargin
+        //
+        //     {
+        //         "borrow_id": "629a7177a4ed4cf09869c6a4343b788c",
+        //     }
+        //
+        // repayMargin
+        //
+        //     {
+        //         "repay_id": "2afcc16d99bd4707818c5a355dc89bed",
+        //     }
+        //
+        const timestamp = this.milliseconds ();
+        return {
+            'id': this.safeString2 (info, 'borrow_id', 'repay_id'),
+            'currency': this.safeCurrencyCode (undefined, currency),
+            'amount': undefined,
+            'symbol': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': info,
         };
     }
 

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -139,15 +139,23 @@ module.exports = class bitmart extends Exchange {
                     },
                     'spot': {
                         'get': {
-                            'wallet': 0.5,
-                            'order_detail': 0.1,
+                            'margin/isolated/account': 0.5,
+                            'margin/isolated/borrow_record': 0.1,
+                            'margin/isolated/pairs': 1,
+                            'margin/isolated/repay_record': 0.1,
                             'orders': 0.5,
+                            'order_detail': 0.1,
                             'trades': 0.5,
+                            'wallet': 0.5,
                         },
                         'post': {
                             'submit_order': 0.1, // https://api-cloud.bitmart.com/spot/v1/submit_order
                             'cancel_order': 0.1, // https://api-cloud.bitmart.com/spot/v2/cancel_order
                             'cancel_orders': 0.1,
+                            'margin/isolated/borrow': 1,
+                            'margin/isolated/repay': 1,
+                            'margin/isolated/transfer': 1,
+                            'margin/submit_order': 0.1,
                         },
                     },
                 },


### PR DESCRIPTION
Added borrowMargin and repayMargin to Bitmart:

### borrowMargin:
```
node examples/js/cli bitmart borrowMargin USDT 15 BTC/USDT

bitmart.borrowMargin (USDT, 15, BTC/USDT)
2022-07-08T19:12:48.670Z iteration 0 passed in 812 ms

{
  id: '0cea00c3b27447809b170dc109f203f2',
  currency: 'USDT',
  amount: 15,
  symbol: 'BTC/USDT',
  timestamp: 1657307568670,
  datetime: '2022-07-08T19:12:48.670Z',
  info: { borrow_id: '0cea00c3b27447809b170dc109f203f2' }
}
2022-07-08T19:12:48.670Z iteration 1 passed in 812 ms
```

### repayMargin:
```
node examples/js/cli bitmart repayMargin USDT 15.00034374 BTC/USDT

bitmart.repayMargin (USDT, 15.00034374, BTC/USDT)
2022-07-08T19:15:27.167Z iteration 0 passed in 687 ms

{
  id: '0a2e86de0a3e4d3baa5ae5ef72e7cfe7',
  currency: 'USDT',
  amount: 15.00034374,
  symbol: 'BTC/USDT',
  timestamp: 1657307727167,
  datetime: '2022-07-08T19:15:27.167Z',
  info: { repay_id: '0a2e86de0a3e4d3baa5ae5ef72e7cfe7' }
}
2022-07-08T19:15:27.167Z iteration 1 passed in 687 ms
```