### PR TITLE
okx: add "Internal Server Error" exception

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -616,6 +616,7 @@ module.exports = class okx extends Exchange {
                     '70016': BadRequest, // Please specify your instrument settings for at least one instType.
                 },
                 'broad': {
+                    'Internal Server Error': ExchangeNotAvailable, // {"code":500,"data":{},"detailMsg":"","error_code":"500","error_message":"Internal Server Error","msg":"Internal Server Error"}
                     'server error': ExchangeNotAvailable, // {"code":500,"data":{},"detailMsg":"","error_code":"500","error_message":"server error 1236805249","msg":"server error 1236805249"}
                 },
             },


### PR DESCRIPTION
We observed the following error in production, which was incorrectly raised as `ExchangeError` instead than `ExchangeNotAvailable`:

```
okx {"code":500,"data":{},"detailMsg":"","error_code":"500","error_message":"Internal Server Error","msg":"Internal Server Error"}
```