### PR TITLE
Okx :: fix fetchLeverage

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -3950,8 +3950,7 @@ module.exports = class okx extends Exchange {
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLeverage', params);
         if (marginMode === undefined) {
-            marginMode = this.safeString (params, 'mgnMode', marginMode);
-            marginMode = (marginMode === undefined) ? 'cross' : marginMode; // default 'cross'
+            marginMode = this.safeString (params, 'mgnMode', 'cross');
         }
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a marginMode parameter that must be either cross or isolated');

--- a/js/okx.js
+++ b/js/okx.js
@@ -3950,7 +3950,7 @@ module.exports = class okx extends Exchange {
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLeverage', params);
         marginMode = this.safeString (params, 'mgnMode', marginMode);
-        marginMode = (marginMode === undefined) ? 'cross' : marginMode; // cross margin as default
+        marginMode = (marginMode === undefined) ? 'cross' : marginMode; // cross margin by default if not provided
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a marginMode parameter that must be either cross or isolated');
         }

--- a/js/okx.js
+++ b/js/okx.js
@@ -3943,6 +3943,7 @@ module.exports = class okx extends Exchange {
          * @see https://www.okx.com/docs-v5/en/#rest-api-account-get-leverage
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the okx api endpoint
+         * @param {string} params.marginMode 'cross' or 'isolated'
          * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/en/latest/manual.html#leverage-structure}
          */
         await this.loadMarkets ();

--- a/js/okx.js
+++ b/js/okx.js
@@ -3949,8 +3949,10 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLeverage', params);
-        marginMode = this.safeString (params, 'mgnMode', marginMode);
-        marginMode = (marginMode === undefined) ? 'cross' : marginMode; // cross margin by default if not provided
+        if (marginMode === undefined) {
+            marginMode = this.safeString (params, 'mgnMode', marginMode);
+            marginMode = (marginMode === undefined) ? 'cross' : marginMode; // default 'cross'
+        }
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a marginMode parameter that must be either cross or isolated');
         }

--- a/js/okx.js
+++ b/js/okx.js
@@ -3946,7 +3946,10 @@ module.exports = class okx extends Exchange {
          * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/en/latest/manual.html#leverage-structure}
          */
         await this.loadMarkets ();
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchLeverage', params);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLeverage', params);
+        marginMode = this.safeString (params, 'mgnMode', marginMode);
+        marginMode = (marginMode === undefined) ? 'cross' : marginMode; // cross margin as default
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a marginMode parameter that must be either cross or isolated');
         }
@@ -3955,7 +3958,7 @@ module.exports = class okx extends Exchange {
             'instId': market['id'],
             'mgnMode': marginMode,
         };
-        const response = await this.privateGetAccountLeverageInfo (this.extend (request, query));
+        const response = await this.privateGetAccountLeverageInfo (this.extend (request, params));
         //
         //     {
         //        "code": "0",

--- a/js/okx.js
+++ b/js/okx.js
@@ -3950,7 +3950,7 @@ module.exports = class okx extends Exchange {
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLeverage', params);
         if (marginMode === undefined) {
-            marginMode = this.safeString (params, 'mgnMode', 'cross');
+            marginMode = this.safeString (params, 'mgnMode', 'cross'); // cross as default marginMode
         }
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
             throw new BadRequest (this.id + ' fetchLeverage() requires a marginMode parameter that must be either cross or isolated');


### PR DESCRIPTION
- Support exchange-specific margin parameter

Demos
```
p okx fetchLeverage "BTC/USDT:USDT" '{"marginMode": "cross"}'          
Python v3.9.13
CCXT v1.92.24
okx.fetchLeverage(BTC/USDT:USDT,{'marginMode': 'cross'})
{'code': '0',
 'data': [{'instId': 'BTC-USDT-SWAP',
           'lever': '3',
           'mgnMode': 'cross',
           'posSide': 'long'},
          {'instId': 'BTC-USDT-SWAP',
           'lever': '3',
           'mgnMode': 'cross',
           'posSide': 'short'}],
 'msg': ''}
```
```
p okx fetchLeverage "BTC/USDT:USDT"                          
Python v3.9.13
CCXT v1.92.24
okx.fetchLeverage(BTC/USDT:USDT)
{'code': '0',
 'data': [{'instId': 'BTC-USDT-SWAP',
           'lever': '3',
           'mgnMode': 'cross',
           'posSide': 'long'},
          {'instId': 'BTC-USDT-SWAP',
           'lever': '3',
           'mgnMode': 'cross',
           'posSide': 'short'}],
 'msg': ''}
 ```
 ```
 p okx fetchLeverage "BTC/USDT:USDT" '{"mgnMode": "cross"}'
Python v3.9.13
CCXT v1.92.24
okx.fetchLeverage(BTC/USDT:USDT,{'mgnMode': 'cross'})
{'code': '0',
 'data': [{'instId': 'BTC-USDT-SWAP',
           'lever': '3',
           'mgnMode': 'cross',
           'posSide': 'long'},
          {'instId': 'BTC-USDT-SWAP',
           'lever': '3',
           'mgnMode': 'cross',
           'posSide': 'short'}],
 'msg': ''}
 ```