### PR TITLE
bitfinex2 handleErrors fix

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -2527,9 +2527,9 @@ module.exports = class bitfinex2 extends Exchange {
             const errorCode = this.numberToString (response[1]);
             const errorText = response[2];
             const feedback = this.id + ' ' + errorText;
+            this.throwBroadlyMatchedException (this.exceptions['broad'], errorText, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], errorText, feedback);
-            this.throwBroadlyMatchedException (this.exceptions['broad'], errorText, feedback);
             throw new ExchangeError (this.id + ' ' + errorText + ' (#' + errorCode + ')');
         }
         return response;


### PR DESCRIPTION
Because we look first in `exact` error we never get in `broad` exception here with such errors
```
ResponseBody:
 ["error",10001,"Invalid order: not enough exchange balance for -1000000 BTTUSD at 9.3e-7"]

PermissionDenied: bitfinex2 Invalid order: not enough exchange balance for -1000000 BTTUSD at 9.3e-7
```
