### PR TITLE
fix(wazirx-php): signature param name

### DIFF
--- a/php/wazirx.php
+++ b/php/wazirx.php
@@ -870,7 +870,7 @@ class wazirx extends Exchange {
             $data = $this->keysort($data);
             $signature = $this->hmac($this->encode($this->urlencode($data)), $this->encode($this->secret), 'sha256');
             $url .= '?' . $this->urlencode($data);
-            $url .= '&$signature=' . $signature;
+            $url .= '&signature=' . $signature;
             $headers = array(
                 'Content-Type' => 'application/x-www-form-urlencoded',
                 'X-Api-Key' => $this->apiKey,


### PR DESCRIPTION
The signature was mistakenly passed to WazirX API in parameter `$signature` while it should say just `signature` as per the WazirX API docs. This caused errors from API saying that `Signature not found`.