### PR TITLE
kucoinfutures fundingTimestamp

### DIFF
--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1505,9 +1505,9 @@ module.exports = class kucoinfutures extends kucoin {
         //
         const data = this.safeValue (response, 'data');
         const previousFundingTimestamp = this.safeInteger (data, 'timePoint');
+        // the website displays the previous funding rate as "funding rate"
         const granularity = this.safeInteger (data, 'granularity');
         const fundingTimestamp = this.sum (previousFundingTimestamp, granularity);
-        // the website displays the previous funding rate as "funding rate"
         return {
             'info': data,
             'symbol': market['symbol'],

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1504,7 +1504,10 @@ module.exports = class kucoinfutures extends kucoin {
         //    }
         //
         const data = this.safeValue (response, 'data');
-        const fundingTimestamp = this.safeNumber (data, 'timePoint');
+        const previousFundingTimestamp = this.safeInteger (data, 'timePoint');
+        const granularity = this.safeInteger (data, 'granularity');
+        const fundingTimestamp = this.sum (previousFundingTimestamp, granularity);
+        
         // the website displayes the previous funding rate as "funding rate"
         return {
             'info': data,
@@ -1516,14 +1519,14 @@ module.exports = class kucoinfutures extends kucoin {
             'timestamp': undefined,
             'datetime': undefined,
             'fundingRate': this.safeNumber (data, 'predictedValue'),
-            'fundingTimestamp': undefined,
-            'fundingDatetime': undefined,
+            'fundingTimestamp': fundingTimestamp,
+            'fundingDatetime': this.iso8601 (fundingTimestamp),
             'nextFundingRate': undefined,
             'nextFundingTimestamp': undefined,
             'nextFundingDatetime': undefined,
             'previousFundingRate': this.safeNumber (data, 'value'),
-            'previousFundingTimestamp': fundingTimestamp,
-            'previousFundingDatetime': this.iso8601 (fundingTimestamp),
+            'previousFundingTimestamp': previousFundingTimestamp,
+            'previousFundingDatetime': this.iso8601 (previousFundingTimestamp),
         };
     }
 

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1507,8 +1507,7 @@ module.exports = class kucoinfutures extends kucoin {
         const previousFundingTimestamp = this.safeInteger (data, 'timePoint');
         const granularity = this.safeInteger (data, 'granularity');
         const fundingTimestamp = this.sum (previousFundingTimestamp, granularity);
-        
-        // the website displayes the previous funding rate as "funding rate"
+        // the website displays the previous funding rate as "funding rate"
         return {
             'info': data,
             'symbol': market['symbol'],


### PR DESCRIPTION
This is update from https://github.com/ccxt/ccxt/pull/14393 as it was closed.
The PR was closed by @samgermain due to the concern that the funding rate interval may change on a random day and may not be fixed. 
1. I think granularity is provided by the kucoin API. If the funding rate interval changes, the granularity response would also be updated to reflect the current interval. So it should not be impacted? 
2. https://futures.kucoin.com/contract/history-rate the funding rate history shows it's every 8 hours for a long time for all markets so its unlikely they will randomly change.
It would be useful to be able to directly get the fundingTimestamp as the info is already available here.