### PR TITLE
binance: update currency code when fetch fiat transactions ccxt/ccxt#16224

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1146,7 +1146,7 @@ module.exports = class binance extends Exchange {
                     'JPY': true,
                     'NZD': true,
                 },
-                'reverseCurrencyToLeagalMoney': {
+                'legalMoneyCurrenciesById': {
                     'BUSD': 'USD',
                 },
             },
@@ -4375,8 +4375,8 @@ module.exports = class binance extends Exchange {
             const txType = this.safeString (transaction, 'transactionType');
             type = (txType === '0') ? 'deposit' : 'withdrawal';
             timestamp = insertTime;
-            const reverseCurrencyToLeagalMoney = this.safeValue (this.options, 'reverseCurrencyToLeagalMoney');
-            code = this.safeString (reverseCurrencyToLeagalMoney, code, code);
+            const legalMoneyCurrenciesById = this.safeValue (this.options, 'legalMoneyCurrenciesById');
+            code = this.safeString (legalMoneyCurrenciesById, code, code);
         }
         const status = this.parseTransactionStatusByType (this.safeString (transaction, 'status'), type);
         const amount = this.safeNumber (transaction, 'amount');

--- a/js/binance.js
+++ b/js/binance.js
@@ -1146,7 +1146,7 @@ module.exports = class binance extends Exchange {
                     'JPY': true,
                     'NZD': true,
                 },
-                'reverseCurrencyToleagalMoney': {
+                'reverseCurrencyToLeagalMoney': {
                     'BUSD': 'USD',
                 },
             },
@@ -4339,6 +4339,7 @@ module.exports = class binance extends Exchange {
         //     {
         //       "orderNo": "25ced37075c1470ba8939d0df2316e23",
         //       "fiatCurrency": "EUR",
+        //       "transactionType": 0,
         //       "indicatedAmount": "15.00",
         //       "amount": "15.00",
         //       "totalFee": "0.00",
@@ -4369,17 +4370,19 @@ module.exports = class binance extends Exchange {
         let timestamp = undefined;
         const insertTime = this.safeInteger2 (transaction, 'insertTime', 'createTime');
         const applyTime = this.parse8601 (this.safeString (transaction, 'applyTime'));
+        const updated = this.safeInteger2 (transaction, 'successTime', 'updateTime');
         let type = this.safeString (transaction, 'type');
         if (type === undefined) {
-            if ((insertTime !== undefined) && (applyTime === undefined)) {
+            const txType = this.safeString (transaction, 'transactionType');
+            if (txType === '0') {
                 type = 'deposit';
                 timestamp = insertTime;
-            } else if ((insertTime === undefined) && (applyTime !== undefined)) {
+            } else {
                 type = 'withdrawal';
-                timestamp = applyTime;
+                timestamp = updated;
             }
-            const reverseCurrencyToleagalMoney = this.safeValue (this.options, 'reverseCurrencyToleagalMoney');
-            code = this.safeString (reverseCurrencyToleagalMoney, code);
+            const reverseCurrencyToLeagalMoney = this.safeValue (this.options, 'reverseCurrencyToLeagalMoney');
+            code = this.safeString (reverseCurrencyToLeagalMoney, code, code);
         }
         const status = this.parseTransactionStatusByType (this.safeString (transaction, 'status'), type);
         const amount = this.safeNumber (transaction, 'amount');
@@ -4388,7 +4391,6 @@ module.exports = class binance extends Exchange {
         if (feeCost !== undefined) {
             fee = { 'currency': code, 'cost': feeCost };
         }
-        const updated = this.safeInteger2 (transaction, 'successTime', 'updateTime');
         let internal = this.safeInteger (transaction, 'transferType');
         if (internal !== undefined) {
             internal = internal ? true : false;

--- a/js/binance.js
+++ b/js/binance.js
@@ -1146,6 +1146,9 @@ module.exports = class binance extends Exchange {
                     'JPY': true,
                     'NZD': true,
                 },
+                'reverseCurrencyToleagalMoney': {
+                    'BUSD': 'USD',
+                },
             },
             // https://binance-docs.github.io/apidocs/spot/en/#error-codes-2
             'exceptions': {
@@ -4362,7 +4365,7 @@ module.exports = class binance extends Exchange {
             txid = txid.slice (18);
         }
         const currencyId = this.safeString2 (transaction, 'coin', 'fiatCurrency');
-        const code = this.safeCurrencyCode (currencyId, currency);
+        let code = this.safeCurrencyCode (currencyId, currency);
         let timestamp = undefined;
         const insertTime = this.safeInteger2 (transaction, 'insertTime', 'createTime');
         const applyTime = this.parse8601 (this.safeString (transaction, 'applyTime'));
@@ -4375,6 +4378,8 @@ module.exports = class binance extends Exchange {
                 type = 'withdrawal';
                 timestamp = applyTime;
             }
+            const reverseCurrencyToleagalMoney = this.safeValue (this.options, 'reverseCurrencyToleagalMoney');
+            code = this.safeString (reverseCurrencyToleagalMoney, code);
         }
         const status = this.parseTransactionStatusByType (this.safeString (transaction, 'status'), type);
         const amount = this.safeNumber (transaction, 'amount');

--- a/js/binance.js
+++ b/js/binance.js
@@ -4373,13 +4373,8 @@ module.exports = class binance extends Exchange {
         let type = this.safeString (transaction, 'type');
         if (type === undefined) {
             const txType = this.safeString (transaction, 'transactionType');
-            if (txType === '0') {
-                type = 'deposit';
-                timestamp = insertTime;
-            } else {
-                type = 'withdrawal';
-                timestamp = updated;
-            }
+            type = (txType === '0') ? 'deposit' : 'withdrawal';
+            timestamp = insertTime;
             const reverseCurrencyToLeagalMoney = this.safeValue (this.options, 'reverseCurrencyToLeagalMoney');
             code = this.safeString (reverseCurrencyToLeagalMoney, code, code);
         }

--- a/js/binance.js
+++ b/js/binance.js
@@ -4369,7 +4369,6 @@ module.exports = class binance extends Exchange {
         let code = this.safeCurrencyCode (currencyId, currency);
         let timestamp = undefined;
         const insertTime = this.safeInteger2 (transaction, 'insertTime', 'createTime');
-        const applyTime = this.parse8601 (this.safeString (transaction, 'applyTime'));
         const updated = this.safeInteger2 (transaction, 'successTime', 'updateTime');
         let type = this.safeString (transaction, 'type');
         if (type === undefined) {


### PR DESCRIPTION
fix: ccxt/ccxt#16224

The currency code of USD is BUSD when get fiat orders. Added a map for this, in case binance use another currency for other fiat.