### PR TITLE
binance - add streams

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -98,8 +98,8 @@ module.exports = class binance extends binanceRest {
             }
             this.options['streamIndex'] = streamIndex;
             stream = this.numberToString (streamIndex);
+            streamBySubscriptionsHash[subscriptionHash] = stream;
         }
-        streamBySubscriptionsHash[subscriptionHash] = stream;
         return stream;
     }
 

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -71,7 +71,7 @@ module.exports = class binance extends binanceRest {
                 'wallet': 'wb', // wb = wallet balance, cw = cross balance
                 'listenKeyRefreshRate': 1200000, // 20 mins
                 'ws': {
-                    'cost': 0,
+                    'cost': 5,
                 },
             },
         });


### PR DESCRIPTION
- Binance was giving an error 1008 of too many requests when subscribing to several markets.
This was because we only used one stream when depending on the market we can use between 200 and 1024 streams.

This PR, divides each subscription equally between the number of streams, allowing users to for example to subscribe to trades of all market symbols

- Partly address issue #15343