### PR TITLE
kucoin fetchBalance stuck at trade account

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -434,6 +434,7 @@ module.exports = class kucoin extends Exchange {
                     'main': 'main',
                     'funding': 'main',
                     'future': 'contract',
+                    'swap': 'contract',
                     'mining': 'pool',
                 },
                 'networks': {

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -388,7 +388,6 @@ module.exports = class kucoin extends Exchange {
                 'version': 'v1',
                 'symbolSeparator': '-',
                 'fetchMyTradesMethod': 'private_get_fills',
-                'fetchBalance': 'trade',
                 'fetchMarkets': {
                     'fetchTickersFees': true,
                 },


### PR DESCRIPTION
fetchBalance here should be removed
it is blocking fetchbalance to return the account selected.
```
import ccxt
client = ccxt.kucoin({
    'apiKey': api_key,
    'secret': secret,
    'password': password,
    'options': {
        'defaultType': 'margin' # spot, trade, margin, main
   }
})
print(client.fetch_balance()) # this returns trade account result instead of margin account. or whichever account that was set
```
