### PR TITLE
Bibox: fetchTrades, change size to limit

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -702,7 +702,7 @@ module.exports = class bibox extends Exchange {
             'symbol': market['id'],
         };
         if (limit !== undefined) {
-            request['size'] = limit; // default = 100
+            request['limit'] = limit; // default = 100
         }
         if (since !== undefined) {
             request['start_time'] = since;


### PR DESCRIPTION
Changes the parameter names from  `size` to `limit` in fetchTrades

https://api.bibox.com/api/v4/marketdata/trades?symbol=ETH_BTC&limit=1000
https://api.bibox.com/api/v4/marketdata/trades?symbol=ETH_BTC&size=1000

fixes: #15740