### PR TITLE
binance: support type=margin in Binance fetchMyTrades

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3432,7 +3432,7 @@ module.exports = class binance extends Exchange {
         const inverse = (type === 'delivery');
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchMyTrades', params);
-        if (market['type'] === 'spot') {
+        if (type === 'spot' || type === 'margin) {
             method = 'privateGetMyTrades';
             if ((type === 'margin') || (marginMode !== undefined)) {
                 method = 'sapiGetMarginMyTrades';

--- a/js/binance.js
+++ b/js/binance.js
@@ -3432,7 +3432,7 @@ module.exports = class binance extends Exchange {
         const inverse = (type === 'delivery');
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchMyTrades', params);
-        if (type === 'spot' || type === 'margin) {
+        if (type === 'spot' || type === 'margin') {
             method = 'privateGetMyTrades';
             if ((type === 'margin') || (marginMode !== undefined)) {
                 method = 'sapiGetMarginMyTrades';


### PR DESCRIPTION
Support fetching the trades for the Binance Cross-Margin markets, where the user sets `defaultType='margin'` in the client options.

Without this fix, the below script crashes with `TypeError: getattr(): attribute name must be string` because the variable `method` is `None`.

Repro for the bug:

```python
import asyncio

from ccxt.async_support import binance


async def main() -> None:
    client = binance({'options': {'defaultType': 'margin', 'defaultMarginMode': 'cross', 'apiKey': 'MY_API_KEY',
                                  'secret': 'MY_API_SECRET'}})

    await client.load_markets()
    mkt = client.markets["SOL/USDT"]
    print(f'{mkt["symbol"]}: {mkt["type"]}')
    print(await client.fetch_my_trades("SOL/USDT"))


if __name__ == '__main__':
    asyncio.run(main())
```