### PR TITLE
binance.options["accountsByType"] added swap key

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -902,6 +902,7 @@ module.exports = class binance extends Exchange {
                     'funding': 'FUNDING',
                     'margin': 'MARGIN',
                     'cross': 'MARGIN',
+                    'swap': 'UMFUTURE',
                     'future': 'UMFUTURE',
                     'delivery': 'CMFUTURE',
                 },


### PR DESCRIPTION
This change allows stuff like this to happen

```
% binance transfer USDT 1 swap spot                         
2023-01-04T20:45:07.331Z
Node.js: v18.4.0
CCXT v2.5.29
binance.transfer (USDT, 1, swap, spot)
2023-01-04T20:45:09.346Z iteration 0 passed in 798 ms

{
  info: { tranId: '125525867174' },
  id: '125525867174',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 1,
  fromAccount: 'swap',
  toAccount: 'spot',
  status: undefined
}
2023-01-04T20:45:09.346Z iteration 1 passed in 798 ms
```