### PR TITLE
binance: fix market type parsing when `defaultType` is margin 

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1427,13 +1427,15 @@ module.exports = class binance extends Exchange {
          * @returns {[object]} an array of objects representing market data
          */
         const defaultType = this.safeString2 (this.options, 'fetchMarkets', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
+        let type = this.safeString (params, 'type', defaultType);
+        if (type === 'margin') {   // Binance margin trading uses the same API as spot
+            type = 'spot';
+        }
         const query = this.omit (params, 'type');
         const spot = (type === 'spot');
-        const margin = (type === 'margin');
         const future = (type === 'future');
         const delivery = (type === 'delivery');
-        if ((!spot) && (!margin) && (!future) && (!delivery)) {
+        if ((!spot) && (!future) && (!delivery)) {
             throw new ExchangeError (this.id + " does not support '" + type + "' type, set exchange.options['defaultType'] to 'spot', 'margin', 'delivery' or 'future'"); // eslint-disable-line quotes
         }
         let method = 'publicGetExchangeInfo';


### PR DESCRIPTION
The Binance exchange supports the "margin" type (as the exception at line 1437 suggests), however that type is not handled correctly when parsing the available markets.

In particular, when `type === 'margin'`, the following fields returned by `fetchMarkets` have unexpected values: `type`, `spot`, `margin`. Take the following snippet in `python3.10`:

```python3
from pprint import pprint

import ccxt.binance

if __name__ == '__main__':
    exchange = ccxt.binance({"options": {"defaultType": "margin"}})
    exchange.load_markets()

    pprint(exchange.market("BTC/USDT"))
```
It prints
```python3
{
   # [...] fields omitted
   'type': 'margin',
   'spot': False,
   'margin': False,
}
```

while one expects
```python3
{
   # [...] fields omitted
   'type': 'spot',
   'spot': True,
   'margin': True,
}
```

This PR fixes the issue by using the same logic as with spot types.