### PR TITLE
Coinbase: cancelOrder, cancelOrders

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -1700,31 +1700,8 @@ module.exports = class coinbase extends Exchange {
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
-        let market = undefined;
-        if (symbol !== undefined) {
-            market = this.market (symbol);
-        }
-        const request = {
-            'order_ids': [ id ],
-        };
-        const response = await this.v3PrivatePostBrokerageOrdersBatchCancel (this.extend (request, params));
-        //
-        //     {
-        //         "results": [
-        //             {
-        //                 "success": true,
-        //                 "failure_reason": "UNKNOWN_CANCEL_FAILURE_REASON",
-        //                 "order_id": "bb8851a3-4fda-4a2c-aa06-9048db0e0f0d"
-        //             }
-        //         ]
-        //     }
-        //
-        const order = this.safeValue (response, 'results', []);
-        const success = this.safeValue (order, 'success');
-        if (success !== true) {
-            throw new BadRequest (this.id + ' cancelOrder() has failed, check your arguments and parameters');
-        }
-        return this.parseOrder (order, market);
+        const orders = await this.cancelOrders ([ id ], symbol, params);
+        return this.safeValue (orders, 0, {});
     }
 
     async cancelOrders (ids, symbol = undefined, params = {}) {

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -29,7 +29,7 @@ module.exports = class coinbase extends Exchange {
                 'future': false,
                 'option': false,
                 'addMargin': false,
-                'cancelOrder': undefined,
+                'cancelOrder': true,
                 'createDepositAddress': true,
                 'createOrder': undefined,
                 'createReduceOnlyOrder': false,
@@ -1631,6 +1631,95 @@ module.exports = class coinbase extends Exchange {
             request['limit'] = limit;
         }
         return request;
+    }
+
+    parseOrder (order, market = undefined) {
+        //
+        // createOrder
+        //
+        //     {
+        //         "order_id": "52cfe5e2-0b29-4c19-a245-a6a773de5030",
+        //         "product_id": "LTC-BTC",
+        //         "side": "SELL",
+        //         "client_order_id": "4d760580-6fca-4094-a70b-ebcca8626288"
+        //     }
+        //
+        // cancelOrder
+        //
+        //     {
+        //         "success": true,
+        //         "failure_reason": "UNKNOWN_CANCEL_FAILURE_REASON",
+        //         "order_id": "bb8851a3-4fda-4a2c-aa06-9048db0e0f0d"
+        //     }
+        //
+        const marketId = this.safeString (order, 'product_id');
+        const symbol = this.safeSymbol (marketId, market, '-');
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const rawSide = this.safeString (order, 'side');
+        const side = (rawSide !== undefined) ? rawSide.toLowerCase () : undefined;
+        return this.safeOrder ({
+            'info': order,
+            'id': this.safeString (order, 'order_id'),
+            'clientOrderId': this.safeString (order, 'client_order_id'),
+            'timestamp': undefined,
+            'datetime': undefined,
+            'lastTradeTimestamp': undefined,
+            'symbol': symbol,
+            'type': undefined,
+            'timeInForce': undefined,
+            'postOnly': undefined,
+            'side': side,
+            'price': undefined,
+            'stopPrice': undefined,
+            'triggerPrice': undefined,
+            'amount': undefined,
+            'filled': undefined,
+            'remaining': undefined,
+            'cost': undefined,
+            'average': undefined,
+            'status': undefined,
+            'fee': {
+                'cost': undefined,
+            },
+            'trades': undefined,
+        }, market);
+    }
+
+    async cancelOrder (id, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name coinbase#cancelOrder
+         * @description cancels an open order
+         * @see https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_cancelorders
+         * @param {string} id order id
+         * @param {string|undefined} symbol not used by coinbase cancelOrder()
+         * @param {object} params extra parameters specific to the coinbase api endpoint
+         * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request = {
+            'order_ids': [ id ],
+        };
+        const response = await this.v3PrivatePostBrokerageOrdersBatchCancel (this.extend (request, params));
+        //
+        //     {
+        //         "results": [
+        //             {
+        //                 "success": true,
+        //                 "failure_reason": "UNKNOWN_CANCEL_FAILURE_REASON",
+        //                 "order_id": "bb8851a3-4fda-4a2c-aa06-9048db0e0f0d"
+        //             }
+        //         ]
+        //     }
+        //
+        const order = this.safeValue (response, 'results', []);
+        return this.parseOrder (order, market);
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ArgumentsRequired, AuthenticationError, RateLimitExceeded, InvalidNonce } = require ('./base/errors');
+const { ExchangeError, ArgumentsRequired, AuthenticationError, BadRequest, RateLimitExceeded, InvalidNonce } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -1720,6 +1720,10 @@ module.exports = class coinbase extends Exchange {
         //     }
         //
         const order = this.safeValue (response, 'results', []);
+        const success = this.safeValue (order, 'success');
+        if (success !== true) {
+            throw new BadRequest (this.id + ' cancelOrder() has failed, check your arguments and parameters');
+        }
         return this.parseOrder (order, market);
     }
 
@@ -1755,6 +1759,10 @@ module.exports = class coinbase extends Exchange {
         //     }
         //
         const orders = this.safeValue (response, 'results', []);
+        const success = this.safeValue (orders, 'success');
+        if (success !== true) {
+            throw new BadRequest (this.id + ' cancelOrders() has failed, check your arguments and parameters');
+        }
         return this.parseOrders (orders, market);
     }
 

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -30,6 +30,7 @@ module.exports = class coinbase extends Exchange {
                 'option': false,
                 'addMargin': false,
                 'cancelOrder': true,
+                'cancelOrders': true,
                 'createDepositAddress': true,
                 'createOrder': undefined,
                 'createReduceOnlyOrder': false,
@@ -1644,7 +1645,7 @@ module.exports = class coinbase extends Exchange {
         //         "client_order_id": "4d760580-6fca-4094-a70b-ebcca8626288"
         //     }
         //
-        // cancelOrder
+        // cancelOrder, cancelOrders
         //
         //     {
         //         "success": true,
@@ -1720,6 +1721,41 @@ module.exports = class coinbase extends Exchange {
         //
         const order = this.safeValue (response, 'results', []);
         return this.parseOrder (order, market);
+    }
+
+    async cancelOrders (ids, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name coinbase#cancelOrders
+         * @description cancel multiple orders
+         * @see https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_cancelorders
+         * @param {[string]} ids order ids
+         * @param {string|undefined} symbol not used by coinbase cancelOrders()
+         * @param {object} params extra parameters specific to the coinbase api endpoint
+         * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
+         */
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request = {
+            'order_ids': ids,
+        };
+        const response = await this.v3PrivatePostBrokerageOrdersBatchCancel (this.extend (request, params));
+        //
+        //     {
+        //         "results": [
+        //             {
+        //                 "success": true,
+        //                 "failure_reason": "UNKNOWN_CANCEL_FAILURE_REASON",
+        //                 "order_id": "bb8851a3-4fda-4a2c-aa06-9048db0e0f0d"
+        //             }
+        //         ]
+        //     }
+        //
+        const orders = this.safeValue (response, 'results', []);
+        return this.parseOrders (orders, market);
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
Added cancelOrder and cancelOrders to coinbase using the advanced trade api:

### cancelOrder:
```
coinbase.cancelOrder (d098f674-3059-4bb2-83e8-8f632c1e0d89)
2023-01-13T08:46:02.892Z iteration 0 passed in 587 ms

{
  info: [
    {
      success: true,
      failure_reason: 'UNKNOWN_CANCEL_FAILURE_REASON',
      order_id: 'd098f674-3059-4bb2-83e8-8f632c1e0d89'
    }
  ],
  id: undefined,
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  average: undefined,
  status: undefined,
  fee: { cost: undefined },
  trades: [],
  fees: [ { cost: undefined } ]
}
```

### cancelOrders:
```
node examples/js/cli coinbase cancelOrders "['d5843c7e-63ea-48b2-abd6-1c9456ef860c']"

                                  id | clientOrderId | timestamp | datetime | lastTradeTimestamp | symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | filled | remaining | cost | average | status | fee | trades | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
d5843c7e-63ea-48b2-abd6-1c9456ef860c |               |           |          |                    |        |      |             |          |      |       |           |              |        |        |           |      |         |        |  {} |     [] | [{}]
1 objects
```