### PR TITLE
base & okx - correct funding-rate

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -1713,6 +1713,7 @@ module.exports = class okx extends Exchange {
             const rate = data[i];
             const timestamp = this.safeNumber (rate, 'fundingTime');
             rates.push ({
+                'info': rate,
                 'symbol': this.safeSymbol (this.safeString (rate, 'instId')),
                 'fundingRate': this.safeNumber (rate, 'realizedRate'),
                 'timestamp': timestamp,

--- a/js/test/Exchange/test.fetchFundingRateHistory.js
+++ b/js/test/Exchange/test.fetchFundingRateHistory.js
@@ -15,7 +15,7 @@ module.exports = async (exchange) => {
         'info': {}, // Or []
         'timestamp': 1638230400000,
         'datetime': '2021-11-30T00:00:00.000Z',
-        'rate': 0.0006,
+        'fundingRate': 0.0006,
     }
 
     if (exchange.has[method]) {


### PR DESCRIPTION
This was breaking tests as `rate` is not correct (all exchanges have `fundingRate` key there)