### PR TITLE
Okx :: fix margin position side

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4344,15 +4344,26 @@ module.exports = class okx extends Exchange {
         let contracts = undefined;
         let side = this.safeString (position, 'posSide');
         const hedged = side !== 'net';
-        if (pos !== undefined) {
-            contracts = this.parseNumber (contractsAbs);
+        if (market['margin']) {
+            // margin position
             if (side === 'net') {
-                if (Precise.stringGt (pos, '0')) {
-                    side = 'long';
-                } else if (Precise.stringLt (pos, '0')) {
-                    side = 'short';
-                } else {
-                    side = undefined;
+                const posCcy = this.safeString (position, 'posCcy');
+                const parsedCurrency = this.safeCurrencyCode (posCcy);
+                if (parsedCurrency !== undefined) {
+                    side = (market['base'] === parsedCurrency) ? 'long' : 'short';
+                }
+            }
+        } else {
+            if (pos !== undefined) {
+                contracts = this.parseNumber (contractsAbs);
+                if (side === 'net') {
+                    if (Precise.stringGt (pos, '0')) {
+                        side = 'long';
+                    } else if (Precise.stringLt (pos, '0')) {
+                        side = 'short';
+                    } else {
+                        side = undefined;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16488


```
p okx fetchPositions '["LTC/USDT"]'
Python v3.10.8
CCXT v2.6.22
okx.fetchPositions(['LTC/USDT'])
[{'collateral': 2.002266436,
  'contractSize': None,
  'contracts': None,
  'datetime': '2023-01-15T16:25:27.171Z',
  'entryPrice': 87.98,
  'hedged': False,
  'id': None,
  'info': {'adl': '1',
           'availPos': '12.00358728382',
           'avgPx': '87.98',
           'baseBal': '',
           'baseBorrowed': '',
           'baseInterest': '',
           'bizRefId': '',
           'bizRefType': '',
           'cTime': '1673799927171',
           'ccy': 'USDT',
           'closeOrderAlgo': [],
           'deltaBS': '',
           'deltaPA': '',
           'gammaBS': '',
           'gammaPA': '',
           'imr': '',
           'instId': 'LTC-USDT',
           'instType': 'MARGIN',
           'interest': '0',
           'last': '87.85',
           'lever': '5',
           'liab': '-0.113791',
           'liabCcy': 'LTC',
           'liqPx': '100.31430948814871',
           'margin': '2.002266436',
           'markPx': '87.81',
           'mgnMode': 'isolated',
           'mgnRatio': '3.903466055555656',
           'mmr': '0.4995993855',
           'notionalUsd': '12.00358728382',
           'optVal': '',
           'pendingCloseOrdLiabVal': '0',
           'pos': '12.00358728382',
           'posCcy': 'USDT',
           'posId': '534890895045840898',
           'posSide': 'net',
           'quoteBal': '',
           'quoteBorrowed': '',
           'quoteInterest': '',
           'spotInUseAmt': '',
           'spotInUseCcy': '',
           'thetaBS': '',
           'thetaPA': '',
           'tradeId': '94941881',
           'uTime': '1673799927171',
           'upl': '0.0093331378199997',
           'uplRatio': '0.0046612866560585',
           'usdPx': '',
           'vegaBS': '',
           'vegaPA': ''},
  'initialMargin': 2.400717456764,
  'initialMarginPercentage': 0.2,
  'leverage': 5.0,
  'liquidationPrice': 100.31430948814871,
  'maintenanceMargin': 0.4995993855,
  'maintenanceMarginPercentage': 0.0416,
  'marginMode': 'isolated',
  'marginRatio': 0.2495,
  'markPrice': 87.81,
  'notional': 12.00358728382,
  'percentage': 0.46612866560585,
  'side': 'short',
  'symbol': 'LTC/USDT',
  'timestamp': 1673799927171,
  'unrealizedPnl': 0.0093331378199997}]
```
```
 p okx fetchPositions '["LTC/USDT"]'
Python v3.10.8
CCXT v2.6.22
okx.fetchPositions(['LTC/USDT'])
[{'collateral': 0.011379,
  'contractSize': None,
  'contracts': None,
  'datetime': '2023-01-15T16:34:12.447Z',
  'entryPrice': 87.65,
  'hedged': False,
  'id': None,
  'info': {'adl': '1',
           'availPos': '0.068217105',
           'avgPx': '87.65',
           'baseBal': '',
           'baseBorrowed': '',
           'baseInterest': '',
           'bizRefId': '',
           'bizRefType': '',
           'cTime': '1673800452447',
           'ccy': 'LTC',
           'closeOrderAlgo': [],
           'deltaBS': '',
           'deltaPA': '',
           'gammaBS': '',
           'gammaPA': '',
           'imr': '',
           'instId': 'LTC-USDT',
           'instType': 'MARGIN',
           'interest': '0',
           'last': '87.68',
           'lever': '5',
           'liab': '-4.98684675',
           'liabCcy': 'USDT',
           'liqPx': '76.87285133444539',
           'margin': '0.011379',
           'markPx': '87.66',
           'mgnMode': 'isolated',
           'mgnRatio': '3.861110888362833',
           'mmr': '0.0028444254791239',
           'notionalUsd': '5.986733134800001',
           'optVal': '',
           'pendingCloseOrdLiabVal': '0',
           'pos': '0.068217105',
           'posCcy': 'LTC',
           'posId': '534890895045840898',
           'posSide': 'net',
           'quoteBal': '',
           'quoteBorrowed': '',
           'quoteInterest': '',
           'spotInUseAmt': '',
           'spotInUseCcy': '',
           'thetaBS': '',
           'thetaPA': '',
           'tradeId': '94942277',
           'uTime': '1673800452447',
           'upl': '-0.0000504045824778',
           'uplRatio': '-0.0044296144193477',
           'usdPx': '',
           'vegaBS': '',
           'vegaPA': ''},
  'initialMargin': 1.1973466269600002,
  'initialMarginPercentage': 0.2,
  'leverage': 5.0,
  'liquidationPrice': 76.87285133444539,
  'maintenanceMargin': 0.0028444254791239,
  'maintenanceMarginPercentage': 0.0005,
  'marginMode': 'isolated',
  'marginRatio': 0.2499,
  'markPrice': 87.66,
  'notional': 5.986733134800001,
  'percentage': -0.44296144193477,
  'side': 'long',
  'symbol': 'LTC/USDT',
  'timestamp': 1673800452447,
  'unrealizedPnl': -5.04045824778e-05}]
```
