### PR TITLE
okx.createOrder market buy string math

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -2085,7 +2085,10 @@ module.exports = class okx extends Exchange {
                     if (createMarketBuyOrderRequiresPrice) {
                         if (price !== undefined) {
                             if (notional === undefined) {
-                                notional = amount * price;
+                                const amountString = this.numberToString (amount);
+                                const priceString = this.numberToString (price);
+                                const quoteAmount = Precise.stringMul (amountString, priceString);
+                                notional = this.parseNumber (quoteAmount);
                             }
                         } else if (notional === undefined) {
                             throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false and supply the total cost value in the 'amount' argument or in the 'cost' unified extra parameter or in exchange-specific 'sz' extra parameter (the exchange-specific behaviour)");


### PR DESCRIPTION
```
% okx createOrder ADA/USDT market buy 5 0.45
2022-09-12T18:23:34.664Z
Node.js: v18.4.0
CCXT v1.93.38
(node:6419) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
okx.createOrder (ADA/USDT, market, buy, 5, 0.45)
2022-09-12T18:23:36.245Z iteration 0 passed in 310 ms

{
  info: {
    clOrdId: 'e847386590ce4dBC45f5c0efa4a69a89',
    ordId: '489622145614639104',
    sCode: '0',
    sMsg: '',
    tag: ''
  },
  id: '489622145614639104',
  clientOrderId: 'e847386590ce4dBC45f5c0efa4a69a89',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'ADA/USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2022-09-12T18:23:36.245Z iteration 1 passed in 310 ms
```