### PR TITLE
Binance :: fix precision type

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1469,7 +1469,7 @@ module.exports = class binance extends Exchange {
             const active = (isWithdrawEnabled && isDepositEnabled && trading);
             let maxDecimalPlaces = undefined;
             if (minPrecision !== undefined) {
-                maxDecimalPlaces = this.parseNumber (this.numberToString (this.precisionFromString (minPrecision)));
+                maxDecimalPlaces = parseInt (this.numberToString (this.precisionFromString (minPrecision)));
             }
             result[code] = {
                 'id': id,


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16000

```
 p binance transfer USDT 2 future spot
Python v3.9.7
CCXT v2.2.79
binance.transfer(USDT,2,future,spot)
{'amount': 2,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': 'future',
 'id': '124000655296',
 'info': {'tranId': '124000655296'},
 'status': None,
 'timestamp': None,
 'toAccount': 'spot'}
```
