### PR TITLE
mexc3 - `commonCurrencies` update

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -421,13 +421,11 @@ module.exports = class mexc3 extends Exchange {
                 'FLUX1': 'FLUX', // switched places
                 'FLUX': 'FLUX1', // switched places
                 'FREE': 'FreeRossDAO', // conflict with FREE Coin
-                'GMT': 'GMT Token',
                 'HERO': 'Step Hero', // conflict with Metahero
                 'MIMO': 'Mimosa',
                 'PROS': 'Pros.Finance', // conflict with Prosper
                 'SIN': 'Sin City Token',
                 'SOUL': 'Soul Swap',
-                'STEPN': 'GMT',
             },
             'exceptions': {
                 'exact': {


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py mexc3 fetchTicker "GMT/USDT"`
```
Python v3.10.6
CCXT v2.1.92
mexc3.fetchTicker(GMT/USDT)
{'ask': 0.0734,
 'askVolume': 8006.86,
 'average': 0.0747,
 'baseVolume': 1608225.51,
 'bid': 0.0719,
 'bidVolume': 4692.2,
 'change': -0.0032,
 'close': 0.0731,
 'datetime': '2022-11-21T13:37:56.936Z',
 'high': 0.0771,
 'info': {'askPrice': '0.0734',
          'askQty': '8006.86',
          'bidPrice': '0.0719',
          'bidQty': '4692.2',
          'closeTime': '1669037876936',
          'count': None,
          'highPrice': '0.0771',
          'lastPrice': '0.0731',
          'lowPrice': '0.07',
          'openPrice': '0.0763',
          'openTime': '1669037700000',
          'prevClosePrice': '0.0763',
          'priceChange': '-0.0032',
          'priceChangePercent': '-0.04193971',
          'quoteVolume': '118875.6759',
          'symbol': 'GMTUSDT',
          'volume': '1608225.51'},
 'last': 0.0731,
 'low': 0.07,
 'open': 0.0763,
 'percentage': -4.193971,
 'previousClose': 0.0763,
 'quoteVolume': 118875.6759,
 'symbol': 'GMT/USDT',
 'timestamp': 1669037876936,
 'vwap': 0.0739172927930984}
```

- fix https://github.com/ccxt/ccxt/issues/15766