### PR TITLE
Fix import statement in basic-chart.py example

### DIFF
--- a/examples/py/basic-chart.py
+++ b/examples/py/basic-chart.py
@@ -2,7 +2,8 @@
 
 import os
 import sys
-from asciichartpy import plot
+
+from asciichart import plot
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes faulty import which lead to this error:

```sh
$ python basic-chart.py 
Traceback (most recent call last):
  File "basic-chart.py", line 5, in <module>
    from asciichartpy import plot
ModuleNotFoundError: No module named 'asciichartpy'
(base) flavio@Workstation:~/git/ccxt/examples/py$ 
```