### PR TITLE
base WS - fix headers

### DIFF
--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -142,7 +142,8 @@ class Client {
         if ($this->verbose) {
             echo date('c'), ' connecting to ', $this->url, "\n";
         }
-        $promise = call_user_func($this->connector, $this->url);
+        $headers = property_exists($this, 'options') && array_key_exists('headers', $this->options) ? $this->options['headers'] : [];
+        $promise = call_user_func($this->connector, $this->url, [], $headers);
         Timer\timeout($promise, $timeout, Loop::get())->then(
             function($connection) {
                 if ($this->verbose) {


### PR DESCRIPTION
fix #15665

eventually i was able to find out the reason for that issue in WS base files - they were not setting $headers at all and all options set inside `describe` was just ignored.
