### PR TITLE
docs: update the Python proxy docs

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -106,6 +106,7 @@ class Exchange(object):
     timeout = 10000   # milliseconds = seconds * 1000
     asyncio_loop = None
     aiohttp_proxy = None
+    trust_env = False
     aiohttp_trust_env = False
     requests_trust_env = False
     session = None  # Session () by default
@@ -370,7 +371,10 @@ class Exchange(object):
     synchronous = True
 
     def __init__(self, config={}):
-
+        
+        self.aiohttp_trust_env = self.aiohttp_trust_env or self.trust_env
+        self.requests_trust_env = self.requests_trust_env or self.trust_env
+        
         self.precision = dict() if self.precision is None else self.precision
         self.limits = dict() if self.limits is None else self.limits
         self.exceptions = dict() if self.exceptions is None else self.exceptions

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -175,7 +175,14 @@ const kraken = new ccxt.kraken ({ agent })
 
 The python version of the library uses the [python-requests](python-requests.org) package for underlying HTTP and supports all means of customization available in the `requests` package, including proxies.
 
-You can configure proxies by setting the environment variables HTTP_PROXY and HTTPS_PROXY.
+You can configure proxies by setting `requests_trust_env` to `True`(default to `False`) and setting the environment variables HTTP_PROXY and HTTPS_PROXY.
+
+```python
+import ccxt
+exchange = ccxt.binance({
+    'requests_trust_env': True
+})
+```
 
 ```shell
 $ export HTTP_PROXY="http://10.10.1.10:3128"

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -175,12 +175,12 @@ const kraken = new ccxt.kraken ({ agent })
 
 The python version of the library uses the [python-requests](python-requests.org) package for underlying HTTP and supports all means of customization available in the `requests` package, including proxies.
 
-You can configure proxies by setting `requests_trust_env` to `True`(default to `False`) and setting the environment variables HTTP_PROXY and HTTPS_PROXY.
+You can configure proxies by setting `trust_env` to `True`(default to `False`) and setting the environment variables HTTP_PROXY and HTTPS_PROXY.
 
 ```python
 import ccxt
 exchange = ccxt.binance({
-    'requests_trust_env': True
+    'trust_env': True
 })
 ```
 


### PR DESCRIPTION
#15783 mentions the current documentation about proxy is out of date due to #14561 introduced `requests_trust_env`.
