### PR TITLE
Fix `margin/trade/last` endpoint's scope for kucoin

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -129,6 +129,7 @@ module.exports = class kucoin extends Exchange {
                         'prices': 1,
                         'mark-price/{symbol}/current': 1,
                         'margin/config': 1,
+                        'margin/trade/last': 1,
                     },
                     'post': {
                         'bullet-public': 1,
@@ -177,7 +178,6 @@ module.exports = class kucoin extends Exchange {
                         'margin/lend/trade/settled': 1,
                         'margin/lend/assets': 1,
                         'margin/market': 1,
-                        'margin/trade/last': 1,
                         'stop-order/{orderId}': 1,
                         'stop-order': 1,
                         'stop-order/queryOrderByClientOid': 1,


### PR DESCRIPTION
https://docs.kucoin.com/#margin-trade-data

```sh
$ curl 'https://api.kucoin.com/api/v1/margin/trade/last?currency=SXP' # 200
```