### PR TITLE
Indodax: modify createOrder logic by removing fiat-to-coin conversion

### DIFF
--- a/js/indodax.js
+++ b/js/indodax.js
@@ -687,13 +687,9 @@ module.exports = class indodax extends Exchange {
             'pair': market['id'],
             'type': side,
             'price': price,
+            'order_type': type
         };
         const currency = market['baseId'];
-        if (side === 'buy') {
-            request[market['quoteId']] = amount * price;
-        } else {
-            request[market['baseId']] = amount;
-        }
         request[currency] = amount;
         const result = await this.privatePostTrade (this.extend (request, params));
         const data = this.safeValue (result, 'return', {});

--- a/js/indodax.js
+++ b/js/indodax.js
@@ -687,7 +687,7 @@ module.exports = class indodax extends Exchange {
             'pair': market['id'],
             'type': side,
             'price': price,
-            'order_type': type
+            'order_type': type,
         };
         const currency = market['baseId'];
         request[currency] = amount;


### PR DESCRIPTION
Following recent change in the Trade API improvement from Indodax on 10th Sep 2022 (more info: [link
](https://github.com/btcid/indodax-official-api-docs/blob/master/Private-RestAPI.md)), now we are able to place limit orders using coin amount rather than fiat amount. It is even mentioned in the official docs that by using fiat amount, one might encounter an underfill issue (which I did!). So I think we should opt for using just coin amount for limit order creation.

<img width="986" alt="image" src="https://user-images.githubusercontent.com/48336496/190622063-f0db95e6-7624-4319-8b1c-6aaaf8f9f071.png">

Previously, CCXT facilitates the lack of coin amount acceptance by the Indodax API by doing a conversion from coin-to-fiat inside createOrder() function before sending an actual request to the exchange. Now the logic can be scrapped, so I dealt with it in this pull request.

However, in order to activate limit order placement using coin amount, the payload must include the field 'order_type': 'limit'.  That is another change I made in this pull request. 
<img width="427" alt="image" src="https://user-images.githubusercontent.com/48336496/190622641-2aa796b0-ee85-4416-9d0b-4ca84d4f8e6e.png">

