### PR TITLE
Okx pro: add algo orders

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -2474,7 +2474,7 @@ module.exports = class okx extends Exchange {
         if ((clientOrderId !== undefined) && (clientOrderId.length < 1)) {
             clientOrderId = undefined; // fix empty clientOrderId string
         }
-        const stopPrice = this.safeNumberN (order, [ 'triggerPx', 'slTriggerPx', 'tpTriggerPx' ]);
+        const stopPrice = this.safeNumberN (order, [ 'tpTriggerPx', 'triggerPx', 'slTriggerPx' ]);
         let reduceOnly = this.safeString (order, 'reduceOnly');
         if (reduceOnly !== undefined) {
             reduceOnly = (reduceOnly === 'true');

--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -880,6 +880,7 @@ module.exports = class okx extends okxRest {
                 'account': this.handleBalance,
                 // 'margin_account': this.handleBalance,
                 'orders': this.handleOrders,
+                'orders-algo': this.handleOrders,
             };
             const method = this.safeValue (methods, channel);
             if (method === undefined) {

--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -643,7 +643,7 @@ module.exports = class okx extends okxRest {
         // By default, receive order updates from any instrument type
         let type = this.safeString (options, 'type', 'ANY');
         type = this.safeString (params, 'type', type);
-        const isStop = this.safeValue ('params', 'stop', false);
+        const isStop = this.safeValue (params, 'stop', false);
         params = this.omit (params, [ 'type', 'stop' ]);
         let market = undefined;
         if (symbol !== undefined) {

--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -622,6 +622,7 @@ module.exports = class okx extends okxRest {
          * @param {int|undefined} since the earliest time in ms to fetch orders for
          * @param {int|undefined} limit the maximum number of  orde structures to retrieve
          * @param {object} params extra parameters specific to the okx api endpoint
+         * @param {bool} params.stop True if fetching trigger or conditional orders
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();

--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -643,7 +643,8 @@ module.exports = class okx extends okxRest {
         // By default, receive order updates from any instrument type
         let type = this.safeString (options, 'type', 'ANY');
         type = this.safeString (params, 'type', type);
-        params = this.omit (params, 'type');
+        const isStop = this.safeValue ('params', 'stop', false);
+        params = this.omit (params, [ 'type', 'stop' ]);
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -657,7 +658,8 @@ module.exports = class okx extends okxRest {
         const request = {
             'instType': uppercaseType,
         };
-        const orders = await this.subscribe ('private', 'orders', symbol, this.extend (request, params));
+        const channel = isStop ? 'orders-algo' : 'orders';
+        const orders = await this.subscribe ('private', channel, symbol, this.extend (request, params));
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);
         }

--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -622,7 +622,7 @@ module.exports = class okx extends okxRest {
          * @param {int|undefined} since the earliest time in ms to fetch orders for
          * @param {int|undefined} limit the maximum number of  orde structures to retrieve
          * @param {object} params extra parameters specific to the okx api endpoint
-         * @param {bool} params.stop True if fetching trigger or conditional orders
+         * @param {bool} params.stop true if fetching trigger or conditional orders
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15779


```
 p okx watchOrders          
Python v3.9.7
CCXT v2.1.102
okx.watchOrders()
[{'amount': 1.0,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': '2022-11-21T17:15:57.155Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'fees': [{'cost': 0.0, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '514972271111860227',
  'info': {'accFillSz': '0',
           'amendResult': '',
           'avgPx': '0',
           'cTime': '1669050957155',
           'cancelSource': '',
           'category': 'normal',
           'ccy': '',
           'clOrdId': '',
           'code': '0',
           'execType': '',
           'fee': '0',
           'feeCcy': 'USDT',
           'fillFee': '',
           'fillFeeCcy': '',
           'fillNotionalUsd': '',
           'fillPx': '',
           'fillSz': '',
           'fillTime': '',
           'instId': 'ADA-USDT-SWAP',
           'instType': 'SWAP',
           'lever': '1',
           'msg': '',
           'notionalUsd': '29.17182898',
           'ordId': '514972271111860227',
           'ordType': 'market',
           'pnl': '0',
           'posSide': 'long',
           'px': '',
           'rebate': '0',
           'rebateCcy': 'USDT',
           'reduceOnly': 'true',
           'reqId': '',
           'side': 'sell',
           'slOrdPx': '0',
           'slTriggerPx': '0',
           'slTriggerPxType': '',
           'source': '',
           'state': 'live',
           'sz': '1',
           'tag': '',
           'tdMode': 'cross',
           'tgtCcy': '',
           'tpOrdPx': '0',
           'tpTriggerPx': '0',
           'tpTriggerPxType': '',
           'tradeId': '',
           'uTime': '1669050957155'},
  'lastTradeTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': True,
  'remaining': 1.0,
  'side': 'sell',
  'status': 'open',
  'stopPrice': 0.0,
  'symbol': 'ADA/USDT:USDT',
  'timeInForce': 'IOC',
  'timestamp': 1669050957155,
  'trades': [],
  'type': 'market'}]
[{'amount': 1.0,
  'average': 0.30435,
  'clientOrderId': None,
  'cost': 0.30435,
  'datetime': '2022-11-21T17:15:57.155Z',
  'fee': {'cost': 0.0152175, 'currency': 'USDT'},
  'fees': [{'cost': 0.0152175, 'currency': 'USDT'}],
  'filled': 1.0,
  'id': '514972271111860227',
  'info': {'accFillSz': '1',
           'amendResult': '',
           'avgPx': '0.30435',
           'cTime': '1669050957155',
           'cancelSource': '',
           'category': 'normal',
           'ccy': '',
           'clOrdId': '',
           'code': '0',
           'execType': 'T',
           'fee': '-0.0152175',
           'feeCcy': 'USDT',
           'fillFee': '-0.0152175',
           'fillFeeCcy': 'USDT',
           'fillNotionalUsd': '30.399391050000002',
           'fillPx': '0.30435',
           'fillSz': '1',
           'fillTime': '1669050957156',
           'instId': 'ADA-USDT-SWAP',
           'instType': 'SWAP',
           'lever': '1',
           'msg': '',
           'notionalUsd': '29.17182898',
           'ordId': '514972271111860227',
           'ordType': 'market',
           'pnl': '0.038',
           'posSide': 'long',
           'px': '',
           'rebate': '0',
           'rebateCcy': 'USDT',
           'reduceOnly': 'true',
           'reqId': '',
           'side': 'sell',
           'slOrdPx': '0',
           'slTriggerPx': '0',
           'slTriggerPxType': '',
           'source': '',
           'state': 'filled',
           'sz': '1',
           'tag': '',
           'tdMode': 'cross',
           'tgtCcy': '',
           'tpOrdPx': '0',
           'tpTriggerPx': '0',
           'tpTriggerPxType': '',
           'tradeId': '66485565',
           'uTime': '1669050957157'},
  'lastTradeTimestamp': 1669050957156,
  'postOnly': None,
  'price': 0.30435,
  'reduceOnly': True,
  'remaining': 0.0,
  'side': 'sell',
  'status': 'closed',
  'stopPrice': 0.0,
  'symbol': 'ADA/USDT:USDT',
  'timeInForce': 'IOC',
  'timestamp': 1669050957155,
  'trades': [],
  'type': 'market'}]
  ```

```
 p okx watchOrders None None None '{"stop":true}'                          
Python v3.9.7
CCXT v2.1.102
okx.watchOrders(None,None,None,{'stop': True})
[{'amount': 1.0,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': '2022-11-21T17:25:24.737Z',
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '514974651723313152',
  'info': {'actualPx': '0',
           'actualSide': '',
           'actualSz': '0',
           'algoId': '514974651723313152',
           'cTime': '1669051524737',
           'ccy': '',
           'clOrdId': '',
           'instId': 'ADA-USDT-SWAP',
           'instType': 'SWAP',
           'last': '0.305',
           'lever': '1',
           'notionalUsd': '30.426',
           'ordId': '0',
           'ordPx': '',
           'ordType': 'conditional',
           'posSide': 'long',
           'reduceOnly': 'false',
           'side': 'buy',
           'slOrdPx': '0',
           'slTriggerPx': '0',
           'slTriggerPxType': 'last',
           'state': 'canceled',
           'sz': '1',
           'tag': '',
           'tdMode': 'cross',
           'tgtCcy': '',
           'tpOrdPx': '0.1',
           'tpTriggerPx': '0.1',
           'tpTriggerPxType': 'mark',
           'triggerPx': '',
           'triggerTime': ''},
  'lastTradeTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': False,
  'remaining': None,
  'side': 'buy',
  'status': 'canceled',
  'stopPrice': 0.1,
  'symbol': 'ADA/USDT:USDT',
  'timeInForce': None,
  'timestamp': 1669051524737,
  'trades': [],
  'type': 'conditional'}]
  ```
