### PR TITLE
huobi - rework for networks

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -126,6 +126,7 @@ module.exports = class Exchange {
                 'fetchTradingLimits': undefined,
                 'fetchTransactions': undefined,
                 'fetchTransfers': undefined,
+                'fetchWithdrawAddresses': undefined,
                 'fetchWithdrawal': undefined,
                 'fetchWithdrawals': undefined,
                 'reduceMargin': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1645,14 +1645,14 @@ module.exports = class Exchange {
         }
     }
 
-    networkCodeToId (networkCode, currencyCode = undefined) {
-        const networkIdsByCodes = this.safeValue (this.options, 'networks', {});
-        return this.safeString (networkIdsByCodes, networkCode, networkCode);
+    networkCodeToId (networkCode) {
+        const networks = this.safeValue (this.options, 'networks', {});
+        return this.safeString (networks, networkCode, networkCode);
     }
 
-    networkIdToCode (networkId, currencyCode = undefined) {
-        const networkCodesByIds = this.safeValue (this.options, 'networksById', {});
-        return this.safeString (networkCodesByIds, networkId, networkId);
+    networkIdToCode (networkId) {
+        const networksById = this.safeValue (this.options, 'networksById', {});
+        return this.safeString (networksById, networkId, networkId);
     }
 
     handleNetworkCodeAndParams (params) {
@@ -1687,7 +1687,7 @@ module.exports = class Exchange {
         const responseNetworksLength = availableNetworkIds.length;
         if (networkCode !== undefined) {
             // if networkCode was provided by user, we should check it after response, as the referenced exchange doesn't support network-code during request
-            const networkId = this.networkCodeToId (networkCode, currencyCode);
+            const networkId = this.networkCodeToId (networkCode);
             if (responseNetworksLength === 0) {
                 throw new NotSupported (this.id + ' - ' + networkCode + ' network did not return any result for ' + currencyCode);
             } else {
@@ -1702,9 +1702,9 @@ module.exports = class Exchange {
                 throw new NotSupported (this.id + ' - no networks were returned for' + currencyCode);
             } else {
                 // if networkCode was not provided by user, then we try to use the default network (if it was defined in "defaultNetworks"), otherwise, we just return the first network entry
-                const defaultNetworkCode = this.defaultNetworkCode (currencyCode);
-                const defaultNetworkId = this.networkCodeToId (defaultNetworkCode, currencyCode);
-                chosenNetworkId = (defaultNetworkId in networkEntriesIndexed) ? defaultNetworkId : availableNetworkIds[0];
+                const defaultNetwordCode = this.defaultNetworkCode (currencyCode);
+                const defaultNetwordId = this.networkCodeToId (defaultNetwordCode);
+                chosenNetworkId = (defaultNetwordId in networkEntriesIndexed) ? defaultNetwordId : availableNetworkIds[0];
             }
         }
         return chosenNetworkId;

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1645,14 +1645,14 @@ module.exports = class Exchange {
         }
     }
 
-    networkCodeToId (networkCode) {
-        const networks = this.safeValue (this.options, 'networks', {});
-        return this.safeString (networks, networkCode, networkCode);
+    networkCodeToId (networkCode, currencyCode = undefined) {
+        const networkIdsByCodes = this.safeValue (this.options, 'networks', {});
+        return this.safeString (networkIdsByCodes, networkCode, networkCode);
     }
 
-    networkIdToCode (networkId) {
-        const networksById = this.safeValue (this.options, 'networksById', {});
-        return this.safeString (networksById, networkId, networkId);
+    networkIdToCode (networkId, currencyCode = undefined) {
+        const networkCodesByIds = this.safeValue (this.options, 'networksById', {});
+        return this.safeString (networkCodesByIds, networkId, networkId);
     }
 
     handleNetworkCodeAndParams (params) {
@@ -1687,7 +1687,7 @@ module.exports = class Exchange {
         const responseNetworksLength = availableNetworkIds.length;
         if (networkCode !== undefined) {
             // if networkCode was provided by user, we should check it after response, as the referenced exchange doesn't support network-code during request
-            const networkId = this.networkCodeToId (networkCode);
+            const networkId = this.networkCodeToId (networkCode, currencyCode);
             if (responseNetworksLength === 0) {
                 throw new NotSupported (this.id + ' - ' + networkCode + ' network did not return any result for ' + currencyCode);
             } else {
@@ -1702,9 +1702,9 @@ module.exports = class Exchange {
                 throw new NotSupported (this.id + ' - no networks were returned for' + currencyCode);
             } else {
                 // if networkCode was not provided by user, then we try to use the default network (if it was defined in "defaultNetworks"), otherwise, we just return the first network entry
-                const defaultNetwordCode = this.defaultNetworkCode (currencyCode);
-                const defaultNetwordId = this.networkCodeToId (defaultNetwordCode);
-                chosenNetworkId = (defaultNetwordId in networkEntriesIndexed) ? defaultNetwordId : availableNetworkIds[0];
+                const defaultNetworkCode = this.defaultNetworkCode (currencyCode);
+                const defaultNetworkId = this.networkCodeToId (defaultNetworkCode, currencyCode);
+                chosenNetworkId = (defaultNetworkId in networkEntriesIndexed) ? defaultNetworkId : availableNetworkIds[0];
             }
         }
         return chosenNetworkId;

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2886,7 +2886,7 @@ module.exports = class huobi extends Exchange {
         return super.networkIdToCode (networkTitle);
     }
 
-    networkCodeToId (networkCode, currencyCode = undefined) {// here network-id is provided as a pair of currency & chain (i.e. trc20usdt)
+    networkCodeToId (networkCode, currencyCode = undefined) { // here network-id is provided as a pair of currency & chain (i.e. trc20usdt)
         if (currencyCode === undefined) {
             throw new ArgumentsRequired (this.id + ' networkIdToCode() requires a currencyCode argument');
         }

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2889,6 +2889,20 @@ module.exports = class huobi extends Exchange {
         }
     }
 
+    networkCodeFromPairId (info, key, currencyCode) {
+        const networkPairId = this.safeString (info, key);
+        const networkIds = this.safeValue (this.networkIdByNetworkPairId, currencyCode, {});
+        const networkId = this.safeValue (networkIds, networkPairId, networkPairId);
+        return this.networkIdToCode (networkId);
+    }
+
+    networkPairIdFromCode (currencyCode, networkCode) {
+        const networkId = this.networkCodeToId (networkCode);
+        const networkPairIds = this.safeValue (this.networkPairIdByNetworkId, currencyCode, {});
+        const networkPairId = this.safeValue (networkPairIds, networkId, networkId);
+        return networkPairId;
+    }
+
     async fetchBalance (params = {}) {
         /**
          * @method
@@ -4731,20 +4745,6 @@ module.exports = class huobi extends Exchange {
         const indexedAddresses = await this.fetchDepositAddressesByNetwork (code, paramsOmited);
         const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, indexedAddresses);
         return indexedAddresses[selectedNetworkId];
-    }
-
-    networkCodeFromPairId (info, key, currencyCode) {
-        const networkPairId = this.safeString (info, key);
-        const networkIds = this.safeValue (this.networkIdByNetworkPairId, currencyCode, {});
-        const networkId = this.safeValue (networkIds, networkPairId, networkPairId);
-        return this.networkIdToCode (networkId);
-    }
-
-    networkPairIdFromCode (currencyCode, networkCode) {
-        const networkId = this.networkCodeToId (networkCode);
-        const networkPairIds = this.safeValue (this.networkPairIdByNetworkId, currencyCode, {});
-        const networkPairId = this.safeValue (networkPairIds, networkId, networkId);
-        return networkPairId;
     }
 
     async fetchWithdrawAddresses (code, note = undefined, networkCode = undefined, params = {}) {


### PR DESCRIPTION
@carlosmiei 
I've been working to redesigning of network-related functionality for huobi, because existing implementation was too much "custom" and based on occasional "if/else" clauses to handle the networks.
I've made a complete rework  and this seems correct (a bit complex though) approach to unify networks  parsing/passing for huobi (which can also be used for other similar exchanges afterwards).

about currencies - in raw response, there were multiple field related to network,  but none of them was suitable except `displayName`:
```
 "chain": "usdterc20",  // unique id, which is actually something like "network-pair-id" of currency name and network id, but they are joined with unorganized manner, i.e. for TRON network, the network name is in the begging `trc20usdt`. moreover, for other coins, this field has very unorganized value
 "fullName": "Ethereum", // in many cases, this field value is just empty
 "baseChain": "ETH",  // this and below key are present only in part of currency response, but are missing from others
 "baseChainProtocol": "ERC20", // as above line says
 "displayName": "ERC20", // this seems existent everywhere and most good one
```
also, our unified definition of `networksById` or generally, network-codes and ids , are meant to be common names, i.e. it's acceptable that `ETH` was  network id, or `Ethereum`, or something, but it's inappropriate that `usdterc20` was network id as it's not common and each coin would have it's 'network-id & network-code' pairs. So, instead of the raw `chain` field we take `displayName` which contain the common name of underlying blockchain(network).
However, as network-related endpoints except that you provide the value that is in  `chain` field, so, to link the network-codes to chain-ids, I've added a few helper methods to seamlessly make links with each other.

This PR might be some kind of urgent to issues like:  fix #15789 and for other upcoming network-related PR.s

below are working & tested responses from unified methods.