### PR TITLE
Bybit :: fix orderbook timestamp

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2176,7 +2176,7 @@ module.exports = class bybit extends Exchange {
         const result = this.safeValue (response, 'result', []);
         let timestamp = this.safeTimestamp (response, 'time_now');
         if (timestamp === undefined) {
-            timestamp = this.safeInteger (response, 'time');
+            timestamp = this.safeInteger (result, 'time');
         }
         const bidsKey = market['spot'] ? 'bids' : 'Buy';
         const asksKey = market['spot'] ? 'asks' : 'Sell';


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15292

```
 p bybit fetchOrderBook "BTC/USDT" 1 --spot --sandbox
Python v3.9.7
CCXT v2.0.16
bybit.fetchOrderBook(BTC/USDT,1)
{'asks': [[19439.84, 0.997823]],
 'bids': [[19438.93, 1.463824]],
 'datetime': '2022-10-14T16:06:55.914Z',
 'nonce': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1665763615914}
 ```
 
