### PR TITLE
Added support for DOGE

### DIFF
--- a/js/bitstamp.js
+++ b/js/bitstamp.js
@@ -302,6 +302,8 @@ module.exports = class bitstamp extends Exchange {
                         'dot_address/': 1,
                         'near_withdrawal/': 1,
                         'near_address/': 1,
+                        'doge_withdrawal/': 1,
+                        'doge_address/': 1,
                     },
                 },
             },


### PR DESCRIPTION
Bitstamp is adding DOGE to their platform: https://blog.bitstamp.net/post/were-listing-dogecoin-doge/