### PR TITLE
lbank2.fetchPublicTransactionFees parse number

### DIFF
--- a/js/lbank2.js
+++ b/js/lbank2.js
@@ -1958,7 +1958,7 @@ module.exports = class lbank2 extends Exchange {
                 if (withdrawFees[code] === undefined) {
                     withdrawFees[code] = {};
                 }
-                withdrawFees[code][network] = fee;
+                withdrawFees[code][network] = this.parseNumber (fee);
             }
         }
         return {


### PR DESCRIPTION
```
2022-09-16T22:00:02.507Z
Node.js: v18.4.0
CCXT v1.93.59
lbank2.fetchPublicTransactionFees ()
2022-09-16T22:00:03.930Z iteration 0 passed in 463 ms

{
  withdraw: {
    LBK: { HT: 100, ERC20: 2000 },
    USDT: { ERC20: 30, TRC20: 1, BSC: 1, HT: 1, MATIC: undefined },
    BTC: { BTC: 0.0006, BTCTRON: 0.0001 },
    ETH: {
      ERC20: undefined,
      BSC: undefined,
      arbitrum: undefined,
      optimism: undefined
    },
    ETC: { ETC: 0.01 },
    ...
    Y1D1S: { Y1D1S: undefined }
  },
  deposit: {},
  info: { ... }
}
2022-09-16T22:00:03.930Z iteration 1 passed in 463 ms
```