### PR TITLE
bithumb - fix fetchTickers, fetching only KRW based pairs

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -159,12 +159,6 @@ module.exports = class bithumb extends Exchange {
                         },
                     },
                 },
-                'fetchTickers': {
-                    'quoteCurrencies': {
-                        'KRW': true,
-                        'BTC': false,
-                    },
-                },
             },
             'commonCurrencies': {
                 'FTC': 'FTC2',
@@ -398,54 +392,46 @@ module.exports = class bithumb extends Exchange {
          * @returns {dict} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
+        const response = await this.publicGetTickerAll (params);
+        //
+        //     {
+        //         "status":"0000",
+        //         "data":{
+        //             "BTC":{
+        //                 "opening_price":"9045000",
+        //                 "closing_price":"9132000",
+        //                 "min_price":"8938000",
+        //                 "max_price":"9168000",
+        //                 "units_traded":"4619.79967497",
+        //                 "acc_trade_value":"42021363832.5187",
+        //                 "prev_closing_price":"9041000",
+        //                 "units_traded_24H":"8793.5045804",
+        //                 "acc_trade_value_24H":"78933458515.4962",
+        //                 "fluctate_24H":"530000",
+        //                 "fluctate_rate_24H":"6.16"
+        //             },
+        //             "date":"1587710878669"
+        //         }
+        //     }
+        //
         const result = {};
-        const fetchTickersOptions = this.safeValue (this.options, 'fetchTickers', {});
-        let quoteCurrencies = this.safeValue (fetchTickersOptions, 'quoteCurrencies', {});
-        quoteCurrencies = this.safeValue (params, 'quoteCurrencies', quoteCurrencies);
-        const quoteKeys = Object.keys (quoteCurrencies);
-        for (let i = 0; i < quoteKeys.length; i++) {
-            const quoteCurrency = quoteKeys[i];
-            if (!quoteCurrencies[quoteCurrency]) {
-                continue;
+        const data = this.safeValue (response, 'data', {});
+        const timestamp = this.safeInteger (data, 'date');
+        const tickers = this.omit (data, 'date');
+        const ids = Object.keys (tickers);
+        for (let i = 0; i < ids.length; i++) {
+            const id = ids[i];
+            let symbol = id;
+            let market = undefined;
+            if (id in this.markets_by_id) {
+                market = this.markets_by_id[id];
+                symbol = market['symbol'];
             }
-            const method = 'publicGetTickerALL' + quoteCurrency;
-            const response = await this[method] (params);
-            //
-            //     {
-            //         "status":"0000",
-            //         "data":{
-            //             "BTC":{
-            //                 "opening_price":"9045000",
-            //                 "closing_price":"9132000",
-            //                 "min_price":"8938000",
-            //                 "max_price":"9168000",
-            //                 "units_traded":"4619.79967497",
-            //                 "acc_trade_value":"42021363832.5187",
-            //                 "prev_closing_price":"9041000",
-            //                 "units_traded_24H":"8793.5045804",
-            //                 "acc_trade_value_24H":"78933458515.4962",
-            //                 "fluctate_24H":"530000",
-            //                 "fluctate_rate_24H":"6.16"
-            //             },
-            //             "date":"1587710878669"
-            //         }
-            //     }
-            //
-            const data = this.safeValue (response, 'data', {});
-            const timestamp = this.safeInteger (data, 'date');
-            const tickers = this.omit (data, 'date');
-            const baseCurrencyIds = Object.keys (tickers);
-            for (let i = 0; i < baseCurrencyIds.length; i++) {
-                const baseCurrencyId = baseCurrencyIds[i];
-                const ticker = tickers[baseCurrencyId];
-                const marketId = this.safeSymbol (baseCurrencyId + '/' + quoteCurrency);
-                const market = this.safeMarket (marketId, undefined);
-                const symbol = market['symbol'];
-                const isArray = Array.isArray (ticker);
-                if (!isArray) {
-                    ticker['date'] = timestamp;
-                    result[symbol] = this.parseTicker (ticker, market);
-                }
+            const ticker = tickers[id];
+            const isArray = Array.isArray (ticker);
+            if (!isArray) {
+                ticker['date'] = timestamp;
+                result[symbol] = this.parseTicker (ticker, market);
             }
         }
         return this.filterByArray (result, 'symbol', symbols);

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -438,7 +438,7 @@ module.exports = class bithumb extends Exchange {
             for (let i = 0; i < ids.length; i++) {
                 const id = ids[i];
                 const ticker = tickers[id];
-                const symbol = id + '/' + quoteCurrency;
+                const symbol = this.safeSymbol (id + '/' + quoteCurrency);
                 const market = this.market (symbol);
                 const isArray = Array.isArray (ticker);
                 if (!isArray) {

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -186,22 +186,24 @@ module.exports = class bithumb extends Exchange {
          */
         const result = [];
         const quoteCurrencies = this.safeValue (this.options, 'quoteCurrencies', {});
-        const quotes = Object.keys (quoteCurrencies);
-        for (let i = 0; i < quotes.length; i++) {
-            const quote = quotes[i];
-            const quoteId = quote;
-            const extension = this.safeValue (quoteCurrencies, quote, {});
-            const method = 'publicGetTickerALL' + quote;
+        const quoteCurrencyIds = Object.keys (quoteCurrencies);
+        for (let i = 0; i < quoteCurrencyIds.length; i++) {
+            const quoteCurrencyId = quoteCurrencyIds[i];
+            const quoteCurrencyCode = this.safeCurrencyCode (quoteCurrencyId);
+            const extension = this.safeValue (quoteCurrencies, quoteCurrencyId, {});
+            const method = 'publicGetTickerALL' + quoteCurrencyId;
             const response = await this[method] (params);
             const data = this.safeValue (response, 'data');
-            const currencyIds = Object.keys (data);
-            for (let j = 0; j < currencyIds.length; j++) {
-                const currencyId = currencyIds[j];
-                if (currencyId === 'date') {
+            const baseCurrencyIds = Object.keys (data);
+            for (let j = 0; j < baseCurrencyIds.length; j++) {
+                const baseCurrencyId = baseCurrencyIds[j];
+                if (baseCurrencyId === 'date') {
                     continue;
                 }
-                const market = data[currencyId];
-                const base = this.safeCurrencyCode (currencyId);
+                const market = data[baseCurrencyId];
+                const marketId = baseCurrencyId + '_' + quoteCurrencyId;
+                const symbol = baseCurrencyId + '/' + quoteCurrencyCode;
+                const base = this.safeCurrencyCode (baseCurrencyId);
                 let active = true;
                 if (Array.isArray (market)) {
                     const numElements = market.length;
@@ -210,13 +212,13 @@ module.exports = class bithumb extends Exchange {
                     }
                 }
                 const entry = this.deepExtend ({
-                    'id': currencyId,
-                    'symbol': base + '/' + quote,
+                    'id': marketId,
+                    'symbol': symbol,
                     'base': base,
-                    'quote': quote,
+                    'quote': quoteCurrencyCode,
                     'settle': undefined,
-                    'baseId': currencyId,
-                    'quoteId': quoteId,
+                    'baseId': baseCurrencyId,
+                    'quoteId': quoteCurrencyId,
                     'settleId': undefined,
                     'type': 'spot',
                     'spot': true,

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -434,11 +434,11 @@ module.exports = class bithumb extends Exchange {
             const data = this.safeValue (response, 'data', {});
             const timestamp = this.safeInteger (data, 'date');
             const tickers = this.omit (data, 'date');
-            const ids = Object.keys (tickers);
-            for (let i = 0; i < ids.length; i++) {
-                const id = ids[i];
-                const ticker = tickers[id];
-                const symbol = this.safeSymbol (id + '/' + quoteCurrency);
+            const baseCurrencyIds = Object.keys (tickers);
+            for (let i = 0; i < baseCurrencyIds.length; i++) {
+                const baseCurrencyId = baseCurrencyIds[i];
+                const ticker = tickers[baseCurrencyId];
+                const symbol = this.safeSymbol (baseCurrencyId + '/' + quoteCurrency);
                 const market = this.market (symbol);
                 const isArray = Array.isArray (ticker);
                 if (!isArray) {

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -438,8 +438,9 @@ module.exports = class bithumb extends Exchange {
             for (let i = 0; i < baseCurrencyIds.length; i++) {
                 const baseCurrencyId = baseCurrencyIds[i];
                 const ticker = tickers[baseCurrencyId];
-                const symbol = this.safeSymbol (baseCurrencyId + '/' + quoteCurrency);
-                const market = this.market (symbol);
+                const marketId = this.safeSymbol (baseCurrencyId + '/' + quoteCurrency);
+                const market = this.safeMarket (marketId, undefined);
+                const symbol = market['symbol'];
                 const isArray = Array.isArray (ticker);
                 if (!isArray) {
                     ticker['date'] = timestamp;

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -159,6 +159,12 @@ module.exports = class bithumb extends Exchange {
                         },
                     },
                 },
+                'fetchTickers': {
+                    'quoteCurrencies': {
+                        'KRW': true,
+                        'BTC': false,
+                    },
+                },
             },
             'commonCurrencies': {
                 'FTC': 'FTC2',
@@ -391,10 +397,15 @@ module.exports = class bithumb extends Exchange {
          */
         await this.loadMarkets ();
         const result = {};
-        const quoteCurrencies = this.safeValue (this.options, 'quoteCurrencies', {});
-        const quotes = Object.keys (quoteCurrencies);
-        for (let i = 0; i < quotes.length; i++) {
-            const quoteCurrency = quotes[i];
+        const fetchTickersOptions = this.safeValue (this.options, 'fetchTickers', {});
+        let quoteCurrencies = this.safeValue (fetchTickersOptions, 'quoteCurrencies', {});
+        quoteCurrencies = this.safeValue (params, 'quoteCurrencies', quoteCurrencies);
+        const quoteKeys = Object.keys (quoteCurrencies);
+        for (let i = 0; i < quoteKeys.length; i++) {
+            const quoteCurrency = quoteKeys[i];
+            if (!quoteCurrencies[quoteCurrency]) {
+                continue;
+            }
             const method = 'publicGetTickerALL' + quoteCurrency;
             const response = await this[method] (params);
             //


### PR DESCRIPTION
Implementations were not correct, as fetchMarkets fetched for both currencies, but fetchticker not. 
this PR fixes #2694 and #8236 
also, it was necessary to remove SOC from commoncurrencies, otherwise it triggers bug specifically in bithumb (actually, SOC doesn't stand for any other major currency, so no need to be there either).