### PR TITLE
binance: send `isIsolated` param for isolated margin mode on `fetchMyTrades`

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3434,10 +3434,11 @@ module.exports = class binance extends Exchange {
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchMyTrades', params);
         if (type === 'spot') {
             method = 'privateGetMyTrades';
-        } else if ((type === 'margin') || (marginMode !== undefined)) {
-            method = 'sapiGetMarginMyTrades';
-            if (marginMode === 'isolated') {
-                request['isIsolated'] = true;
+            if ((type === 'margin') || (marginMode !== undefined)) {
+                method = 'sapiGetMarginMyTrades';
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
             }
         } else if (linear) {
             method = 'fapiPrivateGetUserTrades';

--- a/js/binance.js
+++ b/js/binance.js
@@ -3431,6 +3431,11 @@ module.exports = class binance extends Exchange {
             method = 'privateGetMyTrades';
         } else if (type === 'margin') {
             method = 'sapiGetMarginMyTrades';
+            const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
+            const marginMode = this.safeString (params, 'marginMode', defaultMarginMode); // cross or isolated
+            if (marginMode === 'isolated') {
+                params['isIsolated'] = true;
+            }
         } else if (linear) {
             method = 'fapiPrivateGetUserTrades';
         } else if (inverse) {


### PR DESCRIPTION
When requesting our trades on Binance margin, the related API (i.e. [GET /sapi/v1/margin/myTrades](https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-trade-list-user_data)) requires to specify the `isIsolated` parameter in case the request refers to an isolated-margin wallet.

This PR fixes this behavior by including `isIsolated = true` in the request when the current margin mode is `isolated`.