### PR TITLE
exchange.stringToJson implementation

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -555,6 +555,21 @@ module.exports = class Exchange {
         }
     }
 
+    stringToJson (jsonString) {
+        /**
+         * @ignore
+         * @method
+         * @description converts a json object as a string type to a json object
+         * @param {string} jsonString string version of json object
+         * @returns {object} object version of json string
+         */
+         if (typeof jsonString === 'string' || jsonString instanceof String) {
+             return JSON.parse (jsonString);
+         } else {
+            return jsonString;
+         }
+    }
+
     getResponseHeaders (response) {
         const result = {}
         response.headers.forEach ((value, key) => {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -106,6 +106,7 @@ class Exchange {
         'bw',
         'bybit',
         'bytetrade',
+        'bytex',
         'cex',
         'coinbase',
         'coinbaseprime',
@@ -272,6 +273,7 @@ class Exchange {
         'defineRestApiEndpoint' => 'define_rest_api_endpoint',
         'defineRestApi' => 'define_rest_api',
         'parseJson' => 'parse_json',
+        'stringToJson' => 'string_to_json',
         'getResponseHeaders' => 'get_response_headers',
         'handleRestResponse' => 'handle_rest_response',
         'onRestResponse' => 'on_rest_response',
@@ -1602,6 +1604,21 @@ class Exchange {
 
     public function parse_json($json_string, $as_associative_array = true) {
         return json_decode($this->on_json_response($json_string), $as_associative_array);
+    }
+
+    public function string_to_json($json_string) {
+        /**
+         * @ignore
+         * @method
+         * converts a json object as a string type to a json object
+         * @param {string} $json_string string version of json object
+         * @return array object version of json string
+         */
+        if (is_string($json_string)) {
+            return json_decode($json_string, TRUE);
+        } else {
+            return $json_string;
+        };
     }
 
     public function log() {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -674,6 +674,17 @@ class Exchange(object):
         except ValueError:  # superclass of JsonDecodeError (python2)
             pass
 
+    def string_to_json(self, json_string):
+        """
+        Converts a json object as a string type to a json object
+        :param string json_string: string version of json object
+        :returns object: object version of json string
+        """
+        if isinstance(json_string, str):
+            return json.loads(json_string)
+        else:
+            return json_string
+
     def is_text_response(self, headers):
         # https://github.com/ccxt/ccxt/issues/5302
         content_type = headers.get('Content-Type', '')


### PR DESCRIPTION
```
const ccxt = require ('/Users/sam/Documents/dev/CCXT/ccxt');
const keys = require ('./keys.local.json');

console.log ('CCXT Version:', ccxt.version);

const binance = new ccxt.binance (keys.binance);
const test_string = '{"test": true, "test_2": "a_string", "test_3": 3}';
const test_json = {"test": true, "test_2": "a_string", "test_3": 3};

async function main () {
    const response1 = binance.stringToJson (test_string);
    const response2 = binance.stringToJson (test_json);
    console.log (response1);
    console.log (response2);
};

main ();

>>> % node string_to_json_test.js
>>> CCXT Version: 1.95.16
>>> { test: true, test_2: 'a_string', test_3: 3 }
>>> { test: true, test_2: 'a_string', test_3: 3 }
```

```
import json
import ccxt  # noqa: E402

keys = json.load(open('../keys.local.json'))

binance = ccxt.binance(keys['binance'])
test_string = '{"test": true, "test_2": "a_string", "test_3": 3}'
test_json = {"test": True, "test_2": "a_string", "test_3": 3}


def main():
    response1 = binance.string_to_json(test_string)
    response2 = binance.string_to_json(test_json)
    print(response1)
    print(response2)


main()

>>> % python3 string_to_json_test.py
>>> {'test': True, 'test_2': 'a_string', 'test_3': 3}
>>> {'test': True, 'test_2': 'a_string', 'test_3': 3}
```

----------------------

PHP works when used on an actual exchange, I wrote a php test file but was having trouble running it

```
<?php
$root = dirname(dirname(dirname(__FILE__)));

include $root . '/ccxt.php';

$binance = new \ccxt\binance ();
$test_string = '{"test": true, "test_2": "a_string", "test_3": 3}';
$test_array = array(
    'test' => True,
    'test_2' => 'a_string',
    'test_3'=> 3
);

$response1 = $binance->string_to_json ($test_string);
$response2 = $binance->string_to_json ($test_array);
print($response1);
print($response2);

?>
```