### PR TITLE
fix phemex fetchMarket

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -777,7 +777,7 @@ module.exports = class phemex extends Exchange {
         for (let i = 0; i < products.length; i++) {
             let market = products[i];
             const type = this.safeStringLower (market, 'type');
-            if (type === 'perpetual') {
+            if ((type === 'perpetual') || (type === 'perpetualv2')) {
                 const id = this.safeString (market, 'symbol');
                 const riskLimitValues = this.safeValue (riskLimitsById, id, {});
                 market = this.extend (market, riskLimitValues);


### PR DESCRIPTION
The method is not returning any `:USDT` based symbol as the `type` field in the response for it is `Perpetualv2` thus, it is not getting parsed as `swap` and got parsed as `spot` symbol instead. This change will fix that result.