### PR TITLE
Bitmart: fetchBorrowRates

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2781,7 +2781,7 @@ module.exports = class bitmart extends Exchange {
          */
         await this.loadMarkets ();
         const request = {};
-        const response = await this.privateSpotGetMarginIsolatedPairs (this.extend (request, params));
+        const response = await this.privateGetSpotV1MarginIsolatedPairs (this.extend (request, params));
         //
         //     {
         //         "message": "OK",


### PR DESCRIPTION
Added fetchBorrowRates to Bitmart:
```
bitmart.fetchBorrowRates ()
2022-07-15T19:50:58.940Z iteration 0 passed in 1000 ms

currency |       rate |  period |     timestamp |                 datetime
--------------------------------------------------------------------------
   MOVEZ | 0.00002291 | 3600000 | 1657914658940 | 2022-07-15T19:50:58.940Z
     APE | 0.00002291 | 3600000 | 1657914658940 | 2022-07-15T19:50:58.940Z
    HBAR | 0.00002291 | 3600000 | 1657914658940 | 2022-07-15T19:50:58.940Z
...
    AAVE | 0.00004166 | 3600000 | 1657914658940 | 2022-07-15T19:50:58.940Z
   THETA |   0.000025 | 3600000 | 1657914658940 | 2022-07-15T19:50:58.940Z
     SOL | 0.00002291 | 3600000 | 1657914658940 | 2022-07-15T19:50:58.940Z
109 objects
2022-07-15T19:50:58.940Z iteration 1 passed in 1000 ms
```