### PR TITLE
okx: fix ccxt/ccxt#15468

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4116,7 +4116,9 @@ module.exports = class okx extends Exchange {
                 const market = this.market (entry);
                 marketIds.push (market['id']);
             }
-            request['instId'] = marketIds.toString ();
+            if (marketIds.length > 0) {
+                request['instId'] = marketIds.toString ();
+            }
         }
         const response = await this.privateGetAccountPositions (this.extend (request, params));
         //


### PR DESCRIPTION
fix ccxt/ccxt#15468

Looks like `str([])` would be `'[]'` in python (ccxt/ccxt#15468). I fix this in PR.