### PR TITLE
Okx: handleMarginModeAndParams - setLeverage, fetchMarketLeverageTiers

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4717,8 +4717,13 @@ module.exports = class okx extends Exchange {
             'instId': market['id'],
         };
         const posSide = this.safeString (params, 'posSide');
-        if (posSide !== undefined) {
-            request['posSide'] = posSide;
+        if (marginMode === 'isolated') {
+            if (posSide === undefined) {
+                throw new ArgumentsRequired (this.id + ' setLeverage() requires a posSide argument for isolated margin');
+            }
+            if (posSide !== 'long' && posSide !== 'short') {
+                throw new BadRequest (this.id + ' setLeverage() requires the posSide argument to be either "long" or "short"');
+            }
         }
         const response = await this.privatePostAccountSetLeverage (this.extend (request, params));
         //

--- a/js/okx.js
+++ b/js/okx.js
@@ -4690,6 +4690,7 @@ module.exports = class okx extends Exchange {
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the okx api endpoint
          * @param {string} params.marginMode 'cross' or 'isolated'
+         * @param {string|undefined} params.posSide 'long' or 'short' for isolated margin long/short mode on futures and swap markets
          * @returns {object} response from the exchange
          */
         if (symbol === undefined) {
@@ -4715,6 +4716,10 @@ module.exports = class okx extends Exchange {
             'mgnMode': marginMode,
             'instId': market['id'],
         };
+        const posSide = this.safeString (params, 'posSide');
+        if (posSide !== undefined) {
+            request['posSide'] = posSide;
+        }
         const response = await this.privatePostAccountSetLeverage (this.extend (request, params));
         //
         //     {

--- a/js/okx.js
+++ b/js/okx.js
@@ -4685,9 +4685,11 @@ module.exports = class okx extends Exchange {
          * @method
          * @name okx#setLeverage
          * @description set the level of leverage for a market
+         * @see https://www.okx.com/docs-v5/en/#rest-api-account-set-leverage
          * @param {float} leverage the rate of leverage
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the okx api endpoint
+         * @param {string} params.marginMode 'cross' or 'isolated'
          * @returns {object} response from the exchange
          */
         if (symbol === undefined) {
@@ -4700,10 +4702,13 @@ module.exports = class okx extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const marginMode = this.safeStringLower (params, 'mgnMode');
-        params = this.omit (params, [ 'mgnMode' ]);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('setLeverage', params);
+        if (marginMode === undefined) {
+            marginMode = this.safeString (params, 'mgnMode', 'cross'); // cross as default marginMode
+        }
         if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
-            throw new BadRequest (this.id + ' setLeverage() params["mgnMode"] must be either cross or isolated');
+            throw new BadRequest (this.id + ' setLeverage() requires a marginMode parameter that must be either cross or isolated');
         }
         const request = {
             'lever': leverage,
@@ -5119,6 +5124,7 @@ module.exports = class okx extends Exchange {
          * @see https://www.okx.com/docs-v5/en/#rest-api-public-data-get-position-tiers
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the okx api endpoint
+         * @param {string} params.marginMode 'cross' or 'isolated'
          * @returns {object} a [leverage tiers structure]{@link https://docs.ccxt.com/en/latest/manual.html#leverage-tiers-structure}
          */
         await this.loadMarkets ();
@@ -5130,9 +5136,11 @@ module.exports = class okx extends Exchange {
                 throw new BadRequest (this.id + ' fetchMarketLeverageTiers() cannot fetch leverage tiers for ' + symbol);
             }
         }
-        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
-        const marginMode = this.safeString2 (params, 'marginMode', 'tdMode', defaultMarginMode);
-        params = this.omit (params, 'marginMode');
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchMarketLeverageTiers', params);
+        if (marginMode === undefined) {
+            marginMode = this.safeString (params, 'tdMode', 'cross'); // cross as default marginMode
+        }
         const request = {
             'instType': type,
             'tdMode': marginMode,


### PR DESCRIPTION
Added handleMarginModeAndParams to setLeverage and fetchMarketLeverageTiers:

### setLeverage:
```
okx.setLeverage (2, BTC/USDT)
2022-08-18T21:21:16.723Z iteration 0 passed in 362 ms

{
  code: '0',
  data: [ { instId: 'BTC-USDT', lever: '2', mgnMode: 'cross', posSide: '' } ],
  msg: ''
}
2022-08-18T21:21:16.723Z iteration 1 passed in 362 ms
```

### fetchMarketLeverageTiers:
```
okx.fetchMarketLeverageTiers (BTC/USDT)
2022-08-18T21:24:39.592Z iteration 0 passed in 365 ms

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |     USDT |           0 |          25 |                  0.03 |          10
   2 |     USDT |          25 |          50 |                  0.04 |        9.09
   3 |     USDT |          50 |          75 |                  0.05 |        8.33
...
  89 |     USDT |        2200 |        2225 |                  0.91 |        1.02
  90 |     USDT |        2225 |        2250 |                  0.92 |        1.01
  91 |     USDT |        2250 |        2275 |                  0.93 |           1
91 objects
2022-08-18T21:24:39.592Z iteration 1 passed in 365 ms
```