### PR TITLE
Bitget :: fix timeframes

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -93,6 +93,7 @@ module.exports = class bitget extends Exchange {
                     '30m': '30min',
                     '1h': '1h',
                     '4h': '4h',
+                    '6h': '6h',
                     '12h': '12h',
                     '1d': '1day',
                     '3d': '3day',

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -95,7 +95,9 @@ module.exports = class bitget extends Exchange {
                     '4h': '4h',
                     '12h': '12h',
                     '1d': '1day',
-                    '1w': '7day',  // not documented on the website
+                    '3d': '3day',
+                    '1w': '1week',
+                    '1M': '1M',
                 },
                 'swap': {
                     '1m': '60',


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15482
- fixes https://github.com/ccxt/ccxt/issues/15483

Demo
```
p bitget fetchOHLCV BTC/USDT 1w None 5   
Python v3.9.7
CCXT v2.0.93
bitget.fetchOHLCV(BTC/USDT,1w,None,5)
[[1664726400000, 19143.19, 20451.22, 18922.64, 19536.02, 55732.7885],
 [1665331200000, 19536.02, 19949.28, 18190.07, 19156.27, 54119.1591],
 [1665936000000, 19156.27, 19706.66, 18665.05, 19193.5, 31486.0958],
 [1666540800000, 19193.5, 21070.57, 19163.06, 20678.92, 49213.2876],
 [1667145600000, 20678.92, 20841.08, 20239.6, 20307.25, 5070.3226]]
```