### PR TITLE
remove unnecessary rst huge logs

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,4 +23,4 @@ changedir = {toxinidir}/..
 deps = .[doc]
 commands=
     python build/export-docs.py
-    sphinx-build -a -b html -d {envtmpdir}/doc/doctrees ./doc {envtmpdir}/doc/html
+    sphinx-build -q -a -b html -d {envtmpdir}/doc/doctrees ./doc {envtmpdir}/doc/html

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,4 +23,4 @@ changedir = {toxinidir}/..
 deps = .[doc]
 commands=
     python build/export-docs.py
-    sphinx-build -q -a -b html -d {envtmpdir}/doc/doctrees ./doc {envtmpdir}/doc/html
+    sphinx-build -Q -a -b html -d {envtmpdir}/doc/doctrees ./doc {envtmpdir}/doc/html


### PR DESCRIPTION
as noted in https://www.sphinx-doc.org/en/master/man/sphinx-build.html we'd might better don't pollute the build logs, as currently, probably 50%+ of build log is just dumped with such logs (i.e. [example](https://app.travis-ci.com/github/ccxt/ccxt/builds/255911628)) :

```
doc/readme.rst:93: WARNING: Error parsing content block for the "list-table" directive: uniform two-level bullet list expected, but row 14 does not contain the same number of items as row 1 (6 vs 7).
.. list-table::
   :header-rows: 1
   ...
   * - .. image:: https://user-images.githubusercontent.com/1294454/29604020-d5483cdc-87ee-11e7-94c7-d1a8d9169293.jpg
          :target: https://www.binance.com/en/register?ref=D7YA7CLY
          :alt: binance
     - binance
      ...
      ... 
      <<<<<<<<<<  same log blocks here for 100+ exchanges >>>>>>>>>>
```
and for many next rst warnings  (`... /home/travis/build/ccxt/ccxt/doc/manual.rst:56: WARNING: ...`), the same 100+ exchanges log-blocks are repeated over and over, and takes much space. I think those content-log should be suppressed atm.

--- update ---
(note, the lowercase `-q` flag doesn't seem to do the job, while uppercase `-Q` works, but in addition to file-content outputs, it also suppresses all warnings itself. idk, if it's acceptable at this moment. Though, log is more [cleaner now](https://app.travis-ci.com/github/ccxt/ccxt/builds/255914043).)