### PR TITLE
Bkex: fetchTicker, fetchTickers, add swap support

### DIFF
--- a/js/bkex.js
+++ b/js/bkex.js
@@ -614,6 +614,8 @@ module.exports = class bkex extends Exchange {
          * @method
          * @name bkex#fetchTicker
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
+         * @see https://bkexapi.github.io/docs/api_en.htm?shell#quotationData-2
+         * @see https://bkexapi.github.io/docs/api_en.htm?shell#contract-ticker-data
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} params extra parameters specific to the bkex api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
@@ -623,28 +625,54 @@ module.exports = class bkex extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const response = await this.publicSpotGetQTickers (this.extend (request, params));
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
+        const method = (marketType === 'swap') ? 'publicSwapGetMarketTickers' : 'publicSpotGetQTickers';
+        const response = await this[method] (this.extend (request, query));
         //
-        // {
-        //     "code": "0",
-        //     "data": [
-        //       {
-        //         "change": "6.52",
-        //         "close": "43573.470000",
-        //         "high": "44940.540000",
-        //         "low": "40799.840000",
-        //         "open": "40905.780000",
-        //         "quoteVolume": "225621691.5991",
-        //         "symbol": "BTC_USDT",
-        //         "ts": "1646156490781",
-        //         "volume": 5210.349
-        //       }
-        //     ],
-        //     "msg": "success",
-        //     "status": 0
-        // }
+        // spot
         //
-        const tickers = this.safeValue (response, 'data');
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             {
+        //                 "change": "6.52",
+        //                 "close": "43573.470000",
+        //                 "high": "44940.540000",
+        //                 "low": "40799.840000",
+        //                 "open": "40905.780000",
+        //                 "quoteVolume": "225621691.5991",
+        //                 "symbol": "BTC_USDT",
+        //                 "ts": "1646156490781",
+        //                 "volume": 5210.349
+        //             }
+        //         ],
+        //         "msg": "success",
+        //         "status": 0
+        //     }
+        //
+        // swap
+        //
+        //     {
+        //         "code": 0,
+        //         "msg": "success",
+        //         "data": [
+        //             {
+        //                 "symbol": "btc_usdt",
+        //                 "amount": "171035.45",
+        //                 "volume": "2934757466.3859",
+        //                 "open": "17111.43",
+        //                 "close": "17135.74",
+        //                 "high": "17225.99",
+        //                 "low": "17105.77",
+        //                 "lastPrice": "17135.74",
+        //                 "lastAmount": "1.05",
+        //                 "lastTime": 1670709364912,
+        //                 "change": "0.14"
+        //             }
+        //         ]
+        //     }
+        //
+        const tickers = this.safeValue (response, 'data', []);
         const ticker = this.safeValue (tickers, 0);
         return this.parseTicker (ticker, market);
     }
