### PR TITLE
Ascendex: fetchTrades, adjust side response

### DIFF
--- a/js/ascendex.js
+++ b/js/ascendex.js
@@ -1140,8 +1140,7 @@ module.exports = class ascendex extends Exchange {
         const priceString = this.safeString2 (trade, 'price', 'p');
         const amountString = this.safeString (trade, 'q');
         const buyerIsMaker = this.safeValue (trade, 'bm', false);
-        const makerOrTaker = buyerIsMaker ? 'maker' : 'taker';
-        const side = buyerIsMaker ? 'buy' : 'sell';
+        const side = buyerIsMaker ? 'sell' : 'buy';
         market = this.safeMarket (undefined, market);
         return this.safeTrade ({
             'info': trade,
@@ -1151,7 +1150,7 @@ module.exports = class ascendex extends Exchange {
             'id': undefined,
             'order': undefined,
             'type': undefined,
-            'takerOrMaker': makerOrTaker,
+            'takerOrMaker': undefined,
             'side': side,
             'price': priceString,
             'amount': amountString,
@@ -1165,6 +1164,7 @@ module.exports = class ascendex extends Exchange {
          * @method
          * @name ascendex#fetchTrades
          * @description get the list of most recent trades for a particular symbol
+         * @see https://ascendex.github.io/ascendex-pro-api/#market-trades
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int|undefined} since timestamp in ms of the earliest trade to fetch
          * @param {int|undefined} limit the maximum amount of trades to fetch


### PR DESCRIPTION
Changed the `side` response in parseTrade after testing filling some orders on Ascendex. Set the `takerOrMaker` field to undefined.

fixes: #15892
```
node examples/js/cli ascendex fetchTrades QNT/USDT

    timestamp |                 datetime |   symbol | id | order | type | takerOrMaker | side |  price | amount |     cost | fee | fees
---------------------------------------------------------------------------------------------------------------------------------------
1669905965841 | 2022-12-01T14:46:05.841Z | QNT/USDT |    |       |      |              | sell | 122.16 |  0.646 | 78.91536 |     |   []
1669906005843 | 2022-12-01T14:46:45.843Z | QNT/USDT |    |       |      |              | sell | 117.42 |    0.1 |   11.742 |     |   []
1669906011843 | 2022-12-01T14:46:51.843Z | QNT/USDT |    |       |      |              |  buy | 122.18 |      5 |    610.9 |     |   []
1669906065843 | 2022-12-01T14:47:45.843Z | QNT/USDT |    |       |      |              | sell | 124.59 |   0.75 |  93.4425 |     |   []
1669906142842 | 2022-12-01T14:49:02.842Z | QNT/USDT |    |       |      |              |  buy | 117.56 |   0.15 |   17.634 |     |   []
1670022077558 | 2022-12-02T23:01:17.558Z | QNT/USDT |    |       |      |              |  buy |    150 |   0.06 |        9 |     |   []
1670022123153 | 2022-12-02T23:02:03.153Z | QNT/USDT |    |       |      |              | sell | 118.02 |   0.06 |   7.0812 |     |   []
1670022200028 | 2022-12-02T23:03:20.028Z | QNT/USDT |    |       |      |              |  buy |    150 |  0.008 |      1.2 |     |   []
1670022200028 | 2022-12-02T23:03:20.028Z | QNT/USDT |    |       |      |              |  buy | 188.67 |   0.06 |  11.3202 |     |   []
1670022213519 | 2022-12-02T23:03:33.519Z | QNT/USDT |    |       |      |              | sell | 118.02 |  0.068 |  8.02536 |     |   []
10 objects
```