### PR TITLE
Okx: createReduceOnlyOrder

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -2064,6 +2064,10 @@ module.exports = class okx extends Exchange {
             // 'slTriggerPxType': 'last', // Conditional default is last, mark or index (conditional orders)
             // 'slOrdPx': 10, // Order price for Stop-Loss orders, if -1 will be executed at market price (conditional orders)
         };
+        const reduceOnly = this.safeValue (params, 'reduceOnly', false);
+        if (reduceOnly) {
+            request['reduceOnly'] = reduceOnly;
+        }
         const spot = market['spot'];
         const contract = market['contract'];
         const triggerPrice = this.safeValueN (params, [ 'triggerPrice', 'stopPrice', 'triggerPx' ]);
@@ -2097,7 +2101,7 @@ module.exports = class okx extends Exchange {
         }
         const isMarketOrder = type === 'market';
         const postOnly = this.isPostOnly (isMarketOrder, type === 'post_only', params);
-        params = this.omit (params, [ 'currency', 'ccy', 'marginMode', 'timeInForce', 'stopPrice', 'triggerPrice', 'clientOrderId', 'stopLossPrice', 'takeProfitPrice', 'slOrdPx', 'tpOrdPx', 'margin' ]);
+        params = this.omit (params, [ 'currency', 'ccy', 'marginMode', 'timeInForce', 'stopPrice', 'triggerPrice', 'clientOrderId', 'stopLossPrice', 'takeProfitPrice', 'slOrdPx', 'tpOrdPx', 'margin', 'reduceOnly' ]);
         const ioc = (timeInForce === 'IOC') || (type === 'ioc');
         const fok = (timeInForce === 'FOK') || (type === 'fok');
         const trigger = (triggerPrice !== undefined) || (type === 'trigger');


### PR DESCRIPTION
Added reduceOnly to createOrder:
fixes: #15931
```
node examples/js/cli okx createOrder XRP/USDT market buy 13.45411 undefined '{"marginMode":"cross","reduceOnly":true}'

{
  info: {
    clOrdId: 'e847386590ce4dBCfc4f254a5462b73a',
    ordId: '523756506652106757',
    sCode: '0',
    sMsg: 'Order successfully placed',
    tag: 'e847386590ce4dBC'
  },
  id: '523756506652106757',
  clientOrderId: 'e847386590ce4dBCfc4f254a5462b73a',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'XRP/USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: undefined,
  stopPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  reduceOnly: undefined,
  fees: []
}
```