### PR TITLE
huobi - fetchTickers

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1867,20 +1867,26 @@ module.exports = class huobi extends Exchange {
          * @method
          * @name huobi#fetchTickers
          * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @see https://huobiapi.github.io/docs/spot/v1/en/#get-latest-tickers-for-all-pairs
+         * @see https://huobiapi.github.io/docs/usdt_swap/v1/en/#general-get-a-batch-of-market-data-overview
+         * @see https://huobiapi.github.io/docs/dm/v1/en/#get-a-batch-of-market-data-overview
+         * @see https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#get-a-batch-of-market-data-overview-v2
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the huobi api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        const options = this.safeValue (this.options, 'fetchTickers', {});
-        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
-        let type = this.safeString (options, 'type', defaultType);
-        type = this.safeString (params, 'type', type);
+        const first = this.safeString (symbols, 0);
+        let market = undefined;
+        if (first !== undefined) {
+            market = this.market (first);
+        }
+        let type = undefined;
+        let subType = undefined;
         let method = 'spotPublicGetMarketTickers';
-        const defaultSubType = this.safeString (this.options, 'defaultSubType', 'inverse');
-        let subType = this.safeString (options, 'subType', defaultSubType);
-        subType = this.safeString (params, 'subType', subType);
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('watchOrders', market, params);
         const request = {};
         const future = (type === 'future');
         const swap = (type === 'swap');

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -1886,7 +1886,7 @@ module.exports = class huobi extends Exchange {
         let subType = undefined;
         let method = 'spotPublicGetMarketTickers';
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
-        [ subType, params ] = this.handleSubTypeAndParams ('watchOrders', market, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params);
         const request = {};
         const future = (type === 'future');
         const swap = (type === 'swap');


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py huobi fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.2.12
huobi.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16517.66,
              'askVolume': 0.002245,
              'average': 16376.125,
              'baseVolume': 3340.779015687917,
              'bid': 16510.77,
              'bidVolume': 0.293335,
              'change': 283.25,
              'close': 16517.75,
              'datetime': '2022-11-23T13:41:46.893Z',
              'high': 16650.0,
              'info': {'amount': '3340.779015687917',
                       'ask': '16517.66',
                       'askSize': '0.002245',
                       'bid': '16510.77',
                       'bidSize': '0.293335',
                       'close': '16517.75',
                       'count': '81297',
                       'high': '16650.0',
                       'low': '15760.93',
                       'open': '16234.5',
                       'symbol': 'btcusdt',
                       'vol': '5.461539809948513E7'},
              'last': 16517.75,
              'low': 15760.93,
              'open': 16234.5,
              'percentage': 1.744741137700576,
              'previousClose': None,
              'quoteVolume': 54615398.09948513,
              'symbol': 'BTC/USDT',
              'timestamp': 1669210906893,
              'vwap': 16348.102596136247}}
```

`python3 examples/py/cli.py huobi fetchTickers '["BTC/USDT:USDT"]'`
```
Python v3.10.6
CCXT v2.2.12
huobi.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 16521.3,
                   'askVolume': 11929.0,
                   'average': 16383.45,
                   'baseVolume': 42699.46,
                   'bid': 16521.2,
                   'bidVolume': 2909.0,
                   'change': 275.7,
                   'close': 16521.3,
                   'datetime': '2022-11-23T13:43:24.233Z',
                   'high': 16656.0,
                   'info': {'amount': '42699.46',
                            'ask': ['16521.3', '11929'],
                            'bid': ['16521.2', '2909'],
                            'business_type': 'swap',
                            'close': '16521.3',
                            'contract_code': 'BTC-USDT',
                            'count': '164406',
                            'high': '16656',
                            'id': '1669211004',
                            'low': '16061',
                            'open': '16245.6',
                            'trade_partition': 'USDT',
                            'trade_turnover': '698322042.8932',
                            'ts': '1669211004227',
                            'vol': '42699460'},
                   'last': 16521.3,
                   'low': 16061.0,
                   'open': 16245.6,
                   'percentage': 1.6970749002806913,
                   'previousClose': None,
                   'quoteVolume': 42699460.0,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1669211004233,
                   'vwap': 1000.0}}
```

`python3 examples/py/cli.py huobi fetchTickers '["BTC/USD:BTC"]'`
```
Python v3.10.6
CCXT v2.2.12
huobi.fetchTickers(['BTC/USD:BTC'])
{'BTC/USD:BTC': {'ask': 16513.5,
                 'askVolume': 3.0,
                 'average': 16394.0,
                 'baseVolume': 1761.9959268646353,
                 'bid': 16513.4,
                 'bidVolume': 16.0,
                 'change': 269.4,
                 'close': 16528.7,
                 'datetime': '2022-11-23T13:43:57.242Z',
                 'high': 16660.0,
                 'info': {'amount': '1761.9959268646352461776937271125071343808',
                          'ask': ['16513.5', '3'],
                          'bid': ['16513.4', '16'],
                          'close': '16528.7',
                          'contract_code': 'BTC-USD',
                          'count': '9951',
                          'high': '16660',
                          'id': '1669211037',
                          'low': '16053.5',
                          'open': '16259.3',
                          'ts': '1669211037208',
                          'vol': '288006'},
                 'last': 16528.7,
                 'low': 16053.5,
                 'open': 16259.3,
                 'percentage': 1.6568978984335119,
                 'previousClose': None,
                 'quoteVolume': 288006.0,
                 'symbol': 'BTC/USD:BTC',
                 'timestamp': 1669211037242,
                 'vwap': 163.4544073620472}}
```