### PR TITLE
Binance :: fix timestamp

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4633,7 +4633,7 @@ module.exports = class binance extends Exchange {
             request['startTime'] = since;
         }
         const until = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
-        const endTime = this.safeString (params, 'endTime', until); // exchange-specific in milliseconds
+        const endTime = this.safeInteger (params, 'endTime', until); // exchange-specific in milliseconds
         params = this.omit (params, [ 'endTime', 'till', 'until' ]);
         if (endTime !== undefined) {
             request['endTime'] = endTime;
@@ -6271,7 +6271,7 @@ module.exports = class binance extends Exchange {
             request['startTime'] = since;
         }
         const until = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
-        const endTime = this.safeString (params, 'endTime', until); // exchange-specific in milliseconds
+        const endTime = this.safeInteger (params, 'endTime', until); // exchange-specific in milliseconds
         params = this.omit (params, [ 'endTime', 'until', 'till' ]);
         if (endTime) {
             request['endTime'] = endTime;


### PR DESCRIPTION
- We're mixing strings and numbers to get the timestamp but according to the docs we should be using the number

![image](https://user-images.githubusercontent.com/43336371/178796603-ab90a3d1-76a2-44a6-9352-c817ea595b8b.png)

![image](https://user-images.githubusercontent.com/43336371/178796693-d8e006ca-1100-469b-8bab-d11799a3ca69.png)
