### PR TITLE
Fix memory leaks in stream(...) function in \ccxt\pro\binance

### DIFF
--- a/php/pro/binance.php
+++ b/php/pro/binance.php
@@ -102,7 +102,7 @@ class binance extends \ccxt\async\binance {
             }
             $this->options['streamIndex'] = $streamIndex;
             $stream = $this->number_to_string($streamIndex);
-            $streamBySubscriptionsHash[$subscriptionHash] = $stream;
+            $this->options['streamBySubscriptionsHash'][$subscriptionHash] = $stream;
         }
         return $stream;
     }


### PR DESCRIPTION
Fix memory leaks in stream(...) function in \ccxt\pro\binance for all watch_xxx(...) functions.

Issue: Out of memory in ccxt/pro/binance #15991