### PR TITLE
Sync-only version of ccxt

### DIFF
--- a/ccxt.php
+++ b/ccxt.php
@@ -33,6 +33,7 @@ namespace ccxt;
 if (defined('PATH_TO_CCXT')) {
     return;
 }
+$use_sync_only_version = defined('CCXT_USE_SYNC_VERSION');
 
 define('PATH_TO_CCXT', __DIR__ . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR);
 define('PATH_TO_WS_CCXT', __DIR__ . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . 'pro' .  DIRECTORY_SEPARATOR);
@@ -91,7 +92,9 @@ require_once PATH_TO_CCXT . 'RequestTimeout.php';
 
 require_once PATH_TO_CCXT . 'Precise.php';
 require_once PATH_TO_CCXT . 'Exchange.php';
-require_once PATH_TO_CCXT_ASYNC . 'Exchange.php';
+if (!$use_sync_only_version){
+    require_once PATH_TO_CCXT_ASYNC . 'Exchange.php';
+}
 
 
 $autoloadFile = __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
@@ -99,39 +102,43 @@ if (file_exists($autoloadFile)) {
     require_once $autoloadFile;
 }
 
-spl_autoload_register(function ($class_name) {
-    $sections = explode("\\", $class_name);
-    if (in_array("ccxt\\pro",$sections)) {
-        $class_name = str_replace("ccxt\\pro\\", "", $class_name);
+if (!$use_sync_only_version){
+    spl_autoload_register(function ($class_name) {
         $sections = explode("\\", $class_name);
-        $class_name = str_replace ("ccxt\\pro\\", "", $class_name);
-        $file = PATH_TO_WS_CCXT . $class_name . '.php';
-        if (file_exists ($file)) {
+        if (in_array("ccxt\\pro",$sections)) {
+            $class_name = str_replace("ccxt\\pro\\", "", $class_name);
+            $sections = explode("\\", $class_name);
+            $class_name = str_replace ("ccxt\\pro\\", "", $class_name);
+            $file = PATH_TO_WS_CCXT . $class_name . '.php';
+            if (file_exists ($file)) {
+                require_once $file;
+            }
+            return;
+        }
+
+        $class_name = str_replace("ccxt\\", "", $class_name);
+        $sections = explode("\\", $class_name);
+
+        $file = PATH_TO_CCXT . implode(DIRECTORY_SEPARATOR, $sections) . '.php';
+        if (file_exists($file)) {
             require_once $file;
         }
-        return;
-    }
-
-    $class_name = str_replace("ccxt\\", "", $class_name);
-    $sections = explode("\\", $class_name);
-
-    $file = PATH_TO_CCXT . implode(DIRECTORY_SEPARATOR, $sections) . '.php';
-    if (file_exists($file)) {
-        require_once $file;
-    }
-});
+    });
+}
 
 // require_once __DIR__ . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . 'pro.php';
 
 namespace ccxt\pro;
 
-require_once PATH_TO_WS_CCXT . 'Future.php';
-require_once PATH_TO_WS_CCXT . 'Client.php';
-require_once PATH_TO_WS_CCXT . 'ClientTrait.php';
-require_once PATH_TO_WS_CCXT . 'OrderBook.php';
-require_once PATH_TO_WS_CCXT . 'OrderBookSide.php';
-require_once PATH_TO_WS_CCXT . 'BaseCache.php';
-require_once PATH_TO_WS_CCXT . 'ArrayCache.php';
-require_once PATH_TO_WS_CCXT . 'ArrayCacheByTimestamp.php';
-require_once PATH_TO_WS_CCXT . 'ArrayCacheBySymbolById.php';
-require_once PATH_TO_WS_CCXT . 'Exchange.php';
+if (!$use_sync_only_version){
+    require_once PATH_TO_WS_CCXT . 'Future.php';
+    require_once PATH_TO_WS_CCXT . 'Client.php';
+    require_once PATH_TO_WS_CCXT . 'ClientTrait.php';
+    require_once PATH_TO_WS_CCXT . 'OrderBook.php';
+    require_once PATH_TO_WS_CCXT . 'OrderBookSide.php';
+    require_once PATH_TO_WS_CCXT . 'BaseCache.php';
+    require_once PATH_TO_WS_CCXT . 'ArrayCache.php';
+    require_once PATH_TO_WS_CCXT . 'ArrayCacheByTimestamp.php';
+    require_once PATH_TO_WS_CCXT . 'ArrayCacheBySymbolById.php';
+    require_once PATH_TO_WS_CCXT . 'Exchange.php';
+}


### PR DESCRIPTION
for users (undetermined amount of them, some of them opened several issues here on github) who use ccxt with direct `require` (without composer) got breaks after merging `pro & async` version, so who only wanted to use `sync` version, they can be still able to include it with:
```
...
define('CCXT_USE_SYNC_VERSION', true);
require('./path/ccxt.php')
```
and can continue using it as they used.  (the only change in the edited file is that i've placed those lines inside `if` clause).