### PR TITLE
Huobi: fixed filterBySinceLimit(tail=true) in watchOrders

### DIFF
--- a/js/pro/huobi.js
+++ b/js/pro/huobi.js
@@ -750,7 +750,7 @@ module.exports = class huobi extends huobiRest {
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);
         }
-        return this.filterBySinceLimit (orders, since, limit);
+        return this.filterBySinceLimit (orders, since, limit, 'timestamp', true);
     }
 
     handleOrder (client, message) {


### PR DESCRIPTION
As far as I know, the `watchOrders(undefined, undefined, undefined)` should return latest order that updated just before. While the `limit` variable, calculated by `orders.getLimit(undefined, undefined)`, is the number of newUpdates, it's quite reasonable.

However, `this.filterBySinceLimit(orders, since, limit)` is `this.filterBySinceLimit(orders, since, limit, 'timestamp', false)` returns the `limit` items from `head`, which is OLDEST and always same before your cache is gone.

I guess this is not only the problem of Huobi, ccxt@d4741311665e5b3edf716a22a9cc5ea51f718160 did this kind of fix on few exchanges.