### PR TITLE
Bitmart: transfer

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2698,6 +2698,7 @@ module.exports = class bitmart extends Exchange {
         } else if ((fromAccount === 'margin') && (toAccount === 'spot')) {
             request['side'] = 'out';
         }
+        params = this.omit (params, 'symbol');
         const response = await this.privateSpotPostMarginIsolatedTransfer (this.extend (request, params));
         //
         //     {

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2699,7 +2699,7 @@ module.exports = class bitmart extends Exchange {
             request['side'] = 'out';
         }
         params = this.omit (params, 'symbol');
-        const response = await this.privateSpotPostMarginIsolatedTransfer (this.extend (request, params));
+        const response = await this.privatePostSpotV1MarginIsolatedTransfer (this.extend (request, params));
         //
         //     {
         //         "message": "OK",


### PR DESCRIPTION
Added the transfer method with margin account functionality:

### Transfer Out:
```
node examples/js/cli bitmart transfer USDT 10 margin spot '{"symbol":"BTC_USDT"}'

bitmart.transfer (USDT, 10, margin, spot, [object Object])
2022-07-12T20:32:18.805Z iteration 0 passed in 1005 ms

{
  id: '9d7d222b5df144da88366658dc8c3d79',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 10,
  fromAccount: 'margin',
  toAccount: 'spot',
  status: 'ok'
}
2022-07-12T20:32:18.805Z iteration 1 passed in 1005 ms
```

### Transfer In:
```
node examples/js/cli bitmart transfer USDT 20 spot margin '{"symbol":"BTC_USDT"}'

bitmart.transfer (USDT, 20, spot, margin, [object Object])
2022-07-12T20:33:53.082Z iteration 0 passed in 885 ms

{
  id: 'edac4a2adcce4079a7b78fc7d3e5176a',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 20,
  fromAccount: 'spot',
  toAccount: 'margin',
  status: 'ok'
}
2022-07-12T20:33:53.082Z iteration 1 passed in 885 ms
```