### PR TITLE
bitget: add spot plan order

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -176,6 +176,11 @@ module.exports = class bitget extends Exchange {
                             'wallet/transfer': 4,
                             'wallet/withdrawal': 4,
                             'wallet/subTransfer': 10,
+                            'plan/placePlan': 1,
+                            'plan/modifyPlan': 1,
+                            'plan/cancelPlan': 1,
+                            'plan/currentPlan': 1,
+                            'plan/historyPlan': 1,
                         },
                     },
                     'mix': {
@@ -1432,7 +1437,7 @@ module.exports = class bitget extends Exchange {
          * @name bitget#fetchDepositAddress
          * @description fetch the deposit address for a currency associated with this account
          * @param {string} code unified currency code
-         * @param {object} params extra parameters specific to the binance api endpoint
+         * @param {object} params extra parameters specific to the bitget api endpoint
          * @returns {object} an [address structure]{@link https://docs.ccxt.com/en/latest/manual.html#address-structure}
          */
         await this.loadMarkets ();
@@ -3549,8 +3554,8 @@ module.exports = class bitget extends Exchange {
          * @name bitget#setPositionMode
          * @description set hedged to true or false for a market
          * @param {bool} hedged set to true to use dualSidePosition
-         * @param {string|undefined} symbol not used by binance setPositionMode ()
-         * @param {object} params extra parameters specific to the binance api endpoint
+         * @param {string|undefined} symbol not used by bitget setPositionMode ()
+         * @param {object} params extra parameters specific to the bitget api endpoint
          * @returns {object} response from the exchange
          *
          */

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2292,7 +2292,7 @@ module.exports = class bitget extends Exchange {
         const isStopLossOrder = stopLossPrice !== undefined;
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
         const isTakeProfitOrder = takeProfitPrice !== undefined;
-        const isStopOrder = isStopLossOrder || isTakeProfitOrder;
+        const isStopLossOrTakeProfit = isStopLossOrder || isTakeProfitOrder;
         if (this.sum (isTriggerOrder, isStopLossOrder, isTakeProfitOrder) > 1) {
             throw new ExchangeError (this.id + ' createOrder() params can only contain one of triggerPrice, stopLossPrice, takeProfitPrice');
         }
@@ -2307,8 +2307,8 @@ module.exports = class bitget extends Exchange {
         const exchangeSpecificParam = this.safeString2 (params, 'force', 'timeInForceValue');
         const postOnly = this.isPostOnly (isMarketOrder, exchangeSpecificParam === 'post_only', params);
         if (marketType === 'spot') {
-            if (isStopOrder) {
-                throw new InvalidOrder (this.id + ' createOrder() does not support stop orders on spot markets, only swap markets');
+            if (isStopLossOrTakeProfit) {
+                throw new InvalidOrder (this.id + ' createOrder() does not support stop loss/take profit orders on spot markets, only swap markets');
             }
             let timeInForceKey = 'force';
             let quantityKey = 'quantity';
@@ -2365,7 +2365,7 @@ module.exports = class bitget extends Exchange {
                 request['executePrice'] = this.priceToPrecision (symbol, price);
                 method = 'privateMixPostPlanPlacePlan';
             }
-            if (isStopOrder) {
+            if (isStopLossOrTakeProfit) {
                 if (!isMarketOrder) {
                     throw new ExchangeError (this.id + ' createOrder() bitget stopLoss or takeProfit orders must be market orders');
                 }

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2018,8 +2018,7 @@ module.exports = class bitget extends Exchange {
             'spot': 'publicSpotGetMarketCandles',
             'swap': 'publicMixGetMarketCandles',
         });
-        const until = this.safeInteger2 (params, 'until', 'till');
-        params = this.omit (params, [ 'until', 'till' ]);
+        const until = this.safeInteger2 (query, 'until', 'till');
         if (limit === undefined) {
             limit = 100;
         }
@@ -2052,7 +2051,8 @@ module.exports = class bitget extends Exchange {
                 }
             }
         }
-        const response = await this[method] (this.extend (request, query));
+        const ommitted = this.omit (query, [ 'until', 'till' ]);
+        const response = await this[method] (this.extend (request, ommitted));
         //  [ ["1645911960000","39406","39407","39374.5","39379","35.526","1399132.341"] ]
         const data = this.safeValue (response, 'data', response);
         return this.parseOHLCVs (data, market, timeframe, since, limit);
@@ -2524,7 +2524,7 @@ module.exports = class bitget extends Exchange {
             'symbol': market['id'],
             'orderId': id,
         };
-        const stop = this.safeValue (params, 'stop');
+        const stop = this.safeValue (query, 'stop');
         if (stop) {
             if (marketType === 'spot') {
                 method = 'privateSpotPostPlanCancelPlan';
@@ -2535,13 +2535,13 @@ module.exports = class bitget extends Exchange {
                 }
                 request['planType'] = planType;
                 method = 'privateMixPostPlanCancelPlan';
-                params = this.omit (params, [ 'stop', 'planType' ]);
             }
         }
         if (marketType === 'swap') {
             request['marginCoin'] = market['settleId'];
         }
-        const response = await this[method] (this.extend (request, query));
+        const ommitted = this.omit (query, [ 'stop', 'planType' ]);
+        const response = await this[method] (this.extend (request, ommitted));
         return this.parseOrder (response, market);
     }
 
@@ -2648,14 +2648,13 @@ module.exports = class bitget extends Exchange {
             'productType': productType,
         };
         let method = undefined;
-        const stop = this.safeValue (params, 'stop');
-        const planType = this.safeString (params, 'planType');
+        const stop = this.safeValue (query, 'stop');
+        const planType = this.safeString (query, 'planType');
         if (stop !== undefined || planType !== undefined) {
             if (planType === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan, loss_plan, pos_profit, pos_loss, moving_plan or track_plan');
             }
             method = 'privateMixPostPlanCancelAllPlan';
-            params = this.omit (params, [ 'stop' ]);
         } else {
             const code = this.safeString2 (params, 'code', 'marginCoin');
             if (code === undefined) {
@@ -2665,8 +2664,8 @@ module.exports = class bitget extends Exchange {
             request['marginCoin'] = this.safeCurrencyCode (code, currency);
             method = 'privateMixPostOrderCancelAllOrders';
         }
-        params = this.omit (query, [ 'code', 'marginCoin' ]);
-        const response = await this[method] (this.extend (request, params));
+        const ommitted = this.omit (query, [ 'stop', 'code', 'marginCoin' ]);
+        const response = await this[method] (this.extend (request, ommitted));
         //
         //     {
         //         "code": "00000",
@@ -2941,15 +2940,13 @@ module.exports = class bitget extends Exchange {
             'spot': 'privateSpotPostTradeHistory',
             'swap': 'privateMixGetOrderHistory',
         });
-        let omitted = query;
-        const stop = this.safeValue (omitted, 'stop');
+        const stop = this.safeValue (query, 'stop');
         if (stop) {
             if (marketType === 'spot') {
                 method = 'privateSpotPostPlanHistoryPlan';
             } else {
                 method = 'privateMixGetPlanHistoryPlan';
             }
-            omitted = this.omit (omitted, 'stop');
         }
         if (marketType === 'swap' || stop) {
             if (limit === undefined) {
@@ -2962,6 +2959,7 @@ module.exports = class bitget extends Exchange {
             request['startTime'] = since;
             request['endTime'] = this.milliseconds ();
         }
+        const omitted = this.omit (query, 'stop');
         const response = await this[method] (this.extend (request, omitted));
         //
         //  spot

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2425,13 +2425,17 @@ module.exports = class bitget extends Exchange {
         };
         const stop = this.safeValue (params, 'stop');
         if (stop) {
-            const planType = this.safeString (params, 'planType');
-            if (planType === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
+            if (marketType === 'spot') {
+                method = 'privateSpotPostPlanCancelPlan';
+            } else {
+                const planType = this.safeString (params, 'planType');
+                if (planType === undefined) {
+                    throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan or loss_plan');
+                }
+                request['planType'] = planType;
+                method = 'privateMixPostPlanCancelPlan';
+                params = this.omit (params, [ 'stop', 'planType' ]);
             }
-            request['planType'] = planType;
-            method = 'privateMixPostPlanCancelPlan';
-            params = this.omit (params, [ 'stop', 'planType' ]);
         }
         if (marketType === 'swap') {
             request['marginCoin'] = market['settleId'];

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -916,7 +916,10 @@ module.exports = class bitget extends Exchange {
         //        minTradeNum: '0.001',
         //        priceEndStep: '5',
         //        volumePlace: '3',
-        //        pricePlace: '1'
+        //        pricePlace: '1',
+        //        symbolStatus: "normal",
+        //        offTime: "-1",
+        //        limitOpenTime: "-1"
         //    }
         //
         const marketId = this.safeString (market, 'symbol');
@@ -980,10 +983,10 @@ module.exports = class bitget extends Exchange {
             const amountString = preciseAmount.toString ();
             amountPrecision = this.parseNumber (amountString);
         }
-        const status = this.safeString (market, 'status');
+        const status = this.safeString2 (market, 'status', 'symbolStatus');
         let active = undefined;
         if (status !== undefined) {
-            active = status === 'online';
+            active = (status === 'online' || status === 'normal');
         }
         let minCost = undefined;
         if (quote === 'USDT') {


### PR DESCRIPTION
Bitget had added apis for spot plan order. In this PR I added these apis (https://bitgetlimited.github.io/apidoc/en/spot/#place-plan-order).

SPOT:
```BASH
$ node examples/js/cli bitget createOrder ADA/USDT limit buy 5000 0.001 '{"triggerPrice":"0.002"}'
$ node examples/js/cli bitget fetchOpenOrders ADA/USDT 0 100 '{"stop":true}'
$ node examples/js/cli bitget fetchOpenOrders ADA/USDT 0 100 '{"stop":true}'
$ node examples/js/cli bitget editOrder '"xxxxxxxx"' ADA/USDT limit buy 5000 0.0013 '{"triggerPrice":"0.0013"}'
$ node examples/js/cli bitget fetchClosedOrders ADA/USDT 0 100 '{"stop":true}'
```

SWAP
```BASH
$ node examples/js/cli bitget createOrder ADA/USDT:USDT limit buy 5000 0.001 '{"triggerPrice":"0.002"}'
$ node examples/js/cli bitget fetchOpenOrders ADA/USDT:USDT 0 100 '{"stop":true}'
$ node examples/js/cli bitget fetchOpenOrders ADA/USDT:USDT 0 100 '{"stop":true}'
$ node examples/js/cli bitget editOrder '"xxxxxxxx"' ADA/USDT:USDT limit buy 5000 0.0013 '{"triggerPrice":"0.0013"}'
$ node examples/js/cli bitget fetchClosedOrders ADA/USDT:USDT 0 100 '{"stop":true}'
```

TODO:
- [x] add endpoints for spot plan order
- [x] update create order
- [x] update fetch open orders
- [x] update cancel order
- [x] add edit order (only plan order).