### PR TITLE
Bitmex :: temporary balance fix

### DIFF
--- a/js/bitmex.js
+++ b/js/bitmex.js
@@ -540,8 +540,19 @@ module.exports = class bitmex extends Exchange {
             let free = this.safeString (balance, 'availableMargin');
             let total = this.safeString (balance, 'marginBalance');
             if (code !== 'USDT') {
-                free = Precise.stringDiv (free, '1e8');
-                total = Precise.stringDiv (total, '1e8');
+                // tmp fix until this PR gets merged
+                // https://github.com/ccxt/ccxt/pull/15311
+                const symbol = code + '_USDT';
+                const market = this.safeMarket (symbol);
+                const info = this.safeValue (market, 'info', {});
+                const multiplier = this.safeString (info, 'underlyingToPositionMultiplier');
+                if (multiplier !== undefined) {
+                    free = Precise.stringDiv (free, multiplier);
+                    total = Precise.stringDiv (total, multiplier);
+                } else {
+                    free = Precise.stringDiv (free, '1e8');
+                    total = Precise.stringDiv (total, '1e8');
+                }
             } else {
                 free = Precise.stringDiv (free, '1e6');
                 total = Precise.stringDiv (total, '1e6');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16234
- tmp fix until https://github.com/ccxt/ccxt/pull/15311 gets merged

Demo:

```
 p bitmex fetchBalance                                    
Python v3.10.8
CCXT v2.4.71
bitmex.fetchBalance()
{'BMEX': {'free': 10.0, 'total': 10.0, 'used': 0.0},
 'LINK': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'SOL': {'free': 1.0, 'total': 1.0, 'used': 0.0},
 'TRX': {'free': 100.0, 'total': 100.0, 'used': 0.0},
 'USDT': {'free': 14.92, 'total': 14.92, 'used': 0.0},
 'free': {'BMEX': 10.0, 'LINK': 0.0, 'SOL': 1.0, 'TRX': 100.0, 'USDT': 14.92},
 'info': [{'account': '2059056',
           'action': '',
           'amount': '14920000',
           'availableMargin': '14920000',
           'confirmedDebit': '0',
           'currency': 'USDt',
           'excessMargin': '14920000',
           'excessMarginPcnt': '1',
           'grossComm': '0',
           'grossExecCost': '0',
           'grossMarkValue': '0',
           'grossOpenCost': '0',
           'grossOpenPremium': '0',
           'indicativeTax': '0',
           'initMargin': '0',
           'maintMargin': '0',
           'makerFeeDiscount': None,
           'marginBalance': '14920000',
           'marginBalancePcnt': '1',
           'marginLeverage': '0',
           'marginUsedPcnt': '0',
           'pendingCredit': '0',
           'pendingDebit': '0',
           'prevRealisedPnl': '0',
           'prevState': '',
           'prevUnrealisedPnl': '0',
           'realisedPnl': '0',
           'riskLimit': '500000000000000',
           'riskValue': '0',
           'sessionMargin': '0',
           'state': '',
           'syntheticMargin': None,
           'takerFeeDiscount': None,
           'targetExcessMargin': '0',
           'taxableMargin': '0',
           'timestamp': '2022-12-29T10:22:07.378Z',
           'unrealisedPnl': '0',
           'unrealisedProfit': '0',
           'varMargin': '0',
           'walletBalance': '14920000',
           'withdrawableMargin': '14920000'},
          {'account': '2059056',
           'action': '',
           'amount': '0',
           'availableMargin': '0',
           'confirmedDebit': '0',
           'currency': 'LINk',
           'excessMargin': '0',
           'excessMarginPcnt': '1',
           'grossComm': '0',
           'grossExecCost': '0',
           'grossMarkValue': '0',
           'grossOpenCost': '0',
           'grossOpenPremium': '0',
           'indicativeTax': '0',
           'initMargin': '0',
           'maintMargin': '0',
           'makerFeeDiscount': None,
           'marginBalance': '0',
           'marginBalancePcnt': '1',
           'marginLeverage': '0',
           'marginUsedPcnt': '0',
           'pendingCredit': '0',
           'pendingDebit': '0',
           'prevRealisedPnl': '0',
           'prevState': '',
           'prevUnrealisedPnl': '0',
           'realisedPnl': '0',
           'riskLimit': None,
           'riskValue': '0',
           'sessionMargin': '0',
           'state': '',
           'syntheticMargin': None,
           'takerFeeDiscount': None,
           'targetExcessMargin': '0',
           'taxableMargin': '0',
           'timestamp': '2022-10-26T16:10:00.552Z',
           'unrealisedPnl': '0',
           'unrealisedProfit': '0',
           'varMargin': '0',
           'walletBalance': '0',
           'withdrawableMargin': '0'},
          {'account': '2059056',
           'action': '',
           'amount': '10000000',
           'availableMargin': '10000000',
           'confirmedDebit': '0',
           'currency': 'BMEx',
           'excessMargin': '10000000',
           'excessMarginPcnt': '1',
           'grossComm': '0',
           'grossExecCost': '0',
           'grossMarkValue': '0',
           'grossOpenCost': '0',
           'grossOpenPremium': '0',
           'indicativeTax': '0',
           'initMargin': '0',
           'maintMargin': '0',
           'makerFeeDiscount': None,
           'marginBalance': '10000000',
           'marginBalancePcnt': '1',
           'marginLeverage': '0',
           'marginUsedPcnt': '0',
           'pendingCredit': '0',
           'pendingDebit': '0',
           'prevRealisedPnl': '0',
           'prevState': '',
           'prevUnrealisedPnl': '0',
           'realisedPnl': '0',
           'riskLimit': None,
           'riskValue': '0',
           'sessionMargin': '0',
           'state': '',
           'syntheticMargin': None,
           'takerFeeDiscount': None,
           'targetExcessMargin': '0',
           'taxableMargin': '0',
           'timestamp': '2022-10-26T16:10:00.552Z',
           'unrealisedPnl': '0',
           'unrealisedProfit': '0',
           'varMargin': '0',
           'walletBalance': '10000000',
           'withdrawableMargin': '10000000'},
          {'account': '2059056',
           'action': '',
           'amount': '100000000',
           'availableMargin': '100000000',
           'confirmedDebit': '0',
           'currency': 'TRx',
           'excessMargin': '100000000',
           'excessMarginPcnt': '1',
           'grossComm': '0',
           'grossExecCost': '0',
           'grossMarkValue': '0',
           'grossOpenCost': '0',
           'grossOpenPremium': '0',
           'indicativeTax': '0',
           'initMargin': '0',
           'maintMargin': '0',
           'makerFeeDiscount': None,
           'marginBalance': '100000000',
           'marginBalancePcnt': '1',
           'marginLeverage': '0',
           'marginUsedPcnt': '0',
           'pendingCredit': '0',
           'pendingDebit': '0',
           'prevRealisedPnl': '0',
           'prevState': '',
           'prevUnrealisedPnl': '0',
           'realisedPnl': '0',
           'riskLimit': None,
           'riskValue': '0',
           'sessionMargin': '0',
           'state': '',
           'syntheticMargin': None,
           'takerFeeDiscount': None,
           'targetExcessMargin': '0',
           'taxableMargin': '0',
           'timestamp': '2022-12-29T10:21:09.755Z',
           'unrealisedPnl': '0',
           'unrealisedProfit': '0',
           'varMargin': '0',
           'walletBalance': '100000000',
           'withdrawableMargin': '100000000'},
          {'account': '2059056',
           'action': '',
           'amount': '1000000000',
           'availableMargin': '1000000000',
           'confirmedDebit': '0',
           'currency': 'LAMp',
           'excessMargin': '1000000000',
           'excessMarginPcnt': '1',
           'grossComm': '0',
           'grossExecCost': '0',
           'grossMarkValue': '0',
           'grossOpenCost': '0',
           'grossOpenPremium': '0',
           'indicativeTax': '0',
           'initMargin': '0',
           'maintMargin': '0',
           'makerFeeDiscount': None,
           'marginBalance': '1000000000',
           'marginBalancePcnt': '1',
           'marginLeverage': '0',
           'marginUsedPcnt': '0',
           'pendingCredit': '0',
           'pendingDebit': '0',
           'prevRealisedPnl': '0',
           'prevState': '',
           'prevUnrealisedPnl': '0',
           'realisedPnl': '0',
           'riskLimit': None,
           'riskValue': '0',
           'sessionMargin': '0',
           'state': '',
           'syntheticMargin': None,
           'takerFeeDiscount': None,
           'targetExcessMargin': '0',
           'taxableMargin': '0',
           'timestamp': '2022-12-29T10:22:07.378Z',
           'unrealisedPnl': '0',
           'unrealisedProfit': '0',
           'varMargin': '0',
           'walletBalance': '1000000000',
           'withdrawableMargin': '1000000000'}],
 'total': {'BMEX': 10.0, 'LINK': 0.0, 'SOL': 1.0, 'TRX': 100.0, 'USDT': 14.92},
 'used': {'BMEX': 0.0, 'LINK': 0.0, 'SOL': 0.0, 'TRX': 0.0, 'USDT': 0.0}}
```
