### PR TITLE
bitget - fix transaction type

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2435,7 +2435,7 @@ module.exports = class bitget extends Exchange {
         const timestamp = this.safeInteger (item, 'cTime');
         const bizType = this.safeString (item, 'bizType');
         let direction = undefined;
-        if (bizType !== undefined && bizType.indexOf ('-') !== -1) {
+        if (bizType !== undefined && bizType.indexOf ('-') >= 0) {
             const parts = bizType.split ('-');
             direction = parts[1];
         }

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2435,7 +2435,7 @@ module.exports = class bitget extends Exchange {
         const timestamp = this.safeInteger (item, 'cTime');
         const bizType = this.safeString (item, 'bizType');
         let direction = undefined;
-        if (bizType !== undefined) {
+        if (bizType !== undefined && bizType.indexOf ('-') !== -1) {
             const parts = bizType.split ('-');
             direction = parts[1];
         }


### PR DESCRIPTION
fetch_ledger returns also deposits:
`{'billId': '926384975238303748', 'coinId': '1', 'coinName': 'BTC', 'groupType': 'deposit', 'bizType': 'deposit', 'quantity': '0.00246856', 'balance': '0.00246856', 'fees': '0.00000000', 'cTime': '1656593310172'}`

parse_ledger fails for property bizType, because of the split
```
venv\lib\site-packages\ccxt\bitget.py", line 2344, in parse_ledger_entry
    direction = parts[1]
IndexError: list index out of range
```

this small fix will only split the value to extract direction for the trades and not for deposits and withdraws