### PR TITLE
bigone - fix sign

### DIFF
--- a/js/bigone.js
+++ b/js/bigone.js
@@ -1140,6 +1140,7 @@ module.exports = class bigone extends Exchange {
         const query = this.omit (params, this.extractParams (path));
         const baseUrl = this.implodeHostname (this.urls['api'][api]);
         let url = baseUrl + '/' + this.implodeParams (path, params);
+        headers = {};
         if (api === 'public') {
             if (Object.keys (query).length) {
                 url += '?' + this.urlencode (query);
@@ -1166,6 +1167,7 @@ module.exports = class bigone extends Exchange {
                 body = this.json (query);
             }
         }
+        headers['User-Agent'] = 'ccxt/' + Exchange.ccxtVersion;
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -129,6 +129,7 @@ module.exports = class bigone extends Exchange {
                 'transfer': {
                     'fillResponseFromRequest': true,
                 },
+                'exchangeMillisecondsCorrection': -100,
             },
             'precisionMode': TICK_SIZE,
             'exceptions': {
@@ -1133,7 +1134,8 @@ module.exports = class bigone extends Exchange {
     }
 
     nonce () {
-        return this.microseconds () * 1000;
+        const exchangeTimeCorrection = this.safeInteger (this.options, 'exchangeMillisecondsCorrection', 0) * 1000000;
+        return this.microseconds () * 1000 + exchangeTimeCorrection;
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
@@ -1165,7 +1167,7 @@ module.exports = class bigone extends Exchange {
                 body = this.json (query);
             }
         }
-        headers['User-Agent'] = 'ccxt/' + Exchange.ccxtVersion;
+        headers['User-Agent'] = 'ccxt/' + this.id + '-' + this.version;
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 

--- a/js/bigone.js
+++ b/js/bigone.js
@@ -1155,9 +1155,7 @@ module.exports = class bigone extends Exchange {
                 // 'recv_window': '30', // default 30
             };
             const jwt = this.jwt (request, this.encode (this.secret));
-            headers = {
-                'Authorization': 'Bearer ' + jwt,
-            };
+            headers['Authorization'] = 'Bearer ' + jwt;
             if (method === 'GET') {
                 if (Object.keys (query).length) {
                     url += '?' + this.urlencode (query);


### PR DESCRIPTION
bigone private parts were not implemented correctly. 

fix #15610

however, that exchange additionally has an obvious issue in their api engine time. i.e. https://big.one/api/v3/ping seems to return their exchange time, which "seems" correct. however, the strange thing is that if you test i.e.
```
while (true) {
  try {
    await e.fetchDeposits ('USDT');
  } catch (ex) {
    console.log(ex);
  }
  this.sleep(1000);
}```
without my submitted fix, you will see how frequently the exchange triggers error 'nonce expired'. as I suspect, it's not expired, but in opposite, your synced PC time (which is accurate) is actually "in future" by fraction of seconds compared to their API engine's time (i suspect their engine's time is few MS behind actual time).

so, with this fix, the issue is gone, as far as I tested. 