### PR TITLE
bybit: set networkId to uppercase

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -5775,7 +5775,7 @@ module.exports = class bybit extends Exchange {
         const [ networkCode, query ] = this.handleNetworkCodeAndParams (params);
         const networkId = this.networkCodeToId (networkCode);
         if (networkId !== undefined) {
-            request['chain'] = networkId;
+            request['chain'] = networkId.toUpperCase ();
         }
         const response = await this.privatePostAssetV3PrivateWithdrawCreate (this.extend (request, query));
         //


### PR DESCRIPTION
The network id in withdrawal should be uppercase, see ccxt/ccxt#15967