### PR TITLE
bit2c.createOrder string math

### DIFF
--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -433,7 +433,9 @@ export default class bit2c extends Exchange {
             method += 'MarketPrice' + this.capitalize (side);
         } else {
             request['Price'] = price;
-            request['Total'] = amount * price;
+            const amountString = this.numberToString (amount);
+            const priceString = this.numberToString (price);
+            request['Total'] = this.parseNumber (Precise.stringMul (amountString, priceString));
             request['IsBid'] = (side === 'buy');
         }
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
It doesn't really look like I'll be able to get apiKeys for bit2c, I'm not really sure what to do about that, but this is a pretty small change