### PR TITLE
okx.fetchOHLCV defaults to UTC instead of HK time

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -1608,7 +1608,7 @@ module.exports = class okx extends Exchange {
         }
         const duration = this.parseTimeframe (timeframe);
         let bar = this.timeframes[timeframe];
-        if ((timezone === 'UTC') && (duration >= 21600000)) {
+        if ((timezone === 'UTC') && (duration >= 21600)) { // if utc and timeframe >= 6h
             bar += timezone.toLowerCase ();
         }
         const request = {


### PR DESCRIPTION
fixes: #15565

-------------

2022-11-04T20:44:47.667Z
Node.js: v18.4.0
CCXT v2.1.25

```
% date -ur 1667520000
Fri Nov  4 00:00:00 UTC 2022
```

```
% okx fetchOHLCV BTC/USDT 1d undefined 2
okx.fetchOHLCV (BTC/USDT, 1d, , 2)
2022-11-04T20:44:51.031Z iteration 0 passed in 517 ms

1667433600000 |   20152 | 20393.5 | 20032.2 | 20206.3 |  4257.83656213
1667520000000 | 20206.2 |   21300 | 20184.1 | 21080.8 | 10630.44727579
2 objects
2022-11-04T20:44:51.031Z iteration 1 passed in 517 ms
```


```
% okx fetchOHLCV BTC/USDT 6h undefined 4
okx.fetchOHLCV (BTC/USDT, 6h, , 4)
2022-11-04T20:46:32.050Z iteration 0 passed in 491 ms

1667520000000 | 20206.2 | 20487.4 | 20184.1 |   20449 | 837.91623878
1667541600000 | 20448.3 | 20686.4 | 20448.3 | 20555.2 | 1802.1392065
1667563200000 | 20555.2 |   21300 | 20367.6 | 20775.7 | 7058.8047873
1667584800000 | 20775.1 | 21141.6 | 20718.9 | 21098.9 | 932.53961824
4 objects
2022-11-04T20:46:32.050Z iteration 1 passed in 491 ms
```

```
% okx fetchOHLCV BTC/USDT 4h undefined 6
okx.fetchOHLCV (BTC/USDT, 4h, , 6)
2022-11-04T20:49:03.476Z iteration 0 passed in 508 ms

1667520000000 | 20206.2 |   20328 | 20184.1 | 20324.4 |  377.20529082
1667534400000 | 20324.3 | 20686.4 | 20309.4 | 20609.9 | 1371.31241996
1667548800000 | 20609.9 |   20665 | 20547.8 | 20555.2 |   891.5377345
1667563200000 | 20555.2 |   21300 | 20367.6 | 20836.2 | 6172.49742396
1667577600000 | 20836.3 | 21106.9 | 20675.2 | 21106.9 | 1605.95361883
1667592000000 | 21106.9 | 21141.6 | 21055.1 | 21076.7 |  216.50382072
6 objects
2022-11-04T20:49:03.476Z iteration 1 passed in 508 ms
```