### PR TITLE
okx: add more error codes

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -366,6 +366,7 @@ module.exports = class okx extends Exchange {
                     '50026': ExchangeNotAvailable, // System error, please try again later.
                     '50027': PermissionDenied, // The account is restricted from trading
                     '50028': ExchangeError, // Unable to take the order, please reach out to support center for details
+                    '50044': BadRequest, // Must select one broker type
                     // API Class
                     '50100': ExchangeError, // API frozen, please contact customer service
                     '50101': AuthenticationError, // Broker id of APIKey does not match current environment
@@ -610,6 +611,9 @@ module.exports = class okx extends Exchange {
                     '60018': BadRequest, // The {0} {1} {2} {3} {4} does not exist
                     '60019': BadRequest, // Invalid op {op}
                     '63999': ExchangeError, // Internal system error
+                    '70010': BadRequest, // Timestamp parameters need to be in Unix timestamp format in milliseconds.
+                    '70013': BadRequest, // endTs needs to be bigger than or equal to beginTs.
+                    '70016': BadRequest, // Please specify your instrument settings for at least one instType.
                 },
                 'broad': {
                     'server error': ExchangeNotAvailable, // {"code":500,"data":{},"detailMsg":"","error_code":"500","error_message":"server error 1236805249","msg":"server error 1236805249"}


### PR DESCRIPTION
OKX added some error codes: https://www.okx.com/docs-v5/log_en/#2022-11-07

Note: they also add `begin` and `end` for `privateGetTradeOrdersHistory`, but they didn't add these parameters for `privateGetTradeOrdersAlgoHistory`. Should I add these parameters first in else condition?