### PR TITLE
okx: checkout whether tag is not empty ccxt/ccxt#16389

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -3696,7 +3696,7 @@ module.exports = class okx extends Exchange {
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);
-        if (tag !== undefined) {
+        if ((tag !== undefined) && (tag.length > 0)) {
             address = address + ':' + tag;
         }
         const fee = this.safeString (params, 'fee');


### PR DESCRIPTION
fix ccxt/ccxt#16389

`tag` could be empty string, and I think user couldn't use empty string tag in okx.