### PR TITLE
Zb :: fix fetchCanceledOrders

### DIFF
--- a/js/zb.js
+++ b/js/zb.js
@@ -2373,7 +2373,7 @@ module.exports = class zb extends Exchange {
             if (orderType === undefined) {
                 throw new ArgumentsRequired (this.id + ' fetchCanceledOrders() requires an orderType parameter for stop orders');
             }
-            const side = this.safeInteger (params, 'side');
+            const side = this.safeValue (params, 'side');
             const bizType = this.safeInteger (params, 'bizType');
             if (side === 'sell' && reduceOnly) {
                 request['side'] = 3; // close long


### PR DESCRIPTION
- using `safeValue` instead because `side` can be either a number or a string
![image](https://user-images.githubusercontent.com/43336371/178705650-8b6d9f78-d6fe-40f0-9381-a80a65aebfa4.png)