### PR TITLE
`fetchOHLCV` - normalization of required arguments across exchanges

### DIFF
--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, AuthenticationError, InvalidNonce, InsufficientFunds, InvalidOrder, OrderNotFound, PermissionDenied, ArgumentsRequired } = require ('./base/errors');
+const { ExchangeError, AuthenticationError, InvalidNonce, InsufficientFunds, InvalidOrder, OrderNotFound, PermissionDenied } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 
 //  ---------------------------------------------------------------------------
@@ -460,7 +460,11 @@ module.exports = class bitbank extends Exchange {
          * @returns {[[int]]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         if (since === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a since argument');
+            if (limit === undefined) {
+                limit = 1000; // it doesn't have any defaults, might return 200, might 2000 (i.e. https://public.bitbank.cc/btc_jpy/candlestick/4hour/2020)
+            }
+            const duration = this.parseTimeframe (timeframe);
+            since = this.milliseconds () - duration * 1000 * limit;
         }
         await this.loadMarkets ();
         const market = this.market (symbol);

--- a/js/bitbank.js
+++ b/js/bitbank.js
@@ -447,7 +447,7 @@ module.exports = class bitbank extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name bitbank#fetchOHLCV

--- a/js/bitopro.js
+++ b/js/bitopro.js
@@ -723,7 +723,7 @@ module.exports = class bitopro extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name bitopro#fetchOHLCV

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -999,7 +999,7 @@ module.exports = class bitstamp extends Exchange {
         const duration = this.parseTimeframe (timeframe);
         if (limit === undefined) {
             if (since === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a since argument or a limit argument');
+                request['limit'] = 1000; // we need to specify an allowed amount of `limit` if no `since` is set and there is no default limit by exchange
             } else {
                 limit = 1000;
                 const start = parseInt (since / 1000);

--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { AuthenticationError, BadRequest, ExchangeError, NotSupported, PermissionDenied, InvalidNonce, OrderNotFound, InsufficientFunds, InvalidAddress, InvalidOrder, ArgumentsRequired, OnMaintenance, ExchangeNotAvailable } = require ('./base/errors');
+const { AuthenticationError, BadRequest, ExchangeError, NotSupported, PermissionDenied, InvalidNonce, OrderNotFound, InsufficientFunds, InvalidAddress, InvalidOrder, OnMaintenance, ExchangeNotAvailable } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -76,7 +76,6 @@ module.exports = class btcalpha extends Exchange {
                 'withdraw': false,
             },
             'timeframes': {
-                '1m': '1',
                 '5m': '5',
                 '15m': '15',
                 '30m': '30',
@@ -476,7 +475,7 @@ module.exports = class btcalpha extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name btcalpha#fetchOHLCV

--- a/js/btcalpha.js
+++ b/js/btcalpha.js
@@ -476,7 +476,7 @@ module.exports = class btcalpha extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name btcalpha#fetchOHLCV

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1571,12 +1571,11 @@ module.exports = class bybit extends Exchange {
         const duration = this.parseTimeframe (timeframe);
         const now = this.seconds ();
         let sinceTimestamp = undefined;
+        if (limit === undefined) {
+            limit = 200; // default is 200 when requested with `since`
+        }
         if (since === undefined) {
-            if (limit === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a since argument or a limit argument');
-            } else {
-                sinceTimestamp = now - limit * duration;
-            }
+            sinceTimestamp = now - limit * duration;
         } else {
             sinceTimestamp = parseInt (since / 1000);
         }

--- a/js/coinex.js
+++ b/js/coinex.js
@@ -1195,7 +1195,7 @@ module.exports = class coinex extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name coinex#fetchOHLCV

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1086,11 +1086,10 @@ module.exports = class deribit extends Exchange {
         const now = this.milliseconds ();
         if (since === undefined) {
             if (limit === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a since argument or a limit argument');
-            } else {
-                request['start_timestamp'] = now - (limit - 1) * duration * 1000;
-                request['end_timestamp'] = now;
+                limit = 1000; // at max, it provides 5000 bars, but we set generous default here
             }
+            request['start_timestamp'] = now - (limit - 1) * duration * 1000;
+            request['end_timestamp'] = now;
         } else {
             request['start_timestamp'] = since;
             if (limit === undefined) {

--- a/js/exmo.js
+++ b/js/exmo.js
@@ -732,14 +732,13 @@ module.exports = class exmo extends Exchange {
         const now = this.milliseconds ();
         if (since === undefined) {
             if (limit === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a since argument or a limit argument');
-            } else {
-                if (limit > maxLimit) {
-                    throw new BadRequest (this.id + ' fetchOHLCV() will serve ' + maxLimit.toString () + ' candles at most');
-                }
-                request['from'] = parseInt (now / 1000) - limit * duration - 1;
-                request['to'] = parseInt (now / 1000);
+                limit = 1000; // cap default at generous amount
             }
+            if (limit > maxLimit) {
+                limit = maxLimit; // avoid exception
+            }
+            request['from'] = parseInt (now / 1000) - limit * duration - 1;
+            request['to'] = parseInt (now / 1000);
         } else {
             request['from'] = parseInt (since / 1000) - 1;
             if (limit === undefined) {

--- a/js/gemini.js
+++ b/js/gemini.js
@@ -1525,7 +1525,7 @@ module.exports = class gemini extends Exchange {
         };
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name gemini#fetchOHLCV

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -742,7 +742,7 @@ module.exports = class hollaex extends Exchange {
         return result;
     }
 
-    async fetchOHLCV (symbol, timeframe = '1h', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name hollaex#fetchOHLCV

--- a/js/hollaex.js
+++ b/js/hollaex.js
@@ -763,13 +763,12 @@ module.exports = class hollaex extends Exchange {
         const duration = this.parseTimeframe (timeframe);
         if (since === undefined) {
             if (limit === undefined) {
-                throw new ArgumentsRequired (this.id + " fetchOHLCV() requires a 'since' or a 'limit' argument");
-            } else {
-                const end = this.seconds ();
-                const start = end - duration * limit;
-                request['to'] = end;
-                request['from'] = start;
+                limit = 1000; // they have no defaults and can actually provide tens of thousands of bars in one request, but we should cap "default" at generous amount
             }
+            const end = this.seconds ();
+            const start = end - duration * limit;
+            request['to'] = end;
+            request['from'] = start;
         } else {
             if (limit === undefined) {
                 request['from'] = parseInt (since / 1000);

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1041,7 +1041,7 @@ module.exports = class kucoin extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '15m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name kucoin#fetchOHLCV

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -520,7 +520,7 @@ module.exports = class kucoinfutures extends kucoin {
         return this.safeNumber (response, 'data');
     }
 
-    async fetchOHLCV (symbol, timeframe = '15m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name kucoinfutures#fetchOHLCV

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -431,7 +431,7 @@ module.exports = class lbank extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = 1000, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = 1000, params = {}) {
         /**
          * @method
          * @name lbank#fetchOHLCV

--- a/js/lbank.js
+++ b/js/lbank.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, DDoSProtection, AuthenticationError, InvalidOrder, ArgumentsRequired } = require ('./base/errors');
+const { ExchangeError, DDoSProtection, AuthenticationError, InvalidOrder } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -445,11 +445,12 @@ module.exports = class lbank extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (since === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a `since` argument');
-        }
         if (limit === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a `limit` argument');
+            limit = 100; // as it's defined in lbank2
+        }
+        if (since === undefined) {
+            const duration = this.parseTimeframe (timeframe);
+            since = this.milliseconds () - duration * 1000 * limit;
         }
         const request = {
             'symbol': market['id'],

--- a/js/lbank2.js
+++ b/js/lbank2.js
@@ -673,11 +673,12 @@ module.exports = class lbank2 extends Exchange {
         // endpoint doesnt work
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (since === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOHLCV () requires a since argument');
-        }
         if (limit === undefined) {
             limit = 100;
+        }
+        if (since === undefined) {
+            const duration = this.parseTimeframe (timeframe);
+            since = this.milliseconds () - duration * 1000 * limit;
         }
         const request = {
             'symbol': market['id'],

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -736,7 +736,7 @@ module.exports = class mercado extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name mercado#fetchOHLCV

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -70,17 +70,12 @@ module.exports = class mercado extends Exchange {
                 'withdraw': true,
             },
             'timeframes': {
-                '1m': '1m',
-                '5m': '5m',
                 '15m': '15m',
-                '30m': '30m',
                 '1h': '1h',
-                '6h': '6h',
-                '12h': '12h',
+                '3h': '3h',
                 '1d': '1d',
-                '3d': '3d',
                 '1w': '1w',
-                '2w': '2w',
+                '1M': '1M',
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/27837060-e7c58714-60ea-11e7-9192-f05e86adb83f.jpg',
@@ -88,6 +83,7 @@ module.exports = class mercado extends Exchange {
                     'public': 'https://www.mercadobitcoin.net/api',
                     'private': 'https://www.mercadobitcoin.net/tapi',
                     'v4Public': 'https://www.mercadobitcoin.com.br/v4',
+                    'v4PublicNet': 'https://api.mercadobitcoin.net/api/v4',
                 },
                 'www': 'https://www.mercadobitcoin.com.br',
                 'doc': [
@@ -127,6 +123,11 @@ module.exports = class mercado extends Exchange {
                 'v4Public': {
                     'get': [
                         '{coin}/candle/',
+                    ],
+                },
+                'v4PublicNet': {
+                    'get': [
+                        'candles',
                     ],
                 },
             },
@@ -728,12 +729,12 @@ module.exports = class mercado extends Exchange {
 
     parseOHLCV (ohlcv, market = undefined) {
         return [
-            this.safeTimestamp (ohlcv, 'timestamp'),
-            this.safeNumber (ohlcv, 'open'),
-            this.safeNumber (ohlcv, 'high'),
-            this.safeNumber (ohlcv, 'low'),
-            this.safeNumber (ohlcv, 'close'),
-            this.safeNumber (ohlcv, 'volume'),
+            this.safeTimestamp (ohlcv, 0),
+            this.safeNumber (ohlcv, 1),
+            this.safeNumber (ohlcv, 2),
+            this.safeNumber (ohlcv, 3),
+            this.safeNumber (ohlcv, 4),
+            this.safeNumber (ohlcv, 5),
         ];
     }
 
@@ -752,8 +753,8 @@ module.exports = class mercado extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'precision': this.timeframes[timeframe],
-            'coin': market['id'].toLowerCase (),
+            'resolution': this.timeframes[timeframe],
+            'symbol': market['base'] + '-' + market['quote'],
         };
         if (limit !== undefined && since !== undefined) {
             request['from'] = parseInt (since / 1000);
@@ -765,8 +766,8 @@ module.exports = class mercado extends Exchange {
             request['to'] = this.seconds ();
             request['from'] = request['to'] - (limit * this.parseTimeframe (timeframe));
         }
-        const response = await this.v4PublicGetCoinCandle (this.extend (request, params));
-        const candles = this.safeValue (response, 'candles', []);
+        const response = await this.v4PublicNetGetCandles (this.extend (request, params));
+        const candles = this.convertTradingViewToOHLCV (response, 't', 'o', 'h', 'l', 'c', 'v');
         return this.parseOHLCVs (candles, market, timeframe, since, limit);
     }
 
@@ -863,7 +864,7 @@ module.exports = class mercado extends Exchange {
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = this.urls['api'][api] + '/';
         const query = this.omit (params, this.extractParams (path));
-        if (api === 'public' || (api === 'v4Public')) {
+        if ((api === 'public') || (api === 'v4Public') || (api === 'v4PublicNet')) {
             url += this.implodeParams (path, params);
             if (Object.keys (query).length) {
                 url += '?' + this.urlencode (query);

--- a/js/mercado.js
+++ b/js/mercado.js
@@ -93,6 +93,7 @@ module.exports = class mercado extends Exchange {
                 'doc': [
                     'https://www.mercadobitcoin.com.br/api-doc',
                     'https://www.mercadobitcoin.com.br/trade-api',
+                    'https://api.mercadobitcoin.net/api/v4/docs/',
                 ],
             },
             'api': {

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1053,21 +1053,21 @@ module.exports = class phemex extends Exchange {
         const duration = this.parseTimeframe (timeframe);
         const now = this.seconds ();
         // the exchange does not return the last 1m candle
+        const maxLimit = 2000;
+        if (limit === undefined) {
+            limit = maxLimit;
+        } else {
+            limit = Math.min (limit, maxLimit);
+        }
         if (since !== undefined) {
-            if (limit === undefined) {
-                limit = 2000; // max 2000
-            }
             since = parseInt (since / 1000);
             request['from'] = since;
             // time ranges ending in the future are not accepted
             // https://github.com/ccxt/ccxt/issues/8050
             request['to'] = Math.min (now, this.sum (since, duration * limit));
         } else if (limit !== undefined) {
-            limit = Math.min (limit, 2000);
             request['from'] = now - duration * this.sum (limit, 1);
             request['to'] = now;
-        } else {
-            throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires a since argument, or a limit argument, or both');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1052,12 +1052,10 @@ module.exports = class phemex extends Exchange {
         };
         const duration = this.parseTimeframe (timeframe);
         const now = this.seconds ();
-        // the exchange does not return the last 1m candle
-        const maxLimit = 2000;
         if (limit === undefined) {
-            limit = maxLimit;
+            limit = 1000;
         } else {
-            limit = Math.min (limit, maxLimit);
+            limit = Math.min (limit, 1999); // max bars are 1999 instead 2000, because the exchange does not return the last 1m candle
         }
         if (since !== undefined) {
             since = parseInt (since / 1000);
@@ -1065,7 +1063,7 @@ module.exports = class phemex extends Exchange {
             // time ranges ending in the future are not accepted
             // https://github.com/ccxt/ccxt/issues/8050
             request['to'] = Math.min (now, this.sum (since, duration * limit));
-        } else if (limit !== undefined) {
+        } else {
             request['from'] = now - duration * this.sum (limit, 1);
             request['to'] = now;
         }

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1055,16 +1055,17 @@ module.exports = class phemex extends Exchange {
         if (limit === undefined) {
             limit = 1000;
         } else {
-            limit = Math.min (limit, 1999); // max bars are 1999 instead 2000, because the exchange does not return the last 1m candle
+            limit = Math.min (limit, 1999); // the exchange does not return the last 1m candle, and as we add `1` to the limit window, we have to cap the request at 1999
         }
+        const limitPlusOne = this.sum (limit, 1);
         if (since !== undefined) {
             since = parseInt (since / 1000);
             request['from'] = since;
             // time ranges ending in the future are not accepted
             // https://github.com/ccxt/ccxt/issues/8050
-            request['to'] = Math.min (now, this.sum (since, duration * limit));
+            request['to'] = Math.min (now, this.sum (since, duration * limitPlusOne));
         } else {
-            request['from'] = now - duration * this.sum (limit, 1);
+            request['from'] = now - duration * limitPlusOne;
             request['to'] = now;
         }
         await this.loadMarkets ();

--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1058,16 +1058,18 @@ module.exports = class phemex extends Exchange {
         } else {
             limit = Math.min (limit, maxLimit);
         }
-        if (limit < maxLimit) {
-            limit = limit + 1; // the exchange does not return the last 1m candle, we have to add `1` so user gets their requested 'limit' amout correctly, as exchange returns one bar less than requested window
-        }
         if (since !== undefined) {
+            limit = Math.min (limit, maxLimit);
             since = parseInt (since / 1000);
             request['from'] = since;
             // time ranges ending in the future are not accepted
             // https://github.com/ccxt/ccxt/issues/8050
             request['to'] = Math.min (now, this.sum (since, duration * limit));
         } else {
+            if (limit < maxLimit) {
+                // whenever making a request with `now`, that expects current latest bar to be included, the exchange does not return the last 1m candle and thus excludes one bar. So, we have to add `1` to user's set `limit` amount to get that amount of bars back
+                limit = limit + 1;
+            }
             request['from'] = now - duration * limit;
             request['to'] = now;
         }

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -286,7 +286,7 @@ module.exports = class poloniex extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '5m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name poloniex#fetchOHLCV

--- a/js/probit.js
+++ b/js/probit.js
@@ -906,10 +906,9 @@ module.exports = class probit extends Exchange {
         let endTime = now;
         if (since === undefined) {
             if (limit === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOHLCV() requires either a since argument or a limit argument');
-            } else {
-                startTime = now - limit * duration * 1000;
+                limit = requestLimit;
             }
+            startTime = now - limit * duration * 1000;
         } else {
             if (limit === undefined) {
                 endTime = now;

--- a/js/stex.js
+++ b/js/stex.js
@@ -777,7 +777,7 @@ module.exports = class stex extends Exchange {
         ];
     }
 
-    async fetchOHLCV (symbol, timeframe = '1d', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name stex#fetchOHLCV

--- a/js/timex.js
+++ b/js/timex.js
@@ -648,17 +648,16 @@ module.exports = class timex extends Exchange {
         };
         // if since and limit are not specified
         const duration = this.parseTimeframe (timeframe);
+        if (limit === undefined) {
+            limit = 1000; // exchange provides tens of thousands of data, but we set generous default value
+        }
         if (since !== undefined) {
             request['from'] = this.iso8601 (since);
-            if (limit !== undefined) {
-                request['till'] = this.iso8601 (this.sum (since, this.sum (limit, 1) * duration * 1000));
-            }
-        } else if (limit !== undefined) {
+            request['till'] = this.iso8601 (this.sum (since, this.sum (limit, 1) * duration * 1000));
+        } else {
             const now = this.milliseconds ();
             request['till'] = this.iso8601 (now);
             request['from'] = this.iso8601 (now - limit * duration * 1000 - 1);
-        } else {
-            request['till'] = this.iso8601 (this.milliseconds ());
         }
         const response = await this.publicGetCandles (this.extend (request, params));
         //

--- a/js/woo.js
+++ b/js/woo.js
@@ -1045,7 +1045,7 @@ module.exports = class woo extends Exchange {
         return this.parseOrderBook (response, symbol, timestamp, 'bids', 'asks', 'price', 'quantity');
     }
 
-    async fetchOHLCV (symbol, timeframe = '1h', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name woo#fetchOHLCV


### PR DESCRIPTION
We had talked about this a few times in the past ([here](https://github.com/ccxt/ccxt/issues/14091#issuecomment-1168427549) and also somewhere on discord). 
so, there are some exchanges, that just require anything to be provided in `limit` param. I know, we typically don't invent values ourselves, but as 95%+ exchanges support just firing `e.fetchOHLCV ('BTC/USDT')` and users get some response without need to provide the `limit/since` argument (be it 100,500 or whatever default from any exchange), it is more reasonable that we set non-hurting values for `limit` for those exchanges which require it, so user's doesn't get exception/code-breaks for those 5% exchanges.