### PR TITLE
Binance :: fix parseBorrowRateHistory call

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -6220,7 +6220,7 @@ module.exports = class binance extends Exchange {
         //         },
         //     ]
         //
-        return this.parseBorrowRateHistory (response);
+        return this.parseBorrowRateHistory (response, code, since, limit);
     }
 
     parseBorrowRateHistory (response, code, since, limit) {


### PR DESCRIPTION
```
p binance fetchBorrowRateHistory "USDT" None 2
Python v3.9.7
CCXT v2.2.79
binance.fetchBorrowRateHistory(USDT,None,2)
[{'currency': 'USDT',
  'datetime': '2022-11-30T00:00:00.000Z',
  'info': {'asset': 'USDT',
           'dailyInterestRate': '0.0001164',
           'timestamp': '1669766400000',
           'vipLevel': '0'},
  'period': 86400000,
  'rate': 0.0001164,
  'timestamp': 1669766400000},
 {'currency': 'USDT',
  'datetime': '2022-12-01T00:00:00.000Z',
  'info': {'asset': 'USDT',
           'dailyInterestRate': '0.0001164',
           'timestamp': '1669852800000',
           'vipLevel': '0'},
  'period': 86400000,
  'rate': 0.0001164,
  'timestamp': 1669852800000}]
```