### PR TITLE
Add __float__ to python precise class

### DIFF
--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -186,6 +186,9 @@ class Precise:
     def __repr__(self):
         return "Precise(" + str(self) + ")"
 
+    def __float__(self):
+        return float(str(self))
+
     @staticmethod
     def string_mul(string1, string2):
         if string1 is None or string2 is None:


### PR DESCRIPTION
By doing this, running `float(Precise('5.55'))` won't fail anymore.

While this is not a main usecase in ccxt, it'll further enhance the reusability of the Precise string-calculation methods.