### PR TITLE
gate: fix setLeverage ccxt/ccxt#14495

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -3972,14 +3972,10 @@ module.exports = class gate extends Exchange {
             leverage = crossLeverageLimit;
         }
         if (marginMode === 'cross' || marginMode === 'cross_margin') {
-            request['query'] = {
-                'cross_leverage_limit': leverage.toString (),
-                'leverage': '0',
-            };
+            request['cross_leverage_limit'] = leverage.toString ();
+            request['leverage'] = '0';
         } else {
-            request['query'] = {
-                'leverage': leverage.toString (),
-            };
+            request['leverage'] = leverage.toString ();
         }
         const response = await this[method] (this.extend (request, query));
         //


### PR DESCRIPTION
fix ccxt/ccxt#11495

It turns we had `query` object for gate signing and the signing function encodes the `{ query: {...}}`. Also we didn't use `query` a lot in code.

In the PR, I remove the query when call `setLeverage`.

```
$ node examples/js/cli gateio set_leverage 3 ETH/USDT:USDT --verbose --swap
Node.js: v14.17.0
CCXT v1.91.22
gateio.set_leverage (3, ETH/USDT:USDT)
fetch Request:
 gateio POST https://api.gateio.ws/api/v4/futures/usdt/positions/ETH_USDT/leverage?leverage=3 
RequestHeaders:
 {
  ...
} 
RequestBody:
 undefined 

handleRestResponse:
 gateio POST https://api.gateio.ws/api/v4/futures/usdt/positions/ETH_USDT/leverage?leverage=3 200 OK 
ResponseHeaders:
 {
...
} 
ResponseBody:
 {"value":"0","leverage":"3","mode":"single",...}
 

2022-07-26T06:22:16.401Z iteration 0 passed in 55 ms

{
  value: '0',
  leverage: '3',
  mode: 'single',
  ...
}
2022-07-26T06:22:16.401Z iteration 1 passed in 55 ms
```

Maybe we can revert previous change and update code to use `query` instead.