### PR TITLE
Digifinex :: fix parseTicker

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1093,8 +1093,8 @@ module.exports = class digifinex extends Exchange {
             'change': undefined,
             'percentage': this.safeString2 (ticker, 'change', 'price_change_percent'),
             'average': undefined,
-            'baseVolume': this.safeString (ticker, 'base_vol'),
-            'quoteVolume': this.safeString2 (ticker, 'vol', 'volume_24h'),
+            'baseVolume': this.safeString (ticker, 'vol', 'volume_24h'),
+            'quoteVolume': this.safeString2 (ticker, 'base_vol'),
             'info': ticker,
         }, market);
     }

--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -1093,8 +1093,8 @@ module.exports = class digifinex extends Exchange {
             'change': undefined,
             'percentage': this.safeString2 (ticker, 'change', 'price_change_percent'),
             'average': undefined,
-            'baseVolume': this.safeString (ticker, 'vol', 'volume_24h'),
-            'quoteVolume': this.safeString2 (ticker, 'base_vol'),
+            'baseVolume': this.safeString2 (ticker, 'vol', 'volume_24h'),
+            'quoteVolume': this.safeString (ticker, 'base_vol'),
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/pull/15983
- fixes https://github.com/ccxt/ccxt/issues/15981
 

```
p digifinex fetchTicker "BTC/USDT"
Python v3.9.7
CCXT v2.2.73
digifinex.fetchTicker(BTC/USDT)
{'ask': 16821.7,
 'askVolume': None,
 'average': None,
 'baseVolume': 8803.70899524,
 'bid': 16817.27,
 'bidVolume': None,
 'change': None,
 'close': 16820.81,
 'datetime': '2022-12-07T10:11:49.000Z',
 'high': 17132.95,
 'info': {'base_vol': '149358831.21298',
          'buy': '16817.27',
          'change': '-0.93',
          'date': 1670407909,
          'high': '17132.95',
          'last': '16820.81',
          'low': '16713.83',
          'sell': '16821.7',
          'symbol': 'btc_usdt',
          'vol': '8803.70899524'},
 'last': 16820.81,
 'low': 16713.83,
 'open': None,
 'percentage': -0.93,
 'previousClose': None,
 'quoteVolume': 149358831.21298,
 'symbol': 'BTC/USDT',
 'timestamp': 1670407909000,
 'vwap': 16965.443916164826}
```