### PR TITLE
Bitmart: fetchBorrowInterest

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2684,7 +2684,7 @@ module.exports = class bitmart extends Exchange {
         if (since !== undefined) {
             request['start_time'] = since;
         }
-        const response = await this.privateSpotGetMarginIsolatedBorrowRecord (this.extend (request, params));
+        const response = await this.privateGetSpotV1MarginIsolatedBorrowRecord (this.extend (request, params));
         //
         //     {
         //         "message": "OK",


### PR DESCRIPTION
Added fetchBorrowInterest to Bitmart:
```
node examples/js/cli bitmart fetchBorrowInterest undefined BTC/USDT

bitmart.fetchBorrowInterest (, BTC/USDT)
2022-07-13T03:41:23.687Z iteration 0 passed in 392 ms

  symbol | marginMode | currency |   interest | interestRate | amountBorrowed |     timestamp |                 datetime
------------------------------------------------------------------------------------------------------------------------
BTC/USDT |   isolated |     USDT | 0.00045833 |   0.00002291 |             20 | 1657664329000 | 2022-07-12T22:18:49.000Z
BTC/USDT |   isolated |     USDT | 0.00034374 |   0.00002291 |             15 | 1657307569000 | 2022-07-08T19:12:49.000Z
BTC/USDT |   isolated |     USDT | 0.00034374 |   0.00002291 |             15 | 1657303896000 | 2022-07-08T18:11:36.000Z
3 objects
2022-07-13T03:41:23.687Z iteration 1 passed in 392 ms
```