### PR TITLE
Bitforex - fetch_closed_orders/fetch_open_orders symbol is required 

### DIFF
--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -594,6 +594,9 @@ module.exports = class bitforex extends Exchange {
          * @param {object} params extra parameters specific to the bitforex api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol argument');
+        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
@@ -615,6 +618,9 @@ module.exports = class bitforex extends Exchange {
          * @param {object} params extra parameters specific to the bitforex api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol argument');
+        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {

--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, AuthenticationError, OrderNotFound, InsufficientFunds, DDoSProtection, PermissionDenied, BadSymbol, InvalidOrder } = require ('./base/errors');
+const { ExchangeError, ArgumentsRequired, AuthenticationError, OrderNotFound, InsufficientFunds, DDoSProtection, PermissionDenied, BadSymbol, InvalidOrder } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 
 //  ---------------------------------------------------------------------------

--- a/js/bitforex.js
+++ b/js/bitforex.js
@@ -588,7 +588,7 @@ module.exports = class bitforex extends Exchange {
          * @method
          * @name bitforex#fetchOpenOrders
          * @description fetch all unfilled currently open orders
-         * @param {string|undefined} symbol unified market symbol
+         * @param {string} symbol unified market symbol
          * @param {number|undefined} since the earliest time in ms to fetch open orders for
          * @param {number|undefined} limit the maximum number of  open orders structures to retrieve
          * @param {object} params extra parameters specific to the bitforex api endpoint
@@ -612,7 +612,7 @@ module.exports = class bitforex extends Exchange {
          * @method
          * @name bitforex#fetchClosedOrders
          * @description fetches information on multiple closed orders made by the user
-         * @param {string|undefined} symbol unified market symbol of the market orders were made in
+         * @param {string} symbol unified market symbol of the market orders were made in
          * @param {number|undefined} since the earliest time in ms to fetch orders for
          * @param {number|undefined} limit the maximum number of  orde structures to retrieve
          * @param {object} params extra parameters specific to the bitforex api endpoint

--- a/python/ccxt/bitforex.py
+++ b/python/ccxt/bitforex.py
@@ -561,7 +561,7 @@ class bitforex(Exchange):
     def fetch_open_orders(self, symbol=None, since=None, limit=None, params={}):
         """
         fetch all unfilled currently open orders
-        :param str|None symbol: unified market symbol
+        :param str symbol: unified market symbol
         :param int|float|None since: the earliest time in ms to fetch open orders for
         :param int|float|None limit: the maximum number of  open orders structures to retrieve
         :param dict params: extra parameters specific to the bitforex api endpoint
@@ -581,7 +581,7 @@ class bitforex(Exchange):
     def fetch_closed_orders(self, symbol=None, since=None, limit=None, params={}):
         """
         fetches information on multiple closed orders made by the user
-        :param str|None symbol: unified market symbol of the market orders were made in
+        :param str symbol: unified market symbol of the market orders were made in
         :param int|float|None since: the earliest time in ms to fetch orders for
         :param int|float|None limit: the maximum number of  orde structures to retrieve
         :param dict params: extra parameters specific to the bitforex api endpoint

--- a/python/ccxt/bitforex.py
+++ b/python/ccxt/bitforex.py
@@ -14,6 +14,8 @@ from ccxt.base.errors import OrderNotFound
 from ccxt.base.errors import DDoSProtection
 from ccxt.base.decimal_to_precision import TICK_SIZE
 
+from python.ccxt.base.errors import ArgumentsRequired
+
 
 class bitforex(Exchange):
 
@@ -565,6 +567,8 @@ class bitforex(Exchange):
         :param dict params: extra parameters specific to the bitforex api endpoint
         :returns [dict]: a list of `order structures <https://docs.ccxt.com/en/latest/manual.html#order-structure>`
         """
+        if symbol is None:
+            raise ArgumentsRequired(self.id + ' fetchMyTrades() requires a symbol argument')
         self.load_markets()
         market = self.market(symbol)
         request = {
@@ -583,6 +587,8 @@ class bitforex(Exchange):
         :param dict params: extra parameters specific to the bitforex api endpoint
         :returns [dict]: a list of `order structures <https://docs.ccxt.com/en/latest/manual.html#order-structure>`
         """
+        if symbol is None:
+            raise ArgumentsRequired(self.id + ' fetchMyTrades() requires a symbol argument')
         self.load_markets()
         market = self.market(symbol)
         request = {


### PR DESCRIPTION
Regarding their documentation:
https://github.com/bitforexapi/API_Doc_en/wiki/Search-Order-Information

`symbol` parameter is required. 
So calling:
```
exchange.fetch_closed_orders()
```

Will result in:
```
TypeError: can only concatenate str (not "NoneType") to str
```
