### PR TITLE
Poloniex :: fix precision

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -411,8 +411,8 @@ module.exports = class poloniex extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.safeNumber (symbolTradeLimit, 'quantityScale'),
-                    'price': this.safeNumber (symbolTradeLimit, 'priceScale'),
+                    'amount': this.safeInteger (symbolTradeLimit, 'quantityScale'),
+                    'price': this.safeInteger (symbolTradeLimit, 'priceScale'),
                 },
                 'limits': {
                     'amount': {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/14730

Demo
```
p poloniex createOrder LTC/USDT limit buy 0.2 30.45    
Python v3.9.13
CCXT v1.92.30
poloniex.createOrder(LTC/USDT,limit,buy,0.2,30.45)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '83230315543306240',
 'info': {'clientOrderId': '', 'id': '83230315543306240', 'type': 'buy'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'type': 'buy'}
 ```