### PR TITLE
Cache - new updates by symbol

### DIFF
--- a/js/pro/base/Cache.js
+++ b/js/pro/base/Cache.js
@@ -78,13 +78,15 @@ class ArrayCache extends BaseCache {
             this.shift ()
         }
         this.push (item)
+        if (this.clearAllUpdates) {
+            this.clearAllUpdates = false
+            this.clearUpdatesBySymbol = {}
+            this.allNewUpdates = 0
+            this.newUpdatesBySymbol = {}
+        }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
             this.newUpdatesBySymbol[item.symbol] = 0
-        }
-        if (this.clearAllUpdates) {
-            this.clearAllUpdates = false
-            this.allNewUpdates = 0
         }
         this.newUpdatesBySymbol[item.symbol] = (this.newUpdatesBySymbol[item.symbol] || 0) + 1
         this.allNewUpdates = (this.allNewUpdates || 0) + 1
@@ -183,16 +185,18 @@ class ArrayCacheBySymbolById extends ArrayCache {
             delete this.hashmap[deleteReference.symbol][deleteReference.id]
         }
         this.push (item)
+        if (this.clearAllUpdates) {
+            this.clearAllUpdates = false
+            this.clearUpdatesBySymbol = {}
+            this.allNewUpdates = 0
+            this.newUpdatesBySymbol = {}
+        }
         if (this.newUpdatesBySymbol[item.symbol] === undefined) {
             this.newUpdatesBySymbol[item.symbol] = new Set ()
         }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
             this.newUpdatesBySymbol[item.symbol].clear ()
-        }
-        if (this.clearAllUpdates) {
-            this.clearAllUpdates = false
-            this.allNewUpdates = 0
         }
         // in case an exchange updates the same order id twice
         const idSet = this.newUpdatesBySymbol[item.symbol]

--- a/js/pro/base/Cache.js
+++ b/js/pro/base/Cache.js
@@ -78,15 +78,13 @@ class ArrayCache extends BaseCache {
             this.shift ()
         }
         this.push (item)
-        if (this.clearAllUpdates) {
-            this.clearAllUpdates = false
-            this.clearUpdatesBySymbol = {}
-            this.allNewUpdates = 0
-            this.newUpdatesBySymbol = {}
-        }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
             this.newUpdatesBySymbol[item.symbol] = 0
+        }
+        if (this.clearAllUpdates) {
+            this.clearAllUpdates = false
+            this.allNewUpdates = 0
         }
         this.newUpdatesBySymbol[item.symbol] = (this.newUpdatesBySymbol[item.symbol] || 0) + 1
         this.allNewUpdates = (this.allNewUpdates || 0) + 1
@@ -185,18 +183,16 @@ class ArrayCacheBySymbolById extends ArrayCache {
             delete this.hashmap[deleteReference.symbol][deleteReference.id]
         }
         this.push (item)
-        if (this.clearAllUpdates) {
-            this.clearAllUpdates = false
-            this.clearUpdatesBySymbol = {}
-            this.allNewUpdates = 0
-            this.newUpdatesBySymbol = {}
-        }
         if (this.newUpdatesBySymbol[item.symbol] === undefined) {
             this.newUpdatesBySymbol[item.symbol] = new Set ()
         }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
             this.newUpdatesBySymbol[item.symbol].clear ()
+        }
+        if (this.clearAllUpdates) {
+            this.clearAllUpdates = false
+            this.allNewUpdates = 0
         }
         // in case an exchange updates the same order id twice
         const idSet = this.newUpdatesBySymbol[item.symbol]

--- a/js/pro/test/base/test.Cache.js
+++ b/js/pro/test/base/test.Cache.js
@@ -316,3 +316,40 @@ outsideLimit = 2; // if limit < newsUpdate that should be returned
 limited = cache.getLimit (undefined, outsideLimit);
 
 assert (outsideLimit === limited);
