### PR TITLE
Bitget: fix market precision

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -893,12 +893,12 @@ module.exports = class bitget extends Exchange {
             const priceStep = this.safeString (market, 'priceEndStep');
             const amountStep = this.safeString (market, 'minTradeNum');
             const precisePrice = new Precise (priceStep);
-            precisePrice.decimals = this.sum (precisePrice.decimals, priceDecimals);
+            precisePrice.decimals = Math.max (precisePrice.decimals, priceDecimals);
             precisePrice.reduce ();
             const priceString = precisePrice.toString ();
             pricePrecision = this.parseNumber (priceString);
             const preciseAmount = new Precise (amountStep);
-            preciseAmount.decimals = this.sum (preciseAmount.decimals, amountDecimals);
+            preciseAmount.decimals = Math.max (preciseAmount.decimals, amountDecimals);
             preciseAmount.reduce ();
             const amountString = preciseAmount.toString ();
             amountPrecision = this.parseNumber (amountString);
@@ -912,7 +912,7 @@ module.exports = class bitget extends Exchange {
         const taker = this.safeNumber (market, 'takerFeeRate');
         const limits = {
             'amount': {
-                'min': this.safeNumber (market, 'minTradeAmount'),
+                'min': this.safeNumber (market, 'minTradeNum'),
                 'max': undefined,
             },
             'price': {


### PR DESCRIPTION
fix precision decimals
  - before
    ```
    // BTCUSDT_UMCBL
    precision: { price: 0.5, amount: 0.000001 },
    // ETHUSDT_UMCBL
    precision: { price: 0.01, amount: 0.0001 },
    ```
  - after
    ```
    // BTCUSDT_UMCBL
    precision: { price: 0.5, amount: 0.001 },
    // ETHUSDT_UMCBL
    precision: { price: 0.01, amount: 0.01 },
    ```

fix minimum amount, should be `minTradeNum `
  - before
    ```
    // BTCUSDT_UMCBL
    limits: {
      amount: { min: undefined, max: undefined },
      price: { min: undefined, max: undefined },
      cost: { min: undefined, max: undefined }
    }
    // ETHUSDT_UMCBL
    limits: {
      amount: { min: undefined, max: undefined },
      price: { min: undefined, max: undefined },
      cost: { min: undefined, max: undefined }
    }
    ```
  - after
    ```
    // BTCUSDT_UMCBL
    limits: {
      amount: { min: 0.001, max: undefined },
      price: { min: undefined, max: undefined },
      cost: { min: undefined, max: undefined }
    }
    // ETHUSDT_UMCBL
    limits: {
      amount: { min: 0.01, max: undefined },
      price: { min: undefined, max: undefined },
      cost: { min: undefined, max: undefined }
    }
    ```

reference
- https://bitgetlimited.github.io/apidoc/en/mix/#get-all-symbols
- https://api.bitget.com/api/mix/v1/market/contracts?productType=umcbl