### PR TITLE
Okx: fetchOpenInterest

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4459,6 +4459,27 @@ Funding Rate History Structure
        datetime: "2022-01-23T16:00:00.000Z"
    }
 
+Open Interest
+---------------------
+
+ *contract only*
+
+Use the ``fetchOpenInterest`` method to get a the open interest for a symbol from the exchange.
+
+.. code-block:: JavaScript
+   fetchOpenInterest (symbol, params = {})
+Parameters
+
+
+ * **symbol** (String) Unified CCXT market symbol (e.g. ``"BTC/USDT:USDT"``\ )
+ * **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. ``{"endTime": 1645807945000}``\ )
+
+
+Returns
+
+
+ * A dictionary of :ref:`open interest structures <open interest structure>`
+
 Open Interest History
 ---------------------
 
@@ -4493,8 +4514,8 @@ Open Interest Structure
 
    {
        symbol: 'BTC/USDT',
-       baseVolume: 80872.801,
-       quoteVolume: 3508262107.38,
+       openInterestAmount: 80872.801,
+       openInterestValue: 3508262107.38,
        timestamp: 1649379000000,
        datetime: '2022-04-08T00:50:00.000Z',
        info: {

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4515,6 +4515,8 @@ Open Interest Structure
 
    {
        symbol: 'BTC/USDT',
+       baseVolume: 80872.801,  // deprecated
+       quoteVolume: 3508262107.38, // deprecated
        openInterestAmount: 80872.801,
        openInterestValue: 3508262107.38,
        timestamp: 1649379000000,

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4467,13 +4467,14 @@ Open Interest
 Use the ``fetchOpenInterest`` method to get a the open interest for a symbol from the exchange.
 
 .. code-block:: JavaScript
+
    fetchOpenInterest (symbol, params = {})
+
 Parameters
 
 
  * **symbol** (String) Unified CCXT market symbol (e.g. ``"BTC/USDT:USDT"``\ )
  * **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. ``{"endTime": 1645807945000}``\ )
-
 
 Returns
 

--- a/js/okx.js
+++ b/js/okx.js
@@ -5473,6 +5473,9 @@ module.exports = class okx extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (!market['contract']) {
+            throw new BadRequest (this.id + ' fetchOpenInterest() supports contract markets only');
+        }
         const type = this.convertToInstrumentType (market['type']);
         const uly = this.safeString (market['info'], 'uly');
         const request = {

--- a/js/okx.js
+++ b/js/okx.js
@@ -5581,6 +5581,8 @@ module.exports = class okx extends Exchange {
         const openInterest = this.safeNumber (interest, 1, inCurrency);
         return {
             'symbol': this.safeSymbol (id),
+            'baseVolume': undefined,  // deprecated
+            'quoteVolume': openInterest,  // deprecated
             'openInterestAmount': numContracts,
             'openInterestValue': openInterest,
             'timestamp': timestamp,

--- a/js/okx.js
+++ b/js/okx.js
@@ -71,6 +71,7 @@ module.exports = class okx extends Exchange {
                 'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': true,
                 'fetchOpenOrder': undefined,
                 'fetchOpenOrders': true,
@@ -5460,6 +5461,45 @@ module.exports = class okx extends Exchange {
         };
     }
 
+    async fetchOpenInterest (symbol, params = {}) {
+        /**
+         * @method
+         * @name okx#fetchOpenInterest
+         * @description Retrieves the open interest of a currency
+         * @see https://www.okx.com/docs-v5/en/#rest-api-public-data-get-open-interest
+         * @param {string} symbol Unified CCXT market symbol
+         * @param {object} params exchange specific parameters
+         * @returns {object} an open interest structure{@link https://docs.ccxt.com/en/latest/manual.html#interest-history-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const type = this.convertToInstrumentType (market['type']);
+        const uly = this.safeString (market['info'], 'uly');
+        const request = {
+            'instType': type,
+            'uly': uly,
+            'instId': market['id'],
+        };
+        const response = await this.publicGetPublicOpenInterest (this.extend (request, params));
+        //
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             {
+        //                 "instId": "BTC-USDT-SWAP",
+        //                 "instType": "SWAP",
+        //                 "oi": "2125419",
+        //                 "oiCcy": "21254.19",
+        //                 "ts": "1664005108969"
+        //             }
+        //         ],
+        //         "msg": ""
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        return this.parseOpenInterest (data[0], market);
+    }
+
     async fetchOpenInterestHistory (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
@@ -5514,18 +5554,35 @@ module.exports = class okx extends Exchange {
 
     parseOpenInterest (interest, market = undefined) {
         //
+        // fetchOpenInterestHistory
+        //
         //    [
         //        '1648221300000',  // timestamp
         //        '2183354317.945',  // open interest (USD)
         //        '74285877.617',  // volume (USD)
         //    ]
         //
-        const timestamp = this.safeNumber (interest, 0);
-        const openInterest = this.safeNumber (interest, 1);
+        // fetchOpenInterest
+        //
+        //     {
+        //         "instId": "BTC-USDT-SWAP",
+        //         "instType": "SWAP",
+        //         "oi": "2125419",
+        //         "oiCcy": "21254.19",
+        //         "ts": "1664005108969"
+        //     }
+        //
+        const id = this.safeString (interest, 'instId');
+        market = this.safeMarket (id, market);
+        const time = this.safeInteger (interest, 'ts');
+        const timestamp = this.safeNumber (interest, 0, time);
+        const numContracts = this.safeNumber (interest, 'oi');
+        const inCurrency = this.safeNumber (interest, 'oiCcy');
+        const openInterest = this.safeNumber (interest, 1, inCurrency);
         return {
-            'symbol': undefined,
-            'baseVolume': undefined,
-            'quoteVolume': openInterest,
+            'symbol': this.safeSymbol (id),
+            'openInterestAmount': numContracts,
+            'openInterestValue': openInterest,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,


### PR DESCRIPTION
Added a new unified method `fetchOpenInterest` to Okx:
```
node examples/js/cli okx fetchOpenInterest BTC/USDT:USDT
```
```
okx.fetchOpenInterest (BTC/USDT:USDT)
2022-09-24T07:47:00.201Z iteration 0 passed in 345 ms

{
  symbol: 'BTC/USDT:USDT',
  openInterestAmount: 2136738,
  openInterestValue: 21367.38,
  timestamp: 1664005620715,
  datetime: '2022-09-24T07:47:00.715Z',
  info: {
    instId: 'BTC-USDT-SWAP',
    instType: 'SWAP',
    oi: '2136738',
    oiCcy: '21367.38',
    ts: '1664005620715'
  }
}
2022-09-24T07:47:00.201Z iteration 1 passed in 345 ms
```