### PR TITLE
gate: fix tag error

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -1509,9 +1509,7 @@ module.exports = class gate extends Exchange {
             }
             const network = this.safeString (entry, 'chain');
             const address = this.safeString (entry, 'address');
-            let tag = this.safeString (entry, 'payment_id');
-            const tagLength = tag.length;
-            tag = tagLength ? tag : undefined;
+            const tag = this.safeString (entry, 'payment_id');
             result[network] = {
                 'info': entry,
                 'code': code,


### PR DESCRIPTION
```
  File "/root/miniconda3/envs/mm/lib/python3.10/site-packages/ccxt/async_support/gate.py", line 1471, in fetch_network_deposit_address
    tagLength = len(tag)                    
TypeError: object of type 'NoneType' has no len() 
```
fix none type error. 