### PR TITLE
Helpers :: add checkRequiredArgument methods

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2770,4 +2770,34 @@ module.exports = class Exchange {
         }
         return [ marginMode, params ];
     }
+
+    checkRequiredArgument (argument, argumentName, methodName, options = []) {
+        /**
+         * @ignore
+         * @method
+         * @param {string} argument the argument to check
+         * @param {string} argumentName the name of the argument to check
+         * @param {string} methodName the name of the method that the argument is being checked for
+         * @param {[string]} options a list of options that the argument can be
+         * @returns {undefined}
+         */
+        if (argument === undefined) {
+            const messageOptions = options.join (', ');
+            let message = this.id + ' ' + methodName + '() requires a ' + argumentName + ' argument';
+            if (messageOptions !== '') {
+                message += ', one of ' + '(' + messageOptions + ')';
+            }
+            throw new ArgumentsRequired (message);
+        }
+    }
+
+    checkRequiredSymbol (symbol, methodName) {
+        /**
+         * @ignore
+         * @method
+         * @param {string} symbol unified symbol of the market
+         * @param {string} methodName name of the method that requires a symbol
+         */
+        this.checkRequiredArgument (symbol, 'symbol', methodName);
+    }
 };

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2781,7 +2781,7 @@ module.exports = class Exchange {
          * @param {[string]} options a list of options that the argument can be
          * @returns {undefined}
          */
-        if (argument === undefined) {
+        if ((argument === undefined) || ((options.length > 0) && (!(this.inArray (argument, options))))) {
             const messageOptions = options.join (', ');
             let message = this.id + ' ' + methodName + '() requires a ' + argumentName + ' argument';
             if (messageOptions !== '') {


### PR DESCRIPTION
- With these helper methods instead of 

```Javascript

if (symbol === undefined) {
    throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument');
}
if (side === undefined) {
    throw new ArgumentsRequired (this.id + ' cancelOrders() requires a `side` parameter (sell or buy)');
}
```

We can do this:

```Javascript
this.checkRequiredSymbol(symbol, "cancelOrders");
this.checkRequiredArgument(side, "side", "cancelOrders", ["buy","sell"])
```


