### PR TITLE
currency.com - order & fetchOrder

### DIFF
--- a/js/currencycom.js
+++ b/js/currencycom.js
@@ -254,6 +254,8 @@ module.exports = class currencycom extends Exchange {
                     'Only leverage symbol allowed here:': BadSymbol, // when you fetchLeverage for non-leverage symbols, like 'BTC/USDT' instead of 'BTC/USDT_LEVERAGE': {"code":"-1128","msg":"Only leverage symbol allowed here: BTC/USDT"}
                     'market data service is not available': ExchangeNotAvailable, // {"code":"-1021","msg":"market data service is not available"}
                     'your time is ahead of server': InvalidNonce, // {"code":"-1021","msg":"your time is ahead of server"}
+                    'Can not find account': BadRequest, // -1128
+                    'You mentioned an invalid value for the price parameter': BadRequest, // -1030
                 },
                 'exact': {
                     '-1000': ExchangeNotAvailable, // {"code":-1000,"msg":"An unknown error occured while processing the request."}
@@ -264,7 +266,7 @@ module.exports = class currencycom extends Exchange {
                     '-1100': InvalidOrder, // createOrder(symbol, 1, asdf) -> 'Illegal characters found in parameter 'price'
                     '-1104': ExchangeError, // Not all sent parameters were read, read 8 parameters but was sent 9
                     '-1025': AuthenticationError, // {"code":-1025,"msg":"Invalid API-key, IP, or permissions for action"}
-                    '-1128': BadRequest, // {"code":-1128,"msg":"Combination of optional parameters invalid."} | {"code":"-1128","msg":"Combination of parameters invalid"} | {"code":"-1128","msg":"Invalid limit price"}
+                    '-1128': BadRequest, // {"code":-1128,"msg":"Combination of optional parameters invalid."} | {"code":"-1128","msg":"Combination of parameters invalid"} | {"code":"-1128","msg":"Invalid limit price"} | {"code":"-1128","msg":"Can not find account: null"}
                     '-2010': ExchangeError, // generic error code for createOrder -> 'Account has insufficient balance for requested action.', {"code":-2010,"msg":"Rest API trading is not enabled."}, etc...
                     '-2011': OrderNotFound, // cancelOrder(1, 'BTC/USDT') -> 'UNKNOWN_ORDER'
                     '-2013': OrderNotFound, // fetchOrder (1, 'BTC/USDT') -> 'Order does not exist'

--- a/js/currencycom.js
+++ b/js/currencycom.js
@@ -1211,7 +1211,7 @@ module.exports = class currencycom extends Exchange {
         //       "leverage": false, // whether it's swap or not
         //       "working": true,
         //   }
-        // 
+        //
         const marketId = this.safeString (order, 'symbol');
         const symbol = this.safeSymbol (marketId, market, '/');
         const id = this.safeString (order, 'orderId');

--- a/js/currencycom.js
+++ b/js/currencycom.js
@@ -464,7 +464,7 @@ module.exports = class currencycom extends Exchange {
             const margin = swap; // as we decided to set
             if (swap) {
                 symbol = symbol.replace (this.options['leverage_markets_suffix'], '');
-                symbol += ':' + 'QUANTO';
+                symbol += ':' + quote;
             }
             const active = this.safeString (market, 'status') === 'TRADING';
             // to set taker & maker fees, we use one from the below data - pairs either have 'exchangeFee' or 'tradingFee', if none of them (rare cases), then they should have 'takerFee & makerFee'


### PR DESCRIPTION
this is the correct rework of symbols & orders, mostly for `swap` symbols/orders.
Till this update, settle currency ( i.e. `BTC/USDT:XYZ`, where `XYZ` is settle currency) has been mistakenly set to `quote` currency. however, that was completely mistake, as quote currency is not the only real settle-currency (i.e. each swap symbol has around 5-6 settle currencies) but even that currency might not be existent at all as 'settle currency'  (i.e. `LTC/BTC:BTC` where BTC is not available as settle currency at all).

This PR additionally includes the correct way to set/get settleCurrency or accountId in order-creation method, and if something is not inputed correctly, user gets exception to hint about the correct usage. 