### PR TITLE
exchange.depositWithdrawFee and exchange.parseDepositWithdrawFees

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2837,4 +2837,46 @@ module.exports = class Exchange {
          */
         this.checkRequiredArgument (methodName, symbol, 'symbol');
     }
+
+    parseDepositWithdrawFees (response, codes = undefined, currencyIdKey = undefined) {
+        /**
+         * @ignore
+         * @method
+         * @param {[object]|object} response unparsed response from the exchange
+         * @param {[string]|undefined} codes the unified currency codes to fetch transactions fees for, returns all currencies when undefined
+         * @param {str|undefined} currencyIdKey *should only be undefined when response is a dictionary* the object key that corresponds to the currency id
+         * @returns {object} objects with withdraw and deposit fees, indexed by currency codes
+         */
+        const depositWithdrawFees = {
+            'info': response,
+        };
+        codes = this.marketCodes (codes);
+        const isArray = Array.isArray (response);
+        const array = isArray ? response : Object.keys (response);
+        for (let i = 0; i < array.length; i++) {
+            const entry = array[i];
+            const dictionary = isArray ? entry : response[entry];
+            const currencyId = isArray ? this.safeString (dictionary, currencyIdKey) : entry;
+            const currency = this.safeValue (this.currencies_by_id, currencyId);
+            const code = this.safeString (currency, 'code', currencyId);
+            if ((codes === undefined) || (this.inArray (code, codes))) {
+                depositWithdrawFees[code] = this.parseDepositWithdrawFee (dictionary, currency);
+            }
+        }
+        return depositWithdrawFees;
+    }
+
+    depositWithdrawFee () {
+        return {
+            'withdraw': {
+                'fee': undefined,
+                'percentage': undefined,
+            },
+            'deposit': {
+                'fee': undefined,
+                'percentage': undefined,
+            },
+            'networks': {},
+        };
+    }
 };

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2852,9 +2852,12 @@ module.exports = class Exchange {
         };
         codes = this.marketCodes (codes);
         const isArray = Array.isArray (response);
-        const array = isArray ? response : Object.keys (response);
-        for (let i = 0; i < array.length; i++) {
-            const entry = array[i];
+        let responseKeys = response;
+        if (!isArray) {
+            responseKeys = Object.keys (response);
+        }
+        for (let i = 0; i < responseKeys.length; i++) {
+            const entry = responseKeys[i];
             const dictionary = isArray ? entry : response[entry];
             const currencyId = isArray ? this.safeString (dictionary, currencyIdKey) : entry;
             const currency = this.safeValue (this.currencies_by_id, currencyId);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2867,8 +2867,9 @@ module.exports = class Exchange {
         return depositWithdrawFees;
     }
 
-    depositWithdrawFee () {
+    depositWithdrawFee (info) {
         return {
+            'info': info,
             'withdraw': {
                 'fee': undefined,
                 'percentage': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2071,6 +2071,14 @@ module.exports = class Exchange {
         throw new NotSupported (this.id + ' fetchTransactionFees() is not supported yet');
     }
 
+    async fetchDepositWithdrawFee (code, params = {}) {
+        if (!this.has['fetchDepositWithdrawFees']) {
+            throw new NotSupported (this.id + ' fetchDepositWithdrawFee() is not supported yet');
+        }
+        const fees = await this.fetchDepositWithdrawFees ([ code ], params);
+        return this.safeValue (fees, code);
+    }
+
     getSupportedMapping (key, mapping = {}) {
         if (key in mapping) {
             return mapping[key];

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2847,9 +2847,7 @@ module.exports = class Exchange {
          * @param {str|undefined} currencyIdKey *should only be undefined when response is a dictionary* the object key that corresponds to the currency id
          * @returns {object} objects with withdraw and deposit fees, indexed by currency codes
          */
-        const depositWithdrawFees = {
-            'info': response,
-        };
+        const depositWithdrawFees = {};
         codes = this.marketCodes (codes);
         const isArray = Array.isArray (response);
         let responseKeys = response;


### PR DESCRIPTION
adds methods to base/exchange

- `fetchDepositWithdrawFee` (default for use when `fetchDepositWithdrawFees` is implemented)
- `parseDepositWithdrawFees`
- `depositWithdrawFee` (returns a basic depositWithdrawFee structure)