### PR TITLE
Mexc3: transfer, add margin support

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3845,18 +3845,21 @@ module.exports = class mexc3 extends Exchange {
          * @method
          * @name mexc3#transfer
          * @description transfer currency internally between wallets on the same account
+         * @see https://mxcdevelop.github.io/apidocs/spot_v3_en/#user-universal-transfer
          * @param {string} code unified currency code
          * @param {float} amount amount to transfer
          * @param {string} fromAccount account to transfer from
          * @param {string} toAccount account to transfer to
          * @param {object} params extra parameters specific to the mexc3 api endpoint
+         * @param {string|undefined} params.symbol market symbol required for margin account transfers eg:BTCUSDT
          * @returns {object} a [transfer structure]{@link https://docs.ccxt.com/en/latest/manual.html#transfer-structure}
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
         const accounts = {
-            'spot': 'MAIN',
-            'swap': 'CONTRACT',
+            'spot': 'SPOT',
+            'swap': 'FUTURES',
+            'margin': 'ISOLATED_MARGIN',
         };
         const fromId = this.safeString (accounts, fromAccount);
         const toId = this.safeString (accounts, toAccount);
@@ -3869,32 +3872,36 @@ module.exports = class mexc3 extends Exchange {
             throw new ExchangeError (this.id + ' toAccount must be one of ' + keys.join (', '));
         }
         const request = {
-            'currency': currency['id'],
+            'asset': currency['id'],
             'amount': amount,
-            'from': fromId,
-            'to': toId,
+            'fromAccountType': fromId,
+            'toAccountType': toId,
         };
-        const response = await this.spot2PrivatePostAssetInternalTransfer (this.extend (request, params));
+        if ((fromId === 'ISOLATED_MARGIN') || (toId === 'ISOLATED_MARGIN')) {
+            const symbol = this.safeString (params, 'symbol');
+            if (symbol === undefined) {
+                throw new ArgumentsRequired (this.id + ' transfer() requires a symbol argument for isolated margin');
+            }
+            const market = this.market (symbol);
+            request['symbol'] = market['id'];
+        }
+        const response = await this.spotPrivatePostCapitalTransfer (this.extend (request, params));
         //
         //     {
-        //         code: '200',
-        //         data: {
-        //             currency: 'USDT',
-        //             amount: '1',
-        //             transact_id: 'b60c1df8e7b24b268858003f374ecb75',
-        //             from: 'MAIN',
-        //             to: 'CONTRACT',
-        //             transact_state: 'WAIT'
-        //         }
+        //         "tranId": "ebb06123e6a64f4ab234b396c548d57e"
         //     }
         //
-        const data = this.safeValue (response, 'data', {});
-        return this.parseTransfer (data, currency);
+        const transaction = this.parseTransfer (response, currency);
+        return this.extend (transaction, {
+            'amount': amount,
+            'fromAccount': fromAccount,
+            'toAccount': toAccount,
+        });
     }
 
     parseTransfer (transfer, currency = undefined) {
         //
-        // spot:
+        // spot: fetchTransfer
         //
         //     {
         //         currency: 'USDT',
@@ -3905,7 +3912,7 @@ module.exports = class mexc3 extends Exchange {
         //         transact_state: 'WAIT'
         //     }
         //
-        // swap
+        // swap: fetchTransfer
         //
         //     {
         //         "currency": "USDT",
@@ -3918,8 +3925,14 @@ module.exports = class mexc3 extends Exchange {
         //         "updateTime": "1648849076000"
         //     }
         //
+        // transfer
+        //
+        //     {
+        //         "tranId": "ebb06123e6a64f4ab234b396c548d57e"
+        //     }
+        //
         const currencyId = this.safeString (transfer, 'currency');
-        const id = this.safeString2 (transfer, 'transact_id', 'txid');
+        const id = this.safeStringN (transfer, [ 'transact_id', 'txid', 'tranId' ]);
         const timestamp = this.safeInteger (transfer, 'createTime');
         const datetime = (timestamp !== undefined) ? this.iso8601 (timestamp) : undefined;
         const direction = this.safeString (transfer, 'type');


### PR DESCRIPTION
Added margin support to transfer by using the v3 endpoint:
```
node examples/js/cli mexc3 transfer USDT 10 margin spot '{"symbol":"BTCUSDT"}'

mexc3.transfer (USDT, 10, margin, spot, [object Object])
2022-09-06T08:13:08.502Z iteration 0 passed in 452 ms

{
  info: { tranId: 'ecfedadc760a457fb13e6df90ae2689b' },
  id: 'ecfedadc760a457fb13e6df90ae2689b',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 10,
  fromAccount: 'margin',
  toAccount: 'spot',
  status: undefined
}
2022-09-06T08:13:08.502Z iteration 1 passed in 452 ms
```