+
+
+// ----------------------------------------------------------------------------
+// test ArrayCacheBySymbolById, watch all orders, same symbol and order id gets updated
+
+cache = new ArrayCacheBySymbolById ();
+symbol = 'BTC/USDT';
+outsideLimit = 5;
+cache.append ({ 'symbol': symbol, 'id': 'oneId', 'i': 3 }); // create first order
+cache.getLimit (undefined, outsideLimit) // watch all orders
+cache.append ({ 'symbol': symbol, 'id': 'oneId', 'i': 4 }); // first order is closed
+cache.getLimit (undefined, outsideLimit) // watch all orders
+cache.append ({ 'symbol': symbol, 'id': 'twoId', 'i': 5 }); // create second order
+cache.getLimit (undefined, outsideLimit) // watch all orders
+cache.append ({ 'symbol': symbol, 'id': 'twoId', 'i': 6 }); // second order is closed
+limited = cache.getLimit (undefined, outsideLimit); // watch all orders
+assert (limited === 1); // one new update
+
+// ----------------------------------------------------------------------------
+// test ArrayCacheBySymbolById, watch all orders, and watchOrders (symbol) work independently
+
+cache = new ArrayCacheBySymbolById ();
+symbol = 'BTC/USDT';
+const symbol2 = 'ETH/USDT';
+
+outsideLimit = 5;
+cache.append ({ 'symbol': symbol, 'id': 'one', 'i': 1 }); // create first order
+cache.append ({ 'symbol': symbol2, 'id': 'two', 'i': 1 }); // create second order
+assert (cache.getLimit (undefined, outsideLimit) === 2); // watch all orders
+assert (cache.getLimit (symbol, outsideLimit) === 1); // watch by symbol
+cache.append ({ 'symbol': symbol, 'id': 'one', 'i': 2 }); // update first order
+cache.append ({ 'symbol': symbol2, 'id': 'two', 'i': 2 }); // update second order
+assert (cache.getLimit (symbol, outsideLimit) === 1); // watch by symbol
+assert (cache.getLimit (undefined, outsideLimit) === 2); // watch all orders
+cache.append ({ 'symbol': symbol2, 'id': 'two', 'i': 3 }); // update second order
+cache.append ({ 'symbol': symbol2, 'id': 'three', 'i': 3 }); // create third order
+assert (cache.getLimit (undefined, outsideLimit) === 2); // watch all orders

--- a/js/pro/test/base/test.Cache.js
+++ b/js/pro/test/base/test.Cache.js
@@ -325,11 +325,11 @@ cache = new ArrayCacheBySymbolById ();
 symbol = 'BTC/USDT';
 outsideLimit = 5;
 cache.append ({ 'symbol': symbol, 'id': 'oneId', 'i': 3 }); // create first order
-cache.getLimit (undefined, outsideLimit) // watch all orders
+cache.getLimit (undefined, outsideLimit); // watch all orders
 cache.append ({ 'symbol': symbol, 'id': 'oneId', 'i': 4 }); // first order is closed
-cache.getLimit (undefined, outsideLimit) // watch all orders
+cache.getLimit (undefined, outsideLimit); // watch all orders
 cache.append ({ 'symbol': symbol, 'id': 'twoId', 'i': 5 }); // create second order
-cache.getLimit (undefined, outsideLimit) // watch all orders
+cache.getLimit (undefined, outsideLimit); // watch all orders
 cache.append ({ 'symbol': symbol, 'id': 'twoId', 'i': 6 }); // second order is closed
 limited = cache.getLimit (undefined, outsideLimit); // watch all orders
 assert (limited === 1); // one new update

--- a/php/pro/ArrayCache.php
+++ b/php/pro/ArrayCache.php
@@ -47,13 +47,15 @@ class ArrayCache extends BaseCache {
             array_shift($this->deque);
         }
         $this->deque[] = $item;
+        if ($this->clear_all_updates) {
+            $this->clear_all_updates = false;
+            $this->clear_updates_by_symbol = array();
+            $this->all_new_updates = 0;
+            $this->new_updates_by_symbol = array();
+        }
         if ($this->clear_updates_by_symbol[$item['symbol']] ?? false) {
             $this->clear_updates_by_symbol[$item['symbol']] = false;
             $this->new_updates_by_symbol[$item['symbol']] = 0;
-        }
-        if ($this->clear_all_updates) {
-            $this->clear_all_updates = false;
-            $this->all_new_updates = 0;
         }
         $this->new_updates_by_symbol[$item['symbol']] = ($this->new_updates_by_symbol[$item['symbol']] ?? 0) + 1;
         $this->all_new_updates = ($this->all_new_updates ?? 0) + 1;

