### PR TITLE
Bybit :: stop order fix

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3592,7 +3592,7 @@ module.exports = class bybit extends Exchange {
             // logical xor
             const ascending = stopLossPrice ? !isBuy : isBuy;
             const delta = this.numberToString (market['precision']['price']);
-            request['basePrice'] = !ascending ? Precise.stringAdd (preciseTriggerPrice, delta) : Precise.stringSub (preciseTriggerPrice, delta);
+            request['basePrice'] = ascending ? Precise.stringSub (preciseTriggerPrice, delta) : Precise.stringAdd (preciseTriggerPrice, delta);
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');
         if (clientOrderId !== undefined) {

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3592,7 +3592,7 @@ module.exports = class bybit extends Exchange {
             // logical xor
             const ascending = stopLossPrice ? !isBuy : isBuy;
             const delta = this.numberToString (market['precision']['price']);
-            request['basePrice'] = ascending ? Precise.stringAdd (preciseTriggerPrice, delta) : Precise.stringSub (preciseTriggerPrice, delta);
+            request['basePrice'] = !ascending ? Precise.stringAdd (preciseTriggerPrice, delta) : Precise.stringSub (preciseTriggerPrice, delta);
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');
         if (clientOrderId !== undefined) {


### PR DESCRIPTION
Demo:

```
p bybit createOrder "LTC/USDT:USDT" "market" "buy" 0.1 50 '{"takeProfitPrice": 90}' --sandbox          
Python v3.10.8
CCXT v2.5.21
bybit.createOrder(LTC/USDT:USDT,market,buy,0.1,50,{'takeProfitPrice': 90})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '26295d69-0a0b-4047-8fc3-a01a4877d4da',
 'info': {'orderId': '26295d69-0a0b-4047-8fc3-a01a4877d4da', 'orderLinkId': ''},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
```
p bybit createOrder "LTC/USDT:USDT" "market" "buy" 0.1 50 '{"takeProfitPrice": 90}' --sandbox          
Python v3.10.8
CCXT v2.5.21
bybit.createOrder(LTC/USDT:USDT,market,buy,0.1,50,{'takeProfitPrice': 90})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': 'ed79e885-2857-470f-b590-8a7eafe4c4d9',
 'info': {'orderId': 'ed79e885-2857-470f-b590-8a7eafe4c4d9', 'orderLinkId': ''},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
