### PR TITLE
Cex :: fix handleOrderUpdate crash

### DIFF
--- a/js/pro/cex.js
+++ b/js/pro/cex.js
@@ -673,6 +673,10 @@ module.exports = class cex extends cexRest {
         const symbol = base + '/' + quote;
         const market = this.safeMarket (symbol);
         remains = this.currencyFromPrecision (base, remains);
+        if (this.orders === undefined) {
+            const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
+            this.orders = new ArrayCacheBySymbolById (limit);
+        }
         const ordersBySymbol = this.safeValue (this.orders['hashmap'], symbol, {});
         let order = this.safeValue (ordersBySymbol, orderId);
         if (order === undefined) {
@@ -854,7 +858,9 @@ module.exports = class cex extends cexRest {
         }
         this.orders = myOrders;
         const messageHash = 'orders:' + symbol;
-        client.resolve (myOrders, messageHash);
+        if (myOrders.length > 0) {
+            client.resolve (myOrders, messageHash);
+        }
     }
 
     async watchOrderBook (symbol, limit = undefined, params = {}) {


### PR DESCRIPTION

```
cex.watchOrders (LTC/USDT)
         id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |   symbol | type | timeInForce | postOnly | side |  price | stopPrice | average |          cost |    amount |    filled | remaining |                                 fee | trades |                                  fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
62335875433 |               | 1670253531852 | 2022-12-05T15:18:51.852Z |                    | closed | LTC/USDT |      |             |          |  buy | 85.379 |           |  85.379 | 14.9625929089 | 0.1752491 | 0.1752491 |         0 | {"cost":0.037407,"currency":"USDT"} |     [] | [{"cost":0.037407,"currency":"USDT"}]
```
