### PR TITLE
huobi.createOrder market buy string math

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4105,7 +4105,7 @@ module.exports = class huobi extends Exchange {
                     // we use amountToPrecision here because the exchange requires cost in base precision
                     const amountString = this.numberToString (amount);
                     const priceString = this.numberToString (price);
-                    request['amount'] = this.costToPrecision (symbol, parseFloat (Precise.stringMul (amountString, priceString)));
+                    request['amount'] = this.costToPrecision (symbol, Precise.stringMul (amountString, priceString));
                 }
             } else {
                 request['amount'] = this.costToPrecision (symbol, amount);

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4103,7 +4103,9 @@ module.exports = class huobi extends Exchange {
                     // https://github.com/ccxt/ccxt/pull/4395
                     // https://github.com/ccxt/ccxt/issues/7611
                     // we use amountToPrecision here because the exchange requires cost in base precision
-                    request['amount'] = this.costToPrecision (symbol, parseFloat (amount) * parseFloat (price));
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    request['amount'] = this.costToPrecision (symbol, parseFloat (Precise.stringMul (amountString, priceString)));
                 }
             } else {
                 request['amount'] = this.costToPrecision (symbol, amount);

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1601,8 +1601,8 @@ module.exports = class huobi extends Exchange {
             let maker = undefined;
             let taker = undefined;
             if (spot) {
-                maker = (base === 'OMG') ? 0 : 0.2 / 100;
-                taker = (base === 'OMG') ? 0 : 0.2 / 100;
+                maker = (base === 'OMG') ? this.parseNumber ('0') : this.parseNumber ('0.002');
+                taker = (base === 'OMG') ? this.parseNumber ('0') : this.parseNumber ('0.002');
             }
             const minAmount = this.safeNumber (market, 'min-order-amt');
             const maxAmount = this.safeNumber (market, 'max-order-amt');


### PR DESCRIPTION
```
% huobi createOrder ADA/USDT market buy 5 0.45
2022-09-09T21:17:53.203Z
Node.js: v18.4.0
CCXT v1.93.20
(node:10505) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
huobi.createOrder (ADA/USDT, market, buy, 5, 0.45)
2022-09-09T21:17:55.964Z iteration 0 passed in 531 ms

{
  info: { status: 'ok', data: '620820981916256' },
  id: '620820981916256',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  trades: undefined,
  fee: undefined,
  clientOrderId: undefined,
  average: undefined
}
2022-09-09T21:17:55.964Z iteration 1 passed in 531 ms
```

```
% huobi fetchMarkets | condense
(node:10687) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2022-09-09T21:21:14.498Z
Node.js: v18.4.0
CCXT v1.93.20
huobi.fetchMarkets ()
2022-09-09T21:21:17.045Z iteration 0 passed in 676 ms
             id |     lowercaseId |               symbol |           base | quote | settle |    baseId | lowercaseBaseId | quoteId | settleId |   type |  spot | margin |  swap | future | option | active | contract | linear | inverse | taker | maker | contractSize |        expiry |           expiryDatetime | strike | optionType |                                        precision |                                                                              limits
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
         rsrbtc |          rsrbtc |              RSR/BTC |            RSR |   BTC |        |       rsr |             rsr |     btc |          |   spot |  true |   true | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |               |                          |        |            |        {"amount":0.01,"price":1e-10,"cost":1e-8} |                                                                     [object Object]
...
        FTM-USD |         ftm-usd |          FTM/USD:FTM |            FTM |   USD |    FTM |       FTM |             ftm |     usd |      FTM |   swap | false |  false |  true |  false |  false |   true |     true |  false |    true |       |       |           10 |               |                          |        |            |                      {"amount":1,"price":0.0001} | {"leverage":{"min":1,"max":1,"superMax":1},"amount":{},"price":{},"cost":{"min":0}}
1614 objects
2022-09-09T21:21:17.045Z iteration 1 passed in 676 ms
```