### PR TITLE
Correctly parse tag for FTX withdrawals

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -2589,6 +2589,8 @@ module.exports = class ftx extends Exchange {
         if (typeof address !== 'string') {
             tag = this.safeString (address, 'tag');
             address = this.safeString (address, 'address');
+        } else {
+            tag = this.safeString (transaction, 'tag');
         }
         if (address === undefined) {
             // parse address from internal transfer


### PR DESCRIPTION
Add logic to parse the destination `tag` information in FTX's withdrawal responses.

Currently, CCXT sets `tag` and `tagTo` to `null` because it isn't able to parse the `tag` attribute directly in the payload.
See API docs: https://docs.ftx.com/#request-withdrawal