### PR TITLE
digifinex - correct tera

### DIFF
--- a/js/digifinex.js
+++ b/js/digifinex.js
@@ -303,7 +303,7 @@ module.exports = class digifinex extends Exchange {
                     'SOLANA': 'SOL', // SOL & SPL
                     'STELLAR': 'Stella', // XLM
                     'TERRACLASSIC': 'TerraClassic',
-                    'TERRANEW': 'Terra',
+                    'TERRA': 'Terra',
                     'TON': 'Ton',
                     'TRC20': 'TRC20',
                     'TRON': 'TRC20',
@@ -333,7 +333,7 @@ module.exports = class digifinex extends Exchange {
                     'XRP': 'RIPPLE',
                     'SOL': 'SOLANA',
                     'Stella': 'STELLAR',
-                    'Terra': 'TERRANEW',
+                    'Terra': 'TERRA',
                     'TerraClassic': 'TERRACLASSIC',
                     'Ton': 'TON',
                     'TRC20': 'TRC20',


### PR DESCRIPTION
It was mistake, should have been `TERRA` (not `TERRANEW`) as the new network is now called `TERRA` without `new` suffix.