### PR TITLE
exmo fetchMarkets active key set to undefined instead of true

### DIFF
--- a/js/exmo.js
+++ b/js/exmo.js
@@ -663,7 +663,7 @@ module.exports = class exmo extends Exchange {
                 'swap': false,
                 'future': false,
                 'option': false,
-                'active': true,
+                'active': undefined,
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,


### PR DESCRIPTION
```
2022-12-12T21:59:02.160Z
Node.js: v18.4.0
CCXT v2.2.98
exmo.fetchMarkets ()
2022-12-12T21:59:06.482Z iteration 0 passed in 837 ms
         id |      symbol |      base | quote | settle | baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | taker | maker | contractSize | expiry | expiryDatetime | strike | optionType |                        precision |          limits
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   BTC_USDT |    BTC/USDT |       BTC |  USDT |        |    BTC |    USDT |          | spot | true |   true | false |  false |  false |        |    false |        |         | 0.001 | 0.001 |              |        |                |        |            |     {"amount":1e-8,"price":0.01} | [object Object]
...
   LYO_USDT |    LYO/USDT |       LYO |  USDT |        |    LYO |    USDT |          | spot | true |   true | false |  false |  false |        |    false |        |         | 0.001 | 0.001 |              |        |                |        |            |     {"amount":1e-8,"price":1e-8} | [object Object]
194 objects
2022-12-12T21:59:06.482Z iteration 1 passed in 837 ms
```