### PR TITLE
indodax - fetchTickers

### DIFF
--- a/js/indodax.js
+++ b/js/indodax.js
@@ -446,6 +446,38 @@ module.exports = class indodax extends Exchange {
         return this.parseTicker (ticker, market);
     }
 
+    async fetchTickers (symbols = undefined, params = {}) {
+        /**
+         * @method
+         * @name indodax#fetchTickers
+         * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @see https://github.com/btcid/indodax-official-api-docs/blob/master/Public-RestAPI.md#ticker-all
+         * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
+         * @param {object} params extra parameters specific to the indodax api endpoint
+         * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
+         */
+        await this.loadMarkets ();
+        //
+        // {
+        //     "tickers": {
+        //         "btc_idr": {
+        //             "high": "120009000",
+        //             "low": "116735000",
+        //             "vol_btc": "218.13777777",
+        //             "vol_idr": "25800033297",
+        //             "last": "117088000",
+        //             "buy": "117002000",
+        //             "sell": "117078000",
+        //             "server_time": 1571207881
+        //         }
+        //     }
+        // }
+        //
+        const response = await this.publicGetTickerAll (params);
+        const tickers = this.safeValue (response, 'tickers');
+        return this.parseTickers (tickers, symbols);
+    }
+
     parseTrade (trade, market = undefined) {
         const timestamp = this.safeTimestamp (trade, 'date');
         return this.safeTrade ({


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py indodax fetchTickers '["BTC/USDT","ETH/USDT"]'`
```
Python v3.10.6
CCXT v2.2.12
indodax.fetchTickers(['BTC/USDT', 'ETH/USDT'])
{'BTC/USDT': {'ask': 16300.0,
              'askVolume': None,
              'average': None,
              'baseVolume': 0.17369679,
              'bid': 16000.000006,
              'bidVolume': None,
              'change': None,
              'close': 16396.0,
              'datetime': '2022-11-23T15:12:56.000Z',
              'high': 16575.0,
              'info': {'buy': '16000.000006',
                       'high': '16575',
                       'last': '16396',
                       'low': '15849',
                       'sell': '16300',
                       'server_time': '1669216376',
                       'vol_btc': '0.17369679',
                       'vol_usdt': '2768.33680193'},
              'last': 16396.0,
              'low': 15849.0,
              'open': None,
              'percentage': None,
              'previousClose': None,
              'quoteVolume': 2768.33680193,
              'symbol': 'BTC/USDT',
              'timestamp': 1669216376000,
              'vwap': 15937.754531502856},
 'ETH/USDT': {'ask': 1197.9999,
              'askVolume': None,
              'average': None,
              'baseVolume': 3.027623,
              'bid': 1196.9,
              'bidVolume': None,
              'change': None,
              'close': 1196.9,
              'datetime': '2022-11-23T15:12:56.000Z',
              'high': 1199.0,
              'info': {'buy': '1196.9',
                       'high': '1199',
                       'last': '1196.9',
                       'low': '1101',
                       'sell': '1197.9999',
                       'server_time': '1669216376',
                       'vol_eth': '3.02762300',
                       'vol_usdt': '3551.33859654'},
              'last': 1196.9,
              'low': 1101.0,
              'open': None,
              'percentage': None,
              'previousClose': None,
              'quoteVolume': 3551.33859654,
              'symbol': 'ETH/USDT',
              'timestamp': 1669216376000,
              'vwap': 1172.9791313317412}}
```