### PR TITLE
kucoin - params `chain` fix `fetchTransactionFee`

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -479,6 +479,7 @@ module.exports = class kucoin extends Exchange {
                 'networks': {
                     'ETH': 'eth',
                     'ERC20': 'eth',
+                    'BEP20': 'bsc',
                     'TRX': 'trx',
                     'TRC20': 'trx',
                     'KCC': 'kcc',
@@ -786,6 +787,7 @@ module.exports = class kucoin extends Exchange {
          * @method
          * @name kucoin#fetchTransactionFee
          * @description fetch the fee for a transaction
+         * @see https://docs.kucoin.com/#get-withdrawal-quotas
          * @param {string} code unified currency code
          * @param {object} params extra parameters specific to the kucoin api endpoint
          * @returns {object} a [fee structure]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
@@ -796,11 +798,11 @@ module.exports = class kucoin extends Exchange {
             'currency': currency['id'],
         };
         const networks = this.safeValue (this.options, 'networks', {});
-        let network = this.safeStringUpper (params, 'network');
+        let network = this.safeStringUpper (params, 'chain');
         network = this.safeStringLower (networks, network, network);
         if (network !== undefined) {
-            request['chain'] = network;
-            params = this.omit (params, 'network');
+            request['chain'] = this.safeStringLower (network);
+            params = this.omit (params, 'chain');
         }
         const response = await this.privateGetWithdrawalsQuotas (this.extend (request, params));
         const data = response['data'];

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -798,11 +798,11 @@ module.exports = class kucoin extends Exchange {
             'currency': currency['id'],
         };
         const networks = this.safeValue (this.options, 'networks', {});
-        let network = this.safeStringUpper (params, 'chain');
+        let network = this.safeStringUpper (params, 'network');
         network = this.safeStringLower (networks, network, network);
         if (network !== undefined) {
             request['chain'] = this.safeStringLower (network);
-            params = this.omit (params, 'chain');
+            params = this.omit (params, 'network');
         }
         const response = await this.privateGetWithdrawalsQuotas (this.extend (request, params));
         const data = response['data'];

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -798,11 +798,11 @@ module.exports = class kucoin extends Exchange {
             'currency': currency['id'],
         };
         const networks = this.safeValue (this.options, 'networks', {});
-        let network = this.safeStringUpper (params, 'network');
+        let network = this.safeStringUpper2 (params, 'network', 'chain');
         network = this.safeStringLower (networks, network, network);
         if (network !== undefined) {
-            request['chain'] = this.safeStringLower (network);
-            params = this.omit (params, 'network');
+            request['chain'] = network.lower ();
+            params = this.omit (params, [ 'network', 'chain' ]);
         }
         const response = await this.privateGetWithdrawalsQuotas (this.extend (request, params));
         const data = response['data'];


### PR DESCRIPTION
#15692
# Testing
## Python
`python3 examples/py/cli.py kucoin fetchTransactionFee "USDT" '{"network":"BEP20"}'`
`python3 examples/py/cli.py kucoin fetchTransactionFee "USDT" '{"network":"bsc"}'`
`python3 examples/py/cli.py kucoin fetchTransactionFee "USDT" '{"network":"BSC"}'`
```
Python v3.10.6
CCXT v2.1.79
kucoin.fetchTransactionFee(USDT,{'network': 'BEP20'})
{'deposit': {},
 'info': {'code': '200000',
          'data': {'availableAmount': '0.00000094',
                   'chain': 'BEP20',
                   'currency': 'USDT',
                   'innerWithdrawMinFee': '0',
                   'isWithdrawEnabled': False,
                   'limitBTCAmount': '1.00000000',
                   'precision': 8,
                   'remainAmount': '16515.27663088',
                   'usedBTCAmount': '0.00000000',
                   'withdrawMinFee': '5',
                   'withdrawMinSize': '10'}},
 'withdraw': {'USDT': 5.0}}
```