### PR TITLE
base parseOHLCVV / parseOHLCVVs methods

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1571,7 +1571,7 @@ module.exports = class Exchange {
         return ohlcv;
     }
 
-    parseOHLCVVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined, params = {}, keyTimestamp = 0, keyOpen = 1, keyHigh = 2, keyLow = 3, keyClose = 4, keyBasevolume = 5, keyQuotevolume = 6) {
+    parseOHLCVVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined, keyTimestamp = 0, keyOpen = 1, keyHigh = 2, keyLow = 3, keyClose = 4, keyBasevolume = 5, keyQuotevolume = 6) {
         const results = [];
         const useOHLCVV = this.safeValue (this.options, 'useNewOHLCV', false);
         for (let i = 0; i < ohlcvs.length; i++) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1588,7 +1588,7 @@ module.exports = class Exchange {
 
     parseOHLCVVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined, params = {}, keyTimestamp = 0, keyOpen = 1, keyHigh = 2, keyLow = 3, keyClose = 4, keyBasevolume = 5, keyQuotevolume = 6) {
         const results = [];
-        const useOHLCVV = this.safeValue (this.options, 'useOHLCVV', false);
+        const useOHLCVV = this.safeValue (this.options, 'useNewOHLCV', false);
         for (let i = 0; i < ohlcvs.length; i++) {
             const ohlcvv = !useOHLCVV ? this.parseOHLCV (ohlcvs[i], market) : this.parseOHLCVV (ohlcvs[i], market, keyTimestamp, keyOpen, keyHigh, keyLow, keyClose, keyBasevolume, keyQuotevolume);
             results.push (ohlcvv);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1571,21 +1571,6 @@ module.exports = class Exchange {
         return ohlcv;
     }
 
-    async fetchOHLCVV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
-        if (!this.has['fetchTrades']) {
-            throw new NotSupported (this.id + ' fetchOHLCVV() is not supported yet');
-        }
-        await this.loadMarkets ();
-        const trades = await this.fetchTrades (symbol, since, limit, params);
-        const ohlcvc = this.buildOHLCVC (trades, timeframe, since, limit);
-        const result = [];
-        const market = symbol !== undefined ? this.market (symbol) : undefined;
-        for (let i = 0; i < ohlcvc.length; i++) {
-            result.push (this.parseOHLCVV (ohlcvc, market));
-        }
-        return result;
-    }
-
     parseOHLCVVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined, params = {}, keyTimestamp = 0, keyOpen = 1, keyHigh = 2, keyLow = 3, keyClose = 4, keyBasevolume = 5, keyQuotevolume = 6) {
         const results = [];
         const useOHLCVV = this.safeValue (this.options, 'useNewOHLCV', false);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1571,28 +1571,16 @@ module.exports = class Exchange {
         return ohlcv;
     }
 
-    parseOHLCVVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined, keyTimestamp = 0, keyOpen = 1, keyHigh = 2, keyLow = 3, keyClose = 4, keyBasevolume = 5, keyQuotevolume = 6) {
+    parseOHLCVVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined) {
         const results = [];
         const useOHLCVV = this.safeValue (this.options, 'useNewOHLCV', false);
         for (let i = 0; i < ohlcvs.length; i++) {
-            const ohlcvv = !useOHLCVV ? this.parseOHLCV (ohlcvs[i], market) : this.parseOHLCVV (ohlcvs[i], market, keyTimestamp, keyOpen, keyHigh, keyLow, keyClose, keyBasevolume, keyQuotevolume);
+            const ohlcvv = !useOHLCVV ? this.parseOHLCV (ohlcvs[i], market) : this.parseOHLCVV (ohlcvs[i], market);
             results.push (ohlcvv);
         }
         const sorted = this.sortBy (results, 0);
         const tail = (since === undefined);
         return this.filterBySinceLimit (sorted, since, limit, 0, tail);
-    }
-
-    parseOHLCVV (ohlcv, market = undefined, keyTimestamp = 0, keyOpen = 1, keyHigh = 2, keyLow = 3, keyClose = 4, keyBasevolume = 5, keyQuotevolume = 6) {
-        return [
-            this.safeInteger (ohlcv, keyTimestamp), // timestamp
-            this.safeNumber (ohlcv, keyOpen), // open
-            this.safeNumber (ohlcv, keyHigh), // high
-            this.safeNumber (ohlcv, keyLow), // low
-            this.safeNumber (ohlcv, keyClose), // close
-            this.safeNumber (ohlcv, keyBasevolume), // base-volume
-            this.safeNumber (ohlcv, keyQuotevolume), // quote-volume
-        ];
     }
 
     getNetwork (network, code) {


### PR DESCRIPTION
this is possible base methods for `fetchOHLCVV` (which will renamed `fetchOHLCV` upon merge). However, till merge, it will be ok to temporarily co-exists aside it, as you see `useNewOHLCV` option is being used (which defaults to `false` and no-one out there will get exceptions even upon merge) and by specific moment, we will just set it `true` in base and all implementations will be railed onto `parseOHLCVV` response (with 7 array item, instead of 6). I couldn't think of better transition, if I missed smth, lmk.

(also, worth to note, new `parseOHLCVVs` would be able to get the arguments for keys, to sort out everything without singular `parseOHLCV`)