### PR TITLE
bibox createOrderV4

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1144,6 +1144,7 @@ module.exports = class bibox extends Exchange {
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} params extra parameters specific to the bibox api endpoint
+         * @param {string} params.clientOrderId client order id
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
@@ -1158,85 +1159,35 @@ module.exports = class bibox extends Exchange {
             // 'time_in_force': // Valid value gtc, ioc
             // 'post_only':
         };
-        const clientOrderId = this.safeString2 (params, 'client_order_id', 'clientOrderId');
+        const clientOrderId = this.safeString (params, 'clientOrderId');
         if (clientOrderId !== undefined) {
             request['client_order_id'] = clientOrderId;
-            params = this.omit (params, [ 'client_order_id', 'clientOrderId' ]);
+            params = this.omit (params, 'clientOrderId');
         }
         const response = await this.v4PrivatePostUserdataOrder (this.deepExtend (request, params));
         //
         //     {
-        //         "i":14580623695947906,
-        //         "I":"0",
-        //         "m":"LUNC_USDT",
-        //         "T":"limit",
-        //         "s":"sell",
-        //         "Q":-1015236.00000,
-        //         "P":0.0002900000,
-        //         "t":"gtc",
-        //         "o":false,
-        //         "S":"accepted",
-        //         "E":0,
-        //         "e":0,
-        //         "C":1665670398046,
-        //         "U":1665670398046,
-        //         "V":582952205212,
-        //         "n":0,
-        //         "F":[],
-        //         "f":[]
+        //         "i": 14580623695947906,
+        //         "I": "0",
+        //         "m": "LUNC_USDT",
+        //         "T": "limit",
+        //         "s": "sell",
+        //         "Q": -1015236.00000,
+        //         "P": 0.0002900000,
+        //         "t": "gtc",
+        //         "o": false,
+        //         "S": "accepted",
+        //         "E": 0,
+        //         "e": 0,
+        //         "C": 1665670398046,
+        //         "U": 1665670398046,
+        //         "V": 582952205212,
+        //         "n": 0,
+        //         "F": [],
+        //         "f": []
         //     }
         //
         return this.parseOrder (response, market);
