### PR TITLE
huobi - rework for networks

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -126,6 +126,7 @@ module.exports = class Exchange {
                 'fetchTradingLimits': undefined,
                 'fetchTransactions': undefined,
                 'fetchTransfers': undefined,
+                'fetchWithdrawAddresses': undefined,
                 'fetchWithdrawal': undefined,
                 'fetchWithdrawals': undefined,
                 'reduceMargin': undefined,

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1699,10 +1699,18 @@ module.exports = class Exchange {
         return defaultNetworkCode;
     }
 
-    selectNetworkIdFromAvailableNetworks (currencyCode, networkCode, networkEntriesIndexed, isIndexedByUnifiedNetworkCode = false) {
+    selectNetworkCodeFromUnifiedNetworks (currencyCode, networkCode, indexedNetworkEntries) {
+        return this.selectNetworkKeyFromNetworks (currencyCode, networkCode, indexedNetworkEntries, true);
+    }
+
+    selectNetworkIdFromRawNetworks (currencyCode, networkCode, indexedNetworkEntries) {
+        return this.selectNetworkKeyFromNetworks (currencyCode, networkCode, indexedNetworkEntries, false);
+    }
+
+    selectNetworkKeyFromNetworks (currencyCode, networkCode, indexedNetworkEntries, isIndexedByUnifiedNetworkCode = false) {
         // this method is used against raw & unparse network entries, which are just indexed by network id
         let chosenNetworkId = undefined;
-        const availableNetworkIds = Object.keys (networkEntriesIndexed);
+        const availableNetworkIds = Object.keys (indexedNetworkEntries);
         const responseNetworksLength = availableNetworkIds.length;
         if (networkCode !== undefined) {
             if (responseNetworksLength === 0) {
@@ -1710,7 +1718,7 @@ module.exports = class Exchange {
             } else {
                 // if networkCode was provided by user, we should check it after response, as the referenced exchange doesn't support network-code during request
                 const networkId = isIndexedByUnifiedNetworkCode ? networkCode : this.networkCodeToId (networkCode, currencyCode);
-                if (networkId in networkEntriesIndexed) {
+                if (networkId in indexedNetworkEntries) {
                     chosenNetworkId = networkId;
                 } else {
                     throw new NotSupported (this.id + ' - ' + networkId + ' network was not found for ' + currencyCode + ', use one of ' + availableNetworkIds.join (', '));
@@ -1723,7 +1731,7 @@ module.exports = class Exchange {
                 // if networkCode was not provided by user, then we try to use the default network (if it was defined in "defaultNetworks"), otherwise, we just return the first network entry
                 const defaultNetworkCode = this.defaultNetworkCode (currencyCode);
                 const defaultNetworkId = isIndexedByUnifiedNetworkCode ? defaultNetworkCode : this.networkCodeToId (defaultNetworkCode, currencyCode);
-                chosenNetworkId = (defaultNetworkId in networkEntriesIndexed) ? defaultNetworkId : availableNetworkIds[0];
+                chosenNetworkId = (defaultNetworkId in indexedNetworkEntries) ? defaultNetworkId : availableNetworkIds[0];
             }
         }
         return chosenNetworkId;

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1718,7 +1718,7 @@ module.exports = class Exchange {
             }
         } else {
             if (responseNetworksLength === 0) {
-                throw new NotSupported (this.id + ' - no networks were returned for' + currencyCode);
+                throw new NotSupported (this.id + ' - no networks were returned for ' + currencyCode);
             } else {
                 // if networkCode was not provided by user, then we try to use the default network (if it was defined in "defaultNetworks"), otherwise, we just return the first network entry
                 const defaultNetworkCode = this.defaultNetworkCode (currencyCode);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1699,17 +1699,17 @@ module.exports = class Exchange {
         return defaultNetworkCode;
     }
 
-    selectNetworkIdFromAvailableNetworks (currencyCode, networkCode, networkEntriesIndexed) {
+    selectNetworkIdFromAvailableNetworks (currencyCode, networkCode, networkEntriesIndexed, isIndexedByUnifiedNetworkCode = false) {
         // this method is used against raw & unparse network entries, which are just indexed by network id
         let chosenNetworkId = undefined;
         const availableNetworkIds = Object.keys (networkEntriesIndexed);
         const responseNetworksLength = availableNetworkIds.length;
         if (networkCode !== undefined) {
-            // if networkCode was provided by user, we should check it after response, as the referenced exchange doesn't support network-code during request
-            const networkId = this.networkCodeToId (networkCode, currencyCode);
             if (responseNetworksLength === 0) {
                 throw new NotSupported (this.id + ' - ' + networkCode + ' network did not return any result for ' + currencyCode);
             } else {
+                // if networkCode was provided by user, we should check it after response, as the referenced exchange doesn't support network-code during request
+                const networkId = isIndexedByUnifiedNetworkCode ? networkCode : this.networkCodeToId (networkCode, currencyCode);
                 if (networkId in networkEntriesIndexed) {
                     chosenNetworkId = networkId;
                 } else {
@@ -1722,7 +1722,7 @@ module.exports = class Exchange {
             } else {
                 // if networkCode was not provided by user, then we try to use the default network (if it was defined in "defaultNetworks"), otherwise, we just return the first network entry
                 const defaultNetworkCode = this.defaultNetworkCode (currencyCode);
-                const defaultNetworkId = this.networkCodeToId (defaultNetworkCode, currencyCode);
+                const defaultNetworkId = isIndexedByUnifiedNetworkCode ? defaultNetworkCode : this.networkCodeToId (defaultNetworkCode, currencyCode);
                 chosenNetworkId = (defaultNetworkId in networkEntriesIndexed) ? defaultNetworkId : availableNetworkIds[0];
             }
         }

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4468,7 +4468,7 @@ module.exports = class bybit extends Exchange {
         const result = this.safeValue (response, 'result', {});
         const chains = this.safeValue (result, 'chains', []);
         const chainsIndexedById = this.indexBy (chains, 'chain');
-        const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, chainsIndexedById);
+        const selectedNetworkId = this.selectNetworkIdFromRawNetworks (code, networkCode, chainsIndexedById);
         const addressObject = this.safeValue (chainsIndexedById, selectedNetworkId, {});
         return this.parseDepositAddress (addressObject, currency);
     }

--- a/js/cex.js
+++ b/js/cex.js
@@ -1548,7 +1548,7 @@ module.exports = class cex extends Exchange {
         const data = this.safeValue (response, 'data', {});
         const addresses = this.safeValue (data, 'addresses', []);
         const chainsIndexedById = this.indexBy (addresses, 'blockchain');
-        const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, chainsIndexedById);
+        const selectedNetworkId = this.selectNetworkIdFromRawNetworks (code, networkCode, chainsIndexedById);
         const addressObject = this.safeValue (chainsIndexedById, selectedNetworkId, {});
         const address = this.safeString2 (addressObject, 'address', 'destination');
         this.checkAddress (address);

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2783,14 +2783,14 @@ module.exports = class huobi extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         const result = {};
-        this.networkJunctionsByTitles = {};
-        this.networkTitlesByJunctions = {};
+        this.options['networkJunctionsByTitles'] = {};
+        this.options['networkTitlesByJunctions'] = {};
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
             const currencyId = this.safeString (entry, 'currency');
             const code = this.safeCurrencyCode (currencyId);
-            this.networkJunctionsByTitles[code] = {};
-            this.networkTitlesByJunctions[code] = {};
+            this.options['networkJunctionsByTitles'][code] = {};
+            this.options['networkTitlesByJunctions'][code] = {};
             const chains = this.safeValue (entry, 'chains', []);
             const networks = {};
             const instStatus = this.safeString (entry, 'instStatus');
@@ -2804,8 +2804,8 @@ module.exports = class huobi extends Exchange {
                 const chainEntry = chains[j];
                 const uniqueChainId = this.safeString (chainEntry, 'chain'); // i.e. usdterc20, trc20usdt ...
                 const title = this.safeString (chainEntry, 'displayName');
-                this.networkJunctionsByTitles[code][title] = uniqueChainId;
-                this.networkTitlesByJunctions[code][uniqueChainId] = title;
+                this.options['networkJunctionsByTitles'][code][title] = uniqueChainId;
+                this.options['networkTitlesByJunctions'][code][uniqueChainId] = title;
                 const networkCode = this.networkIdToCode (title, code);
                 minWithdraw = this.safeNumber (chainEntry, 'minWithdrawAmt');
                 maxWithdraw = this.safeNumber (chainEntry, 'maxWithdrawAmt');
@@ -2877,24 +2877,24 @@ module.exports = class huobi extends Exchange {
         if (currencyCode === undefined) {
             throw new ArgumentsRequired (this.id + ' networkIdToCode() requires a currencyCode argument');
         }
-        const keysLength = (Object.keys (this.networkTitlesByJunctions)).length;
+        const keysLength = (Object.keys (this.options['networkTitlesByJunctions'])).length;
         if (keysLength === 0) {
             throw new ExchangeError (this.id + ' networkIdToCode() - markets need to be loaded at first');
         }
-        const networkTitles = this.safeValue (this.networkTitlesByJunctions, currencyCode, {});
+        const networkTitles = this.safeValue (this.options['networkTitlesByJunctions'], currencyCode, {});
         const networkTitle = this.safeValue (networkTitles, networkId, networkId);
         return super.networkIdToCode (networkTitle);
     }
 
     networkCodeToId (networkCode, currencyCode = undefined) { // here network-id is provided as a pair of currency & chain (i.e. trc20usdt)
         if (currencyCode === undefined) {
-            throw new ArgumentsRequired (this.id + ' networkIdToCode() requires a currencyCode argument');
+            throw new ArgumentsRequired (this.id + ' networkCodeToId() requires a currencyCode argument');
         }
-        const keysLength = (Object.keys (this.networkJunctionsByTitles)).length;
+        const keysLength = (Object.keys (this.options['networkJunctionsByTitles'])).length;
         if (keysLength === 0) {
             throw new ExchangeError (this.id + ' networkCodeToId() - markets need to be loaded at first');
         }
-        const uniqueNetworkIds = this.safeValue (this.networkJunctionsByTitles, currencyCode, {});
+        const uniqueNetworkIds = this.safeValue (this.options['networkJunctionsByTitles'], currencyCode, {});
         const networkTitle = super.networkCodeToId (networkCode);
         return this.safeValue (uniqueNetworkIds, networkTitle, networkTitle);
     }

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -838,6 +838,7 @@ module.exports = class huobi extends Exchange {
                     // err-code
                     '403': AuthenticationError,  // {"status":"error","err_code":403,"err_msg":"Incorrect Access key [Access key错误]","ts":1652774224344}
                     '1010': AccountNotEnabled, // {"status":"error","err_code":1010,"err_msg":"Account doesnt exist.","ts":1648137970490}
+                    '1003': AuthenticationError, // {code: '1003', message: 'invalid signature'}
                     '1013': BadSymbol, // {"status":"error","err_code":1013,"err_msg":"This contract symbol doesnt exist.","ts":1640550459583}
                     '1017': OrderNotFound, // {"status":"error","err_code":1017,"err_msg":"Order doesnt exist.","ts":1640550859242}
                     '1034': InvalidOrder, // {"status":"error","err_code":1034,"err_msg":"Incorrect field of order price type.","ts":1643802870182}
@@ -4735,6 +4736,7 @@ module.exports = class huobi extends Exchange {
          * @param {object} params extra parameters specific to the huobi api endpoint
          * @returns {object} an [address structure]{@link https://docs.ccxt.com/en/latest/manual.html#address-structure}
          */
+        await this.loadMarkets ();
         const [ networkCode, paramsOmited ] = this.handleNetworkCodeAndParams (params);
         const indexedAddresses = await this.fetchDepositAddressesByNetwork (code, paramsOmited);
         const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, indexedAddresses);
@@ -5692,6 +5694,12 @@ module.exports = class huobi extends Exchange {
                 this.throwExactlyMatchedException (this.exceptions['exact'], message, feedback);
                 throw new ExchangeError (feedback);
             }
+        }
+        if ('code' in response) {
+            // {code: '1003', message: 'invalid signature'}
+            const feedback = this.id + ' ' + body;
+            const code = this.safeString (response, 'code');
+            this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);
         }
     }
 

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -911,6 +911,8 @@ module.exports = class huobi extends Exchange {
                 'defaultNetwork': 'ERC20',
                 'defaultNetworks': {
                     'ETH': 'ERC20',
+                    'BTC': 'BTC',
+                    'USDT': 'TRC20',
                 },
                 'networks': {
                     // by displaynames
@@ -4739,7 +4741,7 @@ module.exports = class huobi extends Exchange {
         await this.loadMarkets ();
         const [ networkCode, paramsOmited ] = this.handleNetworkCodeAndParams (params);
         const indexedAddresses = await this.fetchDepositAddressesByNetwork (code, paramsOmited);
-        const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, indexedAddresses);
+        const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, indexedAddresses, true);
         return indexedAddresses[selectedNetworkId];
     }
 

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2886,7 +2886,7 @@ module.exports = class huobi extends Exchange {
         return super.networkIdToCode (networkTitle);
     }
 
-    networkCodeToId (networkCode, currencyCode = undefined) {// here network-id is provided as a pair of currency & chain (i.e. trc20usdt)
+    networkCodeToId (networkCode, currencyCode = undefined) { // here network-id is provided as a pair of currency & chain (i.e. trc20usdt)
         if (currencyCode === undefined) {
             throw new ArgumentsRequired (this.id + ' networkIdToCode() requires a currencyCode argument');
         }

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2790,7 +2790,6 @@ module.exports = class huobi extends Exchange {
             const currencyId = this.safeString (entry, 'currency');
             const code = this.safeCurrencyCode (currencyId);
             this.options['networkChainIdsByNames'][code] = {};
-            this.options['networkNamesByChainIds'][code] = {};
             const chains = this.safeValue (entry, 'chains', []);
             const networks = {};
             const instStatus = this.safeString (entry, 'instStatus');
@@ -2805,7 +2804,7 @@ module.exports = class huobi extends Exchange {
                 const uniqueChainId = this.safeString (chainEntry, 'chain'); // i.e. usdterc20, trc20usdt ...
                 const title = this.safeString (chainEntry, 'displayName');
                 this.options['networkChainIdsByNames'][code][title] = uniqueChainId;
-                this.options['networkNamesByChainIds'][code][uniqueChainId] = title;
+                this.options['networkNamesByChainIds'][uniqueChainId] = title;
                 const networkCode = this.networkIdToCode (title, code);
                 minWithdraw = this.safeNumber (chainEntry, 'minWithdrawAmt');
                 maxWithdraw = this.safeNumber (chainEntry, 'maxWithdrawAmt');
@@ -2874,15 +2873,12 @@ module.exports = class huobi extends Exchange {
 
     networkIdToCode (networkId, currencyCode = undefined) {
         // here network-id is provided as a pair of currency & chain (i.e. trc20usdt)
-        if (currencyCode === undefined) {
-            throw new ArgumentsRequired (this.id + ' networkIdToCode() requires a currencyCode argument');
-        }
-        const keysLength = (Object.keys (this.options['networkNamesByChainIds'])).length;
+        const keys = Object.keys (this.options['networkNamesByChainIds']);
+        const keysLength = keys.length;
         if (keysLength === 0) {
             throw new ExchangeError (this.id + ' networkIdToCode() - markets need to be loaded at first');
         }
-        const networkTitles = this.safeValue (this.options['networkNamesByChainIds'], currencyCode, {});
-        const networkTitle = this.safeValue (networkTitles, networkId, networkId);
+        const networkTitle = this.safeValue (this.options['networkNamesByChainIds'], networkId, networkId);
         return super.networkIdToCode (networkTitle);
     }
 
@@ -2890,7 +2886,8 @@ module.exports = class huobi extends Exchange {
         if (currencyCode === undefined) {
             throw new ArgumentsRequired (this.id + ' networkCodeToId() requires a currencyCode argument');
         }
-        const keysLength = (Object.keys (this.options['networkChainIdsByNames'])).length;
+        const keys = Object.keys (this.options['networkChainIdsByNames']);
+        const keysLength = keys.length;
         if (keysLength === 0) {
             throw new ExchangeError (this.id + ' networkCodeToId() - markets need to be loaded at first');
         }

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4741,7 +4741,7 @@ module.exports = class huobi extends Exchange {
         await this.loadMarkets ();
         const [ networkCode, paramsOmited ] = this.handleNetworkCodeAndParams (params);
         const indexedAddresses = await this.fetchDepositAddressesByNetwork (code, paramsOmited);
-        const selectedNetworkCode = this.selectNetworkCodeFromUnifiedNetworks (code, networkCode, indexedAddresses, true);
+        const selectedNetworkCode = this.selectNetworkCodeFromUnifiedNetworks (code, networkCode, indexedAddresses);
         return indexedAddresses[selectedNetworkCode];
     }
 

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2783,14 +2783,14 @@ module.exports = class huobi extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         const result = {};
-        this.options['networkJunctionsByTitles'] = {};
-        this.options['networkTitlesByJunctions'] = {};
+        this.options['networkChainIdsByNames'] = {};
+        this.options['networkNamesByChainIds'] = {};
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
             const currencyId = this.safeString (entry, 'currency');
             const code = this.safeCurrencyCode (currencyId);
-            this.options['networkJunctionsByTitles'][code] = {};
-            this.options['networkTitlesByJunctions'][code] = {};
+            this.options['networkChainIdsByNames'][code] = {};
+            this.options['networkNamesByChainIds'][code] = {};
             const chains = this.safeValue (entry, 'chains', []);
             const networks = {};
             const instStatus = this.safeString (entry, 'instStatus');
@@ -2804,8 +2804,8 @@ module.exports = class huobi extends Exchange {
                 const chainEntry = chains[j];
                 const uniqueChainId = this.safeString (chainEntry, 'chain'); // i.e. usdterc20, trc20usdt ...
                 const title = this.safeString (chainEntry, 'displayName');
-                this.options['networkJunctionsByTitles'][code][title] = uniqueChainId;
-                this.options['networkTitlesByJunctions'][code][uniqueChainId] = title;
+                this.options['networkChainIdsByNames'][code][title] = uniqueChainId;
+                this.options['networkNamesByChainIds'][code][uniqueChainId] = title;
                 const networkCode = this.networkIdToCode (title, code);
                 minWithdraw = this.safeNumber (chainEntry, 'minWithdrawAmt');
                 maxWithdraw = this.safeNumber (chainEntry, 'maxWithdrawAmt');
@@ -2877,11 +2877,11 @@ module.exports = class huobi extends Exchange {
         if (currencyCode === undefined) {
             throw new ArgumentsRequired (this.id + ' networkIdToCode() requires a currencyCode argument');
         }
-        const keysLength = (Object.keys (this.options['networkTitlesByJunctions'])).length;
+        const keysLength = (Object.keys (this.options['networkNamesByChainIds'])).length;
         if (keysLength === 0) {
             throw new ExchangeError (this.id + ' networkIdToCode() - markets need to be loaded at first');
         }
-        const networkTitles = this.safeValue (this.options['networkTitlesByJunctions'], currencyCode, {});
+        const networkTitles = this.safeValue (this.options['networkNamesByChainIds'], currencyCode, {});
         const networkTitle = this.safeValue (networkTitles, networkId, networkId);
         return super.networkIdToCode (networkTitle);
     }
@@ -2890,11 +2890,11 @@ module.exports = class huobi extends Exchange {
         if (currencyCode === undefined) {
             throw new ArgumentsRequired (this.id + ' networkCodeToId() requires a currencyCode argument');
         }
-        const keysLength = (Object.keys (this.options['networkJunctionsByTitles'])).length;
+        const keysLength = (Object.keys (this.options['networkChainIdsByNames'])).length;
         if (keysLength === 0) {
             throw new ExchangeError (this.id + ' networkCodeToId() - markets need to be loaded at first');
         }
-        const uniqueNetworkIds = this.safeValue (this.options['networkJunctionsByTitles'], currencyCode, {});
+        const uniqueNetworkIds = this.safeValue (this.options['networkChainIdsByNames'], currencyCode, {});
         const networkTitle = super.networkCodeToId (networkCode);
         return this.safeValue (uniqueNetworkIds, networkTitle, networkTitle);
     }

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4741,8 +4741,8 @@ module.exports = class huobi extends Exchange {
         await this.loadMarkets ();
         const [ networkCode, paramsOmited ] = this.handleNetworkCodeAndParams (params);
         const indexedAddresses = await this.fetchDepositAddressesByNetwork (code, paramsOmited);
-        const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, indexedAddresses, true);
-        return indexedAddresses[selectedNetworkId];
+        const selectedNetworkCode = this.selectNetworkCodeFromUnifiedNetworks (code, networkCode, indexedAddresses, true);
+        return indexedAddresses[selectedNetworkCode];
     }
 
     async fetchWithdrawAddresses (code, note = undefined, networkCode = undefined, params = {}) {

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -2889,6 +2889,20 @@ module.exports = class huobi extends Exchange {
         }
     }
 
+    networkCodeFromPairId (info, key, currencyCode) {
+        const networkPairId = this.safeString (info, key);
+        const networkIds = this.safeValue (this.networkIdByNetworkPairId, currencyCode, {});
+        const networkId = this.safeValue (networkIds, networkPairId, networkPairId);
+        return this.networkIdToCode (networkId);
+    }
+
+    networkPairIdFromCode (currencyCode, networkCode) {
+        const networkId = this.networkCodeToId (networkCode);
+        const networkPairIds = this.safeValue (this.networkPairIdByNetworkId, currencyCode, {});
+        const networkPairId = this.safeValue (networkPairIds, networkId, networkId);
+        return networkPairId;
+    }
+
     async fetchBalance (params = {}) {
         /**
          * @method
@@ -4731,20 +4745,6 @@ module.exports = class huobi extends Exchange {
         const indexedAddresses = await this.fetchDepositAddressesByNetwork (code, paramsOmited);
         const selectedNetworkId = this.selectNetworkIdFromAvailableNetworks (code, networkCode, indexedAddresses);
         return indexedAddresses[selectedNetworkId];
-    }
-
-    networkCodeFromPairId (info, key, currencyCode) {
-        const networkPairId = this.safeString (info, key);
-        const networkIds = this.safeValue (this.networkIdByNetworkPairId, currencyCode, {});
-        const networkId = this.safeValue (networkIds, networkPairId, networkPairId);
-        return this.networkIdToCode (networkId);
-    }
-
-    networkPairIdFromCode (currencyCode, networkCode) {
-        const networkId = this.networkCodeToId (networkCode);
-        const networkPairIds = this.safeValue (this.networkPairIdByNetworkId, currencyCode, {});
-        const networkPairId = this.safeValue (networkPairIds, networkId, networkId);
-        return networkPairId;
     }
 
     async fetchWithdrawAddresses (code, note = undefined, networkCode = undefined, params = {}) {


### PR DESCRIPTION
@carlosmiei 
I've been working to redesigning of network-related functionality for huobi, because existing implementation was too much "custom" and based on occasional "if/else" clauses to handle the networks.
I've made a complete rework  and this seems correct (a bit complex though) approach to unify networks  parsing/passing for huobi (which can also be used for other similar exchanges afterwards).

about currencies - in raw response, there were multiple field related to network,  but none of them was suitable except `displayName`:
```
 "chain": "usdterc20",  // unique id, which is actually something like "network-pair-id" of currency name and network id, but they are joined with unorganized manner, i.e. for TRON network, the network name is in the begging `trc20usdt`. moreover, for other coins, this field has very unorganized value
 "fullName": "Ethereum", // in many cases, this field value is just empty
 "baseChain": "ETH",  // this and below key are present only in part of currency response, but are missing from others
 "baseChainProtocol": "ERC20", // as above line says
 "displayName": "ERC20", // this seems existent everywhere and most good one
```
also, our unified definition of `networksById` or generally, network-codes and ids , are meant to be common names, i.e. it's acceptable that `ETH` was  network id, or `Ethereum`, or something, but it's inappropriate that `usdterc20` was network id as it's not common and each coin would have it's 'network-id & network-code' pairs. So, instead of the raw `chain` field we take `displayName` which contain the common name of underlying blockchain(network).
However, as network-related endpoints except that you provide the value that is in  `chain` field, so, to link the network-codes to chain-ids, I've added a few helper methods to seamlessly make links with each other.

This PR might be some kind of urgent to issues like:  fix #15789 and for other upcoming network-related PR.s

below are working & tested responses from unified methods.