### PR TITLE
binance.borrowMargin and repayMargin uses handleMarginModeAndParams

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -6385,7 +6385,7 @@ module.exports = class binance extends Exchange {
          * @param {object} params extra parameters specific to the binance api endpoint
          * @returns {object} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
-        const marginMode = this.safeString (params, 'marginMode'); // cross or isolated
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('repayMargin', params); // cross or isolated
         this.checkRequiredMarginArgument ('repayMargin', symbol, marginMode);
         await this.loadMarkets ();
         const currency = this.currency (code);
@@ -6398,8 +6398,7 @@ module.exports = class binance extends Exchange {
             request['symbol'] = market['id'];
             request['isIsolated'] = 'TRUE';
         }
-        params = this.omit (params, 'marginMode');
-        const response = await this.sapiPostMarginRepay (this.extend (request, params));
+        const response = await this.sapiPostMarginRepay (this.extend (request, query));
         //
         //     {
         //         "tranId": 108988250265,
@@ -6421,8 +6420,7 @@ module.exports = class binance extends Exchange {
          * @param {object} params extra parameters specific to the binance api endpoint
          * @returns {object} a [margin loan structure]{@link https://docs.ccxt.com/en/latest/manual.html#margin-loan-structure}
          */
-        const marginMode = this.safeString (params, 'marginMode'); // cross or isolated
-        params = this.omit (params, 'marginMode');
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('borrowMargin', params); // cross or isolated
         this.checkRequiredMarginArgument ('borrowMargin', symbol, marginMode);
         await this.loadMarkets ();
         const currency = this.currency (code);
@@ -6435,7 +6433,7 @@ module.exports = class binance extends Exchange {
             request['symbol'] = market['id'];
             request['isIsolated'] = 'TRUE';
         }
-        const response = await this.sapiPostMarginLoan (this.extend (request, params));
+        const response = await this.sapiPostMarginLoan (this.extend (request, query));
         //
         //     {
         //         "tranId": 108988250265,


### PR DESCRIPTION
```
% binance borrowMargin USDT 2 ADA/USDT             
2022-11-21T13:32:50.241Z
Node.js: v18.4.0
CCXT v2.1.102
binance.borrowMargin (USDT, 2, ADA/USDT)
2022-11-21T13:32:53.625Z iteration 0 passed in 1127 ms

{
  id: 122812933917,
  currency: 'USDT',
  amount: undefined,
  symbol: undefined,
  timestamp: undefined,
  datetime: undefined,
  info: { tranId: '122812933917', clientTag: '' }
}
2022-11-21T13:32:53.625Z iteration 1 passed in 1127 ms
```
```
% binance repayMargin USDT 2.0000097 ADA/USDT      
2022-11-21T13:34:56.858Z
Node.js: v18.4.0
CCXT v2.1.102
binance.repayMargin (USDT, 2.0000097, ADA/USDT)
2022-11-21T13:34:59.949Z iteration 0 passed in 1022 ms

{
  id: 122813061111,
  currency: 'USDT',
  amount: undefined,
  symbol: undefined,
  timestamp: undefined,
  datetime: undefined,
  info: { tranId: '122813061111', clientTag: '' }
}
2022-11-21T13:34:59.949Z iteration 1 passed in 1022 ms
```
```
% binance borrowMargin USDT 2 undefined '{"marginMode": "isolated"}'
2022-11-21T13:35:27.635Z
Node.js: v18.4.0
CCXT v2.1.102
binance.borrowMargin (USDT, 2, , [object Object])
ArgumentsRequired binance borrowMargin() requires a symbol argument for isolated margin
---------------------------------------------------
[ArgumentsRequired] binance borrowMargin() requires a symbol argument for isolated margin

    at checkRequiredMarginArgument  ../../ccxt/ccxt/js/base/Exchange.js:2835  throw new ArgumentsRequired (this.id + ' ' + methodName + '() requires a symbol…
    at borrowMargin                 ../../ccxt/ccxt/js/binance.js:6424        this.checkRequiredMarginArgument ('borrowMargin', symbol, marginMode);          
    at run                          ../../ccxt/ccxt/examples/js/cli.js:281    const result = await exchange[methodName] (... args)                            

binance borrowMargin() requires a symbol argument for isolated margin
```