### PR TITLE
`Skipped` in uppercase

### DIFF
--- a/js/pro/test/test.js
+++ b/js/pro/test/test.js
@@ -233,7 +233,7 @@ async function testExchange (exchange) {
 
 async function test () {
     if (exchange.alias) {
-        console.log ('Alias skipped')
+        console.log ('Skipped alias')
         process.exit ()
     }
     await exchange.loadMarkets ()

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -107,7 +107,7 @@ if (settings && settings.skip) {
     process.exit ();
 }
 if (exchange.alias) {
-    console.log ('[Alias skipped]', { 'exchange': exchangeId, 'symbol': exchangeSymbol || 'all' });
+    console.log ('[Skipped alias]', { 'exchange': exchangeId, 'symbol': exchangeSymbol || 'all' });
     process.exit ();
 }
 

--- a/php/pro/test/test.php
+++ b/php/pro/test/test.php
@@ -197,7 +197,7 @@ $test = function () use ($id, $config, $verbose) {
 
     } else if (@$exchange->alias) {
 
-        echo $exchange->id, " [Alias skipped]\n";
+        echo $exchange->id, " [Skipped alias]\n";
         echo "Done.\n";
         exit();
 

--- a/php/test/test_async.php
+++ b/php/test/test_async.php
@@ -510,7 +510,7 @@ $main = function() use ($args, $exchanges, $proxies, $config, $common_codes) {
             }
             $alias = $exchange->alias;
             if ($alias) {
-                dump(red('[Alias skipped] ' . $id));
+                dump(red('[Skipped alias] ' . $id));
                 exit();
             }
 

--- a/php/test/test_sync.php
+++ b/php/test/test_sync.php
@@ -510,7 +510,7 @@ $main = function() use ($args, $exchanges, $proxies, $config, $common_codes) {
             }
             $alias = $exchange->alias;
             if ($alias) {
-                dump(red('[Alias skipped] ' . $id));
+                dump(red('[Skipped alias] ' . $id));
                 exit();
             }
 

--- a/python/ccxt/pro/test/test_async.py
+++ b/python/ccxt/pro/test/test_async.py
@@ -238,7 +238,7 @@ async def test():
         sys.stdout.write(exchange.id + ' [Skipped]\n')
         sys.stdout.flush()
     elif (hasattr(exchange, 'alias') and exchange.alias):
-        sys.stdout.write(exchange.id + ' [Alias skipped]\n')
+        sys.stdout.write(exchange.id + ' [Skipped alias]\n')
         sys.stdout.flush()
     else:
         print(exchange.id, argv.verbose)

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -638,7 +638,7 @@ async def main():
             if hasattr(exchange, 'skip') and exchange.skip:
                 dump(green(exchange.id), 'skipped')
             elif hasattr(exchange, 'alias') and exchange.alias:
-                dump(green(exchange.id), 'alias skipped')
+                dump(green(exchange.id), 'Skipped alias')
             else:
                 if symbol:
                     await load_exchange(exchange)

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -609,7 +609,7 @@ def main():
             if hasattr(exchange, 'skip') and exchange.skip:
                 dump(green(exchange.id), 'skipped')
             elif hasattr(exchange, 'alias') and exchange.alias:
-                dump(green(exchange.id), 'alias skipped')
+                dump(green(exchange.id), 'Skipped alias')
             else:
                 if symbol:
                     load_exchange(exchange)


### PR DESCRIPTION
another modifications, the word `Skipped` needs to be exactly that like capitalized, as it is being matched from `run-tests`.