### PR TITLE
Bitmex: convertAmount helper method

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -1776,7 +1776,7 @@ module.exports = class bitmex extends Exchange {
             }
         }
         const convertAmount = this.safeValue (this.options, 'convertAmount', false);
-        const orderQty = (convertAmount !== false) ? this.convertAmount (amount, market) : parseFloat (this.amountToPrecision (symbol, amount));
+        const orderQty = (convertAmount === true) ? this.convertAmount (amount, market) : parseFloat (this.amountToPrecision (symbol, amount));
         const request = {
             'symbol': market['id'],
             'side': this.capitalize (side),
@@ -1823,7 +1823,7 @@ module.exports = class bitmex extends Exchange {
             request['orderID'] = id;
         }
         const convertAmount = this.safeValue (this.options, 'convertAmount', false);
-        const orderQty = (convertAmount !== false) ? this.convertAmount (amount, market) : parseFloat (this.amountToPrecision (symbol, amount));
+        const orderQty = (convertAmount === true) ? this.convertAmount (amount, market) : parseFloat (this.amountToPrecision (symbol, amount));
         if (amount !== undefined) {
             request['orderQty'] = orderQty;
         }
@@ -2230,7 +2230,7 @@ module.exports = class bitmex extends Exchange {
         amount = this.numberToString (amount);
         const symbol = market['symbol'];
         const conversionMultiplier = market['info']['underlyingToPositionMultiplier'];
-        let resultValue = (conversionMultiplier !== null) ? Precise.stringMul (amount, conversionMultiplier) : undefined;
+        let resultValue = (conversionMultiplier == null) ? undefined : Precise.stringMul (amount, conversionMultiplier);
         resultValue = (resultValue !== undefined) ? parseFloat (this.amountToPrecision (symbol, resultValue)) : undefined;
         return resultValue;
     }


### PR DESCRIPTION
Added a convertAmount helper method to Bitmex, used for converting the amount parameter of post requests to Bitmex's number system, doesn't work for inverse swaps or futures.

 Related to: https://github.com/ccxt/ccxt/issues/15394

### Spot createOrder:
```
bitmex.createOrder (MATIC_USDT, limit, buy, 10, 1.1)
2022-11-05T04:12:02.467Z iteration 0 passed in 667 ms

{
  info: {
    orderID: '9c59ae34-4d5b-4c09-8968-d326d23b2792',
    clOrdID: '',
    clOrdLinkID: '',
    account: '2079371',
    symbol: 'MATIC_USDT',
    side: 'Buy',
    simpleOrderQty: null,
    orderQty: '1000000000',
    price: '1.1',
    displayQty: null,
    stopPx: null,
    pegOffsetValue: null,
    pegPriceType: '',
    currency: 'USDT',
    settlCurrency: '',
    ordType: 'Limit',
    timeInForce: 'GoodTillCancel',
    execInst: '',
    contingencyType: '',
    exDestination: 'XBME',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: true,
    ordRejReason: '',
    simpleLeavesQty: null,
    leavesQty: '1000000000',
    simpleCumQty: null,
    cumQty: '0',
    avgPx: null,
    multiLegReportingType: 'SingleSecurity',
    text: 'Submitted via API.',
    transactTime: '2022-11-05T04:12:03.147Z',
    timestamp: '2022-11-05T04:12:03.147Z'
  },
  id: '9c59ae34-4d5b-4c09-8968-d326d23b2792',
  clientOrderId: undefined,
  timestamp: 1667621523147,
  datetime: '2022-11-05T04:12:03.147Z',
  lastTradeTimestamp: 1667621523147,
  symbol: 'MATIC_USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: undefined,
  side: 'buy',
  price: 1.1,
  stopPrice: undefined,
  amount: 1000000000,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 1000000000,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: []
}
2022-11-05T04:12:02.467Z iteration 1 passed in 667 ms
```

### Linear Swap createOrder:
```
bitmex.createOrder (BTC/USDT:USDT, limit, buy, 0.01, 20000)
2022-11-05T04:35:34.762Z iteration 0 passed in 666 ms

{
  info: {
    orderID: '70ceb0c1-4e8f-4b7a-a592-66a16f2bf5fa',
    clOrdID: '',
    clOrdLinkID: '',
    account: '2079371',
    symbol: 'XBTUSDT',
    side: 'Buy',
    simpleOrderQty: null,
    orderQty: '10000',
    price: '20000',
    displayQty: null,
    stopPx: null,
    pegOffsetValue: null,
    pegPriceType: '',
    currency: 'USDT',
    settlCurrency: 'USDt',
    ordType: 'Limit',
    timeInForce: 'GoodTillCancel',
    execInst: '',
    contingencyType: '',
    exDestination: 'XBME',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: true,
    ordRejReason: '',
    simpleLeavesQty: null,
    leavesQty: '10000',
    simpleCumQty: null,
    cumQty: '0',
    avgPx: null,
    multiLegReportingType: 'SingleSecurity',
    text: 'Submitted via API.',
    transactTime: '2022-11-05T04:35:35.454Z',
    timestamp: '2022-11-05T04:35:35.454Z'
  },
  id: '70ceb0c1-4e8f-4b7a-a592-66a16f2bf5fa',
  clientOrderId: undefined,
  timestamp: 1667622935454,
  datetime: '2022-11-05T04:35:35.454Z',
  lastTradeTimestamp: 1667622935454,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: undefined,
  side: 'buy',
  price: 20000,
  stopPrice: undefined,
  amount: 10000,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 10000,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: []
}
2022-11-05T04:35:34.762Z iteration 1 passed in 666 ms
```

### Spot editOrder:
```
bitmex.editOrder (88821de0-0395-4dc5-a06b-4c0f88061e75, MATIC_USDT, limit, buy, 11, 1.09)
2022-11-05T05:14:49.877Z iteration 0 passed in 684 ms

{
  info: {
    orderID: '88821de0-0395-4dc5-a06b-4c0f88061e75',
    clOrdID: '',
    clOrdLinkID: '',
    account: '2079371',
    symbol: 'MATIC_USDT',
    side: 'Buy',
    simpleOrderQty: null,
    orderQty: '1100000000',
    price: '1.09',
    displayQty: null,
    stopPx: null,
    pegOffsetValue: null,
    pegPriceType: '',
    currency: 'USDT',
    settlCurrency: '',
    ordType: 'Limit',
    timeInForce: 'GoodTillCancel',
    execInst: '',
    contingencyType: '',
    exDestination: 'XBME',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: true,
    ordRejReason: '',
    simpleLeavesQty: null,
    leavesQty: '1100000000',
    simpleCumQty: null,
    cumQty: '0',
    avgPx: null,
    multiLegReportingType: 'SingleSecurity',
    text: 'Amended orderQty price: Amended via API.\nSubmitted via API.',
    transactTime: '2022-11-05T05:14:50.580Z',
    timestamp: '2022-11-05T05:14:50.580Z'
  },
  id: '88821de0-0395-4dc5-a06b-4c0f88061e75',
  clientOrderId: undefined,
  timestamp: 1667625290580,
  datetime: '2022-11-05T05:14:50.580Z',
  lastTradeTimestamp: 1667625290580,
  symbol: 'MATIC_USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: undefined,
  side: 'buy',
  price: 1.09,
  stopPrice: undefined,
  amount: 1100000000,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 1100000000,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: []
}
2022-11-05T05:14:49.877Z iteration 1 passed in 684 ms
```