### PR TITLE
ftx: add exception "Order took too long to process"

### DIFF
--- a/js/ftx.js
+++ b/js/ftx.js
@@ -374,6 +374,7 @@ module.exports = class ftx extends Exchange {
                     'Not authorized for subaccount-specific access': PermissionDenied, // {"success":false,"error":"Not authorized for subaccount-specific access"}
                     'Not approved to trade this product': PermissionDenied, // {"success":false,"error":"Not approved to trade this product"}
                     'Internal Error': ExchangeNotAvailable, // {"success":false,"error":"Internal Error"}
+                    'Order took too long to process': ExchangeNotAvailable, // {"success":false,"error":"Order took too long to process"}
                 },
                 'broad': {
                     // {"error":"Not logged in","success":false}


### PR DESCRIPTION
We just saw this new error in production, which raises an `ExchangeError`. It should raise an `ExchangeNotAvailable` so that the clients can retry it as subclass of `NetworkError`.