### PR TITLE
coinone: pass market when create order ccxt/ccxt#15048

### DIFF
--- a/js/coinone.js
+++ b/js/coinone.js
@@ -639,19 +639,9 @@ module.exports = class coinone extends Exchange {
             }
         }
         status = this.parseOrderStatus (status);
-        let symbol = undefined;
-        let base = undefined;
-        let quote = undefined;
-        if (market === undefined) {
-            const currencyId = this.safeStringLower (order, 'currency');
-            base = this.safeCurrencyCode (currencyId);
-            quote = 'KRW';
-            symbol = base + '/' + quote;
-        } else {
-            symbol = market['symbol'];
-            base = market['base'];
-            quote = market['quote'];
-        }
+        const symbol = market['symbol'];
+        const base = market['base'];
+        const quote = market['quote'];
         let fee = undefined;
         const feeCostString = this.safeString (order, 'fee');
         if (feeCostString !== undefined) {

--- a/js/coinone.js
+++ b/js/coinone.js
@@ -526,7 +526,7 @@ module.exports = class coinone extends Exchange {
         //         "orderId": "8a82c561-40b4-4cb3-9bc0-9ac9ffc1d63b"
         //     }
         //
-        return this.parseOrder (response);
+        return this.parseOrder (response, market);
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {


### PR DESCRIPTION
ccxt/ccxt#15048

Also, this code block looks non-reachable, should I remove?
```JS
parseOrder (order, market = undefined) {
    // .....
    if (market === undefined) {
            const currencyId = this.safeStringLower (order, 'currency');
            base = this.safeCurrencyCode (currencyId);
            quote = 'KRW';
            symbol = base + '/' + quote; // => might break because there is no currency id when create order
    }
    // .....
}
```