### PR TITLE
Kucoin: handleMarginModeAndParams

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -2851,7 +2851,7 @@ module.exports = class kucoin extends Exchange {
          * @param {int|undefined} since the earliest time in ms to fetch borrrow interest for
          * @param {int|undefined} limit the maximum number of structures to retrieve
          * @param {object} params extra parameters specific to the kucoin api endpoint
-         * @param {string} params.marginMode 'cross' or 'isolated'
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' default is 'cross'
          * @returns {[object]} a list of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure}
          */
         await this.loadMarkets ();
@@ -2859,9 +2859,6 @@ module.exports = class kucoin extends Exchange {
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params);
         if (marginMode === undefined) {
             marginMode = 'cross'; // cross as default marginMode
-        }
-        if (symbol !== undefined) {
-            marginMode = 'isolated'; // default to isolated if the symbol argument is defined
         }
         const request = {};
         let method = 'privateGetMarginBorrowOutstanding';
@@ -3031,7 +3028,7 @@ module.exports = class kucoin extends Exchange {
          * @param {string|undefined} symbol unified market symbol, required for isolated margin
          * @param {object} params extra parameters specific to the kucoin api endpoints
          * @param {string} params.timeInForce either IOC or FOK
-         * @param {string} params.marginMode 'cross' or 'isolated'
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' default is 'cross'
          * @returns {object} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
         await this.loadMarkets ();
@@ -3044,9 +3041,6 @@ module.exports = class kucoin extends Exchange {
         [ marginMode, params ] = this.handleMarginModeAndParams ('borrowMargin', params);
         if (marginMode === undefined) {
             marginMode = 'cross'; // cross as default marginMode
-        }
-        if (symbol !== undefined) {
-            marginMode = 'isolated'; // default to isolated if the symbol argument is defined
         }
         let method = 'privatePostMarginBorrow';
         const timeInForce = this.safeStringN (params, [ 'timeInForce', 'type', 'borrowStrategy' ], 'IOC');
@@ -3105,9 +3099,9 @@ module.exports = class kucoin extends Exchange {
          * @param {float} amount the amount to repay
          * @param {string|undefined} symbol unified market symbol
          * @param {object} params extra parameters specific to the kucoin api endpoints
-         * @param {string} params.sequence cross margin repay sequence, either 'RECENTLY_EXPIRE_FIRST' or 'HIGHEST_RATE_FIRST'
-         * @param {string} params.seqStrategy isolated margin repay sequence, either 'RECENTLY_EXPIRE_FIRST' or 'HIGHEST_RATE_FIRST'
-         * @param {string} params.marginMode 'cross' or 'isolated'
+         * @param {string|undefined} params.sequence cross margin repay sequence, either 'RECENTLY_EXPIRE_FIRST' or 'HIGHEST_RATE_FIRST' default is 'RECENTLY_EXPIRE_FIRST'
+         * @param {string|undefined} params.seqStrategy isolated margin repay sequence, either 'RECENTLY_EXPIRE_FIRST' or 'HIGHEST_RATE_FIRST' default is 'RECENTLY_EXPIRE_FIRST'
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' default is 'cross'
          * @returns {object} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
         await this.loadMarkets ();
@@ -3122,9 +3116,6 @@ module.exports = class kucoin extends Exchange {
         [ marginMode, params ] = this.handleMarginModeAndParams ('repayMargin', params);
         if (marginMode === undefined) {
             marginMode = 'cross'; // cross as default marginMode
-        }
-        if (symbol !== undefined) {
-            marginMode = 'isolated'; // default to isolated if the symbol argument is defined
         }
         let method = 'privatePostMarginRepayAll';
         const sequence = this.safeString2 (params, 'sequence', 'seqStrategy', 'RECENTLY_EXPIRE_FIRST');

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -2860,6 +2860,9 @@ module.exports = class kucoin extends Exchange {
         if (marginMode === undefined) {
             marginMode = 'cross'; // cross as default marginMode
         }
+        if (symbol !== undefined) {
+            marginMode = 'isolated'; // default to isolated if the symbol argument is defined
+        }
         const request = {};
         let method = 'privateGetMarginBorrowOutstanding';
         if (marginMode === 'isolated') {

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -2854,8 +2854,11 @@ module.exports = class kucoin extends Exchange {
          * @returns {[object]} a list of [borrow interest structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-interest-structure}
          */
         await this.loadMarkets ();
-        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
-        const marginMode = this.safeString (params, 'marginMode', defaultMarginMode); // cross or isolated
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params);
+        if (marginMode === undefined) {
+            marginMode = 'cross'; // cross as default marginMode
+        }
         const request = {};
         let method = 'privateGetMarginBorrowOutstanding';
         if (marginMode === 'isolated') {


### PR DESCRIPTION
Added handleMarginModeAndParams support to Kucoin.

### fetchBorrowInterest:
```
node examples/js/cli kucoin fetchBorrowInterest USDT BTC/USDT undefined undefined '{"marginMode":"isolated"}'

kucoin.fetchBorrowInterest (USDT, BTC/USDT, , , [object Object])
2022-08-24T02:31:28.910Z iteration 0 passed in 356 ms

     symbol | marginMode | currency | interest | interestRate | amountBorrowed | timestamp | datetime
-----------------------------------------------------------------------------------------------------
  MANA/USDT |   isolated |     MANA |        0 |              |              0 |           |
   EOS/USDC |   isolated |      EOS |        0 |              |              0 |           |
   NKN/USDT |   isolated |      NKN |        0 |              |              0 |           |
...
192 objects
2022-08-24T02:31:28.910Z iteration 1 passed in 356 ms
```

### borrowMargin:
```
node examples/js/cli kucoin borrowMargin USDT 100 BTC/USDT '{"marginMode":"isolated"}'

kucoin.borrowMargin (USDT, 100, BTC/USDT, [object Object])
2022-08-24T03:05:21.850Z iteration 0 passed in 779 ms

{
  id: '630595729a8f5500018fe2a4',
  currency: 'USDT',
  amount: 100,
  symbol: 'BTC/USDT',
  timestamp: 1661310321850,
  datetime: '2022-08-24T03:05:21.850Z',
  info: {
    orderId: '630595729a8f5500018fe2a4',
    currency: 'USDT',
    actualSize: '100'
  }
}
2022-08-24T03:05:21.850Z iteration 1 passed in 779 ms
```

### repayMargin:
```
node examples/js/cli kucoin repayMargin USDT 100.00016667 BTC/USDT '{"marginMode":"isolated"}'

kucoin.repayMargin (USDT, 100.00016667, BTC/USDT, [object Object])
2022-08-24T03:09:17.849Z iteration 0 passed in 572 ms

{
  id: undefined,
  currency: 'USDT',
  amount: 100.00016667,
  symbol: 'BTC/USDT',
  timestamp: 1661310557849,
  datetime: '2022-08-24T03:09:17.849Z',
  info: { code: '200000', data: null }
}
2022-08-24T03:09:17.849Z iteration 1 passed in 572 ms
```