### PR TITLE
Remove limiting from orderbooks

### DIFF
--- a/js/pro/aax.js
+++ b/js/pro/aax.js
@@ -251,7 +251,7 @@ module.exports = class aax extends aaxRest {
         };
         const request = this.extend (subscribe, params);
         const orderbook = await this.watch (url, messageHash, request, messageHash);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleDelta (bookside, delta) {

--- a/js/pro/ascendex.js
+++ b/js/pro/ascendex.js
@@ -210,7 +210,7 @@ module.exports = class ascendex extends ascendexRest {
             'ch': channel,
         });
         const orderbook = await this.watchPublic (channel, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async watchOrderBookSnapshot (symbol, limit = undefined, params = {}) {
@@ -226,7 +226,7 @@ module.exports = class ascendex extends ascendexRest {
             'op': 'req',
         });
         const orderbook = await this.watchPublic (channel, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSnapshot (client, message) {

--- a/js/pro/base/OrderBook.js
+++ b/js/pro/base/OrderBook.js
@@ -60,9 +60,9 @@ class OrderBook {
         }
     }
 
-    limit (n = undefined) {
-        this.asks.limit (n)
-        this.bids.limit (n)
+    limit () {
+        this.asks.limit ()
+        this.bids.limit ()
         return this
     }
 

--- a/js/pro/base/OrderBookSide.js
+++ b/js/pro/base/OrderBookSide.js
@@ -99,24 +99,7 @@ class OrderBookSide extends Array {
     }
 
     // replace stored orders with new values
-    limit (n = undefined) {
-        if (n < this.length) {
-            // we store some hidden stuff for when the book is temporarily limited to the user
-            for (let i = n; i < this.length; i++) {
-                this.hidden.set (this.index[i], this[i])
-            }
-            this.length = n
-        }
-        if (this.hidden.size) {
-            let end = this.length + this.hidden.size
-            if (n !== undefined) {
-                end = Math.min (end, n)
-            }
-            for (let i = this.length; i < end; i++) {
-                this.push (this.hidden.get (this.index[i]))
-                this.hidden.delete (this.index[i])
-            }
-        }
+    limit () {
         if (this.length > this.depth) {
             for (let i = this.depth; i < this.length; i++) {
                 this.index[i] = Number.MAX_VALUE
@@ -299,24 +282,7 @@ class IndexedOrderBookSide extends Array  {
     }
 
     // replace stored orders with new values
-    limit (n = undefined) {
-        if (n < this.length) {
-            // we store some hidden stuff for when the book is temporarily limited to the user
-            for (let i = n; i < this.length; i++) {
-                this.hidden.set (this.index[i], this[i])
-            }
-            this.length = n
-        }
-        if (this.hidden.size) {
-            let end = this.length + this.hidden.size
-            if (n !== undefined) {
-                end = Math.min (end, n)
-            }
-            for (let i = this.length; i < end; i++) {
-                this.push (this.hidden.get (this.index[i]))
-                this.hidden.delete (this.index[i])
-            }
-        }
+    limit () {
         if (this.length > this.depth) {
             for (let i = this.depth; i < this.length; i++) {
                 // diff

--- a/js/pro/base/OrderBookSide.js
+++ b/js/pro/base/OrderBookSide.js
@@ -51,23 +51,13 @@ class OrderBookSide extends Array {
         const index = bisectLeft (this.index, index_price)
         if (size) {
             if (this.index[index] === index_price) {
-                if (index < this.length) {
-                    this[index][1] = size
-                } else {
-                    const entry = this.hidden.get (index_price)
-                    entry[1] = size
-                }
+                this[index][1] = size
             } else {
                 this.length++
                 this.index.copyWithin (index + 1, index, this.index.length)
                 this.index[index] = index_price
-                if (index < this.length) {
-                    this.copyWithin (index + 1, index, this.length)
-                    this[index] = delta
-                } else {
-                    this.hidden.set(index_price, delta)
-                    this.length--
-                }
+                this.copyWithin (index + 1, index, this.length)
+                this[index] = delta
                 // in the rare case of very large orderbooks being sent
                 if (this.length > this.index.length - 1) {
                     const existing = Array.from (this.index)
@@ -78,13 +68,9 @@ class OrderBookSide extends Array {
             }
         } else if (this.index[index] === index_price) {
             this.index.copyWithin (index, index + 1, this.index.length)
-            this.index[this.length + this.hidden.size - 1] = Number.MAX_VALUE
-            if (this.hidden.has (index_price)) {
-                this.hidden.delete (index_price)
-            } else {
-                this.copyWithin (index, index + 1, this.length)
-                this.length--
-            }
+            this.index[this.length - 1] = Number.MAX_VALUE
+            this.copyWithin (index, index + 1, this.length)
+            this.length--
         }
     }
 
@@ -99,7 +85,6 @@ class OrderBookSide extends Array {
             for (let i = this.depth; i < this.length; i++) {
                 this.index[i] = Number.MAX_VALUE
             }
-            this.hidden.clear ()
             this.length = this.depth
         }
     }
@@ -122,27 +107,16 @@ class CountedOrderBookSide extends OrderBookSide {
         const index_price = this.side ? -price : price
         const index = bisectLeft (this.index, index_price)
         if (size && count) {
-            if (this.index[index] == index_price) {
-                if (index < this.length) {
-                    const entry = this[index]
-                    entry[1] = size
-                    entry[2] = count
-                } else {
-                    const entry = this.hidden.get (index_price)
-                    entry[1] = size
-                    entry[2] = count
-                }
+            if (this.index[index] === index_price) {
+                const entry = this[index]
+                entry[1] = size
+                entry[2] = count
             } else {
                 this.length++
                 this.index.copyWithin (index + 1, index, this.index.length)
                 this.index[index] = index_price
-                if (index < this.length) {
-                    this.copyWithin (index + 1, index, this.length)
-                    this[index] = delta
-                } else {
-                    this.hidden.set(index_price, delta)
-                    this.length--
-                }
+                this.copyWithin (index + 1, index, this.length)
+                this[index] = delta
                 // in the rare case of very large orderbooks being sent
                 if (this.length > this.index.length - 1) {
                     const existing = Array.from (this.index)
@@ -151,15 +125,11 @@ class CountedOrderBookSide extends OrderBookSide {
                     this.index = new Float64Array (existing)
                 }
             }
-        } else if (this.index[index] == index_price) {
+        } else if (this.index[index] === index_price) {
             this.index.copyWithin (index, index + 1, this.index.length)
-            this.index[this.length + this.hidden.size - 1] = Number.MAX_VALUE
-            if (this.hidden.has (index_price)) {
-                this.hidden.delete (index_price)
-            } else {
-                this.copyWithin (index, index + 1, this.length)
-                this.length--
-            }
+            this.index[this.length - 1] = Number.MAX_VALUE
+            this.copyWithin (index, index + 1, this.length)
+            this.length--
         }
     }
 }
@@ -221,23 +191,15 @@ class IndexedOrderBookSide extends Array  {
                 if (index_price === old_price) {
                     const index = bisectLeft (this.index, index_price)
                     this.index[index] = index_price
-                    if (index < this.length) {
-                        this[index] = delta
-                    } else {
-                        this.hidden.set (index_price, delta)
-                    }
+                    this[index] = delta
                     return
                 } else {
                     // remove old price from index
                     const old_index = bisectLeft (this.index, old_price)
                     this.index.copyWithin (old_index, old_index + 1, this.index.length)
-                    this.index[this.length + this.hidden.size - 1] = Number.MAX_VALUE
-                    if (this.hidden.has (old_price)) {
-                        this.hidden.delete (old_price)
-                    } else {
-                        this.copyWithin (old_index, old_index + 1, this.length)
-                        this.length--
-                    }
+                    this.index[this.length - 1] = Number.MAX_VALUE
+                    this.copyWithin (old_index, old_index + 1, this.length)
+                    this.length--
                 }
             }
             // insert new price level
@@ -247,13 +209,8 @@ class IndexedOrderBookSide extends Array  {
             this.length++
             this.index.copyWithin (index + 1, index, this.index.length)
             this.index[index] = index_price
-            if (index < this.length) {
-                this.copyWithin (index + 1, index, this.length)
-                this[index] = delta
-            } else {
-                this.hidden.set (index_price, delta)
-                this.length--
-            }
+            this.copyWithin (index + 1, index, this.length)
+            this[index] = delta
             // in the rare case of very large orderbooks being sent
             if (this.length > this.index.length - 1) {
                 const existing = Array.from (this.index)
@@ -266,12 +223,8 @@ class IndexedOrderBookSide extends Array  {
             const index = bisectLeft (this.index, old_price)
             this.index.copyWithin (index, index + 1, this.index.length)
             this.index[this.length - 1] = Number.MAX_VALUE
-            if (this.hidden.has (old_price)) {
-                this.hidden.delete (old_price)
-            } else {
-                this.copyWithin (index, index + 1, this.length)
-                this.length--
-            }
+            this.copyWithin (index, index + 1, this.length)
+            this.length--
             this.hashmap.delete (id)
         }
     }
@@ -284,7 +237,6 @@ class IndexedOrderBookSide extends Array  {
                 this.hashmap.delete (this.index[i])
                 this.index[i] = Number.MAX_VALUE
             }
-            this.hidden.clear ()
             this.length = this.depth
         }
     }

--- a/js/pro/base/OrderBookSide.js
+++ b/js/pro/base/OrderBookSide.js
@@ -37,11 +37,6 @@ class OrderBookSide extends Array {
             value: depth || Number.MAX_SAFE_INTEGER,
             writable: true,
         })
-        Object.defineProperty (this, 'hidden', {
-            __proto__: null, // make it invisible
-            value: new Map (),
-            writable: true,
-        })
         // sort upon initiation
         this.length = 0
         for (let i = 0; i < deltas.length; i++) {

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -160,7 +160,7 @@ module.exports = class binance extends binanceRest {
         const message = this.extend (request, query);
         // 1. Open a stream to wss://stream.binance.com:9443/ws/bnbbtc@depth.
         const orderbook = await this.watch (url, messageHash, message, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async fetchOrderBookSnapshot (client, message, subscription) {

--- a/js/pro/bitfinex.js
+++ b/js/pro/bitfinex.js
@@ -284,7 +284,7 @@ module.exports = class bitfinex extends bitfinexRest {
             'len': limit, // string, number of price points, '25', '100', default = '25'
         };
         const orderbook = await this.subscribe ('book', symbol, this.deepExtend (request, params));
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message, subscription) {

--- a/js/pro/bitfinex2.js
+++ b/js/pro/bitfinex2.js
@@ -549,7 +549,7 @@ module.exports = class bitfinex2 extends bitfinex2Rest {
             request['len'] = limit; // string, number of price points, '25', '100', default = '25'
         }
         const orderbook = await this.subscribe ('book', symbol, this.deepExtend (request, params));
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message, subscription) {

--- a/js/pro/bitmart.js
+++ b/js/pro/bitmart.js
@@ -390,7 +390,7 @@ module.exports = class bitmart extends bitmartRest {
         const options = this.safeValue (this.options, 'watchOrderBook', {});
         const depth = this.safeString (options, 'depth', 'depth400');
         const orderbook = await this.subscribe (depth, symbol, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleDelta (bookside, delta) {

--- a/js/pro/bitmex.js
+++ b/js/pro/bitmex.js
@@ -972,7 +972,7 @@ module.exports = class bitmex extends bitmexRest {
             ],
         };
         const orderbook = await this.watch (url, messageHash, this.deepExtend (request, params), messageHash);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async watchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {

--- a/js/pro/bitopro.js
+++ b/js/pro/bitopro.js
@@ -77,7 +77,7 @@ module.exports = class bitopro extends bitoproRest {
             endPart = market['id'] + ':' + limit;
         }
         const orderbook = await this.watchPublic ('order-books', messageHash, endPart);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/bitstamp.js
+++ b/js/pro/bitstamp.js
@@ -76,7 +76,7 @@ module.exports = class bitstamp extends bitstampRest {
         };
         const message = this.extend (request, params);
         const orderbook = await this.watch (url, messageHash, message, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async fetchOrderBookSnapshot (client, message, subscription) {

--- a/js/pro/bittrex.js
+++ b/js/pro/bittrex.js
@@ -617,7 +617,7 @@ module.exports = class bittrex extends bittrexRest {
         //     8. If a message is received that is not the next in order, return to step 2 in this process
         //
         const orderbook = await this.subscribeToOrderBook (negotiation, symbol, limit, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async subscribeToOrderBook (negotiation, symbol, limit = undefined, params = {}) {

--- a/js/pro/bitvavo.js
+++ b/js/pro/bitvavo.js
@@ -257,7 +257,7 @@ module.exports = class bitvavo extends bitvavoRest {
         };
         const message = this.extend (request, params);
         const orderbook = await this.watch (url, messageHash, message, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleDelta (bookside, delta) {
@@ -348,7 +348,7 @@ module.exports = class bitvavo extends bitvavoRest {
             'market': marketId,
         };
         const orderbook = await this.watch (url, messageHash, this.extend (request, params), messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSnapshot (client, message) {

--- a/js/pro/bitvavo.js
+++ b/js/pro/bitvavo.js
@@ -337,7 +337,6 @@ module.exports = class bitvavo extends bitvavoRest {
     }
 
     async watchOrderBookSnapshot (client, message, subscription) {
-        const limit = this.safeInteger (subscription, 'limit');
         const params = this.safeValue (subscription, 'params');
         const marketId = this.safeString (subscription, 'marketId');
         const name = 'getBook';

--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -694,7 +694,7 @@ module.exports = class bybit extends bybitRest {
             const reqParams = [ channel ];
             orderbook = await this.watchContractPublic (url, messageHash, reqParams, params);
         }
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/coinbasepro.js
+++ b/js/pro/coinbasepro.js
@@ -191,7 +191,7 @@ module.exports = class coinbasepro extends coinbaseproRest {
             'limit': limit,
         };
         const orderbook = await this.watch (url, messageHash, request, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleTrade (client, message) {

--- a/js/pro/coinex.js
+++ b/js/pro/coinex.js
@@ -461,7 +461,7 @@ module.exports = class coinex extends coinexRest {
         };
         const request = this.deepExtend (subscribe, params);
         const orderbook = await this.watch (url, messageHash, request, messageHash);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async watchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {

--- a/js/pro/cryptocom.js
+++ b/js/pro/cryptocom.js
@@ -68,7 +68,7 @@ module.exports = class cryptocom extends cryptocomRest {
         }
         const messageHash = 'book' + '.' + market['id'];
         const orderbook = await this.watchPublic (messageHash, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSnapshot (client, message) {

--- a/js/pro/currencycom.js
+++ b/js/pro/currencycom.js
@@ -411,7 +411,7 @@ module.exports = class currencycom extends currencycomRest {
         await this.loadMarkets ();
         symbol = this.symbol (symbol);
         const orderbook = await this.watchPublic ('depthMarketData.subscribe', symbol, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async watchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {

--- a/js/pro/deribit.js
+++ b/js/pro/deribit.js
@@ -412,7 +412,7 @@ module.exports = class deribit extends deribitRest {
         };
         const request = this.deepExtend (subscribe, params);
         const orderbook = await this.watch (url, channel, request, channel);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/exmo.js
+++ b/js/pro/exmo.js
@@ -480,7 +480,7 @@ module.exports = class exmo extends exmoRest {
         };
         const request = this.deepExtend (subscribe, params);
         const orderbook = await this.watch (url, messageHash, request, messageHash);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/ftx.js
+++ b/js/pro/ftx.js
@@ -152,7 +152,7 @@ module.exports = class ftx extends ftxRest {
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-book-structure} indexed by market symbols
          */
         const orderbook = await this.watchPublic (symbol, 'orderbook');
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handlePartial (client, message) {

--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -113,7 +113,7 @@ module.exports = class gate extends gateRest {
             'limit': limit,
         };
         const orderbook = await this.subscribePublic (url, method, messageHash, payload, subscriptionParams);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSubscription (client, message, subscription) {

--- a/js/pro/hitbtc.js
+++ b/js/pro/hitbtc.js
@@ -69,7 +69,7 @@ module.exports = class hitbtc extends hitbtcRest {
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-book-structure} indexed by market symbols
          */
         const orderbook = await this.watchPublic (symbol, 'orderbook', undefined, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSnapshot (client, message) {

--- a/js/pro/hollaex.js
+++ b/js/pro/hollaex.js
@@ -66,7 +66,7 @@ module.exports = class hollaex extends hollaexRest {
         const market = this.market (symbol);
         const messageHash = 'orderbook' + ':' + market['id'];
         const orderbook = await this.watchPublic (messageHash, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/huobi.js
+++ b/js/pro/huobi.js
@@ -306,7 +306,7 @@ module.exports = class huobi extends huobiRest {
             params['data_type'] = 'incremental';
         }
         const orderbook = await this.subscribePublic (url, symbol, messageHash, this.handleOrderBookSubscription, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSnapshot (client, message, subscription) {
@@ -398,7 +398,7 @@ module.exports = class huobi extends huobiRest {
             'method': this.handleOrderBookSnapshot,
         };
         const orderbook = await this.watch (url, requestId, request, requestId, snapshotSubscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async fetchOrderBookSnapshot (client, message, subscription) {

--- a/js/pro/huobijp.js
+++ b/js/pro/huobijp.js
@@ -291,7 +291,7 @@ module.exports = class huobijp extends huobijpRest {
             'method': this.handleOrderBookSubscription,
         };
         const orderbook = await this.watch (url, messageHash, this.extend (request, params), messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBookSnapshot (client, message, subscription) {
@@ -356,7 +356,7 @@ module.exports = class huobijp extends huobijpRest {
             'method': this.handleOrderBookSnapshot,
         };
         const orderbook = await this.watch (url, requestId, request, requestId, snapshotSubscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleDelta (bookside, delta) {

--- a/js/pro/idex.js
+++ b/js/pro/idex.js
@@ -425,7 +425,7 @@ module.exports = class idex extends idexRest {
         }
         // 1. Connect to the WebSocket API endpoint and subscribe to the L2 Order Book for the target market.
         const orderbook = await this.subscribe (subscribeObject, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/kraken.js
+++ b/js/pro/kraken.js
@@ -284,7 +284,7 @@ module.exports = class kraken extends krakenRest {
             }
         }
         const orderbook = await this.watchPublic (name, symbol, this.extend (request, params));
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async watchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {

--- a/js/pro/kucoin.js
+++ b/js/pro/kucoin.js
@@ -372,7 +372,7 @@ module.exports = class kucoin extends kucoinRest {
         const topic = '/market/level2:' + market['id'];
         const messageHash = topic;
         const orderbook = await this.subscribe (negotiation, topic, messageHash, this.handleOrderBookSubscription, symbol, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     retryFetchOrderBookSnapshot (client, message, subscription) {

--- a/js/pro/mexc.js
+++ b/js/pro/mexc.js
@@ -298,7 +298,7 @@ module.exports = class mexc extends mexcRest {
             requestParams['depth'] = limit;
             orderbook = await this.watchSpotPublic (messageHash, channel, requestParams, params);
         }
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/ndax.js
+++ b/js/pro/ndax.js
@@ -353,7 +353,7 @@ module.exports = class ndax extends ndaxRest {
         };
         const message = this.extend (request, params);
         const orderbook = await this.watch (url, messageHash, message, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/okcoin.js
+++ b/js/pro/okcoin.js
@@ -327,7 +327,7 @@ module.exports = class okcoin extends okcoinRest {
         const options = this.safeValue (this.options, 'watchOrderBook', {});
         const depth = this.safeString (options, 'depth', 'depth_l2_tbt');
         const orderbook = await this.subscribe (depth, symbol, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleDelta (bookside, delta) {

--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -295,7 +295,7 @@ module.exports = class okx extends okxRest {
         //
         const depth = this.safeString (options, 'depth', 'books');
         const orderbook = await this.subscribe ('public', depth, symbol, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleDelta (bookside, delta) {

--- a/js/pro/phemex.js
+++ b/js/pro/phemex.js
@@ -420,7 +420,7 @@ module.exports = class phemex extends phemexRest {
         };
         const request = this.deepExtend (subscribe, params);
         const orderbook = await this.watch (url, messageHash, request, messageHash);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async watchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {

--- a/js/pro/ripio.js
+++ b/js/pro/ripio.js
@@ -183,7 +183,7 @@ module.exports = class ripio extends ripioRest {
             this.delay (delay, this.fetchOrderBookSnapshot, client, subscription);
         }
         const orderbook = await this.watch (url, messageHash, undefined, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     async fetchOrderBookSnapshot (client, subscription) {

--- a/js/pro/test/base/test.OrderBook.js
+++ b/js/pro/test/base/test.OrderBook.js
@@ -253,9 +253,7 @@ const limited = new OrderBook (orderBookInput, 5);
 orderBook.limit ();
 assert (equals (orderBook, orderBookTarget));
 
-orderBook.limit (5);
 limited.limit ();
-assert (equals (orderBook, limitedOrderBookTarget));
 assert (equals (limited, limitedOrderBookTarget));
 
 orderBook.limit ();
@@ -279,11 +277,6 @@ asks.store (15.5, 0);
 limited.limit ();
 assert (equals (limited, limitedDeletedOrderBookTarget));
 
-limited.limit (5);
-asks.store (100, 1);
-asks.store (101, 1);
-asks.store (101, 3);
-
 // --------------------------------------------------------------------------------------------------------------------
 
 let indexedOrderBook = new IndexedOrderBook (indexedOrderBookInput);
@@ -291,9 +284,7 @@ const limitedIndexedOrderBook = new IndexedOrderBook (indexedOrderBookInput, 5);
 indexedOrderBook.limit ();
 assert (equals (indexedOrderBook, indexedOrderBookTarget));
 
-indexedOrderBook.limit (5);
 limitedIndexedOrderBook.limit ();
-assert (equals (indexedOrderBook, limitedIndexedOrderBookTarget));
 assert (equals (limitedIndexedOrderBook, limitedIndexedOrderBookTarget));
 indexedOrderBook.limit ();
 assert (equals (indexedOrderBook, indexedOrderBookTarget));
@@ -317,9 +308,7 @@ const limitedCountedOrderBook = new CountedOrderBook (countedOrderBookInput, 5);
 countedOrderBook.limit ();
 assert (equals (countedOrderBook, countedOrderBookTarget));
 
-countedOrderBook.limit (5);
 limitedCountedOrderBook.limit ();
-assert (equals (countedOrderBook, limitedCountedOrderBookTarget));
 assert (equals (limitedCountedOrderBook, limitedCountedOrderBookTarget));
 countedOrderBook.limit ();
 assert (equals (countedOrderBook, countedOrderBookTarget));

--- a/js/pro/upbit.js
+++ b/js/pro/upbit.js
@@ -95,7 +95,7 @@ module.exports = class upbit extends upbitRest {
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-book-structure} indexed by market symbols
          */
         const orderbook = await this.watchPublic (symbol, 'orderbook');
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleTicker (client, message) {

--- a/js/pro/whitebit.js
+++ b/js/pro/whitebit.js
@@ -159,7 +159,7 @@ module.exports = class whitebit extends whitebitRest {
             true, // true for allowing multiple subscriptions
         ];
         const orderbook = await this.watchPublic (messageHash, method, reqParams, params);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message) {

--- a/js/pro/zb.js
+++ b/js/pro/zb.js
@@ -180,7 +180,7 @@ module.exports = class zb extends zbRest {
             'method': this.handleOrderBook,
         };
         const orderbook = await this.watch (url, messageHash, message, messageHash, subscription);
-        return orderbook.limit (limit);
+        return orderbook.limit ();
     }
 
     handleOrderBook (client, message, subscription) {

--- a/php/pro/OrderBook.php
+++ b/php/pro/OrderBook.php
@@ -32,9 +32,9 @@ class OrderBook extends \ArrayObject implements \JsonSerializable {
         return $this->getArrayCopy();
     }
 
-    public function limit($n = PHP_INT_MAX) {
-        $this['asks']->limit($n);
-        $this['bids']->limit($n);
+    public function limit() {
+        $this['asks']->limit();
+        $this['bids']->limit();
         return $this;
     }
 

--- a/php/pro/OrderBookSide.php
+++ b/php/pro/OrderBookSide.php
@@ -31,12 +31,6 @@ class OrderBookSide extends \ArrayObject implements \JsonSerializable {
         }
     }
 
-    #[\ReturnTypeWillChange]
-    public function getIterator() {
-        // look at the python for equivalence
-        return new \LimitIterator(parent::getIterator(), 0, $this->n);
-    }
-
     public function storeArray($delta) {
         $price = $delta[0];
         $size = $delta[1];
@@ -66,8 +60,7 @@ class OrderBookSide extends \ArrayObject implements \JsonSerializable {
         $this->storeArray(array($price, $size));
     }
 
-    public function limit($n = null) {
-        $this->n = $n ? $n : PHP_INT_MAX;
+    public function limit() {
         $difference = count($this) - $this->depth;
         if ($difference > 0) {
             array_splice($this->index, -$difference);

--- a/python/ccxt/pro/base/order_book.py
+++ b/python/ccxt/pro/base/order_book.py
@@ -27,9 +27,9 @@ class OrderBook(dict):
         # merge to self
         super(OrderBook, self).__init__(defaults)
 
-    def limit(self, n=None):
-        self['asks'].limit(n)
-        self['bids'].limit(n)
+    def limit(self):
+        self['asks'].limit()
+        self['bids'].limit()
         return self
 
     def reset(self, snapshot={}):

--- a/python/ccxt/pro/base/order_book_side.py
+++ b/python/ccxt/pro/base/order_book_side.py
@@ -2,7 +2,6 @@
 
 import sys
 import bisect
-import itertools
 
 """Author: Carlo Revelli"""
 """Fast bisect bindings"""
@@ -40,8 +39,7 @@ class OrderBookSide(list):
     def store(self, price, size):
         self.storeArray([price, size])
 
-    def limit(self, n=None):
-        self._n = sys.maxsize if n is None else n
+    def limit(self):
         difference = len(self) - self._depth
         for _ in range(difference):
             self.remove_index(self.pop())
@@ -49,12 +47,6 @@ class OrderBookSide(list):
 
     def remove_index(self, order):
         pass
-
-    def __iter__(self):
-        # a call to limit only temporarily limits the order book
-        # so we hide the rest of the cached data after self._n
-        iterator = super(OrderBookSide, self).__iter__()
-        return itertools.islice(iterator, self._n)
 
     def __len__(self):
         length = super(OrderBookSide, self).__len__()


### PR DESCRIPTION
so instead we will only return the entire result of the orderbook as responded by the exchange. This will allow users to see that there limit argument is being correctly parsed to the exchange since most users will care more about reducing the amount of bytes they sent over tcp than have our code slice the orderbook for them - that should be done in userland.