### PR TITLE
FTX: fetchOpenInterest

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -3207,6 +3207,9 @@ module.exports = class ftx extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (!market['contract']) {
+            throw new BadRequest (this.id + ' fetchOpenInterest() supports contract markets only');
+        }
         const request = {
             'future_name': market['id'],
         };

--- a/js/ftx.js
+++ b/js/ftx.js
@@ -3239,10 +3239,13 @@ module.exports = class ftx extends Exchange {
         //     }
         //
         market = this.safeMarket (undefined, market);
+        const openInterest = this.safeNumber (interest, 'openInterest');
         return {
             'symbol': market['symbol'],
-            'openInterestAmount': this.safeNumber (interest, 'openInterest'),
+            'openInterestAmount': openInterest,
             'openInterestValue': undefined,
+            'baseVolume': openInterest, // deprecated
+            'quoteVolume': undefined, // deprecated
             'timestamp': undefined,
             'datetime': undefined,
             'info': interest,


### PR DESCRIPTION
Added fetchOpenInterest to FTX:

```
node examples/js/cli ftx fetchOpenInterest BTC/USD:USD
```
```
ftx.fetchOpenInterest (BTC/USD:USD)
2022-09-30T22:01:42.436Z iteration 0 passed in 90 ms

{
  symbol: 'BTC/USD:USD',
  openInterestAmount: 64768.3668,
  openInterestValue: undefined,
  timestamp: undefined,
  datetime: undefined,
  info: {
    volume: '208126.4559',
    nextFundingRate: '-6e-6',
    nextFundingTime: '2022-09-30T23:00:00+00:00',
    openInterest: '64768.3668'
  }
}
2022-09-30T22:01:42.436Z iteration 1 passed in 90 ms
```