### PR TITLE
Bybit :: fix fetchPosition

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -5890,12 +5890,16 @@ module.exports = class bybit extends Exchange {
 
     async fetchUnifiedMarginPositions (symbols = undefined, params = {}) {
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols);
         const request = {};
         let type = undefined;
         if (Array.isArray (symbols)) {
-            throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array of symbols');
+            if (symbols.length > 1) {
+                throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
+            }
+        } else {
+            symbols = [ symbols ];
         }
+        symbols = this.marketSymbols (symbols);
         // market undefined
         [ type, params ] = this.handleMarketTypeAndParams ('fetchPositions', undefined, params);
         let subType = undefined;
@@ -6118,7 +6122,11 @@ module.exports = class bybit extends Exchange {
          * @returns {[object]} a list of [position structure]{@link https://docs.ccxt.com/en/latest/manual.html#position-structure}
          */
         if (Array.isArray (symbols)) {
-            throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array of symbols');
+            if (symbols.length > 1) {
+                throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
+            }
+        } else {
+            symbols = [ symbols ];
         }
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -5896,7 +5896,7 @@ module.exports = class bybit extends Exchange {
             if (symbols.length > 1) {
                 throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
             }
-        } else {
+        } else if (symbols !== undefined) {
             symbols = [ symbols ];
         }
         symbols = this.marketSymbols (symbols);
@@ -5971,11 +5971,12 @@ module.exports = class bybit extends Exchange {
             }
             const symbol = this.safeString (symbols, 0);
             market = this.market (symbol);
-            type = market['type'];
             request['symbol'] = market['id'];
-        } else {
-            [ type, params ] = this.handleMarketTypeAndParams ('fetchUSDCPositions', undefined, params);
+        } else if (symbols !== undefined) {
+            market = this.market (symbols);
+            request['symbol'] = market['id'];
         }
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchUSDCPositions', market, params);
         request['category'] = (type === 'option') ? 'OPTION' : 'PERPETUAL';
         const response = await this.privatePostOptionUsdcOpenapiPrivateV1QueryPosition (this.extend (request, params));
         //
@@ -6125,7 +6126,7 @@ module.exports = class bybit extends Exchange {
             if (symbols.length > 1) {
                 throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
             }
-        } else {
+        } else if (symbols !== undefined) {
             symbols = [ symbols ];
         }
         await this.loadMarkets ();

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -6036,6 +6036,13 @@ module.exports = class bybit extends Exchange {
 
     async fetchDerivativesPositions (symbols = undefined, params = {}) {
         await this.loadMarkets ();
+        if (Array.isArray (symbols)) {
+            if (symbols.length > 1) {
+                throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
+            }
+        } else if (symbols !== undefined) {
+            symbols = [ symbols ];
+        }
         symbols = this.marketSymbols (symbols);
         const request = {
             'dataFilter': 'valid',


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15927


```
 p bybit fetchPositions "BTC/USDT:USDT" --sandbox                
Python v3.10.8
CCXT v2.2.55
bybit.fetchPositions(BTC/USDT:USDT)
[{'collateral': None,
  'contractSize': 1.0,
  'contracts': 0.1,
  'datetime': None,
  'entryPrice': 16505.0,
  'id': None,
  'info': {'createdTime': '1668507933974',
           'cumRealisedPnl': '-223.65394754',
           'entryPrice': '16505.00000000',
           'leverage': '2',
           'markPrice': '16959.21000000',
           'positionIM': '826.73545000',
           'positionIdx': '0',
           'positionMM': '9.73795000',
           'positionValue': '1650.50000000',
           'riskId': '1',
           'side': 'Sell',
           'size': '-0.1000',
           'stopLoss': '',
           'symbol': 'BTCUSDT',
           'takeProfit': '',
           'tpslMode': 'Full',
           'trailingStop': '',
           'unrealisedPnl': '-45.42100000',
           'updatedTime': '1669968000123'},
  'initialMargin': 826.73545,
  'initialMarginPercentage': 0.5009,
  'leverage': 2.0,
  'liquidationPrice': None,
  'maintenanceMargin': 9.73795,
  'maintenanceMarginPercentage': 0.0059,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': 16959.21,
  'notional': 1650.5,
  'percentage': -5.49401867308339,
  'side': 'short',
  'symbol': 'BTC/USDT:USDT',
  'timestamp': None,
  'unrealizedPnl': -45.421}]
```
```
p bybit fetchPositions '["BTC/USDT:USDT"]' --sandbox  
Python v3.10.8
CCXT v2.2.55
bybit.fetchPositions(['BTC/USDT:USDT'])
[{'collateral': None,
  'contractSize': 1.0,
  'contracts': 0.1,
  'datetime': None,
  'entryPrice': 16505.0,
  'id': None,
  'info': {'createdTime': '1668507933974',
           'cumRealisedPnl': '-223.65394754',
           'entryPrice': '16505.00000000',
           'leverage': '2',
           'markPrice': '16961.52000000',
           'positionIM': '826.73545000',
           'positionIdx': '0',
           'positionMM': '9.73795000',
           'positionValue': '1650.50000000',
           'riskId': '1',
           'side': 'Sell',
           'size': '-0.1000',
           'stopLoss': '',
           'symbol': 'BTCUSDT',
           'takeProfit': '',
           'tpslMode': 'Full',
           'trailingStop': '',
           'unrealisedPnl': '-45.63000000',
           'updatedTime': '1669968000123'},
  'initialMargin': 826.73545,
  'initialMarginPercentage': 0.5009,
  'leverage': 2.0,
  'liquidationPrice': None,
  'maintenanceMargin': 9.73795,
  'maintenanceMarginPercentage': 0.0059,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': 16961.52,
  'notional': 1650.5,
  'percentage': -5.519298827696333,
  'side': 'short',
  'symbol': 'BTC/USDT:USDT',
  'timestamp': None,
  'unrealizedPnl': -45.63}]
```