### PR TITLE
exchanges - fix `code` instead of `currency`

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2737,13 +2737,6 @@ module.exports = class Exchange {
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[string|undefined, object]} the marginMode in lowercase as specified by params["marginMode"], params["defaultMarginMode"] this.options["marginMode"] or this.options["defaultMarginMode"]
          */
-        const defaultMarginMode = this.safeString2 (this.options, 'marginMode', 'defaultMarginMode');
-        const methodOptions = this.safeValue (this.options, methodName, {});
-        const methodMarginMode = this.safeString2 (methodOptions, 'marginMode', 'defaultMarginMode', defaultMarginMode);
-        const marginMode = this.safeStringLower2 (params, 'marginMode', 'defaultMarginMode', methodMarginMode);
-        if (marginMode !== undefined) {
-            params = this.omit (params, [ 'marginMode', 'defaultMarginMode' ]);
-        }
-        return [ marginMode, params ];
+        return this.handleOptionAndParams (params, methodName, 'marginMode');
     }
 };

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2737,6 +2737,13 @@ module.exports = class Exchange {
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[string|undefined, object]} the marginMode in lowercase as specified by params["marginMode"], params["defaultMarginMode"] this.options["marginMode"] or this.options["defaultMarginMode"]
          */
-        return this.handleOptionAndParams (params, methodName, 'marginMode');
+        const defaultMarginMode = this.safeString2 (this.options, 'marginMode', 'defaultMarginMode');
+        const methodOptions = this.safeValue (this.options, methodName, {});
+        const methodMarginMode = this.safeString2 (methodOptions, 'marginMode', 'defaultMarginMode', defaultMarginMode);
+        const marginMode = this.safeStringLower2 (params, 'marginMode', 'defaultMarginMode', methodMarginMode);
+        if (marginMode !== undefined) {
+            params = this.omit (params, [ 'marginMode', 'defaultMarginMode' ]);
+        }
+        return [ marginMode, params ];
     }
 };

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1400,8 +1400,10 @@ module.exports = class bitget extends Exchange {
         const feeAmount = this.safeString (trade, 'fees');
         const type = this.safeString (trade, 'orderType');
         if (feeAmount !== undefined) {
+            const currencyCode = this.safeCurrencyCode (this.safeString (trade, 'feeCcy'));
             fee = {
-                'code': this.safeCurrencyCode (this.safeString (trade, 'feeCcy')),
+                'code': currencyCode, // kept here for backward-compatibility, but will be removed soon
+                'currency': currencyCode,
                 'cost': feeAmount,
             };
         }

--- a/js/buda.js
+++ b/js/buda.js
@@ -869,7 +869,8 @@ module.exports = class buda extends Exchange {
             const feeCurrencyCode = this.safeCurrencyCode (feeCurrencyId);
             fee = {
                 'cost': feeCost,
-                'code': feeCurrencyCode,
+                'code': feeCurrencyCode, // kept here for backward-compatibility, but will be removed soon
+                'currency': feeCurrencyCode,
             };
         }
         return this.safeOrder ({

--- a/js/gate.js
+++ b/js/gate.js
@@ -1513,7 +1513,8 @@ module.exports = class gate extends Exchange {
             const tag = this.safeString (entry, 'payment_id');
             result[network] = {
                 'info': entry,
-                'code': code,
+                'code': code, // kept here for backward-compatibility, but will be removed soon
+                'currency': code,
                 'address': address,
                 'tag': tag,
             };
@@ -1568,7 +1569,8 @@ module.exports = class gate extends Exchange {
         this.checkAddress (address);
         return {
             'info': response,
-            'code': code,
+            'code': code, // kept here for backward-compatibility, but will be removed soon
+            'currency': code,
             'address': address,
             'tag': tag,
             'network': undefined,

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -671,7 +671,8 @@ module.exports = class hitbtc3 extends Exchange {
             'info': response,
             'address': address,
             'tag': tag,
-            'code': parsedCode,
+            'code': parsedCode, // kept here for backward-compatibility, but will be removed soon
+            'currency': parsedCode,
             'network': undefined,
         };
     }
@@ -1124,7 +1125,8 @@ module.exports = class hitbtc3 extends Exchange {
             'info': transaction,
             'id': id,
             'txid': txhash,
-            'code': code,
+            'code': code, // kept here for backward-compatibility, but will be removed soon
+            'currency': code,
             'amount': amount,
             'network': undefined,
             'address': address,

--- a/js/novadax.js
+++ b/js/novadax.js
@@ -1154,11 +1154,13 @@ module.exports = class novadax extends Exchange {
         //
         const id = this.safeString (transfer, 'data');
         const status = this.safeString (transfer, 'message');
+        const currencyCode = this.safeCurrencyCode (undefined, currency);
         return {
             'info': transfer,
             'id': id,
             'amount': undefined,
-            'code': this.safeCurrencyCode (undefined, currency),
+            'code': currencyCode, // kept here for backward-compatibility, but will be removed soon
+            'currency': currencyCode,
             'fromAccount': undefined,
             'toAccount': undefined,
             'timestamp': undefined,

--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -1093,7 +1093,8 @@ module.exports = class wavesexchange extends Exchange {
                 const address = this.safeString (response, 'address');
                 return {
                     'address': address,
-                    'code': code,
+                    'code': code, // kept here for backward-compatibility, but will be removed soon
+                    'currency': code,
                     'network': network,
                     'tag': undefined,
                     'info': response,
@@ -1137,7 +1138,8 @@ module.exports = class wavesexchange extends Exchange {
         const address = this.safeString (addresses, 0);
         return {
             'address': address,
-            'code': code,
+            'code': code, // kept here for backward-compatibility, but will be removed soon
+            'currency': code,
             'tag': undefined,
             'network': unifiedNetwork,
             'info': response,


### PR DESCRIPTION
at this moment, it's quite hard to detect these even through tests, so I've manually searched and found those mistakes.
note: this is non-breaking change, can be merged instantly.

[fix #15024]