### PR TITLE
gate fetchSpotMarkets max cost

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -759,7 +759,7 @@ module.exports = class gate extends Exchange {
                     },
                     'cost': {
                         'min': this.safeNumber (market, 'min_quote_amount'),
-                        'max': undefined,
+                        'max': margin ? this.safeNumber (market, 'max_quote_amount') : undefined,
                     },
                 },
                 'info': market,

--- a/js/gate.js
+++ b/js/gate.js
@@ -759,7 +759,7 @@ module.exports = class gate extends Exchange {
                     },
                     'cost': {
                         'min': this.safeNumber (market, 'min_quote_amount'),
-                        'max': this.safeNumber (market, 'max_quote_amount'),
+                        'max': undefined,
                     },
                 },
                 'info': market,


### PR DESCRIPTION
`max_quote_amount` probably actual for margin trading, but for spot markets it is not actual, I can create order more than specified