### PR TITLE
Digifinex - `fetchTicker(s)`

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -27,8 +27,6 @@ module.exports = class digifinex extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': true,
                 'createOrder': true,
-                'createPostOnlyOrder': true,
-                'createReduceOnlyOrder': true,
                 'createStopLimitOrder': false,
                 'createStopMarketOrder': false,
                 'createStopOrder': false,
@@ -765,13 +763,27 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#fetchTickers
          * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#ticker-price
+         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#tickers
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        const response = await this.publicSpotGetTicker (params);
+        let market = undefined;
+        if (symbols !== undefined) {
+            const symbol = this.safeValue (symbols, 0);
+            market = this.market (symbol);
+        }
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPublicGetPublicGetTicker',
+            'future': 'derivativesPublicGetPublicGetTickers',
+            'swap': 'derivativesPublicGetPublicGetTickers',
+        });
+        const response = await this[method] (query);
+        // spot
         //
         //    {
         //        "ticker": [{
@@ -788,6 +800,32 @@ module.exports = class digifinex extends Exchange {
         //        "date": 1589874294,
         //        "code": 0
         //    }
+        //
+        // swap
+        //
+        //     {"code": 0,
+        //      "data": [
+        //      {
+        //          "instrument_id": "VETUSDTPERP",
+        //          "index_price": "0.01915",
+        //          "mark_price": "0.01916",
+        //          "max_buy_price": "0.02010",
+        //          "min_sell_price": "0.01818",
+        //          "best_bid": "0.01915",
+        //          "best_bid_size": "1126.000000",
+        //          "best_ask": "0.01918",
+        //          "best_ask_size": "48.000000",
+        //          "high_24h": "0.0198",
+        //          "open_24h": "0.01976",
+        //          "low_24h": "0.01792",
+        //          "last": "0.01917",
+        //          "last_qty": "28.000000",
+        //          "volume_24h": "4573318",
+        //          "price_change_percent": "-0.02985829959514171",
+        //          "open_interest": "1090849.208",
+        //          "timestamp": 1668440426119
+        //      }]
+        //     }
         //
         const result = {};
         const tickers = this.safeValue (response, 'ticker', []);
@@ -808,16 +846,31 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#fetchTicker
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
+         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#ticker-price
+         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#ticker
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const request = {
-            'symbol': market['id'],
-        };
-        const response = await this.publicSpotGetTicker (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        let request = undefined;
+        if (marketType === 'spot') {
+            request = {
+                'symbol': market['id'],
+            };
+        } else {
+            request = {
+                'instrument_id': market['id'],
+            };
+        }
+        const method = this.getSupportedMapping (marketType, {
+            'spot': 'publicSpotGetTicker',
+            'future': 'publicSpotGetTicker',
+            'swap': 'publicSpotGetTicker',
+        });
+        const response = await this[method] (this.extend (request, query));
         //
         //    {
         //        "ticker": [{
@@ -835,6 +888,32 @@ module.exports = class digifinex extends Exchange {
         //        "code": 0
         //    }
         //
+        // swap
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "instrument_id": "BTCUSDTPERP",
+        //             "index_price": "16588.2",
+        //             "mark_price": "16587.0",
+        //             "max_buy_price": "17415.6",
+        //             "min_sell_price": "15756.7",
+        //             "best_bid": "16584.8",
+        //             "best_bid_size": "3037.000000",
+        //             "best_ask": "16584.9",
+        //             "best_ask_size": "3568.000000",
+        //             "high_24h": "17191.4",
+        //             "open_24h": "16558.3",
+        //             "low_24h": "15809.5",
+        //             "last": "16584.9",
+        //             "last_qty": "94.000000",
+        //             "volume_24h": "76305148",
+        //             "price_change_percent": "0.0016064451060798623",
+        //             "open_interest": "163541126.4048",
+        //             "timestamp": 1668441806062
+        //         }
+        //     }
+        //
         const date = this.safeInteger (response, 'date');
         const tickers = this.safeValue (response, 'ticker', []);
         const firstTicker = this.safeValue (tickers, 0, {});
@@ -844,7 +923,7 @@ module.exports = class digifinex extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         //
-        // fetchTicker, fetchTickers
+        // spot
         //
         //     {
         //         "last":0.021957,
@@ -859,23 +938,47 @@ module.exports = class digifinex extends Exchange {
         //         "date"1564518452, // injected from fetchTicker/fetchTickers
         //     }
         //
+        // swap
+        //
+        //     {
+        //         "instrument_id": "VETUSDTPERP",
+        //         "index_price": "0.01915",
+        //         "mark_price": "0.01916",
+        //         "max_buy_price": "0.02010",
+        //         "min_sell_price": "0.01818",
+        //         "best_bid": "0.01915",
+        //         "best_bid_size": "1126.000000",
+        //         "best_ask": "0.01918",
+        //         "best_ask_size": "48.000000",
+        //         "high_24h": "0.0198",
+        //         "open_24h": "0.01976",
+        //         "low_24h": "0.01792",
+        //         "last": "0.01917",
+        //         "last_qty": "28.000000",
+        //         "volume_24h": "4573318",
+        //         "price_change_percent": "-0.02985829959514171",
+        //         "open_interest": "1090849.208",
+        //         "timestamp": 1668440426119
+        //     }
+        //
         const marketId = this.safeStringUpper (ticker, 'symbol');
+        // TODO: If '_' in symbolId
         const symbol = this.safeSymbol (marketId, market, '_');
-        const timestamp = this.safeTimestamp (ticker, 'date');
+        const timestamp = this.safeTimestamp (ticker, 'date', '');
         const last = this.safeString (ticker, 'last');
-        const percentage = this.safeString (ticker, 'change');
+        const percentage = this.safeString2 (ticker, 'change', 'price_change_percent');
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeString (ticker, 'high'),
-            'low': this.safeString (ticker, 'low'),
-            'bid': this.safeString (ticker, 'buy'),
-            'bidVolume': undefined,
-            'ask': this.safeString (ticker, 'sell'),
-            'askVolume': undefined,
+            'high': this.safeString2 (ticker, 'high'),
+            'low': this.safeString2 (ticker, 'low'),
+            'bid': this.safeString2 (ticker, 'buy', 'best_bid'),
+            'bidVolume': this.safeString (ticker, 'best_bid_size'),
+            'ask': this.safeString2 (ticker, 'sell', 'best_ask'),
+            'askVolume': this.safeString (ticker, 'best_ask_size'),
             'vwap': undefined,
-            'open': undefined,
+            'open': this.safeString (ticker, 'open_24h'),
             'close': last,
             'last': last,
             'previousClose': undefined,
@@ -1117,109 +1220,44 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#createOrder
          * @description create a trade order
-         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#create-new-order
-         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#orderplace
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} params extra parameters specific to the digifinex api endpoint
-         * @param {string} params.timeInForce "GTC", "IOC", "FOK", or "PO"
-         * @param {bool} params.postOnly true or false
-         * @param {bool} params.reduceOnly true or false
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        symbol = market['symbol'];
-        let marketType = undefined;
-        let marginMode = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('createOrder', market, params);
-        let method = this.getSupportedMapping (marketType, {
-            'spot': 'privateSpotPostSpotOrderNew',
-            'margin': 'privateSpotPostMarginOrderNew',
-            'swap': 'privateSwapPostTradeOrderPlace',
-        });
-        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
-        if (marginMode !== undefined) {
-            method = 'privateSpotPostMarginOrderNew';
-            marketType = 'margin';
-        }
-        const request = {};
-        const swap = (marketType === 'swap');
-        const isMarketOrder = (type === 'market');
-        const isLimitOrder = (type === 'limit');
-        const marketIdRequest = swap ? 'instrument_id' : 'symbol';
-        request[marketIdRequest] = market['id'];
-        let postOnly = this.isPostOnly (isMarketOrder, false, params);
-        if (swap) {
-            const reduceOnly = this.safeValue (params, 'reduceOnly', false);
-            const timeInForce = this.safeString (params, 'timeInForce');
-            let orderType = undefined;
-            if (side === 'buy') {
-                const requestType = (reduceOnly) ? 4 : 1;
-                request['type'] = requestType;
-            } else {
-                const requestType = (reduceOnly) ? 3 : 2;
-                request['type'] = requestType;
-            }
-            if (isLimitOrder) {
-                orderType = 0;
-            }
-            if (timeInForce === 'FOK') {
-                orderType = isMarketOrder ? 15 : 9;
-            } else if (timeInForce === 'IOC') {
-                orderType = isMarketOrder ? 13 : 4;
-            } else if ((timeInForce === 'GTC') || (isMarketOrder)) {
-                orderType = 14;
-            } else if (timeInForce === 'PO') {
-                postOnly = true;
-            }
-            if (price !== undefined) {
-                request['price'] = this.priceToPrecision (symbol, price);
-            }
-            request['order_type'] = orderType;
-            request['size'] = amount;  // swap orders require the amount to be the number of contracts
-            params = this.omit (params, [ 'reduceOnly', 'timeInForce' ]);
+        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
+        const orderType = this.safeString (params, 'type', defaultType);
+        params = this.omit (params, 'type');
+        const request = {
+            'market': orderType,
+            'symbol': market['id'],
+            'amount': this.amountToPrecision (market['symbol'], amount),
+            // 'post_only': 0, // 0 by default, if set to 1 the order will be canceled if it can be executed immediately, making sure there will be no market taking
+        };
+        let suffix = '';
+        if (type === 'market') {
+            suffix = '_market';
         } else {
-            postOnly = (postOnly === true) ? 1 : 2;
-            request['market'] = marketType;
-            let suffix = '';
-            if (type === 'market') {
-                suffix = '_market';
-            } else {
-                request['price'] = this.priceToPrecision (symbol, price);
-            }
-            request['type'] = side + suffix;
-            // limit orders require the amount in the base currency, market orders require the amount in the quote currency
-            request['amount'] = this.amountToPrecision (symbol, amount);
+            request['price'] = this.priceToPrecision (market['symbol'], price);
         }
-        if (postOnly) {
-            request['postOnly'] = postOnly;
-        }
-        const query = this.omit (params, [ 'postOnly', 'post_only' ]);
-        const response = await this[method] (this.extend (request, query));
-        //
-        // spot
+        request['type'] = side + suffix;
+        const response = await this.privateSpotPostMarketOrderNew (this.extend (request, params));
         //
         //     {
         //         "code": 0,
         //         "order_id": "198361cecdc65f9c8c9bb2fa68faec40"
         //     }
         //
-        // swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": "1590873693003714560"
-        //     }
-        //
         const result = this.parseOrder (response, market);
         return this.extend (result, {
-            'symbol': symbol,
-            'type': type,
+            'symbol': market['symbol'],
             'side': side,
+            'type': type,
             'amount': amount,
             'price': price,
         });
@@ -1230,43 +1268,20 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#cancelOrder
          * @description cancels an open order
-         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#cancel-order
-         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#cancelorder
          * @param {string} id order id
          * @param {string|undefined} symbol not used by digifinex cancelOrder ()
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
-        let market = undefined;
-        if (symbol !== undefined) {
-            market = this.market (symbol);
-        }
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
-        let method = this.getSupportedMapping (marketType, {
-            'spot': 'privateSpotPostSpotOrderCancel',
-            'margin': 'privateSpotPostMarginOrderCancel',
-            'swap': 'privateSwapPostTradeCancelOrder',
-        });
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('cancelOrder', params);
-        if (marginMode !== undefined) {
-            method = 'privateSpotPostMarginOrderCancel';
-            marketType = 'margin';
-        }
-        id = id.toString ();
+        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
+        const orderType = this.safeString (params, 'type', defaultType);
+        params = this.omit (params, 'type');
         const request = {
+            'market': orderType,
             'order_id': id,
         };
-        if (marketType === 'swap') {
-            this.checkRequiredSymbol ('cancelOrder', symbol);
-            request['instrument_id'] = market['id'];
-        } else {
-            request['market'] = marketType;
-        }
-        const response = await this[method] (this.extend (request, query));
-        //
-        // spot
+        const response = await this.privateSpotPostMarketOrderCancel (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1279,19 +1294,10 @@ module.exports = class digifinex extends Exchange {
         //         ]
         //     }
         //
-        // swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": "1590923061186531328"
-        //     }
-        //
-        if ((marketType === 'spot') || (marketType === 'margin')) {
-            const canceledOrders = this.safeValue (response, 'success', []);
-            const numCanceledOrders = canceledOrders.length;
-            if (numCanceledOrders !== 1) {
-                throw new OrderNotFound (this.id + ' cancelOrder() ' + id + ' not found');
-            }
+        const canceledOrders = this.safeValue (response, 'success', []);
+        const numCanceledOrders = canceledOrders.length;
+        if (numCanceledOrders !== 1) {
+            throw new OrderNotFound (this.id + ' cancelOrder() ' + id + ' not found');
         }
         return response;
     }
@@ -1348,21 +1354,14 @@ module.exports = class digifinex extends Exchange {
 
     parseOrder (order, market = undefined) {
         //
-        // spot: createOrder
+        // createOrder
         //
         //     {
         //         "code": 0,
         //         "order_id": "198361cecdc65f9c8c9bb2fa68faec40"
         //     }
         //
-        // swap: createOrder
-        //
-        //     {
-        //         "code": 0,
-        //         "data": "1590873693003714560"
-        //     }
-        //
-        // spot: fetchOrder, fetchOpenOrders, fetchOrders
+        // fetchOrder, fetchOpenOrders, fetchOrders
         //
         //     {
         //         "symbol": "BTC_USDT",
@@ -1379,98 +1378,49 @@ module.exports = class digifinex extends Exchange {
         //         "kind": "margin"
         //     }
         //
-        // swap: fetchOrder, fetchOpenOrders, fetchOrders
-        //
-        //     {
-        //         "order_id": "1590898207657824256",
-        //         "instrument_id": "BTCUSDTPERP",
-        //         "margin_mode": "crossed",
-        //         "contract_val": "0.001",
-        //         "type": 1,
-        //         "order_type": 0,
-        //         "price": "14000",
-        //         "size": "6",
-        //         "filled_qty": "0",
-        //         "price_avg": "0",
-        //         "fee": "0",
-        //         "state": 0,
-        //         "leverage": "20",
-        //         "turnover": "0",
-        //         "has_stop": 0,
-        //         "insert_time": 1668134664828,
-        //         "time_stamp": 1668134664828
-        //     }
-        //
-        let timestamp = undefined;
-        let lastTradeTimestamp = undefined;
-        let timeInForce = undefined;
-        let type = undefined;
+        const id = this.safeString (order, 'order_id');
+        const timestamp = this.safeTimestamp (order, 'created_date');
+        const lastTradeTimestamp = this.safeTimestamp (order, 'finished_date');
         let side = this.safeString (order, 'type');
-        const marketId = this.safeString2 (order, 'symbol', 'instrument_id');
-        const symbol = this.safeSymbol (marketId, market, '_');
-        market = this.market (symbol);
-        if (market['type'] === 'swap') {
-            const orderType = this.safeInteger (order, 'order_type');
-            if ((orderType === 9) || (orderType === 10) || (orderType === 11) || (orderType === 12) || (orderType === 15)) {
-                timeInForce = 'FOK';
-            } else if ((orderType === 1) || (orderType === 2) || (orderType === 3) || (orderType === 4) || (orderType === 13)) {
-                timeInForce = 'IOC';
-            } else if ((orderType === 6) || (orderType === 7) || (orderType === 8) || (orderType === 14)) {
-                timeInForce = 'GTC';
-            }
-            if ((orderType === 0) || (orderType === 1) || (orderType === 4) || (orderType === 5) || (orderType === 9) || (orderType === 10)) {
-                type = 'limit';
+        let type = undefined;
+        if (side !== undefined) {
+            const parts = side.split ('_');
+            const numParts = parts.length;
+            if (numParts > 1) {
+                side = parts[0];
+                type = parts[1];
             } else {
-                type = 'market';
-            }
-            if (side === '1') {
-                side = 'open long';
-            } else if (side === '2') {
-                side = 'open short';
-            } else if (side === '3') {
-                side = 'close long';
-            } else if (side === '4') {
-                side = 'close short';
-            }
-            timestamp = this.safeInteger (order, 'insert_time');
-            lastTradeTimestamp = this.safeInteger (order, 'time_stamp');
-        } else {
-            timestamp = this.safeTimestamp (order, 'created_date');
-            lastTradeTimestamp = this.safeTimestamp (order, 'finished_date');
-            if (side !== undefined) {
-                const parts = side.split ('_');
-                const numParts = parts.length;
-                if (numParts > 1) {
-                    side = parts[0];
-                    type = parts[1];
-                } else {
-                    type = 'limit';
-                }
+                type = 'limit';
             }
         }
+        const status = this.parseOrderStatus (this.safeString (order, 'status'));
+        const marketId = this.safeString (order, 'symbol');
+        const symbol = this.safeSymbol (marketId, market, '_');
+        const amountString = this.safeString (order, 'amount');
+        const filledString = this.safeString (order, 'executed_amount');
+        const priceString = this.safeString (order, 'price');
+        const averageString = this.safeString (order, 'avg_price');
         return this.safeOrder ({
             'info': order,
-            'id': this.safeString2 (order, 'order_id', 'data'),
+            'id': id,
             'clientOrderId': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,
             'symbol': symbol,
             'type': type,
-            'timeInForce': timeInForce,
+            'timeInForce': undefined,
             'postOnly': undefined,
             'side': side,
-            'price': this.safeNumber (order, 'price'),
+            'price': priceString,
             'stopPrice': undefined,
-            'amount': this.safeNumber2 (order, 'amount', 'size'),
-            'filled': this.safeNumber2 (order, 'executed_amount', 'filled_qty'),
+            'amount': amountString,
+            'filled': filledString,
             'remaining': undefined,
             'cost': undefined,
-            'average': this.safeNumber2 (order, 'avg_price', 'price_avg'),
-            'status': this.parseOrderStatus (this.safeString2 (order, 'status', 'state')),
-            'fee': {
-                'cost': this.safeNumber (order, 'fee'),
-            },
+            'average': averageString,
+            'status': status,
+            'fee': undefined,
             'trades': undefined,
         }, market);
     }
@@ -1480,50 +1430,25 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#fetchOpenOrders
          * @description fetch all unfilled currently open orders
-         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#current-active-orders
-         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#openorder
          * @param {string|undefined} symbol unified market symbol
          * @param {int|undefined} since the earliest time in ms to fetch open orders for
          * @param {int|undefined} limit the maximum number of  open orders structures to retrieve
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
+        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
+        const orderType = this.safeString (params, 'type', defaultType);
+        params = this.omit (params, 'type');
         await this.loadMarkets ();
         let market = undefined;
+        const request = {
+            'market': orderType,
+        };
         if (symbol !== undefined) {
             market = this.market (symbol);
+            request['symbol'] = market['id'];
         }
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
-        let method = this.getSupportedMapping (marketType, {
-            'spot': 'privateSpotGetSpotOrderCurrent',
-            'margin': 'privateSpotGetMarginOrderCurrent',
-            'swap': 'privateSwapGetTradeOpenOrders',
-        });
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOpenOrders', params);
-        if (marginMode !== undefined) {
-            method = 'privateSpotGetMarginOrderCurrent';
-            marketType = 'margin';
-        }
-        const request = {};
-        const swap = (marketType === 'swap');
-        if (swap) {
-            if (since !== undefined) {
-                request['start_timestamp'] = since;
-            }
-            if (limit !== undefined) {
-                request['limit'] = limit;
-            }
-        } else {
-            request['market'] = marketType;
-        }
-        if (market !== undefined) {
-            const marketIdRequest = swap ? 'instrument_id' : 'symbol';
-            request[marketIdRequest] = market['id'];
-        }
-        const response = await this[method] (this.extend (request, query));
-        //
-        // spot
+        const response = await this.privateSpotGetMarketOrderCurrent (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1542,34 +1467,6 @@ module.exports = class digifinex extends Exchange {
         //                 "type": "buy",
         //                 "kind": "margin"
         //             }
-        //         ]
-        //     }
-        //
-        // swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": [
-        //             {
-        //                 "order_id": "1590898207657824256",
-        //                 "instrument_id": "BTCUSDTPERP",
-        //                 "margin_mode": "crossed",
-        //                 "contract_val": "0.001",
-        //                 "type": 1,
-        //                 "order_type": 0,
-        //                 "price": "14000",
-        //                 "size": "6",
-        //                 "filled_qty": "0",
-        //                 "price_avg": "0",
-        //                 "fee": "0",
-        //                 "state": 0,
-        //                 "leverage": "20",
-        //                 "turnover": "0",
-        //                 "has_stop": 0,
-        //                 "insert_time": 1668134664828,
-        //                 "time_stamp": 1668134664828
-        //             },
-        //             ...
         //         ]
         //     }
         //
@@ -1582,52 +1479,31 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#fetchOrders
          * @description fetches information on multiple orders made by the user
-         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#get-all-orders-including-history-orders
-         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#historyorder
          * @param {string|undefined} symbol unified market symbol of the market orders were made in
          * @param {int|undefined} since the earliest time in ms to fetch orders for
          * @param {int|undefined} limit the maximum number of  orde structures to retrieve
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
+        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
+        const orderType = this.safeString (params, 'type', defaultType);
+        params = this.omit (params, 'type');
         await this.loadMarkets ();
         let market = undefined;
+        const request = {
+            'market': orderType,
+        };
         if (symbol !== undefined) {
             market = this.market (symbol);
+            request['symbol'] = market['id'];
         }
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
-        let method = this.getSupportedMapping (marketType, {
-            'spot': 'privateSpotGetSpotOrderHistory',
-            'margin': 'privateSpotGetMarginOrderHistory',
-            'swap': 'privateSwapGetTradeHistoryOrders',
-        });
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrders', params);
-        if (marginMode !== undefined) {
-            method = 'privateSpotGetMarginOrderHistory';
-            marketType = 'margin';
-        }
-        const request = {};
-        if (marketType === 'swap') {
-            if (since !== undefined) {
-                request['start_timestamp'] = since;
-            }
-        } else {
-            request['market'] = marketType;
-            if (since !== undefined) {
-                request['start_time'] = parseInt (since / 1000); // default 3 days from now, max 30 days
-            }
-        }
-        if (market !== undefined) {
-            const marketIdRequest = (marketType === 'swap') ? 'instrument_id' : 'symbol';
-            request[marketIdRequest] = market['id'];
+        if (since !== undefined) {
+            request['start_time'] = parseInt (since / 1000); // default 3 days from now, max 30 days
         }
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = limit; // default 10, max 100
         }
-        const response = await this[method] (this.extend (request, query));
-        //
-        // spot
+        const response = await this.privateSpotGetMarketOrderHistory (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1646,34 +1522,6 @@ module.exports = class digifinex extends Exchange {
         //                 "type": "buy",
         //                 "kind": "margin"
         //             }
-        //         ]
-        //     }
-        //
-        // swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": [
-        //             {
-        //                 "order_id": "1590136768156405760",
-        //                 "instrument_id": "BTCUSDTPERP",
-        //                 "margin_mode": "crossed",
-        //                 "contract_val": "0.001",
-        //                 "type": 1,
-        //                 "order_type": 8,
-        //                 "price": "18660.2",
-        //                 "size": "1",
-        //                 "filled_qty": "1",
-        //                 "price_avg": "18514.5",
-        //                 "fee": "0.00925725",
-        //                 "state": 2,
-        //                 "leverage": "20",
-        //                 "turnover": "18.5145",
-        //                 "has_stop": 0,
-        //                 "insert_time": 1667953123526,
-        //                 "time_stamp": 1667953123596
-        //             },
-        //             ...
         //         ]
         //     }
         //
@@ -1686,43 +1534,23 @@ module.exports = class digifinex extends Exchange {
          * @method
          * @name digifinex#fetchOrder
          * @description fetches information on an order made by the user
-         * @see https://docs.digifinex.com/en-ww/spot/v3/rest.html#get-order-status
-         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#orderinfo
-         * @param {string} id order id
          * @param {string|undefined} symbol unified symbol of the market the order was made in
          * @param {object} params extra parameters specific to the digifinex api endpoint
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
+        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
+        const orderType = this.safeString (params, 'type', defaultType);
+        params = this.omit (params, 'type');
         await this.loadMarkets ();
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
-        let method = this.getSupportedMapping (marketType, {
-            'spot': 'privateSpotGetSpotOrder',
-            'margin': 'privateSpotGetMarginOrder',
-            'swap': 'privateSwapGetTradeOrderInfo',
-        });
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrder', params);
-        if (marginMode !== undefined) {
-            method = 'privateSpotGetMarginOrder';
-            marketType = 'margin';
-        }
         const request = {
+            'market': orderType,
             'order_id': id,
         };
-        if (marketType === 'swap') {
-            if (market !== undefined) {
-                request['instrument_id'] = market['id'];
-            }
-        } else {
-            request['market'] = marketType;
-        }
-        const response = await this[method] (this.extend (request, query));
-        //
-        // spot
+        const response = await this.privateSpotGetMarketOrder (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -1744,35 +1572,10 @@ module.exports = class digifinex extends Exchange {
         //         ]
         //     }
         //
-        // swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "order_id": "1590923061186531328",
-        //             "instrument_id": "ETHUSDTPERP",
-        //             "margin_mode": "crossed",
-        //             "contract_val": "0.01",
-        //             "type": 1,
-        //             "order_type": 0,
-        //             "price": "900",
-        //             "size": "6",
-        //             "filled_qty": "0",
-        //             "price_avg": "0",
-        //             "fee": "0",
-        //             "state": 0,
-        //             "leverage": "20",
-        //             "turnover": "0",
-        //             "has_stop": 0,
-        //             "insert_time": 1668140590372,
-        //             "time_stamp": 1668140590372
-        //         }
-        //     }
-        //
-        const data = this.safeValue (response, 'data');
-        const order = (marketType === 'swap') ? data : this.safeValue (data, 0);
+        const data = this.safeValue (response, 'data', []);
+        const order = this.safeValue (data, 0);
         if (order === undefined) {
-            throw new OrderNotFound (this.id + ' fetchOrder() order ' + id.toString () + ' not found');
+            throw new OrderNotFound (this.id + ' fetchOrder() order ' + id + ' not found');
         }
         return this.parseOrder (order, market);
     }


### PR DESCRIPTION
# Testing
## Python
Swap
`python3 examples/py/cli.py digifinex fetchTickers '["XRP/USD:XRP"]'`
```
Python v3.10.6
CCXT v2.1.92
digifinex.fetchTickers(['XRP/USD:XRP'])
{'XRP/USD:XRP': {'ask': 0.3554,
                 'askVolume': 500.0,
                 'average': 0.3634,
                 'baseVolume': None,
                 'bid': 0.3552,
                 'bidVolume': 135.0,
                 'change': -0.04360699865410496,
                 'close': 0.3553,
                 'datetime': '2022-11-21T17:20:49.808Z',
                 'high': 0.3784,
                 'info': {'best_ask': '0.3554',
                          'best_ask_size': '500.000000',
                          'best_bid': '0.3552',
                          'best_bid_size': '135.000000',
                          'high_24h': '0.3784',
                          'index_price': '0.3560',
                          'instrument_id': 'XRPPERP',
                          'last': '0.3553',
                          'last_qty': '1656.000000',
                          'low_24h': '0.3452',
                          'mark_price': '0.3553',
                          'max_buy_price': '0.3731',
                          'min_sell_price': '0.3375',
                          'open_24h': '0.3715',
                          'open_interest': '3064917.15',
                          'price_change_percent': '-0.04360699865410496',
                          'timestamp': '1669051249808',
                          'volume_24h': '24112663'},
                 'last': 0.3553,
                 'low': 0.3452,
                 'open': 0.3715,
                 'percentage': -0.04360699865410496,
                 'previousClose': None,
                 'quoteVolume': 24112663.0,
                 'symbol': 'XRP/USD:XRP',
                 'timestamp': 1669051249808,
                 'vwap': None}}
```
Spot
`python3 examples/py/cli.py digifinex fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.1.92
digifinex.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16042.56,
              'askVolume': None,
              'average': None,
              'baseVolume': 7080.09439093,
              'bid': 16041.78,
              'bidVolume': None,
              'change': None,
              'close': 16045.8,
              'datetime': '2022-11-21T17:22:09.000Z',
              'high': 16605.48,
              'info': {'base_vol': '114463278.75664',
                       'buy': '16041.78',
                       'change': '-3.17',
                       'date': 1669051329,
                       'high': '16605.48',
                       'last': '16045.8',
                       'low': '15905.36',
                       'sell': '16042.56',
                       'symbol': 'btc_usdt',
                       'vol': '7080.09439093'},
              'last': 16045.8,
              'low': 15905.36,
              'open': None,
              'percentage': -3.17,
              'previousClose': None,
              'quoteVolume': 114463278.75664,
              'symbol': 'BTC/USDT',
              'timestamp': 1669051329000,
              'vwap': 16166.914229741613}}
```