### PR TITLE
huobi fetchDeposits, fetchWithdrawals edit

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -4806,6 +4806,7 @@ module.exports = class huobi extends Exchange {
         }
         const request = {
             'type': 'deposit',
+            'direct': 'next',
             'from': 0, // From 'id' ... if you want to get results after a particular transaction id, pass the id in params.from
         };
         if (currency !== undefined) {
@@ -4865,6 +4866,7 @@ module.exports = class huobi extends Exchange {
         }
         const request = {
             'type': 'withdraw',
+            'direct': 'next',
             'from': 0, // From 'id' ... if you want to get results after a particular transaction id, pass the id in params.from
         };
         if (currency !== undefined) {


### PR DESCRIPTION
https://huobiapi.github.io/docs/spot/v1/en/#search-for-existed-withdraws-and-deposits
by default huobi gives old transactions from first to last. We want to see newest transactions so we need to set `'direct': 'next'`