### PR TITLE
Bybit: update transfer methods, add examples

### DIFF
--- a/examples/py/async-bybit-transfer.py
+++ b/examples/py/async-bybit-transfer.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt.async_support as ccxt  # noqa: E402
+
+
+async def main():
+    exchange = ccxt.bybit({
+        'apiKey': 'YOUR_API_KEY',
+        'secret': 'YOUR_SECRET',
+        # 'verbose': True,  # for debug output
+    })
+    await exchange.load_markets()
+    try:
+        pprint(await exchange.fetch_transfers())  # Fetch your transfer history
+        # pprint(await exchange.transfer('USDT', 1.0, 'swap', 'spot'))  # Transfer to the spot wallet
+        # pprint(await exchange.transfer('USDT', 1.0, 'spot', 'future'))  # Transfer to the Derivatives wallet
+        # pprint(await exchange.transfer('USDT', 1.0, 'spot', 'swap'))  # Transfer to the Derivatives wallet
+        # pprint(await exchange.transfer('USDC', 1.0, 'spot', 'option'))  # Transfer to the USDC Derivatives wallet
+    except Exception as e:
+        print(e)
+    await exchange.close()
+
+
+asyncio.run(main())

--- a/examples/py/binance-universal-transfer.py
+++ b/examples/py/binance-universal-transfer.py
@@ -14,14 +14,14 @@ def main():
 
     # apiKey must have universal transfer permissions
     binance = ccxt.binance({
-        "apiKey": "...",
-        "secret": "...",
+        "apiKey": "YOUR_API_KEY",
+        "secret": "YOUR_SECRET",
     })
     binance.load_markets()
 
     pprint(binance.transfer('USDT', 0.1, 'spot', 'future'))
-    transfers = binance.fetchTransfers()
-    pprint('got ' + str(len(transfers)) + ' transfers')
+    transfers = binance.fetch_transfers()
+    pprint('there is ' + str(len(transfers)) + ' transfers')
     pprint(binance.transfer('USDT', 0.1, 'spot', 'cross'))  # For transfer to cross margin wallet
     pprint(binance.transfer('USDT', 0.1, 'spot', 'ADA/USDT'))  # For transfer to an isolated margin wallet
 


### PR DESCRIPTION
Updated `transfer` and `fetchTransfers` to use the new V3 endpoints, added an example file using the transfer methods.

### transfer:
```
bybit.transfer (USDT, 2, swap, spot)
2022-11-06T08:27:42.991Z iteration 0 passed in 347 ms

{
  info: { transferId: '4768dad4-dd5a-4b83-8823-ebbf103ad23d' },
  id: '4768dad4-dd5a-4b83-8823-ebbf103ad23d',
  timestamp: 1667723263723,
  datetime: '2022-11-06T08:27:43.723Z',
  currency: 'USDT',
  amount: 2,
  fromAccount: 'swap',
  toAccount: 'spot',
  status: 'ok'
}
2022-11-06T08:27:42.991Z iteration 1 passed in 347 ms
```

### fetchTransfers:
```
bybit.fetchTransfers ()
2022-11-06T08:28:10.797Z iteration 0 passed in 288 ms

                                               id |     timestamp |                 datetime | currency |   amount | fromAccount | toAccount | status
-----------------------------------------------------------------------------------------------------------------------------------------------------
             d326babe-b146-4773-b143-2087652df94c | 1658438497000 | 2022-07-21T21:21:37.000Z |     USDT |       15 |        spot |  contract |     ok
             7cdd0aeb-9012-4407-ae82-72be9f05c8bb | 1658438522000 | 2022-07-21T21:22:02.000Z |     USDT |       60 |    contract |      spot |     ok
...
20 objects
2022-11-06T08:28:10.797Z iteration 1 passed in 288 ms
```