### PR TITLE
kraken.parseWSOrder string math

### DIFF
--- a/js/pro/kraken.js
+++ b/js/pro/kraken.js
@@ -1004,7 +1004,7 @@ module.exports = class kraken extends krakenRest {
         if (rawTrades !== undefined) {
             trades = this.parseTrades (rawTrades, market, undefined, undefined, { 'order': id });
         }
-        const stopPrice = this.safeString (order, 'stopprice');
+        const stopPrice = this.safeNumber (order, 'stopprice');
         return this.safeOrder ({
             'id': id,
             'clientOrderId': clientOrderId,

--- a/js/pro/kraken.js
+++ b/js/pro/kraken.js
@@ -5,6 +5,7 @@
 const krakenRest = require ('../kraken.js');
 const { BadSymbol, BadRequest, ExchangeError, NotSupported, InvalidNonce } = require ('../base/errors');
 const { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } = require ('./base/Cache');
+const Precise = require ('../base/Precise.js');
 
 //  ---------------------------------------------------------------------------
 
@@ -952,10 +953,10 @@ module.exports = class kraken extends krakenRest {
         if (orderDescription !== undefined) {
             const parts = orderDescription.split (' ');
             side = this.safeString (parts, 0);
-            amount = this.safeFloat (parts, 1);
+            amount = this.safeString (parts, 1);
             wsName = this.safeString (parts, 2);
             type = this.safeString (parts, 4);
-            price = this.safeFloat (parts, 5);
+            price = this.safeString (parts, 5);
         }
         side = this.safeString (description, 'type', side);
         type = this.safeString (description, 'ordertype', type);
@@ -963,27 +964,23 @@ module.exports = class kraken extends krakenRest {
         market = this.safeValue (this.options['marketsByWsName'], wsName, market);
         let symbol = undefined;
         const timestamp = this.safeTimestamp (order, 'opentm');
-        amount = this.safeFloat (order, 'vol', amount);
-        const filled = this.safeFloat (order, 'vol_exec');
-        let remaining = undefined;
-        if ((amount !== undefined) && (filled !== undefined)) {
-            remaining = amount - filled;
-        }
+        amount = this.safeString (order, 'vol', amount);
+        const filled = this.safeString (order, 'vol_exec');
         let fee = undefined;
-        const cost = this.safeFloat (order, 'cost');
-        price = this.safeFloat (description, 'price', price);
-        if ((price === undefined) || (price === 0.0)) {
-            price = this.safeFloat (description, 'price2');
+        const cost = this.safeString (order, 'cost');
+        price = this.safeString (description, 'price', price);
+        if ((price === undefined) || (Precise.stringEq (price, '0.0'))) {
+            price = this.safeString (description, 'price2');
         }
-        if ((price === undefined) || (price === 0.0)) {
-            price = this.safeFloat (order, 'price', price);
+        if ((price === undefined) || (Precise.stringEq (price, '0.0'))) {
+            price = this.safeString (order, 'price', price);
         }
-        const average = this.safeFloat2 (order, 'avg_price', 'price');
+        const average = this.safeString2 (order, 'avg_price', 'price');
         if (market !== undefined) {
             symbol = market['symbol'];
             if ('fee' in order) {
                 const flags = order['oflags'];
-                const feeCost = this.safeFloat (order, 'fee');
+                const feeCost = this.safeString (order, 'fee');
                 fee = {
                     'cost': feeCost,
                     'rate': undefined,
@@ -1007,8 +1004,8 @@ module.exports = class kraken extends krakenRest {
         if (rawTrades !== undefined) {
             trades = this.parseTrades (rawTrades, market, undefined, undefined, { 'order': id });
         }
-        const stopPrice = this.safeFloat (order, 'stopprice');
-        return {
+        const stopPrice = this.safeString (order, 'stopprice');
+        return this.safeOrder ({
             'id': id,
             'clientOrderId': clientOrderId,
             'info': order,
@@ -1028,10 +1025,10 @@ module.exports = class kraken extends krakenRest {
             'amount': amount,
             'filled': filled,
             'average': average,
-            'remaining': remaining,
+            'remaining': undefined,
             'fee': fee,
             'trades': trades,
-        };
+        });
     }
 
     handleSubscriptionStatus (client, message) {


### PR DESCRIPTION
```
% kraken watchOrders
Debugger listening on ws://127.0.0.1:51700/f43bb4ea-7ea0-4cbc-802a-92cc52e80039
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2023-01-13T17:00:26.345Z
Node.js: v18.4.0
CCXT v2.6.4
kraken.watchOrders ()
                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |   symbol |  type | timeInForce | postOnly | side | price |  stopPrice | triggerPrice | cost | amount | filled | average | remaining |                          fee | trades |                           fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
OQQGF3-6VZYS-YKHE3V |             0 | 1673573001411 | 2023-01-13T01:23:21.411Z |                    |   open | ADA/USDT | limit |             |          |  buy |   0.3 | 0.00000000 |   0.00000000 |    0 |     15 |      0 |         |        15 | {"cost":0,"currency":"USDT"} |     [] | [{"cost":0,"currency":"USDT"}]
1 objects
                 id | clientOrderId | timestamp | datetime | lastTradeTimestamp |   status | symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | cost | amount | filled | average | remaining | fee | trades | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
OQQGF3-6VZYS-YKHE3V |             0 |           |          |                    | canceled |        |      |             |          |      |       |           |              |    0 |        |      0 |         |           |     |     [] |   []
1 objects
                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |   symbol |   type | timeInForce | postOnly | side |    price |  stopPrice | triggerPrice |      cost | amount | filled |  average | remaining |                                   fee | trades |                                    fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
OALFYA-TH3YZ-FPVQRZ |             0 | 1673629310645 | 2023-01-13T17:01:50.645Z |                    | closed | ADA/USDT | market |         IOC |          |  buy | 0.330539 | 0.00000000 |   0.00000000 | 11.568865 |     35 |     35 | 0.330539 |         0 | {"cost":0.03007905,"currency":"USDT"} |     [] | [{"cost":0.03007905,"currency":"USDT"}]
1 objects
```