### PR TITLE
gate - watchOrderBook - reset subscription on error

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -154,6 +154,7 @@ module.exports = class gate extends gateRest {
                     }
                 } else {
                     // throw upon failing to synchronize in maxAttempts
+                    client.subscriptions[messageHash] = undefined;
                     throw new InvalidNonce (this.id + ' failed to synchronize WebSocket feed with the snapshot for symbol ' + symbol + ' in ' + maxAttempts.toString () + ' attempts');
                 }
             } else {


### PR DESCRIPTION
Reset `watchOrderBook` subscription if failed to fetchSnapshot.

- Addresses https://github.com/ccxt/ccxt/issues/15083

Note: was unable to find a case to test