### PR TITLE
binance: add more portfolio margin apis

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -336,7 +336,8 @@ module.exports = class binance extends Exchange {
                         'algo/futures/historicalOrders': 0.1,
                         'algo/futures/subOrders': 0.1,
                         'portfolio/account': 0.1,
-                        'portfolio/collateralRate': 0.1,
+                        'portfolio/collateralRate': 5,
+                        'portfolio/pmLoan': 3.3335,
                         // staking
                         'staking/productList': 0.1,
                         'staking/position': 0.1,
@@ -423,6 +424,7 @@ module.exports = class binance extends Exchange {
                         'staking/purchase': 0.1,
                         'staking/redeem': 0.1,
                         'staking/setAutoStaking': 0.1,
+                        'portfolio/repay': 20.001,
                     },
                     'put': {
                         'userDataStream': 0.1,


### PR DESCRIPTION
Add these api in Binance:

GET `/sapi/v1/portfolio/pmLoan` Query Portfolio Margin Bankruptcy Loan Record
POST `/sapi/v1/portfolio/repay` Portfolio Margin Bankruptcy Loan Repay