### PR TITLE
bitmart.createOrder string math

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1875,7 +1875,9 @@ module.exports = class bitmart extends Exchange {
                     if (createMarketBuyOrderRequiresPrice) {
                         if (price !== undefined) {
                             if (notional === undefined) {
-                                notional = amount * price;
+                                const amountString = this.numberToString (amount);
+                                const priceString = this.numberToString (price);
+                                notional = this.parseNumber (Precise.stringMul (amountString, priceString));
                             }
                         } else if (notional === undefined) {
                             throw new InvalidOrder (this.id + " createOrder () requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false and supply the total cost value in the 'amount' argument or in the 'notional' extra parameter (the exchange-specific behaviour)");


### PR DESCRIPTION
```
$ bitmart createOrder MATIC/USDT market buy 7 0.795 
2022-09-21T04:55:47.664Z
Node.js: v18.9.0
CCXT v1.93.9
(node:20873) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
bitmart.createOrder (MATIC/USDT, market, buy, 7, 0.795)
2022-09-21T04:55:50.338Z iteration 0 passed in 867 ms

{
  id: '54725861463',
  clientOrderId: undefined,
  info: { order_id: '54725861463' },
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'MATIC/USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 0.795,
  stopPrice: undefined,
  amount: 7,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2022-09-21T04:55:50.338Z iteration 1 passed in 867 ms
```