### PR TITLE
AAX: fetchOpenInterest

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -75,6 +75,8 @@ module.exports = class aax extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterest': true,
+                'fetchOpenInterestHistory': false,
                 'fetchOpenOrder': undefined,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
@@ -3130,6 +3132,63 @@ module.exports = class aax extends Exchange {
             }));
         }
         return this.filterByArray (result, 'symbol', symbols, false);
+    }
+
+    async fetchOpenInterest (symbol, params = {}) {
+        /**
+         * @method
+         * @name aax#fetchOpenInterest
+         * @description Retrieves the open interest of a currency
+         * @see https://www.aax.com/apidoc/index.html#open-interest
+         * @param {string} symbol Unified CCXT market symbol
+         * @param {object} params exchange specific parameters
+         * @returns {object} an open interest structure{@link https://docs.ccxt.com/en/latest/manual.html#interest-history-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.publicGetFuturesPositionOpenInterest (this.extend (request, params));
+        //
+        //     {
+        //         "code": 1,
+        //         "data": {
+        //             "openInterest": "37137299.49007",
+        //             "openInterestUSD": "721016725.9898761994667",
+        //             "symbol": "BTCUSDTFP"
+        //         },
+        //         "message": "success",
+        //         "ts": 1664486817471
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const timestamp = this.safeInteger (response, 'ts');
+        const openInterest = this.parseOpenInterest (data, market);
+        return this.extend (openInterest, {
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+        });
+    }
+
+    parseOpenInterest (interest, market = undefined) {
+        //
+        //     {
+        //         "openInterest": "37137299.49007",
+        //         "openInterestUSD": "721016725.9898761994667",
+        //         "symbol": "BTCUSDTFP"
+        //     }
+        //
+        const id = this.safeString (interest, 'symbol');
+        market = this.safeMarket (id, market);
+        return {
+            'symbol': this.safeSymbol (id),
+            'openInterestAmount': this.safeNumber (interest, 'openInterest'),
+            'openInterestValue': this.safeNumber (interest, 'openInterestUSD'),
+            'timestamp': undefined,
+            'datetime': undefined,
+            'info': interest,
+        };
     }
 
     nonce () {

--- a/js/aax.js
+++ b/js/aax.js
@@ -3184,10 +3184,14 @@ module.exports = class aax extends Exchange {
         //
         const id = this.safeString (interest, 'symbol');
         market = this.safeMarket (id, market);
+        const amount = this.safeNumber (interest, 'openInterest');
+        const value = this.safeNumber (interest, 'openInterestUSD');
         return {
             'symbol': this.safeSymbol (id),
-            'openInterestAmount': this.safeNumber (interest, 'openInterest'),
-            'openInterestValue': this.safeNumber (interest, 'openInterestUSD'),
+            'openInterestAmount': amount,
+            'baseVolume': amount, // deprecated
+            'openInterestValue': value,
+            'quoteVolume': value, // deprecated
             'timestamp': undefined,
             'datetime': undefined,
             'info': interest,

--- a/js/aax.js
+++ b/js/aax.js
@@ -3146,6 +3146,9 @@ module.exports = class aax extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (!market['contract']) {
+            throw new BadRequest (this.id + ' fetchOpenInterest() supports contract markets only');
+        }
         const request = {
             'symbol': market['id'],
         };


### PR DESCRIPTION
Added a new unified method `fetchOpenInterest` to aax:
```
node examples/js/cli aax fetchOpenInterest BTC/USDT:USDT
```
```
aax.fetchOpenInterest (BTC/USDT:USDT)
2022-09-29T21:36:50.505Z iteration 0 passed in 1026 ms

{
  symbol: 'BTC/USDT:USDT',
  openInterestAmount: 36792773.23495,
  openInterestValue: 714244027.6874783,
  timestamp: 1664487411122,
  datetime: '2022-09-29T21:36:51.122Z',
  info: {
    openInterest: '36792773.23495',
    openInterestUSD: '714244027.687478264033',
    symbol: 'BTCUSDTFP'
  }
}
2022-09-29T21:36:50.505Z iteration 1 passed in 1026 ms
```