### PR TITLE
tokocrypto parseTransaction unification

### DIFF
--- a/js/tokocrypto.js
+++ b/js/tokocrypto.js
@@ -2135,36 +2135,35 @@ module.exports = class tokocrypto extends Exchange {
         // fetchDeposits
         //
         //     {
-        //         "id":5167969,
-        //         "asset":"BIDR",
-        //         "network":"BSC",
-        //         "address":"0x101a925704f6ff13295ab8dd7a60988d116aaedf",
-        //         "addressTag":"",
-        //         "txId":"113409337867",
-        //         "amount":"15000",
-        //         "transferType":1,
-        //         "status":1,
-        //         "insertTime":"1659429390000"
+        //         "id": 5167969,
+        //         "asset": "BIDR",
+        //         "network": "BSC",
+        //         "address": "0x101a925704f6ff13295ab8dd7a60988d116aaedf",
+        //         "addressTag": "",
+        //         "txId": "113409337867",
+        //         "amount": "15000",
+        //         "transferType": 1,
+        //         "status": 1,
+        //         "insertTime": "1659429390000"
         //     }
         //
         // fetchWithdrawals
         //
         //     {
-        //         "id":4245859,
-        //         "clientId":"198",
-        //         "asset":"BIDR",
-        //         "network":"BSC",
-        //         "address":"0xff1c75149cc492e7d5566145b859fcafc900b6e9",
-        //         "addressTag":"",
-        //         "amount":"10000",
-        //         "fee":"0",
-        //         "txId":"113501794501",
-        //         "transferType":1,
-        //         "status":10,
-        //         "createTime":1659521314413
+        //         "id": 4245859,
+        //         "clientId": "198",
+        //         "asset": "BIDR",
+        //         "network": "BSC",
+        //         "address": "0xff1c75149cc492e7d5566145b859fcafc900b6e9",
+        //         "addressTag": "",
+        //         "amount": "10000",
+        //         "fee": "0",
+        //         "txId": "113501794501",
+        //         "transferType": 1,
+        //         "status": 10,
+        //         "createTime": 1659521314413
         //     }
         //
-        const id = this.safeString (transaction, 'id');
         const address = this.safeString (transaction, 'address');
         let tag = this.safeString (transaction, 'addressTag'); // set but unused
         if (tag !== undefined) {
@@ -2191,37 +2190,39 @@ module.exports = class tokocrypto extends Exchange {
                 timestamp = createTime;
             }
         }
-        const status = this.parseTransactionStatusByType (this.safeString (transaction, 'status'), type);
-        const amount = this.safeNumber (transaction, 'amount');
         const feeCost = this.safeNumber2 (transaction, 'transactionFee', 'totalFee');
-        let fee = undefined;
+        const fee = {
+            'currency': undefined,
+            'cost': undefined,
+            'rate': undefined,
+        };
         if (feeCost !== undefined) {
-            fee = { 'currency': code, 'cost': feeCost };
+            fee['currency'] = code;
+            fee['cost'] = feeCost;
         }
-        const updated = this.safeInteger2 (transaction, 'successTime', 'updateTime');
         let internal = this.safeInteger (transaction, 'transferType');
         if (internal !== undefined) {
             internal = internal ? true : false;
         }
-        const network = this.safeString (transaction, 'network');
         return {
             'info': transaction,
-            'id': id,
+            'id': this.safeString (transaction, 'id'),
             'txid': txid,
+            'type': type,
+            'currency': code,
+            'network': this.safeString (transaction, 'network'),
+            'amount': this.safeNumber (transaction, 'amount'),
+            'status': this.parseTransactionStatusByType (this.safeString (transaction, 'status'), type),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'network': network,
             'address': address,
-            'addressTo': address,
             'addressFrom': undefined,
+            'addressTo': address,
             'tag': tag,
-            'tagTo': tag,
             'tagFrom': undefined,
-            'type': type,
-            'amount': amount,
-            'currency': code,
-            'status': status,
-            'updated': updated,
+            'tagTo': tag,
+            'updated': this.safeInteger2 (transaction, 'successTime', 'updateTime'),
+            'comment': undefined,
             'internal': internal,
             'fee': fee,
         };


### PR DESCRIPTION
Tokocrypto is the only exchange with the key internal as part of it's response. It means it's an internal transfer, which what other exchanges would return for fetchTransfers. Should we leave it like that, or should I add the key internal to other exchanges?

--------------------

```
2022-12-19T17:23:40.440Z
Node.js: v18.4.0
CCXT v2.4.32
tokocrypto.fetchDeposits (, , 5)
2022-12-19T17:23:45.624Z iteration 0 passed in 2865 ms

     id |                                                             txid |    type | currency | network | amount | status |     timestamp |                 datetime |                                    address | addressFrom |                                  addressTo | tag | tagFrom | tagTo | updated | comment | internal | fee
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5135373 |                                                     113017125982 | deposit |          |     BSC |  65012 |     ok | 1659088434000 | 2022-07-29T09:53:54.000Z | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |             | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |     |         |       |         |         |     true |  {}
5167969 |                                                     113409337867 | deposit |          |     BSC |  15000 |     ok | 1659429390000 | 2022-08-02T08:36:30.000Z | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |             | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |     |         |       |         |         |     true |  {}
5337556 |                                                     115305800749 | deposit |          |     BSC |    0.4 |     ok | 1661504421000 | 2022-08-26T09:00:21.000Z | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |             | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |     |         |       |         |         |     true |  {}
5426556 | 99d627c4c30429550595d725d14e5026dccacb127c72c03c9568324a657e56c7 | deposit |          |     LTC |   0.16 |     ok | 1662737888000 | 2022-09-09T15:38:08.000Z |         LVRcEB1RF8At4UsWaBHvanZpXTdN58g2wU |             |         LVRcEB1RF8At4UsWaBHvanZpXTdN58g2wU |     |         |       |         |         |    false |  {}
5446511 |                                                     116756115119 | deposit |          |     BSC |  15.71 |     ok | 1663009665000 | 2022-09-12T19:07:45.000Z | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |             | 0x101a925704f6ff13295ab8dd7a60988d116aaedf |     |         |       |         |         |     true |  {}
5 objects
2022-12-19T17:23:45.624Z iteration 1 passed in 2865 ms
```

```
% tokocrypto fetchWithdrawals undefined undefined 5
Debugger listening on ws://127.0.0.1:62533/59eeab21-a17f-418a-a8d2-b523b658c4d5
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2022-12-19T17:24:03.880Z
Node.js: v18.4.0
CCXT v2.4.32
tokocrypto.fetchWithdrawals (, , 5)
2022-12-19T17:24:08.376Z iteration 0 passed in 2224 ms

     id |         txid |       type | currency | network | amount | status |     timestamp |                 datetime |                                    address | addressFrom |                                  addressTo | tag | tagFrom | tagTo | updated | comment | internal | fee
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4222398 | 113014805669 | withdrawal |          |     BSC |   5000 |     ok | 1659086623514 | 2022-07-29T09:23:43.514Z | 0xff1c75149cc492e7d5566145b859fcafc900b6e9 |             | 0xff1c75149cc492e7d5566145b859fcafc900b6e9 |     |         |       |         |         |     true |  {}
4222559 | 113017137111 | withdrawal |          |     BSC |   5000 |     ok | 1659088362119 | 2022-07-29T09:52:42.119Z | 0xff1c75149cc492e7d5566145b859fcafc900b6e9 |             | 0xff1c75149cc492e7d5566145b859fcafc900b6e9 |     |         |       |         |         |     true |  {}
4245859 | 113501794501 | withdrawal |          |     BSC |  10000 |     ok | 1659521314413 | 2022-08-03T10:08:34.413Z | 0xff1c75149cc492e7d5566145b859fcafc900b6e9 |             | 0xff1c75149cc492e7d5566145b859fcafc900b6e9 |     |         |       |         |         |     true |  {}
4340226 | 115305441904 | withdrawal |          |     BSC |    0.4 |     ok | 1661503997939 | 2022-08-26T08:53:17.939Z | 0xe8989f15df9e57c6f00101a12c66bab26e6d3c15 |             | 0xe8989f15df9e57c6f00101a12c66bab26e6d3c15 |     |         |       |         |         |     true |  {}
4352740 | 115537243534 | withdrawal |          |     BSC |    0.4 |     ok | 1661764048655 | 2022-08-29T09:07:28.655Z | 0xe8989f15df9e57c6f00101a12c66bab26e6d3c15 |             | 0xe8989f15df9e57c6f00101a12c66bab26e6d3c15 |     |         |       |         |         |     true |  {}
5 objects
2022-12-19T17:24:08.376Z iteration 1 passed in 2224 ms
```