### PR TITLE
Fix novadax private requests.

### DIFF
--- a/js/novadax.js
+++ b/js/novadax.js
@@ -1491,7 +1491,7 @@ module.exports = class novadax extends Exchange {
             let queryString = undefined;
             if (method === 'POST') {
                 body = this.json (query);
-                queryString = this.hash (body, 'md5');
+                queryString = this.hash (this.encode (body), 'md5');
                 headers['Content-Type'] = 'application/json';
             } else {
                 if (Object.keys (query).length) {


### PR DESCRIPTION
By encoding the request before hashing. In python 3.x, the previous version would translate into calling hashlib with a Unicode `str`, instead of the expected `bytes` type.