### PR TITLE
Bitmex adding stop orders

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1835,10 +1835,10 @@ module.exports = class bitmex extends Exchange {
                     request['stopPx'] = this.priceToPrecision (symbol, takeProfitPrice);
                 }
             } else if (isLimitOrder) {
+                request['price'] = this.priceToPrecision (symbol, price);
                 if ((triggerPrice !== undefined) || (stopLossPrice !== undefined)) {
                     // StopLimit
                     request['ordType'] = 'StopLimit';
-                    request['price'] = this.priceToPrecision (symbol, price);
                     if (triggerPrice !== undefined) {
                         request['stopPx'] = this.priceToPrecision (symbol, triggerPrice);
                     } else if (stopLossPrice !== undefined) {
@@ -1868,9 +1868,6 @@ module.exports = class bitmex extends Exchange {
                     throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + market['type'] + ' orders, reduceOnly orders are supported for swap and future markets only');
                 }
                 execInstArr.push ('ReduceOnly');
-            }
-            if (isStopOrder) {
-                execInstArr.push ('LastPrice'); // override default MarkPrice for consistency across exchanges (most have last as trigger)
             }
             request['execInst'] = execInstArr.join (',');
         }

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1609,8 +1609,8 @@ module.exports = class bitmex extends Exchange {
             'Market': 'market',
             'Stop': 'market', // Stop Loss Market
             'StopLimit': 'limit',
-            'MarketIfTouched': 'market',
-            'LimitIfTouched': 'limit',
+            'MarketIfTouched': 'market', // Take Profit Market
+            'LimitIfTouched': 'limit', // Take Profit Limit
         };
         return this.safeString (orderTypes, orderType, orderType);
     }
@@ -1813,16 +1813,19 @@ module.exports = class bitmex extends Exchange {
         const isStopOrder = (triggerPrice !== undefined) || (stopLossPrice !== undefined) || (takeProfitPrice !== undefined);
         if (isStopOrder) {
             //
-            // Stop and StopLimit
+            // Stop and StopLimit (Classic Stop Orders)
             // triggered when the price is below the trigger stop price for sell orders
             // triggered when the price is above the trigger stop price for buy orders
             //
-            // LimitIfTouched and StopIfTouched
+            // LimitIfTouched and StopIfTouched (Take Profit Orders)
             // Similar to a Stop and StopLimit, but triggers are done in the opposite direction.
+            // triggered when the price is above the takeProfitPrice for sell orders
+            // triggered when the price is below the takeProfitPrice for buy orders
             // Used for Take Profit orders.
+            //
             if (isMarketOrder) {
                 if ((triggerPrice !== undefined) || (stopLossPrice !== undefined)) {
-                    // Stop (stopPrice / stopLoss)
+                    // Stop and StopLimit
                     request['ordType'] = 'Stop';
                     if (triggerPrice !== undefined) {
                         request['stopPx'] = this.priceToPrecision (symbol, triggerPrice);
@@ -1830,14 +1833,14 @@ module.exports = class bitmex extends Exchange {
                         request['stopPx'] = this.priceToPrecision (symbol, stopLossPrice);
                     }
                 } else if (takeProfitPrice !== undefined) {
-                    // MarketIfTouched (takeProfitPrice / takeProfit orders) opposite trigger crossing directions from Stop Orders
+                    // LimitIfTouched and StopIfTouched
                     request['ordType'] = 'MarketIfTouched';
                     request['stopPx'] = this.priceToPrecision (symbol, takeProfitPrice);
                 }
             } else if (isLimitOrder) {
                 request['price'] = this.priceToPrecision (symbol, price);
                 if ((triggerPrice !== undefined) || (stopLossPrice !== undefined)) {
-                    // StopLimit
+                    // Stop and StopLimit
                     request['ordType'] = 'StopLimit';
                     if (triggerPrice !== undefined) {
                         request['stopPx'] = this.priceToPrecision (symbol, triggerPrice);
@@ -1845,7 +1848,7 @@ module.exports = class bitmex extends Exchange {
                         request['stopPx'] = this.priceToPrecision (symbol, stopLossPrice);
                     }
                 } else if (takeProfitPrice !== undefined) {
-                    // LimitIfTouched (takeProfitPrice / takeProfit orders) opposite trigger crossing directions from Stop Orders
+                    // LimitIfTouched and StopIfTouched
                     request['ordType'] = 'LimitIfTouched';
                     request['stopPx'] = this.priceToPrecision (symbol, takeProfitPrice);
                 }

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1796,15 +1796,24 @@ module.exports = class bitmex extends Exchange {
         const timeInForce = this.safeString (params, 'timeInForce');
         const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const isStopOrder = (triggerPrice !== undefined);
+        // TODO stopLossPrice and takeProfitPrice Order logic for type.2 Stop Orders
+        // TODO type.2 stopLoss can be processed into type.1 trigger from above
+        // TODO type.2 takeProfit can be processed using (See Below)
+        //
+        // MarketIfTouched: Similar to a Stop, but triggers are done in the opposite direction. Useful for Take Profit orders.
+        // LimitIfTouched: As above; use for Take Profit Limit orders.
+        //
         if (isStopOrder) {
-            // stop orders
+            // TODO stop orders
+            // On sell orders, the order will trigger if the triggering price is lower than the stopPx.
+            // On buy orders, the order will trigger if the triggering price is higher than the stopPx. (for takeProfit See Above)
             if (isMarketOrder) {
                 console.log ('Stop');
             } else {
                 console.log ('StopLimit');
             }
         } else {
-            // vanilla orders
+            // TODO vanilla orders
             if (isMarketOrder) {
                 console.log ('Market');
             } else {


### PR DESCRIPTION
**Vanilla Trigger and StopLossPrice**
sell orders are placed onto the book when the asset price is below the `triggerPrice` / `stopLossPrice` / `stopPrice`
buy orders are placed onto the book when the asset price is above the `triggerPrice` / `stopLossPrice` / `stopPrice`


```JavaScript

exchange.createOrder ('DOGE/USDT:USDT', 'market', 'sell',  1000, undefined, {'stopLossPrice': 0.05})

// equivalent to 
exchange.createOrder ('DOGE/USDT:USDT', 'market', 'sell',  1000, undefined, {'triggerPrice': 0.05}) // or stopPrice
```

**TakeProfitPrice**
Similar to a Stop and StopLimit, but triggers are done in the opposite directions.
Used for Take Profit orders.
sell orders are placed onto the book when the asset price is above the `takeProfitPrice`
buy orders are placed onto the book when the asset price is below the `takeProfitPrice`


```JavaScript

exchange.createOrder ('DOGE/USDT:USDT', 'limit', 'sell',  1000, 0.052, {"takeProfitPrice": 0.05})
```

Note: Only Tested so far with Swaps as I couldnt figure out where the Spot Trading Was in the API

