### PR TITLE
Fix fetchFundingRates issues

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2556,7 +2556,8 @@ module.exports = class Exchange {
 
     async fetchFundingRate (symbol, params = {}) {
         if (this.has['fetchFundingRates']) {
-            const market = await this.market (symbol);
+            await this.loadMarkets ();
+            const market = this.market (symbol);
             if (!market['contract']) {
                 throw new BadSymbol (this.id + ' fetchFundingRate() supports contract markets only');
             }


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/14416

```
python cli.py ascendex fetch_funding_rate "BTC/USDT:USDT"
Python v3.9.13
CCXT v1.90.92
ascendex.fetch_funding_rate(BTC/USDT:USDT)
{'datetime': '2022-07-20T08:31:24.726Z',
 'estimatedSettlePrice': None,
 'indexPrice': 23431.316666667,
 'info': {'fundingRate': '0.000172612',
          'indexPrice': '23431.316666667',
          'markPrice': '23435.359607322',
          'nextFundingTime': '1658332800000',
          'openInterest': '95.0183',
          'symbol': 'BTC-PERP',
          'time': '1658305884726'},
 'interestRate': 0.0,
 'markPrice': 23435.359607322,
 'nextFundingDatetime': '2022-07-20T16:00:00.000Z',
 'nextFundingRate': 0.000172612,
 'nextFundingTimestamp': 1658332800000,
 'previousFundingDatetime': None,
 'previousFundingRate': None,
 'previousFundingTimestamp': None,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1658305884726}
```