### PR TITLE
Huobi :: fix market order parsing

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3876,12 +3876,17 @@ module.exports = class huobi extends Exchange {
         market = this.safeMarket (marketId, market);
         const timestamp = this.safeIntegerN (order, [ 'created_at', 'created-at', 'create_date' ]);
         const clientOrderId = this.safeString2 (order, 'client_order_id', 'client-order-id');
-        const amount = this.safeString2 (order, 'volume', 'amount');
-        let filled = this.safeString2 (order, 'filled-amount', 'field-amount'); // typo in their API, filled amount
-        filled = this.safeString (order, 'trade_volume', filled);
+        let cost = undefined;
+        let amount = undefined;
+        if (type.indexOf ('market') >= 0) {
+            // for market orders amount is in quote currency, meaning it is the cost
+            cost = this.safeString (order, 'amount');
+        } else {
+            amount = this.safeString2 (order, 'volume', 'amount');
+            cost = this.safeStringN (order, [ 'filled-cash-amount', 'field-cash-amount', 'trade_turnover' ]); // same typo
+        }
+        const filled = this.safeStringN (order, [ 'filled-amount', 'field-amount', 'trade_volume' ]); // typo in their API, filled amount
         const price = this.safeString (order, 'price');
-        let cost = this.safeString2 (order, 'filled-cash-amount', 'field-cash-amount'); // same typo
-        cost = this.safeString (order, 'trade_turnover', cost);
         let feeCost = this.safeString2 (order, 'filled-fees', 'field-fees'); // typo in their API, filled feeSide
         feeCost = this.safeString (order, 'fee', feeCost);
         let fee = undefined;

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -3878,7 +3878,7 @@ module.exports = class huobi extends Exchange {
         const clientOrderId = this.safeString2 (order, 'client_order_id', 'client-order-id');
         let cost = undefined;
         let amount = undefined;
-        if (type.indexOf ('market') >= 0) {
+        if ((type !== undefined) && (type.indexOf ('market') >= 0)) {
             // for market orders amount is in quote currency, meaning it is the cost
             cost = this.safeString (order, 'amount');
         } else {


### PR DESCRIPTION
- For market orders the `amount` returned is actually the cost
- Fixes https://github.com/ccxt/ccxt/issues/14336

Demo
```
node cli.js huobi fetchOrder "'585258014773560'"                                                      
2022-07-14T08:44:38.844Z
Node.js: v18.4.0
CCXT v1.90.68
huobi.fetchOrder (585258014773560)
2022-07-14T08:44:41.378Z iteration 0 passed in 857 ms

{
  info: {
    id: '585258014773560',
    symbol: 'adausdt',
    'account-id': '44234548',
    'client-order-id': 'AA03022abc9ab3355c-7c33-4923-911b-18cdc1cc92e1',
    amount: '1.350000000000000000',
    price: '0.0',
    'created-at': '1657786302054',
    type: 'buy-market',
    'field-amount': '3.159653795563377970',
    'field-cash-amount': '1.349999999999999998',
    'field-fees': '0.006319307591126756',
    'finished-at': '1657786302072',
    source: 'spot-api',
    state: 'filled',
    'canceled-at': '0'
  },
  id: '585258014773560',
  clientOrderId: 'AA03022abc9ab3355c-7c33-4923-911b-18cdc1cc92e1',
  timestamp: 1657786302054,
  datetime: '2022-07-14T08:11:42.054Z',
  lastTradeTimestamp: undefined,
  symbol: 'ADA/USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: undefined,
  side: 'buy',
  price: 0.427262,
  stopPrice: undefined,
  average: 0.427262,
  cost: 1.35,
  amount: 3.159653795563378,
  filled: 3.159653795563378,
  remaining: 0,
  status: 'closed',
  fee: { cost: 0.006319307591126756, currency: 'ADA' },
  trades: [],
  fees: [ { cost: 0.006319307591126756, currency: 'ADA' } ]
}
2022-07-14T08:44:41.378Z iteration 1 passed in 857 ms
```