### PR TITLE
Bitget :: add missing endpoint

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -199,6 +199,7 @@ module.exports = class bitget extends Exchange {
                             'trade/profitDateList': 2,
                             'trace/waitProfitDateList': 2,
                             'trace/traderSymbols': 2,
+                            'order/marginCoinCurrent': 2,
                         },
                         'post': {
                             'account/setLeverage': 8,


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15216

Demo

```
 p bitget privateMixGetOrderMarginCoinCurrent '{"productType":"umcbl"}'
Python v3.9.7
CCXT v1.95.19
bitget.privateMixGetOrderMarginCoinCurrent({'productType': 'umcbl'})
{'code': '00000',
 'data': [{'cTime': '1663418419093',
           'clientOid': 'CCXT#9beda3d93adad63dd9c8d',
           'fee': '0E-8',
           'filledAmount': '0.0000',
           'filledQty': '0.0',
           'leverage': '3',
           'marginCoin': 'USDT',
           'marginMode': 'crossed',
           'orderId': '955011556817145857',
           'orderType': 'limit',
           'posSide': 'long',
           'price': '25.00',
           'side': 'open_long',
           'size': '0.2',
           'state': 'new',
           'symbol': 'LTCUSDT_UMCBL',
           'timeInForce': 'normal',
           'totalProfits': '0E-8',
           'uTime': '1663418419093'}],
 'msg': 'success',
 'requestTime': '1665157112129'}
 ```
