### PR TITLE
Whitebit: add margin support to fetchMarkets

### DIFF
--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -152,6 +152,7 @@ module.exports = class whitebit extends Exchange {
                     'public': {
                         'get': [
                             'assets',
+                            'collateral/markets',
                             'fee',
                             'orderbook/{market}',
                             'ticker',
@@ -242,6 +243,8 @@ module.exports = class whitebit extends Exchange {
          * @method
          * @name whitebit#fetchMarkets
          * @description retrieves data on all markets for whitebit
+         * @see https://github.com/whitebit-exchange/api-docs/blob/main/docs/Public/http-v2.md#market-info
+         * @see https://github.com/whitebit-exchange/api-docs/blob/main/docs/Public/http-v4.md#collateral-markets-list
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[object]} an array of objects representing market data
          */
@@ -252,22 +255,30 @@ module.exports = class whitebit extends Exchange {
         //        "message": "",
         //        "result": [
         //            {
-        //                "name":
-        //                "C98_USDT",
-        //                "stock":"C98",
-        //                "money":"USDT",
-        //                "stockPrec":"3",
-        //                "moneyPrec":"5",
-        //                "feePrec":"6",
-        //                "makerFee":"0.001",
-        //                "takerFee":"0.001",
-        //                "minAmount":"2.5",
-        //                "minTotal":"5.05",
-        //                "tradesEnabled":true
+        //                "name": "C98_USDT",
+        //                "stock": "C98",
+        //                "money": "USDT",
+        //                "stockPrec": "3",
+        //                "moneyPrec": "5",
+        //                "feePrec": "6",
+        //                "makerFee": "0.001",
+        //                "takerFee": "0.001",
+        //                "minAmount": "2.5",
+        //                "minTotal": "5.05",
+        //                "tradesEnabled": true
         //            },
         //            ...
         //        ]
         //    }
+        //
+        const marginMarkets = await this.v4PublicGetCollateralMarkets (params);
+        //
+        //     [
+        //         "ADA_BTC",
+        //         "ADA_USDT",
+        //         "APE_USDT",
+        //         ...
+        //     ]
         //
         const markets = this.safeValue (response, 'result', []);
         const result = [];
@@ -291,7 +302,7 @@ module.exports = class whitebit extends Exchange {
                 'settleId': undefined,
                 'type': 'spot',
                 'spot': true,
-                'margin': undefined,
+                'margin': (marginMarkets.indexOf (id) >= 0) ? true : false,
                 'swap': false,
                 'future': false,
                 'option': false,

--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -297,7 +297,7 @@ module.exports = class whitebit extends Exchange {
             const quote = this.safeCurrencyCode (quoteId);
             const symbol = base + '/' + quote;
             const active = this.safeValue (market, 'tradesEnabled');
-            const isMargin = (marginMarkets.indexOf (id) >= 0) ? true : false;
+            const isMargin = this.inArray (id, marginMarkets);
             const entry = {
                 'id': id,
                 'symbol': symbol,


### PR DESCRIPTION
Added margin support to fetchMarkets:
```
whitebit.fetchMarkets ()
2022-08-02T06:12:35.560Z iteration 0 passed in 1351 ms

         id |      symbol |   base | quote | settle | baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | taker | maker | contractSize | expiry | expiryDatetime | strike | optionType |                          precision |
                                             limits
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1INCH_BTC |   1INCH/BTC |  1INCH |   BTC |        |  1INCH |     BTC |          | spot | true |  false | false |  false |  false |   true |    false |        |         |   0.1 |   0.1 |              |        |                |        |            |          {"amount":1,"price":1e-8} |         {"leverage":{},"amount":{"min":2},"price":{},"cost":{"min":0.0001}}
  1INCH_UAH |   1INCH/UAH |  1INCH |   UAH |        |  1INCH |     UAH |          | spot | true |  false | false |  false |  false |   true |    false |        |         |   0.1 |   0.1 |              |        |                |        |            |   {"amount":0.01,"price":0.000001} |            {"leverage":{},"amount":{"min":2},"price":{},"cost":{"min":140}}
    ADA_BTC |     ADA/BTC |    ADA |   BTC |        |    ADA |     BTC |          | spot | true |   true | false |  false |  false |   true |    false |        |         |   0.1 |   0.1 |              |        |                |        |            |          {"amount":1,"price":1e-8} |         {"leverage":{},"amount":{"min":3},"price":{},"cost":{"min":0.0001}}
...
```