### PR TITLE
Fix binance futures stoploss orders

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3311,7 +3311,6 @@ module.exports = class binance extends Exchange {
         }
         const initialUppercaseType = type.toUpperCase ();
         let uppercaseType = initialUppercaseType;
-        request['type'] = uppercaseType;
         const stopPrice = this.safeNumber (query, 'stopPrice');
         if (stopPrice !== undefined) {
             if (uppercaseType === 'MARKET') {
@@ -3348,6 +3347,7 @@ module.exports = class binance extends Exchange {
             // delivery and future
             request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
         }
+        request['type'] = uppercaseType;
         // additional required fields depending on the order type
         let timeInForceIsRequired = false;
         let priceIsRequired = false;


### PR DESCRIPTION
In older versions of ccxt (prior to 2.1.81) - opening a stoploss order on binance futures worked as follows:

```
pair='SOL/USDT'
params = {
    'stopPrice': 10,
}
ct.verbose=True
ct.create_order(pair, 'market', 'buy', 1, 10, params=params)
```

This was no longer possible, since the request type is assigned to the request object before it's updated for stop orders -  so the order type remained as market (or limit) - instead of stop / stoploss  / stop-market.

Simply moving this to later in the function fixes this problem.

Observing this in verbose mode:

prior:

```

fetch Request: binance POST https://fapi.binance.com/fapi/v1/order RequestHeaders: {'X-MBX-APIKEY': 'xxxxx', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'python-requests/2.28.1', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'} RequestBody: timestamp=1671896268810&symbol=SOLUSDT&side=BUY&newClientOrderId=x-xcKtGhcu673eb35cd890ecbc64c2b8&newOrderRespType=RESULT&type=MARKET&quantity=1&stopPrice=30&recvWindow=10000&signature=xxxxxxx

```

after:

```

fetch Request: binance POST https://fapi.binance.com/fapi/v1/order RequestHeaders: {'X-MBX-APIKEY': 'xxxxx', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'python-requests/2.28.1', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'} RequestBody: timestamp=1671896268810&symbol=SOLUSDT&side=BUY&newClientOrderId=x-xcKtGhcu673eb35cd890ecbc64c2b8&newOrderRespType=RESULT&type=STOP_MARKET&quantity=1&stopPrice=30&recvWindow=10000&signature=xxxxxxx

```

(notice the "type" parameter).
