### PR TITLE
Binance :: fix watchTickers

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -771,11 +771,11 @@ module.exports = class binance extends binanceRest {
         symbols = this.marketSymbols (symbols);
         const marketIds = this.marketIds (symbols);
         let market = undefined;
-        if (marketIds !== undefined) {
-            market = this.safeMarket (marketIds[0]);
-        }
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('watchTickers', market, params);
+        if (marketIds !== undefined) {
+            market = this.safeMarket (marketIds[0], undefined, undefined, type);
+        }
         let subType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('watchTickers', market, params);
         if (this.isLinear (type, subType)) {
@@ -818,7 +818,7 @@ module.exports = class binance extends binanceRest {
         for (let i = 0; i < tickers.length; i++) {
             const ticker = tickers[i];
             const tickerSymbol = ticker['symbol'];
-            if (symbols !== undefined && this.inArray (tickerSymbol, symbols)) {
+            if (symbols === undefined || this.inArray (tickerSymbol, symbols)) {
                 result[tickerSymbol] = ticker;
             }
         }


### PR DESCRIPTION
- fix safeMarket
- fix infinite recursive call

```
Python v3.10.8
CCXT v2.5.70
binanceusdm.watchTickers()
{'ADA/BUSD:BUSD': {'ask': None,
                   'askVolume': None,
                   'average': None,
                   'baseVolume': 2824950.0,
                   'bid': None,
                   'bidVolume': None,
                   'change': -0.0027,
                   'close': 0.324,
                   'datetime': '2023-01-10T08:43:30.929Z',
                   'high': 0.3343,
                   'info': {'C': 1673340210929,
                            'E': 1673340210933,
                            'F': 631161,
                            'L': 632618,
                            'O': 1673253780000,
                            'P': '-0.826',
                            'Q': '1136',
                            'c': '0.32400',
                            'e': '24hrTicker',
                            'h': '0.33430',
                            'l': '0.31650',
                            'n': 1458,
                            'o': '0.32670',
                            'p': '-0.00270',
                            'q': '921496.81000',
                            's': 'ADABUSD',
                            'v': '2824950',
                            'w': '0.32620'},
                   'last': 0.324,
                   'low': 0.3165,
                   'open': 0.3267,
```

```
Python v3.10.8
CCXT v2.5.70
binanceusdm.watchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': None,
                   'askVolume': None,
                   'average': None,
                   'baseVolume': 155752.606,
                   'bid': None,
                   'bidVolume': None,
                   'change': 35.1,
                   'close': 17240.6,
                   'datetime': '2023-01-10T08:44:24.406Z',
                   'high': 17398.0,
                   'info': {'C': 1673340264406,
                            'E': 1673340264410,
                            'F': 248135735,
                            'L': 248168376,
                            'O': 1673253840000,
                            'P': '0.204',
                            'Q': '0.724',
                            'c': '17240.60',
                            'e': '24hrTicker',
                            'h': '17398.00',
                            'l': '17120.00',
                            'n': 32636,
                            'o': '17205.50',
                            'p': '35.10',
                            'q': '2685802248.38',
                            's': 'BTCUSDT',
                            'v': '155752.606',
                            'w': '17244.03'},
                   'last': 17240.6,
                   'low': 17120.0,
                   'open': 17205.5,
                   'percentage': 0.204,
                   'previousClose': None,
                   'quoteVolume': 2685802248.38,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1673340264406,
                   'vwap': 17244.03}}
```
