### PR TITLE
exchange - filterBySymbol, filterBySymbolSinceLimit, marketSymbols

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1523,7 +1523,7 @@ module.exports = class Exchange {
         for (let i = 0; i < symbols.length; i++) {
             result.push (this.symbol (symbols[i]));
         }
-        return result;
+        return (result.length === 0) ? undefined : result;
     }
 
     parseBidsAsks (bidasks, priceKey = 0, amountKey = 1) {
@@ -1547,6 +1547,7 @@ module.exports = class Exchange {
         if (symbol === undefined) {
             return objects;
         }
+        symbol = this.symbol (symbol);
         const result = [];
         for (let i = 0; i < objects.length; i++) {
             const objectSymbol = this.safeString (objects[i], 'symbol');
@@ -2424,6 +2425,9 @@ module.exports = class Exchange {
     }
 
     filterBySymbolSinceLimit (array, symbol = undefined, since = undefined, limit = undefined, tail = false) {
+        if (symbol !== undefined) {
+            symbol = this.symbol (symbol);
+        }
         return this.filterByValueSinceLimit (array, 'symbol', symbol, since, limit, 'timestamp', tail);
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1523,7 +1523,8 @@ module.exports = class Exchange {
         for (let i = 0; i < symbols.length; i++) {
             result.push (this.symbol (symbols[i]));
         }
-        return (result.length === 0) ? undefined : result;
+        const resultLength = result.length;
+        return (resultLength === 0) ? undefined : result;
     }
 
     parseBidsAsks (bidasks, priceKey = 0, amountKey = 1) {


### PR DESCRIPTION
- have `filterBySymbolSinceLimit` call `this.symbol ()` to allow the use of both marketId and symbols.

- have `filterBySymbol()` call `this.symbol ()` to allow the use fo both marketId and the unified symbol.

- have `this.marketSymbols()` return `undefined` instead of an empty array. This is because they are many times we check `if (symbols === undefined) ` after calling `this.marketSymbols()` However if the users sends in an empty array as symbols, this can cause errors. Therefore to protect for this I think we should always return undefined instead of an empty array.