### PR TITLE
HUOBI: fix `handleBalance` for linear cross swap

### DIFF
--- a/js/pro/huobi.js
+++ b/js/pro/huobi.js
@@ -1384,7 +1384,13 @@ module.exports = class huobi extends huobiRest {
                 // client.subscription hash = 'accounts.usdt'
                 // we do 'accounts' + '.' + data[0]]['margin_asset'] to get it
                 const marginAsset = this.safeString (first, 'margin_asset');
-                messageHash += '.' + marginAsset.toLowerCase ();
+                // if linear cross swap, marginAsset is 'USDT' and
+                // client.subscription hash should be 'accounts_cross.*'
+                if (messageHash === 'accounts_cross' && marginAsset === 'USDT') {
+                    messageHash = 'accounts_cross.*';
+                } else {
+                    messageHash += '.' + marginAsset.toLowerCase ();
+                }
                 subscription = this.safeValue (client.subscriptions, messageHash);
             }
             const type = this.safeString (subscription, 'type');


### PR DESCRIPTION
USDT Swap (Linear) is the only websocket api that uses `accounts_cross`, and the stream returns `accounts_cross.*`

more information at https://huobiapi.github.io/docs/usdt_swap/v1/en/#cross-subscribe-account-equity-updates-data-sub