### PR TITLE
bibox fetchDepositWithdrawFee

### DIFF
--- a/js/bibox.js
+++ b/js/bibox.js
@@ -54,6 +54,8 @@ module.exports = class bibox extends Exchange {
                 'fetchTradingFee': false,
                 'fetchTradingFees': false,
                 'fetchTransactionFees': true,
+                'fetchDepositWithdrawFee': true,
+                'fetchDepositWithdrawFees': false,
                 'fetchWithdrawals': true,
                 'transfer': true,
                 'withdraw': true,
@@ -2049,7 +2051,7 @@ module.exports = class bibox extends Exchange {
         /**
          * @method
          * @name bibox#fetchTransactionFees
-         * @description fetch transaction fees
+         * @description *DEPRECATED* please use fetchDepositWithdrawFees instead
          * @param {[string]|undefined} codes list of unified currency codes
          * @param {object} params extra parameters specific to the bibox api endpoint
          * @returns {[object]} a list of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
@@ -2104,6 +2106,81 @@ module.exports = class bibox extends Exchange {
             'info': info,
             'withdraw': withdrawFees,
             'deposit': {},
+        };
+    }
+
+    async fetchDepositWithdrawFee (code, params = {}) {
+        /**
+         * @method
+         * @name bibox#fetchDepositWithdrawFee
+         * @description fetch withdrawal fees for currencies
+         * @param {string} code unified currency code
+         * @param {object} params extra parameters specific to the bibox api endpoint
+         * @returns {object} a [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'cmd': 'transfer/coinConfig',
+            'body': this.extend ({
+                'coin_symbol': currency['id'],
+            }, params),
+        };
+        const response = await this.v1PrivatePostTransfer (request);
+        //
+        //    {
+        //        "result": [
+        //            {
+        //                "result": [
+        //                    {
+        //                        "coin_symbol": "ETH",
+        //                        "is_active": 1,
+        //                        "original_decimals": 18,
+        //                        "enable_deposit": 1,
+        //                        "enable_withdraw": 1,
+        //                        "withdraw_fee": 0.008,
+        //                        "withdraw_min": 0.05,
+        //                        "deposit_avg_spent": 173700,
+        //                        "withdraw_avg_spent": 322600
+        //                    }
+        //                ],
+        //                "cmd": "transfer/coinConfig"
+        //            }
+        //        ]
+        //    }
+        //
+        const outerResults = this.safeValue (response, 'result', []);
+        const firstOuterResult = this.safeValue (outerResults, 0, {});
+        const innerResults = this.safeValue (firstOuterResult, 'result', []);
+        const firstInnerResult = this.safeValue (innerResults, 0, {});
+        return this.parseDepositWithdrawFee (firstInnerResult, currency);
+    }
+
+    parseDepositWithdrawFee (fee, currency = undefined) {
+        //
+        //    {
+        //        "coin_symbol": "ETH",
+        //        "is_active": 1,
+        //        "original_decimals": 18,
+        //        "enable_deposit": 1,
+        //        "enable_withdraw": 1,
+        //        "withdraw_fee": 0.008,
+        //        "withdraw_min": 0.05,
+        //        "deposit_avg_spent": 173700,
+        //        "withdraw_avg_spent": 322600
+        //    }
+        //
+        return {
+            'info': fee,
+            'withdraw': {
+                'fee': this.safeNumber (fee, 'withdraw_fee'),
+                'percentage': undefined,
+            },
+            'deposit': {
+                'fee': undefined,
+                'percentage': undefined,
+            },
+            'networks': {},
         };
     }
 


### PR DESCRIPTION
```
% bibox fetchDepositWithdrawFee USDT
2022-11-21T13:45:34.683Z
Node.js: v18.4.0
CCXT v2.1.102
bibox.fetchDepositWithdrawFee (USDT)
2022-11-21T13:45:37.659Z iteration 0 passed in 509 ms

{
  info: {
    coin_symbol: 'USDT',
    is_active: '1',
    original_decimals: '8',
    enable_deposit: '1',
    enable_withdraw: '1',
    withdraw_fee: '59',
    withdraw_min: '60',
    deposit_avg_spent: '8500',
    withdraw_avg_spent: '-165718887200'
  },
  withdraw: { fee: 59, percentage: undefined },
  deposit: { fee: undefined, percentage: undefined },
  networks: {}
}
2022-11-21T13:45:37.659Z iteration 1 passed in 509 ms
```