### PR TITLE
tests - debuger detection

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -18,7 +18,10 @@ const ansi = require ('ansicolor').nice
 process.on ('uncaughtException',  e => { log.bright.red.error (e); process.exit (1) })
 process.on ('unhandledRejection', e => { log.bright.red.error (e); process.exit (1) })
 
-const isDebugMode = require('inspector').url() !== undefined; // https://stackoverflow.com/a/67445850/2377343
+// Notes:
+// 1) detect if we are running in debug mode of VSCODE , per https://stackoverflow.com/a/67445850/2377343
+// 2) also, to avoid "warnings" from test outputs, which will lead to incorrect CCXT results, use `--no-warnings` argument when running in debug
+const isDebugMode = require('inspector').url() !== undefined;
 
 /*  --------------------------------------------------------------------------- */
 
@@ -81,7 +84,7 @@ const exec = (bin, ...args) =>
         ps.stdout.on ('data', data => { output += data.toString () })
         ps.stderr.on ('data', data => { 
             const dataString = data.toString ();
-            if (!isDebugMode || !dataString.includes('ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time')) {
+            if (!isDebugMode) {
                 output += dataString; stderr += dataString; hasWarnings = true;
             }
         })

--- a/run-tests.js
+++ b/run-tests.js
@@ -82,17 +82,12 @@ const exec = (bin, ...args) =>
         let hasWarnings = false
 
         ps.stdout.on ('data', data => { output += data.toString () })
-        ps.stderr.on ('data', data => { 
-            const dataString = data.toString ();
-            if (!isDebugMode || !dataString.includes('ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time')) {
-                output += dataString; stderr += dataString; hasWarnings = true;
-            }
-        })
+        ps.stderr.on ('data', data => { output += data.toString (); stderr += data.toString (); hasWarnings = true })
 
         ps.on ('exit', code => {
 
             if (isDebugMode) {
-                stderr = stderr.replace('Debugger attached.\r\n','').replace ('Waiting for the debugger to disconnect...\r\n', '');
+                stderr = stderr.replace('Debugger attached.\r\n','').replace ('Waiting for the debugger to disconnect...\r\n', '').replace(/\(node:\d+\) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\)\n/, '');
                 if (stderr === '') { hasWarnings = false; }
             }
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -84,7 +84,7 @@ const exec = (bin, ...args) =>
         ps.stdout.on ('data', data => { output += data.toString () })
         ps.stderr.on ('data', data => { 
             const dataString = data.toString ();
-            if (!isDebugMode) {
+            if (!isDebugMode || !dataString.includes('ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time')) {
                 output += dataString; stderr += dataString; hasWarnings = true;
             }
         })


### PR DESCRIPTION
@lead, It has been while I used custom 'workarounds' to avoid this, but more time goes seems more frustrating, and I've decided to make a PR for this.
So, basically, if you try to run `run-tests.js` in debug in VSCODE ( which is the most devs use, so needs to be considered), all exchanges do logs with those 'debug-related' phrases, which causes process's `stderr` to make outputs, ending in incorrect result for us (`hasWarnings = true` for those exchanges). 
You can try it yourself, to debug the `run-tests.js` and see that all exchanges currently are ending tests with `WARN` (so, neither success, nor fail). for a quick test, you can put this in your `launch.json`:
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "runtests.js ALL-JS",
            "type": "node",
            "request": "launch",
            "program": "${workspaceFolder}/run-tests.js",
            "args": ["--js", "100"],
            "console": "integratedTerminal",
            "localRoot": "${workspaceFolder}"
        }
    ]
}
```
I am constiniously working on tests in these periods, and use `run-tests` frequently to debug things. So, if you can please revise this (or if you know better way, please lmk)