### PR TITLE
mexc GAS -> GASDAO

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -296,6 +296,7 @@ module.exports = class mexc extends Exchange {
                 'FLUX1': 'FLUX', // switched places
                 'FLUX': 'FLUX1', // switched places
                 'FREE': 'FreeRossDAO', // conflict with FREE Coin
+                'GAS': 'GASDAO',
                 'GMT': 'GMT Token',
                 'HERO': 'Step Hero', // conflict with Metahero
                 'MIMO': 'Mimosa',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/gas-dao#markets conflict with https://www.coingecko.com/en/coins/gas#markets naming like on Gate.io