### PR TITLE
wazirx pro - string math

### DIFF
--- a/js/pro/wazirx.js
+++ b/js/pro/wazirx.js
@@ -781,10 +781,10 @@ module.exports = class wazirx extends wazirxRest {
         const messageHash = 'authenticated';
         const now = this.milliseconds ();
         let subscription = this.safeValue (client.subscriptions, messageHash);
-        const expires = this.safeNumber (subscription, 'expires');
+        const expires = this.safeInteger (subscription, 'expires');
         if (subscription === undefined || now > expires) {
             subscription = await this.privatePostCreateAuthToken ();
-            subscription['expires'] = now + this.safeNumber (subscription, 'timeout_duration') * 1000;
+            subscription['expires'] = now + this.safeInteger (subscription, 'timeout_duration') * 1000;
             //
             //     {
             //         "auth_key": "Xx***dM",


### PR DESCRIPTION
```
% wazirx watchBalance
Debugger listening on ws://127.0.0.1:59027/9b2a9742-3e91-4262-aa86-2b2de73238d6
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2023-01-10T01:49:22.157Z
Node.js: v18.4.0
CCXT v2.5.36
wazirx.watchBalance ()
{
  USDT: { free: 17.67095894, used: 79.808, total: 97.47895894 },
  free: { USDT: 17.67095894 },
  used: { USDT: 79.808 },
  total: { USDT: 97.47895894 }
}
{
  USDT: { free: 17.6670263, used: 77, total: 94.6670263 },
  free: { USDT: 17.6670263, XRP: 16 },
  used: { USDT: 77, XRP: 0 },
  total: { USDT: 94.6670263, XRP: 16 },
  XRP: { free: 16, used: 0, total: 16 }
}
```

-----------

replaces https://github.com/ccxt/ccxt/pull/16369