### PR TITLE
bit2c - added support for 'fetchOrder'

### DIFF
--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -46,6 +46,7 @@ module.exports = class bit2c extends Exchange {
                 'fetchMyTrades': true,
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
+                'fetchOrder': true,
                 'fetchOrderBook': true,
                 'fetchPosition': false,
                 'fetchPositionMode': false,
@@ -91,6 +92,7 @@ module.exports = class bit2c extends Exchange {
                         'Funds/AddCoinFundsRequest',
                         'Order/AddFund',
                         'Order/AddOrder',
+                        'Order/GetById',
                         'Order/AddOrderMarketPriceBuy',
                         'Order/AddOrderMarketPriceSell',
                         'Order/CancelOrder',
@@ -397,10 +399,7 @@ module.exports = class bit2c extends Exchange {
             request['IsBid'] = (side === 'buy');
         }
         const response = await this[method] (this.extend (request, params));
-        return {
-            'info': response,
-            'id': response['NewOrder']['id'],
-        };
+        return this.parseOrder (response, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
@@ -445,19 +444,157 @@ module.exports = class bit2c extends Exchange {
         return this.parseOrders (this.arrayConcat (asks, bids), market, since, limit);
     }
 
+    async fetchOrder(id, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name bit2c#fetchOrder
+         * @description fetches information on an order made by the user
+         * @param {string} symbol unified market symbol
+         * @param {object} params extra parameters specific to the bit2c api endpoint
+         * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'id': id,
+        };
+
+        const response = await this.privateGetOrderGetById (this.extend (request, params));
+
+        //         {
+        //             "pair": "BtcNis",
+        //             "status": "Completed",
+        //             "created": 1666689837,
+        //             "type": 0,
+        //             "order_type": 0,
+        //             "amount": 0.00000000,
+        //             "price": 50000.00000000,
+        //             "stop": 0,
+        //             "id": 10951473,
+        //             "initialAmount": 2.00000000
+        //         }
+        return this.parseOrder (response, market);
+    }
+
     parseOrder (order, market = undefined) {
-        const timestamp = this.safeInteger (order, 'created');
-        const price = this.safeString (order, 'price');
-        const amount = this.safeString (order, 'amount');
-        market = this.safeMarket (undefined, market);
-        let side = this.safeValue (order, 'type');
-        if (side === 0) {
+        //             createOrder
+        //             {
+        //                 "OrderResponse": {"pair": "BtcNis", "HasError": False, "Error": "", "Message": ""},
+        //                 "NewOrder": {
+        //                     "created": 1505531577,
+        //                     "type": 0,
+        //                     "order_type": 0,
+        //                     "status_type": 0,
+        //                     "amount": 0.01,
+        //                     "price": 10000,
+        //                     "stop": 0,
+        //                     "id": 9244416,
+        //                     "initialAmount": None,
+        //                 },
+        //             }
+        //
+        //             fetchOrder, fetchOpenOrders
+        //             {
+        //                 "pair": "BtcNis",
+        //                 "status": "Completed",
+        //                 "created": 1535555837,
+        //                 "type": 0,
+        //                 "order_type": 0,
+        //                 "amount": 0.00000000,
+        //                 "price": 120000.00000000,
+        //                 "stop": 0,
+        //                 "id": 10555173,
+        //                 "initialAmount": 2.00000000
+        //             }
+
+        // order related responses differ in dict structure
+        let orderUnified = undefined;
+        let isNewOrder = false;
+        if ('NewOrder' in order) {
+            orderUnified = order['NewOrder'];
+            isNewOrder = true;
+        }
+        else {
+            orderUnified = order;
+        }
+
+        const id = this.safeString (order, 'id');
+        const symbol = this.safeSymbol (undefined, market);
+        const market = this.safeMarket (undefined, market);
+
+        // bit2c timestamp string unix epoch in seconds (standard is milliseconds)
+        const timestamp = this.safeInteger (order, 'created') * 1000;
+
+        // status field vary between responses
+        // bit2c status type:
+        // 0 = New
+        // 1 = Open
+        // 5 = Completed
+        let status = undefined;
+        tempStatus = undefined
+        if (isNewOrder) {
+            tempStatus = this.safeInteger (orderUnified, 'status_type');
+            if (tempStatus == 0) or (tempStatus == 1) {
+                status = 'open';
+            }
+            else if (tempStatus == 5) {
+                status = 'closed';
+            }
+        }
+        else {
+            tempStatus = this.safeString (order, 'status');
+            if (tempStatus == 'New') or (tempStatus == 'Open') {
+                status = 'open';
+            }
+            else if (tempStatus == 'Completed') {
+                status = 'closed';
+            }
+        }
+
+        // bit2c order type:
+        // 0 = LMT,  1 = MKT
+        let type = this.safeInteger (orderUnified, 'order_type');
+        if (type == 0) {
+            type = 'limit';
+        }
+        else if (type == 1) {
+            type = 'market';
+        }
+
+        // bit2c side:
+        // 0 = buy, 1 = sell
+        let side = this.safeInteger (orderUnified, 'type');
+        if (side == 0) {
             side = 'buy';
-        } else if (side === 1) {
+        }
+        else if (side == 1) {
             side = 'sell';
         }
-        const id = this.safeString (order, 'id');
-        const status = this.safeString (order, 'status');
+
+
+        const price = this.safeNumber (order, 'price');
+        let amount = undefined;
+        let cost = undefined;
+        let remaining = undefined;
+        let filled = undefined;
+
+        if (isNewOrder) {
+            amount = this.safeNumber (orderUnified, 'amount');  // NOTE:'initialAmount' is currently not set on new order
+            remaining = this.safeNumber (orderUnified, 'amount');
+            filled = 0.0;
+        }
+        else {
+            amount = this.safeNumber (order, 'initialAmount');
+            remaining = this.safeNumber (order, 'amount');
+            filled = amount - remaining;
+        }
+
+        if (price) {
+            if (amount) {
+                cost = price * amount;
+            }
+        }
+
         return this.safeOrder ({
             'id': id,
             'clientOrderId': undefined,
@@ -465,17 +602,17 @@ module.exports = class bit2c extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': undefined,
             'status': status,
-            'symbol': market['symbol'],
-            'type': undefined,
+            'symbol': symbol,
+            'type': type,
             'timeInForce': undefined,
             'postOnly': undefined,
             'side': side,
             'price': price,
             'stopPrice': undefined,
             'amount': amount,
-            'filled': undefined,
-            'remaining': undefined,
-            'cost': undefined,
+            'filled': filled,
+            'remaining': remaining,
+            'cost': cost,
             'trades': undefined,
             'fee': undefined,
             'info': order,

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -523,7 +523,10 @@ module.exports = class bit2c extends Exchange {
         const market = this.safeMarket (undefined, market);
 
         // bit2c timestamp string unix epoch in seconds (standard is milliseconds)
-        const timestamp = this.safeInteger (order, 'created') * 1000;
+        let timestamp = this.safeInteger (order, 'created');
+        if (timestamp) {
+            timestamp = timestamp * 1000;
+        }
 
         // status field vary between responses
         // bit2c status type:
@@ -534,7 +537,7 @@ module.exports = class bit2c extends Exchange {
         tempStatus = undefined
         if (isNewOrder) {
             tempStatus = this.safeInteger (orderUnified, 'status_type');
-            if (tempStatus == 0) or (tempStatus == 1) {
+            if (tempStatus == 0) || (tempStatus == 1) {
                 status = 'open';
             }
             else if (tempStatus == 5) {
@@ -543,7 +546,7 @@ module.exports = class bit2c extends Exchange {
         }
         else {
             tempStatus = this.safeString (order, 'status');
-            if (tempStatus == 'New') or (tempStatus == 'Open') {
+            if (tempStatus == 'New') || (tempStatus == 'Open') {
                 status = 'open';
             }
             else if (tempStatus == 'Completed') {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -458,7 +458,6 @@ module.exports = class bit2c extends Exchange {
         const request = {
             'id': id,
         };
-
         const response = await this.privateGetOrderGetById (this.extend (request, params));
         //         {
         //             "pair": "BtcNis",
@@ -511,8 +510,7 @@ module.exports = class bit2c extends Exchange {
         if ('NewOrder' in order) {
             orderUnified = order['NewOrder'];
             isNewOrder = true;
-        }
-        else {
+        } else {
             orderUnified = order;
         }
         const id = this.safeString (order, 'id');
@@ -528,22 +526,19 @@ module.exports = class bit2c extends Exchange {
         // 1 = Open
         // 5 = Completed
         let status = undefined;
-        tempStatus = undefined
+        tempStatus = undefined;
         if (isNewOrder) {
             tempStatus = this.safeInteger (orderUnified, 'status_type');
             if (tempStatus === 0 || tempStatus === 1) {
                 status = 'open';
-            }
-            else if (tempStatus === 5) {
+            } else if (tempStatus === 5) {
                 status = 'closed';
             }
-        }
-        else {
+        } else {
             tempStatus = this.safeString (order, 'status');
             if (tempStatus === 'New' || tempStatus === 'Open') {
                 status = 'open';
-            }
-            else if (tempStatus === 'Completed') {
+            } else if (tempStatus === 'Completed') {
                 status = 'closed';
             }
         }
@@ -552,8 +547,7 @@ module.exports = class bit2c extends Exchange {
         let type = this.safeInteger (orderUnified, 'order_type');
         if (type === 0) {
             type = 'limit';
-        }
-        else if (type === 1) {
+        } else if (type === 1) {
             type = 'market';
         }
         // bit2c side:
@@ -561,8 +555,7 @@ module.exports = class bit2c extends Exchange {
         let side = this.safeInteger (orderUnified, 'type');
         if (side === 0) {
             side = 'buy';
-        }
-        else if (side === 1) {
+        } else if (side === 1) {
             side = 'sell';
         }
         const price = this.safeNumber (order, 'price');
@@ -574,8 +567,7 @@ module.exports = class bit2c extends Exchange {
             amount = this.safeNumber (orderUnified, 'amount');  // NOTE:'initialAmount' is currently not set on new order
             remaining = this.safeNumber (orderUnified, 'amount');
             filled = 0.0;
-        }
-        else {
+        } else {
             amount = this.safeNumber (order, 'initialAmount');
             remaining = this.safeNumber (order, 'amount');
             filled = amount - remaining;

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -527,14 +527,14 @@ module.exports = class bit2c extends Exchange {
         // 5 = Completed
         let status = undefined;
         if (isNewOrder) {
-            tempStatus = this.safeInteger (orderUnified, 'status_type');
+            let tempStatus = this.safeInteger (orderUnified, 'status_type');
             if (tempStatus === 0 || tempStatus === 1) {
                 status = 'open';
             } else if (tempStatus === 5) {
                 status = 'closed';
             }
         } else {
-            tempStatus = this.safeString (order, 'status');
+            let tempStatus = this.safeString (order, 'status');
             if (tempStatus === 'New' || tempStatus === 'Open') {
                 status = 'open';
             } else if (tempStatus === 'Completed') {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -444,7 +444,7 @@ module.exports = class bit2c extends Exchange {
         return this.parseOrders (this.arrayConcat (asks, bids), market, since, limit);
     }
 
-    async fetchOrder(id, symbol = undefined, params = {}) {
+    async fetchOrder (id, symbol = undefined, params = {}) {
         /**
          * @method
          * @name bit2c#fetchOrder
@@ -460,7 +460,6 @@ module.exports = class bit2c extends Exchange {
         };
 
         const response = await this.privateGetOrderGetById (this.extend (request, params));
-
         //         {
         //             "pair": "BtcNis",
         //             "status": "Completed",
@@ -506,7 +505,6 @@ module.exports = class bit2c extends Exchange {
         //                 "id": 10555173,
         //                 "initialAmount": 2.00000000
         //             }
-
         // order related responses differ in dict structure
         let orderUnified = undefined;
         let isNewOrder = false;
@@ -517,16 +515,13 @@ module.exports = class bit2c extends Exchange {
         else {
             orderUnified = order;
         }
-
         const id = this.safeString (order, 'id');
         const symbol = this.safeSymbol (undefined, market);
-
         // bit2c timestamp string unix epoch in seconds (standard is milliseconds)
         let timestamp = this.safeInteger (order, 'created');
         if (timestamp) {
             timestamp = timestamp * 1000;
         }
-
         // status field vary between responses
         // bit2c status type:
         // 0 = New
@@ -536,50 +531,45 @@ module.exports = class bit2c extends Exchange {
         tempStatus = undefined
         if (isNewOrder) {
             tempStatus = this.safeInteger (orderUnified, 'status_type');
-            if (tempStatus == 0 || tempStatus == 1) {
+            if (tempStatus === 0 || tempStatus === 1) {
                 status = 'open';
             }
-            else if (tempStatus == 5) {
+            else if (tempStatus === 5) {
                 status = 'closed';
             }
         }
         else {
             tempStatus = this.safeString (order, 'status');
-            if (tempStatus == 'New' || tempStatus == 'Open') {
+            if (tempStatus === 'New' || tempStatus === 'Open') {
                 status = 'open';
             }
-            else if (tempStatus == 'Completed') {
+            else if (tempStatus === 'Completed') {
                 status = 'closed';
             }
         }
-
         // bit2c order type:
         // 0 = LMT,  1 = MKT
         let type = this.safeInteger (orderUnified, 'order_type');
-        if (type == 0) {
+        if (type === 0) {
             type = 'limit';
         }
-        else if (type == 1) {
+        else if (type === 1) {
             type = 'market';
         }
-
         // bit2c side:
         // 0 = buy, 1 = sell
         let side = this.safeInteger (orderUnified, 'type');
-        if (side == 0) {
+        if (side === 0) {
             side = 'buy';
         }
-        else if (side == 1) {
+        else if (side === 1) {
             side = 'sell';
         }
-
-
         const price = this.safeNumber (order, 'price');
         let amount = undefined;
         let cost = undefined;
         let remaining = undefined;
         let filled = undefined;
-
         if (isNewOrder) {
             amount = this.safeNumber (orderUnified, 'amount');  // NOTE:'initialAmount' is currently not set on new order
             remaining = this.safeNumber (orderUnified, 'amount');
@@ -590,13 +580,11 @@ module.exports = class bit2c extends Exchange {
             remaining = this.safeNumber (order, 'amount');
             filled = amount - remaining;
         }
-
         if (price) {
             if (amount) {
                 cost = price * amount;
             }
         }
-
         return this.safeOrder ({
             'id': id,
             'clientOrderId': undefined,

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ArgumentsRequired, ExchangeError, InvalidNonce, AuthenticationError, PermissionDenied, NotSupported } = require ('./base/errors');
+const { ArgumentsRequired, ExchangeError, InvalidNonce, AuthenticationError, PermissionDenied, NotSupported, OrderNotFound } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -131,6 +131,7 @@ module.exports = class bit2c extends Exchange {
             'exceptions': {
                 'exact': {
                     'Please provide valid APIkey': AuthenticationError, // { "error" : "Please provide valid APIkey" }
+                    'No order found.': OrderNotFound, // { "Error" : "No order found." }
                 },
                 'broad': {
                     // { "error": "Please provide valid nonce in Request Nonce (1598218490) is not bigger than last nonce (1598218490)."}
@@ -853,8 +854,12 @@ module.exports = class bit2c extends Exchange {
         //
         //     { "error" : "please approve new terms of use on site." }
         //     { "error": "Please provide valid nonce in Request Nonce (1598218490) is not bigger than last nonce (1598218490)."}
+        //     { "Error" : "No order found." }
         //
-        const error = this.safeString (response, 'error');
+        let error = this.safeString (response, 'error');
+        if (error === undefined) {
+            error = this.safeString (response, 'Error');
+        }
         if (error !== undefined) {
             const feedback = this.id + ' ' + body;
             this.throwExactlyMatchedException (this.exceptions['exact'], error, feedback);

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -527,14 +527,14 @@ module.exports = class bit2c extends Exchange {
         // 5 = Completed
         let status = undefined;
         if (isNewOrder) {
-            let tempStatus = this.safeInteger (orderUnified, 'status_type');
+            const tempStatus = this.safeInteger (orderUnified, 'status_type');
             if (tempStatus === 0 || tempStatus === 1) {
                 status = 'open';
             } else if (tempStatus === 5) {
                 status = 'closed';
             }
         } else {
-            let tempStatus = this.safeString (order, 'status');
+            const tempStatus = this.safeString (order, 'status');
             if (tempStatus === 'New' || tempStatus === 'Open') {
                 status = 'open';
             } else if (tempStatus === 'Completed') {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -537,7 +537,7 @@ module.exports = class bit2c extends Exchange {
         tempStatus = undefined
         if (isNewOrder) {
             tempStatus = this.safeInteger (orderUnified, 'status_type');
-            if (tempStatus == 0) || (tempStatus == 1) {
+            if (tempStatus == 0 || tempStatus == 1) {
                 status = 'open';
             }
             else if (tempStatus == 5) {
@@ -546,7 +546,7 @@ module.exports = class bit2c extends Exchange {
         }
         else {
             tempStatus = this.safeString (order, 'status');
-            if (tempStatus == 'New') || (tempStatus == 'Open') {
+            if (tempStatus == 'New' || tempStatus == 'Open') {
                 status = 'open';
             }
             else if (tempStatus == 'Completed') {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -526,7 +526,6 @@ module.exports = class bit2c extends Exchange {
         // 1 = Open
         // 5 = Completed
         let status = undefined;
-        tempStatus = undefined;
         if (isNewOrder) {
             tempStatus = this.safeInteger (orderUnified, 'status_type');
             if (tempStatus === 0 || tempStatus === 1) {

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -520,7 +520,6 @@ module.exports = class bit2c extends Exchange {
 
         const id = this.safeString (order, 'id');
         const symbol = this.safeSymbol (undefined, market);
-        const market = this.safeMarket (undefined, market);
 
         // bit2c timestamp string unix epoch in seconds (standard is milliseconds)
         let timestamp = this.safeInteger (order, 'created');

--- a/js/bit2c.js
+++ b/js/bit2c.js
@@ -460,6 +460,7 @@ module.exports = class bit2c extends Exchange {
             'id': id,
         };
         const response = await this.privateGetOrderGetById (this.extend (request, params));
+        //
         //         {
         //             "pair": "BtcNis",
         //             "status": "Completed",
@@ -472,40 +473,41 @@ module.exports = class bit2c extends Exchange {
         //             "id": 10951473,
         //             "initialAmount": 2.00000000
         //         }
+        //
         return this.parseOrder (response, market);
     }
 
     parseOrder (order, market = undefined) {
-        //             createOrder
-        //             {
-        //                 "OrderResponse": {"pair": "BtcNis", "HasError": False, "Error": "", "Message": ""},
-        //                 "NewOrder": {
-        //                     "created": 1505531577,
-        //                     "type": 0,
-        //                     "order_type": 0,
-        //                     "status_type": 0,
-        //                     "amount": 0.01,
-        //                     "price": 10000,
-        //                     "stop": 0,
-        //                     "id": 9244416,
-        //                     "initialAmount": None,
-        //                 },
-        //             }
         //
-        //             fetchOrder, fetchOpenOrders
-        //             {
-        //                 "pair": "BtcNis",
-        //                 "status": "Completed",
-        //                 "created": 1535555837,
-        //                 "type": 0,
-        //                 "order_type": 0,
-        //                 "amount": 0.00000000,
-        //                 "price": 120000.00000000,
-        //                 "stop": 0,
-        //                 "id": 10555173,
-        //                 "initialAmount": 2.00000000
-        //             }
-        // order related responses differ in dict structure
+        //      createOrder
+        //      {
+        //          "OrderResponse": {"pair": "BtcNis", "HasError": False, "Error": "", "Message": ""},
+        //          "NewOrder": {
+        //              "created": 1505531577,
+        //              "type": 0,
+        //              "order_type": 0,
+        //              "status_type": 0,
+        //              "amount": 0.01,
+        //              "price": 10000,
+        //              "stop": 0,
+        //              "id": 9244416,
+        //              "initialAmount": None,
+        //          },
+        //      }
+        //      fetchOrder, fetchOpenOrders
+        //      {
+        //          "pair": "BtcNis",
+        //          "status": "Completed",
+        //          "created": 1535555837,
+        //          "type": 0,
+        //          "order_type": 0,
+        //          "amount": 0.00000000,
+        //          "price": 120000.00000000,
+        //          "stop": 0,
+        //          "id": 10555173,
+        //          "initialAmount": 2.00000000
+        //      }
+        //
         let orderUnified = undefined;
         let isNewOrder = false;
         if ('NewOrder' in order) {
@@ -516,11 +518,7 @@ module.exports = class bit2c extends Exchange {
         }
         const id = this.safeString (order, 'id');
         const symbol = this.safeSymbol (undefined, market);
-        // bit2c timestamp string unix epoch in seconds (standard is milliseconds)
-        let timestamp = this.safeInteger (order, 'created');
-        if (timestamp) {
-            timestamp = timestamp * 1000;
-        }
+        const timestamp = this.safeIntegerProduct (order, 'created', 1000);
         // status field vary between responses
         // bit2c status type:
         // 0 = New
@@ -558,24 +556,15 @@ module.exports = class bit2c extends Exchange {
         } else if (side === 1) {
             side = 'sell';
         }
-        const price = this.safeNumber (order, 'price');
+        const price = this.safeString (order, 'price');
         let amount = undefined;
-        let cost = undefined;
         let remaining = undefined;
-        let filled = undefined;
         if (isNewOrder) {
-            amount = this.safeNumber (orderUnified, 'amount');  // NOTE:'initialAmount' is currently not set on new order
-            remaining = this.safeNumber (orderUnified, 'amount');
-            filled = 0.0;
+            amount = this.safeString (orderUnified, 'amount');  // NOTE:'initialAmount' is currently not set on new order
+            remaining = this.safeString (orderUnified, 'amount');
         } else {
-            amount = this.safeNumber (order, 'initialAmount');
-            remaining = this.safeNumber (order, 'amount');
-            filled = amount - remaining;
-        }
-        if (price) {
-            if (amount) {
-                cost = price * amount;
-            }
+            amount = this.safeString (order, 'initialAmount');
+            remaining = this.safeString (order, 'amount');
         }
         return this.safeOrder ({
             'id': id,
@@ -592,9 +581,9 @@ module.exports = class bit2c extends Exchange {
             'price': price,
             'stopPrice': undefined,
             'amount': amount,
-            'filled': filled,
+            'filled': undefined,
             'remaining': remaining,
-            'cost': cost,
+            'cost': undefined,
             'trades': undefined,
             'fee': undefined,
             'info': order,


### PR DESCRIPTION
added 'fetchOrder' support on bit2c + rework on 'parseOrder'

parseOrder had been reworked to generalize to fit two different responses regarding the order.
first was the response type for creating an order (createOrder) and the second for retrieving order info (fetchOrder, fetchOpenOrders)

*createOrder was altered also to refer to the new unification of parseOrder 


  

