### PR TITLE
Bitget: fetchOpenInterest

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4515,6 +4515,8 @@ Open Interest Structure
 
    {
        symbol: 'BTC/USDT',
+       baseVolume: 80872.801,  // deprecated
+       quoteVolume: 3508262107.38, // deprecated
        openInterestAmount: 80872.801,
        openInterestValue: 3508262107.38,
        timestamp: 1649379000000,

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4489,7 +4489,7 @@ Open Interest Structure
 
    {
        symbol: 'BTC/USDT',
-       openInterest: 80872.801,
+       openInterestAmount: 80872.801,
        openInterestValue: 3508262107.38,
        timestamp: 1649379000000,
        datetime: '2022-04-08T00:50:00.000Z',
@@ -4535,8 +4535,8 @@ Open Interest History Structure
 
    {
        symbol: 'BTC/USDT',
-       baseVolume: 80872.801,
-       quoteVolume: 3508262107.38,
+       openInterestAmount: 80872.801,
+       openInterestValue: 3508262107.38,
        timestamp: 1649379000000,
        datetime: '2022-04-08T00:50:00.000Z',
        info: {

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4459,6 +4459,48 @@ Funding Rate History Structure
        datetime: "2022-01-23T16:00:00.000Z"
    }
 
+Open Interest
+---------------------
+
+ *contract only*
+
+Use the ``fetchOpenInterest`` method to get a the open interest for a symbol from the exchange.
+
+.. code-block:: JavaScript
+
+   fetchOpenInterest (symbol, params = {})
+
+Parameters
+
+
+ * **symbol** (String) Unified CCXT market symbol (e.g. ``"BTC/USDT:USDT"``\ )
+ * **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. ``{"endTime": 1645807945000}``\ )
+
+
+Returns
+
+
+ * A dictionary of :ref:`open interest structures <open interest structure>`
+
+Open Interest Structure
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: JavaScript
+
+   {
+       symbol: 'BTC/USDT',
+       openInterest: 80872.801,
+       openInterestValue: 3508262107.38,
+       timestamp: 1649379000000,
+       datetime: '2022-04-08T00:50:00.000Z',
+       info: {
+           symbol: 'BTCUSDT',
+           sumOpenInterest: '80872.80100000',
+           sumOpenInterestValue: '3508262107.38000000',
+           timestamp: '1649379000000'
+       }
+   }
+
 Open Interest History
 ---------------------
 
@@ -4484,9 +4526,9 @@ Parameters
 Returns
 
 
- * An array of :ref:`open interest structures <open interest structure>`
+ * An array of :ref:`open interest history structures <open interest structure>`
 
-Open Interest Structure
+Open Interest History Structure
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: JavaScript

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4476,30 +4476,10 @@ Parameters
  * **symbol** (String) Unified CCXT market symbol (e.g. ``"BTC/USDT:USDT"``\ )
  * **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. ``{"endTime": 1645807945000}``\ )
 
-
 Returns
 
 
  * A dictionary of :ref:`open interest structures <open interest structure>`
-
-Open Interest Structure
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: JavaScript
-
-   {
-       symbol: 'BTC/USDT',
-       openInterestAmount: 80872.801,
-       openInterestValue: 3508262107.38,
-       timestamp: 1649379000000,
-       datetime: '2022-04-08T00:50:00.000Z',
-       info: {
-           symbol: 'BTCUSDT',
-           sumOpenInterest: '80872.80100000',
-           sumOpenInterestValue: '3508262107.38000000',
-           timestamp: '1649379000000'
-       }
-   }
 
 Open Interest History
 ---------------------
@@ -4526,9 +4506,9 @@ Parameters
 Returns
 
 
- * An array of :ref:`open interest history structures <open interest structure>`
+ * An array of :ref:`open interest structures <open interest structure>`
 
-Open Interest History Structure
+Open Interest Structure
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: JavaScript

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4459,28 +4459,6 @@ Funding Rate History Structure
        datetime: "2022-01-23T16:00:00.000Z"
    }
 
