### PR TITLE
mexc networks updated to working values

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -257,10 +257,8 @@ module.exports = class mexc extends Exchange {
                 },
                 'defaultType': 'spot', // spot, swap
                 'networks': {
-                    'TRX': 'TRC-20',
-                    'TRC20': 'TRC-20',
-                    'ETH': 'ERC-20',
-                    'ERC20': 'ERC-20',
+                    'TRX': 'TRC20',
+                    'ETH': 'ERC20',
                     'BEP20': 'BEP20(BSC)',
                 },
                 'accountsByType': {
@@ -3079,7 +3077,7 @@ module.exports = class mexc extends Exchange {
          */
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         const networks = this.safeValue (this.options, 'networks', {});
-        let network = this.safeString2 (params, 'network', 'chain'); // this line allows the user to specify either ERC20 or ETH
+        let network = this.safeStringUpper2 (params, 'network', 'chain'); // this line allows the user to specify either ERC20 or ETH
         network = this.safeString (networks, network, network); // handle ETH > ERC-20 alias
         this.checkAddress (address);
         await this.loadMarkets ();


### PR DESCRIPTION
fixes: #15251

```
% mexc withdraw USDT 11 '"0xa4d50e44877cbf7fe983420967d27a783807a79f"' '{"network": "BEP20"}'
2022-10-12T01:35:32.374Z
Node.js: v18.4.0
CCXT v1.95.35
(node:7423) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
mexc.withdraw (USDT, 11, 0xa4d50e44877cbf7fe983420967d27a783807a79f, [object Object])
2022-10-12T01:35:34.921Z iteration 0 passed in 379 ms

{
  info: { withdrawId: 'fe2a535f5cf6427aa470690b5def4f12' },
  id: 'fe2a535f5cf6427aa470690b5def4f12'
}
2022-10-12T01:35:34.921Z iteration 1 passed in 379 ms
```

```
% mexc withdraw USDT 10 TEY6qjnKDyyq5jDc3DJizWLCdUySrpQ4yp '{"network": "trc20"}'
2022-10-12T01:48:47.684Z
Node.js: v18.4.0
CCXT v1.95.35
(node:7980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
mexc.withdraw (USDT, 10, TEY6qjnKDyyq5jDc3DJizWLCdUySrpQ4yp, [object Object])
2022-10-12T01:48:50.053Z iteration 0 passed in 374 ms

{
  info: { withdrawId: '8fea1067efd94e87bc0dba3baadbecfd' },
  id: '8fea1067efd94e87bc0dba3baadbecfd'
}
2022-10-12T01:48:50.053Z iteration 1 passed in 374 ms
```