### PR TITLE
Binance :: add testnet link

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -133,6 +133,7 @@ module.exports = class binance extends Exchange {
                 'test': {
                     'dapiPublic': 'https://testnet.binancefuture.com/dapi/v1',
                     'dapiPrivate': 'https://testnet.binancefuture.com/dapi/v1',
+                    'dapiPrivateV2': 'https://testnet.binancefuture.com/dapi/v2',
                     'eapiPublic': 'https://testnet.binanceops.com/eapi/v1',
                     'eapiPrivate': 'https://testnet.binanceops.com/eapi/v1',
                     'fapiPublic': 'https://testnet.binancefuture.com/fapi/v1',


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16518

Demo:

```
 p binancecoinm fetchPositions '["BTC/USD:BTC"]' --sandbox
Python v3.10.8
CCXT v2.6.26
binancecoinm.fetchPositions(['BTC/USD:BTC'])
[{'collateral': 9.9947437,
  'contractSize': 100.0,
  'contracts': 1.0,
  'datetime': '2023-01-17T09:21:16.562Z',
  'entryPrice': 21170.99999979,
  'hedged': False,
  'id': None,
  'info': {'entryPrice': '21170.99999979',
           'isAutoAddMargin': 'false',
           'isolatedMargin': '0.00000000',
           'isolatedWallet': '0',
           'leverage': '20',
           'liquidationPrice': '10.04053501',
           'marginType': 'cross',
           'markPrice': '21168.10890196',
           'maxQty': '50',
           'notionalValue': '0.00472408',
           'positionAmt': '1',
           'positionSide': 'BOTH',
           'symbol': 'BTCUSD_PERP',
           'unRealizedProfit': '-0.00000064',
           'updateTime': '1673947276562'},
  'initialMargin': 0.0002362,
  'initialMarginPercentage': 0.05,
  'leverage': 20.0,
  'liquidationPrice': 10.04053501,
  'maintenanceMargin': 1.889632e-05,
  'maintenanceMarginPercentage': 0.004,
  'marginMode': 'cross',
  'marginRatio': 0.0,
  'marginType': 'cross',
  'markPrice': 21168.10890196,
  'notional': 0.00472408,
  'percentage': -0.27,
  'side': 'long',
  'symbol': 'BTC/USD:BTC',
  'timestamp': 1673947276562,
  'unrealizedPnl': -6.4e-07}]
```
