### PR TITLE
woo: update symbols

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -1891,12 +1891,13 @@ module.exports = class woo extends Exchange {
         //
         //
         const symbol = this.safeString (fundingRate, 'symbol');
+        market = this.market (symbol);
         const nextFundingTimestamp = this.safeInteger (fundingRate, 'next_funding_time');
         const estFundingRateTimestamp = this.safeInteger (fundingRate, 'est_funding_rate_timestamp');
         const lastFundingRateTimestamp = this.safeInteger (fundingRate, 'last_funding_rate_timestamp');
         return {
             'info': fundingRate,
-            'symbol': symbol,
+            'symbol': market['symbol'],
             'markPrice': undefined,
             'indexPrice': undefined,
             'interestRate': this.parseNumber ('0'),
@@ -1958,6 +1959,7 @@ module.exports = class woo extends Exchange {
         //
         const rows = this.safeValue (response, 'rows', {});
         const result = this.parseFundingRates (rows);
+        symbols = this.marketSymbols (symbols);
         return this.filterByArray (result, 'symbol', symbols);
     }
 


### PR DESCRIPTION
Before:

```
% node examples/js/cli woo fetchFundingRates '["PERP_KSM_USDT"]'
2022-07-24T02:11:40.551Z
Node.js: v14.17.0
CCXT v1.91.20
woo.fetchFundingRates (PERP_KSM_USDT)
2022-07-24T02:11:41.090Z iteration 0 passed in 178 ms

{}
```

After:
```
% node examples/js/cli woo fetchFundingRates '["PERP_KSM_USDT"]'
2022-07-24T02:11:40.551Z
Node.js: v14.17.0
CCXT v1.91.20
woo.fetchFundingRates (PERP_KSM_USDT)
2022-07-24T02:11:41.090Z iteration 0 passed in 178 ms

{
  'KSM/USDT:USDT': {
    info: {
      symbol: 'PERP_KSM_USDT',
      est_funding_rate: '-0.00006542',
      est_funding_rate_timestamp: '1658628659001',
      last_funding_rate: '-0.00006508',
      last_funding_rate_timestamp: '1658628000000',
      next_funding_time: '1658631600000'
    },
    symbol: 'KSM/USDT:USDT',
    markPrice: undefined,
    indexPrice: undefined,
    interestRate: 0,
    estimatedSettlePrice: undefined,
    timestamp: 1658628659001,
    datetime: '2022-07-24T02:10:59.001Z',
    fundingRate: -0.00006542,
    fundingTimestamp: 1658631600000,
    fundingDatetime: '2022-07-24T03:00:00.000Z',
    nextFundingRate: undefined,
    nextFundingTimestamp: undefined,
    nextFundingDatetime: undefined,
    previousFundingRate: -0.00006508,
    previousFundingTimestamp: 1658628000000,
    previousFundingDatetime: '2022-07-24T02:00:00.000Z'
  }
}
```