### PR TITLE
Poloniex: editOrder

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1055,7 +1055,7 @@ module.exports = class poloniex extends Exchange {
             // 'accountType': 'SPOT',
             // 'amount': amount,
         };
-        const orderRequest = this.orderRequest ('createOrder()', symbol, type, side, amount, request, price, params);
+        const orderRequest = this.orderRequest (symbol, type, side, amount, request, price, params);
         let response = await this.privatePostOrders (this.extend (orderRequest[0], orderRequest[1]));
         //
         //     {
@@ -1069,7 +1069,7 @@ module.exports = class poloniex extends Exchange {
         return this.parseOrder (response, market);
     }
 
-    orderRequest (method, symbol, type, side, amount, request, price = undefined, params = {}) {
+    orderRequest (symbol, type, side, amount, request, price = undefined, params = {}) {
         const market = this.market (symbol);
         let upperCaseType = type.toUpperCase ();
         const isMarket = upperCaseType === 'MARKET';
@@ -1122,7 +1122,7 @@ module.exports = class poloniex extends Exchange {
             'id': id,
             // 'timeInForce': timeInForce,
         };
-        const orderRequest = this.orderRequest ('editOrder()', symbol, type, side, amount, request, price, params);
+        const orderRequest = this.orderRequest (symbol, type, side, amount, request, price, params);
         let response = await this.privatePutOrdersId (this.extend (orderRequest[0], orderRequest[1]));
         //
         //     {

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ArgumentsRequired, ExchangeError, ExchangeNotAvailable, RequestTimeout, AuthenticationError, PermissionDenied, RateLimitExceeded, InsufficientFunds, OrderNotFound, InvalidOrder, AccountSuspended, CancelPending, InvalidNonce, OnMaintenance, BadSymbol } = require ('./base/errors');
+const { ArgumentsRequired, ExchangeError, ExchangeNotAvailable, NotSupported, RequestTimeout, AuthenticationError, PermissionDenied, RateLimitExceeded, InsufficientFunds, OrderNotFound, InvalidOrder, AccountSuspended, CancelPending, InvalidNonce, OnMaintenance, BadSymbol } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -31,7 +31,7 @@ module.exports = class poloniex extends Exchange {
                 'createDepositAddress': true,
                 'createMarketOrder': undefined,
                 'createOrder': true,
-                'editOrder': false,
+                'editOrder': true,
                 'fetchBalance': true,
                 'fetchClosedOrder': false,
                 'fetchCurrencies': true,
@@ -883,7 +883,7 @@ module.exports = class poloniex extends Exchange {
         //         "updateTime": 1646925216548
         //     }
         //
-        // createOrder
+        // createOrder, editOrder
         //
         //     {
         //         "id": "29772698821328896",
@@ -1031,6 +1031,7 @@ module.exports = class poloniex extends Exchange {
          * @method
          * @name poloniex#createOrder
          * @description create a trade order
+         * @see https://docs.poloniex.com/#authenticated-endpoints-orders-create-order
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -1044,6 +1045,32 @@ module.exports = class poloniex extends Exchange {
         // }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createOrder() does not support ' + market['type'] + ' orders, only spot orders are accepted');
+        }
+        const request = {
+            'symbol': market['id'],
+            'side': side,
+            // 'timeInForce': timeInForce,
+            // 'accountType': 'SPOT',
+            // 'amount': amount,
+        };
+        const orderRequest = this.orderRequest ('createOrder()', symbol, type, side, amount, request, price, params);
+        let response = await this.privatePostOrders (this.extend (orderRequest[0], orderRequest[1]));
+        //
+        //     {
+        //         "id" : "78923648051920896",
+        //         "clientOrderId" : ""
+        //     }
+        //
+        response = this.extend (response, {
+            'type': side,
+        });
+        return this.parseOrder (response, market);
+    }
+
+    orderRequest (method, symbol, type, side, amount, request, price = undefined, params = {}) {
+        const market = this.market (symbol);
         let upperCaseType = type.toUpperCase ();
         const isMarket = upperCaseType === 'MARKET';
         const isPostOnly = this.isPostOnly (isMarket, upperCaseType === 'LIMIT_MAKER', params);
@@ -1051,14 +1078,7 @@ module.exports = class poloniex extends Exchange {
             upperCaseType = 'LIMIT_MAKER';
             params = this.omit (params, 'postOnly');
         }
-        const request = {
-            'symbol': market['id'],
-            'side': side,
-            'type': upperCaseType,
-            // 'timeInForce': timeInForce,
-            // 'accountType': 'SPOT',
-            // 'amount': amount,
-        };
+        request['type'] = upperCaseType;
         if (isMarket) {
             if (side === 'buy') {
                 request['amount'] = this.currencyToPrecision (market['quote'], amount);
@@ -1075,7 +1095,35 @@ module.exports = class poloniex extends Exchange {
             params = this.omit (params, 'clientOrderId');
         }
         // remember the timestamp before issuing the request
-        let response = await this.privatePostOrders (this.extend (request, params));
+        return [ request, params ];
+    }
+
+    async editOrder (id, symbol, type, side, amount, price = undefined, params = {}) {
+        /**
+         * @method
+         * @name poloniex#editOrder
+         * @description edit a trade order
+         * @see https://docs.poloniex.com/#authenticated-endpoints-orders-cancel-replace-order
+         * @param {string} id order id
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much of the currency you want to trade in units of the base currency
+         * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {object} params extra parameters specific to the poloniex api endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' editOrder() does not support ' + market['type'] + ' orders, only spot orders are accepted');
+        }
+        const request = {
+            'id': id,
+            // 'timeInForce': timeInForce,
+        };
+        const orderRequest = this.orderRequest ('editOrder()', symbol, type, side, amount, request, price, params);
+        let response = await this.privatePutOrdersId (this.extend (orderRequest[0], orderRequest[1]));
         //
         //     {
         //         "id" : "78923648051920896",


### PR DESCRIPTION
Added editOrder to Poloniex:
#16165
```
node examples/js/cli poloniex editOrder '"132088070949392384"' BTC/USDT limit buy 0.000150 13400

poloniex.editOrder (132088070949392384, BTC/USDT, limit, buy, 0.00015, 13400)
2022-12-31T03:51:38.151Z iteration 0 passed in 283 ms

{
  info: { id: '132088274981318656', clientOrderId: '', type: 'buy' },
  id: '132088274981318656',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'BTC/USDT',
  type: 'buy',
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  cost: undefined,
  average: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  trades: [],
  fee: undefined,
  fees: []
}
```