### PR TITLE
 wazirx - watchTrades

### DIFF
--- a/js/pro/wazirx.js
+++ b/js/pro/wazirx.js
@@ -151,7 +151,7 @@ module.exports = class wazirx extends wazirxRest {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'symbol': market['symbol'],
-            'order': this.safeStringN (trade, [ 'o', 'a', 'b' ]),
+            'order': this.safeStringN (trade, [ 'o' ]),
             'type': undefined,
             'side': this.safeString (trade, 'S'),
             'takerOrMaker': isMaker ? 'maker' : 'taker',


### PR DESCRIPTION
Message returns both seller and buyer order id. I put that orderId defaults to buyer id.

```
py wazirx watchTrades BTC/INR

2022-11-25T19:35:14.598Z message {"data":{"trades":[{"E":1669404915000,"S":"buy","a":3473727534,"b":3473675768,"m":false,"p":"1432001.0","q":"0.00005","s":"btcinr","t":394537346}]},"stream":"btcinr@trades"}
[{'amount': 5e-05,
  'cost': 71.60005,
  'datetime': '2022-11-25T19:35:15.000Z',
  'fee': None,
  'fees': [],
  'id': '394537346',
  'info': {'E': 1669404915000,
           'S': 'buy',
           'a': 3473727534,
           'b': 3473675768,
           'm': False,
           'p': '1432001.0',
           'q': '0.00005',
           's': 'btcinr',
           't': 394537346},
  'order': '3473727534',
  'price': 1432001.0,
  'side': 'buy',
  'symbol': 'BTC/INR',
  'takerOrMaker': 'taker',
  'timestamp': 1669404915000,
  'type': None}]
  ```