### PR TITLE
Bitmart: createOrder margin support

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -350,7 +350,7 @@ module.exports = class bitmart extends Exchange {
                 'defaultNetworks': {
                     'USDT': 'ERC20',
                 },
-                'defaultType': 'spot', // 'spot', 'swap', 'margin'
+                'defaultType': 'spot', // 'spot', 'swap'
                 'fetchBalance': {
                     'type': 'spot', // 'spot', 'swap', 'contract', 'account'
                 },
@@ -1815,16 +1815,14 @@ module.exports = class bitmart extends Exchange {
         if (ioc) {
             request['type'] = 'ioc';
         }
-        const defaultType = this.safeString (this.options, 'defaultType');
-        if ((defaultType === 'margin') || (market['type'] === 'margin')) {
-            method = 'privateSpotPostMarginSubmitOrder';
-            const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'isolated');
-            const marginMode = this.safeString (params, 'marginMode', defaultMarginMode);
+        const marginMode = this.safeString (params, 'marginMode');
+        if ((marginMode === 'cross') || (marginMode === 'isolated')) {
             if (marginMode !== 'isolated') {
                 throw new BadRequest (this.id + ' createOrder() is only available for isolated margin');
             }
-            params = this.omit (params, 'marginMode');
+            method = 'privateSpotPostMarginSubmitOrder';
         }
+        params = this.omit (params, 'marginMode');
         const response = await this[method] (this.extend (request, params));
         //
         // spot and margin

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1820,7 +1820,7 @@ module.exports = class bitmart extends Exchange {
             if (marginMode !== 'isolated') {
                 throw new BadRequest (this.id + ' createOrder() is only available for isolated margin');
             }
-            method = 'privateSpotPostMarginSubmitOrder';
+            method = 'privatePostSpotV1MarginSubmitOrder';
         }
         params = this.omit (params, 'marginMode');
         const response = await this[method] (this.extend (request, params));

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -97,68 +97,66 @@ module.exports = class bitmart extends Exchange {
             },
             'api': {
                 'public': {
-                    'system': {
-                        'get': {
-                            'time': 5, // https://api-cloud.bitmart.com/system/time
-                            'service': 5, // https://api-cloud.bitmart.com/system/service
-                        },
-                    },
-                    'account': {
-                        'get': {
-                            'currencies': 10, // https://api-cloud.bitmart.com/account/v1/currencies
-                        },
-                    },
-                    'spot': {
-                        'get': {
-                            'currencies': 1,
-                            'symbols': 1,
-                            'symbols/details': 1,
-                            'ticker': 1, // ?symbol=BTC_USDT
-                            'steps': 1, // ?symbol=BMX_ETH
-                            'symbols/kline': 1, // ?symbol=BMX_ETH&step=15&from=1525760116&to=1525769116
-                            'symbols/book': 1, // ?symbol=BMX_ETH&precision=6
-                            'symbols/trades': 1, // ?symbol=BMX_ETH
-                        },
-                    },
-                    'contract': {
-                        'get': {
-                            'tickers': 0.5,
-                        },
+                    'get': {
+                        'system/time': 3,
+                        'system/service': 3,
+                        // spot markets
+                        'spot/v1/currencies': 7.5,
+                        'spot/v1/symbols': 7.5,
+                        'spot/v1/symbols/details': 5,
+                        'spot/v1/ticker': 5,
+                        'spot/v1/steps': 30,
+                        'spot/v1/symbols/kline': 5,
+                        'spot/v1/symbols/book': 5,
+                        'spot/v1/symbols/trades': 5,
+                        // contract markets
+                        'contract/v1/tickers': 15,
                     },
                 },
                 'private': {
-                    'account': {
-                        'get': {
-                            'wallet': 0.5, // ?account_type=1
-                            'deposit/address': 1, // ?currency=USDT-TRC20
-                            'withdraw/charge': 1, // ?currency=BTC
-                            'deposit-withdraw/history': 1, // ?limit=10&offset=1&operationType=withdraw
-                            'deposit-withdraw/detail': 1, // ?id=1679952
-                        },
-                        'post': {
-                            'withdraw/apply': 1,
-                        },
+                    'get': {
+                        // sub-account
+                        'account/sub-account/v1/transfer-list': 7.5,
+                        'account/sub-account/v1/transfer-history': 7.5,
+                        'account/sub-account/main/v1/wallet': 5,
+                        'account/sub-account/main/v1/subaccount-list': 7.5,
+                        // account
+                        'account/v1/wallet': 5,
+                        'account/v1/currencies': 30,
+                        'spot/v1/wallet': 5,
+                        'account/v1/deposit/address': 30,
+                        'account/v1/withdraw/charge': 32, // should be 30 but errors
+                        'account/v2/deposit-withdraw/history': 7.5,
+                        'account/v1/deposit-withdraw/detail': 7.5,
+                        // order
+                        'spot/v1/order_detail': 1,
+                        'spot/v2/orders': 5,
+                        'spot/v1/trades': 5,
+                        // margin
+                        'spot/v1/margin/isolated/borrow_record': 1,
+                        'spot/v1/margin/isolated/repay_record': 1,
+                        'spot/v1/margin/isolated/pairs': 1,
+                        'spot/v1/margin/isolated/account': 6,
                     },
-                    'spot': {
-                        'get': {
-                            'margin/isolated/account': 0.5,
-                            'margin/isolated/borrow_record': 0.1,
-                            'margin/isolated/pairs': 1,
-                            'margin/isolated/repay_record': 0.1,
-                            'orders': 0.5,
-                            'order_detail': 0.1,
-                            'trades': 0.5,
-                            'wallet': 0.5,
-                        },
-                        'post': {
-                            'submit_order': 0.1, // https://api-cloud.bitmart.com/spot/v1/submit_order
-                            'cancel_order': 0.1, // https://api-cloud.bitmart.com/spot/v2/cancel_order
-                            'cancel_orders': 0.1,
-                            'margin/isolated/borrow': 1,
-                            'margin/isolated/repay': 1,
-                            'margin/isolated/transfer': 1,
-                            'margin/submit_order': 0.1,
-                        },
+                    'post': {
+                        // sub-account endpoints
+                        'account/sub-account/main/v1/sub-to-main': 30,
+                        'account/sub-account/sub/v1/sub-to-main': 30,
+                        'account/sub-account/main/v1/main-to-sub': 30,
+                        'account/sub-account/sub/v1/sub-to-sub': 30,
+                        'account/sub-account/main/v1/sub-to-sub': 30,
+                        // account
+                        'account/v1/withdraw/apply': 7.5,
+                        // transaction and trading
+                        'spot/v1/submit_order': 1,
+                        'spot/v1/batch_orders': 1,
+                        'spot/v2/cancel_order': 1,
+                        'spot/v1/cancel_orders': 15,
+                        // margin
+                        'spot/v1/margin/submit_order': 1,
+                        'spot/v1/margin/isolated/borrow': 6,
+                        'spot/v1/margin/isolated/repay': 6,
+                        'spot/v1/margin/isolated/transfer': 6,
                     },
                 },
             },


### PR DESCRIPTION
Added margin orders to createOrder:
```
node examples/js/cli bitmart createOrder BTC/USDT limit buy 0.00095 18000 '{"marginMode":"isolated"}'

bitmart.createOrder (BTC/USDT, limit, buy, 0.00095, 18000)
2022-07-13T23:50:34.958Z iteration 0 passed in 537 ms

{
  id: '45158352744',
  clientOrderId: undefined,
  info: { order_id: '45158352744' },
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 18000,
  stopPrice: undefined,
  amount: 0.00095,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2022-07-13T23:50:34.958Z iteration 1 passed in 537 ms
```