### PR TITLE
Bybit :: fix USDC set leverage

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -6446,7 +6446,7 @@ module.exports = class bybit extends Exchange {
                 'symbol': market['id'],
                 'leverage': leverage,
             };
-            method = 'privatePostOptionUsdcOpenapiPrivateV1PositionSetLeverage';
+            method = 'privatePostPerpetualUsdcOpenapiPrivateV1PositionLeverageSave';
         }
         return await this[method] (this.extend (request, params));
     }


### PR DESCRIPTION
Demo:

```
onnector object at 0x106ba0700>
➜  ccxt git:(bybit-set-leverage) ✗ p bybit setLeverage 3 "ETH/USD:USDC" --sandbox 
Python v3.10.8
CCXT v2.5.36
bybit.setLeverage(3,ETH/USD:USDC)
{'result': {'leverage': '3.00'}, 'retCode': '0', 'retMsg': ''}
```
