### PR TITLE
bitget: add wallet subTransfer

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -184,6 +184,7 @@ module.exports = class bitget extends Exchange {
                             'trade/fills': 1,
                             'wallet/transfer': 4,
                             'wallet/withdrawal': 4,
+                            'wallet/subTransfer': 10,
                         },
                     },
                     'mix': {


### PR DESCRIPTION
In this PR, I added wallet/subTransfer in bitget exchange (https://bitgetlimited.github.io/apidoc/en/spot/#sub-transfer)