### PR TITLE
kucoin: use v2 symbols

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -3206,6 +3206,9 @@ module.exports = class kucoin extends Exchange {
         const query = this.omit (params, this.extractParams (path));
         let endpart = '';
         headers = (headers !== undefined) ? headers : {};
+        if (path === 'symbols') {
+            endpoint = '/api/v2/' + this.implodeParams (path, params);
+        }
         if (Object.keys (query).length) {
             if ((method === 'GET') || (method === 'DELETE')) {
                 endpoint += '?' + this.rawencode (query);


### PR DESCRIPTION
kucoin deprecated `/api/v1/symbols` api (https://docs.kucoin.com/#upcoming-changes).

In this PR, I add workaround to call `/api/v2/symbols` (another way is to add version to the implicit method).