### PR TITLE
Improve cli parsing

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -82,6 +82,16 @@ const httpsAgent = new Agent ({
     keepAlive: true,
 })
 
+
+// check here if we have a arg like this: binance.fetchOrders()
+const callRegex = /(\w+)\.(\w+)\(([^()]*)\)/
+if (callRegex.test (exchangeId)) {
+    const res = callRegex.exec (exchangeId);
+    exchangeId = res[1];
+    methodName = res[2];
+    params = res[3].split(",").map(x => x.trim());
+}
+
 try {
     if (ccxt.pro.exchanges.includes(exchangeId)) {
         exchange = new (ccxt.pro)[exchangeId] ({ timeout, httpsAgent, ... settings })
@@ -200,6 +210,8 @@ const printHumanReadable = (exchange, result) => {
 //-----------------------------------------------------------------------------
 
 async function run () {
+
+
 
     if (!exchangeId) {
 

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -125,8 +125,6 @@ async def main():
         argv.exchange_id = groups[0]
         argv.method = groups[1]
         argv.args = list(map(lambda x: x.strip().replace("'", "\""), groups[2].split(',')))
-        print(argv.args)
-        print("\n\n\n")
 
     # ------------------------------------------------------------------------------
 

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -116,6 +116,17 @@ async def main():
     if not argv.exchange_id:
         print_usage()
         sys.exit()
+    
+    # check here if we have a arg like this: binance.fetchOrders()
+    call_reg = "(\w+)\.(\w+)\(([^()]*)\)"
+    match = re.match(call_reg, argv.exchange_id)
+    if match is not None:
+        groups = match.groups()
+        argv.exchange_id = groups[0]
+        argv.method = groups[1]
+        argv.args = list(map(lambda x: x.strip().replace("'", "\""), groups[2].split(',')))
+        print(argv.args)
+        print("\n\n\n")
 
     # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
- allow calling methods as we do in the code
- added to JS and Py for now 
- everything else remains the same
- JSON object don't need to be escaped anymore
- easier to copy from/to user reports/examples/etc

Demo:
```
python cli.py 'bybit.fetchTickers(["BTC/USDT"])' --sandbox --spot
Python v3.10.8
CCXT v2.5.37
bybit.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16725.65,
              'askVolume': None,
              'average': 16731.24,
              'baseVolume': 6229.679468,
              'bid': 16723.69,
              'bidVolume': None,
              'change': -11.18,
              'close': 16725.65,
              'datetime': '2023-01-08T14:51:13.287Z',
              'high': 16759.51,
              'info': {'ap': '16725.65',
                       'bp': '16723.69',
                       'h': '16759.51',
                       'l': '15120',
                       'lp': '16725.65',
                       'o': '16736.83',
                       'qv': '103941863.68857247',
                       's': 'BTCUSDT',
                       't': '1673189473287',
                       'v': '6229.679468'},
              'last': 16725.65,
              'low': 15120.0,
              'open': 16736.83,
              'percentage': -0.0667987904519553,
              'previousClose': None,
              'quoteVolume': 103941863.68857247,
              'symbol': 'BTC/USDT',
              'timestamp': 1673189473287,
              'vwap': 16684.94570587311}}
```
