### PR TITLE
throttle ws new connections

### DIFF
--- a/examples/ccxt.pro/js/binance-throttle.js
+++ b/examples/ccxt.pro/js/binance-throttle.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const ccxt = require ('../../../ccxt');
+
+
+const ohlcvsBySymbol = {}
+
+function handleAllOHLCVs (exchange, ohlcvs, symbol, timeframe) {
+    const now = exchange.iso8601 (exchange.milliseconds ())
+    const lastCandle = exchange.safeValue (ohlcvs, ohlcvs.length - 1)
+    const datetime = exchange.iso8601 (lastCandle[0])
+    console.log (now, datetime, symbol, timeframe, lastCandle.slice (1))
+}
+
+async function pollOHLCV (exchange, symbol, timeframe) {
+    while (true) {
+        try {
+            const response = await exchange.watchOHLCV (symbol, timeframe)
+            ohlcvsBySymbol[symbol] = response
+            handleAllOHLCVs(exchange, response, symbol, timeframe)
+        } catch (e) {
+            console.log (e.constructor.name, e.message)
+        }
+    }
+}
+
+async function main () {
+    const exchange = new ccxt.pro.binance({
+        'tokenBucket': {
+            delay: 2, // delay in seconds
+            capacity: 1,
+            cost: 2,
+            maxCapacity: 50000,
+        }
+    })
+    await exchange.loadMarkets ()
+    // exchange.verbose = true uncomment to debug
+    const timeframe = '1m'
+
+    const symbols = exchange.symbols.slice (0, 500)
+
+    console.log ('connecting to ', symbols.length, ' symbol')
+
+    await Promise.all (symbols.map (symbol => pollOHLCV (exchange, symbol, timeframe)))
+}
+
+main ()

--- a/js/pro/base/Exchange.js
+++ b/js/pro/base/Exchange.js
@@ -79,7 +79,12 @@ module.exports = class Exchange extends BaseExchange {
         //     const client = this.client (url)
         //     const backoffDelay = 0
         //     const future = client.future (messageHash)
-        //     const connected = client.connect (backoffDelay)
+        //     let connected = undefined;
+        //     if (this.enableRateLimit) {
+        //         connected = this.throttle ().then (() => client.connect (backoffDelay));
+        //     } else {
+        //         connected = client.connect (backoffDelay);
+        //     }
         //     connected.then (() => {
         //         if (message && !client.subscriptions[subscribeHash]) {
         //             client.subscriptions[subscribeHash] = true
@@ -109,7 +114,12 @@ module.exports = class Exchange extends BaseExchange {
         // the policy is to make sure that 100% of promises are resolved or rejected
         // either with a call to client.resolve or client.reject with
         //  a proper exception class instance
-        const connected = client.connect (backoffDelay);
+        let connected = undefined;
+        if (this.enableRateLimit) {
+            connected = this.throttle ().then (() => client.connect (backoffDelay));
+        } else {
+            connected = client.connect (backoffDelay);
+        }
         // the following is executed only if the catch-clause does not
         // catch any connection-level exceptions from the client
         // (connection established successfully)

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -79,7 +79,16 @@ trait ClientTrait {
         // todo: calculate the backoff delay in php
         $backoff_delay = 0; // milliseconds
         $future = $client->future($message_hash);
-        $connected = $client->connect($backoff_delay);
+        $connected;
+        if ($this->enableRateLimit) {
+            $connected = $this->throttle()->then(
+                function () use ($client, $backoff_delay) {
+                    return $client->connect($backoff_delay);
+                }
+            );
+        } else {
+            $connected = $client->connect($backoff_delay);
+        }
         $connected->then(
             function($result) use ($client, $message_hash, $message, $subscribe_hash, $subscription) {
                 if (!isset($client->subscriptions[$subscribe_hash])) {

--- a/python/ccxt/pro/base/exchange.py
+++ b/python/ccxt/pro/base/exchange.py
@@ -111,8 +111,15 @@ class Exchange(BaseExchange):
 
         # base exchange self.open starts the aiohttp Session in an async context
         self.open()
-        connected = client.connected if client.connected.done() \
-            else asyncio.ensure_future(client.connect(self.session, backoff_delay))
+        connected = None
+        if client.connected.done():
+            connected = client.connected
+        else:
+            async def connect():
+                if self.enableRateLimit:
+                    await self.throttle()
+                await client.connect(self.session, backoff_delay)
+            connected = asyncio.ensure_future(connect())
 
         def after(fut):
             if subscribe_hash not in client.subscriptions:


### PR DESCRIPTION
Several users complained about a timeout error when connecting to several streams. I was able to reproduce this when connecting though a VPN using binance and using over 300 streams.
- This PR adds throttling to creating new WS connections
- Add JS example to customize throttling