### PR TITLE
Bybit :: ticker fix

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1567,8 +1567,8 @@ module.exports = class bybit extends Exchange {
         percentage = Precise.stringMul (percentage, '100');
         const quoteVolume = this.safeStringN (ticker, [ 'turnover_24h', 'turnover24h', 'quoteVolume' ]);
         const baseVolume = this.safeStringN (ticker, [ 'volume_24h', 'volume24h', 'volume' ]);
-        const bid = this.safeStringN (ticker, [ 'bid_price', 'bid', 'bestBidPrice', 'bidPrice' ]);
-        const ask = this.safeStringN (ticker, [ 'ask_price', 'ask', 'bestAskPrice', 'askPrice' ]);
+        const bid = this.safeStringN (ticker, [ 'bid_price', 'bid', 'bestBidPrice', 'bidPrice', 'bid1Price' ]);
+        const ask = this.safeStringN (ticker, [ 'ask_price', 'ask', 'bestAskPrice', 'askPrice', 'ask1Price' ]);
         const high = this.safeStringN (ticker, [ 'high_price_24h', 'high24h', 'highPrice', 'highPrice24h' ]);
         const low = this.safeStringN (ticker, [ 'low_price_24h', 'low24h', 'lowPrice', 'lowPrice24h' ]);
         return this.safeTicker ({
@@ -1578,9 +1578,9 @@ module.exports = class bybit extends Exchange {
             'high': high,
             'low': low,
             'bid': bid,
-            'bidVolume': this.safeString (ticker, 'bidSize'),
+            'bidVolume': this.safeString2 (ticker, 'bidSize', 'bid1Size'),
             'ask': ask,
-            'askVolume': this.safeString (ticker, 'askSize'),
+            'askVolume': this.safeString (ticker, 'askSize', 'ask1Size'),
             'vwap': undefined,
             'open': open,
             'close': last,

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1580,7 +1580,7 @@ module.exports = class bybit extends Exchange {
             'bid': bid,
             'bidVolume': this.safeString2 (ticker, 'bidSize', 'bid1Size'),
             'ask': ask,
-            'askVolume': this.safeString (ticker, 'askSize', 'ask1Size'),
+            'askVolume': this.safeString2 (ticker, 'askSize', 'ask1Size'),
             'vwap': undefined,
             'open': open,
             'close': last,


### PR DESCRIPTION


```
 p bybit watchTicker "BTCUSDT" --sandbox
Python v3.10.8
CCXT v2.5.30
bybit.watchTicker(BTCUSDT)
{'ask': 16812.0,
 'askVolume': 521.183,
 'average': 16832.5,
 'baseVolume': 752504.87299999,
 'bid': 16811.5,
 'bidVolume': 412.196,
 'change': -41.0,
 'close': 16812.0,
 'datetime': '2023-01-05T09:25:13.308Z',
 'high': 16984.0,
 'info': {'ask1Price': '16812.00',
          'ask1Size': '521.183',
          'bid1Price': '16811.50',
          'bid1Size': '412.196',
          'fundingRate': '0.0001',
          'highPrice24h': '16984.00',
          'indexPrice': '16811.69',
          'lastPrice': '16812.00',
          'lowPrice24h': '16771.00',
          'markPrice': '16812.96',
          'nextFundingTime': '1672934400000',
          'openInterest': '76500.122',
          'openInterestValue': '1286193491.18',
          'prevPrice1h': '16817.00',
          'prevPrice24h': '16853.00',
          'price24hPcnt': '-0.002432',
          'symbol': 'BTCUSDT',
          'tickDirection': 'ZeroPlusTick',
          'turnover24h': '12676705574.19001',
          'volume24h': '752504.87299999'},
 'last': 16812.0,
 'low': 16771.0,
 'open': 16853.0,
 'percentage': -0.2432,
 'previousClose': None,
 'quoteVolume': 12676705574.19001,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1672910713308,
 'vwap': 16846.0112738568}
```
