### PR TITLE
exmo Math -> Precise

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -1721,9 +1721,9 @@ module.exports = class exmo extends Exchange {
         const id = this.safeString2 (transaction, 'order_id', 'task_id');
         const timestamp = this.safeTimestamp2 (transaction, 'dt', 'created');
         const updated = this.safeTimestamp (transaction, 'updated');
-        let amount = this.safeNumber (transaction, 'amount');
+        let amount = this.safeString (transaction, 'amount');
         if (amount !== undefined) {
-            amount = Math.abs (amount);
+            amount = Precise.stringAbs (amount);
         }
         const status = this.parseTransactionStatus (this.safeStringLower (transaction, 'status'));
         let txid = this.safeString (transaction, 'txid');
@@ -1758,22 +1758,22 @@ module.exports = class exmo extends Exchange {
         // fixed funding fees only (for now)
         if (!this.fees['transaction']['percentage']) {
             const key = (type === 'withdrawal') ? 'withdraw' : 'deposit';
-            let feeCost = this.safeNumber (transaction, 'commission');
+            let feeCost = this.safeString (transaction, 'commission');
             if (feeCost === undefined) {
-                feeCost = this.safeNumber (this.options['transactionFees'][key], code);
+                feeCost = this.safeString (this.options['transactionFees'][key], code);
             }
             // users don't pay for cashbacks, no fees for that
             const provider = this.safeString (transaction, 'provider');
             if (provider === 'cashback') {
-                feeCost = 0;
+                feeCost = '0';
             }
             if (feeCost !== undefined) {
                 // withdrawal amount includes the fee
                 if (type === 'withdrawal') {
-                    amount = amount - feeCost;
+                    amount = Precise.stringSub (amount, feeCost);
                 }
                 fee = {
-                    'cost': feeCost,
+                    'cost': this.parseNumber (feeCost),
                     'currency': code,
                     'rate': undefined,
                 };


### PR DESCRIPTION
```
% exmo fetchDeposits | condense
(node:10270) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2022-09-03T00:14:00.398Z
Node.js: v18.4.0
CCXT v1.93.1
exmo.fetchDeposits ()
2022-09-03T00:14:03.273Z iteration 0 passed in 593 ms
      id |     timestamp |                 datetime | currency |     amount |          network | address | addressTo | addressFrom | tag | tagTo | tagFrom | status |    type |       updated | comment | txid |                           fee
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
65206466 | 1559257849000 | 2019-05-30T23:10:49.000Z |      BTG | 0.00093914 | referral program |         |           |             |     |       |         |     ok | deposit | 1559257849000 |         |      |   {"cost":0,"currency":"BTG"}
...
68409035 | 1569379371000 | 2019-09-25T02:42:51.000Z |      ETH | 0.00012522 |         cashback |         |           |             |     |       |         |     ok | deposit | 1569379371000 |         |      |   {"cost":0,"currency":"ETH"}
97 objects
2022-09-03T00:14:03.273Z iteration 1 passed in 593 ms
```