### PR TITLE
okx - fetchTickers

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -1451,7 +1451,13 @@ module.exports = class okx extends Exchange {
          * @param {object} params extra parameters specific to the okx api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        symbols = this.marketSymbols (symbols);
+        const first = this.safeString (symbols, 0);
+        let market = undefined;
+        if (first !== undefined) {
+            market = this.market (first);
+        }
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         return await this.fetchTickersByType (type, symbols, query);
     }
 


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py okx fetchTickers '["BTC/USDT"]'`
```
Python v3.10.6
CCXT v2.2.12
okx.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16580.5,
              'askVolume': 0.06592435,
              'average': 16511.25,
              'baseVolume': 6179.15803045,
              'bid': 16580.4,
              'bidVolume': 0.52074136,
              'change': 138.3,
              'close': 16580.4,
              'datetime': '2022-11-24T13:46:45.011Z',
              'high': 16810.8,
              'info': {'askPx': '16580.5',
                       'askSz': '0.06592435',
                       'bidPx': '16580.4',
                       'bidSz': '0.52074136',
                       'high24h': '16810.8',
                       'instId': 'BTC-USDT',
                       'instType': 'SPOT',
                       'last': '16580.4',
                       'lastSz': '0.085',
                       'low24h': '16325',
                       'open24h': '16442.1',
                       'sodUtc0': '16604.9',
                       'sodUtc8': '16426.2',
                       'ts': '1669297605011',
                       'vol24h': '6179.15803045',
                       'volCcy24h': '102494387.61764882'},
              'last': 16580.4,
              'low': 16325.0,
              'open': 16442.1,
              'percentage': 0.8411334318608936,
              'previousClose': None,
              'quoteVolume': 102494387.61764883,
              'symbol': 'BTC/USDT',
              'timestamp': 1669297605011,
              'vwap': 16587.1122105263}}
```