### PR TITLE
Bybit `fetchTickers` spot v3

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -774,21 +774,21 @@ module.exports = class bybit extends Exchange {
         if (this.options['adjustForTimeDifference']) {
             await this.loadTimeDifference ();
         }
-        // let type = undefined;
-        // [ type, params ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
-        // if (type === 'spot') {
-        // spot and swap ids are equal
-        // so they can't be loaded together
-        const spotMarkets = await this.fetchSpotMarkets (params);
-        return spotMarkets;
-        // }
-        // let promises = [ this.fetchSwapAndFutureMarkets (params), this.fetchUSDCMarkets (params) ];
-        // promises = await Promise.all (promises);
-        // const contractMarkets = promises[0];
-        // const usdcMarkets = promises[1];
-        // let markets = contractMarkets;
-        // markets = this.arrayConcat (markets, usdcMarkets);
-        // return markets;
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
+        if (type === 'spot') {
+            // spot and swap ids are equal
+            // so they can't be loaded together
+            const spotMarkets = await this.fetchSpotMarkets (params);
+            return spotMarkets;
+        }
+        let promises = [ this.fetchSwapAndFutureMarkets (params), this.fetchUSDCMarkets (params) ];
+        promises = await Promise.all (promises);
+        const contractMarkets = promises[0];
+        const usdcMarkets = promises[1];
+        let markets = contractMarkets;
+        markets = this.arrayConcat (markets, usdcMarkets);
+        return markets;
     }
 
     async fetchSpotMarkets (params) {

--- a/php/bybit.php
+++ b/php/bybit.php
@@ -1237,20 +1237,58 @@ class bybit extends Exchange {
     }
 
     public function parse_ticker($ticker, $market = null) {
+        if (is_array($ticker) && array_key_exists('s', $ticker)) {
+            return $this->parse_spot_ticker($ticker, $market);
+        } else {
+            return $this->parse_contract_ticker($ticker, $market);
+        }
+    }
+
+    public function parse_spot_ticker($ticker, $market = null) {
+        //
         // spot
         //
-        //    {
-        //        "time" => "1651743420061",
-        //        "symbol" => "BTCUSDT",
-        //        "bestBidPrice" => "39466.75",
-        //        "bestAskPrice" => "39466.83",
-        //        "volume" => "4396.082921",
-        //        "quoteVolume" => "172664909.03216557",
-        //        "lastPrice" => "39466.71",
-        //        "highPrice" => "40032.79",
-        //        "lowPrice" => "38602.39",
-        //        "openPrice" => "39031.53"
-        //    }
+        //     {
+        //         "t" => "1666771860025",
+        //         "s" => "AAVEUSDT",
+        //         "lp" => "83.8",
+        //         "h" => "86.4",
+        //         "l" => "81",
+        //         "o" => "82.9",
+        //         "bp" => "83.5",
+        //         "ap" => "83.7",
+        //         "v" => "7433.527",
+        //         "qv" => "619835.8676"
+        //     }
+        //
+        $marketId = $this->safe_string($ticker, 's');
+        $symbol = $this->safe_symbol($marketId, $market);
+        $timestamp = $this->safe_integer($ticker, 't');
+        return $this->safe_ticker(array(
+            'symbol' => $symbol,
+            'timestamp' => $timestamp,
+            'datetime' => $this->iso8601($timestamp),
+            'high' => $this->safe_string($ticker, 'h'),
+            'low' => $this->safe_string($ticker, 'l'),
+            'bid' => $this->safe_string($ticker, 'bp'),
+            'bidVolume' => null,
+            'ask' => $this->safe_string($ticker, 'ap'),
+            'askVolume' => null,
+            'vwap' => null,
+            'open' => $this->safe_string($ticker, 'o'),
+            'close' => $this->safe_string($ticker, 'lp'),
+            'last' => null,
+            'previousClose' => null,
+            'change' => null,
+            'percentage' => null,
+            'average' => null,
+            'baseVolume' => $this->safe_string($ticker, 'v'),
+            'quoteVolume' => $this->safe_string($ticker, 'qv'),
+            'info' => $ticker,
+        ), $market);
+    }
+
+    public function parse_contract_ticker($ticker, $market = null) {
         //
         // linear usdt/ inverse swap and future
         //     {
@@ -1311,7 +1349,7 @@ class bybit extends Exchange {
         //          "theta" => "-0.03262827"
         //      }
         //
-        $timestamp = $this->safe_integer($ticker, 'time');
+        $timestamp = $this->safe_integer($ticker, 'time', $this->milliseconds());
         $marketId = $this->safe_string($ticker, 'symbol');
         $symbol = $this->safe_symbol($marketId, $market);
         $last = $this->safe_string_2($ticker, 'last_price', 'lastPrice');
@@ -1456,10 +1494,12 @@ class bybit extends Exchange {
 
     public function fetch_tickers($symbols = null, $params = array ()) {
         /**
-         * fetches price $tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each $market
-         * @param {[string]|null} $symbols unified $symbols of the markets to fetch the $ticker for, all $market $tickers are returned if not assigned
+         * fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each $market
+         * @see https://bybit-exchange.github.io/docs/futuresV2/linear/#t-latestsymbolinfo
+         * @see https://bybit-exchange.github.io/docs/spot/v3/#t-spot_latestsymbolinfo
+         * @param {[string]|null} $symbols unified $symbols of the markets to fetch the ticker for, all $market tickers are returned if not assigned
          * @param {array} $params extra parameters specific to the bybit api endpoint
-         * @return {array} an array of {@link https://docs.ccxt.com/en/latest/manual.html#$ticker-structure $ticker structures}
+         * @return {array} an array of {@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure ticker structures}
          */
         $this->load_markets();
         $symbols = $this->market_symbols($symbols);
@@ -1469,10 +1509,10 @@ class bybit extends Exchange {
         if ($symbols !== null) {
             $symbol = $this->safe_value($symbols, 0);
             $market = $this->market($symbol);
-            $type = $market['type'];
+            list($type, $params) = $this->handle_market_type_and_params('fetchTickers', $market, $params);
             $isUsdcSettled = $market['settle'] === 'USDC';
         } else {
-            list($type, $params) = $this->handle_market_type_and_params('fetchTickers', $market, $params);
+            list($type, $params) = $this->handle_market_type_and_params('fetchTickers', null, $params);
             if ($type !== 'spot') {
                 $defaultSettle = $this->safe_string($this->options, 'defaultSettle', 'USDT');
                 $defaultSettle = $this->safe_string_2($params, 'settle', 'defaultSettle', $isUsdcSettled);
@@ -1482,7 +1522,7 @@ class bybit extends Exchange {
         }
         $method = null;
         if ($type === 'spot') {
-            $method = 'publicGetSpotQuoteV1Ticker24hr';
+            $method = 'publicGetSpotV3PublicQuoteTicker24hr';
         } elseif (!$isUsdcSettled) {
             // inverse perpetual // usdt linear // inverse futures
             $method = 'publicGetV2PublicTickers';
@@ -1490,14 +1530,37 @@ class bybit extends Exchange {
             throw new NotSupported($this->id . ' fetchTickers() is not supported for USDC markets');
         }
         $response = $this->$method ($params);
+        //
+        // spot
+        //
+        //    {
+        //         "retCode" => "0",
+        //         "retMsg" => "OK",
+        //         "result" => array(
+        //             "list" => array(
+        //                 array(
+        //                     "t" => "1666772160002",
+        //                     "s" => "XDCUSDT",
+        //                     "lp" => "0.03109",
+        //                     "h" => "0.03116",
+        //                     "l" => "0.03001",
+        //                     "o" => "0.03044",
+        //                     "bp" => "0.03105",
+        //                     "ap" => "0.03109",
+        //                     "v" => "1362796.9",
+        //                     "qv" => "41423.411932"
+        //                 ),
+        //             )
+        //         ),
+        //         "retExtInfo" => array(),
+        //         "time" => "1666772209124"
+        //     }
+        //
         $result = $this->safe_value($response, 'result', array());
-        $tickers = array();
-        for ($i = 0; $i < count($result); $i++) {
-            $ticker = $this->parse_ticker($result[$i]);
-            $symbol = $ticker['symbol'];
-            $tickers[$symbol] = $ticker;
+        if (gettype($result) !== 'array' || array_keys($result) !== array_keys(array_keys($result))) {
+            $result = $this->safe_value($result, 'list', array());
         }
-        return $this->filter_by_array($tickers, 'symbol', $symbols);
+        return $this->parse_tickers($result, $symbols, $params);
     }
 
     public function parse_ohlcv($ohlcv, $market = null) {

--- a/python/ccxt/async_support/bybit.py
+++ b/python/ccxt/async_support/bybit.py
@@ -1229,20 +1229,55 @@ class bybit(Exchange):
         return result
 
     def parse_ticker(self, ticker, market=None):
+        if 's' in ticker:
+            return self.parse_spot_ticker(ticker, market)
+        else:
+            return self.parse_contract_ticker(ticker, market)
+
+    def parse_spot_ticker(self, ticker, market=None):
+        #
         # spot
         #
-        #    {
-        #        "time": "1651743420061",
-        #        "symbol": "BTCUSDT",
-        #        "bestBidPrice": "39466.75",
-        #        "bestAskPrice": "39466.83",
-        #        "volume": "4396.082921",
-        #        "quoteVolume": "172664909.03216557",
-        #        "lastPrice": "39466.71",
-        #        "highPrice": "40032.79",
-        #        "lowPrice": "38602.39",
-        #        "openPrice": "39031.53"
-        #    }
+        #     {
+        #         "t": "1666771860025",
+        #         "s": "AAVEUSDT",
+        #         "lp": "83.8",
+        #         "h": "86.4",
+        #         "l": "81",
+        #         "o": "82.9",
+        #         "bp": "83.5",
+        #         "ap": "83.7",
+        #         "v": "7433.527",
+        #         "qv": "619835.8676"
+        #     }
+        #
+        marketId = self.safe_string(ticker, 's')
+        symbol = self.safe_symbol(marketId, market)
+        timestamp = self.safe_integer(ticker, 't')
+        return self.safe_ticker({
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': self.iso8601(timestamp),
+            'high': self.safe_string(ticker, 'h'),
+            'low': self.safe_string(ticker, 'l'),
+            'bid': self.safe_string(ticker, 'bp'),
+            'bidVolume': None,
+            'ask': self.safe_string(ticker, 'ap'),
+            'askVolume': None,
+            'vwap': None,
+            'open': self.safe_string(ticker, 'o'),
+            'close': self.safe_string(ticker, 'lp'),
+            'last': None,
+            'previousClose': None,
+            'change': None,
+            'percentage': None,
+            'average': None,
+            'baseVolume': self.safe_string(ticker, 'v'),
+            'quoteVolume': self.safe_string(ticker, 'qv'),
+            'info': ticker,
+        }, market)
+
+    def parse_contract_ticker(self, ticker, market=None):
         #
         # linear usdt/ inverse swap and future
         #     {
@@ -1303,7 +1338,7 @@ class bybit(Exchange):
         #          "theta": "-0.03262827"
         #      }
         #
-        timestamp = self.safe_integer(ticker, 'time')
+        timestamp = self.safe_integer(ticker, 'time', self.milliseconds())
         marketId = self.safe_string(ticker, 'symbol')
         symbol = self.safe_symbol(marketId, market)
         last = self.safe_string_2(ticker, 'last_price', 'lastPrice')
@@ -1445,6 +1480,8 @@ class bybit(Exchange):
     async def fetch_tickers(self, symbols=None, params={}):
         """
         fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+        see https://bybit-exchange.github.io/docs/futuresV2/linear/#t-latestsymbolinfo
+        see https://bybit-exchange.github.io/docs/spot/v3/#t-spot_latestsymbolinfo
         :param [str]|None symbols: unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
         :param dict params: extra parameters specific to the bybit api endpoint
         :returns dict: an array of `ticker structures <https://docs.ccxt.com/en/latest/manual.html#ticker-structure>`
@@ -1457,10 +1494,10 @@ class bybit(Exchange):
         if symbols is not None:
             symbol = self.safe_value(symbols, 0)
             market = self.market(symbol)
-            type = market['type']
+            type, params = self.handle_market_type_and_params('fetchTickers', market, params)
             isUsdcSettled = market['settle'] == 'USDC'
         else:
-            type, params = self.handle_market_type_and_params('fetchTickers', market, params)
+            type, params = self.handle_market_type_and_params('fetchTickers', None, params)
             if type != 'spot':
                 defaultSettle = self.safe_string(self.options, 'defaultSettle', 'USDT')
                 defaultSettle = self.safe_string_2(params, 'settle', 'defaultSettle', isUsdcSettled)
@@ -1468,20 +1505,43 @@ class bybit(Exchange):
                 isUsdcSettled = defaultSettle == 'USDC'
         method = None
         if type == 'spot':
-            method = 'publicGetSpotQuoteV1Ticker24hr'
+            method = 'publicGetSpotV3PublicQuoteTicker24hr'
         elif not isUsdcSettled:
             # inverse perpetual  # usdt linear  # inverse futures
             method = 'publicGetV2PublicTickers'
         else:
             raise NotSupported(self.id + ' fetchTickers() is not supported for USDC markets')
         response = await getattr(self, method)(params)
+        #
+        # spot
+        #
+        #    {
+        #         "retCode": "0",
+        #         "retMsg": "OK",
+        #         "result": {
+        #             "list": [
+        #                 {
+        #                     "t": "1666772160002",
+        #                     "s": "XDCUSDT",
+        #                     "lp": "0.03109",
+        #                     "h": "0.03116",
+        #                     "l": "0.03001",
+        #                     "o": "0.03044",
+        #                     "bp": "0.03105",
+        #                     "ap": "0.03109",
+        #                     "v": "1362796.9",
+        #                     "qv": "41423.411932"
+        #                 },
+        #             ]
+        #         },
+        #         "retExtInfo": {},
+        #         "time": "1666772209124"
+        #     }
+        #
         result = self.safe_value(response, 'result', [])
-        tickers = {}
-        for i in range(0, len(result)):
-            ticker = self.parse_ticker(result[i])
-            symbol = ticker['symbol']
-            tickers[symbol] = ticker
-        return self.filter_by_array(tickers, 'symbol', symbols)
+        if not isinstance(result, list):
+            result = self.safe_value(result, 'list', [])
+        return self.parse_tickers(result, symbols, params)
 
     def parse_ohlcv(self, ohlcv, market=None):
         #


### PR DESCRIPTION
# Testing
## Python
spot
`python3 examples/py/cli.py bybit fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.1.7
bybit.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 20825.69,
              'askVolume': None,
              'average': 20478.845,
              'baseVolume': 13287.272735,
              'bid': 20822.16,
              'bidVolume': None,
              'change': 693.69,
              'close': 20825.69,
              'datetime': '2022-11-04T13:31:58.950Z',
              'high': 20889.55,
              'info': {'ap': '20825.69',
                       'bp': '20822.16',
                       'h': '20889.55',
                       'l': '20084.83',
                       'lp': '20825.69',
                       'o': '20132',
                       'qv': '271787853.59996857',
                       's': 'BTCUSDT',
                       't': '1667568718950',
                       'v': '13287.272735'},
              'last': 20825.69,
              'low': 20084.83,
              'open': 20132.0,
              'percentage': 3.4457083250546394,
              'previousClose': None,
              'quoteVolume': 271787853.59996855,
              'symbol': 'BTC/USDT',
              'timestamp': 1667568718950,
              'vwap': 20454.75087480159}}
```
swap
`python3 examples/py/cli.py bybit fetchTickers '["BTC/USDT:USDT"]'`
```
Python v3.10.6
CCXT v2.1.7
bybit.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 20791.5,
                   'askVolume': None,
                   'average': 20480.75,
                   'baseVolume': 136844.95699999,
                   'bid': 20791.0,
                   'bidVolume': None,
                   'change': 620.5,
                   'close': 20791.0,
                   'datetime': '2022-11-04T13:33:57.942Z',
                   'high': 20871.5,
                   'info': {'ask_price': '20791.5',
                            'bid_price': '20791',
                            'countdown_hour': '0',
                            'delivery_fee_rate': '',
                            'delivery_time': '',
                            'funding_rate': '-0.000103',
                            'high_price_24h': '20871.50',
                            'index_price': '20803.32',
                            'last_price': '20791.00',
                            'last_tick_direction': 'ZeroPlusTick',
                            'low_price_24h': '20079.00',
                            'mark_price': '20788.04',
                            'next_funding_time': '2022-11-04T16:00:00Z',
                            'open_interest': '60655.887',
                            'open_value': '',
                            'predicted_delivery_price': '',
                            'predicted_funding_rate': '',
                            'prev_price_1h': '20525.50',
                            'prev_price_24h': '20170.50',
                            'price_1h_pcnt': '',
                            'price_24h_pcnt': '0.030762',
                            'symbol': 'BTCUSDT',
                            'total_turnover': '',
                            'total_volume': '0',
                            'turnover_24h': '2799138997.8364997',
                            'volume_24h': '136844.95699999'},
                   'last': 20791.0,
                   'low': 20079.0,
                   'open': 20170.5,
                   'percentage': 3.0762,
                   'previousClose': None,
                   'quoteVolume': 2799138997.8364997,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1667568837942,
                   'vwap': 20454.820252066023}}
```