### PR TITLE
Bit2c create market buy bug fix

### DIFF
--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -369,7 +369,7 @@ module.exports = class bit2c extends Exchange {
         return result;
     }
 
-    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
+    async createOrder (symbol, type, side, amount, yes = false, price = undefined, params = {}) {
         /**
          * @method
          * @name bit2c#createOrder
@@ -395,6 +395,9 @@ module.exports = class bit2c extends Exchange {
             request['Price'] = price;
             request['Total'] = amount * price;
             request['IsBid'] = (side === 'buy');
+        }
+        if (yes === false) {
+            return request;
         }
         const response = await this[method] (this.extend (request, params));
         return {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -369,7 +369,7 @@ module.exports = class bit2c extends Exchange {
         return result;
     }
 
-    async createOrder (symbol, type, side, amount, yes = false, price = undefined, params = {}) {
+    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
         /**
          * @method
          * @name bit2c#createOrder
@@ -389,15 +389,14 @@ module.exports = class bit2c extends Exchange {
             'Amount': amount,
             'Pair': market['id'],
         };
+        if ('Total' in params) {
+            request['Total'] = params['Total'];
+        }
         if (type === 'market') {
             method += 'MarketPrice' + this.capitalize (side);
         } else {
             request['Price'] = price;
-            request['Total'] = amount * price;
             request['IsBid'] = (side === 'buy');
-        }
-        if (yes === false) {
-            return request;
         }
         const response = await this[method] (this.extend (request, params));
         return {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -396,6 +396,7 @@ module.exports = class bit2c extends Exchange {
             method += 'MarketPrice' + this.capitalize (side);
         } else {
             request['Price'] = price;
+            request['Total'] = amount * price;
             request['IsBid'] = (side === 'buy');
         }
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
As can be seen in this following link : [https://bit2c.co.il/home/api](https://bit2c.co.il/home/api)
bit2c trade API requires 'Total' in the request of 'Add Buy Order market price' method
we added the option to send this parameter after we encountered bugs in creating market orders due to this problem.
