### PR TITLE
add ltc for kucoin

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -442,6 +442,7 @@ module.exports = class kucoin extends Exchange {
                     'TRC20': 'trx',
                     'KCC': 'kcc',
                     'TERRA': 'luna',
+                    'LTC': 'ltc',
                 },
             },
         });


### PR DESCRIPTION
adds ltc for kucoin. for kucoin, 

i think networks are in lower case in order for it to work.
`network = this.safeStringLower (networks, network, network); // handle ERC20>ETH alias`
so can we change line 1102 to make it lowercase the network value even if its not inside the networks dictionary to avoid adding all lower case version of all the different networks?