### PR TITLE
bitopro: add bsc network

### DIFF
--- a/js/bitopro.js
+++ b/js/bitopro.js
@@ -177,6 +177,8 @@ module.exports = class bitopro extends Exchange {
                     'ETH': 'ERC20',
                     'TRX': 'TRX',
                     'TRC20': 'TRX',
+                    'BEP20': 'BSC',
+                    'BSC': 'BSC',
                 },
             },
             'precisionMode': TICK_SIZE,


### PR DESCRIPTION
Just see bitopro added bsc network in withdrawal api (https://github.com/bitoex/bitopro-offical-api-docs/commit/9ee2fb5b4c9efc253d19ad9957dbb6fcfd84f4f1)