### PR TITLE
Bibox withdraw

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -1927,6 +1927,7 @@ module.exports = class bibox extends Exchange {
          * @method
          * @name bibox#withdraw
          * @description make a withdrawal
+         * @see https://biboxcom.github.io/api/spot/v3/en/#withdrawal
          * @param {string} code unified currency code
          * @param {float} amount the amount to withdraw
          * @param {string} address the address to withdraw to


### PR DESCRIPTION
I get invalid address everytime I try to make a withdrawal currently, I'm not sure why

```
% bibox withdraw SOL 0.99 '"62hQ481duMpwoxcbMRmfjsVWvqd5bX5JdCEPFb3BnGEq"' --verbose
2022-10-27T02:02:19.029Z
Node.js: v18.9.0
CCXT v2.0.71
(node:16603) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
bibox.withdraw (SOL, 0.99, 62hQ481duMpwoxcbMRmfjsVWvqd5bX5JdCEPFb3BnGEq)
fetch Request:
 bibox POST https://api.bibox.com/v3.1/transfer/transferOut 
RequestHeaders:
 {
  'content-type': 'application/json',
  'bibox-api-key': '',
  'bibox-api-sign': '',
  'bibox-timestamp': ''
} 
RequestBody:
 {"coin_symbol":"SOL","amount":0.99,"addr":"62hQ481duMpwoxcbMRmfjsVWvqd5bX5JdCEPFb3BnGEq"} 

handleRestResponse:
 bibox POST https://api.bibox.com/v3.1/transfer/transferOut 200 OK 
ResponseHeaders:
 {
  'Access-Control-Allow-Credentials': 'true',
  'Access-Control-Allow-Headers': 'Content-Type, Accept, x-access-token, X-Requested-With, user-agent, device-id',
  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
  'Access-Control-Allow-Origin': 'undefined',
  'Alt-Svc': 'h3=":443"; ma=86400, h3-29=":443"; ma=86400',
  'Cf-Cache-Status': 'DYNAMIC',
  'Cf-Ray': '7607d97f3fd9cc56-ZRH',
  Connection: 'keep-alive',
  'Content-Length': '38',
  'Content-Type': 'application/json; charset=utf-8',
  Date: 'Thu, 27 Oct 2022 02:02:27 GMT',
  Etag: 'W/"26-xVEMUMedWvZFA6Cmc0xlq7+DCBg"',
  Server: 'cloudflare',
  'Server-Timing': 'cf-q-config;dur=7.0000023697503e-06',
  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
  Vary: 'Accept-Encoding',
  'X-Ca-Request-Id': '6FE73B23-CDD8-4939-9364-43A05A05C7D9',
  'X-Content-Type-Options': 'nosniff',
  'X-Powered-By': 'Express',
  'X-Ratelimit-Limit': '2000',
  'X-Ratelimit-Remaining': '1997',
  'X-Ratelimit-Reset': '1666836163'
} 
ResponseBody:
 {"state":5001,"msg":"无效的地址"} 

ExchangeError bibox {"state":5001,"msg":"无效的地址"}
---------------------------------------------------
[ExchangeError] bibox {"state":5001,"msg":"无效的地址"}

    at handleErrors               js/bibox.js:2244                      throw new ExchangeError (this.id + ' ' + body);                                 
    at                            js/base/Exchange.js:598               const skipFurtherErrorHandling = this.handleErrors (response.status, response.s…
    at processTicksAndRejections  node:internal/process/task_queues:95                                                                                  
    at async timeout              js/base/functions/time.js:181         return await Promise.race ([promise, expires.then (() => { throw new TimedOut (…
    at fetch2                     js/base/Exchange.js:1803              return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    js/base/Exchange.js:1807              return await this.fetch2 (path, api, method, params, headers, body, config, con…
    at withdraw                   js/bibox.js:1951                      const response = await this[method] (this.extend (request, params));            
    at async run                  examples/js/cli.js:281                const result = await exchange[methodName] (... args)                            

bibox {"state":5001,"msg":"无效的地址"}
```