### PR TITLE
phemex parseTrade fix

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1386,8 +1386,8 @@ module.exports = class phemex extends Exchange {
                     }
                 }
                 fee = {
-                    'cost': this.parseNumber (feeCostString),
-                    'rate': this.parseNumber (feeRateString),
+                    'cost': feeCostString,
+                    'rate': feeRateString,
                     'currency': feeCurrencyCode,
                 };
             }


### PR DESCRIPTION
`TypeError: number.toLowerCase is not a function`