### PR TITLE
test- fix fetchFundingRateHistory

### DIFF
--- a/js/test/Exchange/test.fetchFundingRateHistory.js
+++ b/js/test/Exchange/test.fetchFundingRateHistory.js
@@ -36,7 +36,7 @@ module.exports = async (exchange, symbol) => {
                 const key = keys[i]
                 assert (key in fundingRate)
             }
-            assert (fundingRate['rate'] >= 0)
+            assert (typeof fundingRate['fundingRate'] === 'number')
             assert (fundingRate['timestamp'] >= 1199145600000) // 2008-01-01 00:00:00
         }
         return fundingRates


### PR DESCRIPTION
it should be `fundingRate`, as `rate` is nowhere used. bug.

also, it shouldn't be gt than zero, it can be negative too. so, should be just numeric.