### PR TITLE
aax.createOrder postOnly bug

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -1288,11 +1288,15 @@ module.exports = class aax extends Exchange {
         if (clientOrderId !== undefined) {
             request['clOrdID'] = clientOrderId;
         }
-        const postOnly = this.safeValue (params, 'postOnly', false);
-        if (postOnly !== undefined) {
+        const postOnly = this.isPostOnly (orderType === 'MARKET', undefined, params);
+        const timeInForce = this.safeString (params, 'timeInForce');
+        if (postOnly) {
             request['execInst'] = 'Post-Only';
         }
-        params = this.omit (params, [ 'clOrdID', 'clientOrderId', 'postOnly' ]);
+        if (timeInForce !== undefined && timeInForce !== 'PO') {
+            request['timeInForce'] = timeInForce;
+        }
+        params = this.omit (params, [ 'clOrdID', 'clientOrderId', 'postOnly', 'timeInForce' ]);
         const stopPrice = this.safeNumber (params, 'stopPrice');
         if (stopPrice === undefined) {
             if ((orderType === 'STOP-LIMIT') || (orderType === 'STOP')) {


### PR DESCRIPTION
# SWAP

```
 % aax createOrder ADA/USDT:USDT market buy 10
2022-08-03T09:37:01.629Z
Node.js: v18.4.0
CCXT v1.91.64
(node:45746) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.createOrder (ADA/USDT:USDT, market, buy, 10)
2022-08-03T09:37:06.228Z iteration 0 passed in 990 ms

{
  id: '2bXYD3cyoU',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '1',
    leverage: '10',
    marketPrice: '0.508651',
    code: 'FP',
    avgPrice: '0',
    execInst: null,
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '0.524271',
    orderQty: '10',
    commission: '0',
    id: '474994132905168896',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '2bXYD3cyoU',
    leavesQty: '10',
    cumQty: '0',
    priceType: '0',
    updateTime: null,
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-08-03T09:37:06.248Z',
    transactTime: null,
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1659519426248,
  datetime: '2022-08-03T09:37:06.248Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'market',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.524271,
  stopPrice: 0,
  average: undefined,
  amount: 10,
  filled: 0,
  remaining: 10,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
2022-08-03T09:37:06.228Z iteration 1 passed in 990 ms

% aax createOrder ADA/USDT:USDT limit buy 10 0.49
2022-08-03T09:37:31.549Z
Node.js: v18.4.0
CCXT v1.91.64
(node:45768) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.createOrder (ADA/USDT:USDT, limit, buy, 10, 0.49)
2022-08-03T09:37:35.945Z iteration 0 passed in 1034 ms

{
  id: '2bXYLyrmjC',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '2',
    leverage: '10',
    marketPrice: '0.508951',
    code: 'FP',
    avgPrice: '0',
    execInst: null,
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '0.49',
    orderQty: '10',
    commission: '0',
    id: '474994257555689472',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '2bXYLyrmjC',
    leavesQty: '10',
    cumQty: '0',
    priceType: null,
    updateTime: null,
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-08-03T09:37:35.967Z',
    transactTime: null,
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1659519455967,
  datetime: '2022-08-03T09:37:35.967Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.49,
  stopPrice: 0,
  average: undefined,
  amount: 10,
  filled: 0,
  remaining: 10,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
2022-08-03T09:37:35.945Z iteration 1 passed in 1034 ms

% aax createOrder ADA/USDT:USDT limit buy 10 0.49 '{"postOnly": true}'
2022-08-03T09:38:35.977Z
Node.js: v18.4.0
CCXT v1.91.64
(node:45818) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.createOrder (ADA/USDT:USDT, limit, buy, 10, 0.49, [object Object])
2022-08-03T09:38:40.537Z iteration 0 passed in 1000 ms

{
  id: '2bXZ42uNZ6',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '2',
    leverage: '10',
    marketPrice: '0.508642',
    code: 'FP',
    avgPrice: '0',
    execInst: 'Post-Only',
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '0.49',
    orderQty: '10',
    commission: '0',
    id: '474994528507727872',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '2bXZ42uNZ6',
    leavesQty: '10',
    cumQty: '0',
    priceType: null,
    updateTime: null,
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-08-03T09:38:40.567Z',
    transactTime: null,
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1659519520567,
  datetime: '2022-08-03T09:38:40.567Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 0.49,
  stopPrice: 0,
  average: undefined,
  amount: 10,
  filled: 0,
  remaining: 10,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
2022-08-03T09:38:40.537Z iteration 1 passed in 1000 ms

% aax createOrder ADA/USDT:USDT limit buy 10 0.49 '{"timeInForce": "PO"}'
2022-08-03T09:38:57.538Z
Node.js: v18.4.0
CCXT v1.91.64
(node:45836) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.createOrder (ADA/USDT:USDT, limit, buy, 10, 0.49, [object Object])
2022-08-03T09:39:02.030Z iteration 0 passed in 1012 ms

{
  id: '2bXZabGZtC',
  info: {
    liqType: '0',
    symbol: 'ADAUSDTFP',
    orderType: '2',
    leverage: '10',
    marketPrice: '0.508651',
    code: 'FP',
    avgPrice: '0',
    execInst: 'Post-Only',
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '0.49',
    orderQty: '10',
    commission: '0',
    id: '474994618630737920',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '2bXZabGZtC',
    leavesQty: '10',
    cumQty: '0',
    priceType: null,
    updateTime: null,
    bonusID: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-08-03T09:39:02.054Z',
    transactTime: null,
    settleType: 'VANILLA',
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1659519542054,
  datetime: '2022-08-03T09:39:02.054Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 0.49,
  stopPrice: 0,
  average: undefined,
  amount: 10,
  filled: 0,
  remaining: 10,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
2022-08-03T09:39:02.030Z iteration 1 passed in 1012 ms
```

# SPOT

```
% aax createOrder ADA/USDT limit buy 21 0.49
2022-08-03T09:41:53.638Z
Node.js: v18.4.0
CCXT v1.91.64
(node:45917) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.createOrder (ADA/USDT, limit, buy, 21, 0.49)
2022-08-03T09:41:58.164Z iteration 0 passed in 993 ms

{
  id: '2bXZYAwnh6',
  info: {
    symbol: 'ADAUSDT',
    orderType: '2',
    avgPrice: '0',
    execInst: null,
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '0.49',
    orderQty: '21',
    commission: '0',
    id: '474995357407055872',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '2bXZYAwnh6',
    leavesQty: '0',
    cumQty: '0',
    priceType: null,
    updateTime: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-08-03T09:41:58.192Z',
    transactTime: null,
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1659519718192,
  datetime: '2022-08-03T09:41:58.192Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.49,
  stopPrice: 0,
  average: undefined,
  amount: 21,
  filled: 0,
  remaining: 21,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
2022-08-03T09:41:58.164Z iteration 1 passed in 993 ms

% aax createOrder ADA/USDT limit buy 21 0.49 '{"postOnly": true}'
2022-08-03T09:42:58.545Z
Node.js: v18.4.0
CCXT v1.91.64
(node:45958) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.createOrder (ADA/USDT, limit, buy, 21, 0.49, [object Object])
2022-08-03T09:43:03.279Z iteration 0 passed in 1005 ms

{
  id: '2bY0hdNMFG',
  info: {
    symbol: 'ADAUSDT',
    orderType: '2',
    avgPrice: '0',
    execInst: 'Post-Only',
    orderStatus: '0',
    userID: '3204388',
    quote: 'USDT',
    rejectReason: null,
    rejectCode: '0',
    price: '0.49',
    orderQty: '21',
    commission: '0',
    id: '474995630540132352',
    timeInForce: '1',
    tradeID: null,
    isTriggered: false,
    side: '1',
    orderID: '2bY0hdNMFG',
    leavesQty: '0',
    cumQty: '0',
    priceType: null,
    updateTime: null,
    lastQty: '0',
    clOrdID: null,
    stopPrice: '0',
    createTime: '2022-08-03T09:43:03.312Z',
    transactTime: null,
    base: 'ADA',
    lastPrice: '0'
  },
  clientOrderId: undefined,
  timestamp: 1659519783312,
  datetime: '2022-08-03T09:43:03.312Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 0.49,
  stopPrice: 0,
  average: undefined,
  amount: 21,
  filled: 0,
  remaining: 21,
  cost: 0,
  trades: [],
  fee: { currency: 'ADA', cost: 0 },
  fees: [ { currency: 'ADA', cost: 0 } ]
}
2022-08-03T09:43:03.279Z iteration 1 passed in 1005 ms
```