### PR TITLE
cryptocom - fix watchOrderBook limit issue and marketId clash

### DIFF
--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -294,12 +294,12 @@ module.exports = class cryptocom extends Exchange {
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[object]} an array of objects representing market data
          */
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
-        let method = 'fetchSpotMarkets';
-        if (type === 'future' || type === 'swap' || type === 'option') {
-            method = 'fetchDerivativesMarkets';
-        }
-        return await this[method] (query);
+        let promises = [ this.fetchSpotMarkets (params), this.fetchDerivativesMarkets (params) ];
+        promises = await Promise.all (promises);
+        const spotMarkets = promises[0];
+        const derivativeMarkets = promises[1];
+        const markets = this.arrayConcat (spotMarkets, derivativeMarkets);
+        return markets;
     }
 
     async fetchSpotMarkets (params = {}) {

--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -288,10 +288,22 @@ module.exports = class cryptocom extends Exchange {
         /**
          * @method
          * @name cryptocom#fetchMarkets
+         * @see https://exchange-docs.crypto.com/spot/index.html#public-get-instruments
+         * @see https://exchange-docs.crypto.com/derivatives/index.html#public-get-instruments
          * @description retrieves data on all markets for cryptocom
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[object]} an array of objects representing market data
          */
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
+        let method = 'fetchSpotMarkets';
+        if (type === 'future' || type === 'swap' || type === 'option') {
+            method = 'fetchDerivativesMarkets';
+        }
+        return await this[method] (query);
+    }
+
+    async fetchSpotMarkets (params = {}) {
+        const response = await this.spotPublicGetPublicGetInstruments (params);
         //
         //    {
         //        id: 11,
@@ -315,7 +327,6 @@ module.exports = class cryptocom extends Exchange {
         //        }
         //    }
         //
-        const response = await this.spotPublicGetPublicGetInstruments (params);
         const resultResponse = this.safeValue (response, 'result', {});
         const markets = this.safeValue (resultResponse, 'instruments', []);
         const result = [];
@@ -387,6 +398,11 @@ module.exports = class cryptocom extends Exchange {
                 'info': market,
             });
         }
+        return result;
+    }
+
+    async fetchDerivativesMarkets (params = {}) {
+        const result = [];
         const futuresResponse = await this.derivativesPublicGetPublicGetInstruments ();
         //
         //     {
@@ -425,6 +441,9 @@ module.exports = class cryptocom extends Exchange {
             const inst_type = this.safeString (market, 'inst_type');
             const swap = inst_type === 'PERPETUAL_SWAP';
             const future = inst_type === 'FUTURE';
+            if (inst_type === 'CCY_PAIR') {
+                continue; // Found some inconsistencies between spot and derivatives api so use spot api for currency pairs.
+            }
             const baseId = this.safeString (market, 'base_ccy');
             const quoteId = this.safeString (market, 'quote_ccy');
             const base = this.safeCurrencyCode (baseId);

--- a/js/pro/cryptocom.js
+++ b/js/pro/cryptocom.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const cryptocomRest = require ('../cryptocom.js');
-const { AuthenticationError, NotSupported, ExchangeError } = require ('../base/errors');
+const { AuthenticationError, NotSupported } = require ('../base/errors');
 const { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } = require ('./base/Cache');
 
 //  ---------------------------------------------------------------------------
@@ -55,25 +55,18 @@ module.exports = class cryptocom extends cryptocomRest {
          * @method
          * @name cryptocom#watchOrderBook
          * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
+         * @see https://exchange-docs.crypto.com/spot/index.html#book-instrument_name-depth
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int|undefined} limit the maximum amount of order book entries to return
          * @param {object} params extra parameters specific to the cryptocom api endpoint
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-book-structure} indexed by market symbols
          */
-        if (limit !== undefined) {
-            if ((limit !== 10) && (limit !== 50)) {
-                throw new ExchangeError (this.id + ' watchOrderBook limit argument must be undefined, 10 or 50');
-            }
-        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['spot']) {
             throw new NotSupported (this.id + ' watchOrderBook() supports spot markets only');
         }
-        let messageHash = 'book' + '.' + market['id'];
-        if (limit !== undefined) {
-            messageHash += '.' + limit;
-        }
+        const messageHash = 'book' + '.' + market['id'];
         const orderbook = await this.watchPublic (messageHash, params);
         return orderbook.limit (limit);
     }

--- a/js/pro/cryptocom.js
+++ b/js/pro/cryptocom.js
@@ -61,18 +61,19 @@ module.exports = class cryptocom extends cryptocomRest {
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-book-structure} indexed by market symbols
          */
         if (limit !== undefined) {
-            if ((limit !== 10) && (limit !== 150)) {
-                throw new ExchangeError (this.id + ' watchOrderBook limit argument must be undefined, 10 or 150');
+            if ((limit !== 10) && (limit !== 50)) {
+                throw new ExchangeError (this.id + ' watchOrderBook limit argument must be undefined, 10 or 50');
             }
-        } else {
-            limit = 150; // default value
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['spot']) {
             throw new NotSupported (this.id + ' watchOrderBook() supports spot markets only');
         }
-        const messageHash = 'book' + '.' + market['id'] + '.' + limit.toString ();
+        let messageHash = 'book' + '.' + market['id'];
+        if (limit !== undefined) {
+            messageHash += '.' + limit;
+        }
         const orderbook = await this.watchPublic (messageHash, params);
         return orderbook.limit (limit);
     }


### PR DESCRIPTION
This PR solves 2 errors:

1. Build was failing because accepted limit of cryptocom was changed from 150 to 50. (Was shown through testing)
- Removed error if exchange limitation of limit to 10, or 50 as we can limit to any number using `orderbook.limit()`
- Also Cryptocom now allows not passing a depth, so changed to send this as default.

2. There was a marketId clash between the derivatives and spot markets
- solved by ignoring the spot markets returned by the derivativesAPI

Made calls in `fetchMarkets` run in parallel
