### PR TITLE
bugfix(websocket): fix websocket in browsers

### DIFF
--- a/js/pro/base/WsClient.js
+++ b/js/pro/base/WsClient.js
@@ -18,7 +18,11 @@ module.exports = class WsClient extends Client {
         }
         this.connectionStarted = milliseconds ()
         this.setConnectionTimeout ()
-        this.connection = new WebSocket (this.url, this.protocols, this.options)
+        if (isNode) {
+            this.connection = new WebSocket (this.url, this.protocols, this.options)
+        } else {
+            this.connection = new WebSocket (this.url, this.protocols)
+        }
 
         this.connection.onopen = this.onOpen.bind (this)
         this.connection.onmessage = this.onMessage.bind (this)


### PR DESCRIPTION
The Websocket constructor API is not the same between the browser and the `ws` package. 

`new WebSocket(url [, protocols]);`
vs
`new WebSocket(address[, protocols][, options])`

source :

[ws](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options)
[mdn](https://developer.mozilla.org/fr/docs/Web/API/WebSocket/WebSocket)

The call should be differentiated depending on the context. 

fixes ccxt/ccxt#16011