### PR TITLE
[FIX] kraken.py: fixing amount variable type convertion

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -917,7 +917,7 @@ module.exports = class kraken extends Exchange {
         const type = this.parseLedgerEntryType (this.safeString (item, 'type'));
         const code = this.safeCurrencyCode (this.safeString (item, 'asset'), currency);
         let amount = this.safeString (item, 'amount');
-        if (amount < 0) {
+        if (Precise.stringLt (amount, '0')) {
             direction = 'out';
             amount = Precise.stringAbs (amount);
         } else {

--- a/python/ccxt/kraken.py
+++ b/python/ccxt/kraken.py
@@ -886,10 +886,10 @@ class kraken(Exchange):
         referenceAccount = None
         type = self.parse_ledger_entry_type(self.safe_string(item, 'type'))
         code = self.safe_currency_code(self.safe_string(item, 'asset'), currency)
-        amount = self.safe_string(item, 'amount')
+        amount = self.safe_number(item, 'amount')
         if amount < 0:
             direction = 'out'
-            amount = Precise.string_abs(amount)
+            amount = abs(amount)
         else:
             direction = 'in'
         time = self.safe_number(item, 'time')
@@ -905,7 +905,7 @@ class kraken(Exchange):
             'referenceAccount': referenceAccount,
             'type': type,
             'currency': code,
-            'amount': self.parse_number(amount),
+            'amount': amount,
             'before': None,
             'after': self.safe_number(item, 'balance'),
             'status': 'ok',

--- a/python/ccxt/kraken.py
+++ b/python/ccxt/kraken.py
@@ -886,10 +886,10 @@ class kraken(Exchange):
         referenceAccount = None
         type = self.parse_ledger_entry_type(self.safe_string(item, 'type'))
         code = self.safe_currency_code(self.safe_string(item, 'asset'), currency)
-        amount = self.safe_number(item, 'amount')
+        amount = self.safe_string(item, 'amount')
         if amount < 0:
             direction = 'out'
-            amount = abs(amount)
+            amount = Precise.string_abs(amount)
         else:
             direction = 'in'
         time = self.safe_number(item, 'time')
@@ -905,7 +905,7 @@ class kraken(Exchange):
             'referenceAccount': referenceAccount,
             'type': type,
             'currency': code,
-            'amount': amount,
+            'amount': self.parse_number(amount),
             'before': None,
             'after': self.safe_number(item, 'balance'),
             'status': 'ok',


### PR DESCRIPTION
Hello Community,

Problem appears when amount (type 'str') compared with number 0 (type 'int').

Thanks

```

Traceback (most recent call last):
  File "kraken.py", line 27, in <module>
    trades = exchange.fetch_ledger(code=None, since=None, limit=None, params={'ofs': offset})
  File "/venv/lib/python3.8/site-packages/ccxt/kraken.py", line 958, in fetch_ledger
    return self.parse_ledger(items, currency, since, limit)
  File "/venv/lib/python3.8/site-packages/ccxt/base/exchange.py", line 2574, in parse_ledger
    itemOrItems = self.parse_ledger_entry(arrayData[i], currency)
  File "/venv/lib/python3.8/site-packages/ccxt/kraken.py", line 891, in parse_ledger_entry
    if amount < 0:
TypeError: '<' not supported between instances of 'str' and 'int'
```