### PR TITLE
Add gateio sub accounts

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -466,10 +466,13 @@ module.exports = class Exchange {
         const splitPath = path.split (/[^a-zA-Z0-9]/)
         const camelcaseSuffix  = splitPath.map (this.capitalize).join ('')
         const underscoreSuffix = splitPath.map ((x) => x.trim ().toLowerCase ()).filter ((x) => x.length > 0).join ('_')
-        const camelcasePrefix = [ paths[0] ].concat (paths.slice (1).map (this.capitalize)).join ('')
+        const camelcasePrefix = [ paths[0] ].concat (paths.slice (1).map ((x) => this.capitalize (x.split (/[^a-zA-Z0-9]/).map (this.capitalize).join ('')))).join ('')
         const underscorePrefix = [ paths[0] ].concat (paths.slice (1).map ((x) => x.trim ()).filter ((x) => x.length > 0)).join ('_')
         const camelcase  = camelcasePrefix + camelcaseMethod + this.capitalize (camelcaseSuffix)
-        const underscore = underscorePrefix + '_' + lowercaseMethod + '_' + underscoreSuffix
+        let underscore = underscorePrefix + '_' + lowercaseMethod
+        if (underscoreSuffix.length > 0) {
+            underscore += '_' + underscoreSuffix
+        }
         const typeArgument = (paths.length > 1) ? paths : paths[0]
         // handle call costs here
         const partial = async (params = {}, context = {}) => this[methodName] (path, typeArgument, uppercaseMethod, params, undefined, undefined, config, context)

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -466,13 +466,10 @@ module.exports = class Exchange {
         const splitPath = path.split (/[^a-zA-Z0-9]/)
         const camelcaseSuffix  = splitPath.map (this.capitalize).join ('')
         const underscoreSuffix = splitPath.map ((x) => x.trim ().toLowerCase ()).filter ((x) => x.length > 0).join ('_')
-        const camelcasePrefix = [ paths[0] ].concat (paths.slice (1).map ((x) => this.capitalize (x.split (/[^a-zA-Z0-9]/).map (this.capitalize).join ('')))).join ('')
+        const camelcasePrefix = [ paths[0] ].concat (paths.slice (1).map (this.capitalize)).join ('')
         const underscorePrefix = [ paths[0] ].concat (paths.slice (1).map ((x) => x.trim ()).filter ((x) => x.length > 0)).join ('_')
         const camelcase  = camelcasePrefix + camelcaseMethod + this.capitalize (camelcaseSuffix)
-        let underscore = underscorePrefix + '_' + lowercaseMethod
-        if (underscoreSuffix.length > 0) {
-            underscore += '_' + underscoreSuffix
-        }
+        const underscore = underscorePrefix + '_' + lowercaseMethod + '_' + underscoreSuffix
         const typeArgument = (paths.length > 1) ? paths : paths[0]
         // handle call costs here
         const partial = async (params = {}, context = {}) => this[methodName] (path, typeArgument, uppercaseMethod, params, undefined, undefined, config, context)

--- a/js/gate.js
+++ b/js/gate.js
@@ -2845,7 +2845,7 @@ module.exports = class gate extends Exchange {
             request['chain'] = network;
             params = this.omit (params, 'network');
         }
-        const response = await this.privateWithdrawalsWithdrawalsPost (this.extend (request, params));
+        const response = await this.privateWithdrawalsPostWithdrawals (this.extend (request, params));
         //
         //    {
         //        "id": "w13389675",

--- a/js/gate.js
+++ b/js/gate.js
@@ -39,7 +39,7 @@ module.exports = class gate extends Exchange {
                         'delivery': 'https://api.gateio.ws/api/v4',
                         'spot': 'https://api.gateio.ws/api/v4',
                         'options': 'https://api.gateio.ws/api/v4',
-                        'sub_accounts': 'https://api.gateio.ws/api/v4',
+                        'subAccounts': 'https://api.gateio.ws/api/v4',
                     },
                 },
                 'test': {
@@ -190,10 +190,10 @@ module.exports = class gate extends Exchange {
                 'private': {
                     'withdrawals': {
                         'post': {
-                            '': 3000, // 3000 = 10 seconds
+                            'withdrawals': 3000, // 3000 = 10 seconds
                         },
                         'delete': {
-                            '{withdrawal_id}': 300,
+                            'withdrawals/{withdrawal_id}': 300,
                         },
                     },
                     'wallet': {
@@ -212,24 +212,24 @@ module.exports = class gate extends Exchange {
                             'sub_account_transfers': 300,
                         },
                     },
-                    'sub_accounts': {
+                    'subAccounts': {
                         'get': {
-                            '': 1,
-                            '{user_id}': 1,
-                            '{user_id}/keys': 1,
-                            '{user_id}/keys/{key}': 1,
+                            'sub_accounts': 1,
+                            'sub_accounts/{user_id}': 1,
+                            'sub_accounts/{user_id}/keys': 1,
+                            'sub_accounts/{user_id}/keys/{key}': 1,
                         },
                         'post': {
-                            '': 1,
-                            '{user_id}/keys': 1,
-                            '{user_id}/lock': 1,
-                            '{user_id}/unlock': 1,
+                            'sub_accounts': 1,
+                            'sub_accounts/{user_id}/keys': 1,
+                            'sub_accounts/{user_id}/lock': 1,
+                            'sub_accounts/{user_id}/unlock': 1,
                         },
                         'put': {
-                            '{user_id}/keys/{key}': 1,
+                            'sub_accounts/{user_id}/keys/{key}': 1,
                         },
                         'delete': {
-                            '{user_id}/keys/{key}': 1,
+                            'sub_accounts/{user_id}/keys/{key}': 1,
                         },
                     },
                     'spot': {
@@ -2845,7 +2845,7 @@ module.exports = class gate extends Exchange {
             request['chain'] = network;
             params = this.omit (params, 'network');
         }
-        const response = await this.privateWithdrawalsPost (this.extend (request, params));
+        const response = await this.privateWithdrawalsWithdrawalsPost (this.extend (request, params));
         //
         //    {
         //        "id": "w13389675",

--- a/js/gate.js
+++ b/js/gate.js
@@ -29,6 +29,7 @@ module.exports = class gate extends Exchange {
                         'delivery': 'https://api.gateio.ws/api/v4',
                         'spot': 'https://api.gateio.ws/api/v4',
                         'options': 'https://api.gateio.ws/api/v4',
+                        'sub_accounts': 'https://api.gateio.ws/api/v4',
                     },
                     'private': {
                         'withdrawals': 'https://api.gateio.ws/api/v4',
@@ -38,6 +39,7 @@ module.exports = class gate extends Exchange {
                         'delivery': 'https://api.gateio.ws/api/v4',
                         'spot': 'https://api.gateio.ws/api/v4',
                         'options': 'https://api.gateio.ws/api/v4',
+                        'sub_accounts': 'https://api.gateio.ws/api/v4',
                     },
                 },
                 'test': {
@@ -208,6 +210,26 @@ module.exports = class gate extends Exchange {
                         'post': {
                             'transfers': 300,
                             'sub_account_transfers': 300,
+                        },
+                    },
+                    'sub_accounts': {
+                        'get': {
+                            '': 1,
+                            '{user_id}': 1,
+                            '{user_id}/keys': 1,
+                            '{user_id}/keys/{key}': 1,
+                        },
+                        'post': {
+                            '': 1,
+                            '{user_id}/keys': 1,
+                            '{user_id}/lock': 1,
+                            '{user_id}/unlock': 1,
+                        },
+                        'put': {
+                            '{user_id}/keys/{key}': 1,
+                        },
+                        'delete': {
+                            '{user_id}/keys/{key}': 1,
                         },
                     },
                     'spot': {


### PR DESCRIPTION
Add gateio sub accounts:
https://www.gate.io/docs/developers/apiv4/en/#subaccount

In this PR, I also update `defineRestApiEndpoint`, support empty string and xxx_xxx key in apis object.
eg: `privateSubAccountsGet`, `private_sub_accounts_get`

```
'sub_accounts': {
  '': 1,
}
```