### PR TITLE
Update ftx network mapping

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -410,7 +410,7 @@ module.exports = class ftx extends Exchange {
                     'BNB': 'bep2',
                     'BSC': 'bsc',
                     'ERC20': 'erc20',
-                    'ETH': 'erc20',
+                    'ETH': 'eth',
                     'FTM': 'ftm',
                     'MATIC': 'matic',
                     'OMNI': 'omni',


### PR DESCRIPTION
If one tries to wiithdraw native `ETH` on FTX specifying the `erc20` method, FTX returns this error:

```
ftx: ftx {"success":false,"error":"Please specify method: 'eth' instead"}
```

Therefore we should specify `eth` instead. Note that this is [not documented](https://docs.ftx.com/#request-withdrawal).