### PR TITLE
Bybit :: fix watchOrders

### DIFF
--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -1484,10 +1484,16 @@ module.exports = class bybit extends bybitRest {
         const symbols = Object.keys (marketSymbols);
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
-            const messageHash = 'order:' + symbol + ':' + topic;
+            let messageHash = 'order:' + symbol;
+            if (topic !== undefined) {
+                messageHash += ':' + topic;
+            }
             client.resolve (orders, messageHash);
         }
-        const messageHash = 'order:' + topic;
+        let messageHash = 'order';
+        if (topic !== undefined) {
+            messageHash += ':' + topic;
+        }
         // non-symbol specific
         client.resolve (orders, messageHash);
     }

--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -1485,13 +1485,13 @@ module.exports = class bybit extends bybitRest {
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             let messageHash = 'order:' + symbol;
-            if (topic !== undefined) {
+            if (topic) {
                 messageHash += ':' + topic;
             }
             client.resolve (orders, messageHash);
         }
         let messageHash = 'order';
-        if (topic !== undefined) {
+        if (topic) {
             messageHash += ':' + topic;
         }
         // non-symbol specific


### PR DESCRIPTION
- fix messageHash

```
p bybit watchOrders  "DOGE/USDT" --spot          
Python v3.10.8
CCXT v2.1.51
bybit.watchOrders(DOGE/USDT)
[{'amount': 118.7,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2022-11-09T11:30:52.087Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '1285616688638751232',
  'info': {'A': '0',
           'C': False,
           'E': '1667993452096',
           'L': '0',
           'M': '0',
           'N': '',
           'O': '1667993452087',
           'S': 'BUY',
           'X': 'NEW',
           'Z': '0',
           'c': '1667993451899',
           'd': 'NO_LIQ',
           'e': 'executionReport',
           'f': 'GTC',
           'i': '1285616688638751232',
           'l': '0',
           'm': False,
           'n': '0',
           'o': 'LIMIT',
           'p': '0.0843',
           'q': '118.7',
           's': 'DOGEUSDT',
           'u': True,
           'v': '0',
           'w': True,
           'z': '0'},
  'lastTradeTimestamp': 1667993452096,
  'postOnly': None,
  'price': 0.0843,
  'remaining': 118.7,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'DOGE/USDT',
  'timeInForce': 'GTC',
  'timestamp': 1667993452087,
  'trades': [],
  'type': 'limit'}]
[{'amount': 118.7,
  'average': None,
  'clientOrderId': None,
  'cost': 10.00641,
  'datetime': '2022-11-09T11:30:52.087Z',
  'fee': None,
  'fees': [],
  'filled': 118.7,
  'id': '1285616688638751232',
  'info': {'A': '0',
           'C': False,
           'E': '1667993452145',
           'L': '0.08413',
           'M': '1285616684402614016',
           'N': 'DOGE',
           'O': '1667993452087',
           'S': 'BUY',
           'X': 'FILLED',
           'Z': '9.986231',
           'c': '1667993451899',
           'd': 'NO_LIQ',
           'e': 'executionReport',
           'f': 'GTC',
           'i': '1285616688638751232',
           'l': '118.7',
           'm': False,
           'n': '0',
           'o': 'LIMIT',
           'p': '0.0843',
           'q': '118.7',
           's': 'DOGEUSDT',
           't': '2200000000024789823',
           'u': True,
           'v': '0',
           'w': True,
           'z': '118.7'},
  'lastTradeTimestamp': 1667993452145,
  'postOnly': None,
  'price': 0.0843,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopPrice': None,
  'symbol': 'DOGE/USDT',
  'timeInForce': 'GTC',
  'timestamp': 1667993452087,
  'trades': [],
  'type': 'limit'}]
```
