### PR TITLE
exmo - parseTransaction fee

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -238,7 +238,7 @@ module.exports = class exmo extends Exchange {
         }
         const response = await this[method] (this.extend (request, params));
         //
-        //      {}
+        //     {}
         //
         const margin = this.parseMarginModification (response, market);
         const options = this.safeValue (this.options, 'margin', {});

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -176,7 +176,7 @@ module.exports = class exmo extends Exchange {
                 },
                 'transaction': {
                     'tierBased': false,
-                    'percentage': undefined, // some are fixed, some are percentage
+                    'percentage': false, // fixed transaction fees for crypto, see fetchTransactionFees below
                 },
             },
             'options': {


### PR DESCRIPTION
Current implementation calculates the transaction fees from it's cached rates. This would throw an error if the transaction fees weren't cached or if they didn't exist for the symbol.

In my opinion, I think it's a good idea to be able to calculate and fill the transaction fees from the cached fees. However I don't think we should do this in each exchange, it should be done from the base Exchange level. And would also require that in `await loadMarkets ()` the transaction fees are cached, or have another endpoint that is `await loadTransactionFees ()`

Will open a thread in discord about this.