### PR TITLE
okx - fix: remove NotSupported when trading spot on multi-currency margin account

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -2044,9 +2044,6 @@ module.exports = class okx extends Exchange {
             marginMode = defaultMarginMode;
             margin = this.safeValue (params, 'margin', false);
         }
-        if (margin === true && market['spot'] && !market['margin']) {
-            throw new NotSupported (this.id + ' does not support margin trading for ' + symbol + ' market');
-        }
         if (spot) {
             if (margin) {
                 const defaultCurrency = (side === 'buy') ? market['quote'] : market['base'];


### PR DESCRIPTION
According to OKx documentation about order creation and the `tdMode` setting, if the current account is a `Multi-currency margin account`, then the `"cash"` `tdMode` is not available. See [highlighted reference](https://www.okx.com/docs-v5/en/#rest-api-trade-place-order:~:text=request%20is%20unsuccessful.-,tdMode,-Trade%20Mode%2C%20when) about `tdMode` and the [OKx guide](https://www.okx.com/academy/en/expert-guide-to-multi-currency-margin-trading) about unified accounts.

When trading on multi-currency margin accounts, one must specify the `tdMode=cross` **even** for markets which don't support margin trading. This case is currently impossible as CCXT internally raises `NotSupported` when trying to create an order with `tdMode=cross` for markets which don't support margin trading.

NB: if `tdMode=cash` is specified instead, OKx reject the order with `"sCode":"51000","sMsg":"Parameter tdMode  error "`

<details>
  <summary>Steps to reproduce</summary>

  ### Set OKx account to `Multi-currency margin mode`

  From the OKx trading screen, click on the settings cogwheel:

<img width="1140" alt="Screenshot 2022-09-09 at 14 29 07" src="https://user-images.githubusercontent.com/15276897/189351454-8bd7a25f-b574-4593-a868-ae3b6da2c032.png">

Click on `Account mode`

![image](https://user-images.githubusercontent.com/15276897/189351599-0f407e88-0a3b-4183-8a42-ab2b17f12ac9.png)

Make sure `Multi-currency margin` is selected

![image](https://user-images.githubusercontent.com/15276897/189351664-1665448e-e6be-4bbf-85e8-6481fd8b0c70.png)


  ### Create limit orders on non-margin markets

Let's take for example the `ZBC-USDT` market and this minimal script in `python3.10` to reproduce:

  ```python3
import asyncio
from decimal import Decimal

import ccxt.async_support.okx

async def create_order() -> None:
    exchange = ccxt.async_support.okx({"apiKey": "***", "secret": "***", "password": "***"})  # Redacted
    await exchange.load_markets()

    print(exchange.market("ZBC-USDT")["margin"])  # Prints False
    
    # This fails with `ccxt.base.errors.BadRequest` due to "Parameter tdMode  error"
    await exchange.create_order(
        symbol="ZBC-USDT",
        type="post_only",
        side="buy",
        amount=Decimal("100"),
        price=Decimal("0.01"),
        params={"tdMode": "cash"}
    )

    # This fails with `ccxt.base.errors.NotSupported` for "okx does not support margin trading for ZBC-USDT market"
    await exchange.create_order(
        symbol="ZBC-USDT",
        type="post_only",
        side="buy",
        amount=Decimal("100"),
        price=Decimal("0.01"),
        params={"tdMode": "cross"}
    )

if __name__ == '__main__':
    asyncio.run(create_order())
  ```

With the proposed fix the latter call to `create_order` succeeds

</details>
