### PR TITLE
Bitget ::  update cancelAllOrders

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2493,7 +2493,7 @@ module.exports = class bitget extends Exchange {
         } else {
             const code = this.safeString2 (params, 'code', 'marginCoin');
             if (code === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument in the params');
+                throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument (marginCoin) in the params');
             }
             const currency = this.currency (code);
             method = 'privateMixPostOrderCancelAllOrders';

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2486,7 +2486,7 @@ module.exports = class bitget extends Exchange {
         const planType = this.safeString (params, 'planType');
         if (stop !== undefined || planType !== undefined) {
             if (planType === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
+                throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan, loss_plan, pos_profit, pos_loss, moving_plan or track_plan');
             }
             method = 'privateMixPostPlanCancelPlan';
             params = this.omit (params, [ 'stop' ]);

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2492,10 +2492,10 @@ module.exports = class bitget extends Exchange {
             params = this.omit (params, [ 'stop' ]);
         } else {
             const code = this.safeString2 (params, 'code', 'marginCoin');
-            const currency = this.currency (code);
             if (code === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument in the params');
             }
+            const currency = this.currency (code);
             method = 'privateMixPostOrderCancelAllOrders';
             request['marginCoin'] = this.safeCurrencyCode (code, currency);
         }

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2494,7 +2494,7 @@ module.exports = class bitget extends Exchange {
         } else {
             const code = this.safeString2 (params, 'code', 'marginCoin');
             if (code === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument (marginCoin) in the params');
+                throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument [marginCoin] in the params');
             }
             const currency = this.currency (code);
             request['marginCoin'] = this.safeCurrencyCode (code, currency);

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -216,6 +216,7 @@ module.exports = class bitget extends Exchange {
                             'plan/placePositionsTPSL': 2,
                             'plan/modifyTPSLPlan': 2,
                             'plan/cancelPlan': 2,
+                            'plan/cancelAllPlan': 2,
                             'trace/closeTrackOrder': 2,
                             'trace/setUpCopySymbols': 2,
                         },
@@ -2460,7 +2461,7 @@ module.exports = class bitget extends Exchange {
          * @name bitget#cancelAllOrders
          * @description cancel all open orders
          * @see https://bitgetlimited.github.io/apidoc/en/mix/#cancel-all-order
-         * @see https://bitgetlimited.github.io/apidoc/en/mix/#cancel-plan-order-tpsl
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#cancel-all-trigger-order-tpsl
          * @param {string|undefined} symbol unified market symbol
          * @param {object} params extra parameters specific to the bitget api endpoint
          * @param {string} params.code marginCoin unified currency code
@@ -2488,7 +2489,7 @@ module.exports = class bitget extends Exchange {
             if (planType === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan, loss_plan, pos_profit, pos_loss, moving_plan or track_plan');
             }
-            method = 'privateMixPostPlanCancelPlan';
+            method = 'privateMixPostPlanCancelAllPlan';
             params = this.omit (params, [ 'stop' ]);
         } else {
             const code = this.safeString2 (params, 'code', 'marginCoin');
@@ -2496,8 +2497,8 @@ module.exports = class bitget extends Exchange {
                 throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument (marginCoin) in the params');
             }
             const currency = this.currency (code);
-            method = 'privateMixPostOrderCancelAllOrders';
             request['marginCoin'] = this.safeCurrencyCode (code, currency);
+            method = 'privateMixPostOrderCancelAllOrders';
         }
         params = this.omit (query, [ 'code', 'marginCoin' ]);
         const response = await this[method] (this.extend (request, params));

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2460,16 +2460,13 @@ module.exports = class bitget extends Exchange {
          * @name bitget#cancelAllOrders
          * @description cancel all open orders
          * @see https://bitgetlimited.github.io/apidoc/en/mix/#cancel-all-order
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#cancel-plan-order-tpsl
          * @param {string|undefined} symbol unified market symbol
          * @param {object} params extra parameters specific to the bitget api endpoint
          * @param {string} params.code marginCoin unified currency code
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
-        const code = this.safeString2 (params, 'code', 'marginCoin');
-        if (code === undefined) {
-            throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument in the params');
-        }
         let market = undefined;
         let defaultSubType = this.safeString (this.options, 'defaultSubType');
         if (symbol !== undefined) {
@@ -2481,13 +2478,29 @@ module.exports = class bitget extends Exchange {
         if (marketType === 'spot') {
             throw new NotSupported (this.id + ' cancelAllOrders () does not support spot markets');
         }
-        const currency = this.currency (code);
         const request = {
-            'marginCoin': this.safeCurrencyCode (code, currency),
             'productType': productType,
         };
+        let method = undefined;
+        const stop = this.safeValue (params, 'stop');
+        const planType = this.safeString (params, 'planType');
+        if (stop !== undefined || planType !== undefined) {
+            if (planType === undefined) {
+                throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
+            }
+            method = 'privateMixPostPlanCancelPlan';
+            params = this.omit (params, [ 'stop' ]);
+        } else {
+            const code = this.safeString2 (params, 'code', 'marginCoin');
+            const currency = this.currency (code);
+            if (code === undefined) {
+                throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument in the params');
+            }
+            method = 'privateMixPostOrderCancelAllOrders';
+            request['marginCoin'] = this.safeCurrencyCode (code, currency);
+        }
         params = this.omit (query, [ 'code', 'marginCoin' ]);
-        const response = await this.privateMixPostOrderCancelAllOrders (this.extend (request, params));
+        const response = await this[method] (this.extend (request, params));
         //
         //     {
         //         "code": "00000",


### PR DESCRIPTION
```
p bitget cancelAllOrders "LTC/USDT:USDT" '{"code":"USDT"}'
Python v3.10.8
CCXT v2.2.31
bitget.cancelAllOrders(LTC/USDT:USDT,{'code': 'USDT'})
{'code': '00000',
 'data': {'fail_infos': [],
          'order_ids': ['979995917735858177'],
          'result': True},
 'msg': 'success',
 'requestTime': '1669375193605'}
 ```

```
n bitget cancelAllOrders "LTC/USDT:USDT" '{"planType":"normal_plan"}'
2022-11-25T11:30:41.708Z
Node.js: v19.0.1
CCXT v2.2.31
bitget.cancelAllOrders (LTC/USDT:USDT, [object Object])
2022-11-25T11:30:46.199Z iteration 0 passed in 1741 ms

{
  code: '00000',
  msg: 'success',
  requestTime: '1669375846078',
  data: true
}
2022-11-25T11:30:46.199Z iteration 1 passed in 1741 ms

```
