### PR TITLE
[binance] restore deposit and withdrawal timestamp parsing

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4473,12 +4473,13 @@ module.exports = class binance extends Exchange {
         let code = this.safeCurrencyCode (currencyId, currency);
         let timestamp = undefined;
         const insertTime = this.safeInteger2 (transaction, 'insertTime', 'createTime');
+        const applyTime = this.parse8601 (this.safeString (transaction, 'applyTime'));
         const updated = this.safeInteger2 (transaction, 'successTime', 'updateTime');
         let type = this.safeString (transaction, 'type');
         if (type === undefined) {
             const txType = this.safeString (transaction, 'transactionType');
             type = (txType === '0') ? 'deposit' : 'withdrawal';
-            timestamp = insertTime;
+            timestamp = insertTime || applyTime;
             const legalMoneyCurrenciesById = this.safeValue (this.options, 'legalMoneyCurrenciesById');
             code = this.safeString (legalMoneyCurrenciesById, code, code);
         }


### PR DESCRIPTION
Commit https://github.com/ccxt/ccxt/commit/b8152c20f28594ef46c48d86c4458a4d3e9c62e4 broke Binance deposit and withdrawal timestamp parsing.

The problem is that both deposit and withdrawal events returned by Binance have only the `applyTime` field as a timestamp field, not `updateTime` nor `insertTime` nor `successTime`.

This PR takes `applyTime` as a fallback.

See docs:
- https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data
- https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data