### PR TITLE
Inverted baseVolume and quoteVolume in fetchTicker

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1093,8 +1093,8 @@ module.exports = class digifinex extends Exchange {
             'change': undefined,
             'percentage': this.safeString2 (ticker, 'change', 'price_change_percent'),
             'average': undefined,
-            'baseVolume': this.safeString (ticker, 'base_vol'),
-            'quoteVolume': this.safeString2 (ticker, 'vol', 'volume_24h'),
+            'baseVolume': this.safeString (ticker, 'vol', 'volume_24h'),
+            'quoteVolume': this.safeString2 (ticker, 'base_vol'),
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
The fetchTicker method for ccxt.digifinex client the base and quote volume are inverted: { "symbol": "BTC/USDT", "timestamp": 1670317245000, "datetime": "2022-12-06T09:00:45.000Z", "high": 17356.85, "low": 16871.91, "bid": 17034.7, "ask": 17034.79, "vwap": 0.000058533906817033, "close": 17032.84, "last": 17032.84, "percentage": -1.86, "baseVolume": 118289294.0687, "quoteVolume": 6923.93451647, "info": { "date": 1670317245, "vol": "6923.93451647", "change": "-1.86", "base_vol": "118289294.0687", "sell": "17034.79", "last": "17032.84", "symbol": "btc_usdt", "low": "16871.91", "buy": "17034.7", "high": "17356.85" } }

Those are the ticker volume for BTC:
"baseVolume": 118289294.0687
"quoteVolume": 6923.9345164

I've inverted the values in the right order