### PR TITLE
Deribit: createOrder, USDC Swap

### DIFF
--- a/js/deribit.js
+++ b/js/deribit.js
@@ -1643,6 +1643,8 @@ module.exports = class deribit extends Exchange {
         const market = this.market (symbol);
         if (market['inverse']) {
             amount = this.amountToPrecision (symbol, amount);
+        } else if (market['settle'] === 'USDC') {
+            amount = this.amountToPrecision (symbol, amount);
         } else {
             amount = this.currencyToPrecision (symbol, amount);
         }


### PR DESCRIPTION
Added support for linear USDC settled swaps:
fixes: #16073
```
node examples/js/cli deribit createOrder LINK/USDC:USDC market buy 1

deribit.createOrder (LINK/USDC:USDC, market, buy, 1)
2022-12-20T05:22:05.316Z iteration 0 passed in 195 ms

{
  info: {
    web: false,
    time_in_force: 'good_til_cancelled',
    risk_reducing: false,
    replaced: false,
    reduce_only: false,
    profit_loss: '0.0',
    price: '6.121',
    post_only: false,
    order_type: 'market',
    order_state: 'filled',
    order_id: 'USDC-3570684930',
    mmp: false,
    max_show: '1.0',
    last_update_timestamp: '1671513728033',
    label: '',
    is_liquidation: false,
    instrument_name: 'LINK_USDC-PERPETUAL',
    filled_amount: '1.0',
    direction: 'buy',
    creation_timestamp: '1671513728033',
    commission: '0.0030145',
    average_price: '6.029',
    api: true,
    amount: '1.0',
    trades: [
      {
        trade_seq: '58742',
        trade_id: 'USDC-6634134',
        timestamp: '1671513728033',
        tick_direction: '0',
        state: 'filled',
        self_trade: false,
        risk_reducing: false,
        reduce_only: false,
        profit_loss: '0.0',
        price: '6.029',
        post_only: false,
        order_type: 'market',
        order_id: 'USDC-3570684930',
        mmp: false,
        matching_id: null,
        mark_price: '6.0308',
        liquidity: 'T',
        instrument_name: 'LINK_USDC-PERPETUAL',
        index_price: '6.0377',
        fee_currency: 'USDC',
        fee: '0.0030145',
        direction: 'buy',
        api: true,
        amount: '1.0'
      }
    ]
  },
  id: 'USDC-3570684930',
  clientOrderId: undefined,
  timestamp: 1671513728033,
  datetime: '2022-12-20T05:22:08.033Z',
  lastTradeTimestamp: 1671513728033,
  symbol: 'LINK/USDC:USDC',
  type: 'market',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 6.121,
  stopPrice: undefined,
  amount: 1,
  cost: 6.029,
  average: 6.029,
  filled: 1,
  remaining: 0,
  status: 'closed',
  fee: { cost: '0.0030145', currency: 'LINK' },
  trades: [
    {
      id: 'USDC-6634134',
      info: {
        trade_seq: '58742',
        trade_id: 'USDC-6634134',
        timestamp: '1671513728033',
        tick_direction: '0',
        state: 'filled',
        self_trade: false,
        risk_reducing: false,
        reduce_only: false,
        profit_loss: '0.0',
        price: '6.029',
        post_only: false,
        order_type: 'market',
        order_id: 'USDC-3570684930',
        mmp: false,
        matching_id: null,
        mark_price: '6.0308',
        liquidity: 'T',
        instrument_name: 'LINK_USDC-PERPETUAL',
        index_price: '6.0377',
        fee_currency: 'USDC',
        fee: '0.0030145',
        direction: 'buy',
        api: true,
        amount: '1.0'
      },
      timestamp: 1671513728033,
      datetime: '2022-12-20T05:22:08.033Z',
      symbol: 'LINK/USDC:USDC',
      order: 'USDC-3570684930',
      type: 'market',
      side: 'buy',
      takerOrMaker: 'taker',
      price: 6.029,
      amount: 1,
      cost: 6.029,
      fee: { cost: 0.0030145, currency: 'USDC' },
      fees: [ { currency: 'USDC', cost: '0.0030145' } ]
    }
  ],
  fees: [ { currency: 'USDC', cost: 0.0030145 } ]
}
```