### PR TITLE
Added 1s timeframe to binance.js (according to their CHANGELOG)

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -107,6 +107,7 @@ module.exports = class binance extends Exchange {
                 'withdraw': true,
             },
             'timeframes': {
+                '1s': '1s',
                 '1m': '1m',
                 '3m': '3m',
                 '5m': '5m',


### PR DESCRIPTION
Binance recently added the 1s candles on their Spot API, on 23rd of August 2022, as you can see on their [SPOT API changelog](https://binance-docs.github.io/apidocs/spot/en/#change-log).

These Klines both work for the web socket API and REST API, returning 1s historical closed Klines.

