### PR TITLE
bitget.createOrder market buy string math

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1911,7 +1911,9 @@ module.exports = class bitget extends Exchange {
                 if (price === undefined) {
                     throw new InvalidOrder (this.id + ' createOrder() requires price argument for market buy orders on spot markets to calculate the total amount to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option to false and pass in the cost to spend into the amount parameter');
                 } else {
-                    const cost = amount * price;
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    const cost = this.parseNumber (Precise.stringMul (amountString, priceString));
                     request['quantity'] = this.priceToPrecision (symbol, cost);
                 }
             } else {


### PR DESCRIPTION
```
 % bitget createOrder XRP/USDT market buy 15 0.45
2022-09-07T03:37:19.798Z
Node.js: v18.4.0
CCXT v1.93.9
(node:11750) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
bitget.createOrder (XRP/USDT, market, buy, 15, 0.45)
2022-09-07T03:37:21.192Z iteration 0 passed in 281 ms
```
```JavaScript
{
  info: {
    orderId: '951251036739641344',
    clientOrderId: 'CCXT#d04946b04a694e9ebaf31c'
  },
  id: '951251036739641344',
  clientOrderId: 'CCXT#d04946b04a694e9ebaf31c',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```
`2022-09-07T03:37:21.192Z iteration 1 passed in 281 ms`
