### PR TITLE
Gate WS :: add book ticker option

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -2093,13 +2093,27 @@ module.exports = class gate extends Exchange {
         //         "index_price": "6531"
         //     }
         //
-        const marketId = this.safeString2 (ticker, 'currency_pair', 'contract');
+        // bookTicker
+        //    {
+        //        t: 1671363004228,
+        //        u: 9793320464,
+        //        s: 'BTC_USDT',
+        //        b: '16716.8', // best bid price
+        //        B: '0.0134', // best bid size
+        //        a: '16716.9', // best ask price
+        //        A: '0.0353' // best ask size
+        //     }
+        //
+        const marketId = this.safeStringN (ticker, [ 'currency_pair', 'contract', 's' ]);
         const symbol = this.safeSymbol (marketId, market);
         const last = this.safeString (ticker, 'last');
-        const ask = this.safeString (ticker, 'lowest_ask');
-        const bid = this.safeString (ticker, 'highest_bid');
+        const ask = this.safeString2 (ticker, 'lowest_ask', 'a');
+        const bid = this.safeString2 (ticker, 'highest_bid', 'b');
         const high = this.safeString (ticker, 'high_24h');
         const low = this.safeString (ticker, 'low_24h');
+        const bidVolume = this.safeString (ticker, 'B');
+        const askVolume = this.safeString (ticker, 'A');
+        const timestamp = this.safeInteger (ticker, 't');
         let baseVolume = this.safeString2 (ticker, 'base_volume', 'volume_24h_base');
         if (baseVolume === 'nan') {
             baseVolume = '0';
@@ -2111,14 +2125,14 @@ module.exports = class gate extends Exchange {
         const percentage = this.safeString (ticker, 'change_percentage');
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'high': high,
             'low': low,
             'bid': bid,
-            'bidVolume': undefined,
+            'bidVolume': bidVolume,
             'ask': ask,
-            'askVolume': undefined,
+            'askVolume': askVolume,
             'vwap': undefined,
             'open': undefined,
             'close': last,

--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -54,6 +54,9 @@ module.exports = class gate extends gateRest {
                 'watchTradesSubscriptions': {},
                 'watchTickerSubscriptions': {},
                 'watchOrderBookSubscriptions': {},
+                'watchTicker': {
+                    'name': 'tickers', // or book_ticker
+                },
                 'watchOrderBook': {
                     'interval': '100ms',
                 },
@@ -358,7 +361,9 @@ module.exports = class gate extends gateRest {
         const marketId = market['id'];
         const type = market['type'];
         const messageType = this.getUniformType (type);
-        const channel = messageType + '.' + 'tickers';
+        const options = this.safeValue (this.options, 'watchTicker', {});
+        const topic = this.safeString (options, 'topic', 'tickers');
+        const channel = messageType + '.' + topic;
         const messageHash = channel + '.' + market['symbol'];
         const payload = [ marketId ];
         const url = this.getUrlByMarketType (type, market['inverse']);
@@ -381,6 +386,21 @@ module.exports = class gate extends gateRest {
         //          quote_volume: '227267634.93123952',
         //          high_24h: '47698',
         //          low_24h: '42721.03'
+        //        }
+        //    }
+        //    {
+        //        time: 1671363004,
+        //        time_ms: 1671363004235,
+        //        channel: 'spot.book_ticker',
+        //        event: 'update',
+        //        result: {
+        //          t: 1671363004228,
+        //          u: 9793320464,
+        //          s: 'BTC_USDT',
+        //          b: '16716.8',
+        //          B: '0.0134',
+        //          a: '16716.9',
+        //          A: '0.0353'
         //        }
         //    }
         //
@@ -1126,6 +1146,7 @@ module.exports = class gate extends gateRest {
             'candlesticks': this.handleOHLCV,
             'orders': this.handleOrder,
             'tickers': this.handleTicker,
+            'book_ticker': this.handleTicker,
             'trades': this.handleTrades,
             'order_book_update': this.handleOrderBook,
             'balances': this.handleBalanceMessage,

--- a/keys.json
+++ b/keys.json
@@ -38,5 +38,6 @@
     "cex":           { "skip": true },
     "ascendex":      { "skip": true },
     "btcex":         { "skip": true },
-    "wazirx":        { "skipWs": true }
+    "wazirx":        { "skipWs": true },
+    "okx":          { "skipWs": true }
 }


### PR DESCRIPTION
- add `book_ticker` option to allow the best bid/best ask query
- configurable through an option

Swap
```
 n gate watchTicker "BTC/USDT:USDT"  --swap         
Debugger attached.
2022-12-18T11:43:07.046Z
Node.js: v17.9.0
CCXT v2.4.26
gate.watchTicker (BTC/USDT:USDT)
{
  symbol: 'BTC/USDT:USDT',
  timestamp: 1671363791595,
  datetime: '2022-12-18T11:43:11.595Z',
  high: undefined,
  low: undefined,
  bid: 16719.5,
  bidVolume: 53462,
  ask: 16719.6,
  askVolume: 84827,
  vwap: undefined,
  open: undefined,
  close: undefined,
  last: undefined,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: undefined,
  quoteVolume: undefined,
  info: {
    t: 1671363791595,
    u: 25128744662,
    s: 'BTC_USDT',
    b: '16719.5',
    B: 53462,
    a: '16719.6',
    A: 84827
  }
}
```

Spot
```
 n gate watchTicker "BTC/USDT"  --spot 
Debugger attached.
2022-12-18T11:44:12.945Z
Node.js: v17.9.0
CCXT v2.4.26
gate.watchTicker (BTC/USDT)
{
  symbol: 'BTC/USDT',
  timestamp: 1671363856144,
  datetime: '2022-12-18T11:44:16.144Z',
  high: undefined,
  low: undefined,
  bid: 16723.5,
  bidVolume: 0.0047,
  ask: 16723.6,
  askVolume: 0.0077,
  vwap: undefined,
  open: undefined,
  close: undefined,
  last: undefined,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: undefined,
  quoteVolume: undefined,
  info: {
    t: 1671363856144,
    u: 9793590567,
    s: 'BTC_USDT',
    b: '16723.5',
    B: '0.0047',
    a: '16723.6',
    A: '0.0077'
  }
}
```
