### PR TITLE
bitmart cancelOrder fix

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1869,7 +1869,7 @@ module.exports = class bitmart extends Exchange {
         const market = this.market (symbol);
         const request = {};
         if (market['spot']) {
-            request['order_id'] = parseInt (id);
+            request['order_id'] = id.toString ();
             request['symbol'] = market['id'];
         } else if (market['swap'] || market['future']) {
             throw new NotSupported (this.id + ' cancelOrder () does not accept swap or future orders, only spot orders are allowed');


### PR DESCRIPTION
https://developer-pro.bitmart.com/en/spot/#cancel-order
here specified that `order_id` is `long` but also works with `string`.
The problem is that some pairs (FIU/USDT for example) have very big `order_id` and `parseInt ()` rounds it. 

`exchange.cancelOrder ('34344405335606313', pair)`
```
RequestBody:
 {"order_id":34344405335606310,"symbol":"FIU_USDT"}
```