### PR TITLE
Bibox v4 fetch ticker

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -476,17 +476,15 @@ module.exports = class bibox extends Exchange {
         //        low_usd: '0.0153'
         //    }
         //
-        const timestamp = this.safeInteger (ticker, 'timestamp');
-        let marketId = undefined;
+        const timestamp = this.safeInteger2 (ticker, 'timestamp', 't');
         const baseId = this.safeString (ticker, 'coin_symbol');
         const quoteId = this.safeString (ticker, 'currency_symbol');
-        if ((baseId !== undefined) && (quoteId !== undefined)) {
+        let marketId = this.safeString (ticker, 's');
+        if ((marketId === undefined) && (baseId !== undefined) && (quoteId !== undefined)) {
             marketId = baseId + '_' + quoteId;
         }
         market = this.safeMarket (marketId, market);
-        const last = this.safeString (ticker, 'last');
-        const change = this.safeString (ticker, 'change');
-        const baseVolume = this.safeString2 (ticker, 'vol', 'vol24H');
+        const last = this.safeString2 (ticker, 'last', 'p');
         let percentage = this.safeString (ticker, 'percent');
         if (percentage !== undefined) {
             percentage = percentage.replace ('%', '');
@@ -495,22 +493,22 @@ module.exports = class bibox extends Exchange {
             'symbol': market['symbol'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeString (ticker, 'high'),
-            'low': this.safeString (ticker, 'low'),
-            'bid': this.safeString (ticker, 'buy'),
-            'bidVolume': this.safeString (ticker, 'buy_amount'),
-            'ask': this.safeString (ticker, 'sell'),
-            'askVolume': this.safeString (ticker, 'sell_amount'),
+            'high': this.safeString2 (ticker, 'high', 'h'),
+            'low': this.safeString2 (ticker, 'low', 'l'),
+            'bid': this.safeString (ticker, 'bp'),
+            'bidVolume': this.safeString (ticker, 'bq'),
+            'ask': this.safeString (ticker, 'ap'),
+            'askVolume': this.safeString (ticker, 'aq'),
             'vwap': undefined,
-            'open': undefined,
+            'open': this.safeString (ticker, 'o'),
             'close': last,
             'last': last,
             'previousClose': undefined,
-            'change': change,
+            'change': this.safeString2 (ticker, 'change', 'c'),
             'percentage': percentage,
             'average': undefined,
-            'baseVolume': baseVolume,
-            'quoteVolume': this.safeString (ticker, 'amount'),
+            'baseVolume': this.safeString2 (ticker, 'a', 'vol24H'),
+            'quoteVolume': this.safeString2 (ticker, 'v', 'amount'),
             'info': ticker,
         }, market);
     }
@@ -553,7 +551,8 @@ module.exports = class bibox extends Exchange {
         //        }
         //    ]
         //
-        return this.parseTicker (response, market);
+        const ticker = this.safeValue (response, 0);
+        return this.parseTicker (ticker, market);
     }
 
     async fetchTickers (symbols = undefined, params = {}) {

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -504,7 +504,7 @@ module.exports = class bibox extends Exchange {
             'close': last,
             'last': last,
             'previousClose': undefined,
-            'change': this.safeString2 (ticker, 'change', 'c'),
+            'change': this.safeString (ticker, 'change'),
             'percentage': percentage,
             'average': undefined,
             'baseVolume': this.safeString2 (ticker, 'a', 'vol24H'),

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -510,7 +510,6 @@ module.exports = class bibox extends Exchange {
     }
 
     async fetchTickers (symbols = undefined, params = {}) {
-        await this.loadMarkets ();
         /**
          * @method
          * @name bibox#fetchTickers

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -524,6 +524,37 @@ module.exports = class bibox extends Exchange {
             'cmd': 'marketAll',
         };
         const response = await this.v1PublicGetMdata (this.extend (request, params));
+        //
+        //    {
+        //        result: [
+        //            {
+        //                is_hide: '0',
+        //                high_cny: '0.1094',
+        //                amount: '5.34',
+        //                coin_symbol: 'BIX',
+        //                last: '0.00000080',
+        //                currency_symbol: 'BTC',
+        //                change: '+0.00000001',
+        //                low_cny: '0.1080',
+        //                base_last_cny: '0.10935854',
+        //                area_id: '7',
+        //                percent: '+1.27%',
+        //                last_cny: '0.1094',
+        //                high: '0.00000080',
+        //                low: '0.00000079',
+        //                pair_type: '0',
+        //                last_usd: '0.0155',
+        //                vol24H: '6697325',
+        //                id: '1',
+        //                high_usd: '0.0155',
+        //                low_usd: '0.0153'
+        //            },
+        //            ...
+        //        ],
+        //        cmd: 'marketAll',
+        //        ver: '1.1'
+        //    }
+        //
         const tickers = this.parseTickers (response['result'], symbols);
         const result = this.indexBy (tickers, 'symbol');
         return this.filterByArray (result, 'symbol', symbols);

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -429,6 +429,53 @@ module.exports = class bibox extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         // we don't set values that are not defined by the exchange
+        //
+        // fetchTicker
+        //
+        //    {
+        //        "s": "ADA_USDT",             // trading pair code
+        //        "t": 1666143212000,          // 24 hour transaction count
+        //        "o": 0.371735,               // opening price
+        //        "h": 0.373646,               // highest price
+        //        "l": 0.358383,               // lowest price
+        //        "p": 0.361708,               // latest price
+        //        "q": 8.1,                    // latest volume
+        //        "v": 1346397.88,             // 24 hour volume
+        //        "a": 494366.08822867,        // 24 hour transaction value
+        //        "c": -0.0267,                // 24 hour Change
+        //        "n": 244631,
+        //        "f": 16641250,               // 24 hour first transaction id
+        //        "bp": 0.361565,              // Best current bid price
+        //        "bq": 4324.26,               // Best current bid quantity
+        //        "ap": 0.361708,              // Best current ask price
+        //        "aq": 7726.59                // Best current ask quantity
+        //    }
+        //
+        // fetchTickers
+        //
+        //    {
+        //        is_hide: '0',
+        //        high_cny: '0.1094',
+        //        amount: '5.34',
+        //        coin_symbol: 'BIX',
+        //        last: '0.00000080',
+        //        currency_symbol: 'BTC',
+        //        change: '+0.00000001',
+        //        low_cny: '0.1080',
+        //        base_last_cny: '0.10935854',
+        //        area_id: '7',
+        //        percent: '+1.27%',
+        //        last_cny: '0.1094',
+        //        high: '0.00000080',
+        //        low: '0.00000079',
+        //        pair_type: '0',
+        //        last_usd: '0.0155',
+        //        vol24H: '6697325',
+        //        id: '1',
+        //        high_usd: '0.0155',
+        //        low_usd: '0.0153'
+        //    }
+        //
         const timestamp = this.safeInteger (ticker, 'timestamp');
         let marketId = undefined;
         const baseId = this.safeString (ticker, 'coin_symbol');

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -559,7 +559,7 @@ module.exports = class bibox extends Exchange {
         /**
          * @method
          * @name bibox#fetchTickers
-         * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @description v1, fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the bibox api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -251,7 +251,7 @@ module.exports = class bibox extends Exchange {
                             'marketdata/order_book',
                             'marketdata/candles',
                             'marketdata/trades',
-                            'marketdata/tickers',
+                            'marketdata/ticker',
                         ],
                     },
                     'private': {
@@ -473,6 +473,7 @@ module.exports = class bibox extends Exchange {
          * @method
          * @name bibox#fetchTicker
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
+         * @see https://biboxcom.github.io/api/spot/v4/en/#get-tickers
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} params extra parameters specific to the bibox api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
@@ -480,11 +481,32 @@ module.exports = class bibox extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'cmd': 'ticker',
-            'pair': market['id'],
+            'symbol': market['id'],
         };
-        const response = await this.v1PublicGetMdata (this.extend (request, params));
-        return this.parseTicker (response['result'], market);
+        const response = await this.v4PublicGetMarketdataTicker (this.extend (request, params));
+        //
+        //    [
+        //        {
+        //            "s": "ADA_USDT",             // trading pair code
+        //            "t": 1666143212000,          // 24 hour transaction count
+        //            "o": 0.371735,               // opening price
+        //            "h": 0.373646,               // highest price
+        //            "l": 0.358383,               // lowest price
+        //            "p": 0.361708,               // latest price
+        //            "q": 8.1,                    // latest volume
+        //            "v": 1346397.88,             // 24 hour volume
+        //            "a": 494366.08822867,        // 24 hour transaction value
+        //            "c": -0.0267,                // 24 hour Change
+        //            "n": 244631,
+        //            "f": 16641250,               // 24 hour first transaction id
+        //            "bp": 0.361565,              // Best current bid price
+        //            "bq": 4324.26,               // Best current bid quantity
+        //            "ap": 0.361708,              // Best current ask price
+        //            "aq": 7726.59                // Best current ask quantity
+        //        }
+        //    ]
+        //
+        return this.parseTicker (response, market);
     }
 
     async fetchTickers (symbols = undefined, params = {}) {


### PR DESCRIPTION
```
% bibox fetchTicker LTC/BTC                                                  % bibox fetchTicker BTC/USDT
2022-10-19T02:14:36.868Z                                                     2022-10-19T02:17:10.644Z
Node.js: v18.4.0                                                             Node.js: v18.4.0
CCXT v2.0.38                                                                 CCXT v2.0.38
bibox.fetchTicker (LTC/BTC)                                                  bibox.fetchTicker (BTC/USDT)
2022-10-19T02:14:39.119Z iteration 0 passed in 779 ms                        2022-10-19T02:17:12.197Z iteration 0 passed in 362 ms

{                                                                            {
  symbol: 'LTC/BTC',                                                           symbol: 'BTC/USDT',
  timestamp: 1666145678000,                                                    timestamp: 1666145832000,
  datetime: '2022-10-19T02:14:38.000Z',                                        datetime: '2022-10-19T02:17:12.000Z',
  high: 0.00269338,                                                            high: 19699.9,
  low: 0.00262959,                                                             low: 19112.3,
  bid: 0.0026787,                                                              bid: 19304.1,
  bidVolume: 5.9805,                                                           bidVolume: 0.373902,
  ask: 0.00268594,                                                             ask: 19304.7,
  askVolume: 16.0913,                                                          askVolume: 0.429188,
  vwap: 376.781166898081,                                                      vwap: 0.000051365526480858,
  open: 0.00263551,                                                            open: 19527,
  close: 0.00267885,                                                           close: 19304.1,
  last: 0.00267885,                                                            last: 19304.1,
  previousClose: undefined,                                                    previousClose: undefined,
  change: 0.0134,                                                              change: -0.0116,
  percentage: 508.4404915936574,                                               percentage: -0.000059404926512,
  average: 0.00265718,                                                         average: 19415.55,
  baseVolume: 13.45415282227,                                                  baseVolume: 12471598.8696956,
  quoteVolume: 5069.2714,                                                      quoteVolume: 640.610242,
  info: {                                                                      info: {
    s: 'LTC_BTC',                                                                s: 'BTC_USDT',
    t: '1666145678000',                                                          t: '1666145832000',
    o: '0.00263551',                                                             o: '19527',
    h: '0.00269338',                                                             h: '19699.9',
    l: '0.00262959',                                                             l: '19112.3',
    p: '0.00267885',                                                             p: '19304.1',
    q: '0.097',                                                                  q: '0.002341',
    v: '5069.2714',                                                              v: '640.610242',
    a: '13.45415282227',                                                         a: '12471598.8696956',
    c: '0.0134',                                                                 c: '-0.0116',
    n: '40291',                                                                  n: '158712',
    f: '15897305',                                                               f: '58233124',
    bp: '0.0026787',                                                             bp: '19304.1',
    bq: '5.9805',                                                                bq: '0.373902',
    ap: '0.00268594',                                                            ap: '19304.7',
    aq: '16.0913'                                                                aq: '0.429188'
  }                                                                            }
}                                                                            }
2022-10-19T02:14:39.119Z iteration 1 passed in 779 ms                        2022-10-19T02:17:12.197Z iteration 1 passed in 362 ms
```

```
2022-10-19T02:19:33.478Z
Node.js: v18.4.0
CCXT v2.0.38
bibox.fetchTickers ()
2022-10-19T02:19:35.995Z iteration 0 passed in 1088 ms

{
  'BIX/BTC': {
    symbol: 'BIX/BTC',
    timestamp: undefined,
    datetime: undefined,
    high: 8e-7,
    low: 7.9e-7,
    bid: undefined,
    bidVolume: undefined,
    ask: undefined,
    askVolume: undefined,
    vwap: 7.98015899345e-7,
    open: 7.9e-7,
    close: 8e-7,
    last: 8e-7,
    previousClose: undefined,
    change: 1e-8,
    percentage: 1.27,
    average: undefined,
    baseVolume: 6691596,
    quoteVolume: 5.34,
    info: {
      is_hide: '0',
      high_cny: '0.1092',
      amount: '5.34',
      coin_symbol: 'BIX',
      last: '0.00000080',
      currency_symbol: 'BTC',
      change: '+0.00000001',
      low_cny: '0.1078',
      base_last_cny: '0.10918434',
      area_id: '7',
      percent: '+1.27%',
      last_cny: '0.1092',
      high: '0.00000080',
      low: '0.00000079',
      pair_type: '0',
      last_usd: '0.0154',
      vol24H: '6691596',
      id: '1',
      high_usd: '0.0154',
      low_usd: '0.0153'
    }
  },
  ...
}
2022-10-19T02:19:35.995Z iteration 1 passed in 1088 ms
```