### PR TITLE
bitmex: fix ccxt/ccxt#14775

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -2149,8 +2149,10 @@ module.exports = class bitmex extends Exchange {
         const crossMargin = this.safeValue (position, 'crossMargin');
         const marginMode = (crossMargin === true) ? 'cross' : 'isolated';
         let notional = undefined;
-        if (market['quote'] === 'USDT') {
+        if (market['quote'] === 'USDT' || market['quote'] === 'USD' || market['quote'] === 'EUR') {
             notional = Precise.stringMul (this.safeString (position, 'foreignNotional'), '-1');
+        } else {
+            notional = this.safeString (position, 'homeNotional');
         }
         const maintenanceMargin = this.safeNumber (position, 'maintMargin');
         const unrealisedPnl = this.safeNumber (position, 'unrealisedPnl');
@@ -2170,10 +2172,10 @@ module.exports = class bitmex extends Exchange {
             'notional': notional,
             'leverage': this.safeNumber (position, 'leverage'),
             'collateral': undefined,
-            'initialMargin': undefined,
+            'initialMargin': this.safeNumber (position, 'initMargin'),
             'initialMarginPercentage': this.safeNumber (position, 'initMarginReq'),
             'maintenanceMargin': this.convertValue (maintenanceMargin, market),
-            'maintenanceMarginPercentage': undefined,
+            'maintenanceMarginPercentage': this.safeNumber (position, 'maintMarginReq'),
             'unrealizedPnl': this.convertValue (unrealisedPnl, market),
             'liquidationPrice': this.safeNumber (position, 'liquidationPrice'),
             'marginMode': marginMode,
@@ -2190,9 +2192,13 @@ module.exports = class bitmex extends Exchange {
         value = this.numberToString (value);
         if ((market['quote'] === 'USD') || (market['quote'] === 'EUR')) {
             resultValue = Precise.stringMul (value, '0.00000001');
-        }
-        if (market['quote'] === 'USDT') {
+        } else if (market['quote'] === 'USDT') {
             resultValue = Precise.stringMul (value, '0.000001');
+        } else {
+            const currency = this.currency (market['quote']);
+            if (currency !== undefined) {
+                resultValue = Precise.stringMul (this.numberToString (currency['precision']), '0.00000001');
+            }
         }
         return parseFloat (resultValue);
     }

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -124,6 +124,8 @@ module.exports = class bitmex extends Exchange {
                         'stats/history': 5,
                         'trade': 5,
                         'trade/bucketed': 5,
+                        'wallet/assets': 5,
+                        'wallet/networks': 5,
                     },
                 },
                 'private': {
@@ -148,6 +150,7 @@ module.exports = class bitmex extends Exchange {
                         'user/wallet': 5,
                         'user/walletHistory': 5,
                         'user/walletSummary': 5,
+                        'userEvent': 5,
                     },
                     'post': {
                         'apiKey': 5,

--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -419,6 +419,8 @@ module.exports = class bitmex extends Exchange {
                 'precision': {
                     'amount': this.safeNumber (market, 'lotSize'),
                     'price': this.safeNumber (market, 'tickSize'),
+                    'quote': this.safeNumber (market, 'tickSize'),
+                    'base': this.safeNumber (market, 'tickSize'),
                 },
                 'limits': {
                     'leverage': {
@@ -2197,7 +2199,7 @@ module.exports = class bitmex extends Exchange {
         } else {
             const currency = this.currency (market['quote']);
             if (currency !== undefined) {
-                resultValue = Precise.stringMul (this.numberToString (currency['precision']), '0.00000001');
+                resultValue = Precise.stringMul (value, this.numberToString (currency['precision']));
             }
         }
         return parseFloat (resultValue);


### PR DESCRIPTION
Change:
- add api endpoints
- fix ccxt/ccxt#14775
- checkout currency scale (tickSize=> quote scale)

I also update these value when parse position: **notional (set to homeNotional when currency is not USDT/USD/EUR)**, initialMargin, maintenanceMarginPercentage.

In this PR, I also set precision of both `base` and `quote` to `tickSize`, cause the emulated function of fetchCurrencies will use the smaller number (default value 1e-8, that's not correct).