### PR TITLE
ascendex fetchMarkets leveraged tokens

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -485,6 +485,7 @@ module.exports = class ascendex extends Exchange {
         //         "data":[
         //             {
         //                 "symbol":"QTUM/BTC",
+        //                 "displayName":"QTUM/BTC",
         //                 "domain":"BTC",
         //                 "tradingStartTime":1569506400000,
         //                 "collapseDecimals":"0.0001,0.000001,0.00000001",
@@ -555,8 +556,9 @@ module.exports = class ascendex extends Exchange {
             let quote = this.safeCurrencyCode (quoteId);
             const settle = this.safeCurrencyCode (settleId);
             const status = this.safeString (market, 'status');
+            const domain = this.safeString (market, 'domain');
             let active = false;
-            if ((status === 'Normal') || (status === 'InternalTrading')) {
+            if (((status === 'Normal') || (status === 'InternalTrading')) && (domain !== 'LeveragedETF')) {
                 active = true;
             }
             const spot = settle === undefined;


### PR DESCRIPTION
leveraged tokens are not available for API trading now
From telegram group about this question:

> Yes, leveraged token trading is not available via api

`InvalidOrder ascendex {"code":300021,"message":"Trading is disabled on symbol.","reason":"TRADING_DISABLED","accountId":"csxxxxV3","ac":"CASH","action":"place-order","status":"Err","info":{"symbol":"BTC3L/USDT"}}`