### PR TITLE
Digifinex: createOrder, fetchOrder, cancelOrder swap order support

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -770,8 +770,12 @@ class Transpiler {
 
         for (let library in pythonStandardLibraries) {
             const regex = new RegExp ("[^\\'\\\"a-zA-Z]" + library + "[^\\'\\\"a-zA-Z]")
-            if (bodyAsString.match (regex))
-                libraries.push ('import ' + pythonStandardLibraries[library])
+            if (bodyAsString.match (regex)){
+                const importStatement = 'import ' + pythonStandardLibraries[library];
+                if (!libraries.includes(importStatement)) {
+                    libraries.push (importStatement)
+                }
+            }
         }
 
         if (bodyAsString.match (/numbers\.(Real|Integral)/)) {

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -760,6 +760,7 @@ class Transpiler {
             'hashlib': 'hashlib',
             'math': 'math',
             'json.loads': 'json',
+            'json.dumps': 'json',
             'sys': 'sys',
         }
 

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1770,7 +1770,7 @@ module.exports = class digifinex extends Exchange {
         const data = this.safeValue (response, 'data');
         const order = (marketType === 'swap') ? data : this.safeValue (data, 0);
         if (order === undefined) {
-            throw new OrderNotFound (this.id + ' fetchOrder() order ' + id + ' not found');
+            throw new OrderNotFound (this.id + ' fetchOrder() order ' + id.toString () + ' not found');
         }
         return this.parseOrder (order, market);
     }

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1133,12 +1133,18 @@ module.exports = class digifinex extends Exchange {
         const market = this.market (symbol);
         symbol = market['symbol'];
         let marketType = undefined;
+        let marginMode = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('createOrder', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostSpotOrderNew',
             'margin': 'privateSpotPostMarginOrderNew',
             'swap': 'privateSwapPostTradeOrderPlace',
         });
+        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
+        if (marginMode !== undefined) {
+            method = 'privateSpotPostMarginOrderNew';
+            marketType = 'margin';
+        }
         const request = {};
         const swap = (marketType === 'swap');
         const isMarketOrder = (type === 'market');
@@ -1235,12 +1241,18 @@ module.exports = class digifinex extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostSpotOrderCancel',
             'margin': 'privateSpotPostMarginOrderCancel',
             'swap': 'privateSwapPostTradeCancelOrder',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('cancelOrder', params);
+        if (marginMode !== undefined) {
+            method = 'privateSpotPostMarginOrderCancel';
+            marketType = 'margin';
+        }
         const request = {
             'order_id': id,
         };
@@ -1479,12 +1491,18 @@ module.exports = class digifinex extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotGetSpotOrderCurrent',
             'margin': 'privateSpotGetMarginOrderCurrent',
             'swap': 'privateSwapGetTradeOpenOrders',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOpenOrders', params);
+        if (marginMode !== undefined) {
+            method = 'privateSpotGetMarginOrderCurrent';
+            marketType = 'margin';
+        }
         const request = {};
         const swap = (marketType === 'swap');
         if (swap) {
@@ -1575,12 +1593,18 @@ module.exports = class digifinex extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotGetSpotOrderHistory',
             'margin': 'privateSpotGetMarginOrderHistory',
             'swap': 'privateSwapGetTradeHistoryOrders',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrders', params);
+        if (marginMode !== undefined) {
+            method = 'privateSpotGetMarginOrderHistory';
+            marketType = 'margin';
+        }
         const request = {};
         if (marketType === 'swap') {
             if (since !== undefined) {
@@ -1672,12 +1696,18 @@ module.exports = class digifinex extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
-        const method = this.getSupportedMapping (marketType, {
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
+        let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotGetSpotOrder',
             'margin': 'privateSpotGetMarginOrder',
             'swap': 'privateSwapGetTradeOrderInfo',
         });
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrder', params);
+        if (marginMode !== undefined) {
+            method = 'privateSpotGetMarginOrder';
+            marketType = 'margin';
+        }
         const request = {
             'order_id': id,
         };

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1253,6 +1253,7 @@ module.exports = class digifinex extends Exchange {
             method = 'privateSpotPostMarginOrderCancel';
             marketType = 'margin';
         }
+        id = id.toString ();
         const request = {
             'order_id': id,
         };
@@ -1288,7 +1289,7 @@ module.exports = class digifinex extends Exchange {
             const canceledOrders = this.safeValue (response, 'success', []);
             const numCanceledOrders = canceledOrders.length;
             if (numCanceledOrders !== 1) {
-                throw new OrderNotFound (this.id + ' cancelOrder() ' + id.toString () + ' not found');
+                throw new OrderNotFound (this.id + ' cancelOrder() ' + id + ' not found');
             }
         }
         return response;

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1288,7 +1288,7 @@ module.exports = class digifinex extends Exchange {
             const canceledOrders = this.safeValue (response, 'success', []);
             const numCanceledOrders = canceledOrders.length;
             if (numCanceledOrders !== 1) {
-                throw new OrderNotFound (this.id + ' cancelOrder() ' + id + ' not found');
+                throw new OrderNotFound (this.id + ' cancelOrder() ' + id.toString () + ' not found');
             }
         }
         return response;


### PR DESCRIPTION
Added support for swap trading:

- createOrder
- fetchOpenOrders
- fetchOrder
- fetchOrders
- cancelOrder

### createOrder: market buy
```
digifinex.createOrder (BTC/USDT:USDT, market, buy, 6, )

{
  info: { code: '0', data: '1590895070704308224' },
  id: '1590895070704308224',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: undefined,
  stopPrice: undefined,
  amount: 6,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  average: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```

### createOrder: market reduceOnly
```
digifinex.createOrder (BTC/USDT:USDT, market, sell, 6, , [object Object])

{
  info: { code: '0', data: '1590895541762396161' },
  id: '1590895541762396161',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'sell',
  price: undefined,
  stopPrice: undefined,
  amount: 6,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  average: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```

### createOrder: limit buy
```
digifinex.createOrder (BTC/USDT:USDT, limit, buy, 6, 14000)

{
  info: { code: '0', data: '1590895812018180098' },
  id: '1590895812018180098',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 14000,
  stopPrice: undefined,
  amount: 6,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  average: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```

### fetchOpenOrders:
```
digifinex.fetchOpenOrders (BTC/USDT:USDT)

                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol |  type | timeInForce | postOnly |      side | price | stopPrice | amount | filled | remaining | cost | average | status |        fee | trades |         fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1590898207657824256 |               | 1668134664828 | 2022-11-11T02:44:24.828Z |      1668134664828 | BTC/USDT:USDT | limit |             |          | open long | 14000 |           |      6 |      0 |         6 |    0 |         |   open | {"cost":0} |     [] | [{"cost":0}]
1 objects
```

### fetchOrder:
```
digifinex.fetchOrder (1590923061186531328, ETH/USDT:USDT)

{
  info: {
    order_id: '1590923061186531328',
    instrument_id: 'ETHUSDTPERP',
    margin_mode: 'crossed',
    contract_val: '0.01',
    type: '1',
    order_type: '0',
    price: '900',
    size: '6',
    filled_qty: '0',
    price_avg: '0',
    fee: '0',
    state: '0',
    leverage: '20',
    turnover: '0',
    has_stop: '0',
    insert_time: '1668140590372',
    time_stamp: '1668140590372'
  },
  id: '1590923061186531328',
  clientOrderId: undefined,
  timestamp: 1668140590372,
  datetime: '2022-11-11T04:23:10.372Z',
  lastTradeTimestamp: 1668140590372,
  symbol: 'ETH/USDT:USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'open long',
  price: 900,
  stopPrice: undefined,
  amount: 6,
  filled: 0,
  remaining: 6,
  cost: 0,
  average: undefined,
  status: 'open',
  fee: { cost: 0 },
  trades: [],
  fees: [ { cost: 0 } ]
}
```

### fetchOrders:
```
digifinex.fetchOrders ()

                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol |   type | timeInForce | postOnly |        side |   price | stopPrice | amount | filled | remaining |    cost | average | status |                 fee | trades |                  fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1590136768156405760 |               | 1667953123526 | 2022-11-09T00:18:43.526Z |      1667953123596 | BTC/USDT:USDT | market |         GTC |          |   open long | 18660.2 |           |      1 |      1 |         0 | 18.5145 | 18514.5 | closed | {"cost":0.00925725} |     [] | [{"cost":0.00925725}]
1590136799198449664 |               | 1667953130924 | 2022-11-09T00:18:50.924Z |      1667953131059 | BTC/USDT:USDT | market |         GTC |          |  close long |   18429 |           |      1 |      1 |         0 | 18.5155 | 18515.5 | closed | {"cost":0.00925775} |     [] | [{"cost":0.00925775}]
1590138803614388224 |               | 1667953608821 | 2022-11-09T00:26:48.821Z |      1667953608953 | ETH/USDT:USDT | market |         GTC |          |   open long | 1331.47 |           |      2 |      2 |         0 | 26.5992 | 1329.96 | closed |  {"cost":0.0132996} |     [] |  [{"cost":0.0132996}]
...
20 objects
```

### cancelOrder:
```
digifinex.cancelOrder (1590923061186531328, ETH/USDT:USDT)

{ code: '0', data: '1590923061186531328' }
```