### PR TITLE
bybit-fetchTickers-swap-timestamp

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1638,7 +1638,7 @@ module.exports = class bybit extends Exchange {
         if (symbols !== undefined) {
             const symbol = this.safeValue (symbols, 0);
             market = this.market (symbol);
-            [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+            type = market['type'];
             isUsdcSettled = market['settle'] === 'USDC';
         } else {
             [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1455,7 +1455,7 @@ module.exports = class bybit extends Exchange {
         //          "theta": "-0.03262827"
         //      }
         //
-        const timestamp = this.safeInteger (ticker, 'time');
+        const timestamp = this.milliseconds ();
         const marketId = this.safeString (ticker, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
         const last = this.safeString2 (ticker, 'last_price', 'lastPrice');
@@ -1625,6 +1625,8 @@ module.exports = class bybit extends Exchange {
          * @method
          * @name bybit#fetchTickers
          * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @see https://bybit-exchange.github.io/docs/futuresV2/linear/#t-latestsymbolinfo
+         * @see https://bybit-exchange.github.io/docs/spot/v3/#t-spot_latestsymbolinfo
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the bybit api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
@@ -1637,7 +1639,7 @@ module.exports = class bybit extends Exchange {
         if (symbols !== undefined) {
             const symbol = this.safeValue (symbols, 0);
             market = this.market (symbol);
-            type = market['type'];
+            [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
             isUsdcSettled = market['settle'] === 'USDC';
         } else {
             [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1455,7 +1455,6 @@ module.exports = class bybit extends Exchange {
         //          "theta": "-0.03262827"
         //      }
         //
-        const timestamp = this.milliseconds ();
         const marketId = this.safeString (ticker, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
         const last = this.safeString2 (ticker, 'last_price', 'lastPrice');
@@ -1470,8 +1469,8 @@ module.exports = class bybit extends Exchange {
         const low = this.safeStringN (ticker, [ 'low_price_24h', 'low24h', 'lowPrice' ]);
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': high,
             'low': low,
             'bid': bid,


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py bybit fetchTickers '["BTC/USDT:USDT"]'`
```
Python v3.10.6
CCXT v2.0.71
bybit.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 16788.5,
                   'askVolume': None,
                   'average': 16695.0,
                   'baseVolume': 187040.70599999,
                   'bid': 16788.0,
                   'bidVolume': None,
                   'change': 187.0,
                   'close': 16788.5,
                   'datetime': None,
                   'high': 16936.0,
                   'info': {'ask_price': '16788.5',
                            'bid_price': '16788',
                            'countdown_hour': '0',
                            'delivery_fee_rate': '',
                            'delivery_time': '',
                            'funding_rate': '-0.000075',
                            'high_price_24h': '16936.00',
                            'index_price': '16793.69',
                            'last_price': '16788.50',
                            'last_tick_direction': 'ZeroPlusTick',
                            'low_price_24h': '15802.50',
                            'mark_price': '16786.50',
                            'next_funding_time': '2022-11-14T16:00:00Z',
                            'open_interest': '43842.293',
                            'open_value': '',
                            'predicted_delivery_price': '',
                            'predicted_funding_rate': '',
                            'prev_price_1h': '16724.50',
                            'prev_price_24h': '16601.50',
                            'price_1h_pcnt': '',
                            'price_24h_pcnt': '0.011264',
                            'symbol': 'BTCUSDT',
                            'total_turnover': '',
                            'total_volume': '0',
                            'turnover_24h': '3069493913.6064935',
                            'volume_24h': '187040.70599999'},
                   'last': 16788.5,
                   'low': 15802.5,
                   'open': 16601.5,
                   'percentage': 1.1264,
                   'previousClose': None,
                   'quoteVolume': 3069493913.6064935,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': None,
                   'vwap': 16410.833658886306}}
```