### PR TITLE
crex24-fetchTransactionFees

### DIFF
--- a/js/crex24.js
+++ b/js/crex24.js
@@ -492,7 +492,11 @@ module.exports = class crex24 extends Exchange {
          * @returns {object} a list of [transaction fees structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
          */
         await this.loadMarkets ();
-        const response = await this.publicGetCurrenciesWithdrawalFees (params);
+        const request = {};
+        if (codes !== undefined) {
+            request['filter'] = codes.join (',');
+        }
+        const response = await this.publicGetCurrenciesWithdrawalFees (this.extend (request, params));
         //
         //     [
         //         {


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py crex24 fetchTransactionFees '["BTC","ETH"]'`
```
Python v3.10.6
CCXT v2.0.81
crex24.fetchTransactionFees(['BTC', 'ETH'])
{'BTC': {'deposit': None,
         'info': {'currency': 'BTC',
                  'fees': [{'amount': '0.0008', 'feeCurrency': 'BTC'}]},
         'withdraw': {'BTC': 0.0008}},
 'ETH': {'deposit': None,
         'info': {'currency': 'ETH',
                  'fees': [{'amount': '0.001', 'feeCurrency': 'ETH'}]},
         'withdraw': {'ETH': 0.001}}}
```