### PR TITLE
Binance :: fetchDeposits/fetchWithdrawals fiat only

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4052,6 +4052,7 @@ module.exports = class binance extends Exchange {
          * @param {int|undefined} since the earliest time in ms to fetch deposits for
          * @param {int|undefined} limit the maximum number of deposits structures to retrieve
          * @param {object} params extra parameters specific to the binance api endpoint
+         * @param {bool} params.fiat if true, only fiat deposits will be returned
          * @param {int|undefined} params.until the latest time in ms to fetch deposits for
          * @returns {[object]} a list of [transaction structures]{@link https://docs.ccxt.com/en/latest/manual.html#transaction-structure}
          */
@@ -4060,8 +4061,10 @@ module.exports = class binance extends Exchange {
         let response = undefined;
         const request = {};
         const legalMoney = this.safeValue (this.options, 'legalMoney', {});
+        const fiatOnly = this.safeValue (params, 'fiat', false);
+        params = this.omit (params, 'fiatOnly');
         const until = this.safeInteger (params, 'until');
-        if (code in legalMoney) {
+        if (fiatOnly || (code in legalMoney)) {
             if (code !== undefined) {
                 currency = this.currency (code);
             }
@@ -4150,14 +4153,17 @@ module.exports = class binance extends Exchange {
          * @param {int|undefined} since the earliest time in ms to fetch withdrawals for
          * @param {int|undefined} limit the maximum number of withdrawals structures to retrieve
          * @param {object} params extra parameters specific to the binance api endpoint
+         * @param {bool} params.fiat if true, only fiat withdrawals will be returned
          * @returns {[object]} a list of [transaction structures]{@link https://docs.ccxt.com/en/latest/manual.html#transaction-structure}
          */
         await this.loadMarkets ();
         const legalMoney = this.safeValue (this.options, 'legalMoney', {});
+        const fiatOnly = this.safeValue (params, 'fiat', false);
+        params = this.omit (params, 'fiatOnly');
         const request = {};
         let response = undefined;
         let currency = undefined;
-        if (code in legalMoney) {
+        if (fiatOnly || (code in legalMoney)) {
             if (code !== undefined) {
                 currency = this.currency (code);
             }


### PR DESCRIPTION
-fix https://github.com/ccxt/ccxt/issues/16224

Now users don't have to specify the fiat currency to retrieve all fiat deposits/withdrawals

Usage:
```Python
binance.fetch_deposits(params={"fiat":True})
binance.fetch_withdrawals(params={"fiat":True})
```