### PR TITLE
Hitbtc3: handleMarginModeAndParams

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -2204,15 +2204,22 @@ module.exports = class hitbtc3 extends Exchange {
          * @description fetch all open positions
          * @param {[string]|undefined} symbols not used by hitbtc3 fetchPositions ()
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported, defaults to spot-margin endpoint if this is set
+         * @param {bool|undefined} params.margin true for fetching spot-margin positions
          * @returns {[object]} a list of [position structure]{@link https://docs.ccxt.com/en/latest/manual.html#position-structure}
          */
         await this.loadMarkets ();
         const request = {};
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchPositions', undefined, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchPositions', undefined, params);
+        let method = this.getSupportedMapping (marketType, {
             'swap': 'privateGetFuturesAccount',
             'margin': 'privateGetMarginAccount',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchPositions', params);
+        if (marginMode !== undefined) {
+            method = 'privateGetMarginAccount';
+        }
         const response = await this[method] (this.extend (request, query));
         //
         //     [

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1766,12 +1766,17 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('editOrder', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('editOrder', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privatePatchSpotOrderClientOrderId',
             'swap': 'privatePatchFuturesOrderClientOrderId',
             'margin': 'privatePatchMarginOrderClientOrderId',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('editOrder', params);
+        if (marginMode !== undefined) {
+            method = 'privatePatchMarginOrderClientOrderId';
+        }
         const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1432,7 +1432,7 @@ module.exports = class hitbtc3 extends Exchange {
          * @param {int|undefined} limit the maximum number of  orde structures to retrieve
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
          * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported
-         * @param {bool|undefined} params.margin true for fetching margin trades
+         * @param {bool|undefined} params.margin true for fetching margin orders
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1472,7 +1472,7 @@ module.exports = class hitbtc3 extends Exchange {
          * @param {string|undefined} symbol unified symbol of the market the order was made in
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
          * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported
-         * @param {bool|undefined} params.margin true for fetching margin trades
+         * @param {bool|undefined} params.margin true for fetching a margin order
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1528,6 +1528,8 @@ module.exports = class hitbtc3 extends Exchange {
          * @param {int|undefined} since the earliest time in ms to fetch trades for
          * @param {int|undefined} limit the maximum number of trades to retrieve
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported
+         * @param {bool|undefined} params.margin true for fetching margin trades
          * @returns {[object]} a list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html#trade-structure}
          */
         await this.loadMarkets ();
@@ -1538,12 +1540,17 @@ module.exports = class hitbtc3 extends Exchange {
         const request = {
             'order_id': id, // exchange assigned order id as oppose to the client order id
         };
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrderTrades', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrderTrades', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotHistoryTrade',
             'swap': 'privateGetFuturesHistoryTrade',
             'margin': 'privateGetMarginHistoryTrade',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrderTrades', params);
+        if (marginMode !== undefined) {
+            method = 'privateGetMarginHistoryTrade';
+        }
         const response = await this[method] (this.extend (request, query));
         //
         // Spot

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -2267,15 +2267,22 @@ module.exports = class hitbtc3 extends Exchange {
          * @description fetch data on a single open contract trade position
          * @param {string} symbol unified market symbol of the market the position is held in, default is undefined
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported, defaults to spot-margin endpoint if this is set
+         * @param {bool|undefined} params.margin true for fetching a spot-margin position
          * @returns {object} a [position structure]{@link https://docs.ccxt.com/en/latest/manual.html#position-structure}
          */
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchPosition', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchPosition', undefined, params);
+        let method = this.getSupportedMapping (marketType, {
             'swap': 'privateGetFuturesAccountIsolatedSymbol',
             'margin': 'privateGetMarginAccountIsolatedSymbol',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchPosition', params);
+        if (marginMode !== undefined) {
+            method = 'privateGetMarginAccountIsolatedSymbol';
+        }
+        const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
         };

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1655,6 +1655,8 @@ module.exports = class hitbtc3 extends Exchange {
          * @param {string} id order id
          * @param {string|undefined} symbol unified market symbol, default is undefined
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported
+         * @param {bool|undefined} params.margin true for fetching an open margin order
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1662,12 +1664,17 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrder', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrder', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotOrderClientOrderId',
             'swap': 'privateGetFuturesOrderClientOrderId',
             'margin': 'privateGetMarginOrderClientOrderId',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOpenOrder', params);
+        if (marginMode !== undefined) {
+            method = 'privateGetMarginOrderClientOrderId';
+        }
         const request = {
             'client_order_id': id,
         };

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -2591,6 +2591,8 @@ module.exports = class hitbtc3 extends Exchange {
          * @description fetch the set leverage for a market
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported, defaults to the spot-margin endpoint if this is set
+         * @param {bool|undefined} params.margin true for fetching spot-margin leverage
          * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/en/latest/manual.html#leverage-structure}
          */
         await this.loadMarkets ();
@@ -2598,12 +2600,16 @@ module.exports = class hitbtc3 extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const method = this.getSupportedMapping (market['type'], {
+        let method = this.getSupportedMapping (market['type'], {
             'spot': 'privateGetMarginAccountIsolatedSymbol',
             'margin': 'privateGetMarginAccountIsolatedSymbol',
             'swap': 'privateGetFuturesAccountIsolatedSymbol',
         });
-        const response = await this[method] (this.extend (request, params));
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('modifyMarginHelper', params);
+        if (marginMode !== undefined) {
+            method = 'privateGetMarginAccountIsolatedSymbol';
+        }
+        const response = await this[method] (this.extend (request, query));
         //
         //     {
         //         "symbol": "BTCUSDT",

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -2503,11 +2503,16 @@ module.exports = class hitbtc3 extends Exchange {
         if (leverage !== undefined) {
             request['leverage'] = leverage;
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('modifyMarginHelper', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('modifyMarginHelper', undefined, params);
+        let method = this.getSupportedMapping (marketType, {
             'swap': 'privatePutFuturesAccountIsolatedSymbol',
             'margin': 'privatePutMarginAccountIsolatedSymbol',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('modifyMarginHelper', params);
+        if (marginMode !== undefined) {
+            method = 'privatePutMarginAccountIsolatedSymbol';
+        }
         const response = await this[method] (this.extend (request, query));
         //
         //     {
@@ -2554,6 +2559,8 @@ module.exports = class hitbtc3 extends Exchange {
          * @param {string} symbol unified market symbol
          * @param {float} amount the amount of margin to remove
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported, defaults to the spot-margin endpoint if this is set
+         * @param {bool|undefined} params.margin true for reducing spot-margin
          * @returns {object} a [margin structure]{@link https://docs.ccxt.com/en/latest/manual.html#reduce-margin-structure}
          */
         if (amount !== 0) {
@@ -2570,6 +2577,8 @@ module.exports = class hitbtc3 extends Exchange {
          * @param {string} symbol unified market symbol
          * @param {float} amount amount of margin to add
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported, defaults to the spot-margin endpoint if this is set
+         * @param {bool|undefined} params.margin true for adding spot-margin
          * @returns {object} a [margin structure]{@link https://docs.ccxt.com/en/latest/manual.html#add-margin-structure}
          */
         return await this.modifyMarginHelper (symbol, amount, 'add', params);

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -1471,6 +1471,8 @@ module.exports = class hitbtc3 extends Exchange {
          * @description fetches information on an order made by the user
          * @param {string|undefined} symbol unified symbol of the market the order was made in
          * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported
+         * @param {bool|undefined} params.margin true for fetching margin trades
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1478,12 +1480,17 @@ module.exports = class hitbtc3 extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotHistoryOrder',
             'swap': 'privateGetFuturesHistoryOrder',
             'margin': 'privateGetMarginHistoryOrder',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrder', params);
+        if (marginMode !== undefined) {
+            method = 'privateGetMarginHistoryOrder';
+        }
         const request = {
             'client_order_id': id,
         };


### PR DESCRIPTION
Added handleMarginModeAndParams to Hitbtc3.

I noticed an issue with handleMarketTypeAndParams, if the method requires a symbol and handleMarketTypeAndParams takes a market argument, it will set the method to the spot method if there is one available, if there is no spot method in the mapping it will throw an error before selecting the margin endpoint from the added logic. I fixed this by setting the market argument in handleMarketTypeAndParams to undefined in these cases for now. This happens in fetchPosition, fetchPositions and modifyMarginHelper

### fetchMyTrades:
```
node examples/js/cli hitbtc3 fetchMyTrades BTC/USDT undefined undefined '{"margin":true}'

hitbtc3.fetchMyTrades (BTC/USDT, , , [object Object])
2022-08-27T04:55:36.262Z iteration 0 passed in 225 ms

        id | order |     timestamp |                 datetime |   symbol | type | side | takerOrMaker |    price |  amount |       cost |                                      fee |                                       fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1655137410 |       | 1648086557205 | 2022-03-24T01:49:17.205Z | BTC/USDT |      |  buy |        taker | 42754.43 | 0.00002 |  0.8550886 |  {"cost":0.0021377215,"currency":"USDT"} |  [{"currency":"USDT","cost":0.0021377215}]
1655176498 |       | 1648088865487 | 2022-03-24T02:27:45.487Z | BTC/USDT |      | sell |        taker | 42772.45 | 0.00002 |   0.855449 |  {"cost":0.0021386225,"currency":"USDT"} |  [{"currency":"USDT","cost":0.0021386225}]
1662647578 |       | 1648516584430 | 2022-03-29T01:16:24.430Z | BTC/USDT |      |  buy |        taker | 47435.57 | 0.00005 |  2.3717785 | {"cost":0.00592944625,"currency":"USDT"} | [{"currency":"USDT","cost":0.00592944625}]
...
2022-08-27T04:55:36.262Z iteration 1 passed in 225 ms
```

### fetchClosedOrders:
```
node examples/js/cli hitbtc3 fetchClosedOrders BTC/USDT undefined undefined '{"margin":true}'

hitbtc3.fetchClosedOrders (BTC/USDT, , , [object Object])
2022-08-27T05:03:35.124Z iteration 0 passed in 229 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |    price |  amount |   type | side | timeInForce | postOnly | reduceOnly |  filled | remaining |       cost | status |  average | trades | fee | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1f4a2e68aee44a8482688d864ef996cf | 1f4a2e68aee44a8482688d864ef996cf | 1648086557205 | 2022-03-24T01:49:17.205Z |                    | BTC/USDT | 47029.87 | 0.00002 | market |  buy |         FOK |          |            | 0.00002 |         0 |  0.8550886 | closed | 42754.43 |     [] |     |   []
bfe837e8234d911b970eec282c1c6449 | bfe837e8234d911b970eec282c1c6449 | 1648088865487 | 2022-03-24T02:27:45.487Z |                    | BTC/USDT | 38495.21 | 0.00002 | market | sell |         GTC |          |            | 0.00002 |         0 |   0.855449 | closed | 42772.45 |     [] |     |   []
e7c36e0492be40479e0c29b55081dab6 | e7c36e0492be40479e0c29b55081dab6 | 1648516584430 | 2022-03-29T01:16:24.430Z |                    | BTC/USDT | 52179.12 | 0.00005 | market |  buy |         FOK |          |            | 0.00005 |         0 |  2.3717785 | closed | 47435.57 |     [] |     |   []
...
15 objects
2022-08-27T05:03:35.124Z iteration 1 passed in 229 ms
```

### fetchOrder:
```
node examples/js/cli hitbtc3 fetchOrder 1f4a2e68aee44a8482688d864ef996cf BTC/USDT '{"margin":true}'

hitbtc3.fetchOrder (1f4a2e68aee44a8482688d864ef996cf, BTC/USDT, [object Object])
2022-08-27T05:06:57.694Z iteration 0 passed in 236 ms

{
  info: {
    id: '841283764693',
    client_order_id: '1f4a2e68aee44a8482688d864ef996cf',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'filled',
    type: 'market',
    time_in_force: 'FOK',
    quantity: '0.00002',
    quantity_cumulative: '0.00002',
    price: '47029.87',
    price_average: '42754.43',
    created_at: '2022-03-24T01:49:17.205Z',
    updated_at: '2022-03-24T01:49:17.205Z'
  },
  id: '1f4a2e68aee44a8482688d864ef996cf',
  clientOrderId: '1f4a2e68aee44a8482688d864ef996cf',
  timestamp: 1648086557205,
  datetime: '2022-03-24T01:49:17.205Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  price: 47029.87,
  amount: 0.00002,
  type: 'market',
  side: 'buy',
  timeInForce: 'FOK',
  postOnly: undefined,
  reduceOnly: undefined,
  filled: 0.00002,
  remaining: 0,
  cost: 0.8550886,
  status: 'closed',
  average: 42754.43,
  trades: [],
  fee: undefined,
  fees: []
}
2022-08-27T05:06:57.694Z iteration 1 passed in 236 ms
```

### fetchOrderTrades:
```
node examples/js/cli hitbtc3 fetchOrderTrades 841283764693 BTC/USDT undefined undefined '{"margin":true}'

hitbtc3.fetchOrderTrades (841283764693, BTC/USDT, , , [object Object])
2022-08-27T05:13:18.890Z iteration 0 passed in 234 ms

        id | order |     timestamp |                 datetime |   symbol | type | side | takerOrMaker |    price |  amount |      cost |
                  fee |                                      fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1655137410 |       | 1648086557205 | 2022-03-24T01:49:17.205Z | BTC/USDT |      |  buy |        taker | 42754.43 | 0.00002 | 0.8550886 | {"cost":0.0021377215,"currency":"USDT"} | [{"currency":"USDT","cost":0.0021377215}]
1 objects
2022-08-27T05:13:18.890Z iteration 1 passed in 234 ms
```

### fetchOpenOrders:
```
node examples/js/cli hitbtc3 fetchOpenOrders BTC/USDT undefined undefined '{"margin":true}'

hitbtc3.fetchOpenOrders (BTC/USDT, , , [object Object])
2022-08-27T05:19:52.455Z iteration 0 passed in 193 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol | price |  amount |  type | side | timeInForce | postOnly | reduceOnly | filled | remaining | cost | status | average | trades | fee | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
12453982069545808e58d30bce610c9a | 12453982069545808e58d30bce610c9a | 1661577583083 | 2022-08-27T05:19:43.083Z |                    | BTC/USDT | 18000 | 0.00124 | limit |  buy |         GTC |    false |      false |      0 |   0.00124 |    0 |   open |         |     [] |     |   []
1 objects
2022-08-27T05:19:52.455Z iteration 1 passed in 193 ms
```

### fetchOpenOrder:
```
node examples/js/cli hitbtc3 fetchOpenOrder '"12453982069545808e58d30bce610c9a"' BTC/USDT '{"margin":true}'

hitbtc3.fetchOpenOrder (12453982069545808e58d30bce610c9a, BTC/USDT, [object Object])
2022-08-27T05:24:28.326Z iteration 0 passed in 198 ms

{
  info: {
    id: '965405151933',
    client_order_id: '12453982069545808e58d30bce610c9a',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00124',
    quantity_cumulative: '0',
    price: '18000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-08-27T05:19:43.083Z',
    updated_at: '2022-08-27T05:19:43.083Z'
  },
  id: '12453982069545808e58d30bce610c9a',
  clientOrderId: '12453982069545808e58d30bce610c9a',
  timestamp: 1661577583083,
  datetime: '2022-08-27T05:19:43.083Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  price: 18000,
  amount: 0.00124,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  filled: 0,
  remaining: 0.00124,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
2022-08-27T05:24:28.326Z iteration 1 passed in 198 ms
```

### cancelAllOrders:
```
node examples/js/cli hitbtc3 cancelAllOrders BTC/USDT '{"margin":true}'

hitbtc3.cancelAllOrders (BTC/USDT, [object Object])
2022-08-27T05:28:12.340Z iteration 0 passed in 229 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol | price |  amount |  type | side | timeInForce | postOnly | reduceOnly | filled | remaining | cost | status | average | trades | fee | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
12453982069545808e58d30bce610c9a | 12453982069545808e58d30bce610c9a | 1661577583083 | 2022-08-27T05:19:43.083Z |                    | BTC/USDT | 18000 | 0.00124 | limit |  buy |         GTC |    false |      false |      0 |   0.00124 |    0 |   open |         |     [] |     |   []
1 objects
2022-08-27T05:28:12.340Z iteration 1 passed in 229 ms
```

### cancelOrder:
```
node examples/js/cli hitbtc3 cancelOrder 94d3cf1c975f4ab3b0978fb37daec826 BTC/USDT '{"margin":true}'

hitbtc3.cancelOrder (94d3cf1c975f4ab3b0978fb37daec826, BTC/USDT, [object Object])
2022-08-27T05:42:32.234Z iteration 0 passed in 202 ms

{
  info: {
    id: '965416014551',
    client_order_id: '94d3cf1c975f4ab3b0978fb37daec826',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'canceled',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00124',
    quantity_cumulative: '0',
    price: '18000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-08-27T05:41:01.256Z',
    updated_at: '2022-08-27T05:42:33.559Z'
  },
  id: '94d3cf1c975f4ab3b0978fb37daec826',
  clientOrderId: '94d3cf1c975f4ab3b0978fb37daec826',
  timestamp: 1661578861256,
  datetime: '2022-08-27T05:41:01.256Z',
  lastTradeTimestamp: 1661578953559,
  symbol: 'BTC/USDT',
  price: 18000,
  amount: 0.00124,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  filled: 0,
  remaining: 0.00124,
  cost: 0,
  status: 'canceled',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
2022-08-27T05:42:32.234Z iteration 1 passed in 202 ms
```

### editOrder:
```
node examples/js/cli hitbtc3 editOrder cd3440f18fea48b29891bac8bcbc6963 BTC/USDT limit buy 0.002 18000 '{"margin":true}'

hitbtc3.editOrder (cd3440f18fea48b29891bac8bcbc6963, BTC/USDT, limit, buy, 0.002, 18000, [object Object])
2022-08-27T05:46:18.431Z iteration 0 passed in 198 ms

{
  info: {
    id: '965419032797',
    client_order_id: 'zo2tGC4dq_CmX8yGH5ivefSgMe1Pz2zj',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00200',
    quantity_cumulative: '0',
    price: '18000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-08-27T05:44:58.12Z',
    updated_at: '2022-08-27T05:46:19.754Z'
  },
  id: 'zo2tGC4dq_CmX8yGH5ivefSgMe1Pz2zj',
  clientOrderId: 'zo2tGC4dq_CmX8yGH5ivefSgMe1Pz2zj',
  timestamp: 1661579098120,
  datetime: '2022-08-27T05:44:58.120Z',
  lastTradeTimestamp: 1661579179754,
  symbol: 'BTC/USDT',
  price: 18000,
  amount: 0.002,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  filled: 0,
  remaining: 0.002,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
2022-08-27T05:46:18.431Z iteration 1 passed in 198 ms
```

### createOrder:
```
node examples/js/cli hitbtc3 createOrder BTC/USDT limit buy 0.002 18000 '{"margin":true}'

hitbtc3.createOrder (BTC/USDT, limit, buy, 0.002, 18000, [object Object])
2022-08-27T05:50:00.237Z iteration 0 passed in 212 ms

{
  info: {
    id: '965420886809',
    client_order_id: '5u7TJWlJdjB1UFb30clMsxvl9_prA4A9',
    symbol: 'BTCUSDT',
    side: 'buy',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '0.00200',
    quantity_cumulative: '0',
    price: '18000.00',
    post_only: false,
    reduce_only: false,
    created_at: '2022-08-27T05:50:01.552Z',
    updated_at: '2022-08-27T05:50:01.552Z'
  },
  id: '5u7TJWlJdjB1UFb30clMsxvl9_prA4A9',
  clientOrderId: '5u7TJWlJdjB1UFb30clMsxvl9_prA4A9',
  timestamp: 1661579401552,
  datetime: '2022-08-27T05:50:01.552Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  price: 18000,
  amount: 0.002,
  type: 'limit',
  side: 'buy',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  filled: 0,
  remaining: 0.002,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
2022-08-27T05:50:00.237Z iteration 1 passed in 212 ms
```

### fetchPositions:
```
node examples/js/cli hitbtc3 fetchPositions BTC/USDT '{"margin":true}'

hitbtc3.fetchPositions (BTC/USDT, [object Object])
2022-08-27T05:54:19.673Z iteration 0 passed in 188 ms

  symbol | notional | marginMode | marginType | liquidationPrice | entryPrice | unrealizedPnl | percentage | contracts | contractSize | markPrice | side | hedged |     timestamp |                 datetime | maintenanceMargin | maintenanceMarginPercentage |    collateral | initialMargin | initialMarginPercentage | leverage | marginRatio
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT |          |   isolated |   isolated |                0 |   20097.46 |               |            |   0.00087 |              |           |      |        | 1661579608226 | 2022-08-27T05:53:28.226Z |                   |                             | 25.2562880245 |               |                         |       12 |
1 objects
2022-08-27T05:54:19.673Z iteration 1 passed in 188 ms
```

### fetchPosition:
```
node examples/js/cli hitbtc3 fetchPosition BTC/USDT '{"margin":true}'

hitbtc3.fetchPosition (BTC/USDT, [object Object])
2022-08-27T06:01:25.038Z iteration 0 passed in 201 ms

{
  info: {
    symbol: 'BTCUSDT',
    type: 'isolated',
    leverage: '12.00',
    created_at: '2022-08-27T05:19:29.14Z',
    updated_at: '2022-08-27T05:53:28.226Z',
    currencies: [
      {
        code: 'USDT',
        margin_balance: '25.256288024500',
        reserved_orders: '0',
        reserved_positions: '1.551775130250'
      }
    ],
    positions: [
      {
        id: '682716',
        symbol: 'BTCUSDT',
        quantity: '0.00087',
        price_entry: '20097.46',
        price_margin_call: '0',
        price_liquidation: '0',
        pnl: '0',
        created_at: '2022-08-27T05:19:29.14Z',
        updated_at: '2022-08-27T05:53:28.226Z'
      }
    ]
  },
  symbol: 'BTC/USDT',
  notional: undefined,
  marginMode: 'isolated',
  marginType: 'isolated',
  liquidationPrice: 0,
  entryPrice: 20097.46,
  unrealizedPnl: undefined,
  percentage: undefined,
  contracts: 0.00087,
  contractSize: undefined,
  markPrice: undefined,
  side: undefined,
  hedged: undefined,
  timestamp: 1661579608226,
  datetime: '2022-08-27T05:53:28.226Z',
  maintenanceMargin: undefined,
  maintenanceMarginPercentage: undefined,
  collateral: 25.2562880245,
  initialMargin: undefined,
  initialMarginPercentage: undefined,
  leverage: 12,
  marginRatio: undefined
}
2022-08-27T06:01:25.038Z iteration 1 passed in 201 ms
```

### addMargin:
```
node examples/js/cli hitbtc3 addMargin BTC/USDT 10 '{"margin":true}'

hitbtc3.addMargin (BTC/USDT, 10, [object Object])
2022-08-27T06:08:37.408Z iteration 0 passed in 296 ms

{
  info: {
    symbol: 'BTCUSDT',
    type: 'isolated',
    leverage: '12.00',
    created_at: '2022-08-27T05:19:29.14Z',
    updated_at: '2022-08-27T06:08:38.752Z',
    currencies: [
      {
        code: 'USDT',
        margin_balance: '10.000000000000',
        reserved_orders: '0',
        reserved_positions: '1.551775130250'
      }
    ],
    positions: [
      {
        id: '682716',
        symbol: 'BTCUSDT',
        quantity: '0.00087',
        price_entry: '20097.46',
        price_margin_call: '9267.37',
        price_liquidation: '9081.05',
        pnl: '0',
        created_at: '2022-08-27T05:19:29.14Z',
        updated_at: '2022-08-27T06:08:38.752Z'
      }
    ]
  },
  type: 'add',
  amount: 10,
  code: 'USDT',
  symbol: 'BTC/USDT',
  status: undefined
}
2022-08-27T06:08:37.408Z iteration 1 passed in 296 ms
```

### reduceMargin:
```
node examples/js/cli hitbtc3 reduceMargin BTC/USDT 0 '{"margin":true}'

hitbtc3.reduceMargin (BTC/USDT, 0, [object Object])
2022-08-27T06:10:54.247Z iteration 0 passed in 294 ms

{
  info: {
    symbol: 'BTCUSDT',
    type: 'isolated',
    leverage: '12.00',
    created_at: '2022-08-27T06:10:27.145Z',
    updated_at: '2022-08-27T06:10:55.591Z',
    currencies: [
      {
        code: 'USDT',
        margin_balance: '0',
        reserved_orders: '0',
        reserved_positions: '0'
      }
    ],
    positions: null
  },
  type: 'reduce',
  amount: 0,
  code: 'USDT',
  symbol: 'BTC/USDT',
  status: undefined
}
2022-08-27T06:10:54.247Z iteration 1 passed in 294 ms
```

### fetchLeverage:
```
node examples/js/cli hitbtc3 fetchLeverage BTC/USDT '{"margin":true}'

hitbtc3.fetchLeverage (BTC/USDT, [object Object])
2022-08-27T06:14:02.907Z iteration 0 passed in 230 ms

12
2022-08-27T06:14:02.907Z iteration 1 passed in 230 ms
```