### PR TITLE
bitbns - add withdrawal type detection

### DIFF
--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -1065,12 +1065,13 @@ module.exports = class bitbns extends Exchange {
         const code = this.safeCurrencyCode (currencyId, currency);
         const timestamp = this.parse8601 (this.safeString (transaction, 'date'));
         let type = this.safeString (transaction, 'type');
+        const expTime = this.safeString (transaction, 'expTime');
         let status = undefined;
         if (type !== undefined) {
             if (type.indexOf ('deposit') >= 0) {
                 type = 'deposit';
                 status = 'ok';
-            } else if (type.indexOf ('withdraw') >= 0) {
+            } else if (type.indexOf ('withdraw') >= 0 || expTime.indexOf ('withdraw') >= 0) {
                 type = 'withdrawal';
             }
         }

--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -1065,7 +1065,7 @@ module.exports = class bitbns extends Exchange {
         const code = this.safeCurrencyCode (currencyId, currency);
         const timestamp = this.parse8601 (this.safeString (transaction, 'date'));
         let type = this.safeString (transaction, 'type');
-        const expTime = this.safeString (transaction, 'expTime');
+        const expTime = this.safeString (transaction, 'expTime', '');
         let status = undefined;
         if (type !== undefined) {
             if (type.indexOf ('deposit') >= 0) {


### PR DESCRIPTION
Following the response from exchange for withdrawal:
```
{'type': '0', 'amount': '97.17', 'unit': 'USDT', 'timestamp': '2022-07-28T18:54:46.000Z', 'hash': 'ABC', 'fee': '2', 'to': 'ABC', 'status': '2', 'canSendMail': '0', 'cancelable': '-1', 'refer': '1155080', 'expTime': 'USDT withdraw done'}
```
The relevant information can be found in the `expTime` property

I`m leaving the original detection there aswell, maybe for some cases (different coins) this could work, I was not testing different coin withdrawals.