### PR TITLE
get_object_value_from_key_array php and py do not return empty string as a value

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -570,7 +570,7 @@ class Exchange {
 
     public static function get_object_value_from_key_array($object, $array) {
         foreach($array as $key) {
-            if (isset($object[$key])) {
+            if (isset($object[$key]) && $object[$key] !== '') {
                 return $object[$key];
             }
         }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -853,7 +853,7 @@ class Exchange(object):
 
     @staticmethod
     def get_object_value_from_key_list(dictionary, key_list):
-        filtered_list = list(filter(lambda el: el in dictionary, key_list))
+        filtered_list = list(filter(lambda el: el in dictionary and dictionary[el] != '' and dictionary[el] is not None, key_list))
         if (len(filtered_list) == 0):
             return None
         return dictionary[filtered_list[0]]


### PR DESCRIPTION
Conversation started on https://github.com/ccxt/ccxt/pull/15812#discussion_r1031363996

# Updates

- `safeStringUpperN` and `safeStringLowerN` do not return empty values if the key of a dictionary is matched to an empty value

-------------------------------------

# Testing

## PHP

safe_string_upper ('missing_key', 'default') *returns DEFAULT*: default
safe_string_lower_2 ('missing_key', 'missing_key_2', 'DEFAULT') *returns default*: DEFAULT
safe_string_upper_2 ('missing_key', 'missing_key_2', 'default') *returns DEFAULT*: default
safe_string_lower_n (['missing_key', 'missing_key_2'], 'DEFAULT') *returns default*: DEFAULT
safe_string_upper_n (['missing_key', 'missing_key_2'], 'default') *returns DEFAULT*: default

# {"test":"","test2":"10"}

safe_string_lower ('test'): 
safe_string_upper ('test'): 
safe_string_lower_2 ('test', 'test2'): 10
safe_string_upper_2 ('test', 'test2'): 10
safe_string_lower_n (['test', 'test2']): 10
safe_string_upper_n (['test', 'test2']): 10

# {"test":"5","test2":"10"}

safe_string_lower ('test'): 5
safe_string_upper ('test'): 5
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {"test":"5","test2":"10"}

safe_string_lower ('test'): 5
safe_string_upper ('test'): 5
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {"test":"5"}

safe_string_lower ('test'): 5
safe_string_upper ('test'): 5
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {"test2":"5"}

safe_string_lower ('test'): 
safe_string_upper ('test'): 
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {"test":""}

safe_string_lower ('test'): 
safe_string_upper ('test'): 
safe_string_lower_2 ('test', 'test2'): 
safe_string_upper_2 ('test', 'test2'): 
safe_string_lower_n (['test', 'test2']): 
safe_string_upper_n (['test', 'test2']): 

# {"test2":""}

safe_string_lower ('test'): 
safe_string_upper ('test'): 
safe_string_lower_2 ('test', 'test2'): 
safe_string_upper_2 ('test', 'test2'): 
safe_string_lower_n (['test', 'test2']): 
safe_string_upper_n (['test', 'test2']): 


## Python


# {'test': '', 'test2': '10'}

safe_string_lower ('test'): None
safe_string_upper ('test'): None
safe_string_lower_2 ('test', 'test2'): 10
safe_string_upper_2 ('test', 'test2'): 10
safe_string_lower_n (['test', 'test2']): 10
safe_string_upper_n (['test', 'test2']): 10

# {'test': '5', 'test2': ''}

safe_string_lower ('test'): 5
safe_string_upper ('test'): 5
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {'test': '5', 'test2': '10'}

safe_string_lower ('test'): 5
safe_string_upper ('test'): 5
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {'test': 5}

safe_string_lower ('test'): 5
safe_string_upper ('test'): 5
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {'test2': '5'}

safe_string_lower ('test'): None
safe_string_upper ('test'): None
safe_string_lower_2 ('test', 'test2'): 5
safe_string_upper_2 ('test', 'test2'): 5
safe_string_lower_n (['test', 'test2']): 5
safe_string_upper_n (['test', 'test2']): 5

# {'test': ''}

safe_string_lower ('test'): None
safe_string_upper ('test'): None
safe_string_lower_2 ('test', 'test2'): None
safe_string_upper_2 ('test', 'test2'): None
safe_string_lower_n (['test', 'test2']): None
safe_string_upper_n (['test', 'test2']): None

# {'test2': ''}

safe_string_lower ('test'): None
safe_string_upper ('test'): None
safe_string_lower_2 ('test', 'test2'): None
safe_string_upper_2 ('test', 'test2'): None
safe_string_lower_n (['test', 'test2']): None
safe_string_upper_n (['test', 'test2']): None
