### PR TITLE
digifinex fetchMarkets fix

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -568,7 +568,7 @@ module.exports = class digifinex extends Exchange {
                 'swap': swap,
                 'future': false,
                 'option': false,
-                'active': isAllowed ? true : undefined,
+                'active': isAllowed ? true : false,
                 'contract': swap,
                 'linear': isLinear,
                 'inverse': isInverse,


### PR DESCRIPTION
`"is_allow": 0` pairs is not tradable via API
https://docs.digifinex.com/en-ww/spot/v3/rest.html#whether-is-api-trading-enabled-for-the-trading-pair