### PR TITLE
Kucoin: add fetchBorrowInterest

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -41,6 +41,7 @@ module.exports = class kucoin extends Exchange {
                 'createStopOrder': true,
                 'fetchAccounts': true,
                 'fetchBalance': true,
+                'fetchBorrowInterest': true,
                 'fetchBorrowRate': false,
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': true,
@@ -158,6 +159,8 @@ module.exports = class kucoin extends Exchange {
                         'limit/orders': 1,
                         'fills': 6.66667, // 9/3s = 3/s => cost  = 20 / 3 = 6.666667
                         'limit/fills': 1,
+                        'isolated/accounts': 2, // 30/3s = 10/s => cost = 20 / 10 = 2
+                        'isolated/account/{symbol}': 2,
                         'margin/account': 1,
                         'margin/borrow': 1,
                         'margin/borrow/outstanding': 1,
@@ -2786,6 +2789,173 @@ module.exports = class kucoin extends Exchange {
             'rate': this.safeNumber (info, 'dailyIntRate'),
             'period': 86400000,
             'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': info,
+        };
+    }
+
+    async fetchBorrowInterest (code = undefined, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name kucoin#fetchBorrowInterest
+         * @description fetch the interest owed by the user for borrowing currency for margin trading
+         * @see https://docs.kucoin.com/#get-repay-record
+         * @see https://docs.kucoin.com/#query-isolated-margin-account-info
+         * @param {string|undefined} code unified currency code
+         * @param {string|undefined} symbol unified market symbol, required for isolated margin
+         * @param {int|undefined} since the earliest time in ms to fetch borrrow interest for
+         * @param {int|undefined} limit the maximum number of structures to retrieve
+         * @param {object} params extra parameters specific to the kucoin api endpoint
+         * @returns {[object]} a list of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure}
+         */
+        await this.loadMarkets ();
+        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
+        const marginMode = this.safeString (params, 'marginMode', defaultMarginMode); // cross or isolated
+        const request = {};
+        let method = 'privateGetMarginBorrowOutstanding';
+        if (marginMode === 'isolated') {
+            if (code !== undefined) {
+                const currency = this.currency (code);
+                request['balanceCurrency'] = currency['id'];
+            }
+            method = 'privateGetIsolatedAccounts';
+        } else {
+            if (code !== undefined) {
+                const currency = this.currency (code);
+                request['currency'] = currency['id'];
+            }
+        }
+        const response = await this[method] (this.extend (request, params));
+        //
+        // Cross
+        //
+        //     {
+        //         "code": "200000",
+        //         "data": {
+        //             "currentPage": 1,
+        //             "pageSize": 10,
+        //             "totalNum": 1,
+        //             "totalPage": 1,
+        //             "items": [
+        //                 {
+        //                     "tradeId": "62e1e320ff219600013b44e2",
+        //                     "currency": "USDT",
+        //                     "principal": "100",
+        //                     "accruedInterest": "0.00016667",
+        //                     "liability": "100.00016667",
+        //                     "repaidSize": "0",
+        //                     "dailyIntRate": "0.00004",
+        //                     "term": 7,
+        //                     "createdAt": 1658970912000,
+        //                     "maturityTime": 1659575713000
+        //                 }
+        //             ]
+        //         }
+        //     }
+        //
+        // Isolated
+        //
+        //     {
+        //         "code": "200000",
+        //         "data": {
+        //             "symbol": "BTC-USDT",
+        //             "status": "CLEAR",
+        //             "debtRatio": "0",
+        //             "baseAsset": {
+        //                 "currency": "BTC",
+        //                 "totalBalance": "0",
+        //                 "holdBalance": "0",
+        //                 "availableBalance": "0",
+        //                 "liability": "0",
+        //                 "interest": "0",
+        //                 "borrowableAmount": "0.0592"
+        //             },
+        //             "quoteAsset": {
+        //                 "currency": "USDT",
+        //                 "totalBalance": "149.99991731",
+        //                 "holdBalance": "0",
+        //                 "availableBalance": "149.99991731",
+        //                 "liability": "0",
+        //                 "interest": "0",
+        //                 "borrowableAmount": "1349"
+        //             }
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const assets = (marginMode === 'isolated') ? this.safeValue (data, 'assets', []) : this.safeValue (data, 'items', []);
+        return this.parseBorrowInterests (assets, undefined);
+    }
+
+    parseBorrowInterest (info, market = undefined) {
+        //
+        // Cross
+        //
+        //     {
+        //         "tradeId": "62e1e320ff219600013b44e2",
+        //         "currency": "USDT",
+        //         "principal": "100",
+        //         "accruedInterest": "0.00016667",
+        //         "liability": "100.00016667",
+        //         "repaidSize": "0",
+        //         "dailyIntRate": "0.00004",
+        //         "term": 7,
+        //         "createdAt": 1658970912000,
+        //         "maturityTime": 1659575713000
+        //     },
+        //
+        // Isolated
+        //
+        //     {
+        //         "symbol": "BTC-USDT",
+        //         "status": "CLEAR",
+        //         "debtRatio": "0",
+        //         "baseAsset": {
+        //             "currency": "BTC",
+        //             "totalBalance": "0",
+        //             "holdBalance": "0",
+        //             "availableBalance": "0",
+        //             "liability": "0",
+        //             "interest": "0",
+        //             "borrowableAmount": "0.0592"
+        //         },
+        //         "quoteAsset": {
+        //             "currency": "USDT",
+        //             "totalBalance": "149.99991731",
+        //             "holdBalance": "0",
+        //             "availableBalance": "149.99991731",
+        //             "liability": "0",
+        //             "interest": "0",
+        //             "borrowableAmount": "1349"
+        //         }
+        //     },
+        //
+        const marketId = this.safeString (info, 'symbol');
+        const marginMode = (marketId === undefined) ? 'cross' : 'isolated';
+        market = this.safeMarket (marketId, market);
+        const symbol = this.safeString (market, 'symbol');
+        const timestamp = this.safeNumber (info, 'createdAt');
+        const isolatedBase = this.safeValue (info, 'baseAsset', {});
+        let amountBorrowed = undefined;
+        let interest = undefined;
+        let currencyId = undefined;
+        if (marginMode === 'isolated') {
+            amountBorrowed = this.safeNumber (isolatedBase, 'liability');
+            interest = this.safeNumber (isolatedBase, 'interest');
+            currencyId = this.safeString (isolatedBase, 'currency');
+        } else {
+            amountBorrowed = this.safeNumber (info, 'principal');
+            interest = this.safeNumber (info, 'accruedInterest');
+            currencyId = this.safeString (info, 'currency');
+        }
+        return {
+            'symbol': symbol,
+            'marginMode': marginMode,
+            'currency': this.safeCurrencyCode (currencyId),
+            'interest': interest,
+            'interestRate': this.safeNumber (info, 'dailyIntRate'),
+            'amountBorrowed': amountBorrowed,
+            'timestamp': timestamp,  // create time
             'datetime': this.iso8601 (timestamp),
             'info': info,
         };

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -2940,7 +2940,7 @@ module.exports = class kucoin extends Exchange {
         const marginMode = (marketId === undefined) ? 'cross' : 'isolated';
         market = this.safeMarket (marketId, market);
         const symbol = this.safeString (market, 'symbol');
-        const timestamp = this.safeNumber (info, 'createdAt');
+        const timestamp = this.safeInteger (info, 'createdAt');
         const isolatedBase = this.safeValue (info, 'baseAsset', {});
         let amountBorrowed = undefined;
         let interest = undefined;

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -2858,27 +2858,33 @@ module.exports = class kucoin extends Exchange {
         //     {
         //         "code": "200000",
         //         "data": {
-        //             "symbol": "BTC-USDT",
-        //             "status": "CLEAR",
-        //             "debtRatio": "0",
-        //             "baseAsset": {
-        //                 "currency": "BTC",
-        //                 "totalBalance": "0",
-        //                 "holdBalance": "0",
-        //                 "availableBalance": "0",
-        //                 "liability": "0",
-        //                 "interest": "0",
-        //                 "borrowableAmount": "0.0592"
-        //             },
-        //             "quoteAsset": {
-        //                 "currency": "USDT",
-        //                 "totalBalance": "149.99991731",
-        //                 "holdBalance": "0",
-        //                 "availableBalance": "149.99991731",
-        //                 "liability": "0",
-        //                 "interest": "0",
-        //                 "borrowableAmount": "1349"
-        //             }
+        //             "totalConversionBalance": "0.02138647",
+        //             "liabilityConversionBalance": "0.01480001",
+        //             "assets": [
+        //                 {
+        //                     "symbol": "NKN-USDT",
+        //                     "status": "CLEAR",
+        //                     "debtRatio": "0",
+        //                     "baseAsset": {
+        //                         "currency": "NKN",
+        //                         "totalBalance": "0",
+        //                         "holdBalance": "0",
+        //                         "availableBalance": "0",
+        //                         "liability": "0",
+        //                         "interest": "0",
+        //                         "borrowableAmount": "0"
+        //                     },
+        //                     "quoteAsset": {
+        //                         "currency": "USDT",
+        //                         "totalBalance": "0",
+        //                         "holdBalance": "0",
+        //                         "availableBalance": "0",
+        //                         "liability": "0",
+        //                         "interest": "0",
+        //                         "borrowableAmount": "0"
+        //                     }
+        //                 },
+        //             ]
         //         }
         //     }
         //


### PR DESCRIPTION
### Cross:
```
node examples/js/cli kucoin fetchBorrowInterest

kucoin.fetchBorrowInterest ()
2022-07-28T01:21:38.762Z iteration 0 passed in 272 ms

symbol | marginMode | currency |   interest | interestRate | amountBorrowed |     timestamp |                 datetime
----------------------------------------------------------------------------------------------------------------------
       |      cross |     USDT | 0.00016667 |      0.00004 |            100 | 1658970912000 | 2022-07-28T01:15:12.000Z
1 objects
2022-07-28T01:21:38.762Z iteration 1 passed in 272 ms
```

### Isolated:
```
node examples/js/cli kucoin fetchBorrowInterest undefined undefined undefined undefined '{"marginMode":"isolated"}'

kucoin.fetchBorrowInterest (, , , , [object Object])
2022-07-28T01:40:53.851Z iteration 0 passed in 312 ms

       symbol | marginMode | currency | interest | interestRate | amountBorrowed | timestamp | datetime
-------------------------------------------------------------------------------------------------------
     GMT/USDT |   isolated |      GMT |        0 |              |              0 |           |
     BTC/USDT |   isolated |      BTC |     1e-8 |              |         0.0148 |           |
     WOO/USDT |   isolated |      WOO |        0 |              |              0 |           |
...
212 objects
2022-07-28T01:40:53.851Z iteration 1 passed in 312 ms
```