### PR TITLE
Binance :: fix fetchMyTrades

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3432,7 +3432,7 @@ module.exports = class binance extends Exchange {
         const inverse = (type === 'delivery');
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchMyTrades', params);
-        if (type === 'spot') {
+        if (market['type'] === 'spot') {
             method = 'privateGetMyTrades';
             if ((type === 'margin') || (marginMode !== undefined)) {
                 method = 'sapiGetMarginMyTrades';


### PR DESCRIPTION
- once again, typescript giving us a hand
![image](https://user-images.githubusercontent.com/43336371/187178476-51931885-c587-4026-926b-d07b2968f401.png)

```
p binance fetchMyTrades "LTC/USDT" None 1
Python v3.9.7
CCXT v1.92.85
binance.fetchMyTrades(LTC/USDT,None,1)
[{'amount': 0.174,
  'cost': 9.99282,
  'datetime': '2022-08-24T16:05:36.827Z',
  'fee': {'cost': 0.000174, 'currency': 'LTC'},
  'fees': [{'cost': 0.000174, 'currency': 'LTC'}],
  'id': '249817590',
  'info': {'commission': '0.00017400',
           'commissionAsset': 'LTC',
           'id': '249817590',
           'isBestMatch': True,
           'isBuyer': True,
           'isMaker': False,
           'orderId': '3010478906',
           'orderListId': '-1',
           'price': '57.43000000',
           'qty': '0.17400000',
           'quoteQty': '9.99282000',
           'symbol': 'LTCUSDT',
           'time': '1661357136827'},
  'order': '3010478906',
  'price': 57.43,
  'side': 'buy',
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1661357136827,
  'type': None}]

p binance fetchMyTrades "LTC/USDT" None 1 '{"marginMode":"cross"}'          
Python v3.9.7
CCXT v1.92.85
binance.fetchMyTrades(LTC/USDT,None,1,{'marginMode': 'cross'})
[{'amount': 0.174,
  'cost': 9.96846,
  'datetime': '2022-08-24T16:01:19.338Z',
  'fee': {'cost': 0.000174, 'currency': 'LTC'},
  'fees': [{'cost': 0.000174, 'currency': 'LTC'}],
  'id': '249816972',
  'info': {'commission': '0.000174',
           'commissionAsset': 'LTC',
           'id': '249816972',
           'isBestMatch': True,
           'isBuyer': True,
           'isIsolated': False,
           'isMaker': False,
           'orderId': '3010469360',
           'price': '57.29',
           'qty': '0.174',
           'quoteQty': '9.96846',
           'symbol': 'LTCUSDT',
           'time': '1661356879338'},
  'order': '3010469360',
  'price': 57.29,
  'side': 'buy',
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1661356879338,
  'type': None}]
```
