### PR TITLE
OKX: Hongkong time

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -650,6 +650,7 @@ module.exports = class okx extends Exchange {
                 },
                 'fetchOHLCV': {
                     // 'type': 'Candles', // Candles or HistoryCandles, IndexCandles, MarkPriceCandles
+                    'timezone': 'UTC', // UTC, HK
                 },
                 'createOrder': 'privatePostTradeBatchOrders', // or 'privatePostTradeOrder' or 'privatePostTradeOrderAlgo'
                 'createMarketBuyOrderRequiresPrice': false,
@@ -1613,13 +1614,14 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const price = this.safeString (params, 'price');
-        const isHKTime = this.safeString (params, 'isHkTime');
+        const options = this.safeValue (this.options, 'fetchOHLCV', {});
+        const timezone = this.safeString (options, 'timezone');
         params = this.omit (params, 'price');
         if (limit === undefined) {
             limit = 100; // default 100, max 100
         }
         let barSelect = this.timeframes[timeframe];
-        if (isHKTime) {
+        if (timezone === 'HK') {
             barSelect = this.timeframes[timeframe + 'HK'];
         }
         const request = {
@@ -1646,7 +1648,6 @@ module.exports = class okx extends Exchange {
             request['after'] = until;
             params = this.omit (params, 'until');
         }
-        const options = this.safeValue (this.options, 'fetchOHLCV', {});
         defaultType = this.safeString (options, 'type', defaultType); // Candles or HistoryCandles
         const type = this.safeString (params, 'type', defaultType);
         params = this.omit (params, 'type');

--- a/js/okx.js
+++ b/js/okx.js
@@ -127,6 +127,14 @@ module.exports = class okx extends Exchange {
                 '3M': '3Mutc',
                 '6M': '6Mutc',
                 '1y': '1Yutc',
+                '6hHK': '6H',
+                '12hHK': '12H',
+                '1dHK': '1D',
+                '1wHK': '1W',
+                '1MHK': '1M',
+                '3MHK': '3M',
+                '6MHK': '6M',
+                '1yHK': '1Y',
             },
             'hostname': 'www.okx.com', // or aws.okx.com
             'urls': {
@@ -1605,13 +1613,20 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const price = this.safeString (params, 'price');
+        const isHKTime = this.safeString (params, 'isHkTime');
         params = this.omit (params, 'price');
         if (limit === undefined) {
             limit = 100; // default 100, max 100
         }
+        let barSelect;
+        if (!isHKTime) {
+            barSelect = this.timeframes[timeframe];
+        } else {
+            barSelect = this.timeframes[timeframe + 'HK'];
+        }
         const request = {
             'instId': market['id'],
-            'bar': this.timeframes[timeframe],
+            'bar': barSelect,
             'limit': limit,
         };
         let defaultType = 'Candles';
@@ -2503,7 +2518,7 @@ module.exports = class okx extends Exchange {
          * @param {bool|undefined} params.stop true if fetching trigger orders, params.ordtype set to "trigger" if true
          * @param {string|undefined} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
          * @returns [an order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-        */
+         */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
@@ -5174,24 +5189,24 @@ module.exports = class okx extends Exchange {
          * @param {object} info Exchange response for 1 market
          * @param {object} market CCXT market
          */
-        //
-        //    [
-        //        {
-        //            "baseMaxLoan": "500",
-        //            "imr": "0.1",
-        //            "instId": "ETH-USDT",
-        //            "maxLever": "10",
-        //            "maxSz": "500",
-        //            "minSz": "0",
-        //            "mmr": "0.03",
-        //            "optMgnFactor": "0",
-        //            "quoteMaxLoan": "200000",
-        //            "tier": "1",
-        //            "uly": ""
-        //        },
-        //        ...
-        //    ]
-        //
+            //
+            //    [
+            //        {
+            //            "baseMaxLoan": "500",
+            //            "imr": "0.1",
+            //            "instId": "ETH-USDT",
+            //            "maxLever": "10",
+            //            "maxSz": "500",
+            //            "minSz": "0",
+            //            "mmr": "0.03",
+            //            "optMgnFactor": "0",
+            //            "quoteMaxLoan": "200000",
+            //            "tier": "1",
+            //            "uly": ""
+            //        },
+            //        ...
+            //    ]
+            //
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];

--- a/js/okx.js
+++ b/js/okx.js
@@ -2518,7 +2518,7 @@ module.exports = class okx extends Exchange {
          * @param {bool|undefined} params.stop true if fetching trigger orders, params.ordtype set to "trigger" if true
          * @param {string|undefined} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
          * @returns [an order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-         */
+        */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }

--- a/js/okx.js
+++ b/js/okx.js
@@ -1618,10 +1618,8 @@ module.exports = class okx extends Exchange {
         if (limit === undefined) {
             limit = 100; // default 100, max 100
         }
-        let barSelect;
-        if (!isHKTime) {
-            barSelect = this.timeframes[timeframe];
-        } else {
+        let barSelect = this.timeframes[timeframe];
+        if (isHKTime) {
             barSelect = this.timeframes[timeframe + 'HK'];
         }
         const request = {

--- a/js/okx.js
+++ b/js/okx.js
@@ -1612,8 +1612,9 @@ module.exports = class okx extends Exchange {
         if (limit === undefined) {
             limit = 100; // default 100, max 100
         }
+        const duration = this.parseTimeframe (timeframe);
         let bar = this.timeframes[timeframe];
-        if (timezone === 'UTC') {
+        if ((timezone === 'UTC') && (duration >= 21600000)) {
             bar += timezone.toLowerCase ();
         }
         const request = {
@@ -1623,7 +1624,6 @@ module.exports = class okx extends Exchange {
         };
         let defaultType = 'Candles';
         if (since !== undefined) {
-            const duration = this.parseTimeframe (timeframe);
             const now = this.milliseconds ();
             const difference = now - since;
             // if the since timestamp is more than limit candles back in the past
@@ -2509,7 +2509,7 @@ module.exports = class okx extends Exchange {
          * @param {bool|undefined} params.stop true if fetching trigger orders, params.ordtype set to "trigger" if true
          * @param {string|undefined} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
          * @returns [an order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-        */
+         */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
@@ -5180,24 +5180,24 @@ module.exports = class okx extends Exchange {
          * @param {object} info Exchange response for 1 market
          * @param {object} market CCXT market
          */
-        //
-        //    [
-        //        {
-        //            "baseMaxLoan": "500",
-        //            "imr": "0.1",
-        //            "instId": "ETH-USDT",
-        //            "maxLever": "10",
-        //            "maxSz": "500",
-        //            "minSz": "0",
-        //            "mmr": "0.03",
-        //            "optMgnFactor": "0",
-        //            "quoteMaxLoan": "200000",
-        //            "tier": "1",
-        //            "uly": ""
-        //        },
-        //        ...
-        //    ]
-        //
+            //
+            //    [
+            //        {
+            //            "baseMaxLoan": "500",
+            //            "imr": "0.1",
+            //            "instId": "ETH-USDT",
+            //            "maxLever": "10",
+            //            "maxSz": "500",
+            //            "minSz": "0",
+            //            "mmr": "0.03",
+            //            "optMgnFactor": "0",
+            //            "quoteMaxLoan": "200000",
+            //            "tier": "1",
+            //            "uly": ""
+            //        },
+            //        ...
+            //    ]
+            //
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];

--- a/js/okx.js
+++ b/js/okx.js
@@ -5189,24 +5189,24 @@ module.exports = class okx extends Exchange {
          * @param {object} info Exchange response for 1 market
          * @param {object} market CCXT market
          */
-            //
-            //    [
-            //        {
-            //            "baseMaxLoan": "500",
-            //            "imr": "0.1",
-            //            "instId": "ETH-USDT",
-            //            "maxLever": "10",
-            //            "maxSz": "500",
-            //            "minSz": "0",
-            //            "mmr": "0.03",
-            //            "optMgnFactor": "0",
-            //            "quoteMaxLoan": "200000",
-            //            "tier": "1",
-            //            "uly": ""
-            //        },
-            //        ...
-            //    ]
-            //
+        //
+        //    [
+        //        {
+        //            "baseMaxLoan": "500",
+        //            "imr": "0.1",
+        //            "instId": "ETH-USDT",
+        //            "maxLever": "10",
+        //            "maxSz": "500",
+        //            "minSz": "0",
+        //            "mmr": "0.03",
+        //            "optMgnFactor": "0",
+        //            "quoteMaxLoan": "200000",
+        //            "tier": "1",
+        //            "uly": ""
+        //        },
+        //        ...
+        //    ]
+        //
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];

--- a/js/okx.js
+++ b/js/okx.js
@@ -2509,7 +2509,7 @@ module.exports = class okx extends Exchange {
          * @param {bool|undefined} params.stop true if fetching trigger orders, params.ordtype set to "trigger" if true
          * @param {string|undefined} params.ordType "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
          * @returns [an order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-         */
+        */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
@@ -5180,24 +5180,24 @@ module.exports = class okx extends Exchange {
          * @param {object} info Exchange response for 1 market
          * @param {object} market CCXT market
          */
-            //
-            //    [
-            //        {
-            //            "baseMaxLoan": "500",
-            //            "imr": "0.1",
-            //            "instId": "ETH-USDT",
-            //            "maxLever": "10",
-            //            "maxSz": "500",
-            //            "minSz": "0",
-            //            "mmr": "0.03",
-            //            "optMgnFactor": "0",
-            //            "quoteMaxLoan": "200000",
-            //            "tier": "1",
-            //            "uly": ""
-            //        },
-            //        ...
-            //    ]
-            //
+        //
+        //    [
+        //        {
+        //            "baseMaxLoan": "500",
+        //            "imr": "0.1",
+        //            "instId": "ETH-USDT",
+        //            "maxLever": "10",
+        //            "maxSz": "500",
+        //            "minSz": "0",
+        //            "mmr": "0.03",
+        //            "optMgnFactor": "0",
+        //            "quoteMaxLoan": "200000",
+        //            "tier": "1",
+        //            "uly": ""
+        //        },
+        //        ...
+        //    ]
+        //
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];

--- a/js/okx.js
+++ b/js/okx.js
@@ -119,22 +119,14 @@ module.exports = class okx extends Exchange {
                 '1h': '1H',
                 '2h': '2H',
                 '4h': '4H',
-                '6h': '6Hutc',
-                '12h': '12Hutc',
-                '1d': '1Dutc',
-                '1w': '1Wutc',
-                '1M': '1Mutc',
-                '3M': '3Mutc',
-                '6M': '6Mutc',
-                '1y': '1Yutc',
-                '6hHK': '6H',
-                '12hHK': '12H',
-                '1dHK': '1D',
-                '1wHK': '1W',
-                '1MHK': '1M',
-                '3MHK': '3M',
-                '6MHK': '6M',
-                '1yHK': '1Y',
+                '6h': '6H',
+                '12h': '12H',
+                '1d': '1D',
+                '1w': '1W',
+                '1M': '1M',
+                '3M': '3M',
+                '6M': '6M',
+                '1y': '1Y',
             },
             'hostname': 'www.okx.com', // or aws.okx.com
             'urls': {
@@ -1614,19 +1606,19 @@ module.exports = class okx extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const price = this.safeString (params, 'price');
-        const options = this.safeValue (this.options, 'fetchOHLCV', {});
-        const timezone = this.safeString (options, 'timezone');
         params = this.omit (params, 'price');
+        const options = this.safeValue (this.options, 'fetchOHLCV', {});
+        const timezone = this.safeString (options, 'timezone', 'UTC');
         if (limit === undefined) {
             limit = 100; // default 100, max 100
         }
-        let barSelect = this.timeframes[timeframe];
-        if (timezone === 'HK') {
-            barSelect = this.timeframes[timeframe + 'HK'];
+        let bar = this.timeframes[timeframe];
+        if (timezone === 'UTC') {
+            bar += timezone.toLowerCase ();
         }
         const request = {
             'instId': market['id'],
-            'bar': barSelect,
+            'bar': bar,
             'limit': limit,
         };
         let defaultType = 'Candles';


### PR DESCRIPTION
OKX api offers to get candles as UTC time opening price (default) or Hong Kong time opening price.

For TradingView or other platforms based strategies, their are on the HK time.
The watchOHLCV function is updated in the same manner.
 
°403 in ccxt pro repo
 [https://www.okx.com/docs-v5/en/#rest-api-market-data-get-candlesticks](url) 