### PR TITLE
deribit - parseOrder and parseTrade

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1527,7 +1527,9 @@ module.exports = class deribit extends Exchange {
         if (market['inverse']) { // amount returned in USD
             cost = Precise.stringDiv (amount, averageString);
             amount = undefined;
-            filledString = Precise.stringDiv (filledString, averageString);
+            if (this.parseNumber (averageString) !== 0) {
+                filledString = Precise.stringDiv (filledString, averageString);
+            }
         }
         let lastTradeTimestamp = undefined;
         if (filledString !== undefined) {

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -690,8 +690,8 @@ module.exports = class deribit extends Exchange {
                     'option': option,
                     'active': this.safeValue (market, 'is_active'),
                     'contract': true,
-                    'linear': false,
-                    'inverse': true,
+                    'linear': (settle === quote),
+                    'inverse': (settle !== quote),
                     'taker': this.safeNumber (market, 'taker_commission'),
                     'maker': this.safeNumber (market, 'maker_commission'),
                     'contractSize': this.safeNumber (market, 'contract_size'),
@@ -1173,7 +1173,14 @@ module.exports = class deribit extends Exchange {
         const timestamp = this.safeInteger (trade, 'timestamp');
         const side = this.safeString (trade, 'direction');
         const priceString = this.safeString (trade, 'price');
-        const amountString = this.safeString (trade, 'amount');
+        // Amount for inverse perpetual and futures is in USD which in ccxt is the cost
+        // For options amount and linear is in corresponding cryptocurrency contracts, e.g., BTC or ETH
+        let amount = this.safeString (trade, 'amount');
+        let cost = Precise.stringMul (amount, priceString);
+        if (market['inverse']) {
+            cost = Precise.stringDiv (amount, priceString);
+            amount = undefined;
+        }
         const liquidity = this.safeString (trade, 'liquidity');
         let takerOrMaker = undefined;
         if (liquidity !== undefined) {
@@ -1201,8 +1208,8 @@ module.exports = class deribit extends Exchange {
             'side': side,
             'takerOrMaker': takerOrMaker,
             'price': priceString,
-            'amount': amountString,
-            'cost': undefined,
+            'amount': amount,
+            'cost': cost,
             'fee': fee,
         }, market);
     }
@@ -1211,7 +1218,8 @@ module.exports = class deribit extends Exchange {
         /**
          * @method
          * @name deribit#fetchTrades
-         * @description get the list of most recent trades for a particular symbol
+         * @see https://docs.deribit.com/#private-get_user_trades_by_currency
+         * @description get the list of most recent trades for a particular symbol.
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int|undefined} since timestamp in ms of the earliest trade to fetch
          * @param {int|undefined} limit the maximum amount of trades to fetch
@@ -1503,17 +1511,24 @@ module.exports = class deribit extends Exchange {
         //         "trades": [], // injected by createOrder
         //     }
         //
+        const marketId = this.safeString (order, 'instrument_name');
+        market = this.safeMarket (marketId, market);
         const timestamp = this.safeInteger (order, 'creation_timestamp');
         const lastUpdate = this.safeInteger (order, 'last_update_timestamp');
         const id = this.safeString (order, 'order_id');
-        let priceString = this.safeString (order, 'price');
-        if (priceString === 'market_price') {
-            // for market orders we get a literal 'market_price' string here
-            priceString = undefined;
-        }
+        const priceString = this.safeString (order, 'price');
         const averageString = this.safeString (order, 'average_price');
-        const amountString = this.safeString (order, 'amount');
-        const filledString = this.safeString (order, 'filled_amount');
+        // Invesr contracts amount is in USD which in ccxt is the cost
+        // Linear contracts amount is in corresponding cryptocurrency contracts, e.g., BTC or ETH
+        let cost = undefined;
+        // Filled amount of the order. For perpetual and futures the filled_amount is in USD units, for options and linear contracts- in units or corresponding cryptocurrency contracts, e.g., BTC or ETH.
+        let filledString = this.safeString (order, 'filled_amount');
+        let amount = this.safeString (order, 'amount');
+        if (market['inverse']) { // amount returned in USD
+            cost = Precise.stringDiv (amount, averageString);
+            amount = undefined;
+            filledString = Precise.stringDiv (filledString, averageString);
+        }
         let lastTradeTimestamp = undefined;
         if (filledString !== undefined) {
             const isFilledPositive = Precise.stringGt (filledString, '0');
@@ -1522,8 +1537,6 @@ module.exports = class deribit extends Exchange {
             }
         }
         const status = this.parseOrderStatus (this.safeString (order, 'order_state'));
-        const marketId = this.safeString (order, 'instrument_name');
-        market = this.safeMarket (marketId, market);
         const side = this.safeStringLower (order, 'direction');
         let feeCostString = this.safeString (order, 'commission');
         let fee = undefined;
@@ -1537,10 +1550,7 @@ module.exports = class deribit extends Exchange {
         const rawType = this.safeString (order, 'order_type');
         const type = this.parseOrderType (rawType);
         // injected in createOrder
-        let trades = this.safeValue (order, 'trades');
-        if (trades !== undefined) {
-            trades = this.parseTrades (trades, market);
-        }
+        const trades = this.safeValue (order, 'trades');
         const timeInForce = this.parseTimeInForce (this.safeString (order, 'time_in_force'));
         const stopPrice = this.safeValue (order, 'stop_price');
         const postOnly = this.safeValue (order, 'post_only');
@@ -1558,8 +1568,8 @@ module.exports = class deribit extends Exchange {
             'side': side,
             'price': priceString,
             'stopPrice': stopPrice,
-            'amount': amountString,
-            'cost': undefined,
+            'amount': amount,
+            'cost': cost,
             'average': averageString,
             'filled': filledString,
             'remaining': undefined,
@@ -1620,21 +1630,27 @@ module.exports = class deribit extends Exchange {
          * @method
          * @name deribit#createOrder
          * @description create a trade order
+         * @see https://docs.deribit.com/#private-buy
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float} amount how much of currency you want to trade. For perpetual and futures the amount is in USD. For options it is in corresponding cryptocurrency contracts currency.
          * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} params extra parameters specific to the deribit api endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (market['inverse']) {
+            amount = this.amountToPrecision (symbol, amount);
+        } else {
+            amount = this.currencyToPrecision (symbol, amount);
+        }
         const request = {
             'instrument_name': market['id'],
             // for perpetual and futures the amount is in USD
             // for options it is in corresponding cryptocurrency contracts, e.g., BTC or ETH
-            'amount': this.amountToPrecision (symbol, amount),
+            'amount': amount,
             'type': type, // limit, stop_limit, market, stop_market, default is limit
             // 'label': 'string', // user-defined label for the order (maximum 64 characters)
             // 'price': this.priceToPrecision (symbol, 123.45), // only for limit and stop_limit orders

--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1175,11 +1175,10 @@ module.exports = class deribit extends Exchange {
         const priceString = this.safeString (trade, 'price');
         // Amount for inverse perpetual and futures is in USD which in ccxt is the cost
         // For options amount and linear is in corresponding cryptocurrency contracts, e.g., BTC or ETH
-        let amount = this.safeString (trade, 'amount');
+        const amount = this.safeString (trade, 'amount');
         let cost = Precise.stringMul (amount, priceString);
         if (market['inverse']) {
             cost = Precise.stringDiv (amount, priceString);
-            amount = undefined;
         }
         const liquidity = this.safeString (trade, 'liquidity');
         let takerOrMaker = undefined;
@@ -1518,17 +1517,14 @@ module.exports = class deribit extends Exchange {
         const id = this.safeString (order, 'order_id');
         const priceString = this.safeString (order, 'price');
         const averageString = this.safeString (order, 'average_price');
-        // Invesr contracts amount is in USD which in ccxt is the cost
-        // Linear contracts amount is in corresponding cryptocurrency contracts, e.g., BTC or ETH
-        let cost = undefined;
-        // Filled amount of the order. For perpetual and futures the filled_amount is in USD units, for options and linear contracts- in units or corresponding cryptocurrency contracts, e.g., BTC or ETH.
-        let filledString = this.safeString (order, 'filled_amount');
-        let amount = this.safeString (order, 'amount');
-        if (market['inverse']) { // amount returned in USD
-            cost = Precise.stringDiv (amount, averageString);
-            amount = undefined;
+        // Inverse contracts amount is in USD which in ccxt is the cost
+        // For options and Linear contracts amount is in corresponding cryptocurrency, e.g., BTC or ETH
+        const filledString = this.safeString (order, 'filled_amount');
+        const amount = this.safeString (order, 'amount');
+        let cost = Precise.stringMul (filledString, averageString);
+        if (market['inverse']) {
             if (this.parseNumber (averageString) !== 0) {
-                filledString = Precise.stringDiv (filledString, averageString);
+                cost = Precise.stringDiv (amount, averageString);
             }
         }
         let lastTradeTimestamp = undefined;


### PR DESCRIPTION
- Fix double parsing of trades
- Fix inverse/linear fetchMarkets
- Fix amount/cost in parseOrder and parseTrade

Note didn't have funds in exchange to test options.
## Tests:
### Linear market sell:
```javascript
{
  info: {
    web: false,
    time_in_force: 'good_til_cancelled',
    risk_reducing: false,
    replaced: false,
    reduce_only: false,
    profit_loss: '0.131',
    price: '20387.0',
    post_only: false,
    order_type: 'market',
    order_state: 'filled',
    order_id: 'USDC-3232971461',
    mmp: false,
    max_show: '0.001',
    last_update_timestamp: '1667565713217',
    label: '',
    is_liquidation: false,
    instrument_name: 'BTC_USDC-PERPETUAL',
    filled_amount: '0.001',
    direction: 'sell',
    creation_timestamp: '1667565713217',
    commission: '0.010347',
    average_price: '20694.0',
    api: true,
    amount: '0.001',
    trades: [
      {
        trade_seq: '1330418',
        trade_id: 'USDC-5942714',
        timestamp: '1667565713217',
        tick_direction: '2',
        state: 'filled',
        self_trade: false,
        risk_reducing: false,
        reduce_only: false,
        profit_loss: '0.131',
        price: '20694.0',
        post_only: false,
        order_type: 'market',
        order_id: 'USDC-3232971461',
        mmp: false,
        matching_id: null,
        mark_price: '20696.4093',
        liquidity: 'T',
        instrument_name: 'BTC_USDC-PERPETUAL',
        index_price: '20692.2284',
        fee_currency: 'USDC',
        fee: '0.010347',
        direction: 'sell',
        api: true,
        amount: '0.001'
      }
    ]
  },
  id: 'USDC-3232971461',
  clientOrderId: undefined,
  timestamp: 1667565713217,
  datetime: '2022-11-04T12:41:53.217Z',
  lastTradeTimestamp: 1667565713217,
  symbol: 'BTC/USDC:USDC',
  type: 'market',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  price: 20387,
  stopPrice: undefined,
  amount: 0.001,
  cost: 0.020694,
  average: 20694,
  filled: 0.001,
  remaining: 0,
  status: 'closed',
  fee: { cost: '0.010347', currency: 'BTC' },
  trades: [
    {
      id: 'USDC-5942714',
      info: {
        trade_seq: '1330418',
        trade_id: 'USDC-5942714',
        timestamp: '1667565713217',
        tick_direction: '2',
        state: 'filled',
        self_trade: false,
        risk_reducing: false,
        reduce_only: false,
        profit_loss: '0.131',
        price: '20694.0',
        post_only: false,
        order_type: 'market',
        order_id: 'USDC-3232971461',
        mmp: false,
        matching_id: null,
        mark_price: '20696.4093',
        liquidity: 'T',
        instrument_name: 'BTC_USDC-PERPETUAL',
        index_price: '20692.2284',
        fee_currency: 'USDC',
        fee: '0.010347',
        direction: 'sell',
        api: true,
        amount: '0.001'
      },
      timestamp: 1667565713217,
      datetime: '2022-11-04T12:41:53.217Z',
      symbol: 'BTC/USDC:USDC',
      order: 'USDC-3232971461',
      type: 'market',
      side: 'sell',
      takerOrMaker: 'taker',
      price: 20694,
      amount: 0.001,
      cost: 20.694,
      fee: { cost: 0.010347, currency: 'USDC' },
      fees: [ { currency: 'USDC', cost: '0.010347' } ]
    }
  ],
  fees: [ { currency: 'USDC', cost: 0.010347 } ]
}
```
### Inverse market buy

```javascript
{
  info: {
    web: false,
    time_in_force: 'good_til_cancelled',
    risk_reducing: false,
    replaced: false,
    reduce_only: false,
    profit_loss: '0.0',
    price: '20981.5',
    post_only: false,
    order_type: 'market',
    order_state: 'filled',
    order_id: '51122041345',
    mmp: false,
    max_show: '10.0',
    last_update_timestamp: '1667565812830',
    label: '',
    is_liquidation: false,
    instrument_name: 'BTC-PERPETUAL',
    filled_amount: '10.0',
    direction: 'buy',
    creation_timestamp: '1667565812830',
    commission: '2.4e-7',
    average_price: '20670.51',
    api: true,
    amount: '10.0',
    trades: [
      {
        trade_seq: '159883784',
        trade_id: '233570340',
        timestamp: '1667565812830',
        tick_direction: '0',
        state: 'filled',
        self_trade: false,
        risk_reducing: false,
        reduce_only: false,
        profit_loss: '0.0',
        price: '20670.5',
        post_only: false,
        order_type: 'market',
        order_id: '51122041345',
        mmp: false,
        matching_id: null,
        mark_price: '20670.83',
        liquidity: 'T',
        instrument_name: 'BTC-PERPETUAL',
        index_price: '20658.85',
        fee_currency: 'BTC',
        fee: '2.4e-7',
        direction: 'buy',
        api: true,
        amount: '10.0'
      }
    ]
  },
  id: '51122041345',
  clientOrderId: undefined,
  timestamp: 1667565812830,
  datetime: '2022-11-04T12:43:32.830Z',
  lastTradeTimestamp: 1667565812830,
  symbol: 'BTC/USD:BTC',
  type: 'market',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 20981.5,
  stopPrice: undefined,
  amount: 0.000483781000081758,
  cost: 0.000483781000081758,
  average: 20670.51,
  filled: 0.000483781000081758,
  remaining: 0,
  status: 'closed',
  fee: { cost: '0.00000024', currency: 'BTC' },
  trades: [
    {
      id: '233570340',
      info: {
        trade_seq: '159883784',
        trade_id: '233570340',
        timestamp: '1667565812830',
        tick_direction: '0',
        state: 'filled',
        self_trade: false,
        risk_reducing: false,
        reduce_only: false,
        profit_loss: '0.0',
        price: '20670.5',
        post_only: false,
        order_type: 'market',
        order_id: '51122041345',
        mmp: false,
        matching_id: null,
        mark_price: '20670.83',
        liquidity: 'T',
        instrument_name: 'BTC-PERPETUAL',
        index_price: '20658.85',
        fee_currency: 'BTC',
        fee: '2.4e-7',
        direction: 'buy',
        api: true,
        amount: '10.0'
      },
      timestamp: 1667565812830,
      datetime: '2022-11-04T12:43:32.830Z',
      symbol: 'BTC/USD:BTC',
      order: '51122041345',
      type: 'market',
      side: 'buy',
      takerOrMaker: 'taker',
      price: 20670.5,
      amount: undefined,
      cost: 0.000483781234125928,
      fee: { cost: 2.4e-7, currency: 'BTC' },
      fees: [ { currency: 'BTC', cost: '2.4e-7' } ]
    }
  ],
  fees: [ { currency: 'BTC', cost: 2.4e-7 } ]
}
```