### PR TITLE
woo: add v3 apis

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -131,6 +131,7 @@ module.exports = class woo extends Exchange {
                         'get': {
                             'info': 1,
                             'info/{symbol}': 1,
+                            'system_info': 1,
                             'market_trades': 1,
                             'token': 1,
                             'token_network': 1,
@@ -185,6 +186,23 @@ module.exports = class woo extends Exchange {
                     'private': {
                         'get': {
                             'client/holding': 1,
+                        },
+                    },
+                },
+                'v3': {
+                    'private': {
+                        'get': {
+                            'algo/order/{oid}': 1,
+                            'algo/orders': 1,
+                        },
+                        'post': {
+                            'algo/order': 5,
+                        },
+                        'delete': {
+                            'algo/order/{oid}': 1,
+                            'algo/orders/pending': 1,
+                            'algo/orders/pending/{symbol}': 1,
+                            'orders/pending': 1,
                         },
                     },
                 },

--- a/js/woo.js
+++ b/js/woo.js
@@ -1793,12 +1793,17 @@ module.exports = class woo extends Exchange {
             url += path;
             const ts = this.nonce ().toString ();
             let auth = this.urlencode (params);
-            if (method === 'POST' || method === 'DELETE') {
+            if (version === 'v3' && (method === 'POST')) {
                 body = auth;
+                auth = ts + method + '/' + version + '/' + path + body;
             } else {
-                url += '?' + auth;
+                if (method === 'POST' || method === 'DELETE') {
+                    body = auth;
+                } else {
+                    url += '?' + auth;
+                }
+                auth += '|' + ts;
             }
-            auth += '|' + ts;
             const signature = this.hmac (this.encode (auth), this.encode (this.secret), 'sha256');
             headers = {
                 'x-api-key': this.apiKey,


### PR DESCRIPTION
Woo added new v3 apis: https://docs.woo.org/#release-note. In this PR, I add these api endpoints and update authentication method for v3 apis.

TODO:
- [x] update v3 authentication (ask their support for clarifying the normalized text of body)

After test, I think we only need to use v3 signature for POST method (in v3 apis).