### PR TITLE
kraken parseOrder python id field is a string and not a string of an array in python

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -1426,7 +1426,7 @@ module.exports = class kraken extends Exchange {
         }
         const status = this.parseOrderStatus (this.safeString (order, 'status'));
         let id = this.safeString2 (order, 'id', 'txid');
-        if (id === undefined) {
+        if ((id === undefined) || (id.slice (0, 1) === '[')) {
             const txid = this.safeValue (order, 'txid');
             id = this.safeString (txid, 0);
         }


### PR DESCRIPTION
fixes: #16447

----------------

## node

```
 % node examples/js/cli kraken createOrder ADA/USDT limit buy 15 0.3
2023-01-13T01:23:17.863Z
Node.js: v18.4.0
CCXT v2.6.4
kraken.createOrder (ADA/USDT, limit, buy, 15, 0.3)
2023-01-13T01:23:21.154Z iteration 0 passed in 1411 ms

{
  id: 'OQQGF3-6VZYS-YKHE3V',
  clientOrderId: undefined,
  info: {
    txid: [ 'OQQGF3-6VZYS-YKHE3V' ],
    descr: { order: 'buy 15.00000000 ADAUSDT @ limit 0.300000' }
  },
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'ADA/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 0.3,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  amount: 15,
  filled: undefined,
  average: undefined,
  remaining: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2023-01-13T01:23:21.154Z iteration 1 passed in 1411 ms
```

## python

```
% python3 examples/py/cli.py kraken createOrder ADA/USDT limit buy 15 0.3
Python v3.10.4
CCXT v2.6.4
kraken.createOrder(ADA/USDT,limit,buy,15,0.3)
{'amount': 15.0,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': 'ODIL36-YU6QU-5CK7VB',
 'info': {'descr': {'order': 'buy 15.00000000 ADAUSDT @ limit 0.300000'},
          'txid': ['ODIL36-YU6QU-5CK7VB']},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': 0.3,
 'remaining': None,
 'side': 'buy',
 'status': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT',
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```