### PR TITLE
base: add 407 error in php and python

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1252,6 +1252,7 @@ class Exchange {
             '408' => 'RequestTimeout',
             '504' => 'RequestTimeout',
             '401' => 'AuthenticationError',
+            '407' => 'AuthenticationError',
             '511' => 'AuthenticationError',
         );
         $this->verbose = false;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -204,6 +204,7 @@ class Exchange(object):
         '408': RequestTimeout,
         '504': RequestTimeout,
         '401': AuthenticationError,
+        '407': AuthenticationError,
         '511': AuthenticationError,
     }
     headers = None


### PR DESCRIPTION
It seems the `contructor` or `init` function were not transcompiled (not sure about this), I added 407 in other base exchange files.