### PR TITLE
Gate :: fix signing

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -4630,7 +4630,7 @@ module.exports = class gate extends Exchange {
             let requiresURLEncoding = false;
             if (type === 'futures' && method === 'POST') {
                 const pathParts = path.split ('/');
-                const secondPart = this.safeString (pathParts, 1);
+                const secondPart = this.safeString (pathParts, 1, '');
                 requiresURLEncoding = (secondPart.indexOf ('dual') >= 0) || (secondPart.indexOf ('positions') >= 0);
             }
             if ((method === 'GET') || (method === 'DELETE') || requiresURLEncoding) {

--- a/js/gate.js
+++ b/js/gate.js
@@ -628,6 +628,7 @@ module.exports = class gate extends Exchange {
                     'SERVER_ERROR': ExchangeNotAvailable,
                     'TOO_BUSY': ExchangeNotAvailable,
                     'CROSS_ACCOUNT_NOT_FOUND': ExchangeError,
+                    'RISK_LIMIT_TOO_LOW': BadRequest, // {"label":"RISK_LIMIT_TOO_LOW","detail":"limit 1000000"}
                 },
             },
             'broad': {},
@@ -4626,7 +4627,13 @@ module.exports = class gate extends Exchange {
             }
         } else {
             let queryString = '';
-            if ((method === 'GET') || (method === 'DELETE')) {
+            let requiresURLEncoding = false;
+            if (type === 'futures' && method === 'POST') {
+                const pathParts = path.split ('/');
+                const secondPart = this.safeString (pathParts, 1);
+                requiresURLEncoding = (secondPart.indexOf ('dual') >= 0) || (secondPart.indexOf ('positions') >= 0);
+            }
+            if ((method === 'GET') || (method === 'DELETE') || requiresURLEncoding) {
                 if (Object.keys (query).length) {
                     queryString = this.urlencode (query);
                     url += '?' + queryString;


### PR DESCRIPTION
- In Gateio all of these endpoints although use the POST method, require URL encoding 
![image](https://user-images.githubusercontent.com/43336371/180443757-2cc7955b-cf90-4002-ba35-655ba440ecc9.png)
- Docs: https://www.gate.io/docs/apiv4/en/#update-position-risk-limit-in-dual-mode
- fixes https://github.com/ccxt/ccxt/issues/14440

Demos

```Python
node cli.js gateio private_futures_post_settle_positions_contract_risk_limit "{'settle': 'usdt', 'contract': 'ADA_USDT', 'risk_limit': '500000'}"
Debugger attached.
2022-07-22T12:58:48.834Z
Node.js: v18.4.0
CCXT v1.91.11
2022-07-22T12:58:51.445Z iteration 0 passed in 277 ms

{
  value: '0',
  leverage: '20',
  mode: 'single',
  realised_point: '0',
  contract: 'ADA_USDT',
  entry_price: '0',
  mark_price: '0.50462',
  history_point: '0',
  realised_pnl: '0',
  close_order: null,
  size: '0',
  cross_leverage_limit: '5',
  pending_orders: '0',
  adl_ranking: '6',
  maintenance_rate: '0.025',
  unrealised_pnl: '0',
  user: '10406147',
  leverage_max: '20',
  history_pnl: '-1.465078707',
  risk_limit: '500000',
  margin: '0',
  last_close_pnl: '-0.500087244',
  liq_price: '0'
}
2022-07-22T12:58:51.445Z iteration 1 passed in 277 ms
```

```
 node cli.js gateio createOrder "ADA/USDT:USDT" "limit" "buy" 10 0.3 --verbose --swap
Node.js: v18.4.0
CCXT v1.91.11
gateio.createOrder (ADA/USDT:USDT, limit, buy, 10, 0.3)
{
  id: '183952694964',
  clientOrderId: 'api',
  timestamp: 1658494351216,
  datetime: '2022-07-22T12:52:31.216Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 0.3,
  stopPrice: undefined,
  average: undefined,
  amount: 10,
  cost: 0,
  filled: 0,
  remaining: 10,
  fee: undefined,
  fees: [],
  trades: [],
  info: {
    id: '183952694964',
    contract: 'ADA_USDT',
    mkfr: '0.00015',
    tkfr: '0.0005',
    tif: 'gtc',
    is_reduce_only: false,
    create_time: '1658494351.216',
    price: '0.3',
    size: '10',
    refr: '0.3',
    left: '10',
    text: 'api',
    fill_price: '0',
    user: '10406147',
    status: 'open',
    is_liq: false,
    refu: '2436035',
    is_close: false,
    iceberg: '0'
  }
}
2022-07-22T12:52:31.276Z iteration 1 passed in 316 ms
```

```Python
node cli.js gateio fetchBalance --swap                                              
2022-07-22T12:54:54.119Z
Node.js: v18.4.0
CCXT v1.91.11
gateio.fetchBalance ()
2022-07-22T12:54:56.972Z iteration 0 passed in 309 ms

{
  info: [
    {
      order_margin: '0',
      point: '0',
      bonus: '0',
      history: {
        dnw: '95.1821',
        pnl: '-41.14960000005',
        refr: '0',
        point_fee: '0',
        fund: '-0.006904943',
        bonus_dnw: '0',
        point_refr: '0',
        bonus_offset: '0',
        fee: '-0.34204715',
        point_dnw: '0'
      },
      unrealised_pnl: '0',
      total: '53.68354790695',
      available: '53.68354790695',
      in_dual_mode: false,
      currency: 'USDT',
      position_margin: '0',
      user: '10406147'
    }
  ],
  USDT: { free: 53.68354790695, used: 0, total: 53.68354790695 },
  free: { USDT: 53.68354790695 },
  used: { USDT: 0 },
  total: { USDT: 53.68354790695 }
}
2022-07-22T12:54:56.972Z iteration 1 passed in 309 ms
```