### PR TITLE
sort-swap-markets-by-hourly-price-change uses latest unfinished candle instead of penultimate candle

### DIFF
--- a/examples/js/sort-swap-markets-by-hourly-price-change.js
+++ b/examples/js/sort-swap-markets-by-hourly-price-change.js
@@ -13,7 +13,7 @@ async function fetchOHLCV (symbol) {
      * @returns {[float|str]} 1d array with a single ohlcv record with the market symbol appended
      */
     try {
-        const ohlcv = await exchange.fetchOHLCV (symbol, timeframe, undefined, 2);
+        const ohlcv = await exchange.fetchOHLCV (symbol, timeframe, undefined, 1);
         ohlcv[0].push (symbol);
         return ohlcv[0];
     } catch (err) {


### PR DESCRIPTION
I use this script all the time and have found it to be much more useful when using the latest candle