### PR TITLE
Php safe value n

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -590,7 +590,7 @@ class Exchange {
 
     public static function safe_value_n($object, $array, $default_value = null) {
         $value = static::get_object_value_from_key_array($object, $array);
-        return (isset($value) && is_scalar($value)) ? $value : $default_value;
+        return isset($value) ? $value : $default_value;
     }
 
     public static function get_object_value_from_key_array($object, $array) {


### PR DESCRIPTION
fixes: #16004

------------

I'm not sure why `is_scalar($value)` was a check in `safe_value_n` arrays are not scalars, and would be returned from `safe_value_n`

-------------

# testing

```
PHP v8.1.7
CCXT version :2.4.47
bybit->fetch_balance()
Array
(
    [info] => Array
        (
            [retCode] => 0
            [retMsg] => OK
            [result] => Array
                (
                    [list] => Array
                        (
                            ...

                            [4] => Array
                                (
                                    [coin] => USDT
                                    [equity] => 3.23259766
                                    [walletBalance] => 3.23259766
                                    [positionMargin] => 0
                                    [availableBalance] => 3.23259766
                                    [orderMargin] => 0
                                    [occClosingFee] => 0
                                    [occFundingFee] => 0
                                    [unrealisedPnl] => 0
                                    [cumRealisedPnl] => -0.00040234
                                    [givenCash] => 0
                                    [serviceCash] => 0
                                    [accountIM] => 
                                    [accountMM] => 
                                )

                            ...

                            [8] => Array
                                (
                                    [coin] => USDC
                                    [equity] => 0
                                    [walletBalance] => 0
                                    [positionMargin] => 0
                                    [availableBalance] => 0
                                    [orderMargin] => 0
                                    [occClosingFee] => 0
                                    [occFundingFee] => 0
                                    [unrealisedPnl] => 0
                                    [cumRealisedPnl] => 0
                                    [givenCash] => 0
                                    [serviceCash] => 0
                                    [accountIM] => 0
                                    [accountMM] => 0
                                )

                            ...

                        )

                )

            [retExtInfo] => Array
                (
                )

            [time] => 1671699154800
        )

    ...

    [USDT] => Array
        (
            [free] => 3.23259766
            [used] => 0
            [total] => 3.23259766
        )

    ...

    [USDC] => Array
        (
            [free] => 0
            [used] => 0
            [total] => 0
        )

    ...

    [free] => Array
        (
            [BTC] => 0
            [ETH] => 0
            [EOS] => 0
            [XRP] => 0
            [USDT] => 3.23259766
            [DOT] => 0
            [LTC] => 0
            [BIT] => 0
            [USDC] => 0
            [SOL] => 0
            [ADA] => 0
            [MANA] => 0
        )

    [used] => Array
        (
            [BTC] => 0
            [ETH] => 0
            [EOS] => 0
            [XRP] => 0
            [USDT] => 0
            [DOT] => 0
            [LTC] => 0
            [BIT] => 0
            [USDC] => 0
            [SOL] => 0
            [ADA] => 0
            [MANA] => 0
        )

    [total] => Array
        (
            [BTC] => 0
            [ETH] => 0
            [EOS] => 0
            [XRP] => 0
            [USDT] => 3.23259766
            [DOT] => 0
            [LTC] => 0
            [BIT] => 0
            [USDC] => 0
            [SOL] => 0
            [ADA] => 0
            [MANA] => 0
        )

)
```