### PR TITLE
mexc3 GAS -> GASDAO

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -420,6 +420,7 @@ module.exports = class mexc3 extends Exchange {
                 'FLUX1': 'FLUX', // switched places
                 'FLUX': 'FLUX1', // switched places
                 'FREE': 'FreeRossDAO', // conflict with FREE Coin
+                'GAS': 'GASDAO',
                 'GMT': 'GMT Token',
                 'HERO': 'Step Hero', // conflict with Metahero
                 'MIMO': 'Mimosa',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/gas-dao#markets conflict with https://www.coingecko.com/en/coins/gas#markets naming like on Gate.io