### PR TITLE
Bybit: add transfer, fetchTransfers

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4938,8 +4938,11 @@ module.exports = class bybit extends Exchange {
         //         "rate_limit": 1
         //     }
         //
+        const timestamp = this.safeInteger (response, 'time_now');
         const transfer = this.safeValue (response, 'result', {});
         return this.extend (this.parseTransfer (transfer, currency), {
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'amount': this.parseNumber (amountToPrecision),
             'fromAccount': fromAccount,
             'toAccount': toAccount,
@@ -5041,6 +5044,7 @@ module.exports = class bybit extends Exchange {
         const fromAccount = this.safeString (accountIds, fromAccountId, fromAccountId);
         const toAccount = this.safeString (accountIds, toAccountId, toAccountId);
         return {
+            'info': transfer,
             'id': this.safeString (transfer, 'transfer_id'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),


### PR DESCRIPTION
Added the transfer and fetchTransfer methods to Bybit:

Note: for accountsByType and accountsById, CONTRACT is for futures and swaps, OPTION is for options and USDC perpetuals:
Let me know if I should make any changes to accountsByType or accountsById.
https://bybit-exchange.github.io/docs/account_asset/#account-type-from_account_type-to_account_type

### transfer:
```
bybit.transfer (USDT, 15, spot, swap)
2022-07-21T20:05:34.579Z iteration 0 passed in 345 ms

{
  id: '3976014d-f3d2-4843-b3bb-1cd006babcde',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 15,
  fromAccount: 'spot',
  toAccount: 'swap',
  status: 'ok'
}
2022-07-21T20:05:34.579Z iteration 1 passed in 345 ms
```

### fetchTransfers:
```
bybit.fetchTransfers ()
2022-07-21T21:22:13.585Z iteration 0 passed in 274 ms

                                               id |     timestamp |                 datetime | currency |    amount | fromAccount | toAccount | status
------------------------------------------------------------------------------------------------------------------------------------------------------
             dbd81a7e-e6e7-403d-b26e-7836cf75d17f | 1658438138000 | 2022-07-21T21:15:38.000Z |     USDT |        15 |        spot |  contract |     ok
             d326babe-b146-4773-b143-2087652df94c | 1658438497000 | 2022-07-21T21:21:37.000Z |     USDT |        15 |        spot |  contract |     ok
             7cdd0aeb-9012-4407-ae82-72be9f05c8bb | 1658438522000 | 2022-07-21T21:22:02.000Z |     USDT |        60 |    contract |      spot |     ok
20 objects
2022-07-21T21:22:13.585Z iteration 1 passed in 274 ms
```