### PR TITLE
tests - fix funding rate history

### DIFF
--- a/js/test/Exchange/test.fetchFundingRateHistory.js
+++ b/js/test/Exchange/test.fetchFundingRateHistory.js
@@ -11,7 +11,7 @@ module.exports = async (exchange) => {
     const method = 'fetchFundingRateHistory'
 
     const format = {
-        'currency': 'USDT',
+        'symbol': 'BTC/USDT',
         'info': {}, // Or []
         'timestamp': 1638230400000,
         'datetime': '2021-11-30T00:00:00.000Z',

--- a/js/test/Exchange/test.fetchFundingRateHistory.js
+++ b/js/test/Exchange/test.fetchFundingRateHistory.js
@@ -6,7 +6,7 @@ const assert = require ('assert')
 
 // ----------------------------------------------------------------------------
 
-module.exports = async (exchange) => {
+module.exports = async (exchange, symbol) => {
 
     const method = 'fetchFundingRateHistory'
 
@@ -20,7 +20,7 @@ module.exports = async (exchange) => {
 
     if (exchange.has[method]) {
 
-        const fundingRates = await exchange[method] ()
+        const fundingRates = await exchange[method] (symbol)
         console.log ('fetched all', fundingRates.length, 'funding rates')
 
         for (let i = 0; i < fundingRates.length; i++) {

--- a/js/test/Exchange/test.fetchFundingRateHistory.js
+++ b/js/test/Exchange/test.fetchFundingRateHistory.js
@@ -11,7 +11,7 @@ module.exports = async (exchange, symbol) => {
     const method = 'fetchFundingRateHistory'
 
     const format = {
-        'symbol': 'BTC/USDT',
+        'symbol': 'BTC/USDT:USDT',
         'info': {}, // Or []
         'timestamp': 1638230400000,
         'datetime': '2021-11-30T00:00:00.000Z',

--- a/js/test/Exchange/test.fetchFundingRateHistory.js
+++ b/js/test/Exchange/test.fetchFundingRateHistory.js
@@ -20,6 +20,12 @@ module.exports = async (exchange, symbol) => {
 
     if (exchange.has[method]) {
 
+        const market = exchange.market (symbol);
+        if (market.spot) {
+            console.log (method + '() is not supported for spot market symbol');
+            return;
+        }
+    
         const fundingRates = await exchange[method] (symbol)
         console.log ('fetched all', fundingRates.length, 'funding rates')
 


### PR DESCRIPTION
I didn't notice in previous PR that there needs to be 'symbol' instead of 'currency' . all FFRH methods across lib returns `symbol` in unified response, and there is no `currency` anywhere.