### PR TITLE
Btcalpha :: fix timestamp

### DIFF
--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -412,8 +412,7 @@ module.exports = class btcalpha extends Exchange {
         //          "status": 20
         //      }
         //
-        let timestamp = this.safeTimestamp (transaction, 'timestamp');
-        timestamp = Precise.stringMul (timestamp, '1000');
+        const timestamp = this.safeIntegerProduct (transaction, 'timestamp', 1000);
         const currencyId = this.safeString (transaction, 'currency');
         const statusId = this.safeString (transaction, 'status');
         return {

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -412,7 +412,7 @@ module.exports = class btcalpha extends Exchange {
         //          "status": 20
         //      }
         //
-        const timestamp = this.safeIntegerProduct (transaction, 'timestamp', 1000);
+        const timestamp = this.safeTimestamp (transaction, 'timestamp');
         const currencyId = this.safeString (transaction, 'currency');
         const statusId = this.safeString (transaction, 'status');
         return {


### PR DESCRIPTION
- safeTimestamp already multiplies by 1000 and returns an int, we don't need to use Precise that was actually ruining the timestamp