### PR TITLE
Fix samples due to erroneous __version__ call

### DIFF
--- a/examples/ccxt.pro/py/binance-reload-markets.py
+++ b/examples/ccxt.pro/py/binance-reload-markets.py
@@ -2,7 +2,7 @@ import ccxt.pro
 from asyncio import run, gather
 
 
-print('CCXT Pro version', ccxt.pro.__version__)
+print('CCXT Pro version', ccxt.__version__)
 
 
 async def watch_order_book(exchange, symbol):

--- a/examples/ccxt.pro/py/binance-watch-ohlcv.py
+++ b/examples/ccxt.pro/py/binance-watch-ohlcv.py
@@ -1,7 +1,7 @@
 import ccxt.pro
 from asyncio import run
 
-print('CCXT Pro version', ccxt.pro.__version__)
+print('CCXT Pro version', ccxt.__version__)
 
 
 def table(values):

--- a/examples/ccxt.pro/py/bitvavo-watch-order-book.py
+++ b/examples/ccxt.pro/py/bitvavo-watch-order-book.py
@@ -2,7 +2,7 @@ import ccxt.pro
 from asyncio import run
 
 
-print('CCXT Pro version', ccxt.pro.__version__)
+print('CCXT Pro version', ccxt.__version__)
 
 
 async def main():

--- a/examples/ccxt.pro/py/coinbasepro-watch-all-trades.py
+++ b/examples/ccxt.pro/py/coinbasepro-watch-all-trades.py
@@ -6,7 +6,7 @@ from asyncio import run
 async def main():
     exchange = ccxt.pro.coinbasepro()
     method = 'watchTrades'
-    print('CCXT Pro version', ccxt.pro.__version__)
+    print('CCXT Pro version', ccxt.__version__)
     if exchange.has[method]:
         last_id = ''
         while True:

--- a/examples/ccxt.pro/py/coinbasepro-watch-trades.py
+++ b/examples/ccxt.pro/py/coinbasepro-watch-trades.py
@@ -6,7 +6,7 @@ from asyncio import run
 async def main():
     exchange = ccxt.pro.coinbasepro()
     method = 'watchTrades'
-    print('CCXT Pro version', ccxt.pro.__version__)
+    print('CCXT Pro version', ccxt.__version__)
     if exchange.has[method]:
         while True:
             try:

--- a/examples/ccxt.pro/py/okex-create-swap-order.py
+++ b/examples/ccxt.pro/py/okex-create-swap-order.py
@@ -4,7 +4,7 @@ from asyncio import run
 import ccxt.pro
 
 
-print('CCXT Pro Version: ', ccxt.pro.__version__)
+print('CCXT Pro Version: ', ccxt.__version__)
 
 exchange = ccxt.pro.okex({
     'apiKey': 'YOUR_API_KEY',


### PR DESCRIPTION
Fix samples due to erroneous __version__ call, which causes the samples to fail without reason

the python package does not have `ccxt.pro.__version__` - the proper attribute here is `ccxt.__version__`.