### PR TITLE
Bibox sort params

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -2218,11 +2218,19 @@ module.exports = class bibox extends Exchange {
             } else if (v4) {
                 let strToSign = '';
                 if (method === 'GET') {
-                    url += '?' + this.urlencode (params);
-                    strToSign = this.urlencode (params);
+                    const sortedParams = {};
+                    const keys = Object.keys (params);
+                    keys.sort ();
+                    for (let i = 0; i < keys.length; i++) {
+                        const key = keys[i];
+                        sortedParams[key] = params[key];
+                    }
+                    url += '?' + this.urlencode (sortedParams);
+                    strToSign = this.urlencode (sortedParams);
                 } else {
                     if (jsonParams !== '{}') {
                         const keys = Object.keys (params);
+                        keys.sort ();
                         for (let i = 0; i < keys.length; i++) {
                             const key = keys[i];
                             body[key] = params[key];

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -2184,14 +2184,14 @@ module.exports = class bibox extends Exchange {
         const v4 = (version === 'v4');
         const prefix = v4 ? '/api' : '';
         let url = this.implodeHostname (this.urls['api']['rest']) + prefix + '/' + version + '/' + path;
-        const json_params = v1 ? this.json ([ params ]) : this.json (params);
+        const jsonParams = v1 ? this.json ([ params ]) : this.json (params);
         headers = { 'content-type': 'application/json' };
         if (access === 'public') {
             if (method !== 'GET') {
                 if (v1) {
-                    body = { 'cmds': json_params };
+                    body = { 'cmds': jsonParams };
                 } else {
-                    body = { 'body': json_params };
+                    body = { 'body': jsonParams };
                 }
             } else if (Object.keys (params).length) {
                 url += '?' + this.urlencode (params);
@@ -2201,8 +2201,8 @@ module.exports = class bibox extends Exchange {
             if (version === 'v3' || version === 'v3.1') {
                 const timestamp = this.numberToString (this.milliseconds ());
                 let strToSign = timestamp;
-                if (json_params !== '{}') {
-                    strToSign += json_params;
+                if (jsonParams !== '{}') {
+                    strToSign += jsonParams;
                 }
                 const sign = this.hmac (this.encode (strToSign), this.encode (this.secret), 'md5');
                 headers['bibox-api-key'] = this.apiKey;
@@ -2211,7 +2211,7 @@ module.exports = class bibox extends Exchange {
                 if (method === 'GET') {
                     url += '?' + this.urlencode (params);
                 } else {
-                    if (json_params !== '{}') {
+                    if (jsonParams !== '{}') {
                         body = params;
                     }
                 }
@@ -2221,7 +2221,7 @@ module.exports = class bibox extends Exchange {
                     url += '?' + this.urlencode (params);
                     strToSign = this.urlencode (params);
                 } else {
-                    if (json_params !== '{}') {
+                    if (jsonParams !== '{}') {
                         body = params;
                     }
                     strToSign = this.json (body, { 'convertArraysToObjects': true });
@@ -2230,15 +2230,15 @@ module.exports = class bibox extends Exchange {
                 headers['Bibox-Api-Key'] = this.apiKey;
                 headers['Bibox-Api-Sign'] = sign;
             } else {
-                const sign = this.hmac (this.encode (json_params), this.encode (this.secret), 'md5');
+                const sign = this.hmac (this.encode (jsonParams), this.encode (this.secret), 'md5');
                 body = {
                     'apikey': this.apiKey,
                     'sign': sign,
                 };
                 if (v1) {
-                    body['cmds'] = json_params;
+                    body['cmds'] = jsonParams;
                 } else {
-                    body['body'] = json_params;
+                    body['body'] = jsonParams;
                 }
             }
         }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -2222,7 +2222,11 @@ module.exports = class bibox extends Exchange {
                     strToSign = this.urlencode (params);
                 } else {
                     if (jsonParams !== '{}') {
-                        body = params;
+                        const keys = Object.keys (params);
+                        for (let i = 0; i < keys.length; i++) {
+                            const key = keys[i];
+                            body[key] = params[key];
+                        }
                     }
                     strToSign = this.json (body, { 'convertArraysToObjects': true });
                 }

--- a/js/bibox.js
+++ b/js/bibox.js
@@ -2217,24 +2217,19 @@ module.exports = class bibox extends Exchange {
                 }
             } else if (v4) {
                 let strToSign = '';
+                const sortedParams = {};
+                const keys = Object.keys (params);
+                keys.sort ();
+                for (let i = 0; i < keys.length; i++) {
+                    const key = keys[i];
+                    sortedParams[key] = params[key];
+                }
                 if (method === 'GET') {
-                    const sortedParams = {};
-                    const keys = Object.keys (params);
-                    keys.sort ();
-                    for (let i = 0; i < keys.length; i++) {
-                        const key = keys[i];
-                        sortedParams[key] = params[key];
-                    }
                     url += '?' + this.urlencode (sortedParams);
                     strToSign = this.urlencode (sortedParams);
                 } else {
                     if (jsonParams !== '{}') {
-                        const keys = Object.keys (params);
-                        keys.sort ();
-                        for (let i = 0; i < keys.length; i++) {
-                            const key = keys[i];
-                            body[key] = params[key];
-                        }
+                        body = sortedParams;
                     }
                     strToSign = this.json (body, { 'convertArraysToObjects': true });
                 }


### PR DESCRIPTION
It looks like a lot of v4 endpoints require the signature to be created using the parameters in alphabetical order, if they're not alphabetical you'll receive this error

**Master Branch**

```
% bibox fetchLedger USDT 1664582400000 2
2022-10-27T02:31:14.840Z
Node.js: v18.9.0
CCXT v2.0.71
(node:17712) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
bibox.fetchLedger (USDT, 1664582400000, 2)
ExchangeError bibox {"error":-2006,"message":"Invalid signature"}
---------------------------------------------------
[ExchangeError] bibox {"error":-2006,"message":"Invalid signature"}

    at handleErrors               js/bibox.js:2273                      throw new ExchangeError (feedback);                                             
    at                            js/base/Exchange.js:598               const skipFurtherErrorHandling = this.handleErrors (response.status, response.s…
    at processTicksAndRejections  node:internal/process/task_queues:95                                                                                  
    at async timeout              js/base/functions/time.js:181         return await Promise.race ([promise, expires.then (() => { throw new TimedOut (…
    at fetch2                     js/base/Exchange.js:1803              return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    js/base/Exchange.js:1807              return await this.fetch2 (path, api, method, params, headers, body, config, con…
    at fetchLedger                js/bibox.js:1116                      const response = await this.v4PrivateGetUserdataLedger (this.extend (request, p…
    at async run                  examples/js/cli.js:281                const result = await exchange[methodName] (... args)                            

bibox {"error":-2006,"message":"Invalid signature"}
```

-----------------

**Testing**

```
 % bibox fetchLedger USDT 1664582400000 2
2022-10-27T02:33:38.939Z
Node.js: v18.9.0
CCXT v2.0.71
(node:17811) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
bibox.fetchLedger (USDT, 1664582400000, 2)
2022-10-27T02:33:42.748Z iteration 0 passed in 523 ms

                 id | direction | account |         referenceId | referenceAccount |     type | currency |      amount |     timestamp |                 datetime | before |         after | status | fee
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1125899920846764883 |       out |         | 1125899920846764883 |                  | transfer |     USDT |      -14.71 | 1665304319733 | 2022-10-09T08:31:59.733Z |        |        4.4e-9 |        |    
1125899921171089999 |        in |         | 1125899921171089999 |                  | transfer |     USDT | 15.05952304 | 1665560662976 | 2022-10-12T07:44:22.976Z |        | 15.0595230444 |        |    
2 objects
2022-10-27T02:33:42.748Z iteration 1 passed in 523 ms
```