### PR TITLE
exchange.safeCurrency extra check for currencies_by_id[currencyId] !== undefined

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1897,7 +1897,7 @@ module.exports = class Exchange {
         if ((currencyId === undefined) && (currency !== undefined)) {
             return currency;
         }
-        if ((this.currencies_by_id !== undefined) && (currencyId in this.currencies_by_id)) {
+        if ((this.currencies_by_id !== undefined) && (currencyId in this.currencies_by_id) && (this.currencies_by_id[currencyId] !== undefined)) {
             return this.currencies_by_id[currencyId];
         }
         let code = currencyId;


### PR DESCRIPTION
Regarding this issue

![](https://i.imgur.com/MGEpVCA.png)

I didn't receive an error for fetchMarkets using verbose mode on version 2.2, but this change is in the only spot where it would be possible for the code to get set to `undefined`. This PR may be unnecessary though

--------------

# Testing

```
Python v3.10.4
CCXT v2.1.46
bitget.fetchMarkets()

fetch Request: bitget GET https://api.bitget.com/api/spot/v1/public/products RequestHeaders: {'User-Agent': 'python-requests/2.27.1', 'Accept-Encoding': 'gzip, deflate'} RequestBody: None

fetch Response: bitget GET https://api.bitget.com/api/spot/v1/public/products 200 ResponseHeaders: ...

fetch Request: bitget GET https://api.bitget.com/api/mix/v1/market/contracts?productType=umcbl RequestHeaders: {'User-Agent': 'python-requests/2.27.1', 'Accept-Encoding': 'gzip, deflate'} RequestBody: None

fetch Response: bitget GET https://api.bitget.com/api/mix/v1/market/contracts?productType=umcbl 200 ResponseHeaders: ...

...

[{'active': True,
  'base': 'TRX',
  'baseId': 'TRX',
  'contract': False,
  'contractSize': None,
  'expiry': None,
  'expiryDatetime': None,
  'future': False,
  'id': 'TRXUSDT_SPBL',
  'info': {'baseCoin': 'TRX',
           'makerFeeRate': '0.002',
           'maxTradeAmount': '0',
           'minTradeAmount': '1',
           'minTradeUSDT': '5',
           'priceScale': '6',
           'quantityScale': '4',
           'quoteCoin': 'USDT',
           'status': 'online',
           'symbol': 'TRXUSDT_SPBL',
           'symbolName': 'TRXUSDT',
           'takerFeeRate': '0.002'},
  'inverse': None,
  'limits': {'amount': {'max': None, 'min': None},
             'cost': {'max': None, 'min': None},
             'leverage': {'max': None, 'min': None},
             'price': {'max': None, 'min': None}},
  'linear': None,
  'maker': 0.002,
  'margin': False,
  'option': False,
  'optionType': None,
  'precision': {'amount': 0.0001, 'price': 1e-06},
  'quote': 'USDT',
  'quoteId': 'USDT',
  'settle': None,
  'settleId': None,
  'spot': True,
  'strike': None,
  'swap': False,
  'symbol': 'TRX/USDT',
  'taker': 0.002,
  'type': 'spot'},
 ...
 ```