### PR TITLE
Bitmex - fix negative contracts (from `skipped` list)

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -393,6 +393,7 @@ module.exports = class bitmex extends Exchange {
             const contract = !index;
             const initMargin = this.safeString (market, 'initMargin', '1');
             const maxLeverage = this.parseNumber (Precise.stringDiv ('1', initMargin));
+            const multiplierString = Precise.stringAbs (this.safeString (market, 'multiplier'));
             result.push ({
                 'id': id,
                 'symbol': symbol,
@@ -416,7 +417,7 @@ module.exports = class bitmex extends Exchange {
                 'inverse': contract ? inverse : undefined,
                 'taker': this.safeNumber (market, 'takerFee'),
                 'maker': this.safeNumber (market, 'makerFee'),
-                'contractSize': this.safeNumber (market, 'multiplier'),
+                'contractSize': this.parseNumber (multiplierString),
                 'expiry': expiry,
                 'expiryDatetime': expiryDatetime,
                 'strike': this.safeNumber (market, 'optionStrikePrice'),

--- a/js/test/test-all.js
+++ b/js/test/test-all.js
@@ -1,0 +1,84 @@
+const exchanges = require ('./../../exchanges.json').ids;
+const { spawn } = require('child_process');
+function c(...args){console.log(...args);} function cc(o){console.dir(o, {'maxArrayLength': null});} function x(...args){c(...args);process.exit();} function xx(o){cc(o);process.exit();}
+
+
+
+
+
+const sleep = s => new Promise (resolve => setTimeout (resolve, s*1000))
+const timeout = (s, promise) => Promise.race ([ promise, sleep (s).then (() => { throw new Error ('timed out') }) ])
+
+
+const exec = (bin, ...args) =>
+
+/*  A custom version of child_process.exec that captures both stdout and
+    stderr,  not separating them into distinct buffers — so that we can show
+    the same output as if it were running in a terminal.                        */
+
+    timeout (120, new Promise (return_ => {
+
+        const ps = require ('child_process').spawn (bin, args)
+
+        let output = ''
+        let stderr = ''
+        let hasWarnings = false
+
+        ps.stdout.on ('data', data => { 
+            output += data.toString () 
+        })
+        ps.stderr.on ('data', data => { 
+            output += data.toString (); stderr += data.toString (); hasWarnings = true 
+        })
+
+        ps.on ('exit', code => {
+
+            output = output.trim ()
+
+            const regex = /\[[a-z]+?\]/gmi
+
+            let match = undefined
+            const warnings = []
+
+            match = regex.exec (output)
+
+            if (match) {
+                warnings.push (match[0])
+                do {
+                    if (match = regex.exec (output)) {
+                        warnings.push (match[0])
+                    }
+                } while (match);
+            }
+
+            return_ ({
+                failed: code !== 0,
+                output,
+                hasOutput: output.length > 0,
+                hasWarnings: hasWarnings || warnings.length > 0,
+                warnings: warnings,
+            })
+        })
+
+    })).catch (e => ({
+
+        failed: true,
+        output: e.message
+
+    })).then (x => Object.assign (x, { hasOutput: x.output.length > 0 }))
+
+
+async function init(exchange, symbol)
+{
+    const res = await exec (...['node',      './js/test/test.js',    ...[exchange, symbol === 'all' ? [] : symbol]])
+    c(res);
+}
+
+
+for (const exId of exchanges) {
+    init(exId, 'all');
+    break;
+    //const ps = spawn('node', ['D:\\SAQME\\shekvetebi\\CCXT\\c\\js\\test\\test.js ' + exId + ' BTC/USDT']);
+    //ps.stdout.on ('data', data => { c = data.toString () })
+    //break;
+}


### PR DESCRIPTION
bitmex has negative `multiplier` for inverse markets, causing ending up negative calculations through ccxt.

They also mention that they "just have it with negative value": https://blog.bitmex.com/bitmex-vs-cme-futures-guide/

> Technically speaking, the BitMEX multiplier is negative, even though in the graph uses a positive multiplier for a better visualisation.
