### PR TITLE
okcoin - fetchTickers

### DIFF
--- a/js/okcoin.js
+++ b/js/okcoin.js
@@ -1320,9 +1320,14 @@ module.exports = class okcoin extends Exchange {
          * @param {object} params extra parameters specific to the okcoin api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
-        const defaultType = this.safeString2 (this.options, 'fetchTickers', 'defaultType');
-        const type = this.safeString (params, 'type', defaultType);
         symbols = this.marketSymbols (symbols);
+        const first = this.safeString (symbols, 0);
+        let market = undefined;
+        if (first !== undefined) {
+            market = this.market (first);
+        }
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         return await this.fetchTickersByType (type, symbols, this.omit (params, 'type'));
     }
 


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py okcoin fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.2.12
okcoin.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16582.7,
              'askVolume': 0.052,
              'average': 16537.1,
              'baseVolume': 6.4676,
              'bid': 16568.8,
              'bidVolume': 0.04,
              'change': 25.6,
              'close': 16549.9,
              'datetime': '2022-11-24T13:44:03.217Z',
              'high': 16742.9,
              'info': {'ask': '16582.7',
                       'base_volume_24h': '6.4676',
                       'best_ask': '16582.7',
                       'best_ask_size': '0.052',
                       'best_bid': '16568.8',
                       'best_bid_size': '0.04',
                       'bid': '16568.8',
                       'high_24h': '16742.9',
                       'instrument_id': 'BTC-USDT',
                       'last': '16549.9',
                       'last_qty': '0.0014',
                       'low_24h': '16362.8',
                       'open_24h': '16524.3',
                       'open_utc0': '16557.8',
                       'open_utc8': '16458.7',
                       'product_id': 'BTC-USDT',
                       'quote_volume_24h': '107372.564',
                       'timestamp': '2022-11-24T13:44:03.217Z'},
              'last': 16549.9,
              'low': 16362.8,
              'open': 16524.3,
              'percentage': 0.1549233553009809,
              'previousClose': None,
              'quoteVolume': 107372.564,
              'symbol': 'BTC/USDT',
              'timestamp': 1669297443217,
              'vwap': 16601.60863380543}}
```