### PR TITLE
gateio: order book subscription bug

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -163,7 +163,7 @@ module.exports = class gate extends gateRest {
                     }
                 } else {
                     // throw upon failing to synchronize in maxAttempts
-                    client.subscriptions[messageHash] = undefined;
+                    delete client.subscriptions[messageHash];
                     throw new InvalidNonce (this.id + ' failed to synchronize WebSocket feed with the snapshot for symbol ' + symbol + ' in ' + maxAttempts.toString () + ' attempts');
                 }
             } else {


### PR DESCRIPTION
When subscribing to gateio order books, it may happen that the snapshot fails to synchronize with the deltas and the `fetch_order_book_snapshot()` throws an `InvalidNonce`.
In this case, the line of code `client.subscriptions[messageHash] = undefined;` is executed.

Unfortunately, in Python this translates to `client.subscriptions[messageHash] = None`, not to `del client.subscriptions[messageHash]` as it should be.

## Description of the bug
What happens in Python when a client tries to subscribe to an order book twice, with the first time failing?

On the first time, `watch_order_book()` sets `client.subscriptions[messageHash]` to
```python
{
    'method': self.handle_order_book_subscription,
    'symbol': symbol,
    'limit': limit,
}
```
`fetch_order_book_snapshot()` loads `symbol = self.safe_string(subscription, 'symbol')`, and it starts to fetch the order book snapshot.
Then, synchronization fails in `fetch_order_book_snapshot()`: `client.subscriptions[messageHash] = None` and `InvalidNonce` is raised.

The client calls again `watch_order_book()`. This time, `client.subscriptions[messageHash]` is present and set to `None`, therefore `watch()` does not override it.
`fetch_order_book_snapshot()` loads `symbol = self.safe_string(subscription, 'symbol')`, but now it is `None`, and it crashes.

If instead of setting the dictionary key to `None` we delete it, then the second subscription to the order book goes through.
