### PR TITLE
Base - fetch borrow rates message

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2051,7 +2051,7 @@ module.exports = class Exchange {
         const borrowRates = await this.fetchBorrowRates (params);
         const rate = this.safeValue (borrowRates, code);
         if (rate === undefined) {
-            throw new ExchangeError (this.id + ' fetchBorrowRate() could not find the borrow rate for currency code ' + code);
+            throw new ExchangeError (this.id + ' fetchBorrowRates() endpoint could not find the borrow rate for currency code ' + code);
         }
         return rate;
     }

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2051,7 +2051,7 @@ module.exports = class Exchange {
         const borrowRates = await this.fetchBorrowRates (params);
         const rate = this.safeValue (borrowRates, code);
         if (rate === undefined) {
-            throw new ExchangeError (this.id + ' fetchBorrowRates() endpoint could not find the borrow rate for currency code ' + code);
+            throw new ExchangeError (this.id + ' fetchBorrowRate() method was redirected through fetchBorrowRates() but it could not find the borrow rate for currency code ' + code);
         }
         return rate;
     }


### PR DESCRIPTION
@lead, what about a bit more clear message for emulated methods? I think it's misleading a bit, when we mention that same singular method name, while the code was actually emulated & running through other unified (plural) method. So, maybe we can mention that in more details, would be better for everyone.