### PR TITLE
bybit: update amount for spot market

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2600,7 +2600,7 @@ module.exports = class bybit extends Exchange {
         const type = this.safeStringLowerN (order, [ 'order_type', 'type', 'orderType' ]);
         const price = this.safeString2 (order, 'price', 'orderPrice');
         const average = this.safeString2 (order, 'average_price', 'avgPrice');
-        const amount = this.safeStringN (order, [ 'qty', 'origQty', 'orderQty' ]);
+        let amount = this.safeStringN (order, [ 'qty', 'origQty', 'orderQty' ]);
         const cost = this.safeString2 (order, 'cum_exec_value', 'cumExecValue');
         const filled = this.safeStringN (order, [ 'cum_exec_qty', 'executedQty', 'cumExecQty' ]);
         const remaining = this.safeString2 (order, 'leaves_qty', 'leavesQty');
@@ -2635,6 +2635,9 @@ module.exports = class bybit extends Exchange {
         const timeInForce = this.parseTimeInForce (this.safeString2 (order, 'time_in_force', 'timeInForce'));
         const stopPrice = this.safeStringN (order, [ 'trigger_price', 'stop_px', 'stopPrice', 'triggerPrice' ]);
         const postOnly = (timeInForce === 'PO');
+        if (market['spot'] && type === 'market' && side === 'buy' && filled !== '0') {
+            amount = filled;
+        }
         return this.safeOrder ({
             'info': order,
             'id': id,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2635,7 +2635,7 @@ module.exports = class bybit extends Exchange {
         const timeInForce = this.parseTimeInForce (this.safeString2 (order, 'time_in_force', 'timeInForce'));
         const stopPrice = this.safeStringN (order, [ 'trigger_price', 'stop_px', 'stopPrice', 'triggerPrice' ]);
         const postOnly = (timeInForce === 'PO');
-        if (market['spot'] && type === 'market' && side === 'buy' && filled !== '0') {
+        if ((market['spot'] && type === 'market') && (side === 'buy') && (filled !== '0')) {
             amount = filled;
         }
         return this.safeOrder ({

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2635,7 +2635,7 @@ module.exports = class bybit extends Exchange {
         const timeInForce = this.parseTimeInForce (this.safeString2 (order, 'time_in_force', 'timeInForce'));
         const stopPrice = this.safeStringN (order, [ 'trigger_price', 'stop_px', 'stopPrice', 'triggerPrice' ]);
         const postOnly = (timeInForce === 'PO');
-        if ((market['spot'] && type === 'market') && (side === 'buy') && (filled !== '0')) {
+        if ((market['spot'] && type === 'market') && (side === 'buy')) {
             amount = filled;
         }
         return this.safeOrder ({


### PR DESCRIPTION
The quantity return from bybit spot order api is based on quote currency. In this PR, I update amount for spot market (ccxt/ccxt#15208). https://bybit-exchange.github.io/docs/spot/v1/#t-placeactive

BTW, should I also set amount for createOrder to `filled`? This make amount to `undefined`.