### PR TITLE
Upbit :: add orderbook symbol

### DIFF
--- a/js/pro/upbit.js
+++ b/js/pro/upbit.js
@@ -139,7 +139,8 @@ module.exports = class upbit extends upbitRest {
         const options = this.safeValue (this.options, 'watchOrderBook', {});
         const limit = this.safeInteger (options, 'limit', 15);
         if (type === 'SNAPSHOT') {
-            this.orderbooks[symbol] = this.orderBook ({}, limit);
+            const orderbook = this.orderBook ({}, limit);
+            this.orderbooks[symbol] = orderbook;
         }
         const orderBook = this.orderbooks[symbol];
         // upbit always returns a snapshot of 15 topmost entries
@@ -147,6 +148,7 @@ module.exports = class upbit extends upbitRest {
         // therefore we reset the orderbook on each update
         // and reinitialize it again with new bidasks
         orderBook.reset ({});
+        orderBook['symbol'] = symbol;
         const bids = orderBook['bids'];
         const asks = orderBook['asks'];
         const data = this.safeValue (message, 'orderbook_units', []);

--- a/js/pro/upbit.js
+++ b/js/pro/upbit.js
@@ -139,8 +139,7 @@ module.exports = class upbit extends upbitRest {
         const options = this.safeValue (this.options, 'watchOrderBook', {});
         const limit = this.safeInteger (options, 'limit', 15);
         if (type === 'SNAPSHOT') {
-            const orderbook = this.orderBook ({}, limit);
-            this.orderbooks[symbol] = orderbook;
+            this.orderbooks[symbol] = this.orderBook ({}, limit);
         }
         const orderBook = this.orderbooks[symbol];
         // upbit always returns a snapshot of 15 topmost entries


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15279

```
Python v3.9.7
CCXT v2.0.8
upbit.watchOrderBook(BTC/USDT)
{'asks': [[19144.89946597, 0.007065], [19164.967695, 0.00154258], [19169.98450222, 0.00917313], [19178.23053323, 4.4403], [19180.01871675, 0.025], [19180.3682628, 2.534e-05], [19185.035724, 0.05], [19185.36365853, 1.23e-06], [19201.036, 2.7e-07], [19212.7388, 0.3], [19212.739, 1.30122001], [19252.0, 0.00915293], [19308.60971197, 0.01730717], [19308.8028, 0.3], [19308.803, 0.72687581]],
 'bids': [[19045.0537095, 0.01750235], [19035.08789502, 0.3], [19035.08769502, 1.2473], [19035.087695, 0.03502304], [18973.481, 1.31762852], [18878.63207861, 0.02324718], [18878.6132, 0.7], [18878.613, 0.73604178], [18867.297, 3e-08], [18850.0, 3e-08], [18840.0, 3e-08], [18830.0, 3e-08], [18821.17923071, 3e-08], [18821.16040954, 0.11917834], [18691.0, 0.01820938]],
 'datetime': '2022-10-13T17:17:11.952Z',
 'nonce': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1665681431952}
```