### PR TITLE
btcalpha.createOrder string math

### DIFF
--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -648,7 +648,7 @@ module.exports = class btcalpha extends Exchange {
         const orderAmount = order['amount'].toString ();
         amount = Precise.stringGt (orderAmount, '0') ? order['amount'] : amount;
         return this.extend (order, {
-            'amount': amount,
+            'amount': this.parseNumber (amount),
         });
     }
 

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -645,7 +645,8 @@ module.exports = class btcalpha extends Exchange {
             throw new InvalidOrder (this.id + ' ' + this.json (response));
         }
         const order = this.parseOrder (response, market);
-        amount = (order['amount'] > 0) ? order['amount'] : amount;
+        const orderAmount = order['amount'].toString ();
+        amount = Precise.stringGt (orderAmount, '0') ? order['amount'] : amount;
         return this.extend (order, {
             'amount': amount,
         });


### PR DESCRIPTION
```
% btcalpha createOrder XRP/USDT limit buy 21 0.4
2022-09-20T19:59:18.138Z
Node.js: v18.9.0
CCXT v1.93.66
(node:17021) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
btcalpha.createOrder (XRP/USDT, limit, buy, 21, 0.4)
2022-09-20T19:59:21.090Z iteration 0 passed in 2293 ms

{
  id: '1109057771',
  clientOrderId: undefined,
  datetime: '1970-01-01T00:33:42.000Z',
  timestamp: 2022000,
  status: undefined,
  symbol: 'XRP/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 0.4,
  stopPrice: undefined,
  cost: 0,
  amount: 21,
  filled: 0,
  remaining: 0,
  trades: [],
  fee: undefined,
  info: {
    success: true,
    date: '2022-09-20T19:59:21.019324Z',
    type: 'buy',
    oid: '1109057771',
    price: '0.4',
    amount: '0.0',
    amount_filled: '0.0',
    amount_original: '21.0',
    trades: []
  },
  lastTradeTimestamp: undefined,
  average: undefined,
  fees: []
}
2022-09-20T19:59:21.090Z iteration 1 passed in 2293 ms
```