### PR TITLE
binance support for RSA API keys

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -6355,7 +6355,12 @@ module.exports = class binance extends Exchange {
             } else {
                 query = this.urlencode (extendedParams);
             }
-            const signature = this.hmac (this.encode (query), this.encode (this.secret));
+            let signature = undefined;
+            if (this.secret.indexOf ('-----BEGIN RSA PRIVATE KEY-----') > -1) {
+                signature = this.rsa (this.encode (query), this.encode (this.secret));
+            } else {
+                signature = this.hmac (this.encode (query), this.encode (this.secret));
+            }
             query += '&' + 'signature=' + signature;
             headers = {
                 'X-MBX-APIKEY': this.apiKey,


### PR DESCRIPTION
https://www.binance.com/en/support/announcement/binance-now-supports-rsa-api-keys-2022-12-29-f418fed3f05f4854a7bbccaad3104a1c

you can generate a keypair with the folowing code:

```
openssl genrsa 2> /dev/null | tee /dev/stderr | openssl rsa -pubout 2> /dev/null
```

to use binance with RSA keys, you can use the following code:

```javascript
// generate an asymmetric keypair and store it in the files private.pem and public.pem as base64 ascii
openssl genrsa 2> /dev/null | tee private.pem | openssl rsa -pubout -out public.pem

// upload this public key to binance and download the apiKey from binance
cat public.pem

const fs = require ('fs')
const secret = fs.readFileSync ('./private.pem').toString ()

// create a new API key on binance https://www.binance.com/en/my/settings/api-management
// and select self-generated API key, and upload the public key, binance will give you an API key
const apiKey = 'OnSqRnNxmrXnTaQlg2YLCr7y2XHx6O0YltqgX61lBX1gSARtpfsvRVxKYtLXsaco'
const binance = new ccxt.binance ({ apiKey, secret })

// use the private api as normal
await binance.createOrder (...)
})
```
