### PR TITLE
zaif.describe fess uses parseNumber

### DIFF
--- a/js/zaif.js
+++ b/js/zaif.js
@@ -128,11 +128,11 @@ module.exports = class zaif extends Exchange {
             'options': {
                 // zaif schedule defines several market-specific fees
                 'fees': {
-                    'BTC/JPY': { 'maker': 0, 'taker': 0.1 / 100 },
-                    'BCH/JPY': { 'maker': 0, 'taker': 0.3 / 100 },
-                    'BCH/BTC': { 'maker': 0, 'taker': 0.3 / 100 },
-                    'PEPECASH/JPY': { 'maker': 0, 'taker': 0.01 / 100 },
-                    'PEPECASH/BT': { 'maker': 0, 'taker': 0.01 / 100 },
+                    'BTC/JPY': { 'maker': this.parseNumber ('0'), 'taker': this.parseNumber ('0.001') },
+                    'BCH/JPY': { 'maker': this.parseNumber ('0'), 'taker': this.parseNumber ('0.003') },
+                    'BCH/BTC': { 'maker': this.parseNumber ('0'), 'taker': this.parseNumber ('0.003') },
+                    'PEPECASH/JPY': { 'maker': this.parseNumber ('0'), 'taker': this.parseNumber ('0.0001') },
+                    'PEPECASH/BT': { 'maker': this.parseNumber ('0'), 'taker': this.parseNumber ('0.0001') },
                 },
             },
             'precisionMode': TICK_SIZE,


### PR DESCRIPTION
```
% zaif describe
2022-09-09T23:27:06.941Z
Node.js: v18.4.0
CCXT v1.93.20
(node:14826) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
zaif.describe ()
2022-09-09T23:27:08.076Z iteration 0 passed in 0 ms

{
  id: 'zaif',
  name: 'Zaif',
  countries: [ 'JP' ],
  enableRateLimit: true,
  rateLimit: 100,
  certified: false,
  pro: false,
  alias: false,
  has: {
    publicAPI: true,
    privateAPI: true,
    CORS: undefined,
    spot: true,
    margin: undefined,
    swap: false,
    future: false,
    option: false,
    addMargin: undefined,
    cancelAllOrders: undefined,
    cancelOrder: true,
    cancelOrders: undefined,
    createDepositAddress: undefined,
    createLimitOrder: true,
    createMarketOrder: undefined,
    createOrder: true,
    createPostOnlyOrder: undefined,
    createReduceOnlyOrder: undefined,
    createStopOrder: undefined,
    createStopLimitOrder: undefined,
    createStopMarketOrder: undefined,
    editOrder: 'emulated',
    fetchAccounts: undefined,
    fetchBalance: true,
    fetchBidsAsks: undefined,
    fetchBorrowInterest: undefined,
    fetchBorrowRate: undefined,
    fetchBorrowRateHistory: undefined,
    fetchBorrowRatesPerSymbol: undefined,
    fetchBorrowRates: undefined,
    fetchCanceledOrders: undefined,
    fetchClosedOrder: undefined,
    fetchClosedOrders: true,
    fetchCurrencies: 'emulated',
    fetchDeposit: undefined,
    fetchDepositAddress: undefined,
    fetchDepositAddresses: undefined,
    fetchDepositAddressesByNetwork: undefined,
    fetchDeposits: undefined,
    fetchTransactionFee: undefined,
    fetchTransactionFees: undefined,
    fetchFundingHistory: false,
    fetchFundingRate: false,
    fetchFundingRateHistory: false,
    fetchFundingRates: false,
    fetchIndexOHLCV: false,
    fetchL2OrderBook: true,
    fetchLedger: undefined,
    fetchLedgerEntry: undefined,
    fetchLeverageTiers: undefined,
    fetchMarketLeverageTiers: undefined,
    fetchMarkets: true,
    fetchMarkOHLCV: false,
    fetchMyTrades: undefined,
    fetchOHLCV: 'emulated',
    fetchOpenOrder: undefined,
    fetchOpenOrders: true,
    fetchOrder: undefined,
    fetchOrderBook: true,
    fetchOrderBooks: undefined,
    fetchOrders: undefined,
    fetchOrderTrades: undefined,
    fetchPermissions: undefined,
    fetchPosition: undefined,
    fetchPositions: undefined,
    fetchPositionsRisk: undefined,
    fetchPremiumIndexOHLCV: false,
    fetchStatus: 'emulated',
    fetchTicker: true,
    fetchTickers: undefined,
    fetchTime: undefined,
    fetchTrades: true,
    fetchTradingFee: false,
    fetchTradingFees: false,
    fetchTradingLimits: undefined,
    fetchTransactions: undefined,
    fetchTransfers: undefined,
    fetchWithdrawal: undefined,
    fetchWithdrawals: undefined,
    reduceMargin: undefined,
    setLeverage: undefined,
    setMargin: undefined,
    setMarginMode: undefined,
    setPositionMode: undefined,
    signIn: undefined,
    transfer: undefined,
    withdraw: true,
    fetchOpenInterestHistory: false
  },
  urls: {
    logo: 'https://user-images.githubusercontent.com/1294454/27766927-39ca2ada-5eeb-11e7-972f-1b4199518ca6.jpg',
    api: { rest: 'https://api.zaif.jp' },
    www: 'https://zaif.jp',
    doc: [
      'https://techbureau-api-document.readthedocs.io/ja/latest/index.html',
      'https://corp.zaif.jp/api-docs',
      'https://corp.zaif.jp/api-docs/api_links',
      'https://www.npmjs.com/package/zaif.jp',
      'https://github.com/you21979/node-zaif'
    ],
    fees: 'https://zaif.jp/fee?lang=en'
  },
  api: {
    public: {
      get: {
        'depth/{pair}': 1,
        'currencies/{pair}': 1,
        'currencies/all': 1,
        'currency_pairs/{pair}': 1,
        'currency_pairs/all': 1,
        'last_price/{pair}': 1,
        'ticker/{pair}': 1,
        'trades/{pair}': 1
      }
    },
    private: {
      post: {
        active_orders: 5,
        cancel_order: 5,
        deposit_history: 5,
        get_id_info: 5,
        get_info: 10,
        get_info2: 5,
        get_personal_info: 5,
        trade: 5,
        trade_history: 50,
        withdraw: 5,
        withdraw_history: 5
      }
    },
    ecapi: {
      post: {
        createInvoice: 1,
        getInvoice: 1,
        getInvoiceIdsByOrderNumber: 1,
        cancelInvoice: 1
      }
    },
    tlapi: {
      post: {
        get_positions: 66,
        position_history: 66,
        active_positions: 5,
        create_position: 33,
        change_position: 33,
        cancel_position: 33
      }
    },
    fapi: {
      get: {
        'groups/{group_id}': 1,
        'last_price/{group_id}/{pair}': 1,
        'ticker/{group_id}/{pair}': 1,
        'trades/{group_id}/{pair}': 1,
        'depth/{group_id}/{pair}': 1
      }
    }
  },
  requiredCredentials: {
    apiKey: true,
    secret: true,
    uid: false,
    login: false,
    password: false,
    twofa: false,
    privateKey: false,
    walletAddress: false,
    token: false
  },
  markets: undefined,
  currencies: {},
  timeframes: undefined,
  fees: {
    trading: { tierBased: undefined, percentage: true, taker: 0.001, maker: 0 },
    funding: {
      tierBased: undefined,
      percentage: undefined,
      withdraw: {},
      deposit: {}
    }
  },
  status: { status: 'ok', updated: undefined, eta: undefined, url: undefined },
  exceptions: {
    exact: {
      'unsupported currency_pair': [class BadRequest extends ExchangeError]
    },
    broad: {}
  },
  httpExceptions: {
    '400': [class ExchangeNotAvailable extends NetworkError],
    '401': [class AuthenticationError extends ExchangeError],
    '403': [class ExchangeNotAvailable extends NetworkError],
    '404': [class ExchangeNotAvailable extends NetworkError],
    '405': [class ExchangeNotAvailable extends NetworkError],
    '408': [class RequestTimeout extends NetworkError],
    '409': [class ExchangeNotAvailable extends NetworkError],
    '410': [class ExchangeNotAvailable extends NetworkError],
    '418': [class DDoSProtection extends NetworkError],
    '422': [class ExchangeError extends BaseError],
    '429': [class RateLimitExceeded extends DDoSProtection],
    '500': [class ExchangeNotAvailable extends NetworkError],
    '501': [class ExchangeNotAvailable extends NetworkError],
    '502': [class ExchangeNotAvailable extends NetworkError],
    '503': [class ExchangeNotAvailable extends NetworkError],
    '504': [class RequestTimeout extends NetworkError],
    '511': [class AuthenticationError extends ExchangeError],
    '520': [class ExchangeNotAvailable extends NetworkError],
    '521': [class ExchangeNotAvailable extends NetworkError],
    '522': [class ExchangeNotAvailable extends NetworkError],
    '525': [class ExchangeNotAvailable extends NetworkError],
    '526': [class ExchangeNotAvailable extends NetworkError],
    '530': [class ExchangeNotAvailable extends NetworkError]
  },
  commonCurrencies: { XBT: 'BTC', BCC: 'BCH', BCHABC: 'BCH', BCHSV: 'BSV' },
  precisionMode: 2,
  paddingMode: 0,
  limits: {
    leverage: { min: undefined, max: undefined },
    amount: { min: undefined, max: undefined },
    price: { min: undefined, max: undefined },
    cost: { min: undefined, max: undefined }
  },
  version: '1',
  options: {
    fees: {
      'BTC/JPY': { maker: 0, taker: 0.001 },
      'BCH/JPY': { maker: 0, taker: 0.003 },
      'BCH/BTC': { maker: 0, taker: 0.003 },
      'PEPECASH/JPY': { maker: 0, taker: 0.0001 },
      'PEPECASH/BT': { maker: 0, taker: 0.0001 }
    }
  }
}
2022-09-09T23:27:08.076Z iteration 1 passed in 0 ms
```