### PR TITLE
bybit: update side of position ccxt/ccxt#16429

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -6283,7 +6283,13 @@ module.exports = class bybit extends Exchange {
         const size = Precise.stringAbs (this.safeString (position, 'size'));
         let side = this.safeString (position, 'side');
         if (side !== undefined) {
-            side = (side === 'Buy') ? 'long' : 'short';
+            if (side === 'Buy') {
+                side = 'long';
+            } else if (side === 'Sell') {
+                side = 'short';
+            } else {
+                side = undefined;
+            }
         }
         const notional = this.safeString (position, 'positionValue');
         const unrealisedPnl = this.omitZero (this.safeString (position, 'unrealisedPnl'));


### PR DESCRIPTION
fix: ccxt/ccxt#16429

When the side of position, we set to default value which is `short`. In this PR, I added workaround to fix this.

Not sure why the side could be `None`. Probably the tpSlMode is `Full`?