### PR TITLE
poloniex: fix ccxt/ccxt#14829

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1353,14 +1353,14 @@ module.exports = class poloniex extends Exchange {
         const asksResult = [];
         const bidsResult = [];
         for (let i = 0; i < asks.length; i++) {
-            if ((i % 2) > 0) {
+            if ((i % 2) < 1) {
                 const price = this.safeNumber (asks, i);
                 const amount = this.safeNumber (asks, this.sum (i, 1));
                 asksResult.push ([ price, amount ]);
             }
         }
         for (let i = 0; i < bids.length; i++) {
-            if ((i % 2) > 0) {
+            if ((i % 2) < 1) {
                 const price = this.safeNumber (bids, i);
                 const amount = this.safeNumber (bids, this.sum (i, 1));
                 bidsResult.push ([ price, amount ]);

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1353,14 +1353,14 @@ module.exports = class poloniex extends Exchange {
         const asksResult = [];
         const bidsResult = [];
         for (let i = 0; i < asks.length; i++) {
-            if ((i % 2) === 0) {
+            if (i % 2) {
                 const price = this.safeNumber (asks, i);
                 const amount = this.safeNumber (asks, this.sum (i, 1));
                 asksResult.push ([ price, amount ]);
             }
         }
         for (let i = 0; i < bids.length; i++) {
-            if ((i % 2) === 0) {
+            if (i % 2) {
                 const price = this.safeNumber (bids, i);
                 const amount = this.safeNumber (bids, this.sum (i, 1));
                 bidsResult.push ([ price, amount ]);

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1353,14 +1353,14 @@ module.exports = class poloniex extends Exchange {
         const asksResult = [];
         const bidsResult = [];
         for (let i = 0; i < asks.length; i++) {
-            if (i % 2) {
+            if ((i % 2) > 0) {
                 const price = this.safeNumber (asks, i);
                 const amount = this.safeNumber (asks, this.sum (i, 1));
                 asksResult.push ([ price, amount ]);
             }
         }
         for (let i = 0; i < bids.length; i++) {
-            if (i % 2) {
+            if ((i % 2) > 0) {
                 const price = this.safeNumber (bids, i);
                 const amount = this.safeNumber (bids, this.sum (i, 1));
                 bidsResult.push ([ price, amount ]);


### PR DESCRIPTION
fix ccxt/ccxt#14829

It turns out `fmod` returns float type, and we compare result and types: `fmod (i % 2) === 0`, that's why `fetch_order_book` didn't work in php.