### PR TITLE
Kucoin :: fix sandbox markets loading

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -3295,7 +3295,9 @@ module.exports = class kucoin extends Exchange {
         const query = this.omit (params, this.extractParams (path));
         let endpart = '';
         headers = (headers !== undefined) ? headers : {};
-        if (path === 'symbols') {
+        let url = this.urls['api'][api];
+        const isSandbox = url.indexOf ('sandbox') >= 0;
+        if (path === 'symbols' && !isSandbox) {
             endpoint = '/api/v2/' + this.implodeParams (path, params);
         }
         if (Object.keys (query).length) {
@@ -3307,7 +3309,7 @@ module.exports = class kucoin extends Exchange {
                 headers['Content-Type'] = 'application/json';
             }
         }
-        const url = this.urls['api'][api] + endpoint;
+        url = url + endpoint;
         const isFuturePrivate = (api === 'futuresPrivate');
         const isPrivate = (api === 'private');
         if (isPrivate || isFuturePrivate) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15540


```
 p kucoin fetchTicker "BTC/USDT" --sandbox
Python v3.9.7
CCXT v2.1.17
kucoin.fetchTicker(BTC/USDT)
{'ask': 18064.1361282,
 'askVolume': None,
 'average': 8276.21241398,
 'baseVolume': 3.13576576,
 'bid': 2000.0,
 'bidVolume': None,
 'change': 8070.2361282,
 'close': 18064.1361282,
 'datetime': '2022-11-03T11:34:16.003Z',
 'high': 18064.1361282,
 'info': {'averagePrice': '8276.21241398',
          'buy': '2000',
          'changePrice': '8070.2361282',
          'changeRate': '0.8075',
          'high': '18064.1361282',
          'last': '18064.1361282',
          'low': '430',
          'makerCoefficient': '1',
          'makerFeeRate': '0.001',
          'sell': '18064.1361282',
          'symbol': 'BTC-USDT',
          'takerCoefficient': '1',
          'takerFeeRate': '0.001',
          'time': 1667475256003,
          'vol': '3.13576576',
          'volValue': '30246.580281586710586'},
 'last': 18064.1361282,
 'low': 430.0,
 'open': 9993.9,
 'percentage': 80.75,
 'previousClose': None,
 'quoteVolume': 30246.58028158671,
 'symbol': 'BTC/USDT',
 'timestamp': 1667475256003,
 'vwap': 9645.675919870593}
```

```
 p kucoin fetchTicker "BTC/USDT"          
Python v3.9.7
CCXT v2.1.17
kucoin.fetchTicker(BTC/USDT)
{'ask': 20194.6,
 'askVolume': None,
 'average': 20452.77612374,
 'baseVolume': 20821.45058159,
 'bid': 20193.8,
 'bidVolume': None,
 'change': -266.0,
 'close': 20194.4,
 'datetime': '2022-11-03T11:34:36.158Z',
 'high': 20801.0,
 'info': {'averagePrice': '20452.77612374',
          'buy': '20193.8',
          'changePrice': '-266',
          'changeRate': '-0.013',
          'high': '20801',
          'last': '20194.4',
          'low': '20059.2',
          'makerCoefficient': '0',
          'makerFeeRate': '0.001',
          'sell': '20194.6',
          'symbol': 'BTC-USDT',
          'takerCoefficient': '0',
          'takerFeeRate': '0.001',
          'time': 1667475276158,
          'vol': '20821.45058159',
          'volValue': '424389898.192540031'},
 'last': 20194.4,
 'low': 20059.2,
 'open': 20460.4,
 'percentage': -1.3,
 'previousClose': None,
 'quoteVolume': 424389898.19254005,
 'symbol': 'BTC/USDT',
 'timestamp': 1667475276158,
 'vwap': 20382.340631338095}
```