### PR TITLE
updated basePrice logic for stop loss

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3592,7 +3592,7 @@ module.exports = class bybit extends Exchange {
             // logical xor
             const ascending = stopLossPrice ? !isBuy : isBuy;
             const delta = this.numberToString (market['precision']['price']);
-            request['basePrice'] = ascending ? Precise.stringSub (preciseTriggerPrice, delta) : Precise.stringAdd (preciseTriggerPrice, delta);
+            request['basePrice'] = ascending ? Precise.stringAdd (preciseTriggerPrice, delta) : Precise.stringSub (preciseTriggerPrice, delta);
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');
         if (clientOrderId !== undefined) {


### PR DESCRIPTION
From #16328 

Inverting baseLine price so that stop loss and take_profit may work. (stop loss is broken since this PR).

Request for Swap linear where Buy/Long order exists :

  TP:   
  `{
    "symbol": "ETCUSDT",
    "side": "Sell",
    "orderType": "Limit",
    "timeInForce": "GoodTillCancel",
    "qty": "44.8",
    "category": "linear",
    "price": "18.535"
  }`
  
  SL: 
  `{
    "symbol": "ETCUSDT",
    "side": "Sell",
    "orderType": "Limit",
    "timeInForce": "GoodTillCancel",
    "qty": "44.8",
    "category": "linear",
    "price": "18.27",
    "triggerBy": "LastPrice",
    "triggerPrice": "18.27",
    "basePrice": "18.275"
  }`