### PR TITLE
woo.createOrder stringMul

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -710,7 +710,10 @@ module.exports = class woo extends Exchange {
                         if (price === undefined) {
                             throw new InvalidOrder (this.id + " createOrder() requires the price argument for market buy orders to calculate total order cost. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or alternatively, supply the total cost value in the 'order_amount' in  exchange-specific parameters");
                         } else {
-                            request['order_amount'] = this.costToPrecision (symbol, amount * price);
+                            const amountString = amount.toString ();
+                            const priceString = price.toString ();
+                            const orderAmount = Precise.stringMul (amountString, priceString);
+                            request['order_amount'] = this.costToPrecision (symbol, orderAmount);
                         }
                     } else {
                         request['order_amount'] = this.costToPrecision (symbol, cost);

--- a/js/woo.js
+++ b/js/woo.js
@@ -710,8 +710,8 @@ module.exports = class woo extends Exchange {
                         if (price === undefined) {
                             throw new InvalidOrder (this.id + " createOrder() requires the price argument for market buy orders to calculate total order cost. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or alternatively, supply the total cost value in the 'order_amount' in  exchange-specific parameters");
                         } else {
-                            const amountString = amount.toString ();
-                            const priceString = price.toString ();
+                            const amountString = this.numberToString (amount);
+                            const priceString = this.numberToString (price);
                             const orderAmount = Precise.stringMul (amountString, priceString);
                             request['order_amount'] = this.costToPrecision (symbol, orderAmount);
                         }


### PR DESCRIPTION
```
% woo createOrder ADA/USDT market buy 3 0.45
2022-09-05T05:20:16.225Z
Node.js: v18.4.0
CCXT v1.93.3
(node:38871) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
woo.createOrder (ADA/USDT, market, buy, 3, 0.45)
2022-09-05T05:20:17.614Z iteration 0 passed in 375 ms

{
  id: '162022554',
  clientOrderId: '0',
  timestamp: 1662355217744,
  datetime: '2022-09-05T05:20:17.744Z',
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'ADA/USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: 1.35,
  trades: [],
  fee: { cost: undefined, currency: undefined },
  info: {
    success: true,
    timestamp: '1662355217.744',
    order_id: '162022554',
    order_type: 'MARKET',
    order_price: null,
    order_quantity: null,
    order_amount: '1.35',
    client_order_id: '0'
  },
  fees: [ { cost: undefined, currency: undefined } ]
}
2022-09-05T05:20:17.614Z iteration 1 passed in 375 ms
```