### PR TITLE
Order not found message

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -377,7 +377,7 @@ module.exports = class bitstamp extends Exchange {
                     'Wrong API key format': AuthenticationError,
                     'Your account is frozen': PermissionDenied,
                     'Please update your profile with your FATCA information, before using API.': PermissionDenied,
-                    'Order not found': OrderNotFound,
+                    'Order not found.': OrderNotFound,
                     'Price is more than 20% below market price.': InvalidOrder,
                     "Bitstamp.net is under scheduled maintenance. We'll be back soon.": OnMaintenance, // { "error": "Bitstamp.net is under scheduled maintenance. We'll be back soon." }
                     'Order could not be placed.': ExchangeNotAvailable, // Order could not be placed (perhaps due to internal error or trade halt). Please retry placing order.


### PR DESCRIPTION
The order not found error from bitstamp has a dot at the end. 

See:
`{\"status\":\"error\",\"reason\":\"Order not found.\"}`