### PR TITLE
gate: fix api path for withdrawals/sub_accounts

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -4652,7 +4652,10 @@ module.exports = class gate extends Exchange {
         let query = this.omit (params, this.extractParams (path));
         path = this.implodeParams (path, params);
         const endPart = (path === '') ? '' : ('/' + path);
-        const entirePath = '/' + type + endPart;
+        let entirePath = '/' + type + endPart;
+        if ((type === 'subAccounts') || (type === 'withdrawals')) {
+            entirePath = endPart;
+        }
         let url = this.urls['api'][authentication][type];
         if (url === undefined) {
             throw new NotSupported (this.id + ' does not have a testnet for the ' + type + ' market type.');


### PR DESCRIPTION
```
$ node examples/js/cli gateio privateWithdrawalsPostWithdrawals --verbose
Node.js: v18.8.0
CCXT v2.0.71
gateio.privateWithdrawalsPostWithdrawals ()
withdrawals
fetch Request:
 gateio POST https://api.gateio.ws/api/v4/withdrawals
...
```

```
$ node examples/js/cli gateio privateSubAccountsGetSubAccounts           
2022-10-27T13:07:58.375Z
Node.js: v18.8.0
CCXT v2.0.71
https://api.gateio.ws/api/v4/spot/currencies
(node:91119) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
https://api.gateio.ws/api/v4/margin/currency_pairs
https://api.gateio.ws/api/v4/spot/currency_pairs
gateio.privateSubAccountsGetSubAccounts ()
/sub_accounts
https://api.gateio.ws/api/v4/sub_accounts
2022-10-27T13:07:59.259Z iteration 0 passed in 66 ms

[]
```
 