### PR TITLE
cryptocom-fetchTickers

### DIFF
--- a/js/cryptocom.js
+++ b/js/cryptocom.js
@@ -92,7 +92,10 @@ module.exports = class cryptocom extends Exchange {
                 },
                 'www': 'https://crypto.com/',
                 'referral': 'https://crypto.com/exch/5835vstech',
-                'doc': 'https://exchange-docs.crypto.com/',
+                'doc': [
+                    'https://exchange-docs.crypto.com/spot/index.html',
+                    'https://exchange-docs.crypto.com/derivatives/index.html',
+                ],
                 'fees': 'https://crypto.com/exchange/document/fees-limits',
             },
             'api': {
@@ -517,13 +520,20 @@ module.exports = class cryptocom extends Exchange {
          * @method
          * @name cryptocom#fetchTickers
          * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @see https://exchange-docs.crypto.com/spot/index.html#public-get-ticker
+         * @see https://exchange-docs.crypto.com/derivatives/index.html#public-get-tickers
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the cryptocom api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        let market = undefined;
+        if (symbols !== undefined) {
+            const symbol = this.safeValue (symbols, 0);
+            market = this.market (symbol);
+        }
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPublicGetPublicGetTicker',
             'future': 'derivativesPublicGetPublicGetTickers',


### PR DESCRIPTION
# Testing
# Python
`python3 examples/py/cli.py cryptocom fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.1.79
cryptocom.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16495.9,
              'askVolume': None,
              'average': None,
              'baseVolume': 9761.5255,
              'bid': 16495.13,
              'bidVolume': None,
              'change': -0.0033,
              'close': 16498.22,
              'datetime': '2022-11-14T15:32:30.067Z',
              'high': 17190.12,
              'info': {'a': '16498.22',
                       'b': '16495.13',
                       'c': '-0.0033',
                       'h': '17190.12',
                       'i': 'BTC_USDT',
                       'k': '16495.90',
                       'l': '15815.31',
                       't': '1668439950067',
                       'v': '9761.5255',
                       'vv': '160888055.29'},
              'last': 16498.22,
              'low': 15815.31,
              'open': 16498.2233,
              'percentage': None,
              'previousClose': None,
              'quoteVolume': None,
              'symbol': 'BTC/USDT',
              'timestamp': 1668439950067,
              'vwap': None}}
```
`python3 examples/py/cli.py cryptocom fetchTickers '["BTC/USDC:USDC"]'`
```
ython v3.10.6
CCXT v2.1.79
cryptocom.fetchTickers(['BTC/USDC:USDC'])
{'BTC/USDC:USDC': {'ask': 0.45,
                   'askVolume': None,
                   'average': None,
                   'baseVolume': 0.0,
                   'bid': 0.447,
                   'bidVolume': None,
                   'change': 0.0,
                   'close': 0.211,
                   'datetime': '2022-11-14T15:30:11.750Z',
                   'high': 0.211,
                   'info': {'a': '0.211',
                            'b': '0.447',
                            'c': '0',
                            'h': '0.211',
                            'i': 'BTCUSD-221230-PW20000',
                            'k': '0.450',
                            'l': '0.211',
                            'oi': None,
                            't': '1668439811750',
                            'v': '0',
                            'vv': '0'},
                   'last': 0.211,
                   'low': 0.211,
                   'open': 0.211,
                   'percentage': None,
                   'previousClose': None,
                   'quoteVolume': None,
                   'symbol': 'BTC/USDC:USDC',
                   'timestamp': 1668439811750,
                   'vwap': None}}
```