### PR TITLE
base- network id / code

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -178,6 +178,7 @@ class Transpiler {
             [ /\.currencyToPrecision\s/g, '.currency_to_precision'],
             [ /\.costToPrecision\s/g, '.cost_to_precision'],
             [ /\.commonCurrencyCode\s/g, '.common_currency_code'],
+            [ /\.getDefaultOptions\s/g, '.get_default_options'],
             [ /\.loadAccounts\s/g, '.load_accounts'],
             [ /\.fetchAccounts\s/g, '.fetch_accounts'],
             [ /\.loadFees\s/g, '.load_fees'],

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -234,7 +234,7 @@ module.exports = class Exchange {
         //         }
         //     }
         //
-        this.options = {} // exchange-specific options, if any
+        this.options = this.getDefaultOptions(); // exchange-specific options, if any
         // fetch implementation options (JS only)
         this.fetchOptions = {
             // keepalive: true, // does not work in Chrome, https://github.com/ccxt/ccxt/issues/6368
@@ -796,6 +796,15 @@ module.exports = class Exchange {
 
     // ------------------------------------------------------------------------
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
+
+    getDefaultOptions () {
+        return {
+            'defaultNetworkCodeReplacements': {
+                'ETH': { 'ERC20': 'ETH' },
+                'TRX': { 'TRC20': 'TRX' },
+            },
+        };
+    }
 
     safeLedgerEntry (entry, currency = undefined) {
         currency = this.safeCurrency (undefined, currency);
@@ -1668,7 +1677,15 @@ module.exports = class Exchange {
          * @returns {[string|undefined]} unified network code
          */
         const networkCodesByIds = this.safeValue (this.options, 'networksById', {});
-        return this.safeString (networkCodesByIds, networkId, networkId);
+        let networkCode = this.safeString (networkCodesByIds, networkId, networkId);
+        if (currencyCode !== undefined) {
+            const defaultNetworkCodeReplacements = this.safeValue (this.options, 'defaultNetworkCodeReplacements', {});
+            if (currencyCode in defaultNetworkCodeReplacements) {
+                const replacementObject = this.safeValue (defaultNetworkCodeReplacements, currencyCode, {});
+                networkCode = this.safeString (replacementObject, networkCode, networkCode);
+            }
+        }
+        return networkCode;
     }
 
     handleNetworkCodeAndParams (params) {

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -286,6 +286,7 @@ class Exchange {
         'parseNumber' => 'parse_number',
         'checkOrderArguments' => 'check_order_arguments',
         'handleHttpStatusCode' => 'handle_http_status_code',
+        'getDefaultOptions' => 'get_default_options',
         'safeLedgerEntry' => 'safe_ledger_entry',
         'setMarkets' => 'set_markets',
         'safeBalance' => 'safe_balance',
@@ -1173,7 +1174,7 @@ class Exchange {
         $this->headers = array();
         $this->hostname = null; // in case of inaccessibility of the "main" domain
 
-        $this->options = array(); // exchange-specific options if any
+        $this->options = $this->get_default_options(); // exchange-specific options if any
 
         $this->skipJsonOnStatusCodes = false; // TODO: reserved, rewrite the curl routine to parse JSON body anyway
         $this->quoteJsonNumbers = true; // treat numbers in json as quoted precise strings
@@ -2473,6 +2474,15 @@ class Exchange {
 
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
 
+    public function get_default_options() {
+        return array(
+            'defaultNetworkCodeReplacements' => array(
+                'ETH' => array( 'ERC20' => 'ETH' ),
+                'TRX' => array( 'TRC20' => 'TRX' ),
+            ),
+        );
+    }
+
     public function safe_ledger_entry($entry, $currency = null) {
         $currency = $this->safe_currency(null, $currency);
         $direction = $this->safe_string($entry, 'direction');
@@ -3340,7 +3350,15 @@ class Exchange {
          * @return {[string|null]} unified network code
          */
         $networkCodesByIds = $this->safe_value($this->options, 'networksById', array());
-        return $this->safe_string($networkCodesByIds, $networkId, $networkId);
+        $networkCode = $this->safe_string($networkCodesByIds, $networkId, $networkId);
+        if ($currencyCode !== null) {
+            $defaultNetworkCodeReplacements = $this->safe_value($this->options, 'defaultNetworkCodeReplacements', array());
+            if (is_array($defaultNetworkCodeReplacements) && array_key_exists($currencyCode, $defaultNetworkCodeReplacements)) {
+                $replacementObject = $this->safe_value($defaultNetworkCodeReplacements, $currencyCode, array());
+                $networkCode = $this->safe_string($replacementObject, $networkCode, $networkCode);
+            }
+        }
+        return $networkCode;
     }
 
     public function handle_network_code_and_params($params) {


### PR DESCRIPTION
this would be non-breaking change.

addressed a.k.a. "implied" networks problem.

however, as that name is only used on binance atm, and we instead add a base method, which will totally replace the derived implementations, we might better use more explicit name (as `impliedNetworks` is too broad and vague) - `networkCodeReplacements` , because name itself is self-explanatory (as we only replace returning `networkCode` from `ERC20|TRC20 -- > ETH|TRX`).


`networkIdToCode` 
=
with the following options:
```
'networksById': {
    'Erc_20': 'ERC20',
    'Ether': 'ETH',
}

# outputs #
networkIdToCode('Erc_20') ---> 'ERC20'
networkIdToCode('Erc_20', 'ETH') ---> 'ETH'
networkIdToCode('Ether') ---> 'ETH'
```

with the following options:
```
'networksById': {
    'Erc_20': 'ERC20',
}

# outputs #
e.networkIdToCode('Erc_20') ---> 'ERC20'
e.networkIdToCode('Erc_20', 'ETH') ---> 'ETH'
```




`networkCodeToId` 
=
A) with the following options:
```
'networks': {
    'ERC20': 'Erc_20',
    'ETH' : 'Ether',
}
# outputs #
networkCodeToId('ERC20') ---> 'Erc_20'
networkCodeToId('ETH') ---> 'Ether'
```

B) with the following options:
```
'networks': {
    'ERC20': 'Erc_20',
}
# outputs #
networkCodeToId('ERC20') ---> 'Erc_20'
networkCodeToId('ETH') ---> 'ETH' // here we have no idea what could be network-id, so leaving it as-is
networkCodeToId('ETH', 'ETH') ---> 'Erc_20'  // here we provide currencyCode, and  from `defaultNetworkCodeReplacements` it finds that it has a replacement network-code ERC20, so will use its value
```
 
Only the last one made me to think (whether it's correct that we will do it) is to convert unified network-code to exchange-specific network id reversely ,i.e. : `networkCodeToId('ETH', 'ETH') ---> 'Erc_20'`
however, as we convert exchange-specific network id to unified `networkCode` for ETH coin:
```
networkIdToCode('Erc_20', 'ETH') ---> 'ETH'
```
 then probably we should do it in reverse too:
```
networkCodeToId('ETH', 'ETH') ---> 'Erc_20' 
```
