### PR TITLE
kucoin BIFI -> BIFIF

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -404,11 +404,12 @@ module.exports = class kucoin extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'HOT': 'HOTNOW',
+                'BIFI': 'BIFIF',
                 'EDGE': 'DADI', // https://github.com/ccxt/ccxt/issues/5756
-                'WAX': 'WAXP',
+                'HOT': 'HOTNOW',
                 'TRY': 'Trias',
                 'VAI': 'VAIOT',
+                'WAX': 'WAXP',
             },
             'options': {
                 'version': 'v1',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/bifi#markets
conflict with https://www.coingecko.com/en/coins/beefy-finance naming like on Gate.io and Latoken