### PR TITLE
Bybit :: fix tp sl orders

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2986,8 +2986,6 @@ module.exports = class bybit extends Exchange {
         const isStopLossOrder = stopLossPrice !== undefined;
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
         const isTakeProfitOrder = takeProfitPrice !== undefined;
-        const isSlTpOrder = isStopLossOrder || isTakeProfitOrder;
-        const isStopOrder = isSlTpOrder || isTriggerOrder;
         if (isTriggerOrder) {
             request['trigger_by'] = 'LastPrice';
             const preciseStopPrice = this.priceToPrecision (symbol, triggerPrice);
@@ -3013,12 +3011,12 @@ module.exports = class bybit extends Exchange {
         params = this.omit (params, [ 'stop_px', 'stopPrice', 'base_price', 'basePrice', 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'postOnly', 'reduceOnly', 'clientOrderId' ]);
         let method = undefined;
         if (market['future']) {
-            method = isStopOrder ? 'privatePostFuturesPrivateStopOrderCreate' : 'privatePostFuturesPrivateOrderCreate';
+            method = isTriggerOrder ? 'privatePostFuturesPrivateStopOrderCreate' : 'privatePostFuturesPrivateOrderCreate';
         } else if (market['linear']) {
-            method = isStopOrder ? 'privatePostPrivateLinearStopOrderCreate' : 'privatePostPrivateLinearOrderCreate';
+            method = isTriggerOrder ? 'privatePostPrivateLinearStopOrderCreate' : 'privatePostPrivateLinearOrderCreate';
         } else {
             // inverse swaps
-            method = isStopOrder ? 'privatePostV2PrivateStopOrderCreate' : 'privatePostV2PrivateOrderCreate';
+            method = isTriggerOrder ? 'privatePostV2PrivateStopOrderCreate' : 'privatePostV2PrivateOrderCreate';
         }
         const response = await this[method] (this.extend (request, params));
         //


### PR DESCRIPTION
- tp/sl order might not be a conditional/trigger order

```
Python v3.9.7
CCXT v1.95.29
bybit.createOrder(ETH/USDT:USDT,limit,buy,0.1,1200,{'takeProfitPrice': '1380', 'stopLossPrice': '1109'})
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': 0.0,
 'datetime': '2022-10-09T20:36:23.000Z',
 'fee': {'cost': 0.0, 'currency': 'USDT'},
 'fees': [{'cost': 0.0, 'currency': 'USDT'}],
 'filled': 0.0,
 'id': '95477d87-b6b5-4070-a195-6c662c7a4dcf',
 'info': {'close_on_trigger': False,
          'created_time': '2022-10-09T20:36:23Z',
          'cum_exec_fee': '0',
          'cum_exec_qty': '0',
          'cum_exec_value': '0',
          'last_exec_price': '0',
          'order_id': '95477d87-b6b5-4070-a195-6c662c7a4dcf',
          'order_link_id': '',
          'order_status': 'Created',
          'order_type': 'Limit',
          'position_idx': '1',
          'price': '1200',
          'qty': '0.1',
          'reduce_only': False,
          'side': 'Buy',
          'sl_trigger_by': 'LastPrice',
          'stop_loss': '1109',
          'symbol': 'ETHUSDT',
          'take_profit': '1380',
          'time_in_force': 'GoodTillCancel',
          'tp_trigger_by': 'LastPrice',
          'updated_time': '2022-10-09T20:36:23Z',
          'user_id': '551166'},
 'lastTradeTimestamp': 1665347783000,
 'postOnly': False,
 'price': 1200.0,
 'remaining': 0.1,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'ETH/USDT:USDT',
 'timeInForce': 'GTC',
 'timestamp': 1665347783000,
 'trades': [],
 'type': 'limit'}
 ```

