### PR TITLE
huobi: add mapping for "order would trigger immediately".

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -867,6 +867,7 @@ module.exports = class huobi extends Exchange {
                     'order-marketorder-amount-min-error': InvalidOrder, // market order amount error, min: `0.01`
                     'order-limitorder-price-min-error': InvalidOrder, // limit order price error
                     'order-limitorder-price-max-error': InvalidOrder, // limit order price error
+                    'order-stop-order-hit-trigger': InvalidOrder, // {"status":"error","err-code":"order-stop-order-hit-trigger","err-msg":"Orders that are triggered immediately are not supported.","data":null}
                     'order-value-min-error': InvalidOrder, // {"status":"error","err-code":"order-value-min-error","err-msg":"Order total cannot be lower than: 1 USDT","data":null}
                     'order-invalid-price': InvalidOrder, // {"status":"error","err-code":"order-invalid-price","err-msg":"invalid price","data":null}
                     'order-holding-limit-failed': InvalidOrder, // {"status":"error","err-code":"order-holding-limit-failed","err-msg":"Order failed, exceeded the holding limit of this currency","data":null}


### PR DESCRIPTION
Currently triggers as follows:

```
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/huobi.py", line 3914, in create_order
    return getattr(self, method)(symbol, type, side, amount, price, query)
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/huobi.py", line 3985, in create_spot_order
    response = self.spotPrivatePostV1OrderOrdersPlace(self.extend(request, params))
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/base/exchange.py", line 502, in inner
    return entry(_self, **inner_kwargs)
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/base/exchange.py", line 2803, in request
    return self.fetch2(path, api, method, params, headers, body, config, context)
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/base/exchange.py", line 2800, in fetch2
    return self.fetch(request['url'], request['method'], request['headers'], request['body'])
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/base/exchange.py", line 664, in fetch
    self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
  File "/root/freqtrade/.env/lib/python3.9/site-packages/ccxt/huobi.py", line 5369, in handle_errors
    raise ExchangeError(feedback)
ccxt.base.errors.ExchangeError: huobi {"status":"error","err-code":"order-stop-order-hit-trigger","err-msg":"Orders that are triggered immediately are not supported.","data":null}
```

but should instead trigger an `InvalidOrder` exception.