### PR TITLE
Mexc3: fetchOrders margin support

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -1802,7 +1802,6 @@ module.exports = class mexc3 extends Exchange {
         const reduceOnly = this.safeValue (params, 'reduceOnly', false);
         if (reduceOnly) {
             request['side'] = (side === 'buy') ? 2 : 4;
-            request['reduceOnly'] = true;
         } else {
             request['side'] = (side === 'buy') ? 1 : 3;
         }


### PR DESCRIPTION
Added margin support to `fetchOrders`

Set `'margin': true,` the only other pending PR for Mexc3 margin is: https://github.com/ccxt/ccxt/pull/14896/

```
node examples/js/cli mexc3 fetchOrders BTC/USDT undefined undefined '{"marginMode":"isolated"}'

mexc3.fetchOrders (BTC/USDT, , , [object Object])
2022-09-03T05:26:13.759Z iteration 0 passed in 470 ms

                id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |   symbol |  type | timeInForce | side | price | stopPrice | average |   amount | cost | filled | remaining | fee | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
762634301354414080 |               | 1661992652000 | 2022-09-01T00:37:32.000Z |                    | canceled | BTC/USDT | limit |             |  buy | 18000 |           |         |   0.0014 |    0 |      0 |    0.0014 |     |     [] |   []
762635264408555520 |               | 1661992882000 | 2022-09-01T00:41:22.000Z |                    | canceled | BTC/USDT | limit |             |  buy | 18000 |           |         |   0.0014 |    0 |      0 |    0.0014 |     |     [] |   []
762640232574226432 |               | 1661994066000 | 2022-09-01T01:01:06.000Z |                    | canceled | BTC/USDT | limit |             |  buy | 18000 |           |         |  0.00147 |    0 |      0 |   0.00147 |     |     [] |   []
...
7 objects
2022-09-03T05:26:13.759Z iteration 1 passed in 470 ms
```