### PR TITLE
Cryptocom :: fix fetchTicker

### DIFF
--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -569,16 +569,21 @@ module.exports = class cryptocom extends Exchange {
             throw new NotSupported (this.id + ' fetchTicker() only supports spot markets');
         }
         const response = await this.spotPublicGetPublicGetTicker (this.extend (request, query));
-        // {
-        //     "code":0,
-        //     "method":"public/get-ticker",
-        //     "result":{
-        //       "data": {"i":"CRO_BTC","b":0.00000890,"k":0.00001179,"a":0.00001042,"t":1591770793901,"v":14905879.59,"h":0.00,"l":0.00,"c":0.00}
-        //     }
-        // }
+        //
+        //   {
+        //       "id":"-1",
+        //       "method":"public/get-tickers",
+        //       "code":"0",
+        //       "result":{
+        //          "data":[
+        //             { "i":"BTC_USDT", "h":"20567.16", "l":"20341.39", "a":"20394.23", "v":"2236.3762", "vv":"45739074.30", "c":"-0.0036", "b":"20394.01", "k":"20394.02", "t":"1667406085934" }
+        //          ]
+        //   }
+        //
         const resultResponse = this.safeValue (response, 'result', {});
         const data = this.safeValue (resultResponse, 'data', {});
-        return this.parseTicker (data, market);
+        const first = this.safeValue (data, 0, {});
+        return this.parseTicker (first, market);
     }
 
     async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15528

```
p cryptocom fetchTicker "BTC/USDT" 
Python v3.9.7
CCXT v2.1.9
cryptocom.fetchTicker(BTC/USDT)
{'ask': 20389.98,
 'askVolume': None,
 'average': None,
 'baseVolume': 2218.8269,
 'bid': 20389.97,
 'bidVolume': None,
 'change': -0.0031,
 'close': 20389.98,
 'datetime': '2022-11-02T16:27:55.567Z',
 'high': 20567.16,
 'info': {'a': '20389.98',
          'b': '20389.97',
          'c': '-0.0031',
          'h': '20567.16',
          'i': 'BTC_USDT',
          'k': '20389.98',
          'l': '20341.39',
          't': '1667406475567',
          'v': '2218.8269',
          'vv': '45379690.96'},
 'last': 20389.98,
 'low': 20341.39,
 'open': 20389.9831,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1667406475567,
 'vwap': None}
```
