### PR TITLE
independentreserve.parseOrder string math

### DIFF
--- a/js/independentreserve.js
+++ b/js/independentreserve.js
@@ -407,27 +407,15 @@ module.exports = class independentreserve extends Exchange {
             }
         }
         const timestamp = this.parse8601 (this.safeString (order, 'CreatedTimestampUtc'));
-        const amount = this.safeString2 (order, 'VolumeOrdered', 'Volume');
-        const filled = this.safeNumber (order, 'VolumeFilled');
-        const remaining = this.safeString (order, 'Outstanding');
-        const feeRate = this.safeNumber (order, 'FeePercent');
+        const filled = this.safeString (order, 'VolumeFilled');
+        const feeRate = this.safeString (order, 'FeePercent');
         let feeCost = undefined;
         if (feeRate !== undefined && filled !== undefined) {
-            feeCost = feeRate * filled;
+            feeCost = Precise.stringMul (feeRate, filled);
         }
-        const fee = {
-            'rate': feeRate,
-            'cost': feeCost,
-            'currency': base,
-        };
-        const id = this.safeString (order, 'OrderGuid');
-        const status = this.parseOrderStatus (this.safeString (order, 'Status'));
-        const cost = this.safeString (order, 'Value');
-        const average = this.safeString (order, 'AvgPrice');
-        const price = this.safeString (order, 'Price');
         return this.safeOrder ({
             'info': order,
-            'id': id,
+            'id': this.safeString (order, 'OrderGuid'),
             'clientOrderId': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -437,15 +425,19 @@ module.exports = class independentreserve extends Exchange {
             'timeInForce': undefined,
             'postOnly': undefined,
             'side': side,
-            'price': price,
+            'price': this.safeString (order, 'Price'),
             'stopPrice': undefined,
-            'cost': cost,
-            'average': average,
-            'amount': amount,
+            'cost': this.safeString (order, 'Value'),
+            'average': this.safeString (order, 'AvgPrice'),
+            'amount': this.safeString2 (order, 'VolumeOrdered', 'Volume'),
             'filled': filled,
-            'remaining': remaining,
-            'status': status,
-            'fee': fee,
+            'remaining': this.safeString (order, 'Outstanding'),
+            'status': this.parseOrderStatus (this.safeString (order, 'Status')),
+            'fee': {
+                'rate': feeRate,
+                'cost': feeCost,
+                'currency': base,
+            },
             'trades': undefined,
         }, market);
     }


### PR DESCRIPTION
```
$ independentreserve fetchOrder 44eb19e6-7a0a-4f24-985b-081ae08b1d83
2022-09-21T04:29:07.145Z
Node.js: v18.9.0
CCXT v1.93.59
(node:20480) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
independentreserve.fetchOrder (44eb19e6-7a0a-4f24-985b-081ae08b1d83)
2022-09-21T04:29:12.450Z iteration 0 passed in 1407 ms

{
  info: {
    OrderGuid: '44eb19e6-7a0a-4f24-985b-081ae08b1d83',
    CreatedTimestampUtc: '2022-09-21T04:21:21.3432051Z',
    Type: 'MarketOffer',
    VolumeOrdered: '11.00000000',
    VolumeFilled: '11.00000000',
    Price: null,
    AvgPrice: '1.49303',
    ReservedAmount: '0.0',
    Status: 'Filled',
    PrimaryCurrencyCode: 'Usdc',
    SecondaryCurrencyCode: 'Aud',
    FeePercent: '0.00500000',
    VolumeCurrencyType: 'Primary'
  },
  id: '44eb19e6-7a0a-4f24-985b-081ae08b1d83',
  clientOrderId: undefined,
  timestamp: 1663734081343,
  datetime: '2022-09-21T04:21:21.343Z',
  lastTradeTimestamp: undefined,
  symbol: 'USDC/AUD',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: undefined,
  side: 'sell',
  price: 1.49303,
  stopPrice: undefined,
  cost: 16.42333,
  average: 1.49303,
  amount: 11,
  filled: 11,
  remaining: 0,
  status: 'closed',
  fee: { rate: 0.005, cost: 0.055, currency: 'USDC' },
  trades: [],
  fees: [ { rate: 0.005, cost: 0.055, currency: 'USDC' } ]
}
2022-09-21T04:29:12.450Z iteration 1 passed in 1407 ms
```