### PR TITLE
binance: add get portfolio collateralRate

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -336,6 +336,7 @@ module.exports = class binance extends Exchange {
                         'algo/futures/historicalOrders': 0.1,
                         'algo/futures/subOrders': 0.1,
                         'portfolio/account': 0.1,
+                        'portfolio/collateralRate': 0.1,
                         // staking
                         'staking/productList': 0.1,
                         'staking/position': 0.1,


### PR DESCRIPTION
New endpoint:
https://binance-docs.github.io/apidocs/spot/en/#portfolio-margin-collateral-rate-market_data