### PR TITLE
exchange - safeOrder - parseTrade

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -96,6 +96,7 @@ class Transpiler {
             [ /\.parseTradesData\s/g, '.parse_trades_data'],
             [ /\.parseTrades\s/g, '.parse_trades'],
             [ /\.parseTrade\s/g, '.parse_trade'],
+            [ /\.parseTrade(?=;)/g, '.parse_trade'],
             [ /\.parseTradingFees\s/g, '.parse_trading_fees'],
             [ /\.parseTradingFee\s/g, '.parse_trading_fee'],
             [ /\.parseTradingViewOHLCV\s/g, '.parse_trading_view_ohlcv'],

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -964,7 +964,7 @@ module.exports = class Exchange {
 
     safeOrder (order, market = undefined, parseTrade = undefined) {
         if (parseTrade === undefined) {
-            parseTrade = this.parseTrade
+            parseTrade = this.parseTrade;
         }
         // parses numbers as strings
         // it is important pass the trades as unparsed rawTrades

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1728,14 +1728,11 @@ module.exports = class Exchange {
         return result;
     }
 
-    parseTrades (trades, market = undefined, since = undefined, limit = undefined, params = {}, parseTrade = undefined) {
-        if (parseTrade === undefined) {
-            parseTrade = this.parseTrade;
-        }
+    parseTrades (trades, market = undefined, since = undefined, limit = undefined, params = {}, parseTrade = 'parseTrade') {
         trades = this.toArray (trades);
         let result = [];
         for (let i = 0; i < trades.length; i++) {
-            const trade = this.extend (parseTrade (trades[i], market), params);
+            const trade = this.extend (this[parseTrade] (trades[i], market), params);
             result.push (trade);
         }
         result = this.sortBy2 (result, 'timestamp', 'id');

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -962,7 +962,10 @@ module.exports = class Exchange {
         return balance;
     }
 
-    safeOrder (order, market = undefined) {
+    safeOrder (order, market = undefined, parseTrade = undefined) {
+        if (parseTrade === undefined) {
+            parseTrade = this.parseTrade
+        }
         // parses numbers as strings
         // it is important pass the trades as unparsed rawTrades
         let amount = this.omitZero (this.safeString (order, 'amount'));
@@ -991,7 +994,7 @@ module.exports = class Exchange {
                 'side': order['side'],
                 'type': order['type'],
                 'order': order['id'],
-            });
+            }, parseTrade);
             this.number = oldNumber;
             let tradesLength = 0;
             const isArray = Array.isArray (trades);
@@ -1725,11 +1728,14 @@ module.exports = class Exchange {
         return result;
     }
 
-    parseTrades (trades, market = undefined, since = undefined, limit = undefined, params = {}) {
+    parseTrades (trades, market = undefined, since = undefined, limit = undefined, params = {}, parseTrade = undefined) {
+        if (parseTrade === undefined) {
+            parseTrade = this.parseTrade;
+        }
         trades = this.toArray (trades);
         let result = [];
         for (let i = 0; i < trades.length; i++) {
-            const trade = this.extend (this.parseTrade (trades[i], market), params);
+            const trade = this.extend (parseTrade (trades[i], market), params);
             result.push (trade);
         }
         result = this.sortBy2 (result, 'timestamp', 'id');

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -395,7 +395,7 @@ module.exports = class binance extends binanceRest {
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }
 
-    parseTrade (trade, market = undefined) {
+    parseWsTrade (trade, market = undefined) {
         //
         // public watchTrades
         //
@@ -502,9 +502,6 @@ module.exports = class binance extends binanceRest {
         //
         const executionType = this.safeString (trade, 'x');
         const isTradeExecution = (executionType === 'TRADE');
-        if (!isTradeExecution) {
-            return super.parseTrade (trade, market);
-        }
         const id = this.safeString2 (trade, 't', 'a');
         const timestamp = this.safeInteger (trade, 'T');
         const price = this.safeFloat2 (trade, 'L', 'p');
@@ -566,7 +563,7 @@ module.exports = class binance extends binanceRest {
         const lowerCaseId = this.safeStringLower (message, 's');
         const event = this.safeString (message, 'e');
         const messageHash = lowerCaseId + '@' + event;
-        const trade = this.parseTrade (message, market);
+        const trade = this.parseWsTrade (message, market);
         let tradesArray = this.safeValue (this.trades, symbol);
         if (tradesArray === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
@@ -1340,7 +1337,7 @@ module.exports = class binance extends binanceRest {
         const messageHash = 'myTrades';
         const executionType = this.safeString (message, 'x');
         if (executionType === 'TRADE') {
-            const trade = this.parseTrade (message);
+            const trade = this.parseWsTrade (message);
             const orderId = this.safeString (trade, 'order');
             const tradeFee = this.safeValue (trade, 'fee');
             const symbol = this.safeString (trade, 'symbol');

--- a/js/pro/bitfinex.js
+++ b/js/pro/bitfinex.js
@@ -132,7 +132,7 @@ module.exports = class bitfinex extends bitfinexRest {
                 if (second !== 'tu') {
                     return;
                 }
-                const trade = this.parseTrade (message, market);
+                const trade = this.parseWsTrade (message, market);
                 stored.append (trade);
             }
             client.resolve (stored, messageHash);
@@ -140,7 +140,7 @@ module.exports = class bitfinex extends bitfinexRest {
         return message;
     }
 
-    parseTrade (trade, market = undefined) {
+    parseWsTrade (trade, market = undefined) {
         //
         // snapshot trade
         //
@@ -157,9 +157,6 @@ module.exports = class bitfinex extends bitfinexRest {
         //     // channel id, update type, seq, trade id, time, price, amount
         //     [ 2, 'tu', '28462857-BTCUSD', 413357662, 1580565041, 9374.9, 0.005 ]
         //
-        if (!Array.isArray (trade)) {
-            return super.parseTrade (trade, market);
-        }
         const tradeLength = trade.length;
         const event = this.safeString (trade, 1);
         let id = undefined;

--- a/js/pro/bitstamp.js
+++ b/js/pro/bitstamp.js
@@ -236,7 +236,7 @@ module.exports = class bitstamp extends bitstampRest {
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }
 
-    parseTrade (trade, market = undefined) {
+    parseWsTrade (trade, market = undefined) {
         //
         //     {
         //         buy_order_id: 1211625836466176,
@@ -252,9 +252,6 @@ module.exports = class bitstamp extends bitstampRest {
         //     }
         //
         const microtimestamp = this.safeInteger (trade, 'microtimestamp');
-        if (microtimestamp === undefined) {
-            return super.parseTrade (trade, market);
-        }
         const id = this.safeString (trade, 'id');
         const timestamp = parseInt (microtimestamp / 1000);
         const price = this.safeFloat (trade, 'price');
@@ -316,7 +313,7 @@ module.exports = class bitstamp extends bitstampRest {
         const subscription = this.safeValue (client.subscriptions, channel);
         const symbol = this.safeString (subscription, 'symbol');
         const market = this.market (symbol);
-        const trade = this.parseTrade (data, market);
+        const trade = this.parseWsTrade (data, market);
         let tradesArray = this.safeValue (this.trades, symbol);
         if (tradesArray === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);

--- a/js/pro/coinbasepro.js
+++ b/js/pro/coinbasepro.js
@@ -299,7 +299,7 @@ module.exports = class coinbasepro extends coinbaseproRest {
         //     "side": "buy",
         //     "order_type": "limit"
         // }
-        const parsed = super.parseTrade (trade);
+        const parsed = this.parseTrade (trade);
         let feeRate = undefined;
         if ('maker_fee_rate' in trade) {
             parsed['takerOrMaker'] = 'maker';


### PR DESCRIPTION
Allow passing in a different `parseTrade`  function to `parseTrades` and `safeOrder`.
This will allow to use `safeOrder` with `parseWsTrade`