### PR TITLE
Bybit :: fix fetchFundingRate

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2147,7 +2147,8 @@ module.exports = class bybit extends Exchange {
         const market = this.market (symbol);
         params['symbol'] = market['id'];
         const symbols = [ market['symbol'] ];
-        return await this.fetchFundingRates (symbols, params);
+        const fr = await this.fetchFundingRates (symbols, params);
+        return this.safeValue (fr, market['symbol']);
     }
 
     async fetchFundingRates (symbols = undefined, params = {}) {


### PR DESCRIPTION
LGTM ✅ 

```
p bybit fetchFundingRate "LTC/USDT:USDT" --sandbox  
Python v3.10.8
CCXT v2.6.43
bybit.fetchFundingRate(LTC/USDT:USDT)
{'datetime': '2023-01-19T12:18:48.329Z',
 'estimatedSettlePrice': None,
 'fundingDatetime': '2023-01-19T16:00:00.000Z',
 'fundingRate': 0.0001,
 'fundingTimestamp': 1674144000000,
 'indexPrice': 82.7,
 'info': {'askPrice': '82.72',
          'basisRate': '',
          'bidPrice': '82.70',
          'deliveryFeeRate': '',
          'deliveryTime': '0',
          'fundingRate': '0.0001',
          'highPrice24h': '87.77',
          'indexPrice': '82.70',
          'lastPrice': '82.72',
          'lastTickDirection': 'PlusTick',
          'lowPrice24h': '82.07',
          'markPrice': '82.71',
          'nextFundingTime': '1674144000000',
          'openInterest': '2426193.4',
          'openInterestValue': '200670456.11',
          'predictedDeliveryPrice': '',
          'prevPrice1h': '82.66',
          'prevPrice24h': '86.44',
          'price24hPcnt': '-0.043035',
          'symbol': 'LTCUSDT',
          'turnover24h': '1828476652.4969969',
          'volume24h': '21703393.49999999'},
 'interestRate': None,
 'markPrice': 82.71,
 'nextFundingDatetime': None,
 'nextFundingRate': None,
 'nextFundingTimestamp': None,
 'previousFundingDatetime': None,
 'previousFundingRate': None,
 'previousFundingTimestamp': None,
 'symbol': 'LTC/USDT:USDT',
 'timestamp': 1674130728329}
```
