### PR TITLE
btcmarkets parseTransaction unification minimum changes

### DIFF
--- a/js/btcmarkets.js
+++ b/js/btcmarkets.js
@@ -338,9 +338,11 @@ module.exports = class btcmarkets extends Exchange {
             'currency': code,
             'status': status,
             'updated': lastUpdate,
+            'comment': undefined,
             'fee': {
                 'currency': code,
                 'cost': fee,
+                'rate': undefined,
             },
             'info': transaction,
         };


### PR DESCRIPTION
I can't test this out, but this is the minimum required changes to unify the response, the [other PR](https://github.com/ccxt/ccxt/pull/16149) has some extra stuff in it.

I figured this one might be basic enough to merge without testing