### PR TITLE
[huobi] default subtype as linear

### DIFF
--- a/python/ccxt/async_support/huobi.py
+++ b/python/ccxt/async_support/huobi.py
@@ -899,7 +899,7 @@ class huobi(Exchange):
                     },
                 },
                 'defaultType': 'spot',  # spot, future, swap
-                'defaultSubType': 'inverse',  # inverse, linear
+                'defaultSubType': 'linear',  # inverse, linear
                 'defaultNetwork': 'ERC20',
                 'networks': {
                     'ETH': 'erc20',


### PR DESCRIPTION
I am not sure if this is an accidental bug or intended, but this is very irregular.

I checked other exchanges' default values. bitget, bybit, coinex, and phemex use linear but only huobi use inverse.