### PR TITLE
Okx: fetchPositions, enable margin and option support

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4026,8 +4026,10 @@ module.exports = class okx extends Exchange {
          * @method
          * @name okx#fetchPosition
          * @description fetch data on a single open contract trade position
+         * @see https://www.okx.com/docs-v5/en/#rest-api-account-get-positions
          * @param {string} symbol unified market symbol of the market the position is held in, default is undefined
          * @param {object} params extra parameters specific to the okx api endpoint
+         * @param {string|undefined} params.instType MARGIN, SWAP, FUTURES, OPTION
          * @returns {object} a [position structure]{@link https://docs.ccxt.com/en/latest/manual.html#position-structure}
          */
         await this.loadMarkets ();
@@ -4100,25 +4102,31 @@ module.exports = class okx extends Exchange {
         /**
          * @method
          * @name okx#fetchPositions
+         * @see https://www.okx.com/docs-v5/en/#rest-api-account-get-positions
          * @description fetch all open positions
          * @param {[string]|undefined} symbols list of unified market symbols
          * @param {object} params extra parameters specific to the okx api endpoint
+         * @param {string|undefined} params.instType MARGIN, SWAP, FUTURES, OPTION
          * @returns {[object]} a list of [position structure]{@link https://docs.ccxt.com/en/latest/manual.html#position-structure}
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols);
-        // const defaultType = this.safeString2 (this.options, 'fetchPositions', 'defaultType');
-        // const type = this.safeString (params, 'type', defaultType);
         const request = {
-            // instType String No Instrument type, MARGIN, SWAP, FUTURES, OPTION, instId will be checked against instType when both parameters are passed, and the position information of the instId will be returned.
-            // instId String No Instrument ID, e.g. BTC-USD-190927-5000-C
-            // posId String No Single position ID or multiple position IDs (no more than 20) separated with comma
+            // 'instType': 'MARGIN', // optional string, MARGIN, SWAP, FUTURES, OPTION
+            // 'instId': market['id'], // optional string, e.g. 'BTC-USD-190927-5000-C'
+            // 'posId': '307173036051017730', // optional string, Single or multiple position IDs (no more than 20) separated with commas
         };
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchPositions', undefined, params);
         if (type !== undefined) {
-            if ((type === 'swap') || (type === 'future')) {
-                request['instType'] = this.convertToInstrumentType (type);
+            request['instType'] = this.convertToInstrumentType (type);
+        }
+        if (symbols !== undefined) {
+            const marketIds = [];
+            for (let i = 0; i < symbols.length; i++) {
+                const entry = symbols[i];
+                const market = this.market (entry);
+                marketIds.push (market['id']);
             }
+            request['instId'] = marketIds.toString ();
         }
         const response = await this.privateGetAccountPositions (this.extend (request, query));
         //
@@ -4170,11 +4178,7 @@ module.exports = class okx extends Exchange {
         const positions = this.safeValue (response, 'data', []);
         const result = [];
         for (let i = 0; i < positions.length; i++) {
-            const entry = positions[i];
-            const instrument = this.safeString (entry, 'instType');
-            if ((instrument === 'FUTURES') || (instrument === 'SWAP')) {
-                result.push (this.parsePosition (positions[i]));
-            }
+            result.push (this.parsePosition (positions[i]));
         }
         return this.filterByArray (result, 'symbol', symbols, false);
     }


### PR DESCRIPTION
Added margin and option support to fetchPositions:
```
node examples/js/cli okx fetchPositions undefined '{"type":"margin"}'
```
```
okx.fetchPositions (, [object Object])
2022-10-18T07:21:01.430Z iteration 0 passed in 370 ms

id |   symbol |       notional | marginMode | liquidationPrice | entryPrice |       unrealizedPnl |        percentage |     contracts | contractSize | markPrice | side | hedged |     timestamp |                 datetime | maintenanceMargin | maintenanceMarginPercentage |     collateral | initialMargin | initialMarginPercentage | leverage | marginRatio
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | BTC/USDT | 9.578049794568 |      cross |                  |    19596.5 | -0.0234986128279999 | -0.97911565840839 | 0.00048939012 |              |   19568.1 | long |  false | 1666077247361 | 2022-10-18T07:14:07.361Z |      0.2879980026 |                      0.0301 | 2.376484742172 |   2.399983355 |                  0.2505 |        4 |      0.1211
1 objects
2022-10-18T07:21:01.430Z iteration 1 passed in 370 ms
```