### PR TITLE
getSupportedMapping - return keys in error

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2053,7 +2053,8 @@ module.exports = class Exchange {
         if (key in mapping) {
             return mapping[key];
         } else {
-            throw new NotSupported (this.id + ' ' + key + ' does not have a value in mapping');
+            const keys = Object.keys (mapping);
+            throw new NotSupported (this.id + ' ' + key + ' does not have a value in mapping. Key must be one of the values: ' + keys.join (', '));
         }
     }
 


### PR DESCRIPTION
Return keys in error when fails to `getSupportedMapping` to help users and developers debug