### PR TITLE
Bybit :: fix cancelOrder

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3588,7 +3588,7 @@ module.exports = class bybit extends Exchange {
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         let market = undefined;
-        const symbolDefined = (market !== undefined);
+        const symbolDefined = (symbol !== undefined);
         if (symbolDefined) {
             market = this.market (symbol);
         }


### PR DESCRIPTION


```
 p bybit cancelOrder "1287159910569689088" "BTC/USDT" --sandbox --spot
Python v3.10.8
CCXT v2.1.67
bybit.cancelOrder(1287159910569689088,BTC/USDT)
{'amount': 0.001,
 'average': None,
 'clientOrderId': '1668177418465536',
 'cost': 0.0,
 'datetime': '2022-11-11T14:36:58.477Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '1287159910569689088',
 'info': {'accountId': '551167',
          'createTime': '1668177418477',
          'execQty': '0',
          'orderCategory': '0',
          'orderId': '1287159910569689088',
          'orderLinkId': '1668177418465536',
          'orderPrice': '20000',
          'orderQty': '0.001',
          'orderType': 'LIMIT',
          'side': 'SELL',
          'status': 'NEW',
          'symbol': 'BTCUSDT',
          'timeInForce': 'GTC'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 20000.0,
 'remaining': 0.001,
 'side': 'sell',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'BTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1668177418477,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
