### PR TITLE
Okx :: fix margin check

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -2024,7 +2024,7 @@ module.exports = class okx extends Exchange {
             margin = this.safeValue (params, 'margin', false);
         }
         if (margin === true && market['spot'] && !market['margin']) {
-            throw new NotSupported (this.id + ' does not support margin trading for ' + symbol + 'market');
+            throw new NotSupported (this.id + ' does not support margin trading for ' + symbol + ' market');
         }
         if (spot) {
             if (margin) {

--- a/js/okx.js
+++ b/js/okx.js
@@ -2023,7 +2023,7 @@ module.exports = class okx extends Exchange {
             marginMode = defaultMarginMode;
             margin = this.safeValue (params, 'margin', false);
         }
-        if (margin === true && !market['margin']) {
+        if (margin === true && margin['spot'] && !market['margin']) {
             throw new NotSupported (this.id + ' does not support margin trading for ' + symbol + 'market');
         }
         if (spot) {

--- a/js/okx.js
+++ b/js/okx.js
@@ -2023,7 +2023,7 @@ module.exports = class okx extends Exchange {
             marginMode = defaultMarginMode;
             margin = this.safeValue (params, 'margin', false);
         }
-        if (margin === true && margin['spot'] && !market['margin']) {
+        if (margin === true && market['spot'] && !market['margin']) {
             throw new NotSupported (this.id + ' does not support margin trading for ' + symbol + 'market');
         }
         if (spot) {


### PR DESCRIPTION
- We cannot mix the "margin" check of spot margined markets and the margin of derivatives. Added the check to prevent it
- fixes https://github.com/ccxt/ccxt/issues/14284

Demo Swap order:
```
node cli.js okx createOrder "BTC/USDT:USDT" "market" "buy" 1 undefined '{"posSide":"long"}' --sandbox  
2022-07-09T14:33:01.826Z
okx.createOrder (BTC/USDT:USDT, market, buy, 1, , [object Object])
2022-07-09T14:33:09.379Z iteration 0 passed in 414 ms
{
  info: {
    clOrdId: 'e847386590ce4dBC8049d85444498e7e',
    ordId: '466008939975553039',
    sCode: '0',
    sMsg: '',
    tag: ''
  },
  id: '466008939975553039',
  clientOrderId: 'e847386590ce4dBC8049d85444498e7e',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
``` 

Demo margined spot market:
```
 node cli.js okx createOrder "BTC/USDT" "market" "buy" 20 undefined '{"margin":true}' --sandbox          
2022-07-09T14:34:18.171Z
Node.js: v18.4.0
CCXT v1.90.39
okx.createOrder (BTC/USDT, market, buy, 20, , [object Object])
2022-07-09T14:34:36.776Z iteration 0 passed in 9340 ms

{
  info: {
    clOrdId: 'e847386590ce4dBC8ad62a53447f97da',
    ordId: '466009306528362496',
    sCode: '0',
    sMsg: '',
    tag: ''
  },
  id: '466009306528362496',
  clientOrderId: 'e847386590ce4dBC8ad62a53447f97da',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2022-07-09T14:34:36.776Z iteration 1 passed in 9340 ms
```