### PR TITLE
Luno: replace fetchTradingFees

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -61,7 +61,7 @@ module.exports = class luno extends Exchange {
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,
-                'fetchTradingFees': true,
+                'fetchTradingFees': false,
                 'reduceMargin': false,
                 'setLeverage': false,
                 'setMarginMode': false,
@@ -768,23 +768,6 @@ module.exports = class luno extends Exchange {
         //
         const trades = this.safeValue (response, 'trades', []);
         return this.parseTrades (trades, market, since, limit);
-    }
-
-    async fetchTradingFees (params = {}) {
-        /**
-         * @method
-         * @name luno#fetchTradingFees
-         * @description fetch the trading fees for multiple markets
-         * @param {object} params extra parameters specific to the luno api endpoint
-         * @returns {object} a dictionary of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure} indexed by market symbols
-         */
-        await this.loadMarkets ();
-        const response = await this.privateGetFeeInfo (params);
-        return {
-            'info': response,
-            'maker': this.safeNumber (response, 'maker_fee'),
-            'taker': this.safeNumber (response, 'taker_fee'),
-        };
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/js/luno.js
+++ b/js/luno.js
@@ -61,6 +61,7 @@ module.exports = class luno extends Exchange {
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,
+                'fetchTradingFee': true,
                 'fetchTradingFees': false,
                 'reduceMargin': false,
                 'setLeverage': false,
@@ -768,6 +769,36 @@ module.exports = class luno extends Exchange {
         //
         const trades = this.safeValue (response, 'trades', []);
         return this.parseTrades (trades, market, since, limit);
+    }
+
+    async fetchTradingFee (symbol, params = {}) {
+        /**
+         * @method
+         * @name luno#fetchTradingFee
+         * @description fetch the trading fees for a market
+         * @param {string} symbol unified market symbol
+         * @param {object} params extra parameters specific to the luno api endpoint
+         * @returns {object} a [fee structure]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.privateGetFeeInfo (this.extend (request, params));
+        //
+        //     {
+        //          "maker_fee": "0.00250000",
+        //          "taker_fee": "0.00500000",
+        //          "thirty_day_volume": "0"
+        //     }
+        //
+        return {
+            'info': response,
+            'symbol': symbol,
+            'maker': this.safeNumber (response, 'maker_fee'),
+            'taker': this.safeNumber (response, 'taker_fee'),
+        };
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {


### PR DESCRIPTION
Luno is not supported for fetchTradingFees so it is replaced with fetchTradingFee instead.

Api reference:  [https://www.luno.com/en/developers/api#operation/getFeeInfo](https://www.luno.com/en/developers/api#operation/getFeeInfo) 

