### PR TITLE
kucoinfutures - min max sizes

### DIFF
--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -439,19 +439,16 @@ module.exports = class kucoinfutures extends kucoin {
             const inverse = this.safeValue (market, 'isInverse');
             const status = this.safeString (market, 'status');
             const multiplier = this.safeString (market, 'multiplier');
-            const contractSize = this.parseNumber (Precise.stringAbs (multiplier));
             const tickSize = this.safeNumber (market, 'tickSize');
             const lotSize = this.safeNumber (market, 'lotSize');
-            const maxQuantity = this.safeNumber (market, 'maxOrderQty');
             let limitAmountMin = lotSize;
             if (limitAmountMin === undefined) {
                 limitAmountMin = this.safeNumber (market, 'baseMinSize');
             }
-            let limitAmountMax = maxQuantity;
+            let limitAmountMax = this.safeNumber (market, 'maxOrderQty');
             if (limitAmountMax === undefined) {
                 limitAmountMax = this.safeNumber (market, 'baseMaxSize');
             }
-            let limitPriceMin = tickSize;
             let limitPriceMax = this.safeNumber (market, 'maxPrice');
             if (limitPriceMax === undefined) {
                 const baseMinSizeString = this.safeString (market, 'baseMinSize');
@@ -479,7 +476,7 @@ module.exports = class kucoinfutures extends kucoin {
                 'inverse': inverse,
                 'taker': this.safeNumber (market, 'takerFeeRate'),
                 'maker': this.safeNumber (market, 'makerFeeRate'),
-                'contractSize': contractSize,
+                'contractSize': this.parseNumber (Precise.stringAbs (multiplier)),
                 'expiry': expiry,
                 'expiryDatetime': this.iso8601 (expiry),
                 'strike': undefined,
@@ -498,7 +495,7 @@ module.exports = class kucoinfutures extends kucoin {
                         'max': limitAmountMax,
                     },
                     'price': {
-                        'min': limitPriceMin,
+                        'min': tickSize,
                         'max': limitPriceMax,
                     },
                     'cost': {

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -404,14 +404,7 @@ module.exports = class kucoinfutures extends kucoin {
         //            "lastTradePrice": 4545.4500000000,
         //            "nextFundingRateTime": 25481884,
         //            "maxLeverage": 100,
-        //            "sourceExchanges":  [
-        //                "huobi",
-        //                "Okex",
-        //                "Binance",
-        //                "Kucoin",
-        //                "Poloniex",
-        //                "Hitbtc"
-        //            ],
+        //            "sourceExchanges":  [ "huobi", "Okex", "Binance", "Kucoin", "Poloniex", "Hitbtc" ],
         //            "premiumsSymbol1M": ".ETHUSDTMPI",
         //            "premiumsSymbol8H": ".ETHUSDTMPI8H",
         //            "fundingBaseSymbol1M": ".ETHINT",
@@ -443,11 +436,28 @@ module.exports = class kucoinfutures extends kucoin {
                 symbol = symbol + '-' + this.yymmdd (expiry, '');
                 type = 'future';
             }
-            const baseMinSizeString = this.safeString (market, 'baseMinSize');
-            const quoteMaxSizeString = this.safeString (market, 'quoteMaxSize');
             const inverse = this.safeValue (market, 'isInverse');
             const status = this.safeString (market, 'status');
             const multiplier = this.safeString (market, 'multiplier');
+            const contractSize = this.parseNumber (Precise.stringAbs (multiplier));
+            const tickSize = this.safeNumber (market, 'tickSize');
+            const lotSize = this.safeNumber (market, 'lotSize');
+            const maxQuantity = this.safeNumber (market, 'maxOrderQty');
+            let limitAmountMin = lotSize;
+            if (limitAmountMin === undefined) {
+                limitAmountMin = this.safeNumber (market, 'baseMinSize');
+            }
+            let limitAmountMax = maxQuantity;
+            if (limitAmountMax === undefined) {
+                limitAmountMax = this.safeNumber (market, 'baseMaxSize');
+            }
+            let limitPriceMin = tickSize;
+            let limitPriceMax = this.safeNumber (market, 'maxPrice');
+            if (limitPriceMax === undefined) {
+                const baseMinSizeString = this.safeString (market, 'baseMinSize');
+                const quoteMaxSizeString = this.safeString (market, 'quoteMaxSize');
+                limitPriceMax = this.parseNumber (Precise.stringDiv (quoteMaxSizeString, baseMinSizeString));
+            }
             result.push ({
                 'id': id,
                 'symbol': symbol,
@@ -469,14 +479,14 @@ module.exports = class kucoinfutures extends kucoin {
                 'inverse': inverse,
                 'taker': this.safeNumber (market, 'takerFeeRate'),
                 'maker': this.safeNumber (market, 'makerFeeRate'),
-                'contractSize': this.parseNumber (Precise.stringAbs (multiplier)),
+                'contractSize': contractSize,
                 'expiry': expiry,
                 'expiryDatetime': this.iso8601 (expiry),
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.safeNumber (market, 'lotSize'),
-                    'price': this.safeNumber (market, 'tickSize'),
+                    'amount': lotSize,
+                    'price': tickSize,
                 },
                 'limits': {
                     'leverage': {
@@ -484,16 +494,16 @@ module.exports = class kucoinfutures extends kucoin {
                         'max': this.safeNumber (market, 'maxLeverage'),
                     },
                     'amount': {
-                        'min': this.parseNumber (baseMinSizeString),
-                        'max': this.safeNumber (market, 'baseMaxSize'),
+                        'min': limitAmountMin,
+                        'max': limitAmountMax,
                     },
                     'price': {
-                        'min': undefined,
-                        'max': this.parseNumber (Precise.stringDiv (quoteMaxSizeString, baseMinSizeString)),
+                        'min': limitPriceMin,
+                        'max': limitPriceMax,
                     },
                     'cost': {
                         'min': this.safeNumber (market, 'quoteMinSize'),
-                        'max': this.parseNumber (quoteMaxSizeString),
+                        'max': this.safeNumber (market, 'quoteMaxSize'),
                     },
                 },
                 'info': market,


### PR DESCRIPTION
i dont know from where the existing implementation comes, because in api response, there are no "baseMinSize" or alikes. However, as I have not worked on kucoinfutures before ( @samgermain might have more insights) I havent made a breaking change, and just havent removed those implementations, just i've made a real response fields superior, and if they are undefined ever , then those previous implementation's fields/values will be used.