### PR TITLE
Fix includes() misusage

### DIFF
--- a/js/latoken.js
+++ b/js/latoken.js
@@ -1469,7 +1469,7 @@ module.exports = class latoken extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         let method = undefined;
-        if (toAccount.includes ('@')) {
+        if (toAccount.indexOf ('@') >= 0) {
             method = 'privatePostAuthTransferEmail';
         } else if (toAccount.length === 36) {
             method = 'privatePostAuthTransferId';

--- a/js/okx.js
+++ b/js/okx.js
@@ -4905,7 +4905,7 @@ module.exports = class okx extends Exchange {
         for (let i = 0; i < response.length; i++) {
             const item = response[i];
             const code = this.safeCurrencyCode (this.safeString (item, 'ccy'));
-            if (codes === undefined || codes.includes (code)) {
+            if (codes === undefined || this.inArray (code, codes)) {
                 if (!(code in borrowRateHistories)) {
                     borrowRateHistories[code] = [];
                 }


### PR DESCRIPTION
- we cannot use .includes() because it won't be correctly transpiled. 