### PR TITLE
gateio: missing assignment in gate.handleMyTrades

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -650,6 +650,7 @@ module.exports = class gate extends gateRest {
         if (cachedTrades === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             cachedTrades = new ArrayCacheBySymbolById (limit);
+            this.myTrades = cachedTrades;
         }
         const parsed = this.parseTrades (result);
         const marketIds = {};


### PR DESCRIPTION
The attribute `this.myTrades` is never assigned: the trades get stored in a local variable and then lost.