### PR TITLE
mexc.createSpotOrder string math

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -332,8 +332,8 @@ module.exports = class mexc3 extends Exchange {
                 'trading': {
                     'tierBased': false,
                     'percentage': true,
-                    'maker': 0.2 / 100, // maker / taker
-                    'taker': 0.2 / 100,
+                    'maker': this.parseNumber ('0.002'), // maker / taker
+                    'taker': this.parseNumber ('0.002'),
                 },
             },
             'options': {
@@ -1654,7 +1654,10 @@ module.exports = class mexc3 extends Exchange {
                 if (price === undefined) {
                     throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
                 } else {
-                    amount = amount * price;
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    const quoteAmount = Precise.stringMul (amountString, priceString);
+                    amount = this.parseNumber (quoteAmount);
                 }
             }
             request['quoteOrderQty'] = amount;


### PR DESCRIPTION
```
% ccxt mexc3 createOrder ADA/USDT market buy 12 0.45
2022-09-09T22:49:28.811Z
Node.js: v18.4.0
CCXT v1.93.20
(node:12599) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
mexc3.createOrder (ADA/USDT, market, buy, 12, 0.45)
2022-09-09T22:49:31.244Z iteration 0 passed in 311 ms

{
  id: 'c7fbbc3079c04d8abae00f828e698216',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'ADA/USDT',
  type: 'market',
  timeInForce: undefined,
  side: 'buy',
  price: 0.45,
  stopPrice: undefined,
  average: undefined,
  amount: 5.4,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  trades: [],
  info: {
    symbol: 'ADAUSDT',
    orderId: 'c7fbbc3079c04d8abae00f828e698216',
    orderListId: '-1',
    price: '0.498441',
    origQty: '10.83',
    type: 'IMMEDIATE_OR_CANCEL',
    side: 'BUY',
    transactTime: '1662763771250'
  },
  fees: []
}
2022-09-09T22:49:31.244Z iteration 1 passed in 311 ms
```