### PR TITLE
Bybit :: watchTicker :: fix timestamp

### DIFF
--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -422,9 +422,9 @@ module.exports = class bybit extends bybitRest {
             timestamp = this.parse8601 (this.safeString2 (ticker, 'updated_at', 'updatedAt'));
             if (timestamp === undefined) {
                 const timestampE9 = this.safeString (ticker, 'updated_at_e9');
-                timestamp = Precise.stringDiv (timestampE9, '10000000');
+                timestamp = Precise.stringDiv (timestampE9, '1000000');
                 timestamp = this.parseNumber (timestamp);
-                timestamp = (timestamp !== undefined) ? this.parseInt (timestamp) : undefined;
+                timestamp = (timestamp !== undefined) ? parseInt (timestamp) : undefined;
             }
         }
         const marketId = this.safeString2 (ticker, 'symbol', 's');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15201

Demo

```
Python v3.10.6
CCXT v1.95.12
bybit.watchTicker(ETHUSDH23)
{'ask': 1351.25,
 'askVolume': None,
 'average': 1343.25,
 'baseVolume': 14569882.0,
 'bid': 1350.8,
 'bidVolume': None,
 'change': 13.5,
 'close': 1350.0,
 'datetime': '2022-10-06T10:59:08.156Z',
 'high': 1376.9,
 'info': {'ask1_price': '1351.25',
          'ask1_price_e4': 13512500,
          'basis_in_year_e8': -1133906,
          'bid1_price': '1350.80',
          'bid1_price_e4': 13508000,
          'coin': 'ETH',
          'contract_status': 'Trading',
          'contract_type': 'InverseFutures',
          'created_at_e9': 1663315207126761132,
          'cross_seq': 12101102055,
          'expect_price': '0.00',
          'expect_price_e4': 0,
          'fair_basis_e8': -846000000,
          'fair_basis_rate_e8': -548783,
          'high_price_24h': '1376.90',
          'high_price_24h_e4': 13769000,
          'id': 16,
          'import_time_e9': 0,
          'index_price': '1358.46',
          'index_price_e4': 13584600,
          'is_up_borrowable': 0,
          'last_price': '1350.00',
          'last_price_e4': 13500000,
          'last_tick_direction': 'MinusTick',
          'low_price_24h': '1307.50',
          'low_price_24h_e4': 13075000,
          'mark_price': '1351.07',
          'mark_price_e4': 13510700,
          'mode': 'BothSide',
          'open_interest': 11364787,
          'open_value_e8': 0,
          'prev_price_1h': '1348.90',
          'prev_price_1h_e4': 13489000,
          'prev_price_24h': '1336.50',
          'prev_price_24h_e4': 13365000,
          'price_1h_pcnt_e6': 815,
          'price_24h_pcnt_e6': 10101,
          'quote_symbol': 'ETHUSD',
          'settle_fee_rate_e8': 50000,
          'settle_time_e9': 1680249600000000000,
          'start_trading_time_e9': 1663315200000000000,
          'symbol': 'ETHUSDH23',
          'symbol_name': 'ETHUSD0331',
          'symbol_year': 2023,
          'system_subsidy_e8': 0,
          'time_to_settle': 15195611,
          'total_turnover_e8': 25797242814317,
          'total_volume': 343059999,
          'turnover_24h_e8': 1084044769470,
          'updated_at_e9': 1665053948156100000,
          'volume_24h': 14569882},
 'last': 1350.0,
 'low': 1307.5,
 'open': 1336.5,
 'percentage': 0.010101,
 'previousClose': None,
 'quoteVolume': 10840.4476947,
 'symbol': 'ETH/USD:ETH-220331',
 'timestamp': 1665053948156,
 'vwap': 0.000744031262209261}
 ```