### PR TITLE
woo: update ratelimit for get positions / get position

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -162,7 +162,7 @@ module.exports = class woo extends Exchange {
                             'interest/history': 60,
                             'interest/repay': 60,
                             'funding_fee/history': 30,
-                            'positions': 3.33, // 30 requests per 10 sedonds
+                            'positions': 3.33, // 30 requests per 10 seconds
                             'position/{symbol}': 3.33,
                         },
                         'post': {

--- a/js/woo.js
+++ b/js/woo.js
@@ -162,8 +162,8 @@ module.exports = class woo extends Exchange {
                             'interest/history': 60,
                             'interest/repay': 60,
                             'funding_fee/history': 30,
-                            'positions': 30,
-                            'position/{symbol}': 30,
+                            'positions': 3.33, // 30 requests per 10 sedonds
+                            'position/{symbol}': 3.33,
                         },
                         'post': {
                             'order': 5, // 2 requests per 1 second per symbol


### PR DESCRIPTION
The rate limit for getting positions and position/{symbol} had been updated to 30 requests per 10 sedonds.

(10000/30)/100 = 3.33333333333