### PR TITLE
Update gate orderStatus for for futures trigger orders

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -3200,6 +3200,10 @@ module.exports = class gate extends Exchange {
             'cancelled': 'canceled',
             'liquidated': 'closed',
             'ioc': 'canceled',
+            'failed': 'canceled',
+            'expired': 'canceled',
+            'finished': 'closed',
+            'succeeded': 'closed',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
Gate.io futures stoploss orders are missing their status mapping.

Based on the [futures schema](https://www.gate.io/docs/apiv4/en/#futuresorder) - status can be either `open` or `finished`.

now for gate - it seems ccxt is using `finish_as` - which is (based on the [futurestriggerorder docs](https://www.gate.io/docs/apiv4/en/#futurespricetriggeredorder) `cancelled`, `succeeded`, `failed`, and `expired`.

``` python
import ccxt
exchange = ccxt.gateio({'options': {'defaultType': 'swap'}})
o = exchange.parse_order({
    "user": "<snip>",
    "trigger": {
        "strategy_type": "0",
        "price_type": "0",
        "price": "0.53955",
        "rule": "2",
        "expiration": "0"
    },
    "initial": {
        "contract": "MATIC_USDT",
        "size": "-3",
        "price": "0.53415",
        "tif": "gtc",
        "text": "",
        "iceberg": "0",
        "is_close": False,
        "is_reduce_only": True,
        "auto_size": ""
    },
    "id": "23816262",
    "trade_id": "180587075137",
    "status": "finished",
    "finish_as": "succeeded",
    "reason": "",
    "create_time": "1657497917",
    "finish_time": "1657522327",
    "is_stop_order": False,
    "stop_trigger": {
        "rule": "0",
        "trigger_price": "",
        "order_price": ""
    },
    "me_order_id": "0",
    "order_type": ""
})
print(o)

```

Prior output (notice `"status": "succeeded"`):

```
{'id': '23816262',
 'clientOrderId': None,
 'timestamp': 1657497917000,
 'datetime': '2022-07-11T00:05:17.000Z',
 'lastTradeTimestamp': 1657522327000,
 'status': 'succeeded',
 'symbol': 'MATIC/USDT:USDT',
 'type': 'limit',
 'timeInForce': 'GTC',
 'postOnly': False,
 'reduceOnly': None,
 'side': 'sell',
 'price': 0.53415,
 'stopPrice': 0.53955,
 'average': None,
 'amount': 3.0,
 'cost': 0.0,
 'filled': 0.0,
 'remaining': 3.0,
 'fee': None,
 'fees': [],
 'trades': [],
 'info': {'user': '<snip>',
  'trigger': {'strategy_type': '0',
   'price_type': '0',
   'price': '0.53955',
   'rule': '2',
   'expiration': '0'},
  'initial': {'contract': 'MATIC_USDT',
   'size': '-3',
   'price': '0.53415',
   'tif': 'gtc',
   'text': '',
   'iceberg': '0',
   'is_close': False,
   'is_reduce_only': True,
   'auto_size': ''},
  'id': '23816262',
  'trade_id': '180587075137',
  'status': 'finished',
  'finish_as': 'succeeded',
  'reason': '',
  'create_time': '1657497917',
  'finish_time': '1657522327',
  'is_stop_order': False,
  'stop_trigger': {'rule': '0', 'trigger_price': '', 'order_price': ''},
  'me_order_id': '0',
  'order_type': ''}}
```

New output:
``` 
[{'amount': 13.0,
  'cost': 47.7087,
  'datetime': '2022-06-17T20:54:37.108Z',
  'fee': {'cost': 0.019560567, 'currency': 'USDT'},
  'fees': [{'cost': '0.019560567', 'currency': 'USDT'}],
  'id': '8799416',
  'info': {'contract': 'APE_USDT',
           'create_time': '1655499277.1085',
           'fee': '0.019560567',
           'id': '8799416',
           'order_id': '173423995062',
           'point_fee': '0',
           'price': '3.6699',
           'role': 'taker',
           'size': '13',
           'text': 'api'},
  'order': '173423995062',
  'price': 3.6699,
  'side': 'buy',
  'symbol': 'APE/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1655499277108,
  'type': None},
 {'amount': 13.0,
  'cost': 47.801,
  'datetime': '2022-06-17T20:57:35.618Z',
  'fee': {'cost': 0.01959841, 'currency': 'USDT'},
  'fees': [{'cost': '0.01959841', 'currency': 'USDT'}],
  'id': '8799420',
  'info': {'contract': 'APE_USDT',
           'create_time': '1655499455.6183',
           'fee': '0.01959841',
           'id': '8799420',
           'order_id': '173424385730',
           'point_fee': '0',
           'price': '3.677',
           'role': 'taker',
           'size': '-13',
           'text': 'api'},
  'order': '173424385730',
  'price': 3.677,
  'side': 'sell',
  'symbol': 'APE/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1655499455618,
  'type': None}]

```