### PR TITLE
Bitmart: fetchBalance, add swap support

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1578,9 +1578,6 @@ module.exports = class bitmart extends Exchange {
          */
         await this.loadMarkets ();
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
-        if (marketType === 'future') {
-            throw new NotSupported (this.id + ' fetchBalance () does not accept future balances, only spot, swap and account balances are allowed');
-        }
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateGetSpotV1Wallet',
             'swap': 'privateGetContractPrivateAssetsDetail',

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -1562,7 +1562,7 @@ module.exports = class bitmart extends Exchange {
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
             account['free'] = this.safeString2 (balance, 'available', 'available_balance');
-            account['used'] = this.safeString2 (balance, 'frozen', 'freeze_balance');
+            account['used'] = this.safeString2 (balance, 'frozen', 'frozen_balance');
             result[code] = account;
         }
         return this.safeBalance (result);


### PR DESCRIPTION
Add swap support to fetchBalance:
```
bitmart.fetchBalance ()
2022-10-07T05:30:32.363Z iteration 0 passed in 801 ms

{
  info: {
    code: '1000',
    message: 'Ok',
    data: [
      {
        currency: 'USDT',
        available_balance: '0',
        frozen_balance: '0',
        unrealized: '0',
        equity: '0',
        position_deposit: '0'
      },
      {
        currency: 'BTC',
        available_balance: '0',
        frozen_balance: '0',
        unrealized: '0',
        equity: '0',
        position_deposit: '0'
      },
      {
        currency: 'ETH',
        available_balance: '0',
        frozen_balance: '0',
        unrealized: '0',
        equity: '0',
        position_deposit: '0'
      }
    ],
    trace: 'eaabda4f-9c9b-467d-9b41-d226aae9fb3a'
  },
  USDT: { free: 0, used: undefined, total: undefined },
  BTC: { free: 0, used: undefined, total: undefined },
  ETH: { free: 0, used: undefined, total: undefined },
  free: { USDT: 0, BTC: 0, ETH: 0 },
  used: { USDT: undefined, BTC: undefined, ETH: undefined },
  total: { USDT: undefined, BTC: undefined, ETH: undefined }
}
2022-10-07T05:30:32.363Z iteration 1 passed in 801 ms
```