### PR TITLE
Docker :: add php8.1 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN sed -i 's/archive\.ubuntu\.com/us\.archive\.ubuntu\.com/' /etc/apt/sources.l
 # Miscellaneous deps
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git ca-certificates
 # PHP
-RUN apt-get update && apt-get install -y --no-install-recommends php php-curl php-iconv php-mbstring php-bcmath php-gmp
+RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:ondrej/php
+RUN apt-get update && apt-get install -y --no-install-recommends php8.1 php8.1-curl php8.1-iconv php8.1-mbstring php8.1-bcmath php8.1-gmp
 # Node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y nodejs


### PR DESCRIPTION
- Our docker image was broken because recently, we set PHP 8 as the minimum supported PHP and Ubuntu 20 is shipped with PHP 7.4 only

Demo

```
root@1f61b5472345:/ccxt# php examples/php/cli.php binance fetch_ticker "BTC/USDT"
PHP v8.1.14
CCXT version :2.5.37
binance->fetch_ticker(BTC/USDT)
Array
(
    [symbol] => BTC/USDT
    [timestamp] => 1673179802977
    [datetime] => 2023-01-08T12:10:02.977Z
    [high] => 16967.67
    [low] => 16908.6
    [bid] => 16928.37
    [bidVolume] => 0.02335
    [ask] => 16928.55
    [askVolume] => 0.00634
    [vwap] => 16935.46413617
    [open] => 16911.77
    [close] => 16928.57
    [last] => 16928.57
    [previousClose] => 16911.78
    [change] => 16.8
    [percentage] => 0.099
    [average] => 16920.17
    [baseVolume] => 105132.34601
    [quoteVolume] => 1780465075.4038
    [info] => Array
        (
            [symbol] => BTCUSDT
            [priceChange] => 16.80000000
            [priceChangePercent] => 0.099
            [weightedAvgPrice] => 16935.46413617
            [prevClosePrice] => 16911.78000000
            [lastPrice] => 16928.57000000
            [lastQty] => 0.00080000
            [bidPrice] => 16928.37000000
            [bidQty] => 0.02335000
            [askPrice] => 16928.55000000
            [askQty] => 0.00634000
            [openPrice] => 16911.77000000
            [highPrice] => 16967.67000000
            [lowPrice] => 16908.60000000
            [volume] => 105132.34601000
            [quoteVolume] => 1780465075.40379200
            [openTime] => 1673093402977
            [closeTime] => 1673179802977
            [firstId] => 2438769271
            [lastId] => 2441929835
            [count] => 3160565
        )

)
```