### PR TITLE
Aax currencies

### DIFF
--- a/js/aax.js
+++ b/js/aax.js
@@ -599,30 +599,30 @@ module.exports = class aax extends Exchange {
         const response = await this.publicGetCurrencies (params);
         //
         //     {
-        //         "code":1,
-        //         "data":[
+        //         "code": 1,
+        //         "data": [
         //             {
-        //                 "chain":"BTC",
-        //                 "displayName":"Bitcoin",
-        //                 "withdrawFee":"0.0004",
-        //                 "withdrawMin":"0.001",
-        //                 "otcFee":"0",
-        //                 "enableOTC":true,
-        //                 "visible":true,
-        //                 "enableTransfer":true,
-        //                 "transferMin":"0.00001",
-        //                 "depositMin":"0.0005",
-        //                 "enableWithdraw":true,
-        //                 "enableDeposit":true,
-        //                 "addrWithMemo":false,
-        //                 "withdrawPrecision":"0.00000001",
-        //                 "currency":"BTC",
-        //                 "network":"BTC", // ETH, ERC20, TRX, TRC20, OMNI, LTC, XRP, XLM, ...
-        //                 "minConfirm":"2"
+        //                 "chain": "BTC",
+        //                 "displayName": "Bitcoin",
+        //                 "withdrawFee": "0.0004",
+        //                 "withdrawMin": "0.001",
+        //                 "otcFee": "0",
+        //                 "enableOTC": true,
+        //                 "visible": true,
+        //                 "enableTransfer": true,
+        //                 "transferMin": "0.00001",
+        //                 "depositMin": "0.0005",
+        //                 "enableWithdraw": true,
+        //                 "enableDeposit": true,
+        //                 "addrWithMemo": false,
+        //                 "withdrawPrecision": "0.00000001",
+        //                 "currency": "BTC",
+        //                 "network": "BTC", // ETH, ERC20, TRX, TRC20, OMNI, LTC, XRP, XLM, ...
+        //                 "minConfirm": "2"
         //             },
         //         ],
-        //         "message":"success",
-        //         "ts":1624330530697
+        //         "message": "success",
+        //         "ts": 1624330530697
         //     }
         //
         const result = {};

--- a/js/aax.js
+++ b/js/aax.js
@@ -643,13 +643,14 @@ module.exports = class aax extends Exchange {
                     resultItem['fees'][previousNetwork] = resultItem['fee'];
                     resultItem['fee'] = undefined;
                 }
-                resultItem['fees']['network'] = fee;
+                resultItem['fees'][network] = fee;
+                resultItem['networks'].push (network);
                 const previousPrecision = resultItem['precision'].toString ();
                 const previousDepositMin = resultItem['limits']['deposit']['min'].toString ();
                 const previousWithdrawMin = resultItem['limits']['withdraw']['min'].toString ();
                 resultItem['precision'] = Precise.stringMax (previousPrecision, precision);
-                resultItem['limits']['depositMin'] = Precise.stringMin (previousDepositMin, depositMin);
-                resultItem['limits']['withdrawMin'] = Precise.stringMin (previousWithdrawMin, withdrawMin);
+                resultItem['limits']['deposit']['min'] = Precise.stringMin (previousDepositMin, depositMin);
+                resultItem['limits']['withdraw']['min'] = Precise.stringMin (previousWithdrawMin, withdrawMin);
             } else {
                 const name = this.safeString (currency, 'displayName');
                 const enableWithdraw = this.safeValue (currency, 'enableWithdraw');


### PR DESCRIPTION
fixes: #15256

-----------

I kinda don't know what to do about `info` though, because it will only display info for the one network

------------

```
% aax fetchCurrencies
CCXT v1.95.37
(node:6148) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
aax.fetchCurrencies ()
2022-10-12T23:43:40.698Z iteration 0 passed in 1015 ms

{
  info: {
    chain: 'ERC20USDT',
    displayName: 'TetherUS',
    withdrawFee: '4',
    withdrawMax: '0',
    withdrawMin: '20',
    otcFee: '0',
    enableOTC: true,
    visible: true,
    enableTransfer: true,
    transferMin: '2',
    depositMin: '1',
    enableWithdraw: true,
    enableDeposit: true,
    isLighting: false,
    addrWithMemo: false,
    addrSupportFIO: true,
    withdrawPrecision: '0.000001',
    currency: 'USDT',
    network: 'ERC20',
    minConfirm: '12'
  },
  id: 'USDT',
  name: 'TetherUS',
  code: 'USDT',
  precision: '0.000001',
  active: true,
  deposit: true,
  withdraw: true,
  fee: undefined,
  fees: {
    ERC20: 4,
    TRC20: 1,
    BEP20: 1,
    SOLANA: 0.8,
    POLYGON: 1,
    ALGORAND: 1,
    Arbitrum: 2
  },
  networks: [
    'ERC20',    'TRC20',
    'BEP20',    'SOLANA',
    'POLYGON',  'ALGORAND',
    'Arbitrum'
  ],
  limits: {
    amount: { min: undefined, max: undefined },
    deposit: { min: '1', max: undefined },
    withdraw: { min: '2', max: undefined }
  }
}
2022-10-12T23:43:19.284Z iteration 1 passed in 1033 ms
```