### PR TITLE
btcmarkets.calculateFee string math

### DIFF
--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -159,8 +159,8 @@ module.exports = class btcmarkets extends Exchange {
             'options': {
                 'fees': {
                     'AUD': {
-                        'maker': 0.85 / 100,
-                        'taker': 0.85 / 100,
+                        'maker': this.parseNumber ('0.0085'),
+                        'taker': this.parseNumber ('0.0085'),
                     },
                 },
             },


### PR DESCRIPTION
```
Master                                                                                                                   This Branch

% btcmarkets calculateFee BAT/AUD limit buy 10 0.45 taker                                                                % btcmarkets calculateFee BAT/AUD limit buy 10 0.45 taker
2022-09-08T23:37:19.032Z                                                                                                 2022-09-08T23:37:34.018Z
Node.js: v18.4.0                                                                                                         Node.js: v18.4.0
CCXT v1.93.14                                                                                                            CCXT v1.93.14
(node:14311) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time        (node:14344) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)                                                  (Use `node --trace-warnings ...` to show where the warning was created)
btcmarkets.calculateFee (BAT/AUD, limit, buy, 10, 0.45, taker)                                                           btcmarkets.calculateFee (BAT/AUD, limit, buy, 10, 0.45, taker)
2022-09-08T23:37:19.415Z iteration 0 passed in 0 ms                                                                      2022-09-08T23:37:34.417Z iteration 0 passed in 1 ms
                                                                                                                         
{ type: 'taker', currency: 'AUD', rate: 0.0085, cost: 0.0383 }                                                           { type: 'taker', currency: 'AUD', rate: 0.0085, cost: 0.0383 }
2022-09-08T23:37:19.415Z iteration 1 passed in 0 ms                                                                      2022-09-08T23:37:34.417Z iteration 1 passed in 1 ms
```
