### PR TITLE
Bybit :: fix spot trades

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2310,8 +2310,8 @@ module.exports = class bybit extends Exchange {
             // if private response
             const isBuyer = this.safeInteger (trade, 'isBuyer');
             const isMaker = this.safeInteger (trade, 'isMaker');
-            takerOrMaker = (isMaker === 1) ? 'maker' : 'taker';
-            side = (isBuyer === 1) ? 'buy' : 'sell';
+            takerOrMaker = (isMaker === 0) ? 'maker' : 'taker';
+            side = (isBuyer === 0) ? 'buy' : 'sell';
         }
         const marketId = this.safeString (trade, 'symbol');
         market = this.safeMarket (marketId, market);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16017

```
..
(base) ➜  ccxt git:(bybit-trades-fix) ✗ p bybit fetchMyTrades "LTC/USDT"  --sandbox --spot
Python v3.9.7
CCXT v2.2.89
bybit.fetchMyTrades(LTC/USDT)
[{'amount': 0.15873,
  'cost': 9.99999,
  'datetime': '2022-12-08T20:35:28.647Z',
  'fee': {'cost': 4.7619e-06, 'currency': 'LTC'},
  'fees': [{'cost': 4.7619e-06, 'currency': 'LTC'}],
  'id': '1306909295796958464',
  'info': {'creatTime': '1670531728647',
           'execFee': '0.0000047619',
           'executionTime': '1670531728659',
           'feeTokenId': 'LTC',
           'id': '1306909295796958464',
           'isBuyer': '0',
           'isMaker': '1',
           'makerRebate': '0',
           'matchOrderId': '1306280791271024640',
           'orderId': '1306909295637456640',
           'orderPrice': '63',
           'orderQty': '0.15873',
           'symbol': 'LTCUSDT',
           'tradeId': '2120000000001845127'},
  'order': '1306909295637456640',
  'price': 63.0,
  'side': 'buy',
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1670531728647,
  'type': None}]
```