### PR TITLE
Coinex :: fix setMarginMode

### DIFF
--- a/js/coinex.js
+++ b/js/coinex.js
@@ -3061,11 +3061,10 @@ module.exports = class coinex extends Exchange {
         if (market['type'] !== 'swap') {
             throw new BadSymbol (this.id + ' setMarginMode() supports swap contracts only');
         }
-        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', marginMode);
         let defaultPositionType = undefined;
-        if (defaultMarginMode === 'isolated') {
+        if (marginMode === 'isolated') {
             defaultPositionType = 1;
-        } else if (defaultMarginMode === 'cross') {
+        } else if (marginMode === 'cross') {
             defaultPositionType = 2;
         }
         const leverage = this.safeInteger (params, 'leverage');


### PR DESCRIPTION
- We should not completely ignore the `marginMode` argument explicitly required by this method and go with the default value

Demo:

```
 p coinex setMarginMode "isolated" "BTC/USDT:USDT" '{"leverage":5}' --swap
Python v3.9.13
CCXT v1.93.24
coinex.setMarginMode(cross,BTC/USDT:USDT,{'leverage': 5})
{'code': '0', 'data': {'leverage': '5', 'position_type': '1'}, 'message': 'OK'}
```
```
p coinex setMarginMode "cross" "BTC/USDT:USDT" '{"leverage":5}' --swap
Python v3.9.13
CCXT v1.93.34
coinex.setMarginMode(cross,BTC/USDT:USDT,{'leverage': 5})
{'code': '0', 'data': {'leverage': '5', 'position_type': '2'}, 'message': 'OK'}
```

