### PR TITLE
Bybit :: fix stop orders

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3000,11 +3000,11 @@ module.exports = class bybit extends Exchange {
         }
         if (isTakeProfitOrder) {
             request['tp_trigger_by'] = 'LastPrice';
-            request['take_profit'] = parseFloat (takeProfitPrice);
+            request['take_profit'] = parseFloat (this.priceToPrecision (symbol, takeProfitPrice));
         }
         if (isStopLossOrder) {
             request['sl_trigger_by'] = 'LastPrice';
-            request['sl_trigger_by'] = parseFloat (takeProfitPrice);
+            request['stop_loss'] = parseFloat (this.priceToPrecision (symbol, stopLossPrice));
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');
         if (clientOrderId !== undefined) {

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2992,9 +2992,9 @@ module.exports = class bybit extends Exchange {
             request['trigger_by'] = 'LastPrice';
             const preciseStopPrice = this.priceToPrecision (symbol, triggerPrice);
             request['stop_px'] = parseFloat (preciseStopPrice);
-            const basePrice = this.safeValue (params, 'base_price');
+            const basePrice = this.safeValue2 (params, 'base_price', 'basePrice');
             if (basePrice === undefined) {
-                throw new ArgumentsRequired (this.id + 'requires base_price for trigger orders. If you\'re expecting the price to rise to trigger your conditional order, make sure stop_px > max(market price, base_price) else, stop_px < min(market price, base_price)');
+                throw new ArgumentsRequired (this.id + ' createOrder() requires a base_price parameter for trigger orders, your triggerPrice > max(market price, base_price) or triggerPrice < min(market price, base_price)');
             }
             request['base_price'] = parseFloat (this.priceToPrecision (symbol, basePrice));
         }
@@ -3010,7 +3010,7 @@ module.exports = class bybit extends Exchange {
         if (clientOrderId !== undefined) {
             request['order_link_id'] = clientOrderId;
         }
-        params = this.omit (params, [ 'stop_px', 'stopPrice', 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'postOnly', 'reduceOnly', 'clientOrderId' ]);
+        params = this.omit (params, [ 'stop_px', 'stopPrice', 'basePrice', 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'postOnly', 'reduceOnly', 'clientOrderId' ]);
         let method = undefined;
         if (market['future']) {
             method = isStopOrder ? 'privatePostFuturesPrivateStopOrderCreate' : 'privatePostFuturesPrivateOrderCreate';


### PR DESCRIPTION
I think that all of the current "stop orders" logic is wrong for the following reasons:
- Mixes trigger orders parameters (that affect only the order placement) and tk/sl order parameters (that act after the position is opened), in my opinion, this is conceptually wrong we can't make let's say `triggerPrice` the default value of `stopLossPrice` or vice-versa because their intent is completely different, one decides the "opening" of the order and the other the "closing" of the position
- Assumes that all of this is a mutex, or we set up a trigger or a tk or a sl but we can do it all together as you can see in the demo below, so I think that is wrong too
- That "delta" trick does not seem to be working properly as you can see in the attached issue, so I'm explicitly requiring a `base_price` for trigger orders
- fixes https://github.com/ccxt/ccxt/issues/14352


 Please let me know if you don't agree and the reasons for that, as always I'm open to discussion


Demo of order with stopPrice+TakeProfit+StopLoss simultaneously 
```
node cli.js bybit createOrder "ETH/USDT:USDT" "limit" "buy" 0.1 1200 '{"stopPrice": 1300, "base_price":1299 , "takeProfitPrice": "1380", "stopLossPrice": "1109"}' --sandbox --verbose
Debugger attached.
2022-07-14T11:06:29.656Z
Node.js: v18.4.0
CCXT v1.90.68
bybit.createOrder (ETH/USDT:USDT, limit, buy, 0.1, 1200, [object Object])
fetch Request:
 bybit POST https://api-testnet.bybit.com/private/linear/stop-order/create 
RequestHeaders:
 { 'Content-Type': 'application/json', Referer: 'CCXT' } 
RequestBody:
 {"symbol":"ETHUSDT","side":"Buy","order_type":"Limit","time_in_force":"GoodTillCancel","qty":0.1,"reduce_only":false,"close_on_trigger":false,"price":1200,"trigger_by":"LastPrice","stop_px":1300,"base_price":1299,"tp_trigger_by":"LastPrice","take_profit":1380,"sl_trigger_by":"LastPrice","stop_loss":1109,"api_key":"9rFT6uR4uz9Imkw4Wx","recv_window":5000,"timestamp":"1657796791342","sign":"e6e17c5146c4ddd9a9aa7778352f57835eecfed75d173f4e6c3441be4ff9f088"} 

handleRestResponse:
 bybit POST https://api-testnet.bybit.com/private/linear/stop-order/create 200 OK 
ResponseHeaders:
 {
  'Cache-Control': 'max-age=0, no-cache, no-store',
  Connection: 'keep-alive',
  'Content-Length': '703',
  'Content-Type': 'application/json; charset=utf-8',
  Date: 'Thu, 14 Jul 2022 11:06:31 GMT',
  Expires: 'Thu, 14 Jul 2022 11:06:31 GMT',
  Pragma: 'no-cache',
  Server: 'T-GATEWAY'
} 
ResponseBody:
 {"ret_code":0,"ret_msg":"OK","ext_code":"","ext_info":"","result":{"user_id":551166,"stop_order_id":"2916e180-8fce-4fb9-b143-9f74f7d05823","symbol":"ETHUSDT","side":"Buy","order_type":"Limit","price":1200,"qty":0.1,"time_in_force":"GoodTillCancel","order_status":"Untriggered","trigger_price":1300,"order_link_id":"","created_time":"2022-07-14T11:06:31Z","updated_time":"2022-07-14T11:06:31Z","base_price":"1299.00","trigger_by":"LastPrice","tp_trigger_by":"LastPrice","sl_trigger_by":"LastPrice","take_profit":1380,"stop_loss":1109,"reduce_only":false,"close_on_trigger":false,"position_idx":1},"time_now":"1657796791.518917","rate_limit_status":99,"rate_limit_reset_ms":1657796791516,"rate_limit":100} 

2022-07-14T11:06:31.542Z iteration 0 passed in 222 ms

{
  info: {
    user_id: '551166',
    stop_order_id: '2916e180-8fce-4fb9-b143-9f74f7d05823',
    symbol: 'ETHUSDT',
    side: 'Buy',
    order_type: 'Limit',
    price: '1200',
    qty: '0.1',
    time_in_force: 'GoodTillCancel',
    order_status: 'Untriggered',
    trigger_price: '1300',
    order_link_id: '',
    created_time: '2022-07-14T11:06:31Z',
    updated_time: '2022-07-14T11:06:31Z',
    base_price: '1299.00',
    trigger_by: 'LastPrice',
    tp_trigger_by: 'LastPrice',
    sl_trigger_by: 'LastPrice',
    take_profit: '1380',
    stop_loss: '1109',
    reduce_only: false,
    close_on_trigger: false,
    position_idx: '1'
  },
  id: '2916e180-8fce-4fb9-b143-9f74f7d05823',
  clientOrderId: undefined,
  timestamp: 1657796791000,
  datetime: '2022-07-14T11:06:31.000Z',
  lastTradeTimestamp: 1657796791000,
  symbol: 'ETH/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 1200,
  stopPrice: '1300',
  amount: 0.1,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: []
}
2022-07-14T11:06:31.542Z iteration 1 passed in 222 ms 

```