### PR TITLE
okx - fix network

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -1194,16 +1194,16 @@ module.exports = class okx extends Exchange {
                 if ((networkId !== undefined) && (networkId.indexOf ('-') >= 0)) {
                     const parts = networkId.split ('-');
                     const chainPart = this.safeString (parts, 1, networkId);
-                    const network = this.safeNetwork (chainPart);
+                    const networkCode = this.safeNetwork (chainPart);
                     const precision = this.parsePrecision (this.safeString (chain, 'wdTickSz'));
                     if (maxPrecision === undefined) {
                         maxPrecision = precision;
                     } else {
                         maxPrecision = Precise.stringMin (maxPrecision, precision);
                     }
-                    networks[network] = {
+                    networks[networkCode] = {
                         'id': networkId,
-                        'network': network,
+                        'network': networkCode,
                         'active': active,
                         'deposit': canDeposit,
                         'withdraw': canWithdraw,

--- a/js/okx.js
+++ b/js/okx.js
@@ -629,10 +629,6 @@ module.exports = class okx extends Exchange {
                     'OEC': 'OEC',
                     'ALGO': 'ALGO', // temporarily unavailable
                 },
-                'layerTwo': {
-                    'Lightning': true,
-                    'Liquid': true,
-                },
                 'fetchOpenInterestHistory': {
                     'timeframes': {
                         '5m': '5m',
@@ -1198,16 +1194,7 @@ module.exports = class okx extends Exchange {
                 if ((networkId !== undefined) && (networkId.indexOf ('-') >= 0)) {
                     const parts = networkId.split ('-');
                     const chainPart = this.safeString (parts, 1, networkId);
-                    let network = this.safeNetwork (chainPart);
-                    const mainNet = this.safeValue (chain, 'mainNet', false);
-                    const layerTwo = this.safeValue (this.options, 'layerTwo', {
-                        'Liquid': true,
-                        'Lightning': true,
-                    });
-                    if (mainNet && !(chainPart in layerTwo)) {
-                        // BTC lighting and liquid are both mainnet but not the same as BTC-Bitcoin
-                        network = code;
-                    }
+                    const network = this.safeNetwork (chainPart);
                     const precision = this.parsePrecision (this.safeString (chain, 'wdTickSz'));
                     if (maxPrecision === undefined) {
                         maxPrecision = precision;


### PR DESCRIPTION
I nowhere see and recognize the validity of previous version. As suggested by me in the past, when we encounter a "custom scenario" we'd better document why we do that way. for example, I don't see any reason why that code (which is removed by me atm) was there. `lightning` and `liquid` networks only relate to BTC and moreover, only `lightning` to be precise, because inside fetchCurrencies response, there is no mention of `liquid` phrase anywhere through full raw response body. apart from it, be it 'lightning' but neither I see any explanation why we shouldn't treat it as `networkCode` and instead set `BTC` as network? neither `mainnet : true` changes anything, as all coins on okex have chainName as second part after separator `COINNAME-NETWORKNAME`. so, it is that simple what I see.

_fixes #15204_