### PR TITLE
Bitfinex :: fix swap orders placement

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -662,10 +662,12 @@ module.exports = class bitfinex extends Exchange {
         // https://docs.bitfinex.com/docs/introduction#amount-precision
         // The amount field allows up to 8 decimals.
         // Anything exceeding this will be rounded to the 8th decimal.
+        symbol = this.safeSymbol (symbol);
         return this.decimalToPrecision (amount, TRUNCATE, this.markets[symbol]['precision']['amount'], DECIMAL_PLACES);
     }
 
     priceToPrecision (symbol, price) {
+        symbol = this.safeSymbol (symbol);
         price = this.decimalToPrecision (price, ROUND, this.markets[symbol]['precision']['price'], this.precisionMode);
         // https://docs.bitfinex.com/docs/introduction#price-precision
         // The precision level of all trading prices is based on significant figures.

--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -407,10 +407,12 @@ module.exports = class bitfinex2 extends Exchange {
         // https://docs.bitfinex.com/docs/introduction#amount-precision
         // The amount field allows up to 8 decimals.
         // Anything exceeding this will be rounded to the 8th decimal.
+        symbol = this.safeSymbol (symbol);
         return this.decimalToPrecision (amount, TRUNCATE, this.markets[symbol]['precision']['amount'], DECIMAL_PLACES);
     }
 
     priceToPrecision (symbol, price) {
+        symbol = this.safeSymbol (symbol);
         price = this.decimalToPrecision (price, ROUND, this.markets[symbol]['precision']['price'], this.precisionMode);
         // https://docs.bitfinex.com/docs/introduction#price-precision
         // The precision level of all trading prices is based on significant figures.
@@ -1521,7 +1523,12 @@ module.exports = class bitfinex2 extends Exchange {
         // order types "limit" and "market" immediatley parsed "EXCHANGE LIMIT" and "EXCHANGE MARKET"
         // note: same order types exist for margin orders without the EXCHANGE prefix
         const orderTypes = this.safeValue (this.options, 'orderTypes', {});
-        const orderType = this.safeStringUpper (orderTypes, type, type);
+        let orderType = type.toUpperCase ();
+        if (market['spot']) {
+            // although they claim that type needs to be 'exchange limit' or 'exchange market'
+            // in fact that's not the case for swap markets
+            orderType = this.safeStringUpper (orderTypes, type, type);
+        }
         const stopPrice = this.safeString2 (params, 'stopPrice', 'triggerPrice');
         const timeInForce = this.safeString (params, 'timeInForce');
         const postOnlyParam = this.safeValue (params, 'postOnly', false);


### PR DESCRIPTION
```
p bitfinex2 createOrder "TESTBTC/TESTUSDT:TESTUSDT" limit buy 0.001 14000          
Python v3.10.8
CCXT v2.5.60
bitfinex2.createOrder(TESTBTC/TESTUSDT:TESTUSDT,limit,buy,0.001,14000)
{'amount': 0.001,
 'average': None,
 'clientOrderId': '1673280210702',
 'cost': 0.0,
 'datetime': '2023-01-09T16:03:30.702Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '111123656651',
 'info': ['111123656651',
          None,
          '1673280210702',
          'tTESTBTCF0:TESTUSDTF0',
          '1673280210702',
          '1673280210702',
          '0.001',
          '0.001',
          'LIMIT',
          None,
          None,
          None,
          '0',
          'ACTIVE',
          None,
          None,
          '14000',
          '0',
          '0',
          '0',
          None,
          None,
          None,
          '0',
          '0',
          None,
          None,
          None,
          'API>BFX',
          None,
          None,
          {'$F33': '10', 'lev': '10'}],
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 14000.0,
 'remaining': 0.001,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'TESTBTCF0/TESTUSDTF0',
 'timeInForce': 'GTC',
 'timestamp': 1673280210702,
 'trades': [],
 'triggerPrice': None,
 'type': None}
 ```

```
p bitfinex createOrder "TESTBTCF0:TESTUSDTF0" limit buy 0.001 14000                            
Python v3.10.8
CCXT v2.5.60
bitfinex.createOrder(TESTBTCF0:TESTUSDTF0,limit,buy,0.001,14000)
{'amount': 0.001,
 'average': None,
 'clientOrderId': None,
 'cost': 0.0,
 'datetime': '2023-01-09T16:04:15.000Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '111124973461',
 'info': {'avg_execution_price': '0.0',
          'cid': '1673280255924',
          'cid_date': '2023-01-09',
          'exchange': 'bitfinex',
          'executed_amount': '0.0',
          'gid': None,
          'id': '111124973461',
          'is_cancelled': False,
          'is_hidden': False,
          'is_live': True,
          'lev': '10',
          'meta': {'$F33': '10', 'lev': '10'},
          'oco_order': None,
          'order_id': '111124973461',
          'original_amount': '0.001',
          'price': '14000.0',
          'remaining_amount': '0.001',
          'side': 'buy',
          'src': 'api',
          'symbol': 'testbtcf0:testusdtf0',
          'timestamp': '1673280255.0',
          'type': 'limit',
          'was_forced': False},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': 14000.0,
 'remaining': 0.001,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'TESTBTCF0/TESTUSDTF0',
 'timeInForce': None,
 'timestamp': 1673280255000,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```

```
p bitfinex2 createOrder "LTC/USDT:USDT" market buy 0.1
Python v3.10.8
CCXT v2.5.60
bitfinex2.createOrder(LTC/USDT:USDT,market,buy,0.1)
{'amount': 0.1,
 'average': None,
 'clientOrderId': '1673280327618',
 'cost': 0.0,
 'datetime': '2023-01-09T16:05:27.619Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '111125259328',
 'info': ['111125259328',
          None,
          '1673280327618',
          'tLTCF0:USTF0',
          '1673280327619',
          '1673280327619',
          '0.1',
          '0.1',
          'MARKET',
          None,
          None,
          None,
          '0',
          'ACTIVE',
          None,
          None,
          '82.91',
          '0',
          '0',
          '0',
          None,
          None,
          None,
          '0',
          '0',
          None,
          None,
          None,
          'API>BFX',
          None,
          None,
          {'$F33': '10', 'lev': '10'}],
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 82.91,
 'remaining': 0.1,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTCF0/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1673280327619,
 'trades': [],
 'triggerPrice': None,
 'type': None}
 ```
 