### PR TITLE
kucoin: add new apis for subaccount

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -148,6 +148,8 @@ module.exports = class kucoin extends Exchange {
                         'accounts/transferable': 1,
                         'base-fee': 1,
                         'sub/user': 1,
+                        'user-info': 1,
+                        'sub/api-key': 1,
                         'sub-accounts': 1,
                         'sub-accounts/{subUserId}': 1,
                         'deposit-addresses': 1,
@@ -202,6 +204,9 @@ module.exports = class kucoin extends Exchange {
                         'margin/toggle-auto-lend': 1,
                         'bullet-private': 1,
                         'stop-order': 1,
+                        'sub/user': 1,
+                        'sub/api-key': 1,
+                        'sub/api-key/update': 1,
                     },
                     'delete': {
                         'withdrawals/{withdrawalId}': 1,
@@ -212,6 +217,7 @@ module.exports = class kucoin extends Exchange {
                         'stop-order/cancelOrderByClientOid': 1,
                         'stop-order/{orderId}': 1,
                         'stop-order/cancel': 1,
+                        'sub/api-key': 1,
                     },
                 },
                 'futuresPublic': {


### PR DESCRIPTION
Add api-key endpoints for kucoin: https://docs.kucoin.com/#upcoming-changes.
Related issue: ccxt/ccxt#14888

```
node examples/js/cli kucoin privatePostSubUser '{"subName":"******","password":"******"}'
node examples/js/cli kucoin privateGetSubUser
node examples/js/cli kucoin privatePostSubApiKey '{"subName":"******","passphrase":"******","remark":"******"}'
node examples/js/cli kucoin privatePostSubApiKeyUpdate '{"subName":"******","ipWhitelist":"******","apiKey":"******"}'
node examples/js/cli kucoin privateGetSubApiKey '{"subName":"******"}'
```