### PR TITLE
huobi - min cost and amount

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1591,7 +1591,7 @@ module.exports = class huobi extends Exchange {
             const contractSize = this.safeNumber (market, 'contract_size');
             const maxAmount = this.safeNumber (market, 'max-order-amt');
             let minAmount = this.safeNumber (market, 'min-order-amt');
-            if (contract) {
+            if (contract && linear) {
                 minAmount = contractSize;
             }
             let pricePrecision = undefined;

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1589,6 +1589,11 @@ module.exports = class huobi extends Exchange {
                 }
             }
             const contractSize = this.safeNumber (market, 'contract_size');
+            const maxAmount = this.safeNumber (market, 'max-order-amt');
+            let minAmount = this.safeNumber (market, 'min-order-amt');
+            if (contract) {
+                minAmount = contractSize;
+            }
             let pricePrecision = undefined;
             let amountPrecision = undefined;
             let costPrecision = undefined;
@@ -1606,9 +1611,7 @@ module.exports = class huobi extends Exchange {
                 maker = (base === 'OMG') ? this.parseNumber ('0') : this.parseNumber ('0.002');
                 taker = (base === 'OMG') ? this.parseNumber ('0') : this.parseNumber ('0.002');
             }
-            const minAmount = this.safeNumber (market, 'min-order-amt');
-            const maxAmount = this.safeNumber (market, 'max-order-amt');
-            const minCost = this.safeNumber (market, 'min-order-value', 0);
+            const minCost = this.safeNumber (market, 'min-order-value');
             let active = undefined;
             if (spot) {
                 const state = this.safeString (market, 'state');

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1589,10 +1589,15 @@ module.exports = class huobi extends Exchange {
                 }
             }
             const contractSize = this.safeNumber (market, 'contract_size');
+            let minCost = this.safeNumber (market, 'min-order-value');
             const maxAmount = this.safeNumber (market, 'max-order-amt');
             let minAmount = this.safeNumber (market, 'min-order-amt');
-            if (contract && linear) {
-                minAmount = contractSize;
+            if (contract) {
+                if (linear) {
+                    minAmount = contractSize;
+                } else if (inverse) {
+                    minCost = contractSize;
+                }
             }
             let pricePrecision = undefined;
             let amountPrecision = undefined;
@@ -1611,7 +1616,6 @@ module.exports = class huobi extends Exchange {
                 maker = (base === 'OMG') ? this.parseNumber ('0') : this.parseNumber ('0.002');
                 taker = (base === 'OMG') ? this.parseNumber ('0') : this.parseNumber ('0.002');
             }
-            const minCost = this.safeNumber (market, 'min-order-value');
             let active = undefined;
             if (spot) {
                 const state = this.safeString (market, 'state');


### PR DESCRIPTION
It is bug that we had `0` for cost as default. that is not true, if you try any 
https://futures.huobi.com/en-us/linear_swap/exchange/#contract_code=BTC-USDT&contract_type=swap&type=isolated
or
https://futures.huobi.com/en-us/linear_swap/exchange/#contract_code=BTC-USDT&contract_type=this_week&type=cross

you will be required to make an order that has a cost of `amount` * limit-price (if making market order, then the price is approximately at bid/ask). so, let's say BTC/USDT:USDT-221014 , it has `0.001` as `contract size`, and if price is i.e. `19123`, then the order cost should be at least `19.123` usdt. therefore, the minimum amount seems to be the same value as `contract size`.


for inverse markets, like i.e.: BTC/USDT:BTC https://futures.huobi.com/en-us/swap/exchange/#symbol=BTC in API it says `contract size` is 100, and when you try to make an order in WEB UI, it says minimum btc amount is 0.0053, which is 100$ usd (at current price 19k), so that should go in `minimum cost`