### PR TITLE
Mexc3: fetchBalance, add margin debt field

### DIFF
--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3059,12 +3059,16 @@ module.exports = class mexc3 extends Exchange {
         const isMargin = this.safeValue (params, 'margin', false);
         params = this.omit (params, [ 'margin', 'marginMode' ]);
         if ((marginMode !== undefined) || (isMargin) || (marketType === 'margin')) {
-            let parsedSymbols = this.safeString (params, 'symbol');
-            if (parsedSymbols === undefined) {
+            let parsedSymbols = undefined;
+            const symbol = this.safeString (params, 'symbol');
+            if (symbol === undefined) {
                 const symbols = this.safeValue (params, 'symbols');
                 if (symbols !== undefined) {
-                    parsedSymbols = symbols.join (',');
+                    parsedSymbols = this.marketIds (symbols).join (',');
                 }
+            } else {
+                const market = this.market (symbol);
+                parsedSymbols = market['id'];
             }
             this.checkRequiredArgument ('fetchBalance', parsedSymbols, 'symbol or symbols');
             method = 'spotPrivateGetMarginIsolatedAccount';

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3058,7 +3058,7 @@ module.exports = class mexc3 extends Exchange {
         const marginMode = this.safeString (params, 'marginMode');
         const isMargin = this.safeValue (params, 'margin', false);
         params = this.omit (params, [ 'margin', 'marginMode' ]);
-        if ((marginMode !== undefined) || (isMargin) || (marketType === 'margin'))) {
+        if ((marginMode !== undefined) || (isMargin) || (marketType === 'margin')) {
             const symbols = this.safeString (params, 'symbols');
             this.checkRequiredArgument ('fetchBalance', symbols, 'symbols');
             method = 'spotPrivateGetMarginIsolatedAccount';

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3058,7 +3058,7 @@ module.exports = class mexc3 extends Exchange {
         const marginMode = this.safeString (params, 'marginMode');
         const isMargin = this.safeValue (params, 'margin', false);
         params = this.omit (params, [ 'margin', 'marginMode' ]);
-        if ((marginMode !== undefined) || (isMargin)) {
+        if ((marginMode !== undefined) || (isMargin) || (marketType === 'margin'))) {
             const symbols = this.safeString (params, 'symbols');
             this.checkRequiredArgument ('fetchBalance', symbols, 'symbols');
             method = 'spotPrivateGetMarginIsolatedAccount';

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3059,8 +3059,14 @@ module.exports = class mexc3 extends Exchange {
         const isMargin = this.safeValue (params, 'margin', false);
         params = this.omit (params, [ 'margin', 'marginMode' ]);
         if ((marginMode !== undefined) || (isMargin) || (marketType === 'margin')) {
-            const symbols = this.safeString (params, 'symbols');
-            this.checkRequiredArgument ('fetchBalance', symbols, 'symbols');
+            let parsedSymbols = this.safeString (params, 'symbol');
+            if (parsedSymbols === undefined) {
+                const symbols = this.safeValue (params, 'symbols');
+                if (symbols !== undefined) {
+                    parsedSymbols = symbols.join (',');
+                }
+            }
+            this.checkRequiredArgument ('fetchBalance', parsedSymbols, 'symbol or symbols');
             method = 'spotPrivateGetMarginIsolatedAccount';
             marketType = 'margin';
         }

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -3049,6 +3049,7 @@ module.exports = class mexc3 extends Exchange {
          */
         await this.loadMarkets ();
         let marketType = undefined;
+        const request = {};
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
         let method = this.getSupportedMapping (marketType, {
             'spot': 'spotPrivateGetAccount',
@@ -3057,7 +3058,6 @@ module.exports = class mexc3 extends Exchange {
         });
         const marginMode = this.safeString (params, 'marginMode');
         const isMargin = this.safeValue (params, 'margin', false);
-        params = this.omit (params, [ 'margin', 'marginMode' ]);
         if ((marginMode !== undefined) || (isMargin) || (marketType === 'margin')) {
             let parsedSymbols = undefined;
             const symbol = this.safeString (params, 'symbol');
@@ -3073,8 +3073,10 @@ module.exports = class mexc3 extends Exchange {
             this.checkRequiredArgument ('fetchBalance', parsedSymbols, 'symbol or symbols');
             method = 'spotPrivateGetMarginIsolatedAccount';
             marketType = 'margin';
+            request['symbols'] = parsedSymbols;
         }
-        const response = await this[method] (params);
+        params = this.omit (params, [ 'margin', 'marginMode', 'symbol', 'symbols' ]);
+        const response = await this[method] (this.extend (request, params));
         //
         // spot
         //

--- a/js/mexc3.js
+++ b/js/mexc3.js
@@ -2914,23 +2914,105 @@ module.exports = class mexc3 extends Exchange {
         return result;
     }
 
-    async fetchBalance (params = {}) {
-        /**
-         * @method
-         * @name mexc3#fetchBalance
-         * @description query for balance and get the amount of funds available for trading or funds locked in orders
-         * @param {object} params extra parameters specific to the mexc3 api endpoint
-         * @returns {object} a [balance structure]{@link https://docs.ccxt.com/en/latest/manual.html?#balance-structure}
-         */
-        await this.loadMarkets ();
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
-        const result = {};
-        let response = undefined;
-        if (marketType === 'spot') {
-            response = await this.fetchAccountHelper ('spot', query);
-            const balances = this.safeValue (response, 'balances', []);
-            for (let i = 0; i < balances.length; i++) {
-                const entry = balances[i];
+    parseBalance (response, marketType) {
+        //
+        // spot
+        //
+        //     {
+        //         "asset": "USDT",
+        //         "free": "0.000000000674",
+        //         "locked": "0"
+        //     }
+        //
+        // swap
+        //
+        //     {
+        //         "currency": "BSV",
+        //         "positionMargin": 0,
+        //         "availableBalance": 0,
+        //         "cashBalance": 0,
+        //         "frozenBalance": 0,
+        //         "equity": 0,
+        //         "unrealized": 0,
+        //         "bonus": 0
+        //     }
+        //
+        // margin
+        //
+        //     {
+        //         "baseAsset": {
+        //             "asset": "BTC",
+        //             "borrowEnabled": true,
+        //             "borrowed": "0",
+        //             "free": "0",
+        //             "interest": "0",
+        //             "locked": "0",
+        //             "netAsset": "0",
+        //             "netAssetOfBtc": "0",
+        //             "repayEnabled": true,
+        //             "totalAsset": "0"
+        //         }
+        //         "quoteAsset": {
+        //             "asset": "USDT",
+        //             "borrowEnabled": true,
+        //             "borrowed": "0",
+        //             "free": "10",
+        //             "interest": "0",
+        //             "locked": "0",
+        //             "netAsset": "10",
+        //             "netAssetOfBtc": "0",
+        //             "repayEnabled": true,
+        //             "totalAsset": "10"
+        //         }
+        //         "symbol": "BTCUSDT",
+        //         "isolatedCreated": true,
+        //         "enabled": true,
+        //         "marginLevel": "999",
+        //         "marginRatio": "9",
+        //         "indexPrice": "16741.137068965517241379",
+        //         "liquidatePrice": "--",
+        //         "liquidateRate": "--",
+        //         "tradeEnabled": true
+        //     }
+        //
+        let wallet = undefined;
+        if (marketType === 'margin') {
+            wallet = this.safeValue (response, 'assets', []);
+        } else if (marketType === 'swap') {
+            wallet = this.safeValue (response, 'data', []);
+        } else {
+            wallet = this.safeValue (response, 'balances', []);
+        }
+        const result = { 'info': response };
+        if (marketType === 'margin') {
+            for (let i = 0; i < wallet.length; i++) {
+                const entry = wallet[i];
+                const marketId = this.safeString (entry, 'symbol');
+                const symbol = this.safeSymbol (marketId, undefined);
+                const base = this.safeValue (entry, 'baseAsset', {});
+                const quote = this.safeValue (entry, 'quoteAsset', {});
+                const baseCode = this.safeCurrencyCode (this.safeString (base, 'asset'));
+                const quoteCode = this.safeCurrencyCode (this.safeString (quote, 'asset'));
+                const subResult = {};
+                subResult[baseCode] = this.parseBalanceHelper (base);
+                subResult[quoteCode] = this.parseBalanceHelper (quote);
+                result[symbol] = this.safeBalance (subResult);
+            }
+            return result;
+        } else if (marketType === 'swap') {
+            for (let i = 0; i < wallet.length; i++) {
+                const entry = wallet[i];
+                const currencyId = this.safeString (entry, 'currency');
+                const code = this.safeCurrencyCode (currencyId);
+                const account = this.account ();
+                account['free'] = this.safeString (entry, 'availableBalance');
+                account['used'] = this.safeString (entry, 'frozenBalance');
+                result[code] = account;
+            }
+            return this.safeBalance (result);
+        } else {
+            for (let i = 0; i < wallet.length; i++) {
+                const entry = wallet[i];
                 const currencyId = this.safeString (entry, 'asset');
                 const code = this.safeCurrencyCode (currencyId);
                 const account = this.account ();
@@ -2938,32 +3020,136 @@ module.exports = class mexc3 extends Exchange {
                 account['used'] = this.safeString (entry, 'locked');
                 result[code] = account;
             }
-        } else if (marketType === 'swap') {
-            response = await this.contractPrivateGetAccountAssets (query);
-            //
-            //     {
-            //         "success":true,
-            //         "code":0,
-            //         "data":[
-            //             {"currency":"BSV","positionMargin":0,"availableBalance":0,"cashBalance":0,"frozenBalance":0,"equity":0,"unrealized":0,"bonus":0},
-            //             {"currency":"BCH","positionMargin":0,"availableBalance":0,"cashBalance":0,"frozenBalance":0,"equity":0,"unrealized":0,"bonus":0},
-            //             {"currency":"CRV","positionMargin":0,"availableBalance":0,"cashBalance":0,"frozenBalance":0,"equity":0,"unrealized":0,"bonus":0},
-            //         ]
-            //     }
-            //
-            const data = this.safeValue (response, 'data', []);
-            for (let i = 0; i < data.length; i++) {
-                const balance = data[i];
-                const currencyId = this.safeString (balance, 'currency');
-                const code = this.safeCurrencyCode (currencyId);
-                const account = this.account ();
-                account['free'] = this.safeString (balance, 'availableBalance');
-                account['used'] = this.safeString (balance, 'frozenBalance');
-                result[code] = account;
-            }
+            return this.safeBalance (result);
         }
-        result['info'] = response;
-        return this.safeBalance (result);
+    }
+
+    parseBalanceHelper (entry) {
+        const account = this.account ();
+        account['used'] = this.safeString (entry, 'locked');
+        account['free'] = this.safeString (entry, 'free');
+        account['total'] = this.safeString (entry, 'totalAsset');
+        const debt = this.safeString (entry, 'borrowed');
+        const interest = this.safeString (entry, 'interest');
+        account['debt'] = Precise.stringAdd (debt, interest);
+        return account;
+    }
+
+    async fetchBalance (params = {}) {
+        /**
+         * @method
+         * @name mexc3#fetchBalance
+         * @description query for balance and get the amount of funds available for trading or funds locked in orders
+         * @see https://mxcdevelop.github.io/apidocs/spot_v3_en/#account-information
+         * @see https://mxcdevelop.github.io/apidocs/contract_v1_en/#get-all-informations-of-user-39-s-asset
+         * @see https://mxcdevelop.github.io/apidocs/spot_v3_en/#isolated-account
+         * @param {object} params extra parameters specific to the mexc3 api endpoint
+         * @param {string|undefined} params.symbols // required for margin, market id's separated by commas
+         * @returns {object} a [balance structure]{@link https://docs.ccxt.com/en/latest/manual.html?#balance-structure}
+         */
+        await this.loadMarkets ();
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        let method = this.getSupportedMapping (marketType, {
+            'spot': 'spotPrivateGetAccount',
+            'swap': 'contractPrivateGetAccountAssets',
+            'margin': 'spotPrivateGetMarginIsolatedAccount',
+        });
+        const marginMode = this.safeString (params, 'marginMode');
+        const isMargin = this.safeValue (params, 'margin', false);
+        params = this.omit (params, [ 'margin', 'marginMode' ]);
+        if ((marginMode !== undefined) || (isMargin)) {
+            const symbols = this.safeString (params, 'symbols');
+            this.checkRequiredArgument ('fetchBalance', symbols, 'symbols');
+            method = 'spotPrivateGetMarginIsolatedAccount';
+            marketType = 'margin';
+        }
+        const response = await this[method] (params);
+        //
+        // spot
+        //
+        //     {
+        //         "makerCommission": 0,
+        //         "takerCommission": 20,
+        //         "buyerCommission": 0,
+        //         "sellerCommission": 0,
+        //         "canTrade": true,
+        //         "canWithdraw": true,
+        //         "canDeposit": true,
+        //         "updateTime": null,
+        //         "accountType": "SPOT",
+        //         "balances": [
+        //             {
+        //                 "asset": "USDT",
+        //                 "free": "0.000000000674",
+        //                 "locked": "0"
+        //             },
+        //         ],
+        //         "permissions": ["SPOT"]
+        //     }
+        //
+        // swap
+        //
+        //     {
+        //         "success": true,
+        //         "code": 0,
+        //         "data": [
+        //             {
+        //                 "currency": "BSV",
+        //                 "positionMargin": 0,
+        //                 "availableBalance": 0,
+        //                 "cashBalance": 0,
+        //                 "frozenBalance": 0,
+        //                 "equity": 0,
+        //                 "unrealized": 0,
+        //                 "bonus": 0
+        //             },
+        //         ]
+        //     }
+        //
+        // margin
+        //
+        //     {
+        //         "assets": [
+        //             {
+        //                 "baseAsset": {
+        //                     "asset": "BTC",
+        //                     "borrowEnabled": true,
+        //                     "borrowed": "0",
+        //                     "free": "0",
+        //                     "interest": "0",
+        //                     "locked": "0",
+        //                     "netAsset": "0",
+        //                     "netAssetOfBtc": "0",
+        //                     "repayEnabled": true,
+        //                     "totalAsset": "0"
+        //                 },
+        //                 "quoteAsset": {
+        //                     "asset": "USDT",
+        //                     "borrowEnabled": true,
+        //                     "borrowed": "0",
+        //                     "free": "10",
+        //                     "interest": "0",
+        //                     "locked": "0",
+        //                     "netAsset": "10",
+        //                     "netAssetOfBtc": "0",
+        //                     "repayEnabled": true,
+        //                     "totalAsset": "10"
+        //                 },
+        //                 "symbol": "BTCUSDT",
+        //                 "isolatedCreated": true,
+        //                 "enabled": true,
+        //                 "marginLevel": "999",
+        //                 "marginRatio": "9",
+        //                 "indexPrice": "16741.137068965517241379",
+        //                 "liquidatePrice": "--",
+        //                 "liquidateRate": "--",
+        //                 "tradeEnabled": true
+        //             }
+        //         ]
+        //     }
+        //
+        return this.parseBalance (response, marketType);
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Added the margin debt field to fetchBalance on Mexc3:
```
node examples/js/cli mexc3 fetchBalance '{"defaultType":"margin","symbols":"BTCUSDT"}'

{
  info: {
    assets: [
      {
        baseAsset: {
          asset: 'BTC',
          borrowEnabled: true,
          borrowed: '0',
          free: '0',
          interest: '0',
          locked: '0',
          netAsset: '0',
          netAssetOfBtc: '0',
          repayEnabled: true,
          totalAsset: '0'
        },
        quoteAsset: {
          asset: 'USDT',
          borrowEnabled: true,
          borrowed: '0',
          free: '10',
          interest: '0',
          locked: '0',
          netAsset: '10',
          netAssetOfBtc: '0',
          repayEnabled: true,
          totalAsset: '10'
        },
        symbol: 'BTCUSDT',
        isolatedCreated: true,
        enabled: true,
        marginLevel: '1',
        marginRatio: '9',
        indexPrice: '16722.521206896551724137',
        liquidatePrice: '--',
        liquidateRate: '--',
        tradeEnabled: true
      }
    ]
  },
  'BTC/USDT': {
    BTC: { free: 0, used: 0, total: 0, debt: 0 },
    USDT: { free: 10, used: 0, total: 10, debt: 0 },
    free: { BTC: 0, USDT: 10 },
    used: { BTC: 0, USDT: 0 },
    total: { BTC: 0, USDT: 10 },
    debt: { BTC: 0, USDT: 0 }
  }
}
```