### PR TITLE
huobi parseTrade fix

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2203,7 +2203,7 @@ module.exports = class huobi extends Exchange {
         if (filledPoints !== undefined) {
             if ((feeCost === undefined) || Precise.stringEquals (feeCost, '0')) {
                 const feeDeductCurrency = this.safeString (trade, 'fee-deduct-currency');
-                if (feeDeductCurrency !== '') {
+                if (feeDeductCurrency !== undefined) {
                     feeCost = filledPoints;
                     feeCurrency = this.safeCurrencyCode (feeDeductCurrency);
                 }


### PR DESCRIPTION
Now in case of zero fees we have `fee currency` `undefined` because `safeString` makes `undefined` from empty string
```
{
  id: '631022360692667',
  info: {
    symbol: 'daiusdt',
    'fee-currency': 'usdt',
    source: 'spot-api',
    'filled-amount': '283.33',
    'filled-fees': '0',
    'filled-points': '0.0',
    'fee-deduct-currency': '',
    'fee-deduct-state': 'done',
    price: '0.9994',
    'created-at': '1667229292439',
    role: 'maker',
    'order-id': '651583613273999',
    'match-id': '100136139541',
    'trade-id': '1907801',
    id: '631022360692667',
    type: 'sell-limit'
  },
  order: '651583613273999',
  timestamp: 1667229292439,
  datetime: '2022-10-31T15:14:52.439Z',
  symbol: 'DAI/USDT',
  type: 'limit',
  side: 'sell',
  takerOrMaker: 'maker',
  price: 0.9994,
  amount: 283.33,
  cost: 283.160002,
  fee: { cost: 0, currency: undefined},
  fees: [ { cost: 0, currency: undefined } ]

```