--- a/php/pro/ArrayCacheBySymbolById.php
+++ b/php/pro/ArrayCacheBySymbolById.php
@@ -39,16 +39,18 @@ class ArrayCacheBySymbolById extends ArrayCache {
         # this allows us to effectively pass by reference
         $this->deque[] = &$item;
         $this->index[] = $item['id'];
+        if ($this->clear_all_updates) {
+            $this->clear_all_updates = false;
+            $this->clear_updates_by_symbol = array();
+            $this->all_new_updates = 0;
+            $this->new_updates_by_symbol = array();
+        }
         if (!array_key_exists($item['symbol'], $this->new_updates_by_symbol)) {
             $this->new_updates_by_symbol[$item['symbol']] = array();
         }
         if ($this->clear_updates_by_symbol[$item['symbol']] ?? false) {
             $this->clear_updates_by_symbol[$item['symbol']] = false;
             $this->new_updates_by_symbol[$item['symbol']] = array();
-        }
-        if ($this->clear_all_updates) {
-            $this->clear_all_updates = false;
-            $this->all_new_updates = 0;
         }
         $id_set = &$this->new_updates_by_symbol[$item['symbol']];
         $before_length = count($id_set);

--- a/python/ccxt/pro/base/cache.py
+++ b/python/ccxt/pro/base/cache.py
@@ -77,12 +77,14 @@ class ArrayCache(BaseCache):
 
     def append(self, item):
         self._deque.append(item)
+        if self._clear_all_updates:
+            self._clear_all_updates = False
+            self._clear_updates_by_symbol = {}
+            self._all_new_updates = 0
+            self._new_updates_by_symfbol = {}
         if self._clear_updates_by_symbol.get(item['symbol']):
             self._clear_updates_by_symbol[item['symbol']] = False
             self._new_updates_by_symbol[item['symbol']] = 0
-        if self._clear_all_updates:
-            self._clear_all_updates = False
-            self._all_new_updates = 0
         self._new_updates_by_symbol[item['symbol']] = self._new_updates_by_symbol.get(item['symbol'], 0) + 1
         self._all_new_updates = (self._all_new_updates or 0) + 1
 
@@ -144,14 +146,16 @@ class ArrayCacheBySymbolById(ArrayCache):
             del self.hashmap[delete_item['symbol']][delete_item['id']]
         self._deque.append(item)
         self._index.append(item['id'])
+        if self._clear_all_updates:
+            self._clear_all_updates = False
+            self._clear_updates_by_symbol = False
+            self._all_new_updates = 0
+            self._new_updates_by_symbol = {}
         if item['symbol'] not in self._new_updates_by_symbol:
             self._new_updates_by_symbol[item['symbol']] = set()
         if self._clear_updates_by_symbol.get(item['symbol']):
             self._clear_updates_by_symbol[item['symbol']] = False
             self._new_updates_by_symbol[item['symbol']].clear()
-        if self._clear_all_updates:
-            self._clear_all_updates = False
-            self._all_new_updates = 0
         id_set = self._new_updates_by_symbol[item['symbol']]
         before_length = len(id_set)
         id_set.add(item['id'])

--- a/python/ccxt/pro/base/cache.py
+++ b/python/ccxt/pro/base/cache.py
@@ -58,7 +58,6 @@ class ArrayCache(BaseCache):
         self._clear_all_updates = False
 
     def getLimit(self, symbol, limit):
-        new_updates_value = None
         if symbol is None:
             new_updates_value = self._all_new_updates
             self._clear_all_updates = True
@@ -79,9 +78,9 @@ class ArrayCache(BaseCache):
         self._deque.append(item)
         if self._clear_all_updates:
             self._clear_all_updates = False
-            self._clear_updates_by_symbol = {}
+            self._clear_updates_by_symbol.clear()
             self._all_new_updates = 0
-            self._new_updates_by_symfbol = {}
+            self._new_updates_by_symbol.clear()
         if self._clear_updates_by_symbol.get(item['symbol']):
             self._clear_updates_by_symbol[item['symbol']] = False
             self._new_updates_by_symbol[item['symbol']] = 0
@@ -148,9 +147,9 @@ class ArrayCacheBySymbolById(ArrayCache):
         self._index.append(item['id'])
         if self._clear_all_updates:
             self._clear_all_updates = False
-            self._clear_updates_by_symbol = False
+            self._clear_updates_by_symbol.clear()
             self._all_new_updates = 0
-            self._new_updates_by_symbol = {}
+            self._new_updates_by_symbol.clear()
         if item['symbol'] not in self._new_updates_by_symbol:
             self._new_updates_by_symbol[item['symbol']] = set()
         if self._clear_updates_by_symbol.get(item['symbol']):


### PR DESCRIPTION
This fixes an issue that when clearing the updates, they should be cleared for all symbols also.

Report:
(https://discord.com/channels/690203284119617602/690203284727660739/1030802028047376395)

To reproduce:
- Call `npm run cli.js binanceusdm watchOrders --verbose --test`
- Post one market order  `npm run cli.js binanceusdm createOrder ETH/USDT market buy 1 --verbose --test`
- Expect one update, get one update ✅
- Post a second market order `npm run cli.js binanceusdm createOrder ETH/USDT market buy 1 --verbose --test`
- Expect one update to be returned, however `allNewUpdates = 0` and  `this.orders` is returned. ❌

Also looking at this code, I think we should consider in the future rewriting this as I can see there being issues when a user tries to call both watchOrders for a specific symbol and then watchOrders for all symbols. As the limit will be cleared in the first update, affecting the results of the second watchOrders.