### PR TITLE
base tests - detect missing parser methods

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -686,7 +686,7 @@ class Transpiler {
             'fetchDepositAddresses': ['parseDepositAddresses'],
             'fetchDepositAddressesByNetwork': ['parseDepositAddresses'],
             // ticker/s
-            'fetchTicker': ['parseTicker'],
+            'fetchTicker': ['parseTicker', 'fetchTickers'],
             //     'fetchBidsAsks': ['parseTickers'], // temporarily disabled
             'fetchTickers': ['parseTicker'], // singular also allowed, because some exchanges have iteratation inside implementation
             // transaction/s  (also allow i.e. 'fetchTransactionsByType')


### PR DESCRIPTION
this PR adds feature, as we ensures that each implementation has its parser (`parseX`). This would take the development and standards one level upper.