### PR TITLE
bittrex - fix trade side

### DIFF
--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -737,9 +737,17 @@ module.exports = class bittrex extends Exchange {
         const priceString = this.safeString (trade, 'rate');
         const amountString = this.safeString (trade, 'quantity');
         let takerOrMaker = undefined;
+        let side = this.safeStringLower2 (trade, 'takerSide', 'direction');
         const isTaker = this.safeValue (trade, 'isTaker');
         if (isTaker !== undefined) {
             takerOrMaker = isTaker ? 'taker' : 'maker';
+            if (!isTaker) { // as noted in PR this is misbehaving, API shows opposite side when it's 'maker'
+                if (side === 'buy') {
+                    side = 'sell';
+                } else if (side === 'sell') {
+                    side = 'buy';
+                }
+            }
         }
         let fee = undefined;
         const feeCostString = this.safeString (trade, 'commission');
@@ -749,7 +757,6 @@ module.exports = class bittrex extends Exchange {
                 'currency': market['quote'],
             };
         }
-        const side = this.safeStringLower2 (trade, 'takerSide', 'direction');
         return this.safeTrade ({
             'info': trade,
             'timestamp': timestamp,

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -741,7 +741,7 @@ module.exports = class bittrex extends Exchange {
         const isTaker = this.safeValue (trade, 'isTaker');
         if (isTaker !== undefined) {
             takerOrMaker = isTaker ? 'taker' : 'maker';
-            if (!isTaker) { // as noted in PR this is misbehaving, API shows opposite side when it's 'maker'
+            if (!isTaker) { // as noted in PR #15655 this API provides confusing value - when it's 'maker' trade, then side value should reversed
                 if (side === 'buy') {
                     side = 'sell';
                 } else if (side === 'sell') {


### PR DESCRIPTION
Bittrex provides reversed value in `side` field when trade is maker. you can test out it easily - just place a pending limit order and when it's filled, check it's raw response from API. for taker orders, the api values are correct, but for maker order, it should be reversed.

fix #14746