### PR TITLE
Whitebit: add fetchBorrowInterest

### DIFF
--- a/js/whitebit.js
+++ b/js/whitebit.js
@@ -20,10 +20,11 @@ module.exports = class whitebit extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined, // has but unimplemented
+                'margin': true,
                 'swap': false,
                 'future': false,
                 'option': false,
+                'borrowMargin': false,
                 'cancelAllOrders': false,
                 'cancelOrder': true,
                 'cancelOrders': false,
@@ -37,6 +38,10 @@ module.exports = class whitebit extends Exchange {
                 'editOrder': undefined,
                 'fetchBalance': true,
                 'fetchBidsAsks': undefined,
+                'fetchBorrowRate': false,
+                'fetchBorrowRates': false,
+                'fetchBorrowRateHistory': false,
+                'fetchBorrowRateHistories': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,
                 'fetchDeposit': true,
@@ -64,6 +69,7 @@ module.exports = class whitebit extends Exchange {
                 'fetchTradingFee': false,
                 'fetchTradingFees': true,
                 'fetchTransactionFees': true,
+                'repayMargin': false,
                 'setLeverage': true,
                 'transfer': true,
                 'withdraw': true,
@@ -163,7 +169,11 @@ module.exports = class whitebit extends Exchange {
                     },
                     'private': {
                         'post': [
+                            'collateral-account/balance',
+                            'collateral-account/positions/history',
                             'collateral-account/leverage',
+                            'collateral-account/positions/open',
+                            'collateral-account/summary',
                             'main-account/address',
                             'main-account/balance',
                             'main-account/create-new-address',
@@ -1770,6 +1780,88 @@ module.exports = class whitebit extends Exchange {
         //
         const records = this.safeValue (response, 'records', []);
         return this.parseTransactions (records, currency, since, limit);
+    }
+
+    async fetchBorrowInterest (code = undefined, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name whitebit#fetchBorrowInterest
+         * @description fetch the interest owed by the user for borrowing currency for margin trading
+         * @see https://github.com/whitebit-exchange/api-docs/blob/main/docs/Private/http-trade-v4.md#open-positions
+         * @param {string|undefined} code unified currency code
+         * @param {string|undefined} symbol unified market symbol
+         * @param {int|undefined} since the earliest time in ms to fetch borrrow interest for
+         * @param {int|undefined} limit the maximum number of structures to retrieve
+         * @param {object} params extra parameters specific to the whitebit api endpoint
+         * @returns {[object]} a list of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure}
+         */
+        await this.loadMarkets ();
+        const request = {};
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['market'] = market['id'];
+        }
+        const response = await this.v4PrivatePostCollateralAccountPositionsOpen (this.extend (request, params));
+        //
+        //     [
+        //         {
+        //             "positionId": 191823,
+        //             "market": "BTC_USDT",
+        //             "openDate": 1660340344.027163,
+        //             "modifyDate": 1660340344.027163,
+        //             "amount": "0.003075",
+        //             "basePrice": "24149.24512",
+        //             "liquidationPrice": "7059.02",
+        //             "leverage": "5",
+        //             "pnl": "-0.15",
+        //             "pnlPercent": "-0.20",
+        //             "margin": "14.86",
+        //             "freeMargin": "44.99",
+        //             "funding": "0",
+        //             "unrealizedFunding": "0.0000307828284903",
+        //             "liquidationState": null
+        //         }
+        //     ]
+        //
+        const interest = this.parseBorrowInterests (response, market);
+        return this.filterByCurrencySinceLimit (interest, code, since, limit);
+    }
+
+    parseBorrowInterest (info, market = undefined) {
+        //
+        //     {
+        //         "positionId": 191823,
+        //         "market": "BTC_USDT",
+        //         "openDate": 1660340344.027163,
+        //         "modifyDate": 1660340344.027163,
+        //         "amount": "0.003075",
+        //         "basePrice": "24149.24512",
+        //         "liquidationPrice": "7059.02",
+        //         "leverage": "5",
+        //         "pnl": "-0.15",
+        //         "pnlPercent": "-0.20",
+        //         "margin": "14.86",
+        //         "freeMargin": "44.99",
+        //         "funding": "0",
+        //         "unrealizedFunding": "0.0000307828284903",
+        //         "liquidationState": null
+        //     }
+        //
+        const marketId = this.safeString (info, 'market');
+        const symbol = this.safeSymbol (marketId, market, '_');
+        const timestamp = this.safeTimestamp (info, 'modifyDate');
+        return {
+            'symbol': symbol,
+            'marginMode': 'cross',
+            'currency': 'USDT',
+            'interest': this.safeNumber (info, 'unrealizedFunding'),
+            'interestRate': 0.00098, // https://whitebit.com/fees
+            'amountBorrowed': this.safeNumber (info, 'amount'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': info,
+        };
     }
 
     isFiat (currency) {


### PR DESCRIPTION
Added the fetchBorrowInterest method to Whitebit for margin trading. Added the remaining margin endpoints, and set the remaining margin methods to false.

interest and interestRate are in USDT and amountBorrowed is in the base currency BTC
```
node examples/js/cli whitebit fetchBorrowInterest

whitebit.fetchBorrowInterest ()
2022-08-12T21:57:28.773Z iteration 0 passed in 672 ms

  symbol | marginMode | currency |           interest | interestRate | amountBorrowed |     timestamp |                 datetime
--------------------------------------------------------------------------------------------------------------------------------
BTC/USDT |      cross |     USDT | 0.0000050278648222 |      0.00098 |       0.003075 | 1660341442926 | 2022-08-12T21:57:22.926Z
1 objects
2022-08-12T21:57:28.773Z iteration 1 passed in 672 ms
```