### PR TITLE
Bybit :: fix fetchTickers

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1873,7 +1873,12 @@ module.exports = class bybit extends Exchange {
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
-        const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
+        let market = undefined;
+        if (symbols !== undefined) {
+            symbols = this.marketSymbols (symbols);
+            market = this.market (symbols[0]);
+        }
+        const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         if (type === 'spot') {
             return await this.fetchSpotTickers (symbols, query);
         } else {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16381
- fixes https://github.com/ccxt/ccxt/issues/16375

Demo:

```
p bybit fetchTickers '["BTC/USDT:USDT"]'  --sandbox       
Python v3.10.8
CCXT v2.5.52
bybit.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 16944.5,
                   'askVolume': None,
                   'average': 16945.25,
                   'baseVolume': 178023.75999999,
                   'bid': 16944.0,
                   'bidVolume': None,
                   'change': -2.5,
                   'close': 16944.0,
                   'datetime': None,
                   'high': 16967.0,
                   'info': {'askPrice': '16944.50',
                            'basisRate': '',
                            'bidPrice': '16944.00',
                            'deliveryFeeRate': '',
                            'deliveryTime': '0',
                            'fundingRate': '0.0001',
                            'highPrice24h': '16967.00',
                            'indexPrice': '16945.21',
                            'lastPrice': '16944.00',
                            'lastTickDirection': 'ZeroMinusTick',
                            'lowPrice24h': '16912.50',
                            'markPrice': '16945.37',
                            'nextFundingTime': '1673193600000',
                            'openInterest': '77694.672',
                            'openInterestValue': '1316564964.07',
                            'predictedDeliveryPrice': '',
                            'prevPrice1h': '16936.00',
                            'prevPrice24h': '16946.50',
                            'price24hPcnt': '-0.000147',
                            'symbol': 'BTCUSDT',
                            'turnover24h': '3015176882.956503',
                            'volume24h': '178023.75999999'},
                   'last': 16944.0,
                   'low': 16912.5,
                   'open': 16946.5,
                   'percentage': -0.0147,
                   'previousClose': None,
                   'quoteVolume': 3015176882.956503,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': None,
                   'vwap': 16936.93517627463}}
```
```
p bybit fetchTickers '["BTC/USDT"]'  --sandbox       
Python v3.10.8
CCXT v2.5.52
bybit.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 16732.79,
              'askVolume': None,
              'average': 16736.65,
              'baseVolume': 6217.92123,
              'bid': 16732.07,
              'bidVolume': None,
              'change': -7.72,
              'close': 16732.79,
              'datetime': '2023-01-08T15:14:00.000Z',
              'high': 16759.51,
              'info': {'ap': '16732.79',
                       'bp': '16732.07',
                       'h': '16759.51',
                       'l': '15120',
                       'lp': '16732.79',
                       'o': '16740.51',
                       'qv': '103745153.70304997',
                       's': 'BTCUSDT',
                       't': '1673190840000',
                       'v': '6217.92123'},
              'last': 16732.79,
              'low': 15120.0,
              'open': 16740.51,
              'percentage': -0.0461156798687734,
              'previousClose': None,
              'quoteVolume': 103745153.70304997,
              'symbol': 'BTC/USDT',
              'timestamp': 1673190840000,
              'vwap': 16684.86136532321}}
```
