### PR TITLE
kucoin: add network when fetch transaction fee

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -787,6 +787,13 @@ module.exports = class kucoin extends Exchange {
         const request = {
             'currency': currency['id'],
         };
+        const networks = this.safeValue (this.options, 'networks', {});
+        let network = this.safeStringUpper (params, 'network');
+        network = this.safeStringLower (networks, network, network);
+        if (network !== undefined) {
+            request['chain'] = network;
+            params = this.omit (params, 'network');
+        }
         const response = await this.privateGetWithdrawalsQuotas (this.extend (request, params));
         const data = response['data'];
         const withdrawFees = {};


### PR DESCRIPTION
Related issue: ccxt/ccxt#14672
```
$ node examples/js/cli kucoin fetchTransactionFee USDT '{"network":"trc20"}'
2022-08-16T14:03:51.218Z
Node.js: v14.17.0
CCXT v1.92.27
kucoin.fetchTransactionFee (USDT, [object Object])

{
  info: {
    code: '200000',
    data: {
      currency: 'USDT',
      limitBTCAmount: '1.00000000',
      usedBTCAmount: '0.00040778',
      remainAmount: '24103.983991',
      availableAmount: '27.50000094',
      withdrawMinFee: '1',
      innerWithdrawMinFee: '0',
      withdrawMinSize: '5',
      isWithdrawEnabled: true,
      precision: 6,
      chain: 'TRC20'
    }
  },
  withdraw: { USDT: 1 },
  deposit: {}
}

$ node examples/js/cli kucoin fetchTransactionFee USDT '{"network":"erc20"}'
2022-08-16T14:03:57.878Z
Node.js: v14.17.0
CCXT v1.92.27
kucoin.fetchTransactionFee (USDT, [object Object])

{
  info: {
    code: '200000',
    data: {
      currency: 'USDT',
      limitBTCAmount: '1.00000000',
      usedBTCAmount: '0.00040778',
      remainAmount: '24103.983991',
      availableAmount: '27.50000094',
      withdrawMinFee: '25',
      innerWithdrawMinFee: '0',
      withdrawMinSize: '50',
      isWithdrawEnabled: true,
      precision: 6,
      chain: 'ERC20'
    }
  },
  withdraw: { USDT: 25 },
  deposit: {}
}
```