### PR TITLE
Ndax parseLedgerEntry string math

### DIFF
--- a/js/ndax.js
+++ b/js/ndax.js
@@ -1112,13 +1112,7 @@ module.exports = class ndax extends Exchange {
         //         "TimeStamp": 1607532331591
         //     }
         //
-        const id = this.safeString (item, 'TransactionId');
-        const account = this.safeString (item, 'AccountId');
-        const referenceId = this.safeString (item, 'ReferenceId');
-        const referenceAccount = this.safeString (item, 'Counterparty');
-        const type = this.parseLedgerEntryType (this.safeString (item, 'ReferenceType'));
         const currencyId = this.safeString (item, 'ProductId');
-        const code = this.safeCurrencyCode (currencyId, currency);
         const credit = this.safeString (item, 'CR');
         const debit = this.safeString (item, 'DR');
         let amount = undefined;
@@ -1126,11 +1120,10 @@ module.exports = class ndax extends Exchange {
         if (Precise.stringLt (credit, '0')) {
             amount = credit;
             direction = 'in';
-        } else if (Precise.stringLt (debit, 0)) {
+        } else if (Precise.stringLt (debit, '0')) {
             amount = debit;
             direction = 'out';
         }
-        const timestamp = this.safeInteger (item, 'TimeStamp');
         let before = undefined;
         const after = this.safeString (item, 'Balance');
         if (direction === 'out') {
@@ -1138,20 +1131,20 @@ module.exports = class ndax extends Exchange {
         } else if (direction === 'in') {
             before = Precise.stringMax ('0', Precise.stringSub (after, amount));
         }
-        const status = 'ok';
+        const timestamp = this.safeInteger (item, 'TimeStamp');
         return {
             'info': item,
-            'id': id,
+            'id': this.safeString (item, 'TransactionId'),
             'direction': direction,
-            'account': account,
-            'referenceId': referenceId,
-            'referenceAccount': referenceAccount,
-            'type': type,
-            'currency': code,
-            'amount': amount,
-            'before': before,
-            'after': after,
-            'status': status,
+            'account': this.safeString (item, 'AccountId'),
+            'referenceId': this.safeString (item, 'ReferenceId'),
+            'referenceAccount': this.safeString (item, 'Counterparty'),
+            'type': this.parseLedgerEntryType (this.safeString (item, 'ReferenceType')),
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'amount': this.parseNumber (amount),
+            'before': this.parseNumber (before),
+            'after': this.parseNumber (after),
+            'status': 'ok',
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'fee': undefined,


### PR DESCRIPTION
```
% node examples/js/cli ndax fetchLedger
(node:8005) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Waiting for the debugger to disconnect...
2022-09-14T22:34:50.138Z
Node.js: v18.4.0
CCXT v1.93.38
ndax.fetchLedger ()
2022-09-14T22:34:53.898Z iteration 0 passed in 2219 ms
         id | direction | account | referenceId | referenceAccount |        type | currency | amount | before |          after | status |     timestamp |                 datetime | fee
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1836269538 |           |  187639 |      917312 |                2 | transaction |     USDT |        |        |           92.5 |     ok | 1634549503879 | 2021-10-18T09:31:43.879Z |    
...
10123226690 |           |  187639 |     1446100 |                2 | transaction |     USDT |        |        |    14.71824713 |     ok | 1663190713511 | 2022-09-14T21:25:13.511Z |    
237 objects
2022-09-14T22:34:53.898Z iteration 1 passed in 2219 ms
```