@@ -654,6 +682,8 @@ module.exports = class bkex extends Exchange {
          * @method
          * @name bkex#fetchTickers
          * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
+         * @see https://bkexapi.github.io/docs/api_en.htm?shell#quotationData-2
+         * @see https://bkexapi.github.io/docs/api_en.htm?shell#contract-ticker-data
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the bkex api endpoint
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
@@ -662,19 +692,80 @@ module.exports = class bkex extends Exchange {
         const request = {};
         if (symbols !== undefined) {
             if (!Array.isArray (symbols)) {
-                throw new BadRequest (this.id + ' fetchTickers () symbols argument should be an array');
+                throw new BadRequest (this.id + ' fetchTickers() symbols argument should be an array');
             }
         }
+        let market = undefined;
         if (symbols !== undefined) {
             const marketIds = this.marketIds (symbols);
-            request['symbol'] = marketIds.join (',');
+            const symbol = this.safeString (symbols, 0);
+            market = this.market (symbol);
+            if (market['swap']) {
+                if (Array.isArray (symbols)) {
+                    const symbolsLength = symbols.length;
+                    if (symbolsLength > 1) {
+                        throw new BadRequest (this.id + ' fetchTickers() symbols argument cannot contain more than 1 symbol for swap markets');
+                    }
+                }
+                request['symbol'] = market['id'];
+            } else {
+                request['symbol'] = marketIds.join (',');
+            }
         }
-        const response = await this.publicSpotGetQTickers (this.extend (request, params));
-        const tickers = this.safeValue (response, 'data');
-        return this.parseTickers (tickers, symbols, params);
+        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        const method = (marketType === 'swap') ? 'publicSwapGetMarketTickers' : 'publicSpotGetQTickers';
+        const response = await this[method] (this.extend (request, query));
+        //
+        // spot
+        //
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             {
+        //                 "change": "6.52",
+        //                 "close": "43573.470000",
+        //                 "high": "44940.540000",
+        //                 "low": "40799.840000",
+        //                 "open": "40905.780000",
+        //                 "quoteVolume": "225621691.5991",
+        //                 "symbol": "BTC_USDT",
+        //                 "ts": "1646156490781",
+        //                 "volume": 5210.349
+        //             }
+        //         ],
+        //         "msg": "success",
+        //         "status": 0
+        //     }
+        //
+        // swap
+        //
+        //     {
+        //         "code": 0,
+        //         "msg": "success",
+        //         "data": [
+        //             {
+        //                 "symbol": "btc_usdt",
+        //                 "amount": "171035.45",
+        //                 "volume": "2934757466.3859",
+        //                 "open": "17111.43",
+        //                 "close": "17135.74",
+        //                 "high": "17225.99",
+        //                 "low": "17105.77",
+        //                 "lastPrice": "17135.74",
+        //                 "lastAmount": "1.05",
+        //                 "lastTime": 1670709364912,
+        //                 "change": "0.14"
+        //             }
+        //         ]
+        //     }
+        //
+        const tickers = this.safeValue (response, 'data', []);
+        return this.parseTickers (tickers, symbols, query);
     }
 
     parseTicker (ticker, market = undefined) {
+        //
+        // spot
         //
         //    {
         //          "change":-0.46,
@@ -688,10 +779,29 @@ module.exports = class bkex extends Exchange {
         //          "volume":23684.9416
         //    }
         //
+        // swap
+        //
+        //     {
+        //         "symbol": "btc_usdt",
+        //         "amount": "171035.45",
+        //         "volume": "2934757466.3859",
+        //         "open": "17111.43",
+        //         "close": "17135.74",
+        //         "high": "17225.99",
+        //         "low": "17105.77",
+        //         "lastPrice": "17135.74",
+        //         "lastAmount": "1.05",
+        //         "lastTime": 1670709364912,
+        //         "change": "0.14"
+        //     }
+        //
         const marketId = this.safeString (ticker, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
-        const timestamp = this.safeInteger (ticker, 'ts');
-        const last = this.safeString (ticker, 'close');
+        market = this.market (symbol);
+        const timestamp = this.safeInteger2 (ticker, 'ts', 'lastTime');
+        const baseCurrencyVolume = market['swap'] ? 'amount' : 'volume';
+        const quoteCurrencyVolume = market['swap'] ? 'volume' : 'quoteVolume';
+        const lastPrice = market['swap'] ? 'lastPrice' : 'close';
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
@@ -704,14 +814,14 @@ module.exports = class bkex extends Exchange {
             'askVolume': undefined,
             'vwap': undefined,
             'open': this.safeString (ticker, 'open'),
-            'close': last,
-            'last': last,
+            'close': this.safeString (ticker, 'close'),
+            'last': this.safeString (ticker, lastPrice),
             'previousClose': undefined,
             'change': undefined,
             'percentage': this.safeString (ticker, 'change'), // 24h percentage change (close - open) / open * 100
             'average': undefined,
-            'baseVolume': this.safeString (ticker, 'volume'),
-            'quoteVolume': this.safeString (ticker, 'quoteVolume'),
+            'baseVolume': this.safeString (ticker, baseCurrencyVolume),
+            'quoteVolume': this.safeString (ticker, quoteCurrencyVolume),
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
Added swap support to fetchTicker and fetchTickers:
### fetchTicker:
```
node examples/js/cli bkex fetchTicker BTC/USDT:USDT

{
  symbol: 'BTC/USDT:USDT',
  timestamp: 1670821904957,
  datetime: '2022-12-12T05:11:44.957Z',
  high: 17269.87,
  low: 16872.09,
  bid: undefined,
  bidVolume: undefined,
  ask: undefined,
  askVolume: undefined,
  vwap: 17080.9141966609,
  open: 17157.78,
  close: 16927.12,
  last: 16927.12,
  previousClose: undefined,
  change: -230.66,
  percentage: -1.34,
  average: 17042.45,
  baseVolume: 247821.81,
  quoteVolume: 4233023072.6712,
  info: {
    symbol: 'btc_usdt',
    amount: '247821.81',
    volume: '4233023072.6712',
    open: '17157.78',
    close: '16927.12',
    high: '17269.87',
    low: '16872.09',
    lastPrice: '16927.12',
    lastAmount: '1.06',
    lastTime: '1670821904957',
    change: '-1.34'
  }
}
```

### fetchTickers:
```
node examples/js/cli bkex fetchTickers '["BTC/USDT:USDT"]'

{
  'BTC/USDT:USDT': {
    symbol: 'BTC/USDT:USDT',
    timestamp: 1670821892866,
    datetime: '2022-12-12T05:11:32.866Z',
    high: 17269.87,
    low: 16872.09,
    bid: undefined,
    bidVolume: undefined,
    ask: undefined,
    askVolume: undefined,
    vwap: 17080.93537855592,
    open: 17157.78,
    close: 16925.19,
    last: 16925.19,
    previousClose: undefined,
    change: -232.59,
    percentage: -1.35,
    average: 17041.485,
    baseVolume: 247787.83,
    quoteVolume: 4232447911.8226,
    info: {
      symbol: 'btc_usdt',
      amount: '247787.83',
      volume: '4232447911.8226',
      open: '17157.78',
      close: '16925.19',
      high: '17269.87',
      low: '16872.09',
      lastPrice: '16925.19',
      lastAmount: '0.01',
      lastTime: '1670821892866',
      change: '-1.35'
    }
  }
}
```