### PR TITLE
watchOrders/watchMyTrades support for binance isolated margin

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -1002,20 +1002,27 @@ module.exports = class binance extends binanceRest {
         } else if (this.isInverse (type, subType)) {
             type = 'delivery';
         }
+        const isIsolated = this.safeValue (params, 'isIsolated', false);
         const options = this.safeValue (this.options, type, {});
         const lastAuthenticatedTime = this.safeInteger (options, 'lastAuthenticatedTime', 0);
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
         const delay = this.sum (listenKeyRefreshRate, 10000);
+        const request = {};
         if (time - lastAuthenticatedTime > delay) {
             let method = 'publicPostUserDataStream';
             if (type === 'future') {
                 method = 'fapiPrivatePostListenKey';
             } else if (type === 'delivery') {
                 method = 'dapiPrivatePostListenKey';
-            } else if (type === 'margin') {
+            } else if (type === 'margin' && !isIsolated) {
                 method = 'sapiPostUserDataStream';
+            } else if (type === 'margin' && isIsolated) {
+                method = 'sapiPostUserDataStreamIsolated';
+                let symbol = this.safeString (params, 'symbol');
+                symbol = this.marketId (symbol);
+                request['symbol'] = symbol;
             }
-            const response = await this[method] ();
+            const response = await this[method] (request);
             this.options[type] = this.extend (options, {
                 'listenKey': this.safeString (response, 'listenKey'),
                 'lastAuthenticatedTime': time,
@@ -1035,23 +1042,29 @@ module.exports = class binance extends binanceRest {
         } else if (this.isInverse (type, subType)) {
             type = 'delivery';
         }
+        const isIsolated = this.safeValue (params, 'isIsolated', false);
         const options = this.safeValue (this.options, type, {});
         const listenKey = this.safeString (options, 'listenKey');
         if (listenKey === undefined) {
             // A network error happened: we can't renew a listen key that does not exist.
             return;
         }
+        const request = {
+            'listenKey': listenKey,
+        };
         let method = 'publicPutUserDataStream';
         if (type === 'future') {
             method = 'fapiPrivatePutListenKey';
         } else if (type === 'delivery') {
             method = 'dapiPrivatePutListenKey';
-        } else if (type === 'margin') {
+        } else if (type === 'margin' && !isIsolated) {
             method = 'sapiPutUserDataStream';
+        } else if (type === 'margin' && isIsolated) {
+            method = 'sapiPostUserDataStreamIsolated';
+            let symbol = this.safeString (params, 'symbol');
+            symbol = this.marketId (symbol);
+            request['symbol'] = symbol;
         }
-        const request = {
-            'listenKey': listenKey,
-        };
         const time = this.milliseconds ();
         const sendParams = this.omit (params, 'type');
         try {
@@ -1262,14 +1275,15 @@ module.exports = class binance extends binanceRest {
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
-        await this.authenticate (params);
         let messageHash = 'orders';
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             symbol = market['symbol'];
             messageHash += ':' + symbol;
+            params['symbol'] = symbol;
         }
+        await this.authenticate (params);
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params);
         const url = this.urls['api']['ws'][type] + '/' + this.options[type]['listenKey'];

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -1004,6 +1004,8 @@ module.exports = class binance extends binanceRest {
         }
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('authenticate', params);
+        const isIsolatedMargin = (marginMode === 'isolated');
+        const isCrossMargin = (marginMode === 'cross') || (marginMode === undefined);
         const symbol = this.safeString (params, 'symbol');
         params = this.omit (params, 'symbol');
         const options = this.safeValue (this.options, type, {});
@@ -1016,9 +1018,9 @@ module.exports = class binance extends binanceRest {
                 method = 'fapiPrivatePostListenKey';
             } else if (type === 'delivery') {
                 method = 'dapiPrivatePostListenKey';
-            } else if (type === 'margin' && marginMode === 'cross') {
+            } else if (type === 'margin' && isCrossMargin) {
                 method = 'sapiPostUserDataStream';
-            } else if (marginMode === 'isolated') {
+            } else if (isIsolatedMargin) {
                 method = 'sapiPostUserDataStreamIsolated';
                 if (symbol === undefined) {
                     throw new ArgumentsRequired (this.id + ' authenticate() requires a symbol argument for isolated margin mode');

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -1002,6 +1002,10 @@ module.exports = class binance extends binanceRest {
         } else if (this.isInverse (type, subType)) {
             type = 'delivery';
         }
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('authenticate', params);
+        const symbol = this.safeString (params, 'symbol');
+        params = this.omit (params, 'symbol');
         const options = this.safeValue (this.options, type, {});
         const lastAuthenticatedTime = this.safeInteger (options, 'lastAuthenticatedTime', 0);
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
@@ -1012,10 +1016,17 @@ module.exports = class binance extends binanceRest {
                 method = 'fapiPrivatePostListenKey';
             } else if (type === 'delivery') {
                 method = 'dapiPrivatePostListenKey';
-            } else if (type === 'margin') {
+            } else if (type === 'margin' && marginMode === 'cross') {
                 method = 'sapiPostUserDataStream';
+            } else if (marginMode === 'isolated') {
+                method = 'sapiPostUserDataStreamIsolated';
+                if (symbol === undefined) {
+                    throw new ArgumentsRequired (this.id + ' authenticate() requires a symbol argument for isolated margin mode');
+                }
+                const marketId = this.marketId (symbol);
+                params['symbol'] = marketId;
             }
-            const response = await this[method] ();
+            const response = await this[method] (params);
             this.options[type] = this.extend (options, {
                 'listenKey': this.safeString (response, 'listenKey'),
                 'lastAuthenticatedTime': time,
@@ -1262,14 +1273,15 @@ module.exports = class binance extends binanceRest {
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
-        await this.authenticate (params);
         let messageHash = 'orders';
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
             symbol = market['symbol'];
             messageHash += ':' + symbol;
+            params['symbol'] = symbol; // needed inside authenticate for isolated margin
         }
+        await this.authenticate (params);
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params);
         const url = this.urls['api']['ws'][type] + '/' + this.options[type]['listenKey'];
@@ -1548,7 +1560,6 @@ module.exports = class binance extends binanceRest {
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure
          */
         await this.loadMarkets ();
-        await this.authenticate (params);
         const defaultType = this.safeString2 (this.options, 'watchMyTrades', 'defaultType', 'spot');
         let type = this.safeString (params, 'type', defaultType);
         let subType = undefined;
@@ -1558,11 +1569,14 @@ module.exports = class binance extends binanceRest {
         } else if (this.isInverse (type, subType)) {
             type = 'delivery';
         }
-        const url = this.urls['api']['ws'][type] + '/' + this.options[type]['listenKey'];
         let messageHash = 'myTrades';
         if (symbol !== undefined) {
+            symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
+            params['symbol'] = symbol;
         }
+        await this.authenticate (params);
+        const url = this.urls['api']['ws'][type] + '/' + this.options[type]['listenKey'];
         const client = this.client (url);
         this.setBalanceCache (client, type);
         const message = undefined;


### PR DESCRIPTION
Closes #9746 

As described in the issue. Binance userDataStreams allows listening to isolated margin where symbol is a required parameter ([here](https://binance-docs.github.io/apidocs/spot/en/#listen-key-isolated-margin)). POST /sapi/v1/userDataStream/isolated

Changes were made in pro/binance.js methods watchOrders, authenticate and keepAlive so that there's a new url option and in that case the required parameter 'symbol'.

The user can make use of this functionality like this example:
```js
ccxt.watchOrders("BTCUSDT", since, limit, {
    isIsolated: true,
    type: 'margin'
})
```
Have a great day!