### PR TITLE
Bitget: add Get ApiKey Info api

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -159,6 +159,7 @@ module.exports = class bitget extends Exchange {
                 'private': {
                     'spot': {
                         'get': {
+                            'account/getInfo': 20,
                             'account/assets': 2,
                             'account/transferRecords': 1,
                         },


### PR DESCRIPTION
Add Bitget Get ApiKey Info api: https://bitgetlimited.github.io/apidoc/en/spot/#get-apikey-info