### PR TITLE
base - currency precisions from markets

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -233,6 +233,7 @@ class Transpiler {
             [ /\.checkOrderArguments\s/g, '.check_order_arguments'],
             [ /\.isPostOnly\s/g, '.is_post_only'],
             [ /\.reduceFeesByCurrency\s/g, '.reduce_fees_by_currency'],
+            [ /\.setCurrencyPrecisionsFromMarkets\s/g, '.set_currency_precisions_from_markets'],
             [ /\.omitZero\s/g, '.omit_zero'],
         ]
     }

--- a/js/binance.js
+++ b/js/binance.js
@@ -1235,8 +1235,12 @@ module.exports = class binance extends Exchange {
 
     currencyToPrecision (code, fee, networkCode = undefined) {
         // info is available in currencies only if the user has configured his api keys
-        if (this.safeValue (this.currencies[code], 'precision') !== undefined) {
-            return this.decimalToPrecision (fee, TRUNCATE, this.currencies[code]['precision'], this.precisionMode, this.paddingMode);
+        let precision = this.safeValue (this.currencies[code], 'precision');
+        if (precision === undefined) {
+            precision = this.safeNumber (this.currencyPrecisionsFromMarkets, code);
+        }
+        if (precision !== undefined) {
+            return this.decimalToPrecision (fee, TRUNCATE, precision, this.precisionMode, this.paddingMode);
         } else {
             return this.numberToString (fee);
         }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1165,6 +1165,7 @@ class Exchange {
         $this->tickers = array();
         $this->fees = array('trading' => array(), 'funding' => array());
         $this->precision = array();
+        $this->currencyPrecisionsFromMarkets = array();
         $this->orders = null;
         $this->myTrades = null;
         $this->trades = array();

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -220,6 +220,7 @@ class Exchange(object):
     options = None  # Python does not allow to define properties in run-time with setattr
     accounts = None
     positions = None
+    currencyPrecisionsFromMarkets = None
 
     status = {
         'status': 'ok',
@@ -382,6 +383,7 @@ class Exchange(object):
         self.ohlcvs = dict() if self.ohlcvs is None else self.ohlcvs
         self.currencies = dict() if self.currencies is None else self.currencies
         self.options = dict() if self.options is None else self.options  # Python does not allow to define properties in run-time with setattr
+        self.currencyPrecisionsFromMarkets = dict() if self.currencyPrecisionsFromMarkets is None else self.currencyPrecisionsFromMarkets
         self.decimal_to_precision = decimal_to_precision
         self.number_to_string = number_to_string
 


### PR DESCRIPTION
This is to fix #14344, because otherwise we face an obvious bug.
As a backup method, the only solution (in such cases) is to use precision from loaded markets, if there are `base` and `quote` keys present under `precision`.


1) Additionally, to show a working example, i've included that exchange in question (binance) and you can see that it solves the problem. 

2) of course, at first user needs to `loadMarkets()` otherwise, unloaded exchange cant make any precisions for anything.
I even think that we might better throw exceptions when using any 'xxxxToPrecision` method if markets are unloaded (or add `await this.loadMarkets()` inside them).

---
Additionally I think this PR is not intrusive for the following reasons:
- the `precision ->price & amount` are provided from exchange responses in most cases, however, **additionally** to this some exchanges do also provide `baseAssetPrecision & quoteAssetPrecision` which can be translated into additional `precision ->base & quote`, which doesn't conflict with anything existing. 