### PR TITLE
Bkex: fetchTickers, fix spot tickers bug

### DIFF
--- a/js/bkex.js
+++ b/js/bkex.js
@@ -796,8 +796,8 @@ module.exports = class bkex extends Exchange {
         //     }
         //
         const marketId = this.safeString (ticker, 'symbol');
+        market = this.safeMarket (marketId, market);
         const symbol = this.safeSymbol (marketId, market);
-        market = this.market (symbol);
         const timestamp = this.safeInteger2 (ticker, 'ts', 'lastTime');
         const baseCurrencyVolume = market['swap'] ? 'amount' : 'volume';
         const quoteCurrencyVolume = market['swap'] ? 'volume' : 'quoteVolume';


### PR DESCRIPTION
Fix market bug in parseTicker:
fixes: #16138
```
node examples/js/cli bkex fetchTickers

{
    'RYOSHI/USDT': {
    symbol: 'RYOSHI/USDT',
    timestamp: 1671752413501,
    datetime: '2022-12-22T23:40:13.501Z',
    high: 1.313e-8,
    low: 1.246e-8,
    bid: undefined,
    bidVolume: undefined,
    ask: undefined,
    askVolume: undefined,
    vwap: 1.265271287e-8,
    open: 1.265e-8,
    close: 1.282e-8,
    last: 1.282e-8,
    previousClose: undefined,
    change: 1.7e-10,
    percentage: 1.34,
    average: 1.2735e-8,
    baseVolume: 9995212813013,
    quoteVolume: 126466.5578,
    info: {
      change: '1.34',
      close: '1.282E-8',
      high: '1.313E-8',
      low: '1.246E-8',
      open: '1.265E-8',
      quoteVolume: '126466.5578',
      symbol: 'RYOSHI_USDT',
      tradeSet: 'USDT',
      ts: '1671752413501',
      volume: 9995212813013
    }
  }
...
}
```