### PR TITLE
bitmex: update official websocket endpoint

### DIFF
--- a/js/pro/bitmex.js
+++ b/js/pro/bitmex.js
@@ -24,10 +24,10 @@ module.exports = class bitmex extends bitmexRest {
             },
             'urls': {
                 'test': {
-                    'ws': 'wss://testnet.bitmex.com/realtime',
+                    'ws': 'wss://ws.testnet.bitmex.com/realtime',
                 },
                 'api': {
-                    'ws': 'wss://www.bitmex.com/realtime',
+                    'ws': 'wss://ws.bitmex.com/realtime',
                 },
             },
             'versions': {


### PR DESCRIPTION
Just saw bitmex updated their official endpoint for websocket service (https://github.com/BitMEX/api-connectors/commit/4feab7540bdbbffae5285ceda9e95f99881e00b6). The previous endpoint still work, but I'm not sure whether they'll stop supporting or not.