### PR TITLE
Bybit :: fee fix

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -484,14 +484,12 @@ module.exports = class bybit extends Exchange {
                 'brokerId': 'CCXT',
             },
             'fees': {
-                // spot only because the other markets
-                // have this info returned by the api
                 'trading': {
                     'feeSide': 'get',
                     'tierBased': true,
                     'percentage': true,
-                    'taker': this.parseNumber ('0.001'),
-                    'maker': this.parseNumber ('0.001'),
+                    'taker': 0.00075,
+                    'maker': 0.0001,
                 },
                 'funding': {
                     'tierBased': false,
@@ -712,7 +710,6 @@ module.exports = class bybit extends Exchange {
             const symbol = base + '/' + quote;
             const active = this.safeValue (market, 'showStatus');
             const quotePrecision = this.safeNumber (market, 'quotePrecision');
-            const fees = this.safeValue (this.fees, 'trading', {});
             result.push ({
                 'id': id,
                 'symbol': symbol,
@@ -732,8 +729,8 @@ module.exports = class bybit extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': this.safeNumber (fees, 'taker'),
-                'maker': this.safeNumber (fees, 'maker'),
+                'taker': this.parseNumber ('0.001'),
+                'maker': this.parseNumber ('0.001'),
                 'contractSize': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -484,11 +484,14 @@ module.exports = class bybit extends Exchange {
                 'brokerId': 'CCXT',
             },
             'fees': {
+                // spot only because the other markets
+                // have this info returned by the api
                 'trading': {
-                    'tierBased': false,
+                    'feeSide': 'get',
+                    'tierBased': true,
                     'percentage': true,
-                    'taker': 0.00075,
-                    'maker': -0.00025,
+                    'taker': this.parseNumber ('0.001'),
+                    'maker': this.parseNumber ('0.001'),
                 },
                 'funding': {
                     'tierBased': false,
@@ -728,8 +731,8 @@ module.exports = class bybit extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': undefined,
-                'maker': undefined,
+                'taker': this.safeNumber (this.fees, 'taker'),
+                'maker': this.safeNumber (this.fees, 'maker'),
                 'contractSize': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -712,6 +712,7 @@ module.exports = class bybit extends Exchange {
             const symbol = base + '/' + quote;
             const active = this.safeValue (market, 'showStatus');
             const quotePrecision = this.safeNumber (market, 'quotePrecision');
+            const fees = this.safeValue (this.fees, 'trading', {});
             result.push ({
                 'id': id,
                 'symbol': symbol,
@@ -731,8 +732,8 @@ module.exports = class bybit extends Exchange {
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,
-                'taker': this.safeNumber (this.fees, 'taker'),
-                'maker': this.safeNumber (this.fees, 'maker'),
+                'taker': this.safeNumber (fees, 'taker'),
+                'maker': this.safeNumber (fees, 'maker'),
                 'contractSize': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,


### PR DESCRIPTION
- Add missing spot fees needed in `calculate_fee`
- fixes https://github.com/ccxt/ccxt/issues/14292

Demo 

```
 python cli.py bybit calculate_fee "SOL/USDT" "limit" "buy" 1 1 "maker" --sandbox --spot
Python v3.9.13
CCXT v1.90.39
bybit.calculate_fee(SOL/USDT,limit,buy,1,1,maker)
{'cost': 0.001, 'currency': 'SOL', 'rate': 0.001, 'type': 'maker'}

```