-    }
-
-    async createOrderV1 (symbol, type, side, amount, price = undefined, params = {}) {
-        /**
-         * @method
-         * @name bibox#createOrder
-         * @description create a trade order
-         * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit'
-         * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
-         * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
-         * @param {object} params extra parameters specific to the bibox api endpoint
-         * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-         */
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        const orderType = (type === 'limit') ? 2 : 1;
-        const orderSide = (side === 'buy') ? 1 : 2;
-        const request = {
-            'cmd': 'orderpending/trade',
-            'body': this.extend ({
-                'pair': market['id'],
-                'account_type': 0,
-                'order_type': orderType,
-                'order_side': orderSide,
-                'pay_bix': 0,
-                'amount': amount,
-                'price': price,
-            }, params),
-        };
-        const response = await this.v1PrivatePostOrderpending (request);
-        //
-        //     {
-        //         "result":[
-        //             {
-        //                 "result": "100055558128036", // order id
-        //                 "index": 12345, // random index, specific one in a batch
-        //                 "cmd":"orderpending/trade"
-        //             }
-        //         ]
-        //     }
-        //
-        const outerResults = this.safeValue (response, 'result');
-        const firstResult = this.safeValue (outerResults, 0, {});
-        const id = this.safeValue (firstResult, 'result');
-        return {
-            'info': response,
-            'id': id,
-        };
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {
@@ -1294,23 +1245,23 @@ module.exports = class bibox extends Exchange {
         //     {
         //         "result":[
         //             {
-        //                 "result":{
-        //                     "id":"100055558128036",
+        //                 "result": {
+        //                     "id": "100055558128036",
         //                     "createdAt": 1512756997000,
-        //                     "account_type":0,
-        //                     "coin_symbol":"LTC",        // Trading Token
-        //                     "currency_symbol":"BTC",    // Pricing Token
-        //                     "order_side":2,             // Trading side 1-Buy, 2-Sell
-        //                     "order_type":2,             // 2-limit order
-        //                     "price":"0.00900000",       // order price
-        //                     "amount":"1.00000000",      // order amount
-        //                     "money":"0.00900000",       // currency amount (price * amount)
-        //                     "deal_amount":"0.00000000", // deal amount
-        //                     "deal_percent":"0.00%",     // deal percentage
-        //                     "unexecuted":"0.00000000",  // unexecuted amount
-        //                     "status":3                  // Status, -1-fail, 0,1-to be dealt, 2-dealt partly, 3-dealt totally, 4- cancelled partly, 5-cancelled totally, 6-to be cancelled
+        //                     "account_type": 0,
+        //                     "coin_symbol": "LTC",        // Trading Token
+        //                     "currency_symbol": "BTC",    // Pricing Token
+        //                     "order_side": 2,             // Trading side 1-Buy, 2-Sell
+        //                     "order_type": 2,             // 2-limit order
+        //                     "price": "0.00900000",       // order price
+        //                     "amount": "1.00000000",      // order amount
+        //                     "money": "0.00900000",       // currency amount (price * amount)
+        //                     "deal_amount": "0.00000000", // deal amount
+        //                     "deal_percent": "0.00%",     // deal percentage
+        //                     "unexecuted": "0.00000000",  // unexecuted amount
+        //                     "status": 3                  // Status, -1-fail, 0,1-to be dealt, 2-dealt partly, 3-dealt totally, 4- cancelled partly, 5-cancelled totally, 6-to be cancelled
         //                 },
-        //                 "cmd":"orderpending/order"
+        //                 "cmd": "orderpending/order"
         //             }
         //         ]
         //     }
@@ -1353,8 +1304,8 @@ module.exports = class bibox extends Exchange {
         //             "f": {
         //                 "a": "USDT",  // The asset used for the transaction to pay the handling fee
         //                 "m": 0.09039465000  // The transaction fee
-        //                 }
-        //             }, {
+        //             }
+        //         }, {
         //             "i": 12,
         //             "t": 1643193746266,
         //             "p": 10043.85,
@@ -1374,20 +1325,20 @@ module.exports = class bibox extends Exchange {
         // fetchOrder V1, fetchOpenOrders V1, fetchClosedOrders V1
         //
         //     {
-        //         "id":"100055558128036",
+        //         "id": "100055558128036",
         //         "createdAt": 1512756997000,
-        //         "account_type":0,
-        //         "coin_symbol":"LTC",        // Trading Token
-        //         "currency_symbol":"BTC",    // Pricing Token
-        //         "order_side":2,             // Trading side 1-Buy, 2-Sell
-        //         "order_type":2,             // 2-limit order
-        //         "price":"0.00900000",       // order price
-        //         "amount":"1.00000000",      // order amount
-        //         "money":"0.00900000",       // currency amount (price * amount)
-        //         "deal_amount":"0.00000000", // deal amount
-        //         "deal_percent":"0.00%",     // deal percentage
-        //         "unexecuted":"0.00000000",  // unexecuted amount
-        //         "status":3                  // Status,-1-fail, 0,1-to be dealt, 2-dealt partly, 3-dealt totally, 4- cancelled partly, 5-cancelled totally, 6-to be cancelled
+        //         "account_type": 0,
+        //         "coin_symbol": "LTC",        // Trading Token
+        //         "currency_symbol": "BTC",    // Pricing Token
+        //         "order_side": 2,             // Trading side 1-Buy, 2-Sell
+        //         "order_type": 2,             // 2-limit order
+        //         "price": "0.00900000",       // order price
+        //         "amount": "1.00000000",      // order amount
+        //         "money": "0.00900000",       // currency amount (price * amount)
+        //         "deal_amount": "0.00000000", // deal amount
+        //         "deal_percent": "0.00%",     // deal percentage
+        //         "unexecuted": "0.00000000",  // unexecuted amount
+        //         "status": 3                  // Status,-1-fail, 0,1-to be dealt, 2-dealt partly, 3-dealt totally, 4- cancelled partly, 5-cancelled totally, 6-to be cancelled
         //     }
         //
         let marketId = this.safeString (order, 'm');

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1384,7 +1384,7 @@ module.exports = class bibox extends Exchange {
         }
         let fee = undefined;
         if (fees.length) {
-            fee = this.safeValue (fees, 0)
+            fee = this.safeValue (fees, 0);
         } else {
             const feeCost = this.safeString (order, 'fee');
             if (feeCost !== undefined) {

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1279,48 +1279,53 @@ module.exports = class bibox extends Exchange {
         //
         // createOrder V4
         //
-        //     {
-        //         "i": 4611688217450643477,  // The order id assigned by the exchange
-        //         "I": "",  // User specified order id
-        //         "m": "BTC_USDT",  // trading pair code
-        //         "T": "limit",  // order type
-        //         "s": "sell",  // order direction
-        //         "Q": -0.0100,  // order amount
-        //         "P": 10043.8500,  // order price
-        //         "t": "gtc",  // Time In Force
-        //         "o": false,  // Post Only
-        //         "S": "filled",  // order status
-        //         "E": -0.0100,  // transaction volume
-        //         "e": -100.43850000,  // transaction value
-        //         "C": 1643193746043,  // creation time
-        //         "U": 1643193746464,  // update time
-        //         "n": 2,  // Number of transactions
-        //         "F": [{
-        //             "i": 13,  // transaction id
-        //             "t": 1643193746464,  // Transaction time
-        //             "p": 10043.85,  // transaction price
-        //             "q": -0.009,  // transaction volume
-        //             "l": "maker",  // Maker / Taker transaction
-        //             "f": {
-        //                 "a": "USDT",  // The asset used for the transaction to pay the handling fee
-        //                 "m": 0.09039465000  // The transaction fee
-        //             }
-        //         }, {
-        //             "i": 12,
-        //             "t": 1643193746266,
-        //             "p": 10043.85,
-        //             "q": -0.001,
-        //             "l": "maker",
-        //             "f": {
-        //                 "a": "USDT",
-        //                 "m": 0.01004385000
-        //             }
-        //         }],
-        //         "f": [{
-        //             "a": "USDT",  // Assets used to pay fees
-        //             "m": 0.10043850000  // Total handling fee
-        //         }]
-        //     }
+        //    {
+        //        "i": 4611688217450643477,  // The order id assigned by the exchange
+        //        "I": "",  // User specified order id
+        //        "m": "BTC_USDT",  // trading pair code
+        //        "T": "limit",  // order type
+        //        "s": "sell",  // order direction
+        //        "Q": -0.0100,  // order amount
+        //        "P": 10043.8500,  // order price
+        //        "t": "gtc",  // Time In Force
+        //        "o": false,  // Post Only
+        //        "S": "filled",  // order status
+        //        "E": -0.0100,  // transaction volume
+        //        "e": -100.43850000,  // transaction value
+        //        "C": 1643193746043,  // creation time
+        //        "U": 1643193746464,  // update time
+        //        "n": 2,  // Number of transactions
+        //        "F": [
+        //            {
+        //                "i": 13,  // transaction id
+        //                "t": 1643193746464,  // Transaction time
+        //                "p": 10043.85,  // transaction price
+        //                "q": -0.009,  // transaction volume
+        //                "l": "maker",  // Maker / Taker transaction
+        //                "f": {
+        //                    "a": "USDT",  // The asset used for the transaction to pay the handling fee
+        //                    "m": 0.09039465000  // The transaction fee
+        //                }
+        //            },
+        //            {
+        //                "i": 12,
+        //                "t": 1643193746266,
+        //                "p": 10043.85,
+        //                "q": -0.001,
+        //                "l": "maker",
+        //                "f": {
+        //                    "a": "USDT",
+        //                    "m": 0.01004385000
+        //                }
+        //            }
+        //        ],
+        //        "f": [
+        //            {
+        //                "a": "USDT",  // Assets used to pay fees
+        //                "m": 0.10043850000  // Total handling fee
+        //            }
+        //        ]
+        //    }
         //
         // fetchOrder V1, fetchOpenOrders V1, fetchClosedOrders V1
         //

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1374,13 +1374,25 @@ module.exports = class bibox extends Exchange {
         const clientOrderId = this.safeString (order, 'I');
         const timeInForce = this.safeString (order, 't');
         const postOnly = this.safeValue (order, 'o');
-        const feeCost = this.safeString (order, 'fee');
+        const fees = [];
+        const orderFees = this.safeValue (order, 'f', []);
+        for (let i = 0; i < orderFees.length; i++) {
+            fees.push ({
+                'currency': this.safeCurrencyCode (this.safeString (orderFees[i], 'a')),
+                'cost': this.safeString (orderFees[i], 'm');
+            });
+        }
         let fee = undefined;
-        if (feeCost !== undefined) {
-            fee = {
-                'cost': feeCost,
-                'currency': undefined,
-            };
+        if (fees.length) {
+            fee = this.safeValue (fees, 0)
+        } else {
+            const feeCost = this.safeString (order, 'fee');
+            if (feeCost !== undefined) {
+                fee = {
+                    'cost': feeCost,
+                    'currency': undefined,
+                };
+            }
         }
         return this.safeOrder ({
             'info': order,
@@ -1403,6 +1415,7 @@ module.exports = class bibox extends Exchange {
             'remaining': undefined,
             'status': status,
             'fee': fee,
+            'fees': fees,
             'trades': undefined,
         }, market);
     }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1148,6 +1148,62 @@ module.exports = class bibox extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+            'side': side,
+            'type': type,
+            'quantity': this.amountToPrecision (symbol, amount),
+            'price': this.priceToPrecision (symbol, price),
+            // 'client_order_id': // Order id, a string with a valid value of an int64 integer
+            // 'time_in_force': // Valid value gtc, ioc
+            // 'post_only':
+        };
+        const clientOrderId = this.safeString2 (params, 'client_order_id', 'clientOrderId');
+        if (clientOrderId !== undefined) {
+            request['client_order_id'] = clientOrderId;
+            params = this.omit (params, [ 'client_order_id', 'clientOrderId' ]);
+        }
+        const response = await this.v4PrivatePostUserdataOrder (this.deepExtend (request, params));
+        //
+        //     {
+        //         "i":14580623695947906,
+        //         "I":"0",
+        //         "m":"LUNC_USDT",
+        //         "T":"limit",
+        //         "s":"sell",
+        //         "Q":-1015236.00000,
+        //         "P":0.0002900000,
+        //         "t":"gtc",
+        //         "o":false,
+        //         "S":"accepted",
+        //         "E":0,
+        //         "e":0,
+        //         "C":1665670398046,
+        //         "U":1665670398046,
+        //         "V":582952205212,
+        //         "n":0,
+        //         "F":[],
+        //         "f":[]
+        //     }
+        //
+        return this.parseOrder (response, market);
+    }
+
+    async createOrderV1 (symbol, type, side, amount, price = undefined, params = {}) {
+        /**
+         * @method
+         * @name bibox#createOrder
+         * @description create a trade order
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {object} params extra parameters specific to the bibox api endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
         const orderType = (type === 'limit') ? 2 : 1;
         const orderSide = (side === 'buy') ? 1 : 2;
         const request = {
@@ -1269,25 +1325,104 @@ module.exports = class bibox extends Exchange {
     }
 
     parseOrder (order, market = undefined) {
-        let marketId = undefined;
-        const baseId = this.safeString (order, 'coin_symbol');
-        const quoteId = this.safeString (order, 'currency_symbol');
-        if ((baseId !== undefined) && (quoteId !== undefined)) {
-            marketId = baseId + '_' + quoteId;
+        //
+        // createOrder V4
+        //
+        //     {
+        //         "i": 4611688217450643477,  // The order id assigned by the exchange
+        //         "I": "",  // User specified order id
+        //         "m": "BTC_USDT",  // trading pair code
+        //         "T": "limit",  // order type
+        //         "s": "sell",  // order direction
+        //         "Q": -0.0100,  // order amount
+        //         "P": 10043.8500,  // order price
+        //         "t": "gtc",  // Time In Force
+        //         "o": false,  // Post Only
+        //         "S": "filled",  // order status
+        //         "E": -0.0100,  // transaction volume
+        //         "e": -100.43850000,  // transaction value
+        //         "C": 1643193746043,  // creation time
+        //         "U": 1643193746464,  // update time
+        //         "n": 2,  // Number of transactions
+        //         "F": [{
+        //             "i": 13,  // transaction id
+        //             "t": 1643193746464,  // Transaction time
+        //             "p": 10043.85,  // transaction price
+        //             "q": -0.009,  // transaction volume
+        //             "l": "maker",  // Maker / Taker transaction
+        //             "f": {
+        //                 "a": "USDT",  // The asset used for the transaction to pay the handling fee
+        //                 "m": 0.09039465000  // The transaction fee
+        //                 }
+        //             }, {
+        //             "i": 12,
+        //             "t": 1643193746266,
+        //             "p": 10043.85,
+        //             "q": -0.001,
+        //             "l": "maker",
+        //             "f": {
+        //                 "a": "USDT",
+        //                 "m": 0.01004385000
+        //             }
+        //         }],
+        //         "f": [{
+        //             "a": "USDT",  // Assets used to pay fees
+        //             "m": 0.10043850000  // Total handling fee
+        //         }]
+        //     }
+        //
+        // fetchOrder V1, fetchOpenOrders V1, fetchClosedOrders V1
+        //
+        //     {
+        //         "id":"100055558128036",
+        //         "createdAt": 1512756997000,
+        //         "account_type":0,
+        //         "coin_symbol":"LTC",        // Trading Token
+        //         "currency_symbol":"BTC",    // Pricing Token
+        //         "order_side":2,             // Trading side 1-Buy, 2-Sell
+        //         "order_type":2,             // 2-limit order
+        //         "price":"0.00900000",       // order price
+        //         "amount":"1.00000000",      // order amount
+        //         "money":"0.00900000",       // currency amount (price * amount)
+        //         "deal_amount":"0.00000000", // deal amount
+        //         "deal_percent":"0.00%",     // deal percentage
+        //         "unexecuted":"0.00000000",  // unexecuted amount
+        //         "status":3                  // Status,-1-fail, 0,1-to be dealt, 2-dealt partly, 3-dealt totally, 4- cancelled partly, 5-cancelled totally, 6-to be cancelled
+        //     }
+        //
+        let marketId = this.safeString (order, 'm');
+        if (marketId === undefined) {
+            const baseId = this.safeString (order, 'coin_symbol');
+            const quoteId = this.safeString (order, 'currency_symbol');
+            if ((baseId !== undefined) && (quoteId !== undefined)) {
+                marketId = baseId + '_' + quoteId;
+            }
         }
         market = this.safeMarket (marketId, market);
-        const rawType = this.safeString (order, 'order_type');
-        const type = (rawType === '1') ? 'market' : 'limit';
-        const timestamp = this.safeInteger (order, 'createdAt');
-        const price = this.safeString (order, 'price');
+        let type = this.safeString2 (order, 'T', 'order_type');
+        if (type === '1') {
+            type = 'limit';
+        } else if (type === '2') {
+            type = 'market';
+        }
+        const timestamp = this.safeInteger2 (order, 'C', 'createdAt');
+        const price = this.safeString2 (order, 'P', 'price');
         const average = this.safeString (order, 'deal_price');
         const filled = this.safeString (order, 'deal_amount');
-        const amount = this.safeString (order, 'amount');
-        const cost = this.safeString2 (order, 'deal_money', 'money');
-        const rawSide = this.safeString (order, 'order_side');
-        const side = (rawSide === '1') ? 'buy' : 'sell';
-        const status = this.parseOrderStatus (this.safeString (order, 'status'));
-        const id = this.safeString (order, 'id');
+        let amount = this.safeString2 (order, 'Q', 'amount');
+        amount = Precise.stringAbs (amount);
+        const cost = this.safeString2 (order, 'money', 'deal_money');
+        let side = this.safeString2 (order, 's', 'order_side');
+        if (side === '1') {
+            side = 'buy';
+        } else if (side === '2') {
+            side = 'sell';
+        }
+        const status = this.parseOrderStatus (this.safeString (order, 'S', 'status'));
+        const id = this.safeString2 (order, 'i', 'id');
+        const clientOrderId = this.safeString (order, 'I');
+        const timeInForce = this.safeString (order, 't');
+        const postOnly = this.safeValue (order, 'o');
         const feeCost = this.safeString (order, 'fee');
         let fee = undefined;
         if (feeCost !== undefined) {
@@ -1299,14 +1434,14 @@ module.exports = class bibox extends Exchange {
         return this.safeOrder ({
             'info': order,
             'id': id,
-            'clientOrderId': undefined,
+            'clientOrderId': clientOrderId,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': undefined,
             'symbol': market['symbol'],
             'type': type,
-            'timeInForce': undefined,
-            'postOnly': undefined,
+            'timeInForce': timeInForce,
+            'postOnly': postOnly,
             'side': side,
             'price': price,
             'stopPrice': undefined,
@@ -1326,10 +1461,12 @@ module.exports = class bibox extends Exchange {
             // original comments from bibox:
             '1': 'open', // pending
             '2': 'open', // part completed
+            'accepted': 'open',
             '3': 'closed', // completed
             '4': 'canceled', // part canceled
             '5': 'canceled', // canceled
             '6': 'canceled', // canceling
+            'rejected': 'rejected',
         };
         return this.safeString (statuses, status, status);
     }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1379,7 +1379,7 @@ module.exports = class bibox extends Exchange {
         for (let i = 0; i < orderFees.length; i++) {
             fees.push ({
                 'currency': this.safeCurrencyCode (this.safeString (orderFees[i], 'a')),
-                'cost': this.safeString (orderFees[i], 'm');
+                'cost': this.safeString (orderFees[i], 'm'),
             });
         }
         let fee = undefined;


### PR DESCRIPTION
https://biboxcom.github.io/v3/spotv4/en/#create-an-order
it's not possible to create order with amount over 1000000 using v1 method 
`InvalidOrder bibox {"result":[{"error":{"code":"2131","msg":"下单数量不能大于"},"cmd":"orderpending/trade"}],"error":{"code":"2131","msg":"下单数量不能大于"},"cmd":"orderpending/trade"}`
but it all ok in v4 method

The similar error with precision - when I try to create order for example on `LUNC/USDT` and price `0.0002500001` it creates correctly but with price `0.00025`. It works correctly in v4 method