### PR TITLE
mexc - fetchTickers

### DIFF
--- a/js/mexc.js
+++ b/js/mexc.js
@@ -779,7 +779,13 @@ module.exports = class mexc extends Exchange {
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        symbols = this.marketSymbols (symbols);
+        const first = this.safeString (symbols, 0);
+        let market = undefined;
+        if (first !== undefined) {
+            market = this.market (first);
+        }
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         const method = this.getSupportedMapping (marketType, {
             'spot': 'spotPublicGetMarketTicker',
             'swap': 'contractPublicGetTicker',


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py mexc fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.2.12
mexc.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16425.15,
              'askVolume': None,
              'average': 16335.265,
              'baseVolume': 29318.310706,
              'bid': 16424.66,
              'bidVolume': None,
              'change': 179.15,
              'close': 16424.84,
              'datetime': '2022-11-23T15:55:00.000Z',
              'high': 16659.99,
              'info': {'amount': '480373277.08',
                       'ask': '16425.15',
                       'bid': '16424.66',
                       'change_rate': '0.01102754',
                       'high': '16659.99',
                       'last': '16424.84',
                       'low': '16058.85',
                       'open': '16245.69',
                       'symbol': 'BTC_USDT',
                       'time': '1669218900000',
                       'volume': '29318.310706'},
              'last': 16424.84,
              'low': 16058.85,
              'open': 16245.69,
              'percentage': 1.0,
              'previousClose': None,
              'quoteVolume': None,
              'symbol': 'BTC/USDT',
              'timestamp': 1669218900000,
              'vwap': None}}
```
`python3 examples/py/cli.py mexc fetchTickers '["BTC/USDT:USDT"]' --swap`
```
Python v3.10.6
CCXT v2.2.12
mexc.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 16414.6,
                   'askVolume': None,
                   'average': None,
                   'baseVolume': 1393289569.0,
                   'bid': 16414.5,
                   'bidVolume': None,
                   'change': -1.4,
                   'close': 16414.6,
                   'datetime': '2022-11-23T16:01:44.023Z',
                   'high': 16655.4,
                   'info': {'amount24': '2281651284.54328',
                            'ask1': '16414.6',
                            'bid1': '16414.5',
                            'fairPrice': '16415.7',
                            'fundingRate': '-0.000055',
                            'high24Price': '16655.4',
                            'holdVol': '646953090',
                            'indexPrice': '16424.1',
                            'lastPrice': '16414.6',
                            'lower24Price': '16042.1',
                            'maxBidPrice': '18066.5',
                            'minAskPrice': '14781.6',
                            'riseFallRate': '0',
                            'riseFallRatesOfTimezone': ['0.0111',
                                                        '0.0121',
                                                        '0'],
                            'riseFallValue': '-1.4',
                            'symbol': 'BTC_USDT',
                            'timestamp': '1669219304023',
                            'volume24': '1393289569'},
                   'last': 16414.6,
                   'low': 16042.1,
                   'open': 16416.0,
                   'percentage': 1.0,
                   'previousClose': None,
                   'quoteVolume': 2281651284.54328,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1669219304023,
                   'vwap': 1.6376002055200056}}
```