### PR TITLE
Fix doc building error

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,6 @@
 m2r2==0.2.7
-mistune==2.0.3
+# mistune should remain on 0.8.4 for now
+# https://github.com/CrossNox/m2r2/issues/47
+mistune==0.8.4
 sphinx-rtd-theme==0.5.2
 readthedocs-sphinx-search==0.1.0


### PR DESCRIPTION
Revert #14538 - this causes an incompatibility between m2r2 and mistune.

Details can be found in [this issue](https://github.com/CrossNox/m2r2/issues/47) in m2r2.

I think this will close #15260 - at least it allows building the documentation locally with the same command.
if it's also working on rtd will have to be confirmed still.