### PR TITLE
bitget fixes

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2084,13 +2084,23 @@ module.exports = class bitget extends Exchange {
 
     parseBalance (balance) {
         const result = { 'info': balance };
+        //
+        //     {
+        //       coinId: '1',
+        //       coinName: 'BTC',
+        //       available: '0.00099900',
+        //       frozen: '0.00000000',
+        //       lock: '0.00000000',
+        //       uTime: '1661595535000'
+        //     }
+        //
         for (let i = 0; i < balance.length; i++) {
             const entry = balance[i];
             const currencyId = this.safeString2 (entry, 'coinId', 'marginCoin');
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
             const frozen = this.safeString (entry, 'frozen');
-            const locked = this.safeString (entry, 'locked');
+            const locked = this.safeString (entry, 'lock');
             account['used'] = Precise.stringAdd (frozen, locked);
             account['free'] = this.safeString (entry, 'available');
             result[code] = account;

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2089,7 +2089,9 @@ module.exports = class bitget extends Exchange {
             const currencyId = this.safeString2 (entry, 'coinId', 'marginCoin');
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
-            account['used'] = this.safeString2 (entry, 'frozen', 'locked');
+            const frozen = this.safeString (entry, 'frozen');
+            const locked = this.safeString (entry, 'locked');
+            account['used'] = Precise.stringAdd (frozen, locked);
             account['free'] = this.safeString (entry, 'available');
             result[code] = account;
         }

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -673,6 +673,7 @@ module.exports = class bitget extends Exchange {
                     '40712': InsufficientFunds, // Insufficient margin
                     '40713': ExchangeError, // Cannot exceed the maximum transferable margin amount
                     '40714': ExchangeError, // No direct margin call is allowed
+                    '45110': InvalidOrder, // {"code":"45110","msg":"less than the minimum amount 5 USDT","requestTime":1669911118932,"data":null}
                     // spot
                     'invalid sign': AuthenticationError,
                     'invalid currency': BadSymbol, // invalid trading pair
@@ -2088,7 +2089,7 @@ module.exports = class bitget extends Exchange {
             const currencyId = this.safeString2 (entry, 'coinId', 'marginCoin');
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
-            account['used'] = this.safeString2 (entry, 'lock', 'locked');
+            account['used'] = this.safeString2 (entry, 'frozen', 'locked');
             account['free'] = this.safeString (entry, 'available');
             result[code] = account;
         }
@@ -2098,6 +2099,7 @@ module.exports = class bitget extends Exchange {
     parseOrderStatus (status) {
         const statuses = {
             'new': 'open',
+            'init': 'open',
             'full_fill': 'closed',
             'filled': 'closed',
         };


### PR DESCRIPTION
when I have spot order `fetchBalance` gives
`{"coinId":1,"coinName":"BTC","available":"0.00000611","frozen":"0.00289389","lock":"0.00000000","uTime":"1669914246000"},`

opened order status is `init`:
```
info: {
      accountId: '5988738802',
      symbol: 'AAVEBTC_SPBL',
      orderId: '982257028491038720',
      clientOrderId: 'CCXT#d81f48291cab4e29aa5c16',
      price: '0.003723000000',
      quantity: '0.777300000000',
      orderType: 'limit',
      side: 'buy',
      status: 'init',
      fillPrice: '0.000000000000',
      fillQuantity: '0.000000000000',
      fillTotalAmount: '0.000000000000',
      cTime: '1669914245722'
    },
```
