### PR TITLE
Phemex :: fix fetchTicker

### DIFF
--- a/js/phemex.js
+++ b/js/phemex.js
@@ -1213,7 +1213,7 @@ module.exports = class phemex extends Exchange {
         };
         let method = 'v1GetMdSpotTicker24hr';
         if (market['swap']) {
-            if (!market['linear']) {
+            if (market['inverse'] || market['settle'] === 'USD') {
                 method = 'v1GetMdTicker24hr';
             } else {
                 method = 'v2GetMdV2Ticker24hr';


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16453

```
p phemex fetchTicker "BTC/USDT:USDT"           
Python v3.10.8
CCXT v2.5.94
phemex.fetchTicker(BTC/USDT:USDT)
{'ask': None,
 'askVolume': None,
 'average': None,
 'baseVolume': 40427.927,
 'bid': None,
 'bidVolume': None,
 'change': None,
 'close': 18072.6,
 'datetime': '2023-01-12T14:37:46.356Z',
 'high': 18379.9,
 'info': {'closeRp': '18072.6',
          'fundingRateRr': '0.0001',
          'highRp': '18379.9',
          'indexPriceRp': '18074.09868487',
          'lowRp': '17307.8',
          'markPriceRp': '18074.40839208',
          'openInterestRv': '661.52',
          'openRp': '17403.2',
          'predFundingRateRr': '0.0001',
          'symbol': 'BTCUSDT',
          'timestamp': '1673534266356002417',
          'turnoverRv': '724507361.3876',
          'volumeRq': '40427.927'},
 'last': 18072.6,
 'low': 17307.8,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 724507361.3876,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1673534266356,
 'vwap': 17920.9624423137}
```
```
p phemex fetchTicker "BTC/USD:USD"          
Python v3.10.8
CCXT v2.5.94
phemex.fetchTicker(BTC/USD:USD)
{'ask': 18077.5,
 'askVolume': None,
 'average': 17740.1,
 'baseVolume': 37293978.0,
 'bid': 18077.4,
 'bidVolume': None,
 'change': 657.2,
 'close': 18068.7,
 'datetime': '2023-01-12T14:39:23.214Z',
 'high': 18368.0,
 'info': {'askEp': '180775000',
          'bidEp': '180774000',
          'fundingRateEr': '10000',
          'highEp': '183680000',
          'indexEp': '180823011',
          'lastEp': '180687000',
          'lowEp': '173147000',
          'markEp': '180826047',
          'openEp': '174115000',
          'openInterest': '8305260',
          'predFundingRateEr': '10000',
          'symbol': 'uBTCUSD',
          'timestamp': '1673534363214510234',
          'turnoverEv': '6648658874473',
          'volume': '37293978'},
 'last': 18068.7,
 'low': 17314.7,
 'open': 17411.5,
 'percentage': 3.7745168423168596,
 'previousClose': None,
 'quoteVolume': 6648658874473.0,
 'symbol': 'BTC/USD:USD',
 'timestamp': 1673534363214,
 'vwap': 178277.00961460857}
```
```
p phemex fetchTicker "BTC/USD:BTC" 
Python v3.10.8
CCXT v2.5.94
phemex.fetchTicker(BTC/USD:BTC)
{'ask': 18079.4,
 'askVolume': None,
 'average': 17740.7,
 'baseVolume': 458602140.0,
 'bid': 18079.0,
 'bidVolume': None,
 'change': 677.4,
 'close': 18079.4,
 'datetime': '2023-01-12T14:39:40.528Z',
 'high': 18373.0,
 'info': {'askEp': '180794000',
          'bidEp': '180790000',
          'fundingRateEr': '10000',
          'highEp': '183730000',
          'indexEp': '180904679',
          'lastEp': '180794000',
          'lowEp': '173061000',
          'markEp': '180907706',
          'openEp': '174020000',
          'openInterest': '131521112',
          'predFundingRateEr': '10000',
          'symbol': 'BTCUSD',
          'timestamp': '1673534380528830083',
          'turnoverEv': '2563688218239',
          'volume': '458602140'},
 'last': 18079.4,
 'low': 17306.1,
 'open': 17402.0,
 'percentage': 3.8926560165498216,
 'previousClose': None,
 'quoteVolume': 25636.88218239,
 'symbol': 'BTC/USD:BTC',
 'timestamp': 1673534380528,
 'vwap': 5.5902229724418e-05}
```
