### PR TITLE
coinbase.fetchTicker swap bid and ask. fixes: #14988

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -922,7 +922,7 @@ module.exports = class coinbase extends Exchange {
         let last = undefined;
         const timestamp = this.milliseconds ();
         if (typeof ticker !== 'string') {
-            const [ spot, buy, sell ] = ticker;
+            const [ spot, sell, buy ] = ticker;
             const spotData = this.safeValue (spot, 'data', {});
             const buyData = this.safeValue (buy, 'data', {});
             const sellData = this.safeValue (sell, 'data', {});


### PR DESCRIPTION
```
% coinbase fetchTicker BTC/EUR                             
2022-09-14T08:42:45.325Z
Node.js: v18.4.0
CCXT v1.93.43
(node:28207) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
coinbase.fetchTicker (BTC/EUR)
2022-09-14T08:42:48.517Z iteration 0 passed in 1591 ms

{
  symbol: 'BTC/EUR',
  timestamp: 1663144968517,
  datetime: '2022-09-14T08:42:48.517Z',
  bid: 20225.74,
  ask: 20445.8,
  last: 20317.87,
  high: undefined,
  low: undefined,
  bidVolume: undefined,
  askVolume: undefined,
  vwap: undefined,
  open: undefined,
  close: 20317.87,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: undefined,
  quoteVolume: undefined,
  info: [
    { data: { base: 'BTC', currency: 'EUR', amount: '20317.87' } },
    { data: { base: 'BTC', currency: 'EUR', amount: '20445.80' } },
    { data: { base: 'BTC', currency: 'EUR', amount: '20225.74' } }
  ]
}
2022-09-14T08:42:48.517Z iteration 1 passed in 1591 ms
```

fixes: #14988