### PR TITLE
Huobi :: fix php signing

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -5501,7 +5501,16 @@ module.exports = class huobi extends Exchange {
                 auth += '&' + this.urlencode ({ 'Signature': signature });
                 url += '?' + auth;
                 if (method === 'POST') {
-                    body = this.json (query);
+                    let bodyLength = 0;
+                    // php fix
+                    if (body !== undefined) {
+                        bodyLength = body.length;
+                    }
+                    if (bodyLength === 0) {
+                        body = '{}';
+                    } else {
+                        body = this.json (query);
+                    }
                     headers = {
                         'Content-Type': 'application/json',
                     };


### PR DESCRIPTION

- In php an empty stringified object results in "[]" but we need literally an stringified object "{}" so I'm adding this workaround
- Fixes https://github.com/ccxt/ccxt/issues/14348

Demo PHP:
```
php cli.php huobi fetchBalance --swap
Warning: Module 'ds' already loaded in Unknown on line 0
PHP v7.4.30
CCXT v1.90.75

huobi->fetchBalance()
Array
(
    [info] => Array
        (
            [status] => ok
            [data] => Array
                (
                    [0] => Array
                        (
                            [symbol] => BTC
                            [margin_balance] => 0
                            [margin_position] => 0
                            [margin_frozen] => 0
                            [margin_available] => 0
                            [profit_real] => 0
                            [profit_unreal] => 0
                            [risk_rate] => 
                            [withdraw_available] => 0
                            [liquidation_price] => 
                            [lever_rate] => 5
                            [adjust_factor] => 0.025000000000000000
                            [margin_static] => 0
                            [contract_code] => BTC-USD
                            [transfer_profit_ratio] => 
                        )

```
Demo JS:
```
2022-07-14T11:40:21.750Z
Node.js: v18.4.0
CCXT v1.90.75
huobi.fetchBalance ()
2022-07-14T11:40:24.844Z iteration 0 passed in 401 ms

{
  info: {
    status: 'ok',
    data: [
      {
        symbol: 'BTC',
        margin_balance: '0',
        margin_position: '0',
        margin_frozen: '0',
        margin_available: '0',
        profit_real: '0',
        profit_unreal: '0',
        risk_rate: null,
        withdraw_available: '0',
        liquidation_price: null,
        lever_rate: '5',
        adjust_factor: '0.025000000000000000',
        margin_static: '0',
        contract_code: 'BTC-USD',
        transfer_profit_ratio: null
      }
```

Demo Py:
```
python cli.py huobi fetchBalance --swap
Python v3.9.13
CCXT v1.90.75
huobi.fetchBalance()
{'AAVE': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ACH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ADA': {'free': 1.0, 'total': 1.0, 'used': 0.0},
...
```

