### PR TITLE
Cli parsing: identation

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -84,7 +84,7 @@ const httpsAgent = new Agent ({
 
 
 // check here if we have a arg like this: binance.fetchOrders()
-const callRegex = /(\w+)\.(\w+)\(([^()]*)\)/
+const callRegex = /\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)/
 if (callRegex.test (exchangeId)) {
     const res = callRegex.exec (exchangeId);
     exchangeId = res[1];

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -118,7 +118,7 @@ async def main():
         sys.exit()
     
     # check here if we have a arg like this: binance.fetchOrders()
-    call_reg = "(\w+)\.(\w+)\(([^()]*)\)"
+    call_reg = "\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)"
     match = re.match(call_reg, argv.exchange_id)
     if match is not None:
         groups = match.groups()


### PR DESCRIPTION
- allow arbitrary empty spaces

Example:

```
 p 'bybit . fetchTickers  ( ["BTC/USDT"] )' --sandbox --spot
Python v3.10.8
CCXT v2.5.57
bybit.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 17066.23,
              'askVolume': None,
              'average': 16886.75,
              'baseVolume': 10039.612958,
              'bid': 17061.0,
              'bidVolume': None,
              'change': 348.5,
              'close': 17061.0,
              'datetime': '2023-01-09T11:04:18.658Z',
              'high': 17069.53,
              'info': {'ap': '17066.23',
                       'bp': '17061',
                       'h': '17069.53',
                       'l': '15120',
                       'lp': '17061',
                       'o': '16712.5',
                       'qv': '168881729.16820843',
                       's': 'BTCUSDT',
                       't': '1673262258658',
                       'v': '10039.612958'},
              'last': 17061.0,
              'low': 15120.0,
              'open': 16712.5,
              'percentage': 2.0852655198204935,
              'previousClose': None,
              'quoteVolume': 168881729.16820842,
              'symbol': 'BTC/USDT',
              'timestamp': 1673262258658,
              'vwap': 16821.537829666642}}
```
