### PR TITLE
base - fix null replacement in implode_params

### DIFF
--- a/js/base/functions/misc.js
+++ b/js/base/functions/misc.js
@@ -94,7 +94,8 @@ const implodeParams = (string, params) => {
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
             if (!Array.isArray (params[key])) {
-                string = string.replace ('{' + key + '}', params[key])
+                const value = (params[key] !== undefined) ? params[key] : ''
+                string = string.replace ('{' + key + '}', value)
             }
         }
     }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -836,7 +836,8 @@ class Exchange {
         if (static::is_associative($params)) {
             foreach ($params as $key => $value) {
                 if (gettype($value) !== 'array') {
-                    $string = implode($value, mb_split('{' . preg_quote($key) . '}', $string));
+                    $finalValue = $value !== null ? $value : '';
+                    $string = implode($finalValue, mb_split('{' . preg_quote($key) . '}', $string));
                 }
             }
         }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1006,7 +1006,8 @@ class Exchange(object):
         if isinstance(params, dict):
             for key in params:
                 if not isinstance(params[key], list):
-                    string = string.replace('{' + key + '}', str(params[key]))
+                    finalValue = str(params[key]) if params[key] is not None else ''
+                    string = string.replace('{' + key + '}', finalValue)
         return string
 
     @staticmethod


### PR DESCRIPTION
there are cases, like [this](https://app.travis-ci.com/github/ccxt/ccxt/builds/257640783#L2721) and if you search that warning, you'll find other occasions too happening out there through logs. so, replacing string with `null` is not ideal, and this PR fixes that.