### PR TITLE
hitbtc3-fetchDepositWithdrawFee(s)

### DIFF
--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -41,6 +41,8 @@ module.exports = class hitbtc3 extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
+                'fetchDepositWithdrawFee': 'emulated',
+                'fetchDepositWithdrawFees': true,
                 'fetchFundingHistory': undefined,
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
@@ -76,8 +78,6 @@ module.exports = class hitbtc3 extends Exchange {
                 'setPositionMode': false,
                 'transfer': true,
                 'withdraw': true,
-                'fetchDepositWithdrawFees': true,
-                'fetchDepositWithdrawFee': 'emulated',
             },
             'precisionMode': TICK_SIZE,
             'urls': {

--- a/js/hitbtc3.js
+++ b/js/hitbtc3.js
@@ -76,6 +76,8 @@ module.exports = class hitbtc3 extends Exchange {
                 'setPositionMode': false,
                 'transfer': true,
                 'withdraw': true,
+                'fetchDepositWithdrawFees': true,
+                'fetchDepositWithdrawFee': 'emulated',
             },
             'precisionMode': TICK_SIZE,
             'urls': {
@@ -2682,6 +2684,96 @@ module.exports = class hitbtc3 extends Exchange {
             // 'strict_validate': false,
         };
         return await this.privatePutFuturesAccountIsolatedSymbol (this.extend (request, params));
+    }
+
+    async fetchDepositWithdrawFees (codes = undefined, params = {}) {
+        /**
+         * @method
+         * @name hitbtc3#fetchDepositWithdrawFees
+         * @description fetch deposit and withdraw fees
+         * @see https://api.hitbtc.com/#currencies
+         * @param {[string]|undefined} codes list of unified currency codes
+         * @param {object} params extra parameters specific to the hitbtc3 api endpoint
+         * @returns {[object]} a list of [fees structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.publicGetPublicCurrency (params);
+        //
+        //     {
+        //       "WEALTH": {
+        //         "full_name": "ConnectWealth",
+        //         "payin_enabled": false,
+        //         "payout_enabled": false,
+        //         "transfer_enabled": true,
+        //         "precision_transfer": "0.001",
+        //         "networks": [
+        //           {
+        //             "network": "ETH",
+        //             "protocol": "ERC20",
+        //             "default": true,
+        //             "payin_enabled": false,
+        //             "payout_enabled": false,
+        //             "precision_payout": "0.001",
+        //             "payout_fee": "0.016800000000",
+        //             "payout_is_payment_id": false,
+        //             "payin_payment_id": false,
+        //             "payin_confirmations": "2"
+        //           }
+        //         ]
+        //       }
+        //     }
+        //
+        return this.parseDepositWithdrawFees (response, codes);
+    }
+
+    parseDepositWithdrawFee (fee, currency = undefined) {
+        //
+        //    {
+        //         "full_name": "ConnectWealth",
+        //         "payin_enabled": false,
+        //         "payout_enabled": false,
+        //         "transfer_enabled": true,
+        //         "precision_transfer": "0.001",
+        //         "networks": [
+        //           {
+        //             "network": "ETH",
+        //             "protocol": "ERC20",
+        //             "default": true,
+        //             "payin_enabled": false,
+        //             "payout_enabled": false,
+        //             "precision_payout": "0.001",
+        //             "payout_fee": "0.016800000000",
+        //             "payout_is_payment_id": false,
+        //             "payin_payment_id": false,
+        //             "payin_confirmations": "2"
+        //           }
+        //         ]
+        //    }
+        //
+        const networks = this.safeValue (fee, 'networks', []);
+        const result = this.depositWithdrawFee (fee);
+        for (let j = 0; j < networks.length; j++) {
+            const networkEntry = networks[j];
+            const networkId = this.safeString (networkEntry, 'network');
+            const networkCode = this.networkIdToCode (networkId);
+            const withdrawFee = this.safeNumber (networkEntry, 'payout_fee');
+            const isDefault = this.safeValue (networkEntry, 'default');
+            const withdrawResult = {
+                'fee': withdrawFee,
+                'percentage': (withdrawFee !== undefined) ? false : undefined,
+            };
+            if (isDefault === true) {
+                result['withdraw'] = withdrawResult;
+            }
+            result['networks'][networkCode] = {
+                'withdraw': withdrawResult,
+                'deposit': {
+                    'fee': undefined,
+                    'percentage': undefined,
+                },
+            };
+        }
+        return result;
     }
 
     handleMarginModeAndParams (methodName, params = {}, defaultValue = undefined) {


### PR DESCRIPTION
# Testing
## Python
`python3 examples/py/cli.py hitbtc3 fetchDepositWithdrawFee "ETH"`
```js
Python v3.10.6
CCXT v2.5.44
hitbtc3.fetchDepositWithdrawFee(ETH)
{'deposit': {'fee': None, 'percentage': None},
 'info': {'crypto': True,
          'full_name': 'Ethereum',
          'networks': [{'avg_processing_time': '313.74749999999983',
                        'default': True,
                        'high_processing_time': '1972.166',
                        'low_processing_time': '2.938',
                        'network': 'eth',
                        'payin_confirmations': '9',
                        'payin_enabled': True,
                        'payin_payment_id': False,
                        'payout_enabled': True,
                        'payout_fee': '0.004806848798',
                        'payout_is_payment_id': False,
                        'precision_payout': '0.000000000000000001',
                        'protocol': ''}],
          'payin_enabled': True,
          'payout_enabled': True,
          'precision_transfer': '0.000000000001',
          'transfer_enabled': True},
 'networks': {'eth': {'deposit': {'fee': None, 'percentage': None},
                      'withdraw': {'fee': 0.004806848798,
                                   'percentage': False}}},
 'withdraw': {'fee': 0.004806848798, 'percentage': False}}
```