### PR TITLE
binance - fix limit issue

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3414,6 +3414,9 @@ module.exports = class binance extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
+            if (type === 'future' || type === 'delivery') {
+                limit = Math.min (limit, 1000); // above 1000, returns error
+            }
             request['limit'] = limit;
         }
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
fixes #9904 :
I've reproduced and if above limit `1000` was being sent , fapi/dapi triggers error.
I think we have to cap it at max 1000, so avoid error. 