### PR TITLE
mexc3 withdrawal networks update

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -396,10 +396,8 @@ module.exports = class mexc3 extends Exchange {
                 },
                 'defaultType': 'spot', // spot, swap
                 'networks': {
-                    'TRX': 'TRC-20',
-                    'TRC20': 'TRC-20',
-                    'ETH': 'ERC-20',
-                    'ERC20': 'ERC-20',
+                    'TRX': 'TRC20',
+                    'ETH': 'ERC20',
                     'BEP20': 'BEP20(BSC)',
                     'BSC': 'BEP20(BSC)',
                 },
@@ -4253,7 +4251,7 @@ module.exports = class mexc3 extends Exchange {
          */
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         const networks = this.safeValue (this.options, 'networks', {});
-        let network = this.safeString2 (params, 'network', 'chain'); // this line allows the user to specify either ERC20 or ETH
+        let network = this.safeStringUpper2 (params, 'network', 'chain'); // this line allows the user to specify either ERC20 or ETH
         network = this.safeString (networks, network, network); // handle ETH > ERC-20 alias
         this.checkAddress (address);
         await this.loadMarkets ();


### PR DESCRIPTION
fixes: #15251

-------------------

```
% ccxt mexc3 withdraw USDT 3 TEY6qjnKDyyq5jDc3DJizWLCdUySrpQ4yp '{"network": "trx"}'
2022-10-12T22:58:57.486Z
Node.js: v18.4.0
CCXT v2.0.1
(node:4699) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
mexc3.withdraw (USDT, 3, TEY6qjnKDyyq5jDc3DJizWLCdUySrpQ4yp, [object Object])
2022-10-12T22:59:35.012Z iteration 0 passed in 264 ms

{
  info: { withdrawId: 'a62c7034306641809360fb6dccc7c22d' },
  id: 'a62c7034306641809360fb6dccc7c22d'
}
2022-10-12T22:59:35.012Z iteration 1 passed in 264 ms
```