### PR TITLE
Digifinex: fetchMarkets & fetchFundingRate, add swap support

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -374,8 +374,10 @@ module.exports = class digifinex extends Exchange {
         const defaultType = this.safeString (this.options, 'defaultType');
         const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchMarketsV2', params);
         const method = (marginMode !== undefined) ? 'publicSpotGetMarginSymbols' : 'publicSpotGetTradesSymbols';
-        const spotMarkets = await this[method] (query);
-        const swapMarkets = await this.publicSwapGetPublicInstruments (params);
+        let promises = [ this[method] (query), this.publicSwapGetPublicInstruments (params) ];
+        promises = await Promise.all (promises);
+        const spotMarkets = promises[0];
+        const swapMarkets = promises[1];
         //
         // Spot
         //

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -511,13 +511,13 @@ module.exports = class digifinex extends Exchange {
                 'contract': swap,
                 'linear': isLinear,
                 'inverse': isInverse,
-                'contractSize': undefined,
+                'contractSize': this.safeNumber (market, 'contract_value'),
                 'expiry': undefined,
                 'expiryDatetime': undefined,
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.parseNumber (this.parsePrecision (this.safeString (market, 'amount_precision'))),
+                    'amount': this.parseNumber (this.parsePrecision (this.safeString2 (market, 'amount_precision', 'tick_size'))),
                     'price': this.parseNumber (this.parsePrecision (this.safeString (market, 'price_precision'))),
                 },
                 'limits': {
@@ -526,7 +526,7 @@ module.exports = class digifinex extends Exchange {
                         'max': undefined,
                     },
                     'amount': {
-                        'min': this.safeNumber (market, 'minimum_amount'),
+                        'min': this.safeNumber2 (market, 'minimum_amount', 'min_order_amount'),
                         'max': undefined,
                     },
                     'price': {

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -517,7 +517,7 @@ module.exports = class digifinex extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.parseNumber (this.parsePrecision (this.safeString2 (market, 'amount_precision', 'tick_size'))),
+                    'amount': this.parseNumber (this.parsePrecision (this.safeString (market, 'amount_precision'))),
                     'price': this.parseNumber (this.parsePrecision (this.safeString (market, 'price_precision'))),
                 },
                 'limits': {
@@ -530,7 +530,7 @@ module.exports = class digifinex extends Exchange {
                         'max': undefined,
                     },
                     'price': {
-                        'min': undefined,
+                        'min': this.safeNumber (market, 'tick_size'),
                         'max': undefined,
                     },
                     'cost': {

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -484,7 +484,7 @@ module.exports = class digifinex extends Exchange {
                 type = 'swap';
                 symbol = base + '/' + quote + ':' + settle;
                 isInverse = this.safeValue (market, 'is_inverse');
-                isLinear = (isInverse === false) ? true : false;
+                isLinear = (!isInverse) ? true : false;
                 const isTrading = this.safeValue (market, 'isTrading');
                 if (isTrading) {
                     isAllowed = true;

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -87,63 +87,101 @@ module.exports = class digifinex extends Exchange {
             },
             'api': {
                 'public': {
-                    'get': [
-                        '{market}/symbols',
-                        'kline',
-                        'margin/currencies',
-                        'margin/symbols',
-                        'markets',
-                        'order_book',
-                        'ping',
-                        'spot/symbols',
-                        'time',
-                        'trades',
-                        'trades/symbols',
-                        'ticker',
-                        'currencies',
-                        'swap/v2/public/instruments',
-                        'swap/v2/public/funding_rate',
-                    ],
+                    'spot': {
+                        'get': [
+                            '{market}/symbols',
+                            'kline',
+                            'margin/currencies',
+                            'margin/symbols',
+                            'markets',
+                            'order_book',
+                            'ping',
+                            'spot/symbols',
+                            'time',
+                            'trades',
+                            'trades/symbols',
+                            'ticker',
+                            'currencies',
+                        ],
+                    },
+                    'swap': {
+                        'get': [
+                            'public/api_weight',
+                            'public/candles',
+                            'public/candles_history',
+                            'public/depth',
+                            'public/funding_rate',
+                            'public/funding_rate_history',
+                            'public/instrument',
+                            'public/instruments',
+                            'public/ticker',
+                            'public/tickers',
+                            'public/time',
+                            'public/trades',
+                        ],
+                    },
                 },
                 'private': {
-                    'get': [
-                        '{market}/financelog',
-                        '{market}/mytrades',
-                        '{market}/order',
-                        '{market}/order/detail',
-                        '{market}/order/current',
-                        '{market}/order/history',
-                        'margin/assets',
-                        'margin/financelog',
-                        'margin/mytrades',
-                        'margin/order',
-                        'margin/order/current',
-                        'margin/order/history',
-                        'margin/positions',
-                        'otc/financelog',
-                        'spot/assets',
-                        'spot/financelog',
-                        'spot/mytrades',
-                        'spot/order',
-                        'spot/order/current',
-                        'spot/order/history',
-                        'deposit/address',
-                        'deposit/history',
-                        'withdraw/history',
-                    ],
-                    'post': [
-                        '{market}/order/cancel',
-                        '{market}/order/new',
-                        '{market}/order/batch_new',
-                        'margin/order/cancel',
-                        'margin/order/new',
-                        'margin/position/close',
-                        'spot/order/cancel',
-                        'spot/order/new',
-                        'transfer',
-                        'withdraw/new',
-                        'withdraw/cancel',
-                    ],
+                    'spot': {
+                        'get': [
+                            '{market}/financelog',
+                            '{market}/mytrades',
+                            '{market}/order',
+                            '{market}/order/detail',
+                            '{market}/order/current',
+                            '{market}/order/history',
+                            'margin/assets',
+                            'margin/financelog',
+                            'margin/mytrades',
+                            'margin/order',
+                            'margin/order/current',
+                            'margin/order/history',
+                            'margin/positions',
+                            'otc/financelog',
+                            'spot/assets',
+                            'spot/financelog',
+                            'spot/mytrades',
+                            'spot/order',
+                            'spot/order/current',
+                            'spot/order/history',
+                            'deposit/address',
+                            'deposit/history',
+                            'withdraw/history',
+                        ],
+                        'post': [
+                            '{market}/order/cancel',
+                            '{market}/order/new',
+                            '{market}/order/batch_new',
+                            'margin/order/cancel',
+                            'margin/order/new',
+                            'margin/position/close',
+                            'spot/order/cancel',
+                            'spot/order/new',
+                            'transfer',
+                            'withdraw/new',
+                            'withdraw/cancel',
+                        ],
+                    },
+                    'swap': {
+                        'get': [
+                            'account/balance',
+                            'account/positions',
+                            'account/finance_record',
+                            'account/trading_fee_rate',
+                            'account/transfer_record',
+                            'trade/history_orders',
+                            'trade/history_trades',
+                            'trade/open_orders',
+                            'trade/order_info',
+                        ],
+                        'post': [
+                            'account/leverage',
+                            'trade/batch_cancel_order',
+                            'trade/batch_order',
+                            'trade/cancel_order',
+                            'trade/order_place',
+                        ],
+                    },
                 },
             },
             'fees': {
@@ -235,7 +273,7 @@ module.exports = class digifinex extends Exchange {
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {object} an associative dictionary of currencies
          */
-        const response = await this.publicGetCurrencies (params);
+        const response = await this.publicSpotGetCurrencies (params);
         //
         //     {
         //         "data":[
@@ -335,9 +373,9 @@ module.exports = class digifinex extends Exchange {
     async fetchMarketsV2 (params = {}) {
         const defaultType = this.safeString (this.options, 'defaultType');
         const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchMarketsV2', params);
-        let method = (marginMode !== undefined) ? 'publicGetMarginSymbols' : 'publicGetTradesSymbols';
+        let method = (marginMode !== undefined) ? 'publicSpotGetMarginSymbols' : 'publicSpotGetTradesSymbols';
         if (defaultType === 'swap') {
-            method = 'publicGetSwapV2PublicInstruments';
+            method = 'publicSwapGetPublicInstruments';
         }
         const response = await this[method] (query);
         //
@@ -500,7 +538,7 @@ module.exports = class digifinex extends Exchange {
     }
 
     async fetchMarketsV1 (params = {}) {
-        const response = await this.publicGetMarkets (params);
+        const response = await this.publicSpotGetMarkets (params);
         //
         //     {
         //         "data": [
@@ -603,7 +641,7 @@ module.exports = class digifinex extends Exchange {
         const defaultType = this.safeString (this.options, 'defaultType', 'spot');
         const type = this.safeString (params, 'type', defaultType);
         params = this.omit (params, 'type');
-        const method = 'privateGet' + this.capitalize (type) + 'Assets';
+        const method = 'privateSpotGet' + this.capitalize (type) + 'Assets';
         const response = await this[method] (params);
         //
         //     {
@@ -637,7 +675,7 @@ module.exports = class digifinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 10, max 150
         }
-        const response = await this.publicGetOrderBook (this.extend (request, params));
+        const response = await this.publicSpotGetOrderBook (this.extend (request, params));
         //
         //     {
         //         "bids": [
@@ -669,7 +707,7 @@ module.exports = class digifinex extends Exchange {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        const response = await this.publicGetTicker (params);
+        const response = await this.publicSpotGetTicker (params);
         //
         //    {
         //        "ticker": [{
@@ -715,7 +753,7 @@ module.exports = class digifinex extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const response = await this.publicGetTicker (this.extend (request, params));
+        const response = await this.publicSpotGetTicker (this.extend (request, params));
         //
         //    {
         //        "ticker": [{
@@ -860,7 +898,7 @@ module.exports = class digifinex extends Exchange {
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {int} the current integer timestamp in milliseconds from the exchange server
          */
-        const response = await this.publicGetTime (params);
+        const response = await this.publicSpotGetTime (params);
         //
         //     {
         //         "server_time": 1589873762,
@@ -878,7 +916,7 @@ module.exports = class digifinex extends Exchange {
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {object} a [status structure]{@link https://docs.ccxt.com/en/latest/manual.html#exchange-status-structure}
          */
-        const response = await this.publicGetPing (params);
+        const response = await this.publicSpotGetPing (params);
         //
         //     {
         //         "msg": "pong",
@@ -915,7 +953,7 @@ module.exports = class digifinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 500
         }
-        const response = await this.publicGetTrades (this.extend (request, params));
+        const response = await this.publicSpotGetTrades (this.extend (request, params));
         //
         //     {
         //         "data":[
@@ -995,7 +1033,7 @@ module.exports = class digifinex extends Exchange {
             const duration = this.parseTimeframe (timeframe);
             request['startTime'] = this.sum (endTime, -limit * duration);
         }
-        const response = await this.publicGetKline (this.extend (request, params));
+        const response = await this.publicSpotGetKline (this.extend (request, params));
         //
         //     {
         //         "code":0,
@@ -1041,7 +1079,7 @@ module.exports = class digifinex extends Exchange {
             request['price'] = this.priceToPrecision (market['symbol'], price);
         }
         request['type'] = side + suffix;
-        const response = await this.privatePostMarketOrderNew (this.extend (request, params));
+        const response = await this.privateSpotPostMarketOrderNew (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1076,7 +1114,7 @@ module.exports = class digifinex extends Exchange {
             'market': orderType,
             'order_id': id,
         };
-        const response = await this.privatePostMarketOrderCancel (this.extend (request, params));
+        const response = await this.privateSpotPostMarketOrderCancel (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1115,7 +1153,7 @@ module.exports = class digifinex extends Exchange {
             'market': orderType,
             'order_id': ids.join (','),
         };
-        const response = await this.privatePostCancelOrder (this.extend (request, params));
+        const response = await this.privateSpotPostCancelOrder (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1243,7 +1281,7 @@ module.exports = class digifinex extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const response = await this.privateGetMarketOrderCurrent (this.extend (request, params));
+        const response = await this.privateSpotGetMarketOrderCurrent (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1298,7 +1336,7 @@ module.exports = class digifinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 10, max 100
         }
-        const response = await this.privateGetMarketOrderHistory (this.extend (request, params));
+        const response = await this.privateSpotGetMarketOrderHistory (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1345,7 +1383,7 @@ module.exports = class digifinex extends Exchange {
             'market': orderType,
             'order_id': id,
         };
-        const response = await this.privateGetMarketOrder (this.extend (request, params));
+        const response = await this.privateSpotGetMarketOrder (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1404,7 +1442,7 @@ module.exports = class digifinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 10, max 100
         }
-        const response = await this.privateGetMarketMytrades (this.extend (request, params));
+        const response = await this.privateSpotGetMarketMytrades (this.extend (request, params));
         //
         //      {
         //          "list":[
@@ -1499,7 +1537,7 @@ module.exports = class digifinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 1000
         }
-        const response = await this.privateGetMarketFinancelog (this.extend (request, params));
+        const response = await this.privateSpotGetMarketFinancelog (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1558,7 +1596,7 @@ module.exports = class digifinex extends Exchange {
         const request = {
             'currency': currency['id'],
         };
-        const response = await this.privateGetDepositAddress (this.extend (request, params));
+        const response = await this.privateSpotGetDepositAddress (this.extend (request, params));
         //
         //     {
         //         "data":[
@@ -1597,7 +1635,7 @@ module.exports = class digifinex extends Exchange {
         if (limit !== undefined) {
             request['size'] = Math.min (500, limit);
         }
-        const method = (type === 'deposit') ? 'privateGetDepositHistory' : 'privateGetWithdrawHistory';
+        const method = (type === 'deposit') ? 'privateSpotGetDepositHistory' : 'privateSpotGetWithdrawHistory';
         const response = await this[method] (this.extend (request, params));
         //
         //     {
@@ -1775,7 +1813,7 @@ module.exports = class digifinex extends Exchange {
             'from': fromId, // 1 = SPOT, 2 = MARGIN, 3 = OTC
             'to': toId, // 1 = SPOT, 2 = MARGIN, 3 = OTC
         };
-        const response = await this.privatePostTransfer (this.extend (request, params));
+        const response = await this.privateSpotPostTransfer (this.extend (request, params));
         //
         //     {
         //         "code": 0
@@ -1815,7 +1853,7 @@ module.exports = class digifinex extends Exchange {
         if (tag !== undefined) {
             request['memo'] = tag;
         }
-        const response = await this.privatePostWithdrawNew (this.extend (request, params));
+        const response = await this.privateSpotPostWithdrawNew (this.extend (request, params));
         //
         //     {
         //         "code": 200,
@@ -1833,7 +1871,7 @@ module.exports = class digifinex extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
-        const response = await this.privateGetMarginPositions (this.extend (request, params));
+        const response = await this.privateSpotGetMarginPositions (this.extend (request, params));
         //
         //     {
         //         "margin": "45.71246418952618",
@@ -1895,7 +1933,7 @@ module.exports = class digifinex extends Exchange {
     async fetchBorrowRate (code, params = {}) {
         await this.loadMarkets ();
         const request = {};
-        const response = await this.privateGetMarginAssets (this.extend (request, params));
+        const response = await this.privateSpotGetMarginAssets (this.extend (request, params));
         //
         //     {
         //         "list": [
@@ -1934,7 +1972,7 @@ module.exports = class digifinex extends Exchange {
          * @returns {object} a list of [borrow rate structures]{@link https://docs.ccxt.com/en/latest/manual.html#borrow-rate-structure}
          */
         await this.loadMarkets ();
-        const response = await this.privateGetMarginAssets (params);
+        const response = await this.privateSpotGetMarginAssets (params);
         //
         //     {
         //         "list": [
@@ -2015,7 +2053,7 @@ module.exports = class digifinex extends Exchange {
         const request = {
             'instrument_id': market['id'],
         };
-        const response = await this.publicGetSwapV2PublicFundingRate (this.extend (request, params));
+        const response = await this.publicSwapGetPublicFundingRate (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -2090,18 +2128,16 @@ module.exports = class digifinex extends Exchange {
         return [ marginMode, params ];
     }
 
-    sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
-        const version = this.version;
-        let url = this.urls['api']['rest'] + '/' + version + '/' + this.implodeParams (path, params);
-        const defaultType = this.safeString (this.options, 'defaultType');
-        if (defaultType === 'swap') {
-            if (url !== 'https://openapi.digifinex.com/v3/currencies') {
-                url = this.urls['api']['rest'] + '/' + this.implodeParams (path, params);
-            }
-        }
+    sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {
+        const signed = api[0] === 'private';
+        const endpoint = api[1];
+        const pathPart = (endpoint === 'spot') ? '/v3' : '/swap/v2';
+        const request = '/' + this.implodeParams (path, params);
+        const payload = pathPart + request;
+        let url = this.urls['api']['rest'] + payload;
         const query = this.omit (params, this.extractParams (path));
         const urlencoded = this.urlencode (this.keysort (query));
-        if (api === 'private') {
+        if (signed) {
             const nonce = this.nonce ().toString ();
             const auth = urlencoded;
             // the signature is not time-limited :\


### PR DESCRIPTION
Added swap market support to fetchMarkets and fetchFundingRate:

### fetchMarkets:
```
node examples/js/cli digifinex fetchMarketsV2

digifinex.fetchMarketsV2 ()
2022-09-09T06:40:10.552Z iteration 0 passed in 1163 ms

            id |           symbol |   base | quote | settle | baseId | quoteId | settleId | type | spot | margin | swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |          precision |                                           limits
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   BTCUSDTPERP |    BTC/USDT:USDT |    BTC |  USDT |   USDT |    BTC |    USDT |     USDT | swap |      |        | true |  false |  false |   true |     true |        |         |              |        |                |        |            |   {"price":0.0001} | {"leverage":{},"amount":{},"price":{},"cost":{}}
   ETHUSDTPERP |    ETH/USDT:USDT |    ETH |  USDT |   USDT |    ETH |    USDT |     USDT | swap |      |        | true |  false |  false |   true |     true |        |         |              |        |                |        |            |     {"price":0.01} | {"leverage":{},"amount":{},"price":{},"cost":{}}
   EOSUSDTPERP |    EOS/USDT:USDT |    EOS |  USDT |   USDT |    EOS |    USDT |     USDT | swap |      |        | true |  false |  false |   true |     true |        |         |              |        |                |        |            |   {"price":0.0001} | {"leverage":{},"amount":{},"price":{},"cost":{}}
   ...
64 objects
2022-09-09T06:40:10.552Z iteration 1 passed in 1163 ms
```

### fetchFundingRate:
```
node examples/js/cli digifinex fetchFundingRate BTC/USDT:USDT

digifinex.fetchFundingRate (BTC/USDT:USDT)
2022-09-09T06:42:27.872Z iteration 0 passed in 1146 ms

{
  info: {
    instrument_id: 'BTCUSDTPERP',
    funding_rate: '-0.00012',
    funding_time: '1662710400000',
    next_funding_rate: '9.940991509842048e-05',
    next_funding_time: '1662739200000'
  },
  symbol: 'BTC/USDT:USDT',
  markPrice: undefined,
  indexPrice: undefined,
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: undefined,
  datetime: undefined,
  fundingRate: '-0.00012',
  fundingTimestamp: 1662710400000,
  fundingDatetime: '2022-09-09T08:00:00.000Z',
  nextFundingRate: '9.940991509842048e-05',
  nextFundingTimestamp: 1662739200000,
  nextFundingDatetime: '2022-09-09T16:00:00.000Z',
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
2022-09-09T06:42:27.872Z iteration 1 passed in 1146 ms
```