### PR TITLE
Bitfinex pro precise

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -1078,7 +1078,7 @@ module.exports = class bitfinex extends Exchange {
             'buy_price_oco': 0,
             'sell_price_oco': 0,
         };
-        if (type === 'market') {
+        if (type.indexOf ('market') > -1) {
             request['price'] = this.nonce ().toString ();
         } else {
             request['price'] = this.priceToPrecision (symbol, price);

--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -1063,17 +1063,18 @@ module.exports = class bitfinex extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const postOnly = this.safeValue (params, 'postOnly', false);
+        type = type.toLowerCase ();
         params = this.omit (params, [ 'postOnly' ]);
         if (market['spot']) {
             // although they claim that type needs to be 'exchange limit' or 'exchange market'
             // in fact that's not the case for swap markets
-            type = this.safeString (this.options['orderTypes'], type, type);
+            type = this.safeStringLower (this.options['orderTypes'], type, type);
         }
         const request = {
             'symbol': market['id'],
             'side': side,
             'amount': this.amountToPrecision (symbol, amount),
-            'type': type.toLowerCase (),
+            'type': type,
             'ocoorder': false,
             'buy_price_oco': 0,
             'sell_price_oco': 0,

--- a/js/pro/bitfinex.js
+++ b/js/pro/bitfinex.js
@@ -5,6 +5,7 @@
 const bitfinexRest = require ('../bitfinex.js');
 const { ExchangeError, AuthenticationError } = require ('../base/errors');
 const { ArrayCache, ArrayCacheBySymbolById } = require ('./base/Cache');
+const Precise = require ('../base/Precise');
 
 //  ---------------------------------------------------------------------------
 
@@ -223,11 +224,11 @@ module.exports = class bitfinex extends bitfinexRest {
         const symbol = this.safeSymbol (marketId);
         const channel = 'ticker';
         const messageHash = channel + ':' + marketId;
-        const last = this.safeFloat (message, 7);
-        const change = this.safeFloat (message, 5);
+        const last = this.safeString (message, 7);
+        const change = this.safeString (message, 5);
         let open = undefined;
         if ((last !== undefined) && (change !== undefined)) {
-            open = last - change;
+            open = Precise.stringSub (last, change);
         }
         const result = {
             'symbol': symbol,
@@ -240,11 +241,11 @@ module.exports = class bitfinex extends bitfinexRest {
             'ask': this.safeFloat (message, 3),
             'askVolume': undefined,
             'vwap': undefined,
-            'open': open,
-            'close': last,
-            'last': last,
+            'open': this.parseNumber (open),
+            'close': this.parseNumber (last),
+            'last': this.parseNumber (last),
             'previousClose': undefined,
-            'change': change,
+            'change': this.parseNumber (change),
             'percentage': this.safeFloat (message, 6),
             'average': undefined,
             'baseVolume': this.safeFloat (message, 8),

--- a/js/pro/bitfinex.js
+++ b/js/pro/bitfinex.js
@@ -574,12 +574,12 @@ module.exports = class bitfinex extends bitfinexRest {
         const id = this.safeString (order, 0);
         const marketId = this.safeString (order, 1);
         const symbol = this.safeSymbol (marketId);
-        let amount = this.safeFloat (order, 2);
-        let remaining = this.safeFloat (order, 3);
+        let amount = this.safeString (order, 2);
+        let remaining = this.safeString (order, 3);
         let side = 'buy';
-        if (amount < 0) {
-            amount = Math.abs (amount);
-            remaining = Math.abs (remaining);
+        if (Precise.stringLt (amount, '0')) {
+            amount = Precise.stringAbs (amount);
+            remaining = Precise.stringAbs (remaining);
             side = 'sell';
         }
         let type = this.safeString (order, 4);
@@ -589,10 +589,10 @@ module.exports = class bitfinex extends bitfinexRest {
             type = 'market';
         }
         const status = this.parseWsOrderStatus (this.safeString (order, 5));
-        const price = this.safeFloat (order, 6);
+        const price = this.safeString (order, 6);
         const rawDatetime = this.safeString (order, 8);
         const timestamp = this.parse8601 (rawDatetime);
-        const parsed = {
+        const parsed = this.safeOrder ({
             'info': order,
             'id': id,
             'clientOrderId': undefined,
@@ -608,12 +608,12 @@ module.exports = class bitfinex extends bitfinexRest {
             'average': undefined,
             'amount': amount,
             'remaining': remaining,
-            'filled': amount - remaining,
+            'filled': undefined,
             'status': status,
             'fee': undefined,
             'cost': undefined,
             'trades': undefined,
-        };
+        });
         if (this.orders === undefined) {
             const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
             this.orders = new ArrayCacheBySymbolById (limit);


### PR DESCRIPTION
```
% bitfinex watchTicker BTC/USDT
2023-01-13T17:21:59.201Z
Node.js: v18.4.0
CCXT v2.6.4
bitfinex.watchTicker (BTC/USDT)
{
  symbol: 'BTC/USDT',
  timestamp: 1673630533988,
  datetime: '2023-01-13T17:22:13.988Z',
  high: 19340,
  low: 18254,
  bid: 19306,
  bidVolume: undefined,
  ask: 19308,
  askVolume: undefined,
  vwap: undefined,
  open: 18870,
  close: 19307,
  last: 19307,
  previousClose: undefined,
  change: 437,
  percentage: 0.0232,
  average: undefined,
  baseVolume: 696.81071213,
  quoteVolume: undefined,
  info: [
          619602, 19306,
     26.06823157, 19308,
     24.63077852,   437,
          0.0232, 19307,
    696.81071213, 19340,
           18254
  ]
}
```

------------------

My bitfinex account is restricted right now because I can't access my KYC, so I can't test parseWSOrder