### PR TITLE
Okx: fetchBorrowInterest add handleMarginModeAndParams

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -5215,10 +5215,15 @@ module.exports = class okx extends Exchange {
          * @param {int|undefined} limit the number of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure} to retrieve
          * @param {object} params exchange specific parameters
          * @param {int|undefined} params.type Loan type 1 - VIP loans 2 - Market loans *Default is Market loans*
+         * @param {string} params.marginMode 'cross' or 'isolated'
          * @returns {[object]} An list of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure}
          */
         await this.loadMarkets ();
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params);
+        if (marginMode === undefined) {
+            marginMode = this.safeString (params, 'mgnMode', 'cross'); // cross as default marginMode
+        }
         const request = {
             'mgnMode': marginMode,
         };
@@ -5237,7 +5242,7 @@ module.exports = class okx extends Exchange {
             market = this.market (symbol);
             request['instId'] = market['id'];
         }
-        const response = await this.privateGetAccountInterestAccrued (this.extend (request, query));
+        const response = await this.privateGetAccountInterestAccrued (this.extend (request, params));
         //
         //    {
         //        "code": "0",

--- a/js/okx.js
+++ b/js/okx.js
@@ -5272,7 +5272,7 @@ module.exports = class okx extends Exchange {
         if (instId !== undefined) {
             market = this.safeMarket (instId, market);
         }
-        const timestamp = this.safeNumber (info, 'ts');
+        const timestamp = this.safeInteger (info, 'ts');
         return {
             'symbol': this.safeString (market, 'symbol'),
             'marginMode': this.safeString (info, 'mgnMode'),


### PR DESCRIPTION
### Isolated:
```
node examples/js/cli okx fetchBorrowInterest undefined undefined undefined undefined '{"marginMode":"isolated"}'

okx.fetchBorrowInterest (, , , , [object Object])
2022-07-08T01:18:32.947Z iteration 0 passed in 354 ms

  symbol | marginMode | currency |     interest | interestRate |     amountBorrowed |     timestamp |                 datetime
------------------------------------------------------------------------------------------------------------------------------
BTC/USDT |   isolated |      BTC | 6.1038473e-9 |   0.00000115 | 0.0053076932456129 | 1657224000000 | 2022-07-07T20:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1038403e-9 |   0.00000115 | 0.0053076871417726 | 1657220400000 | 2022-07-07T19:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1038332e-9 |   0.00000115 | 0.0053076810379394 | 1657216800000 | 2022-07-07T18:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1038262e-9 |   0.00000115 | 0.0053076749341132 | 1657213200000 | 2022-07-07T17:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1038192e-9 |   0.00000115 |  0.005307668830294 | 1657209600000 | 2022-07-07T16:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1038122e-9 |   0.00000115 | 0.0053076627264818 | 1657206000000 | 2022-07-07T15:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1038052e-9 |   0.00000115 | 0.0053076566226766 | 1657202400000 | 2022-07-07T14:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1037981e-9 |   0.00000115 | 0.0053076505188785 | 1657198800000 | 2022-07-07T13:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1037911e-9 |   0.00000115 | 0.0053076444150874 | 1657195200000 | 2022-07-07T12:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1037771e-9 |   0.00000115 | 0.0053076322075332 | 1657191600000 | 2022-07-07T11:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1037771e-9 |   0.00000115 | 0.0053076322075332 | 1657188000000 | 2022-07-07T10:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1037701e-9 |   0.00000115 | 0.0053076261037631 | 1657184400000 | 2022-07-07T09:00:00.000Z
BTC/USDT |   isolated |      BTC | 6.1037631e-9 |   0.00000115 |         0.00530762 | 1657180800000 | 2022-07-07T08:00:00.000Z
13 objects
2022-07-08T01:18:32.947Z iteration 1 passed in 354 ms
```

### Cross:
```
node examples/js/cli okx fetchBorrowInterest undefined undefined undefined undefined '{"marginMode":"cross"}'

okx.fetchBorrowInterest (, , , , [object Object])
2022-07-08T01:19:08.268Z iteration 0 passed in 353 ms

  symbol | marginMode | currency |           interest | interestRate | amountBorrowed |     timestamp |                 datetime
--------------------------------------------------------------------------------------------------------------------------------
ETH/USDT |      cross |     USDT | 0.0000727285889536 |   0.00000229 |    31.75920915 | 1657242000000 | 2022-07-08T01:00:00.000Z
1 objects
2022-07-08T01:19:08.268Z iteration 1 passed in 353 ms
```