### PR TITLE
Fix rounding issue in Luno

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -811,14 +811,14 @@ module.exports = class luno extends Exchange {
             request['type'] = side.toUpperCase ();
             // todo add createMarketBuyOrderRequires price logic as it is implemented in the other exchanges
             if (side === 'buy') {
-                request['counter_volume'] = parseFloat (this.amountToPrecision (market['symbol'], amount));
+                request['counter_volume'] = this.amountToPrecision (market['symbol'], amount);
             } else {
-                request['base_volume'] = parseFloat (this.amountToPrecision (market['symbol'], amount));
+                request['base_volume'] = this.amountToPrecision (market['symbol'], amount);
             }
         } else {
             method += 'Postorder';
-            request['volume'] = parseFloat (this.amountToPrecision (market['symbol'], amount));
-            request['price'] = parseFloat (this.priceToPrecision (market['symbol'], price));
+            request['volume'] = this.amountToPrecision (market['symbol'], amount);
+            request['price'] = this.priceToPrecision (market['symbol'], price);
             request['type'] = (side === 'buy') ? 'BID' : 'ASK';
         }
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
The extra float casting is causing the work of e.g., priceToPrecision to be undone, for prices that are very small, such as 0.000016. Casting this to float results in this being sent to Luno, in PHP at least, as 1.6E-5 (instead of as a decimal string), which Luno can't handle.