### PR TITLE
bitmart: fix empty transaction list

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2125,6 +2125,18 @@ module.exports = class bitmart extends Exchange {
             currency = this.currency (code);
             request['currency'] = currency['id'];
         }
+        if (code === 'USDT') {
+            const defaultNetworks = this.safeValue (this.options, 'defaultNetworks');
+            const defaultNetwork = this.safeStringUpper (defaultNetworks, code);
+            const networks = this.safeValue (this.options, 'networks', {});
+            let network = this.safeStringUpper (params, 'network', defaultNetwork); // this line allows the user to specify either ERC20 or ETH
+            network = this.safeString (networks, network, network); // handle ERC20>ETH alias
+            if (network !== undefined) {
+                request['currency'] += '-' + network; // when network the currency need to be changed to currency + '-' + network https://developer-pro.bitmart.com/en/account/withdraw_apply.html on the end of page
+                currency['code'] = request['currency']; // update currency code to filter
+                params = this.omit (params, 'network');
+            }
+        }
         const response = await this.privateGetAccountV2DepositWithdrawHistory (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
When check this issue: https://github.com/ccxt/ccxt/issues/15307, I found bitmart set currency to this format `code-network`  when call deposit/withdrawal history. In this PR, I added network id when call `fetchDeposits`/`fetchWithdrawals`.