### PR TITLE
handleMarketTypeAndParams - do not mutate params

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2106,8 +2106,8 @@ module.exports = class Exchange {
         }
         const marketType = (market === undefined) ? methodType : market['type'];
         const type = this.safeString2 (params, 'defaultType', 'type', marketType);
-        params = this.omit (params, [ 'defaultType', 'type' ]);
-        return [ type, params ];
+        const query = this.omit (params, [ 'defaultType', 'type' ]);
+        return [ type, query ];
     }
 
     handleSubTypeAndParams (methodName, market = undefined, params = {}) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3749,8 +3749,8 @@ class Exchange {
         }
         $marketType = ($market === null) ? $methodType : $market['type'];
         $type = $this->safe_string_2($params, 'defaultType', 'type', $marketType);
-        $params = $this->omit ($params, array( 'defaultType', 'type' ));
-        return array( $type, $params );
+        $query = $this->omit ($params, array( 'defaultType', 'type' ));
+        return array( $type, $query );
     }
 
     public function handle_sub_type_and_params($methodName, $market = null, $params = array ()) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2852,8 +2852,8 @@ class Exchange(object):
                 methodType = self.safe_string_2(methodOptions, 'defaultType', 'type', methodType)
         marketType = methodType if (market is None) else market['type']
         type = self.safe_string_2(params, 'defaultType', 'type', marketType)
-        params = self.omit(params, ['defaultType', 'type'])
-        return [type, params]
+        query = self.omit(params, ['defaultType', 'type'])
+        return [type, query]
 
     def handle_sub_type_and_params(self, methodName, market=None, params={}):
         subType = None


### PR DESCRIPTION
Currently `handleMarketTypeAndParams()`  mutates params. In my opinion we should avoid this as it can lead to confusion and also certain code like this could fail. For example below:

```javascript
await this.loadMarkets (false, params);  // internally calls `this.handleMarketTypeAndParams()` and removes type and defaultType from params
let [type, query] = this.handleMarketTypeAndParams ('createOrder', undefined, params)` // developer might expect for any market type override to be in params but instead the type will be grabed from this.options so it won't know if it's overrided in the params 
```

I propose we should return the query as a copy of params with `defaultType` and `type` omited, but leave params unchanged just in case it is used in other parts of the code. There are also other functions like `handleSubTypeAndParams()` , `handleWithdrawTagAndParams()` and `handleMarginModeAndParams()` I would recommend to do the same.
At the same time I know a change like this where it's used a lot in a our code base has it's risks.

Thoughts?