### PR TITLE
Bitmart: add transfer

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -78,7 +78,7 @@ module.exports = class bitmart extends Exchange {
                 'repayMargin': true,
                 'setLeverage': false,
                 'setMarginMode': false,
-                'transfer': false,
+                'transfer': true,
                 'withdraw': true,
             },
             'hostname': 'bitmart.com', // bitmart.info, bitmart.news for Hong Kong users
@@ -2768,6 +2768,88 @@ module.exports = class bitmart extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': info,
+        };
+    }
+
+    async transfer (code, amount, fromAccount, toAccount, params = {}) {
+        /**
+         * @method
+         * @name bitmart#transfer
+         * @description transfer currency internally between wallets on the same account
+         * @see https://developer-pro.bitmart.com/en/spot/#margin-asset-transfer
+         * @param {string} code unified currency code
+         * @param {float} amount amount to transfer
+         * @param {string} fromAccount account to transfer from
+         * @param {string} toAccount account to transfer to
+         * @param {object} params extra parameters specific to the bitmart api endpoint
+         * @returns {object} a [transfer structure]{@link https://docs.ccxt.com/en/latest/manual.html#transfer-structure}
+         */
+        const symbol = this.safeString (params, 'symbol');
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' transfer() requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const currency = this.currency (code);
+        const amountToPrecision = this.currencyToPrecision (code, amount);
+        const request = {
+            'amount': amountToPrecision,
+            'currency': currency['id'],
+            'symbol': market['id'],
+        };
+        if ((fromAccount === 'spot') && (toAccount === 'margin')) {
+            request['side'] = 'in';
+        } else if ((fromAccount === 'margin') && (toAccount === 'spot')) {
+            request['side'] = 'out';
+        }
+        params = this.omit (params, 'symbol');
+        const response = await this.privatePostSpotV1MarginIsolatedTransfer (this.extend (request, params));
+        //
+        //     {
+        //         "message": "OK",
+        //         "code": 1000,
+        //         "trace": "b26cecec-ef5a-47d9-9531-2bd3911d3d55",
+        //         "data": {
+        //             "transfer_id": "ca90d97a621e47d49774f19af6b029f5"
+        //         }
+        //     }
+        //
+        return this.extend (this.parseTransfer (response, currency), {
+            'amount': this.parseNumber (amountToPrecision),
+            'fromAccount': fromAccount,
+            'toAccount': toAccount,
+        });
+    }
+
+    parseTransferStatus (status) {
+        const statuses = {
+            '1000': 'ok',
+            'OK': 'ok',
+        };
+        return this.safeString (statuses, status, status);
+    }
+
+    parseTransfer (transfer, currency = undefined) {
+        //
+        //     {
+        //         "message": "OK",
+        //         "code": 1000,
+        //         "trace": "b26cecec-ef5a-47d9-9531-2bd3911d3d55",
+        //         "data": {
+        //             "transfer_id": "ca90d97a621e47d49774f19af6b029f5"
+        //         }
+        //     }
+        //
+        const data = this.safeValue (transfer, 'data', {});
+        return {
+            'id': this.safeString (data, 'transfer_id'),
+            'timestamp': undefined,
+            'datetime': undefined,
+            'currency': this.safeCurrencyCode (undefined, currency),
+            'amount': undefined,
+            'fromAccount': undefined,
+            'toAccount': undefined,
+            'status': this.parseTransferStatus (this.safeString2 (transfer, 'code', 'message')),
         };
     }
 

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2775,7 +2775,7 @@ module.exports = class bitmart extends Exchange {
         /**
          * @method
          * @name bitmart#transfer
-         * @description transfer currency internally between wallets on the same account
+         * @description transfer currency internally between wallets on the same account, currently only supports transfer between spot and margin
          * @see https://developer-pro.bitmart.com/en/spot/#margin-asset-transfer
          * @param {string} code unified currency code
          * @param {float} amount amount to transfer


### PR DESCRIPTION
Added the transfer method with margin account functionality:

### Transfer Out:
```
node examples/js/cli bitmart transfer USDT 10 margin spot '{"symbol":"BTC_USDT"}'

bitmart.transfer (USDT, 10, margin, spot, [object Object])
2022-07-25T21:49:28.123Z iteration 0 passed in 1323 ms

{
  id: '93cb51524b3e434da3b8715f4e6b290a',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 10,
  fromAccount: 'margin',
  toAccount: 'spot',
  status: 'ok'
}
2022-07-25T21:49:28.123Z iteration 1 passed in 1323 ms
```

### Transfer In:
```
node examples/js/cli bitmart transfer USDT 10 spot margin '{"symbol":"BTC_USDT"}'

bitmart.transfer (USDT, 10, spot, margin, [object Object])
2022-07-25T21:51:22.214Z iteration 0 passed in 1202 ms

{
  id: '762e66fa44144fb08aec720d62afc3dd',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 10,
  fromAccount: 'spot',
  toAccount: 'margin',
  status: 'ok'
}
2022-07-25T21:51:22.214Z iteration 1 passed in 1202 ms
```