-Open Interest
----------------------
-
- *contract only*
-
-Use the ``fetchOpenInterest`` method to get a the open interest for a symbol from the exchange.
-
-.. code-block:: JavaScript
-
-   fetchOpenInterest (symbol, params = {})
-
-Parameters
-
-
- * **symbol** (String) Unified CCXT market symbol (e.g. ``"BTC/USDT:USDT"``\ )
- * **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. ``{"endTime": 1645807945000}``\ )
-
-Returns
-
-
- * A dictionary of :ref:`open interest structures <open interest structure>`
-
 Open Interest History
 ---------------------
 
@@ -4515,10 +4493,8 @@ Open Interest Structure
 
    {
        symbol: 'BTC/USDT',
-       baseVolume: 80872.801,  // deprecated
-       quoteVolume: 3508262107.38, // deprecated
-       openInterestAmount: 80872.801,
-       openInterestValue: 3508262107.38,
+       baseVolume: 80872.801,
+       quoteVolume: 3508262107.38,
        timestamp: 1649379000000,
        datetime: '2022-04-08T00:50:00.000Z',
        info: {

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -3050,6 +3050,7 @@ module.exports = class bitget extends Exchange {
          * @method
          * @name bitget#fetchOpenInterest
          * @description Retrieves the open interest of a currency
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-open-interest
          * @param {string} symbol Unified CCXT market symbol
          * @param {object} params exchange specific parameters
          * @returns {object} an open interest structure{@link https://docs.ccxt.com/en/latest/manual.html#interest-history-structure}
@@ -3090,9 +3091,12 @@ module.exports = class bitget extends Exchange {
         const timestamp = this.safeInteger (interest, 'timestamp');
         const id = this.safeString (interest, 'symbol');
         market = this.safeMarket (id, market);
+        const amount = this.safeNumber (interest, 'amount');
         return {
             'symbol': this.safeSymbol (id),
-            'openInterestAmount': this.safeNumber (interest, 'amount'),
+            'baseVolume': amount,  // deprecated
+            'quoteVolume': undefined,  // deprecated
+            'openInterestAmount': amount,
             'openInterestValue': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -3081,7 +3081,7 @@ module.exports = class bitget extends Exchange {
         market = this.safeMarket (id, market);
         return {
             'symbol': this.safeSymbol (id),
-            'openInterest': this.safeNumber (interest, 'amount'),
+            'openInterestAmount': this.safeNumber (interest, 'amount'),
             'openInterestValue': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -3049,13 +3049,16 @@ module.exports = class bitget extends Exchange {
         /**
          * @method
          * @name bitget#fetchOpenInterest
-         * @description Retrieves the open intestest history of a currency
+         * @description Retrieves the open interest of a currency
          * @param {string} symbol Unified CCXT market symbol
          * @param {object} params exchange specific parameters
          * @returns {object} an open interest structure{@link https://docs.ccxt.com/en/latest/manual.html#interest-history-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (!market['contract']) {
+            throw new BadRequest (this.id + ' fetchOpenInterest() supports contract markets only');
+        }
         const request = {
             'symbol': market['id'],
         };
@@ -3077,6 +3080,13 @@ module.exports = class bitget extends Exchange {
     }
 
     parseOpenInterest (interest, market = undefined) {
+        //
+        //     {
+        //         "symbol": "BTCUSDT_UMCBL",
+        //         "amount": "130818.967",
+        //         "timestamp": "1663399151127"
+        //     }
+        //
         const timestamp = this.safeInteger (interest, 'timestamp');
         const id = this.safeString (interest, 'symbol');
         market = this.safeMarket (id, market);

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -54,6 +54,7 @@ module.exports = class bitget extends Exchange {
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenInterest': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,


### PR DESCRIPTION
Created a new unified method `fetchOpenInterest` and added it to Bitget:
```
node examples/js/cli bitget fetchOpenInterest BTC/USDT:USDT

bitget.fetchOpenInterest (BTC/USDT:USDT)
2022-09-17T07:43:16.261Z iteration 0 passed in 277 ms

{
  symbol: 'BTC/USDT:USDT',
  openInterest: 131649.723,
  openInterestValue: undefined,
  timestamp: 1663400597023,
  datetime: '2022-09-17T07:43:17.023Z',
  info: {
    symbol: 'BTCUSDT_UMCBL',
    amount: '131649.723',
    timestamp: '1663400597023'
  }
}
2022-09-17T07:43:16.261Z iteration 1 passed in 277 ms
```