### PR TITLE
Bybit: example USDC Option Order

### DIFF
--- a/examples/py/bybit-USDC-create-option-order.py
+++ b/examples/py/bybit-USDC-create-option-order.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+
+exchange = ccxt.bybit ({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    'defaultType': 'option',
+    # 'verbose': True,  # for debug output
+})
+
+# BTC/USD:USDC-YYMMDD-STRIKE-C
+symbol = 'BTC/USD:USDC-221209-18000-C'
+amount = 0.01
+price = 280.0
+
+try:
+    order = exchange.create_order(symbol, 'limit', 'buy', amount, price)
+    pprint(order)
+except Exception as err:
+    print(err)

--- a/examples/py/bybit-USDC-create-option-order.py
+++ b/examples/py/bybit-USDC-create-option-order.py
@@ -9,6 +9,11 @@ sys.path.append(root + '/python')
 
 import ccxt  # noqa: E402
 
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
 
 exchange = ccxt.bybit ({
     'apiKey': 'YOUR_API_KEY',
@@ -17,7 +22,7 @@ exchange = ccxt.bybit ({
     # 'verbose': True,  # for debug output
 })
 
-# BTC/USD:USDC-YYMMDD-STRIKE-C
+# BASE/QUOTE:SETTLE-YYMMDD-STRIKE-C (end with C for call, end with P for put)
 symbol = 'BTC/USD:USDC-221209-18000-C'
 amount = 0.01
 price = 280.0


### PR DESCRIPTION
Added an example for USDC option trading on Bybit:
```python
{
    'amount': 0.01,
    'average': None,
    'clientOrderId': 'bgca436fdea1f4a7',
    'cost': None,
    'datetime': None,
    'fee': None,
    'fees': [],
    'filled': None,
    'id': '11762632-02a1-4fgd-af07-6b8h3122d119',
    'info':
        {
            'orderId': '11762632-02a1-4fgd-af07-6b8h3122d119',
            'orderLinkId': 'bgca436fdea1f4a7',
            'orderPrice': '280',
            'orderQty': '0.01',
            'orderType': 'Limit',
            'side': 'Buy',
            'symbol': 'BTC-9DEC22-18000-C'
        },
    'lastTradeTimestamp': None,
    'postOnly': False,
    'price': 280.0,
    'remaining': None,
    'side': 'buy',
    'status': None,
    'stopPrice': None,
    'symbol': 'BTC/USD:USDC-221209-18000-C',
    'timeInForce': None,
    'timestamp': None,
    'trades': [],
    'triggerPrice': None,
    'type': 'limit'
}
```