### PR TITLE
binanceus - fix private status check

### DIFF
--- a/js/test/Exchange/test.fetchStatus.js
+++ b/js/test/Exchange/test.fetchStatus.js
@@ -4,6 +4,16 @@ const assert = require ('assert')
 
 module.exports = async (exchange) => {
     const method = 'fetchStatus';
+
+    const skippedExchanges = [
+        'binanceus',
+    ];
+
+    if (skippedExchanges.includes (exchange.id)) {
+        console.log (exchange.id, 'found in ignored exchanges, skipping ' + method + '...');
+        return;
+    }
+
     if (exchange.has[method]) {
         const status = await exchange[method] ();
         const sampleStatus = {


### PR DESCRIPTION
binanceus is the exceptional exchange which fails with fetchStatus in public (because for that endpoint they require authorization/apikeys :)

in future I plan to make a better handling private/public tests , but at this stage, we should avoid breaking the test for whole exchange instance just for this method, so we should temporarily skip this specific one test.