### PR TITLE
coinex: fix timeframes

### DIFF
--- a/js/pro/coinex.js
+++ b/js/pro/coinex.js
@@ -52,7 +52,7 @@ module.exports = class coinex extends coinexRest {
                     '6': AuthenticationError, // Permission denied
                 },
             },
-            'timeframes': {
+            'wsTimeframes': {
                 '1m': 60,
                 '3m': 180,
                 '5m': 300,
@@ -495,7 +495,7 @@ module.exports = class coinex extends coinexRest {
             'id': this.requestId (),
             'params': [
                 market['id'],
-                this.safeInteger (this.timeframes, timeframe, timeframe),
+                this.safeInteger (this.wsTimeframes, timeframe, timeframe),
             ],
         };
         const request = this.deepExtend (subscribe, params);

--- a/js/pro/coinex.js
+++ b/js/pro/coinex.js
@@ -32,6 +32,21 @@ module.exports = class coinex extends coinexRest {
                 },
             },
             'options': {
+                'timeframes': {
+                    '1m': 60,
+                    '3m': 180,
+                    '5m': 300,
+                    '15m': 900,
+                    '30m': 1800,
+                    '1h': 3600,
+                    '2h': 7200,
+                    '4h': 14400,
+                    '6h': 21600,
+                    '12h': 43200,
+                    '1d': 86400,
+                    '3d': 259200,
+                    '1w': 604800,
+                },
                 'account': 'spot',
                 'watchOrderBook': {
                     'limits': [ 5, 10, 20, 50 ],
@@ -50,23 +65,6 @@ module.exports = class coinex extends coinexRest {
                     '4': NotSupported, // Method unavailable
                     '5': RequestTimeout, // Service timeout
                     '6': AuthenticationError, // Permission denied
-                },
-            },
-            'options': {
-                'timeframes': {
-                    '1m': 60,
-                    '3m': 180,
-                    '5m': 300,
-                    '15m': 900,
-                    '30m': 1800,
-                    '1h': 3600,
-                    '2h': 7200,
-                    '4h': 14400,
-                    '6h': 21600,
-                    '12h': 43200,
-                    '1d': 86400,
-                    '3d': 259200,
-                    '1w': 604800,
                 },
             },
         });

--- a/js/pro/coinex.js
+++ b/js/pro/coinex.js
@@ -52,20 +52,22 @@ module.exports = class coinex extends coinexRest {
                     '6': AuthenticationError, // Permission denied
                 },
             },
-            'wsTimeframes': {
-                '1m': 60,
-                '3m': 180,
-                '5m': 300,
-                '15m': 900,
-                '30m': 1800,
-                '1h': 3600,
-                '2h': 7200,
-                '4h': 14400,
-                '6h': 21600,
-                '12h': 43200,
-                '1d': 86400,
-                '3d': 259200,
-                '1w': 604800,
+            'options': {
+                'timeframes': {
+                    '1m': 60,
+                    '3m': 180,
+                    '5m': 300,
+                    '15m': 900,
+                    '30m': 1800,
+                    '1h': 3600,
+                    '2h': 7200,
+                    '4h': 14400,
+                    '6h': 21600,
+                    '12h': 43200,
+                    '1d': 86400,
+                    '3d': 259200,
+                    '1w': 604800,
+                },
             },
         });
     }
@@ -490,12 +492,13 @@ module.exports = class coinex extends coinexRest {
             throw new NotSupported (this.id + ' watchOHLCV() is only supported for swap markets');
         }
         const url = this.urls['api']['ws'][type];
+        const timeframes = this.safeValue (this.options, 'timeframes', {});
         const subscribe = {
             'method': 'kline.subscribe',
             'id': this.requestId (),
             'params': [
                 market['id'],
-                this.safeInteger (this.wsTimeframes, timeframe, timeframe),
+                this.safeInteger (timeframes, timeframe, timeframe),
             ],
         };
         const request = this.deepExtend (subscribe, params);


### PR DESCRIPTION
Websocket's `timeframes` is conflicting with the api `timeframes` causing method like `fetch_ohlcv` to fail