### PR TITLE
Bybit :: fix positions filtering

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4477,6 +4477,7 @@ module.exports = class bybit extends Exchange {
             }
             results.push (this.parsePosition (rawPosition, market));
         }
+        symbols = this.marketSymbols (symbols);
         return this.filterByArray (results, 'symbol', symbols, false);
     }
 


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/14350

Demo 
```
node cli.js bybit fetchPositions '["ETHUSDT"]' --sandbox
2022-07-14T09:16:51.450Z
Node.js: v18.4.0
CCXT v1.90.68
bybit.fetchPositions (ETHUSDT)
2022-07-14T09:16:54.832Z iteration 0 passed in 317 ms

       symbol | timestamp | datetime | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice | notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | liquidationPrice | markPrice |     collateral | marginMode |  side |          percentage
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USDT:USDT |           |          |        1.0853 |                     0.1 |                   |                             |     1085.3 |   10.853 |       10 |       -0.0152 |      0.01 |            1 |             |             0.05 |           | 19982.40738239 |      cross |  long | -1.4005344144476182
ETH/USDT:USDT |           |          |               |                         |                   |                             |            |        0 |       10 |               |         0 |            1 |             |                  |           |              0 |      cross | short |                    
2 objects
2022-07-14T09:16:54.832Z iteration 1 passed in 317 ms
```