### PR TITLE
typo: missing ' on example

### DIFF
--- a/examples/html/binance-cors-proxy.html
+++ b/examples/html/binance-cors-proxy.html
@@ -11,7 +11,7 @@
                 const exchange = new ccxt.binance ({
                     'apiKey': 'YOUR_API_KEY',
                     'secret': 'YOUR_API_SECRET',
-                    'proxy: 'https://cors-anywhere.herokuapp.com/',
+                    'proxy': 'https://cors-anywhere.herokuapp.com/',
                 })
                 const response = await exchange.fetchBalance ()
                 console.log (response)


### PR DESCRIPTION
simple typo