### PR TITLE
Reset package-lock.json yarn.lock when cleanup

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-git checkout HEAD package.json README.md ccxt.d.ts ccxt.js wiki python php dist doc
+git checkout HEAD package.json package-lock.json yarn.lock README.md ccxt.d.ts ccxt.js wiki python php dist doc


### PR DESCRIPTION
I found it's useful to reset npm/yarn lock files as well, because I accidentally update these files sometimes.