### PR TITLE
Bitmart :: margin and signature fix

### DIFF
--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -102,6 +102,7 @@ module.exports = class bitmart extends Exchange {
             'requiredCredentials': {
                 'apiKey': true,
                 'secret': true,
+                'uid': true,
             },
             'api': {
                 'public': {
@@ -3034,10 +3035,9 @@ module.exports = class bitmart extends Exchange {
                 body = this.json (query);
                 queryString = body;
             }
-            // The request header of X-BM-SIGN is obtained by encrypting the timestamp + "#" + memo + "#" + queryString
-            // memo is ignored by bitmart so we send "CCXT" here
-            const auth = timestamp + '#CCXT#' + queryString;
-            headers['X-BM-SIGN'] = this.hmac (this.encode (auth), this.encode (this.secret));
+            const auth = timestamp + '#' + this.uid + '#' + queryString;
+            const signature = this.hmac (this.encode (auth), this.encode (this.secret));
+            headers['X-BM-SIGN'] = signature;
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }

--- a/js/bitmart.js
+++ b/js/bitmart.js
@@ -2996,7 +2996,6 @@ module.exports = class bitmart extends Exchange {
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[string|undefined, object]} the marginMode in lowercase
          */
-        defaultValue = (defaultValue === undefined) ? 'isolated' : defaultValue;
         let marginMode = undefined;
         [ marginMode, params ] = super.handleMarginModeAndParams (methodName, params, defaultValue);
         if (marginMode !== undefined) {


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/15964
```
n bitmart createOrder "LTC/USDT" "market" "buy" 0.2 25          
Debugger listening on ws://127.0.0.1:60091/15a35dea-2dc9-4ec6-a987-0a68e9a99262
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2022-12-05T17:47:48.044Z
Node.js: v17.9.0
CCXT v2.2.69
bitmart.createOrder (LTC/USDT, market, buy, 0.2, 25)
2022-12-05T17:47:53.347Z iteration 0 passed in 2876 ms

{
  id: '74498900697603682',
  clientOrderId: undefined,
  info: { order_id: '74498900697603682' },
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'LTC/USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 25,
  stopPrice: undefined,
  amount: 0.2,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2022-12-05T17:47:53.347Z iteration 1 passed in 2876 ms

Waiting for the debugger to disconnect...
```