### PR TITLE
luno.parseLedgerEntry Math -> Precise

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -949,31 +949,31 @@ module.exports = class luno extends Exchange {
         const timestamp = this.safeValue (entry, 'timestamp');
         const currencyId = this.safeString (entry, 'currency');
         const code = this.safeCurrencyCode (currencyId, currency);
-        const available_delta = this.safeNumber (entry, 'available_delta');
-        const balance_delta = this.safeNumber (entry, 'balance_delta');
-        const after = this.safeNumber (entry, 'balance');
+        const available_delta = this.safeString (entry, 'available_delta');
+        const balance_delta = this.safeString (entry, 'balance_delta');
+        const after = this.safeString (entry, 'balance');
         const comment = this.safeString (entry, 'description');
         let before = after;
-        let amount = 0.0;
+        let amount = '0.0';
         const result = this.parseLedgerComment (comment);
         const type = result['type'];
         const referenceId = result['referenceId'];
         let direction = undefined;
         let status = undefined;
-        if (balance_delta !== 0.0) {
-            before = after - balance_delta; // TODO: float precision
+        if (!Precise.stringEquals (balance_delta, '0.0')) {
+            before = after - balance_delta;
             status = 'ok';
-            amount = Math.abs (balance_delta);
-        } else if (available_delta < 0.0) {
+            amount = Precise.stringAbs (balance_delta);
+        } else if (Precise.stringLt (available_delta, '0.0')) {
             status = 'pending';
-            amount = Math.abs (available_delta);
-        } else if (available_delta > 0.0) {
+            amount = Precise.stringAbs (available_delta);
+        } else if (Precise.stringGt (available_delta, '0.0')) {
             status = 'canceled';
-            amount = Math.abs (available_delta);
+            amount = Precise.stringAbs (available_delta);
         }
-        if (balance_delta > 0 || available_delta > 0) {
+        if (Precise.stringGt (balance_delta, '0') || Precise.stringGt (available_delta, '0')) {
             direction = 'in';
-        } else if (balance_delta < 0 || available_delta < 0) {
+        } else if (Precise.stringLt (balance_delta, '0') || Precise.stringLt (available_delta, '0')) {
             direction = 'out';
         }
         return {


### PR DESCRIPTION
```
% luno fetchLedger BTC 
2022-09-03T00:20:12.881Z
Node.js: v18.4.0
CCXT v1.93.1
(node:10672) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
luno.fetchLedger (BTC)
2022-09-03T00:20:14.651Z iteration 0 passed in 903 ms

id | direction |             account | referenceId | referenceAccount |        type | currency |    amount |     timestamp |                 datetime | before |     after | status | fee
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1 |        in | 3707914449784523712 |             |                  | transaction |      BTC | 0.0007092 | 1606342671594 | 2020-11-25T22:17:51.594Z |      0 | 0.0007092 |     ok |    
1 objects
2022-09-03T00:20:14.651Z iteration 1 passed in 903 ms
```