### PR TITLE
Bitget :: fix cancelOrders request

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2059,7 +2059,8 @@ module.exports = class bitget extends Exchange {
         } else if (type === 'swap') {
             method = 'privateMixPostOrderCancelBatchOrders';
             request['symbol'] = market['id'];
-            request['ids'] = ids;
+            request['marginCoin'] = market['quote'];
+            request['orderIds'] = ids;
         }
         const response = await this[method] (this.extend (request, params));
         //


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15058

Demo
```
p bitget cancelOrders '["955879960860069889"]' "LTC/USDT:USDT"          
Python v3.9.7
CCXT v1.93.69
bitget.cancelOrders(['955879960860069889'],LTC/USDT:USDT)
{'code': '00000',
 'data': {'fail_infos': [],
          'order_ids': ['955879960860069889'],
          'result': True,
          'symbol': 'LTCUSDT_UMCBL'},
 'msg': 'success',
 ```