### PR TITLE
Gate :: fix contract market order

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -3157,7 +3157,6 @@ module.exports = class gate extends Exchange {
                     'contract': market['id'], // filled in prepareRequest above
                     'size': amount, // int64, positive = bid, negative = ask
                     // 'iceberg': 0, // int64, display size for iceberg order, 0 for non-iceberg, note that you will have to pay the taker fee for the hidden size
-                    'price': this.priceToPrecision (symbol, price), // 0 for market order with tif set as ioc
                     // 'close': false, // true to close the position, with size set to 0
                     // 'reduce_only': false, // St as true to be reduce-only order
                     // 'tif': 'gtc', // gtc, ioc, poc PendingOrCancelled == postOnly order
@@ -3165,6 +3164,11 @@ module.exports = class gate extends Exchange {
                     // 'auto_size': '', // close_long, close_short, note size also needs to be set to 0
                     'settle': market['settleId'], // filled in prepareRequest above
                 };
+                if (isMarketOrder) {
+                    request['price'] = price; // set to 0 for market orders
+                } else {
+                    request['price'] = this.priceToPrecision (symbol, price);
+                }
                 if (reduceOnly !== undefined) {
                     request['reduce_only'] = reduceOnly;
                 }


### PR DESCRIPTION
- currently, contract market orders crash because the price needs to be 0

```
 p gate createOrder "ADA/USDT:USDT" market buy 1                                      
Python v3.10.8
CCXT v2.6.33
gate.createOrder(ADA/USDT:USDT,market,buy,1)
{'amount': 1.0,
 'average': 0.35252,
 'clientOrderId': 'api',
 'cost': 3.5252,
 'datetime': '2023-01-17T18:37:31.859Z',
 'fee': None,
 'fees': [],
 'filled': 1.0,
 'id': '244632838390',
 'info': {'contract': 'ADA_USDT',
          'create_time': '1673980651.859',
          'fill_price': '0.35252',
          'finish_as': 'filled',
          'finish_time': '1673980651.859',
          'iceberg': '0',
          'id': '244632838390',
          'is_close': False,
          'is_liq': False,
          'is_reduce_only': False,
          'left': '0',
          'mkfr': '0.00015',
          'price': '0',
          'refr': '0.2',
          'refu': '2436035',
          'size': '1',
          'status': 'finished',
          'text': 'api',
          'tif': 'ioc',
          'tkfr': '0.0005',
          'user': '10406147'},
 'lastTradeTimestamp': 1673980651859,
 'postOnly': False,
 'price': 0.35252,
 'reduceOnly': False,
 'remaining': 0.0,
 'side': 'buy',
 'status': 'closed',
 'stopPrice': None,
 'symbol': 'ADA/USDT:USDT',
 'timeInForce': 'IOC',
 'timestamp': 1673980651859,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
