### PR TITLE
fetchOrders - more descriptive error

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2217,6 +2217,12 @@ module.exports = class Exchange {
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        if (this.fetchOpenOrders !== undefined) {
+            throw new NotSupported (this.id + ' fetchOrder() is not supported yet, but you can use fetchOpenOrders() for this exchange instead');
+        }
+        if (this.fetchClosedOrders !== undefined) {
+            throw new NotSupported (this.id + ' fetchOrder() is not supported yet, but you can use fetchClosedOrders() instead');
+        }
         throw new NotSupported (this.id + ' fetchOrders() is not supported yet');
     }
 


### PR DESCRIPTION
- Give more descriptive error when an exchange does not support `fetchOrders` but does support `fetchOpenOrders` 