### PR TITLE
Ascendex: fetchBalance, add margin debt

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -780,7 +780,12 @@ module.exports = class ascendex extends Exchange {
          */
         await this.loadMarkets ();
         await this.loadAccounts ();
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        let query = undefined;
+        let marketType = undefined;
+        [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        const isMargin = this.safeValue (params, 'margin', false);
+        marketType = isMargin ? 'margin' : marketType;
+        params = this.omit (params, 'margin');
         const options = this.safeValue (this.options, 'fetchBalance', {});
         const accountsByType = this.safeValue (this.options, 'accountsByType', {});
         const accountCategory = this.safeString (accountsByType, marketType, 'cash');


### PR DESCRIPTION
Added a debt field when fetching the margin balance on Ascendex:
```
node examples/js/cli ascendex fetchBalance '{"type":"margin"}'

{
  info: {
    code: '0',
    data: [
      {
        asset: 'USDT',
        totalBalance: '20',
        availableBalance: '20',
        borrowed: '0',
        interest: '0'
      }
    ]
  },
  timestamp: 1669797109495,
  datetime: '2022-11-30T08:31:49.495Z',
  USDT: { free: 20, used: 0, total: 20, debt: 0 },
  free: { USDT: 20 },
  used: { USDT: 0 },
  total: { USDT: 20 },
  debt: { USDT: 0 }
}
```