### PR TITLE
cli - add rest flag

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -22,6 +22,7 @@ let [processPath, , exchangeId, methodName, ... params] = process.argv.filter (x
     , isSpot = process.argv.includes ('--spot')
     , isSwap = process.argv.includes ('--swap')
     , isFuture = process.argv.includes ('--future')
+    , rest = process.argv.inlucdes ('--rest')
 
 //-----------------------------------------------------------------------------
 
@@ -93,7 +94,7 @@ if (callRegex.test (exchangeId)) {
 }
 
 try {
-    if (ccxt.pro.exchanges.includes(exchangeId)) {
+    if (!rest && ccxt.pro.exchanges.includes(exchangeId)) {
         exchange = new (ccxt.pro)[exchangeId] ({ timeout, httpsAgent, ... settings })
     } else {
         exchange = new (ccxt)[exchangeId] ({ timeout, httpsAgent, ... settings })

--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -22,7 +22,7 @@ let [processPath, , exchangeId, methodName, ... params] = process.argv.filter (x
     , isSpot = process.argv.includes ('--spot')
     , isSwap = process.argv.includes ('--swap')
     , isFuture = process.argv.includes ('--future')
-    , rest = process.argv.inlucdes ('--rest')
+    , rest = process.argv.includes ('--rest')
 
 //-----------------------------------------------------------------------------
 

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -40,6 +40,9 @@ $main = function() use ($argv) {
         $new_updates = count(array_filter($args, function ($option) { return strstr($option, '--newUpdates') !== false; })) > 0;
         $args = array_values(array_filter($args, function ($option) { return strstr($option, '--newUpdates') === false; }));
 
+        $rest = count(array_filter($args, function ($option) { return strstr($option, '--rest') !== false; })) > 0;
+        $args = array_values(array_filter($args, function ($option) { return strstr($option, '--rest') === false; }));
+
         $id = $args[1];
         $member = $args[2];
         $args = array_slice($args, 3);
@@ -59,7 +62,7 @@ $main = function() use ($argv) {
 
             // instantiate the exchange by id
             $exchange = null;
-            if (in_array($id, \ccxt\pro\Exchange::$exchanges)) {
+            if (!$rest && in_array($id, \ccxt\pro\Exchange::$exchanges)) {
                 $exchange = '\\ccxt\\pro\\' . $id;
             } else {
                 $exchange = '\\ccxt\\async\\' . $id;

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -42,6 +42,7 @@ class Argv(object):
     spot = False
     swap = False
     future = False
+    rest = False
     args = []
 
 
@@ -62,7 +63,7 @@ parser.add_argument('--future', action='store_true', help='enable future markets
 parser.add_argument('exchange_id', type=str, help='exchange id in lowercase', nargs='?')
 parser.add_argument('method', type=str, help='method or property', nargs='?')
 parser.add_argument('args', type=str, help='arguments', nargs='*')
-
+parser.add_argument ('rest', action='store_true', help='default to rest api')
 parser.parse_args(namespace=argv)
 
 # ------------------------------------------------------------------------------
@@ -136,7 +137,7 @@ async def main():
         config.update(keys[argv.exchange_id])
 
     exchange = None
-    if (argv.exchange_id in ccxtpro.exchanges):
+    if (not argv.rest and argv.exchange_id in ccxtpro.exchanges):
         exchange = getattr(ccxtpro, argv.exchange_id)(config)
     else:
         exchange = getattr(ccxt, argv.exchange_id)(config)


### PR DESCRIPTION
Adds rest flag to default to rest exchange instead of pro.

As we add query functions to pro like `createOrder` this flag allows to choose between the rest or ws exchange function.