### PR TITLE
base - code to currency fixes

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -2376,7 +2376,7 @@ module.exports = class aax extends Exchange {
         //     "ts": 1573561743499
         // }
         const data = this.safeValue (response, 'data', []);
-        return this.parseTransactions (data, code, since, limit);
+        return this.parseTransactions (data, currency, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -2429,7 +2429,7 @@ module.exports = class aax extends Exchange {
         //     "ts":1573561743499
         //  }
         const data = this.safeValue (response, 'data', []);
-        return this.parseTransactions (data, code, since, limit);
+        return this.parseTransactions (data, currency, since, limit);
     }
 
     parseTransactionStatusByType (status, type = undefined) {

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -1364,7 +1364,7 @@ module.exports = class bigone extends Exchange {
         //     }
         //
         const deposits = this.safeValue (response, 'data', []);
-        return this.parseTransactions (deposits, code, since, limit);
+        return this.parseTransactions (deposits, currency, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -1416,7 +1416,7 @@ module.exports = class bigone extends Exchange {
         //     }
         //
         const withdrawals = this.safeValue (response, 'data', []);
-        return this.parseTransactions (withdrawals, code, since, limit);
+        return this.parseTransactions (withdrawals, currency, since, limit);
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {

--- a/js/bitso.js
+++ b/js/bitso.js
@@ -1245,6 +1245,10 @@ module.exports = class bitso extends Exchange {
          * @returns {[object]} a list of [transaction structures]{@link https://docs.ccxt.com/en/latest/manual.html#transaction-structure}
          */
         await this.loadMarkets ();
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const response = await this.privateGetFundings (params);
         //
         //     {
@@ -1270,7 +1274,7 @@ module.exports = class bitso extends Exchange {
         //     }
         //
         const transactions = this.safeValue (response, 'payload', []);
-        return this.parseTransactions (transactions, code, since, limit, params);
+        return this.parseTransactions (transactions, currency, since, limit, params);
     }
 
     async fetchDepositAddress (code, params = {}) {

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -1396,8 +1396,12 @@ module.exports = class bittrex extends Exchange {
         const request = {
             'txId': id,
         };
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const response = await this.privateGetDepositsByTxIdTxId (this.extend (request, params));
-        const transactions = this.parseTransactions (response, code, undefined, undefined);
+        const transactions = this.parseTransactions (response, currency, undefined, undefined);
         return this.safeValue (transactions, 0);
     }
 
@@ -1479,8 +1483,12 @@ module.exports = class bittrex extends Exchange {
         const request = {
             'txId': id,
         };
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const response = await this.privateGetWithdrawalsByTxIdTxId (this.extend (request, params));
-        const transactions = this.parseTransactions (response, code, undefined, undefined);
+        const transactions = this.parseTransactions (response, currency, undefined, undefined);
         return this.safeValue (transactions, 0);
     }
 

--- a/js/blockchaincom.js
+++ b/js/blockchaincom.js
@@ -974,8 +974,12 @@ module.exports = class blockchaincom extends Exchange {
         if (since !== undefined) {
             request['from'] = since;
         }
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const response = await this.privateGetWithdrawals (this.extend (request, params));
-        return this.parseTransactions (response, code, since, limit);
+        return this.parseTransactions (response, currency, since, limit);
     }
 
     async fetchWithdrawal (id, code = undefined, params = {}) {
@@ -1015,8 +1019,12 @@ module.exports = class blockchaincom extends Exchange {
         if (since !== undefined) {
             request['from'] = since;
         }
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const response = await this.privateGetDeposits (this.extend (request, params));
-        return this.parseTransactions (response, code, since, limit);
+        return this.parseTransactions (response, currency, since, limit);
     }
 
     async fetchDeposit (id, code = undefined, params = {}) {

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -348,6 +348,10 @@ module.exports = class btcalpha extends Exchange {
          * @returns {[object]} a list of [transaction structures]{@link https://docs.ccxt.com/en/latest/manual.html#transaction-structure}
          */
         await this.loadMarkets ();
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
         const response = await this.privateGetDeposits (params);
         //
         //     [
@@ -359,7 +363,7 @@ module.exports = class btcalpha extends Exchange {
         //         }
         //     ]
         //
-        return this.parseTransactions (response, code, since, limit, { 'type': 'deposit' });
+        return this.parseTransactions (response, currency, since, limit, { 'type': 'deposit' });
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -392,7 +396,7 @@ module.exports = class btcalpha extends Exchange {
         //         }
         //     ]
         //
-        return this.parseTransactions (response, code, since, limit, { 'type': 'withdrawal' });
+        return this.parseTransactions (response, currency, since, limit, { 'type': 'withdrawal' });
     }
 
     parseTransaction (transaction, currency = undefined) {

--- a/js/bw.js
+++ b/js/bw.js
@@ -1357,7 +1357,7 @@ module.exports = class bw extends Exchange {
         //
         const data = this.safeValue (response, 'datas', {});
         const deposits = this.safeValue (data, 'list', []);
-        return this.parseTransactions (deposits, code, since, limit);
+        return this.parseTransactions (deposits, currency, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -1412,7 +1412,7 @@ module.exports = class bw extends Exchange {
         //
         const data = this.safeValue (response, 'datas', {});
         const withdrawals = this.safeValue (data, 'list', []);
-        return this.parseTransactions (withdrawals, code, since, limit);
+        return this.parseTransactions (withdrawals, currency, since, limit);
     }
 
     handleErrors (httpCode, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/js/lbank2.js
+++ b/js/lbank2.js
@@ -1778,8 +1778,9 @@ module.exports = class lbank2 extends Exchange {
             // 'status': Recharge status: ("1","Applying"),("2","Recharge successful"),("3","Recharge failed"),("4","Already Cancel"), ("5", "Transfer")
             // 'endTime': end time, timestamp in milliseconds, default now
         };
+        let currency = undefined;
         if (code !== undefined) {
-            const currency = this.currency (code);
+            currency = this.currency (code);
             request['coin'] = currency['id'];
         }
         if (since !== undefined) {
@@ -1811,7 +1812,7 @@ module.exports = class lbank2 extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const deposits = this.safeValue (data, 'depositOrders', []);
-        return this.parseTransactions (deposits, code, since, limit);
+        return this.parseTransactions (deposits, currency, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -1831,8 +1832,9 @@ module.exports = class lbank2 extends Exchange {
             // 'endTime': end time, timestamp in milliseconds, default now
             // 'withdrawOrderId': Custom withdrawal id
         };
+        let currency = undefined;
         if (code !== undefined) {
-            const currency = this.currency (code);
+            currency = this.currency (code);
             request['coin'] = currency['id'];
         }
         if (since !== undefined) {
@@ -1867,7 +1869,7 @@ module.exports = class lbank2 extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const withdraws = this.safeValue (data, 'withdraws', []);
-        return this.parseTransactions (withdraws, code, since, limit);
+        return this.parseTransactions (withdraws, currency, since, limit);
     }
 
     async fetchTransactionFees (codes = undefined, params = {}) {

--- a/js/mexc.js
+++ b/js/mexc.js
@@ -1599,7 +1599,7 @@ module.exports = class mexc extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const resultList = this.safeValue (data, 'result_list', []);
-        return this.parseTransactions (resultList, code, since, limit);
+        return this.parseTransactions (resultList, currency, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -1660,7 +1660,7 @@ module.exports = class mexc extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const resultList = this.safeValue (data, 'result_list', []);
-        return this.parseTransactions (resultList, code, since, limit);
+        return this.parseTransactions (resultList, currency, since, limit);
     }
 
     parseTransaction (transaction, currency = undefined) {

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3624,7 +3624,7 @@ module.exports = class mexc3 extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const resultList = this.safeValue (data, 'result_list', []);
-        return this.parseTransactions (resultList, currecy, since, limit);
+        return this.parseTransactions (resultList, currency, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3624,7 +3624,7 @@ module.exports = class mexc3 extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const resultList = this.safeValue (data, 'result_list', []);
-        return this.parseTransactions (resultList, code, since, limit);
+        return this.parseTransactions (resultList, currecy, since, limit);
     }
 
     async fetchWithdrawals (code = undefined, since = undefined, limit = undefined, params = {}) {
@@ -3685,7 +3685,7 @@ module.exports = class mexc3 extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const resultList = this.safeValue (data, 'result_list', []);
-        return this.parseTransactions (resultList, code, since, limit);
+        return this.parseTransactions (resultList, currency, since, limit);
     }
 
     parseTransaction (transaction, currency = undefined) {

--- a/js/stex.js
+++ b/js/stex.js
@@ -1979,7 +1979,7 @@ module.exports = class stex extends Exchange {
         //     }
         //
         const deposits = this.safeValue (response, 'data', []);
-        return this.parseTransactions (deposits, code, since, limit);
+        return this.parseTransactions (deposits, currency, since, limit);
     }
 
     async fetchWithdrawal (id, code = undefined, params = {}) {
@@ -2106,7 +2106,7 @@ module.exports = class stex extends Exchange {
         //     }
         //
         const withdrawals = this.safeValue (response, 'data', []);
-        return this.parseTransactions (withdrawals, code, since, limit);
+        return this.parseTransactions (withdrawals, currency, since, limit);
     }
 
     async transfer (code, amount, fromAccount, toAccount, params = {}) {


### PR DESCRIPTION
a bug  (`code` instead of `currency`) was spread across different exchange implementations.

( includes fix #14972 )