### PR TITLE
 binance.fetchFundingRateHistory fix, fixes: #16463 

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2167,8 +2167,8 @@ module.exports = class Exchange {
         if (marketId !== undefined) {
             if ((this.markets_by_id !== undefined) && (marketId in this.markets_by_id)) {
                 const markets = this.markets_by_id[marketId];
-                const length = markets.length;
-                if (length === 1) {
+                const numMarkets = markets.length;
+                if (numMarkets === 1) {
                     return markets[0];
                 } else {
                     if (marketType === undefined) {

--- a/js/binance.js
+++ b/js/binance.js
@@ -5476,7 +5476,7 @@ module.exports = class binance extends Exchange {
             const timestamp = this.safeInteger (entry, 'fundingTime');
             rates.push ({
                 'info': entry,
-                'symbol': this.safeSymbol (this.safeString (entry, 'symbol'), undefined, 'swap'),
+                'symbol': this.safeSymbol (this.safeString (entry, 'symbol'), undefined, undefined, 'swap'),
                 'fundingRate': this.safeNumber (entry, 'fundingRate'),
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),


### PR DESCRIPTION
- added argument to safeSymbol call in fetchFundingRateHistory

fixes: #16463

---------------

```
% binance fetchFundingRateHistory BTC/USDT:USDT | condense
Debugger listening on ws://127.0.0.1:53493/b0857e89-b598-4061-bcdb-fa22aaa4af24
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Waiting for the debugger to disconnect...
2023-01-13T00:42:22.208Z
Node.js: v18.4.0
CCXT v2.6.4
binance.fetchFundingRateHistory (BTC/USDT:USDT)
2023-01-13T00:42:25.392Z iteration 0 passed in 465 ms
       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
BTC/USDT:USDT |  0.00000929 | 1670716800011 | 2022-12-11T00:00:00.011Z
...
BTC/USDT:USDT |      0.0001 | 1673568000004 | 2023-01-13T00:00:00.004Z
100 objects
2023-01-13T00:42:25.392Z iteration 1 passed in 465 ms
```