### PR TITLE
Gemini :: improve fetchTrades

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -727,6 +727,7 @@ module.exports = class gemini extends Exchange {
          * @method
          * @name gemini#fetchTrades
          * @description get the list of most recent trades for a particular symbol
+         * @see https://docs.gemini.com/rest-api/#trade-history
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int|undefined} since timestamp in ms of the earliest trade to fetch
          * @param {int|undefined} limit the maximum amount of trades to fetch
@@ -738,6 +739,12 @@ module.exports = class gemini extends Exchange {
         const request = {
             'symbol': market['id'],
         };
+        if (limit !== undefined) {
+            request['limit_trades'] = limit;
+        }
+        if (since !== undefined) {
+            request['timestamp'] = since;
+        }
         const response = await this.publicGetV1TradesSymbol (this.extend (request, params));
         //
         //     [


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15755

```
p gemini fetchTrades "BTC/USD" 1666346008000 1 
Python v3.9.7
CCXT v2.1.99
gemini.fetchTrades(BTC/USD,1666346008000,1)
[{'amount': 0.00638602,
  'cost': 121.4029019946,
  'datetime': '2022-10-21T09:53:56.384Z',
  'fee': {'cost': None, 'currency': None},
  'fees': [{'cost': None, 'currency': None}],
  'id': '147789247095',
  'info': {'amount': '0.00638602',
           'exchange': 'gemini',
           'price': '19010.73',
           'tid': '147789247095',
           'timestamp': '1666346036',
           'timestampms': '1666346036384',
           'type': 'buy'},
  'order': None,
  'price': 19010.73,
  'side': 'buy',
  'symbol': 'BTC/USD',
  'takerOrMaker': None,
  'timestamp': 1666346036384,
  'type': None}]
```