### PR TITLE
python decimal_to_precision checks for decimal type in assertions

### DIFF
--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -36,7 +36,7 @@ PAD_WITH_ZERO = 6
 def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=DECIMAL_PLACES, padding_mode=NO_PADDING):
     assert precision is not None
     if counting_mode == TICK_SIZE:
-        assert(isinstance(precision, float) or isinstance(precision, numbers.Integral))
+        assert(isinstance(precision, float) or isinstance(precision, decimal.Decimal) or isinstance(precision, numbers.Integral))
     else:
         assert(isinstance(precision, numbers.Integral))
     assert rounding_mode in [TRUNCATE, ROUND]


### PR DESCRIPTION
[Related to this comment](https://github.com/ccxt/ccxt/issues/522#issuecomment-1189001883)

--------------------

# Test Program 

```
import ccxt
import json
import decimal
from pprint import pprint

keys = json.load(open('../keys.local.json', 'r'))

okcoin = ccxt.okcoin(keys['okcoin'])
okcoin.number = decimal.Decimal
order = okcoin.createOrder('USDC/USDT', 'market', 'sell', 10, 1)
pprint(order)
```

# Output

```
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '9797275932049408',
 'info': {'client_oid': '',
          'code': '0',
          'error_code': '0',
          'error_message': '',
          'message': '',
          'order_id': '9797275932049408',
          'result': True},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'remaining': None,
 'side': 'sell',
 'status': None,
 'stopPrice': None,
 'symbol': 'USDC/USDT',
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'type': 'market'}
 ```