### PR TITLE
increase throttle stability

### DIFF
--- a/js/base/functions/throttle.js
+++ b/js/base/functions/throttle.js
@@ -3,48 +3,56 @@
 /*  ------------------------------------------------------------------------ */
 
 const { now, sleep } = require ('./time');
-
 /*  ------------------------------------------------------------------------ */
 
+const DEFAULT_CONFIG = {
+    refillRate: 1.0,
+    delay: 0.001,
+    capacity: 1.0,
+    maxCapacity: Number.MAX_SAFE_INTEGER,
+    tokens: 0,
+    cost: 1.0,
+    lastTimestamp: 0,
+};
+
 class Throttle {
-    constructor (config) {
-        this.config = {
-            refillRate: 1.0,
-            delay: 0.001,
-            capacity: 1.0,
-            maxCapacity: 2000,
-            tokens: 0,
-            cost: 1.0,
-        };
-        Object.assign (this.config, config);
+    constructor () {
         this.queue = [];
         this.running = false;
     }
 
+    instanceOf (config) {
+        return Object.assign ({}, DEFAULT_CONFIG, config);
+    }
+
     async loop () {
-        let lastTimestamp = now ();
         while (this.running) {
-            const { resolver, cost } = this.queue[0];
-            if (this.config['tokens'] >= 0) {
-                this.config['tokens'] -= cost;
-                resolver ();
-                this.queue.shift ();
-                // contextswitch
-                await Promise.resolve ();
-                if (this.queue.length === 0) {
-                    this.running = false;
+            for (let i = 0; i < this.queue.length; i++) {
+                const { resolver, cost, config } = this.queue[i];
+                if (config['tokens'] >= 0) {
+                    config['tokens'] -= cost;
+                    resolver ();
+                    this.queue.splice (i, 1);
+                    i--;
+                    // contextswitch
+                    await Promise.resolve ();
+                    if (this.queue.length === 0) {
+                        this.running = false;
+                    }
+                } else {
+                    const current = now ();
+                    const elapsed = current - config['lastTimestamp'];
+                    config['lastTimestamp'] = current;
+                    const tokens = config['tokens'] + (config['refillRate'] * elapsed);
+                    config['tokens'] = Math.min (tokens, config['capacity']);
                 }
-            } else {
-                await sleep (this.config['delay'] * 1000);
-                const current = now ();
-                const elapsed = current - lastTimestamp;
-                lastTimestamp = current;
-                const tokens = this.config['tokens'] + (this.config['refillRate'] * elapsed);
-                this.config['tokens'] = Math.min (tokens, this.config['capacity']);
             }
+            await sleep (DEFAULT_CONFIG['delay'] * 1000)
         }
     }
 }
+
+const globalThrottle = new Throttle ()
 
 function throttle (config) {
     function inner (cost = undefined) {
@@ -52,21 +60,25 @@ function throttle (config) {
         const promise = new Promise ((resolve, reject) => {
             resolver = resolve;
         });
-        if (this.queue.length > this.config['maxCapacity']) {
+        if (globalThrottle.queue.length > this['maxCapacity']) {
             throw new Error ('throttle queue is over maxCapacity');
         }
-        cost = (cost === undefined) ? this.config['cost'] : cost;
-        this.queue.push ({ resolver, cost });
-        if (!this.running) {
-            this.running = true;
-            this.loop ();
+        cost = (cost === undefined) ? this['cost'] : cost;
+        this['lastTimestamp'] = now ()
+        globalThrottle.queue.push ({
+            resolver,
+            cost,
+            'config': this,
+        });
+        if (!globalThrottle.running) {
+            globalThrottle.running = true;
+            globalThrottle.loop ()
         }
         return promise;
     }
-    const instance = new Throttle (config);
-    const bound = inner.bind (instance);
+    const configInstance = globalThrottle.instanceOf (config);
+    const bound = inner.bind (configInstance);
     // useful for inspecting the tokenBucket
-    bound.config = instance.config;
     return bound;
 }
 


### PR DESCRIPTION
instead of sampling per throttler we sample once per all of the exchanges. this greatly reduces the overhead, since we are running the throttle code 1000 times per second (once per millisecond) per throttler. instead now we will just run this code once per millisecond for all of the throttlers. it also solves a bug where the first 3 requests are made too quickly and I was helped to find this bug by @DoctorSlimm . this is because lastUpdateTime was not set in the correct place.

here is a sample of code that demonstrates the superiority of having just one throttler (new implementation is 2030ms vs 3000ms):

```
;(async () => {
    const throttlers = []
    for (let i = 0; i < 1000; i++) {
        throttlers.push (throttle ())
    }
    const start = performance.now ()
    for (let i = 0; i < 1000; i++) {
        await Promise.all (throttlers.map (x => x (2)))
    }
    const end = performance.now ()
    console.log (end - start)
}) ()
```

here is a sample of code that demonstrates the bug where the first few requests from the existing throttler are made too quickly (current master gets ddoserrors whereas this edit does not):

```
const okx = new ccxt.okx ()
let count = 0
async function k (exchange, symbol) {
    await exchange.fetchTicker (symbol)
    return [ exchange.lastRestRequestTimestamp, count++ ]
}
;(async () => {
    await okx.loadMarkets ()
    await ccxt.sleep (100)
    while (true) {
        const arr = []
        for (let i = 0; i < 50; i++) {
            arr.push (k (okx, 'ETH/BTC'))
        }
        const timestamps = await Promise.all (arr)
        console.log (timestamps)
    }
}) ()
```
