### PR TITLE
kucoin: fetchDepositAddress update

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1128,6 +1128,7 @@ module.exports = class kucoin extends Exchange {
         let network = this.safeStringUpper (params, 'network'); // this line allows the user to specify either ERC20 or ETH
         network = this.safeStringLower (networks, network, network); // handle ERC20>ETH alias
         if (network !== undefined) {
+            network = network.toLowerCase ();
             request['chain'] = network;
             params = this.omit (params, 'network');
         }


### PR DESCRIPTION
remove the need to list out every single network on kucoin just to change it to lowercase

e.g. ETH -> eth, TRX -> trx, KCC -> kcc, LTC -> ltc, BSC -> bsc and so on
```
  'networks': {
      'ETH': 'eth',
      'ERC20': 'eth',
      'TRX': 'trx',
      'TRC20': 'trx',
      'KCC': 'kcc',
      'TERRA': 'luna',
      'LTC': 'ltc',
  },
```