### PR TITLE
Bybit :: fix ohlcv timestamp

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1927,7 +1927,7 @@ module.exports = class bybit extends Exchange {
         //     ]
         //
         return [
-            this.safeNumber (ohlcv, 0),
+            this.safeInteger (ohlcv, 0),
             this.safeNumber (ohlcv, 1),
             this.safeNumber (ohlcv, 2),
             this.safeNumber (ohlcv, 3),


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16107

```
 p bybit fetchOHLCV "BTC/USDT:USDT" 1m None 1 
Python v3.9.7
CCXT v2.4.18
bybit.fetchOHLCV(BTC/USDT:USDT,1m,None,1)
[[1671185220000, 17006.5, 17006.5, 16987.0, 16995.0, 247.133]]