### PR TITLE
bitfinex: use body[0] ccxt/ccxt#16502

### DIFF
--- a/js/bitfinex.js
+++ b/js/bitfinex.js
@@ -1665,8 +1665,7 @@ module.exports = class bitfinex extends Exchange {
         }
         let throwError = false;
         if (code >= 400) {
-            const firstChar = this.safeString (body, 0);
-            if (firstChar === '{') {
+            if (body[0] === '{') {
                 throwError = true;
             }
         } else {


### PR DESCRIPTION
fix: ccxt/ccxt#16502

After check `Exchange.py`, `Exchange.php` and `Exchange.js`, the body we used in handleErrors is string. It might be ok to use `body[0]`.