### PR TITLE
Bybit :: fix parseWsTicker

### DIFF
--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -438,7 +438,7 @@ module.exports = class bybit extends bybitRest {
         }
         const marketId = this.safeString2 (ticker, 'symbol', 's');
         const symbol = this.safeSymbol (marketId, market);
-        const last = this.safeStringN (ticker, [ 'l', 'last_price', 'lastPrice' ]);
+        const last = this.safeStringN (ticker, [ 'c', 'last_price', 'lastPrice' ]);
         const open = this.safeStringN (ticker, [ 'prev_price_24h', 'o', 'prevPrice24h' ]);
         let quoteVolume = this.safeStringN (ticker, [ 'v', 'turnover24h' ]);
         if (quoteVolume === undefined) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15672

```
p bybit watchTicker "BTC/USDT" --spot --sandbox
Python v3.9.7
CCXT v2.1.76
bybit.watchTicker(BTC/USDT)
{'ask': None,
 'askVolume': None,
 'average': 16706.93,
 'baseVolume': 154696348.7908058,
 'bid': None,
 'bidVolume': None,
 'change': 218.22,
 'close': 16816.04,
 'datetime': '2022-11-14T09:57:21.443Z',
 'high': 17070.0,
 'info': {'c': '16816.04',
          'h': '17070',
          'l': '11900.93',
          'm': '0.0131',
          'o': '16597.82',
          'qv': '154696348.7908058',
          's': 'BTCUSDT',
          't': 1668419841443,
          'v': '9329.673208'},
 'last': 16816.04,
 'low': 11900.93,
 'open': 16597.82,
 'percentage': 0.0131,
 'previousClose': None,
 'quoteVolume': 9329.673208,
 'symbol': 'BTC/USDT',
 'timestamp': 1668419841443,
 'vwap': 6.0309588952331e-05}

```
