### PR TITLE
Mexc3: borrowMargin

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -4041,9 +4041,9 @@ module.exports = class mexc3 extends Exchange {
          * @see https://mxcdevelop.github.io/apidocs/spot_v3_en/#loan
          * @param {string} code unified currency code of the currency to borrow
          * @param {float} amount the amount to borrow
-         * @param {string|undefined} symbol unified market symbol
+         * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the mexc3 api endpoint
-         * @param {string} params.marginMode 'cross' or 'isolated' only 'isolated' is supported for borrowMargin()
+         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported for borrowMargin()
          * @returns {object} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
         await this.loadMarkets ();

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -433,6 +433,7 @@ module.exports = class mexc3 extends Exchange {
                     '2003': InvalidOrder,
                     '2005': InsufficientFunds,
                     '600': BadRequest,
+                    '88004': InsufficientFunds, // {"msg":"超出最大可借，最大可借币为:18.09833211","code":88004}
                 },
                 'broad': {
                     'Order quantity error, please try to modify.': BadRequest, // code:2011

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -4043,29 +4043,20 @@ module.exports = class mexc3 extends Exchange {
          * @param {float} amount the amount to borrow
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the mexc3 api endpoint
-         * @param {string|undefined} params.marginMode 'cross' or 'isolated' only 'isolated' is supported for borrowMargin()
          * @returns {object} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
         await this.loadMarkets ();
-        let market = undefined;
-        if (symbol !== undefined) {
-            market = this.market (symbol);
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' borrowMargin() requires a symbol argument for isolated margin');
         }
+        const market = this.market (symbol);
         const currency = this.currency (code);
         const request = {
             'asset': currency['id'],
             'amount': this.currencyToPrecision (code, amount),
+            'symbol': market['id'],
         };
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('borrowMargin', params);
-        if (marginMode === 'cross') {
-            throw new NotSupported (this.id + ' borrowMargin() does not support cross margin');
-        } else {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' borrowMargin() requires a symbol argument for isolated margin');
-            }
-            request['symbol'] = market['id'];
-        }
-        const response = await this.spotPrivatePostMarginLoan (this.extend (request, query));
+        const response = await this.spotPrivatePostMarginLoan (this.extend (request, params));
         //
         //     {
         //         "tranId": "762407666453712896"


### PR DESCRIPTION
Add borrowMargin to Mexc3:
```
node examples/js/cli mexc3 borrowMargin USDT 100 BTC/USDT

mexc3.borrowMargin (USDT, 100, BTC/USDT, [object Object])
2022-08-31T09:34:22.728Z iteration 0 passed in 628 ms

{
  id: 762407014965055500,
  currency: 'USDT',
  amount: 100,
  symbol: 'BTC/USDT',
  timestamp: undefined,
  datetime: undefined,
  info: { tranId: '762407014965055488' }
}
2022-08-31T09:34:22.728Z iteration 1 passed in 628 ms
```