### PR TITLE
bitfinex2 replace Math.whatever with Precise

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1013,7 +1013,7 @@ module.exports = class bitfinex2 extends Exchange {
         for (let i = 0; i < orderbook.length; i++) {
             const order = orderbook[i];
             const price = this.safeNumber (order, priceIndex);
-            const signedAmount = this.safeString (order, '2');
+            const signedAmount = this.safeString (order, 2);
             const amount = Precise.stringAbs (signedAmount);
             const side = Precise.stringGt (signedAmount, '0') ? 'bids' : 'asks';
             result[side].push ([ price, this.parseNumber (amount) ]);

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1015,7 +1015,7 @@ module.exports = class bitfinex2 extends Exchange {
             const price = this.safeNumber (order, priceIndex);
             const signedAmount = this.safeString (order, '2');
             const amount = Precise.stringAbs (signedAmount);
-            const side = (signedAmount > 0) ? 'bids' : 'asks';
+            const side = Precise.stringGt (signedAmount, '0') ? 'bids' : 'asks';
             result[side].push ([ price, this.parseNumber (amount) ]);
         }
         result['bids'] = this.sortBy (result['bids'], 0, true);

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -712,7 +712,7 @@ module.exports = class bitfinex2 extends Exchange {
                 'precision': parseInt (precision),
                 'limits': {
                     'amount': {
-                        'min': this.parseNumber (this.parsePrecision ('e-' + precision)),
+                        'min': this.parseNumber (this.parsePrecision (precision)),
                         'max': undefined,
                     },
                     'withdraw': {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -712,7 +712,7 @@ module.exports = class bitfinex2 extends Exchange {
                 'precision': parseInt (precision),
                 'limits': {
                     'amount': {
-                        'min': 1 / Math.pow (10, precision),
+                        'min': this.parseNumber (this.parsePrecision ('e-' + precision)),
                         'max': undefined,
                     },
                     'withdraw': {

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -696,7 +696,7 @@ module.exports = class bitfinex2 extends Exchange {
             const fees = this.safeValue (feeValues, 1, []);
             const fee = this.safeNumber (fees, 1);
             const undl = this.safeValue (indexed['undl'], id, []);
-            const precision = 8; // default precision, todo: fix "magic constants"
+            const precision = '8'; // default precision, todo: fix "magic constants"
             const fid = 'f' + id;
             result[code] = {
                 'id': fid,
@@ -709,7 +709,7 @@ module.exports = class bitfinex2 extends Exchange {
                 'deposit': undefined,
                 'withdraw': undefined,
                 'fee': fee,
-                'precision': precision,
+                'precision': parseInt (precision),
                 'limits': {
                     'amount': {
                         'min': 1 / Math.pow (10, precision),
@@ -1013,10 +1013,10 @@ module.exports = class bitfinex2 extends Exchange {
         for (let i = 0; i < orderbook.length; i++) {
             const order = orderbook[i];
             const price = this.safeNumber (order, priceIndex);
-            const signedAmount = this.safeNumber (order, 2);
-            const amount = Math.abs (signedAmount);
+            const signedAmount = this.safeString (order, '2');
+            const amount = Precise.stringAbs (signedAmount);
             const side = (signedAmount > 0) ? 'bids' : 'asks';
-            result[side].push ([ price, amount ]);
+            result[side].push ([ price, this.parseNumber (amount) ]);
         }
         result['bids'] = this.sortBy (result['bids'], 0, true);
         result['asks'] = this.sortBy (result['asks'], 0);


### PR DESCRIPTION
```
% bitfinex2 fetchOrderBook ADA/USDT
2022-08-17T03:50:14.630Z
Node.js: v18.4.0
CCXT v1.92.30
(node:15249) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
bitfinex2.fetchOrderBook (ADA/USDT)
2022-08-17T03:50:18.087Z iteration 0 passed in 886 ms

{
  symbol: 'ADA/USDT',
  bids: [
    [ 0.57745, 865.8 ],
    ...
    [ 0.57616, 8677.3 ]
  ],
  asks: [
    [ 0.57827, 4322.9 ],
    ...
    [ 0.57965, 41116 ]
  ],
  timestamp: 1660708218086,
  datetime: '2022-08-17T03:50:18.086Z',
  nonce: undefined
}
2022-08-17T03:50:18.087Z iteration 1 passed in 886 ms
```

```
2022-08-17T03:53:39.714Z
Node.js: v18.4.0
CCXT v1.92.30
bitfinex2.fetchCurrencies ()
2022-08-17T03:53:43.071Z iteration 0 passed in 761 ms

{
  '1INCH': {
    id: 'f1INCH',
    uppercaseId: '1INCH',
    code: '1INCH',
    info: [
      '1INCH',
      [ '1INCH', '1INCH' ],
      [ '1INCH', 'ETH' ],
      [ '1INCH', [ 0, 2.5748 ] ],
      []
    ],
    type: 'ETH',
    name: '1INCH',
    active: true,
    deposit: undefined,
    withdraw: undefined,
    fee: 2.5748,
    precision: 8,
    limits: {
      amount: { min: 1e-8, max: undefined },
      withdraw: { min: 2.5748, max: undefined }
    },
    networks: {
      '1INCH': {
        info: '1INCH',
        id: '1inch',
        network: '1INCH',
        active: undefined,
        deposit: undefined,
        withdraw: undefined,
        fee: undefined,
        precision: undefined,
        limits: { withdraw: { min: undefined, max: undefined } }
      }
    }
  },
  ...
  ZRX: {
    id: 'fZRX',
    uppercaseId: 'ZRX',
    code: 'ZRX',
    info: [
      'ZRX',
      [ 'ZRX', '0x' ],
      [ 'ZRX', 'ETH' ],
      [ 'ZRX', [ 0, 6.0767 ] ],
      []
    ],
    type: 'ETH',
    name: '0x',
    active: true,
    deposit: undefined,
    withdraw: undefined,
    fee: 6.0767,
    precision: 8,
    limits: {
      amount: { min: 1e-8, max: undefined },
      withdraw: { min: 6.0767, max: undefined }
    },
    networks: {
      ZRX: {
        info: 'ZRX',
        id: 'zrx',
        network: 'ZRX',
        active: undefined,
        deposit: undefined,
        withdraw: undefined,
        fee: undefined,
        precision: undefined,
        limits: { withdraw: { min: undefined, max: undefined } }
      }
    }
  }
}
2022-08-17T03:53:43.071Z iteration 1 passed in 761 ms
```