### PR TITLE
Bybit :: add spot balance

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2885,12 +2885,37 @@ module.exports = class bybit extends Exchange {
         //             "serviceCash": "0"
         //         }
         //     ]
+        // spot
+        //     {
+        //       retCode: '0',
+        //       retMsg: 'OK',
+        //       result: {
+        //         balances: [
+        //           {
+        //             coin: 'BTC',
+        //             coinId: 'BTC',
+        //             total: '0.00977041118',
+        //             free: '0.00877041118',
+        //             locked: '0.001'
+        //           },
+        //           {
+        //             coin: 'EOS',
+        //             coinId: 'EOS',
+        //             total: '2000',
+        //             free: '2000',
+        //             locked: '0'
+        //           }
+        //         ]
+        //       },
+        //       retExtInfo: {},
+        //       time: '1670002625754'
+        //  }
         //
         const result = {
             'info': response,
         };
         const responseResult = this.safeValue (response, 'result', {});
-        const currencyList = this.safeValueN (responseResult, [ 'loanAccountList', 'list', 'coin' ]);
+        const currencyList = this.safeValueN (responseResult, [ 'loanAccountList', 'list', 'coin', 'balances' ]);
         if (currencyList === undefined) {
             // usdc wallet
             const code = 'USDC';
@@ -2920,10 +2945,39 @@ module.exports = class bybit extends Exchange {
 
     async fetchSpotBalance (params = {}) {
         await this.loadMarkets ();
-        // here the margin account is the same as the spot account
-        // so we will default to loading the margin account
-        const response = await this.privateGetSpotV3PrivateCrossMarginAccount (params);
-        //
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBalance', params);
+        let method = 'privateGetSpotV3PrivateAccount';
+        if (marginMode !== undefined) {
+            method = 'privateGetSpotV3PrivateCrossMarginAccount';
+        }
+        const response = await this[method] (params);
+        // spot wallet
+        //     {
+        //       retCode: '0',
+        //       retMsg: 'OK',
+        //       result: {
+        //         balances: [
+        //           {
+        //             coin: 'BTC',
+        //             coinId: 'BTC',
+        //             total: '0.00977041118',
+        //             free: '0.00877041118',
+        //             locked: '0.001'
+        //           },
+        //           {
+        //             coin: 'EOS',
+        //             coinId: 'EOS',
+        //             total: '2000',
+        //             free: '2000',
+        //             locked: '0'
+        //           }
+        //         ]
+        //       },
+        //       retExtInfo: {},
+        //       time: '1670002625754'
+        //     }
+        // cross
         //     {
         //         "retCode": 0,
         //         "retMsg": "success",


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/15926


```
p bybit fetchBalance --spot --sandbox
Python v3.10.8
CCXT v2.2.56
bybit.fetchBalance()
{'BTC': {'free': 0.00877041118, 'total': 0.00977041118, 'used': 0.001},
 'EOS': {'free': 2000.0, 'total': 2000.0, 'used': 0.0},
 'ETH': {'free': 0.07825167, 'total': 0.07825167, 'used': 0.0},
 'LTC': {'free': 0.699981, 'total': 0.699981, 'used': 0.0},
 'USDC': {'free': 45000.0, 'total': 45000.0, 'used': 0.0},
 'USDT': {'free': 29677.72202312754, 'total': 29677.72202312754, 'used': 0.0},
 'XRP': {'free': 10000.0, 'total': 10000.0, 'used': 0.0},
 'free': {'BTC': 0.00877041118,
          'EOS': 2000.0,
          'ETH': 0.07825167,
          'LTC': 0.699981,
          'USDC': 45000.0,
          'USDT': 29677.72202312754,
          'XRP': 10000.0},
 'info': {'result': {'balances': [{'coin': 'BTC',
                                   'coinId': 'BTC',
                                   'free': '0.00877041118',
                                   'locked': '0.001',
                                   'total': '0.00977041118'},
                                  {'coin': 'EOS',
                                   'coinId': 'EOS',
                                   'free': '2000',
                                   'locked': '0',
                                   'total': '2000'},
                                  {'coin': 'ETH',
                                   'coinId': 'ETH',
                                   'free': '0.07825167',
                                   'locked': '0',
                                   'total': '0.07825167'},
                                  {'coin': 'LTC',
                                   'coinId': 'LTC',
                                   'free': '0.699981',
                                   'locked': '0',
                                   'total': '0.699981'},
                                  {'coin': 'USDC',
                                   'coinId': 'USDC',
                                   'free': '45000',
                                   'locked': '0',
                                   'total': '45000'},
                                  {'coin': 'USDT',
                                   'coinId': 'USDT',
                                   'free': '29677.72202312754',
                                   'locked': '0',
                                   'total': '29677.72202312754'},
                                  {'coin': 'XRP',
                                   'coinId': 'XRP',
                                   'free': '10000',
                                   'locked': '0',
                                   'total': '10000'}]},
          'retCode': '0',
          'retExtInfo': {},
          'retMsg': 'OK',
          'time': '1670002884983'},
 'total': {'BTC': 0.00977041118,
           'EOS': 2000.0,
           'ETH': 0.07825167,
           'LTC': 0.699981,
           'USDC': 45000.0,
           'USDT': 29677.72202312754,
           'XRP': 10000.0},
 'used': {'BTC': 0.001,
          'EOS': 0.0,
          'ETH': 0.0,
          'LTC': 0.0,
          'USDC': 0.0,
          'USDT': 0.0,
          'XRP': 0.0}}
```