### PR TITLE
Bitget: fix spot fetchTickers 

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1553,7 +1553,14 @@ module.exports = class bitget extends Exchange {
         //         usdtVolume: '5552388715.9215'
         //     }
         //
-        const marketId = this.safeString (ticker, 'symbol');
+        let marketId = this.safeString (ticker, 'symbol');
+        if ((market === undefined) && (marketId !== undefined) && (marketId.indexOf ('_') === -1)) {
+            // fetchTickers fix:
+            // spot symbol are different from the "request id"
+            // so we need to convert it to the exchange-specific id
+            // otherwise we will not be able to find the market
+            marketId = marketId + '_SPBL';
+        }
         const symbol = this.safeSymbol (marketId, market);
         const high = this.safeString (ticker, 'high24h');
         const low = this.safeString (ticker, 'low24h');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16415

```
p bitget fetchTickers '["BTC/USDT"]'         
Python v3.10.8
CCXT v2.5.74
bitget.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 17230.24,
              'askVolume': None,
              'average': None,
              'baseVolume': 14561.5989,
              'bid': 17229.85,
              'bidVolume': None,
              'change': None,
              'close': 17230.13,
              'datetime': '2023-01-10T12:35:40.029Z',
              'high': 17392.0,
              'info': {'askSz': '1',
                       'baseVol': '14561.5989',
                       'bidSz': '3.7282',
                       'buyOne': '17229.85',
                       'change': '-0.0023',
                       'changeUtc': '0.00288',
                       'close': '17230.13',
                       'high24h': '17392',
                       'low24h': '17133.93',
                       'openUtc0': '17180.7',
                       'quoteVol': '251130146.6878',
                       'sellOne': '17230.24',
                       'symbol': 'BTCUSDT',
                       'ts': '1673354140029',
                       'usdtVol': '251130146.687758'},
              'last': 17230.13,
              'low': 17133.93,
              'open': None,
              'percentage': None,
              'previousClose': None,
              'quoteVolume': 251130146.6878,
              'symbol': 'BTC/USDT',
              'timestamp': 1673354140029,
              'vwap': 17246.055767117716}}
```
