### PR TITLE
okx: add more withdraw networks ccxt/ccxt#16236

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -713,6 +713,9 @@ module.exports = class okx extends Exchange {
                     'POLYGON': 'Polygon',
                     'OEC': 'OEC',
                     'ALGO': 'ALGO', // temporarily unavailable
+                    'OPTIMISM': 'Optimism',
+                    'ARBITRUM': 'Arbitrum one',
+                    'AVALANCHE': 'Avalanche C-Chain',
                 },
                 'fetchOpenInterestHistory': {
                     'timeframes': {


### PR DESCRIPTION
fix: ccxt/ccxt#16236

Add these networks:
* OPTIMISM: Optimism
* ARBITRUM: Arbitrum one
* AVALANCHE: Avalanche C-Chain

Just see this PR added these options: https://github.com/ccxt/ccxt/pull/16024, probably merge that one.
