### PR TITLE
Mexc3 :: fix fetchMyTrades

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -1121,7 +1121,7 @@ module.exports = class mexc3 extends Exchange {
                 amountString = this.safeString (trade, 'vol');
                 side = this.parseOrderSide (this.safeString (trade, 'side'));
                 fee = {
-                    'cost': this.safeNumber (trade, 'fee'),
+                    'cost': this.safeString (trade, 'fee'),
                     'currency': this.safeCurrencyCode (this.safeString (trade, 'feeCurrency')),
                 };
                 takerOrMaker = this.safeValue (trade, 'taker') ? 'taker' : 'maker';
@@ -1145,7 +1145,7 @@ module.exports = class mexc3 extends Exchange {
                 const feeAsset = this.safeString (trade, 'commissionAsset');
                 if (feeAsset !== undefined) {
                     fee = {
-                        'cost': this.safeNumber (trade, 'commission'),
+                        'cost': this.safeString (trade, 'commission'),
                         'currency': this.safeCurrencyCode (feeAsset),
                     };
                 }


### PR DESCRIPTION
- fix fee type crash

Demo

```
p mexc3 fetchMyTrades "BTC/USDT"                               
Python v3.9.7
CCXT v1.92.55
mexc3.fetchMyTrades(BTC/USDT)
[{'amount': 0.000236,
  'cost': 4.9791162,
  'datetime': '2022-08-22T21:38:08.000Z',
  'fee': {'cost': 0.0099582324, 'currency': 'USDT'},
  'fees': [{'cost': 0.0099582324, 'currency': 'USDT'}],
  'id': '064c29295c8c47359a194a023bdaa4c2',
  'info': {'clientOrderId': None,
           'commission': '0.0099582324',
           'commissionAsset': 'USDT',
           'id': '064c29295c8c47359a194a023bdaa4c2',
           'isBestMatch': True,
           'isBuyer': True,
           'isMaker': False,
           'isSelfTrade': False,
           'orderId': '5bd130a27d684011811242984cc27f00',
           'orderListId': '-1',
           'price': '21097.95',
           'qty': '0.000236',
           'quoteQty': '4.9791162',
           'symbol': 'BTCUSDT',
           'time': '1661204288000'},
  'order': '5bd130a27d684011811242984cc27f00',
  'price': 21097.95,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1661204288000,
  'type': None}]
```
  