### PR TITLE
tests - fix alias

### DIFF
--- a/js/pro/test/test.js
+++ b/js/pro/test/test.js
@@ -232,7 +232,10 @@ async function testExchange (exchange) {
 //-----------------------------------------------------------------------------
 
 async function test () {
-
+    if (exchange.alias) {
+        console.log ('Alias skipped')
+        process.exit ()
+    }
     await exchange.loadMarkets ()
     exchange.verbose = verbose
     await testExchange (exchange, exchangeSymbol)

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -47,9 +47,6 @@ const exchange = new (ccxt)[exchangeId] ({
     timeout,
 });
 
-if (exchange.alias) {
-    return;
-}
 //-----------------------------------------------------------------------------
 
 const tests = {};
@@ -107,6 +104,10 @@ for (const [credential, isRequired] of Object.entries (requiredCredentials)) {
 
 if (settings && settings.skip) {
     console.log ('[Skipped]', { 'exchange': exchangeId, 'symbol': exchangeSymbol || 'all' });
+    process.exit ();
+}
+if (exchange.alias) {
+    console.log ('[Alias skipped]', { 'exchange': exchangeId, 'symbol': exchangeSymbol || 'all' });
     process.exit ();
 }
 

--- a/php/pro/test/test.php
+++ b/php/pro/test/test.php
@@ -195,6 +195,12 @@ $test = function () use ($id, $config, $verbose) {
         echo "Done.\n";
         exit();
 
+    } else if (@$exchange->alias) {
+
+        echo $exchange->id, " [Alias skipped]\n";
+        echo "Done.\n";
+        exit();
+
     } else {
 
         yield $exchange->load_markets();

--- a/php/test/test_async.php
+++ b/php/test/test_async.php
@@ -63,10 +63,7 @@ $args = array_values(array_filter($argv, function ($option) { return strstr($opt
 
 foreach (Exchange::$exchanges as $id) {
     $exchange = '\\ccxt\\async\\' . $id;
-    $exchange_instance = new $exchange();
-    if (!$exchange_instance->alias) {
-        $exchanges[$id] = $exchange_instance;
-    }
+    $exchanges[$id] = new $exchange();
 }
 
 $keys_global = './keys.json';
@@ -509,6 +506,11 @@ $main = function() use ($args, $exchanges, $proxies, $config, $common_codes) {
             $skip = $exchange->safe_value($exchange_config, 'skip', false);
             if ($skip) {
                 dump(red('[Skipped] ' . $id));
+                exit();
+            }
+            $alias = $exchange->alias;
+            if ($alias) {
+                dump(red('[Alias skipped] ' . $id));
                 exit();
             }
 

--- a/php/test/test_sync.php
+++ b/php/test/test_sync.php
@@ -63,10 +63,7 @@ $args = array_values(array_filter($argv, function ($option) { return strstr($opt
 
 foreach (Exchange::$exchanges as $id) {
     $exchange = '\\ccxt\\' . $id;
-    $exchange_instance = new $exchange();
-    if (!$exchange_instance->alias) {
-        $exchanges[$id] = $exchange_instance;
-    }
+    $exchanges[$id] = new $exchange();
 }
 
 $keys_global = './keys.json';
@@ -509,6 +506,11 @@ $main = function() use ($args, $exchanges, $proxies, $config, $common_codes) {
             $skip = $exchange->safe_value($exchange_config, 'skip', false);
             if ($skip) {
                 dump(red('[Skipped] ' . $id));
+                exit();
+            }
+            $alias = $exchange->alias;
+            if ($alias) {
+                dump(red('[Alias skipped] ' . $id));
                 exit();
             }
 

--- a/python/ccxt/pro/test/test_async.py
+++ b/python/ccxt/pro/test/test_async.py
@@ -237,6 +237,9 @@ async def test():
     if (hasattr(exchange, 'skip') and exchange.skip) or (hasattr(exchange, 'skipWs') and exchange.skipWs):
         sys.stdout.write(exchange.id + ' [Skipped]\n')
         sys.stdout.flush()
+    elif (hasattr(exchange, 'alias') and exchange.alias):
+        sys.stdout.write(exchange.id + ' [Alias skipped]\n')
+        sys.stdout.flush()
     else:
         print(exchange.id, argv.verbose)
         await exchange.load_markets()

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -621,9 +621,7 @@ for id in ccxt.exchanges:
         exchange_config.update()
     if id in config:
         exchange_config = ccxt.Exchange.deep_extend(exchange_config, config[id])
-    exchange_instance = exchange(exchange_config)
-    if not exchange_instance.alias:
-        exchanges[id] = exchange_instance
+    exchanges[id] = exchange(exchange_config)
 
 # ------------------------------------------------------------------------------
 
@@ -639,6 +637,8 @@ async def main():
 
             if hasattr(exchange, 'skip') and exchange.skip:
                 dump(green(exchange.id), 'skipped')
+            elif hasattr(exchange, 'alias') and exchange.alias:
+                dump(green(exchange.id), 'alias skipped')
             else:
                 if symbol:
                     await load_exchange(exchange)

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -592,9 +592,7 @@ for id in ccxt.exchanges:
         exchange_config.update()
     if id in config:
         exchange_config = ccxt.Exchange.deep_extend(exchange_config, config[id])
-    exchange_instance = exchange(exchange_config)
-    if not exchange_instance.alias:
-        exchanges[id] = exchange_instance
+    exchanges[id] = exchange(exchange_config)
 
 # ------------------------------------------------------------------------------
 
@@ -610,6 +608,8 @@ def main():
 
             if hasattr(exchange, 'skip') and exchange.skip:
                 dump(green(exchange.id), 'skipped')
+            elif hasattr(exchange, 'alias') and exchange.alias:
+                dump(green(exchange.id), 'alias skipped')
             else:
                 if symbol:
                     load_exchange(exchange)


### PR DESCRIPTION
My previous PR #15703 did't turn out to be the correct way of removing the alias exchanges from tests.
This PR fixes it correctly.