### PR TITLE
Bybit :: fix watchMyTrades

### DIFF
--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -1267,11 +1267,17 @@ module.exports = class bybit extends bybitRest {
         const symbols = Object.keys (marketSymbols);
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
-            const messageHash = 'usertrade:' + symbol + ':' + topic;
+            let messageHash = 'usertrade:' + symbol;
+            if (topic) {
+                messageHash += ':' + topic;
+            }
             client.resolve (trades, messageHash);
         }
         // non-symbol specific
-        const messageHash = 'usertrade:' + topic;
+        let messageHash = 'usertrade';
+        if (topic) {
+            messageHash += ':' + topic;
+        }
         client.resolve (trades, messageHash);
     }
 


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15626

```
p bybit watchMyTrades "LTC/USDT" --spot          
Python v3.10.8
CCXT v2.1.58
bybit.watchMyTrades(LTC/USDT)
[{'amount': 0.18878,
  'cost': 9.9713596,
  'datetime': '2022-11-10T10:53:47.659Z',
  'fee': None,
  'fees': [],
  'id': '2200000000025256063',
  'info': {'A': '16370429',
           'E': '1668077627667',
           'O': '1286322801227096576',
           'S': 'SELL',
           'T': '2200000000025256063',
           'a': '24478790',
           'c': '1668077627405',
           'e': 'ticketInfo',
           'm': False,
           'o': '1286322804498723840',
           'p': '52.82',
           'q': '0.18878',
           's': 'LTCUSDT',
           't': '1668077627659'},
  'order': '1286322804498723840',
  'price': 52.82,
  'side': None,
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1668077627659,
  'type': None}]
  ```

```
p bybit watchMyTrades --spot           
Python v3.10.8
CCXT v2.1.58
bybit.watchMyTrades()
[{'amount': 0.18924,
  'cost': 10.0032264,
  'datetime': '2022-11-10T10:54:11.708Z',
  'fee': None,
  'fees': [],
  'id': '2200000000025256284',
  'info': {'A': '7067024',
           'E': '1668077651717',
           'O': '1286322999651340800',
           'S': 'BUY',
           'T': '2200000000025256284',
           'a': '24478790',
           'c': '1668077651472',
           'e': 'ticketInfo',
           'm': False,
           'o': '1286323006236291584',
           'p': '52.86',
           'q': '0.18924',
           's': 'LTCUSDT',
           't': '1668077651708'},
  'order': '1286323006236291584',
  'price': 52.86,
  'side': None,
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1668077651708,
  'type': None}]
  ```

