### PR TITLE
Bitget: fetchOrdersByStatus

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2352,13 +2352,13 @@ module.exports = class bitget extends Exchange {
         return this.parseOrders (data, market, since, limit);
     }
 
-    async fetchOrdersByStatus (status, symbol = undefined, since = undefined, limit = undefined, params = {}) {
+    async fetchOrdersUsingStatus (status, symbol = undefined, since = undefined, limit = undefined, params = {}) {
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOrdersByStatus() requires a symbol argument');
+            throw new ArgumentsRequired (this.id + ' fetchOrdersUsingStatus() requires a symbol argument');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrdersByStatus', market, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrdersUsingStatus', market, params);
         const request = {
             'symbol': market['id'],
         };
@@ -2467,7 +2467,7 @@ module.exports = class bitget extends Exchange {
          * @param {object} params extra parameters specific to the bitget api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
-        return await this.fetchOrdersByStatus ('closed', symbol, since, limit, params);
+        return await this.fetchOrdersUsingStatus ('closed', symbol, since, limit, params);
     }
 
     async fetchCanceledOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
@@ -2483,7 +2483,7 @@ module.exports = class bitget extends Exchange {
          * @param {object} params extra parameters specific to the bitget api endpoint
          * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
-        return await this.fetchOrdersByStatus ('canceled', symbol, since, limit, params);
+        return await this.fetchOrdersUsingStatus ('canceled', symbol, since, limit, params);
     }
 
     async fetchLedger (code = undefined, since = undefined, limit = undefined, params = {}) {

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2076,7 +2076,7 @@ module.exports = class bitmart extends Exchange {
          * @description fetch all unfilled currently open orders
          * @param {string} symbol unified market symbol
          * @param {int|undefined} since the earliest time in ms to fetch open orders for
-         * @param {int|undefined} limit the maximum number of  open orders structures to retrieve
+         * @param {int|undefined} limit the maximum number of open order structures to retrieve
          * @param {object} params extra parameters specific to the bitmart api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
@@ -2090,7 +2090,7 @@ module.exports = class bitmart extends Exchange {
          * @description fetches information on multiple closed orders made by the user
          * @param {string} symbol unified market symbol of the market orders were made in
          * @param {int|undefined} since the earliest time in ms to fetch orders for
-         * @param {int|undefined} limit the maximum number of  orde structures to retrieve
+         * @param {int|undefined} limit the maximum number of order structures to retrieve
          * @param {object} params extra parameters specific to the bitmart api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */


### PR DESCRIPTION
Added `fetchCanceledOrders` and adjusted `fetchClosedOrders` to use `fetchOrdersByStatus`:

### fetchCanceledOrders:
```
bitget.fetchCanceledOrders (BTC/USDT:USDT)
2022-09-19T21:37:52.847Z iteration 0 passed in 290 ms

                id |      clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | average | cost | amount | filled | remaining |   status | fee | trades | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
954564352813969409 | 954564352868495360 | 1663311797348 | 2022-09-16T07:03:17.348Z |      1663312536072 | BTC/USDT:USDT | limit |             |          |  buy | 18000 |           |         |    0 |  0.004 |      0 |     0.004 | canceled |     |     [] |   []
954568553644306433 | 954568553677860864 | 1663312798899 | 2022-09-16T07:19:58.899Z |      1663312809425 | BTC/USDT:USDT | limit |             |          |  buy | 18000 |           |         |    0 |  0.004 |      0 |     0.004 | canceled |     |     [] |   []
2 objects
2022-09-19T21:37:52.847Z iteration 1 passed in 290 ms
```

### fetchClosedOrders:
```
bitget.fetchClosedOrders (BTC/USDT)
2022-09-19T21:37:45.038Z iteration 0 passed in 323 ms

                id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | side |    price | stopPrice |  average |      cost | amount | filled | remaining | status | fee | trades | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
867937769556971520 | ca3ca0e1-2b1a-4034-974f-03f838996f6a | 1642658410443 | 2022-01-20T06:00:10.443Z |                    | BTC/USDT | limit |             |          |  buy | 41895.37 |           | 41893.99 |  8.378798 | 0.0002 | 0.0002 |         0 | closed |     |     [] |   []
867944728129605632 | 471446bc-611c-4b8e-b3f1-d77fb44d44c6 | 1642660069496 | 2022-01-20T06:27:49.496Z |                    | BTC/USDT | limit |             |          | sell |    41992 |           | 41993.12 |  8.398624 | 0.0002 | 0.0002 |         0 | closed |     |     [] |   []
909120961395466240 | eca384a5-aad3-4046-8aa7-d7147efb8a3c | 1652477248524 | 2022-05-13T21:27:28.524Z |                    | BTC/USDT | limit |             |          |  buy | 29871.12 |           | 29870.92 | 17.922552 | 0.0006 | 0.0006 |         0 | closed |     |     [] |   []
909129926745432064 | 9e12ee3d-6a87-4e68-b1cc-094422d223a5 | 1652479386030 | 2022-05-13T22:03:06.030Z |                    | BTC/USDT | limit |             |          | sell | 30001.58 |           | 30001.58 | 18.000948 | 0.0006 | 0.0006 |         0 | closed |     |     [] |   []
4 objects
2022-09-19T21:37:45.038Z iteration 1 passed in 323 ms
```