### PR TITLE
bybit: refactor fetchFundingRate

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2145,62 +2145,9 @@ module.exports = class bybit extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (!market['swap']) {
-            throw new BadSymbol (this.id + ' fetchFundingRate() does not support ' + symbol);
-        }
-        const request = {
-            'symbol': market['id'],
-        };
-        let method = undefined;
-        method = 'publicGetDerivativesV3PublicTickers';
-        if (market['linear']) {
-            request['category'] = 'linear';
-        } else if (market['inverse']) {
-            request['category'] = 'inverse';
-        }
-        const response = await this[method] (this.extend (request, params));
-        //
-        // {
-        //     "retCode": 0,
-        //     "retMsg": "OK",
-        //     "result": {
-        //         "category": "linear",
-        //         "list": [
-        //             {
-        //                 "symbol": "BTCUSDT",
-        //                 "bidPrice": "19255",
-        //                 "askPrice": "19255.5",
-        //                 "lastPrice": "19255.50",
-        //                 "lastTickDirection": "ZeroPlusTick",
-        //                 "prevPrice24h": "18634.50",
-        //                 "price24hPcnt": "0.033325",
-        //                 "highPrice24h": "19675.00",
-        //                 "lowPrice24h": "18610.00",
-        //                 "prevPrice1h": "19278.00",
-        //                 "markPrice": "19255.00",
-        //                 "indexPrice": "19260.68",
-        //                 "openInterest": "48069.549",
-        //                 "turnover24h": "4686694853.047006",
-        //                 "volume24h": "243730.252",
-        //                 "fundingRate": "0.0001",
-        //                 "nextFundingTime": "1663689600000",
-        //                 "predictedDeliveryPrice": "",
-        //                 "basisRate": "",
-        //                 "deliveryFeeRate": "",
-        //                 "deliveryTime": "0"
-        //             }
-        //         ]
-        //     },
-        //     "retExtInfo": null,
-        //     "time": 1663670053454
-        // }
-        //
-        const result = this.safeValue (response, 'result', {});
-        const tickers = this.safeValue (result, 'list');
-        const ticker = this.safeValue (tickers, 0);
-        const timestamp = this.safeInteger (response, 'time');
-        ticker['timestamp'] = timestamp; // will be removed inside the parser
-        return this.parseFundingRate (ticker, market);
+        params['symbol'] = market['id'];
+        const symbols = [ market['symbol'] ];
+        return await this.fetchFundingRates (symbols, params);
     }
 
     async fetchFundingRates (symbols = undefined, params = {}) {

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3,7 +3,7 @@
 
 const Exchange = require ('./base/Exchange');
 const { TICK_SIZE } = require ('./base/functions/number');
-const { AuthenticationError, ExchangeError, ArgumentsRequired, PermissionDenied, InvalidOrder, OrderNotFound, InsufficientFunds, BadRequest, RateLimitExceeded, InvalidNonce, NotSupported } = require ('./base/errors');
+const { AuthenticationError, ExchangeError, ArgumentsRequired, PermissionDenied, InvalidOrder, OrderNotFound, InsufficientFunds, BadRequest, BadSymbol, RateLimitExceeded, InvalidNonce, NotSupported } = require ('./base/errors');
 const Precise = require ('./base/Precise');
 
 //  ---------------------------------------------------------------------------
@@ -2080,6 +2080,59 @@ module.exports = class bybit extends Exchange {
         }
     }
 
