### PR TITLE
okx.has fetchTradingLimits: false

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -92,7 +92,7 @@ module.exports = class okx extends Exchange {
                 'fetchTrades': true,
                 'fetchTradingFee': true,
                 'fetchTradingFees': false,
-                'fetchTradingLimits': undefined,
+                'fetchTradingLimits': false,
                 'fetchTransactionFee': false,
                 'fetchTransactionFees': false,
                 'fetchTransactions': false,


### PR DESCRIPTION
In a [former PR](https://github.com/ccxt/ccxt/pull/14195) I implemented a version of `fetchTradingLimits` but the response wasn't exactly the same as other exchanges `fetchTradingLimits` methods