### PR TITLE
gate: fix gateio market type in fetchSpotMarkets

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -722,7 +722,7 @@ module.exports = class gate extends Exchange {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'settleId': undefined,
-                'type': 'spot',
+                'type': margin ? 'margin' : 'spot',
                 'spot': true,
                 'margin': margin,
                 'swap': false,


### PR DESCRIPTION
The `type` attribute in Gateio spot markets should be set to `margin` when margin trading is available.

The option of having a `margin` is already properly handled by other functionalities in the `gateio` exchange, but in practice this never happens as all spots are assigned a hardcoded type `spot` when fetched.

The proposed changes aim at including also the `margin` type for spot markets that support it.