+    parseFundingRate (ticker, market = undefined, timestamp = undefined) {
+        //
+        //     {
+        //         "symbol": "BTCUSDT",
+        //         "bidPrice": "19255",
+        //         "askPrice": "19255.5",
+        //         "lastPrice": "19255.50",
+        //         "lastTickDirection": "ZeroPlusTick",
+        //         "prevPrice24h": "18634.50",
+        //         "price24hPcnt": "0.033325",
+        //         "highPrice24h": "19675.00",
+        //         "lowPrice24h": "18610.00",
+        //         "prevPrice1h": "19278.00",
+        //         "markPrice": "19255.00",
+        //         "indexPrice": "19260.68",
+        //         "openInterest": "48069.549",
+        //         "turnover24h": "4686694853.047006",
+        //         "volume24h": "243730.252",
+        //         "fundingRate": "0.0001",
+        //         "nextFundingTime": "1663689600000",
+        //         "predictedDeliveryPrice": "",
+        //         "basisRate": "",
+        //         "deliveryFeeRate": "",
+        //         "deliveryTime": "0"
+        //     }
+        //
+        const marketId = this.safeString (ticker, 'symbol');
+        const symbol = this.safeSymbol (marketId, market, undefined, 'contract');
+        const fundingRate = this.safeNumber (ticker, 'fundingRate');
+        const fundingTimestamp = this.safeInteger (ticker, 'nextFundingTime');
+        const markPrice = this.safeNumber (ticker, 'markPrice');
+        const indexPrice = this.safeNumber (ticker, 'indexPrice');
+        return {
+            'info': ticker,
+            'symbol': symbol,
+            'markPrice': markPrice,
+            'indexPrice': indexPrice,
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'fundingRate': fundingRate,
+            'fundingTimestamp': fundingTimestamp,
+            'fundingDatetime': this.iso8601 (fundingTimestamp),
+            'nextFundingRate': undefined,
+            'nextFundingTimestamp': undefined,
+            'nextFundingDatetime': undefined,
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
+        };
+    }
+
     async fetchFundingRate (symbol, params = {}) {
         /**
          * @method
@@ -2094,79 +2147,127 @@ module.exports = class bybit extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const isUsdcSettled = market['settle'] === 'USDC';
         let method = undefined;
-        if (isUsdcSettled) {
-            method = 'privatePostPerpetualUsdcOpenapiPrivateV1PredictedFunding';
+        method = 'publicGetDerivativesV3PublicTickers';
+        if (market['linear']) {
+            request['category'] = 'linear';
+        } else if (market['inverse']) {
+            request['category'] = 'inverse';
         } else {
-            method = market['linear'] ? 'privateGetPrivateLinearFundingPredictedFunding' : 'privateGetV2PrivateFundingPredictedFunding';
+            throw new BadSymbol (this.id + ' fetchFundingRate() does not support ' + symbol);
         }
         const response = await this[method] (this.extend (request, params));
         //
-        // linear
-        //     {
-        //       "ret_code": 0,
-        //       "ret_msg": "OK",
-        //       "ext_code": "",
-        //       "ext_info": "",
-        //       "result": {
-        //         "predicted_funding_rate": 0.0001,
-        //         "predicted_funding_fee": 0.00231849
-        //       },
-        //       "time_now": "1658446366.304113",
-        //       "rate_limit_status": 119,
-        //       "rate_limit_reset_ms": 1658446366300,
-        //       "rate_limit": 120
-        //     }
-        //
-        // inverse
-        //     {
-        //       "ret_code": 0,
-        //       "ret_msg": "OK",
-        //       "ext_code": "",
-        //       "ext_info": "",
-        //       "result": {
-        //         "predicted_funding_rate": -0.00001769,
-        //         "predicted_funding_fee": 0
-        //       },
-        //       "time_now": "1658445512.778048",
-        //       "rate_limit_status": 119,
-        //       "rate_limit_reset_ms": 1658445512773,
-        //       "rate_limit": 120
-        //     }
-        //
-        // usdc
-        //     {
-        //       "result": {
-        //         "predictedFundingRate": "0.0002213",
-        //         "predictedFundingFee": "0"
-        //       },
-        //       "retCode": 0,
-        //       "retMsg": "success"
-        //     }
+        // {
+        //     "retCode": 0,
+        //     "retMsg": "OK",
+        //     "result": {
+        //         "category": "linear",
+        //         "list": [
+        //             {
+        //                 "symbol": "BTCUSDT",
+        //                 "bidPrice": "19255",
+        //                 "askPrice": "19255.5",
+        //                 "lastPrice": "19255.50",
+        //                 "lastTickDirection": "ZeroPlusTick",
+        //                 "prevPrice24h": "18634.50",
+        //                 "price24hPcnt": "0.033325",
+        //                 "highPrice24h": "19675.00",
+        //                 "lowPrice24h": "18610.00",
+        //                 "prevPrice1h": "19278.00",
+        //                 "markPrice": "19255.00",
+        //                 "indexPrice": "19260.68",
+        //                 "openInterest": "48069.549",
+        //                 "turnover24h": "4686694853.047006",
+        //                 "volume24h": "243730.252",
+        //                 "fundingRate": "0.0001",
+        //                 "nextFundingTime": "1663689600000",
+        //                 "predictedDeliveryPrice": "",
+        //                 "basisRate": "",
+        //                 "deliveryFeeRate": "",
+        //                 "deliveryTime": "0"
+        //             }
+        //         ]
+        //     },
+        //     "retExtInfo": null,
+        //     "time": 1663670053454
+        // }
         //
         const result = this.safeValue (response, 'result', {});
-        const fundingRate = this.safeNumber2 (result, 'predicted_funding_rate', 'predictedFundingRate');
-        const timestamp = this.safeTimestamp (response, 'time_now');
-        return {
-            'info': response,
-            'symbol': symbol,
-            'markPrice': undefined,
-            'indexPrice': undefined,
-            'interestRate': undefined,
-            'estimatedSettlePrice': undefined,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
-            'fundingRate': fundingRate,
-            'fundingTimestamp': undefined,
-            'fundingDatetime': undefined,
-            'nextFundingRate': undefined,
-            'nextFundingTimestamp': undefined,
-            'nextFundingDatetime': undefined,
-            'previousFundingRate': undefined,
-            'previousFundingTimestamp': undefined,
-            'previousFundingDatetime': undefined,
-        };
+        const tickers = this.safeValue (result, 'list');
+        const ticker = this.safeValue (tickers, 0);
+        const timestamp = this.safeInteger (response, 'time');
+        return this.parseFundingRate (ticker, market, timestamp);
+    }
+
+    async fetchFundingRates (symbols = undefined, params = {}) {
+        /**
+         * @method
+         * @name bybit#fetchFundingRates
+         * @description fetches funding rates for multiple markets
+         * @param {[string]|undefined} symbols unified symbols of the markets to fetch the funding rates for, all market funding rates are returned if not assigned
+         * @param {object} params extra parameters specific to the bybit api endpoint
+         * @returns {object} an array of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html#funding-rate-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols);
+        const request = {};
+        const [ subType, query ] = this.handleSubTypeAndParams ('fetchFundingRates', undefined, params, 'linear');
+        if (subType === 'option') {
+            // bybit requires a symbol when query tockers for options markets
+            throw new NotSupported (this.id + ' fetchTickers() is not supported for option markets');
+        } else {
+            request['category'] = subType;
+        }
+        const response = await this.publicGetDerivativesV3PublicTickers (this.extend (request, query));
+        //
+        //     {
+        //         "retCode": 0,
+        //         "retMsg": "OK",
+        //         "result": {
+        //             "category": "linear",
+        //             "list": [
+        //                 {
+        //                     "symbol": "BTCUSDT",
+        //                     "bidPrice": "19255",
+        //                     "askPrice": "19255.5",
+        //                     "lastPrice": "19255.50",
+        //                     "lastTickDirection": "ZeroPlusTick",
+        //                     "prevPrice24h": "18634.50",
+        //                     "price24hPcnt": "0.033325",
+        //                     "highPrice24h": "19675.00",
+        //                     "lowPrice24h": "18610.00",
+        //                     "prevPrice1h": "19278.00",
+        //                     "markPrice": "19255.00",
+        //                     "indexPrice": "19260.68",
+        //                     "openInterest": "48069.549",
+        //                     "turnover24h": "4686694853.047006",
+        //                     "volume24h": "243730.252",
+        //                     "fundingRate": "0.0001",
+        //                     "nextFundingTime": "1663689600000",
+        //                     "predictedDeliveryPrice": "",
+        //                     "basisRate": "",
+        //                     "deliveryFeeRate": "",
+        //                     "deliveryTime": "0"
+        //                 }
+        //             ]
+        //         },
+        //         "retExtInfo": null,
+        //         "time": 1663670053454
+        //     }
+        //
+        let tickerList = this.safeValue (response, 'result', []);
+        const timestamp = this.safeInteger (response, 'time');
+        if (!Array.isArray (tickerList)) {
+            tickerList = this.safeValue (tickerList, 'list');
+        }
+        const fundingRates = {};
+        for (let i = 0; i < tickerList.length; i++) {
+            const ticker = this.parseFundingRate (tickerList[i], undefined, timestamp);
+            const symbol = ticker['symbol'];
+            fundingRates[symbol] = ticker;
+        }
+        return this.filterByArray (fundingRates, 'symbol', symbols);
     }
 
     async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Current bybit's `fetchFundingRate` has a few disadvantages

1) Uses private api which requires apikey
2) Has a lower rate limit
3) Does not have `fundingTimestamp`
4) Does not support multiple symbols

This PR utilises the ticker api to fetch the results and added `fetchFundingRates` method