### PR TITLE
Poloniex :: fetchDeposits/withdrawals

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1587,9 +1587,6 @@ module.exports = class poloniex extends Exchange {
             'start': start, // UNIX timestamp, required
             'end': now, // UNIX timestamp, required
         };
-        if (limit !== undefined) {
-            request['limit'] = limit;
-        }
         const response = await this.privateGetWalletsActivity (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15098
- API does not support `limit` parameter (https://docs.poloniex.com/#authenticated-endpoints-wallets-wallets-activity-records)

Demo 
```
p poloniex fetchDeposits USDT None 1
Python v3.9.7
CCXT v1.93.93
poloniex.fetchDeposits(USDT,None,1)
[{'address': 'TQmdxSuC16EhFg8FZWtYgrfFRosoRF7bCp',
  'addressFrom': None,
  'addressTo': None,
  'amount': 11.0,
  'currency': 'USDT',
  'datetime': '2022-08-17T10:17:34.000Z',
  'fee': {'cost': None, 'currency': 'USDT'},
  'id': '150365679',
  'info': {'address': 'TQmdxSuC16EhFg8FZWtYgrfFRosoRF7bCp',
           'amount': '11.00000000',
           'confirmations': '0',
           'currency': 'USDTTRON',
           'depositNumber': '150365679',
           'status': 'COMPLETED',
           'timestamp': '1660731454',
           'txid': '96cdbeba9b7cfee51bc2b6aa2b0ad919747c89fe3a3cbc8a56118931484ad0f0'},
  'network': None,
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp': 1660731454000,
  'txid': '96cdbeba9b7cfee51bc2b6aa2b0ad919747c89fe3a3cbc8a56118931484ad0f0',
  'type': 'deposit',
  'updated': None}]
```