### PR TITLE
binance: add new endpoints for giftcard

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -335,6 +335,7 @@ module.exports = class binance extends Exchange {
                         'pay/transactions': 20.001, // Weight(UID): 3000 => cost = 0.006667 * 3000 = 20.001
                         'giftcard/verify': 0.1,
                         'giftcard/cryptography/rsa-public-key': 0.1,
+                        'giftcard/buyCode/token-limit': 0.1,
                         'algo/futures/openOrders': 0.1,
                         'algo/futures/historicalOrders': 0.1,
                         'algo/futures/subOrders': 0.1,
@@ -421,6 +422,7 @@ module.exports = class binance extends Exchange {
                         //
                         'giftcard/createCode': 0.1,
                         'giftcard/redeemCode': 0.1,
+                        'giftcard/buyCode': 0.1,
                         'algo/futures/newOrderVp': 20.001,
                         'algo/futures/newOrderTwap': 20.001,
                         // staking


### PR DESCRIPTION
binance add 2 endpoints for giftcard (https://binance-docs.github.io/apidocs/spot/en/#change-log)

POST /sapi/v1/giftcard/buyCode: For buying a fixed-value Binance Code.
GET /sapi/v1/giftcard/buyCode/token-limit: To verify which tokens are available for you to purchase fixed-value gift cards as mentioned in section 2 and its’ limitation.