### PR TITLE
Fix webWorker usage

### DIFF
--- a/js/pro/base/WsClient.js
+++ b/js/pro/base/WsClient.js
@@ -7,7 +7,8 @@ const functions = require ("../../base/functions.js")
         milliseconds,
     } = functions
     , Client = require ('./Client')
-    , WebSocket = isNode ? require ('ws') : window.WebSocket
+    // eslint-disable-next-line
+    , WebSocket = isNode ? require ('ws') : self.WebSocket
 
 module.exports = class WsClient extends Client {
 


### PR DESCRIPTION
- Webworkers don't have `window` object available, so `self` should be used instead