### PR TITLE
added ignore to networkCodeToId & networkIdToCode docstrings

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1647,11 +1647,12 @@ module.exports = class Exchange {
 
     networkCodeToId (networkCode, currencyCode = undefined) {
         /**
+         * @ignore
          * @method
          * @name exchange#networkCodeToId
          * @description tries to convert the provided networkCode (which is expected to be an unified network code) to a network id. In order to achieve this, derived class needs to have 'options->networks' defined.
          * @param {string} networkCode unified network code
-         * @param {string} currencyCode unified currency code, but this argument is not required by default, unless there is an exchange (like huobi) that needs an override of the method to be able to pass currencyCode argument additionally
+         * @param {string|undefined} currencyCode unified currency code, but this argument is not required by default, unless there is an exchange (like huobi) that needs an override of the method to be able to pass currencyCode argument additionally
          * @returns {[string|undefined]} exchange-specific network id
          */
         const networkIdsByCodes = this.safeValue (this.options, 'networks', {});
@@ -1660,11 +1661,12 @@ module.exports = class Exchange {
 
     networkIdToCode (networkId, currencyCode = undefined) {
         /**
+         * @ignore
          * @method
          * @name exchange#networkIdToCode
          * @description tries to convert the provided exchange-specific networkId to an unified network Code. In order to achieve this, derived class needs to have 'options->networksById' defined.
          * @param {string} networkId unified network code
-         * @param {string} currencyCode unified currency code, but this argument is not required by default, unless there is an exchange (like huobi) that needs an override of the method to be able to pass currencyCode argument additionally
+         * @param {string|undefined} currencyCode unified currency code, but this argument is not required by default, unless there is an exchange (like huobi) that needs an override of the method to be able to pass currencyCode argument additionally
          * @returns {[string|undefined]} unified network code
          */
         const networkCodesByIds = this.safeValue (this.options, 'networksById', {});


### PR DESCRIPTION
If the docstrings ever get compiled to markdown docs, we need `@ignore` in the docstrings for internal methods so that these methods don't show up in the docs

------------

[This PR](https://github.com/ccxt/ccxt/pull/13854) needs to be merged before we can make markdown docs though