### PR TITLE
Bitstamp :: fix parseTrade for delisted markets

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -792,6 +792,9 @@ module.exports = class bitstamp extends Exchange {
         const orderId = this.safeString (trade, 'order_id');
         const type = undefined;
         let costString = this.safeString (trade, 'cost');
+        let rawBaseId = undefined;
+        let rawQuoteId = undefined;
+        let rawMarketId = undefined;
         if (market === undefined) {
             const keys = Object.keys (trade);
             for (let i = 0; i < keys.length; i++) {
@@ -801,20 +804,24 @@ module.exports = class bitstamp extends Exchange {
                     if (marketId in this.markets_by_id) {
                         market = this.markets_by_id[marketId];
                     } else {
+                        rawMarketId = currentKey;
+                        const parts = currentKey.split ('_');
+                        rawBaseId = this.safeString (parts, 0);
+                        rawQuoteId = this.safeString (parts, 1);
                         market = this.safeMarket (marketId);
                     }
                 }
             }
         }
         const feeCostString = this.safeString (trade, 'fee');
-        let feeCurrency = undefined;
-        if (market !== undefined) {
-            priceString = this.safeString (trade, market['marketId'], priceString);
-            amountString = this.safeString (trade, market['baseId'], amountString);
-            costString = this.safeString (trade, market['quoteId'], costString);
-            feeCurrency = market['quote'];
-            symbol = market['symbol'];
-        }
+        const feeCurrency = (market['quote'] !== undefined) ? market['quote'] : rawQuoteId;
+        const baseId = (market['baseId'] !== undefined) ? market['baseId'] : rawBaseId;
+        const quoteId = (market['quoteId'] !== undefined) ? market['quoteId'] : rawQuoteId;
+        const priceId = (rawMarketId !== undefined) ? rawMarketId : market['marketId'];
+        priceString = this.safeString (trade, priceId, priceString);
+        amountString = this.safeString (trade, baseId, amountString);
+        costString = this.safeString (trade, quoteId, costString);
+        symbol = market['symbol'];
         const datetimeString = this.safeString2 (trade, 'date', 'datetime');
         let timestamp = undefined;
         if (datetimeString !== undefined) {

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -828,7 +828,7 @@ module.exports = class bitstamp extends Exchange {
             for (let i = 0; i < keys.length; i++) {
                 const currentKey = keys[i];
                 if (currentKey !== 'order_id' && currentKey.indexOf ('_') >= 0) {
-                    const marketId = keys[i].replace ('_', '');
+                    const marketId = currentKey.replace ('_', '');
                     if (marketId in this.markets_by_id) {
                         market = this.markets_by_id[marketId];
                     } else {


### PR DESCRIPTION
- `fetchMyTrades` crashed when the exchange returned trades for delisted markets


Demo with delisted market

```

       id |     timestamp |                 datetime | symbol |            order | type | side | takerOrMaker | price | amount |       cost |                               fee |                                fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
207238415 | 1636610093808 | 2021-11-11T05:54:53.808Z | rgteur | 1424486888038400 |      |  buy |              | 36.45 | 4.6579 | 169.780455 | {"cost":0.33956,"currency":"eur"} | [{"currency":"eur","cost":0.33956}]

```


Demo regular trade:

```
[ {'amount': 355.0,
  'cost': 330.82095,
  'datetime': '2022-05-24T08:18:28.842Z',
  'fee': {'cost': 0.16541, 'currency': 'EUR'},
  'fees': [{'cost': 0.16541, 'currency': 'EUR'}],
  'id': '233876273',
  'info': {'btc': '0.0',
           'datetime': '2022-05-24 08:18:28.842000',
           'eur': '330.82095',
           'fee': '0.16541',
           'id': '233876273',
           'order_id': '1493177688821760',
           'type': '2',
           'usd': '0.0',
           'usdt': '-355.00000',
           'usdt_eur': '0.93189000'},
  'order': '1493177688821760',
  'price': 0.93189,
  'side': 'sell',
  'symbol': 'USDT/EUR',
  'takerOrMaker': None,
  'timestamp': 

```