### PR TITLE
binance: support `postOnly` for cross margin

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -2933,8 +2933,8 @@ module.exports = class binance extends Exchange {
         } else if (marketType === 'margin' || marginMode !== undefined) {
             method = 'sapiPostMarginOrder';
         }
-        // the next 5 lines are added to support for testing orders
         if (market['spot'] || marketType === 'margin') {
+            // support for testing orders
             const test = this.safeValue (query, 'test', false);
             if (test) {
                 method += 'Test';

--- a/js/binance.js
+++ b/js/binance.js
@@ -2934,7 +2934,7 @@ module.exports = class binance extends Exchange {
             method = 'sapiPostMarginOrder';
         }
         // the next 5 lines are added to support for testing orders
-        if (market['spot']) {
+        if (market['spot'] || marketType === 'margin') {
             const test = this.safeValue (query, 'test', false);
             if (test) {
                 method += 'Test';


### PR DESCRIPTION
Sending a post-only order in Binance Cross-Margin is analogous to spot (the API is exactly the same): the order type must be `LIMIT_MAKER`.

With this PR, specifying `params={"postOnly": True}` will result in a post-only limit order for cross margin, as well as for spot. Currently, the parameter is ignored, and a regular limit order is always created.