### PR TITLE
OKX :: fix contracts field

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4341,9 +4341,9 @@ module.exports = class okx extends Exchange {
         const symbol = market['symbol'];
         const pos = this.safeString (position, 'pos'); // 'pos' field: One way mode: 0 if position is not open, 1 if open | Two way (hedge) mode: -1 if short, 1 if long, 0 if position is not open
         const contractsAbs = Precise.stringAbs (pos);
-        let contracts = undefined;
         let side = this.safeString (position, 'posSide');
         const hedged = side !== 'net';
+        const contracts = this.parseNumber (contractsAbs);
         if (market['margin']) {
             // margin position
             if (side === 'net') {
@@ -4355,7 +4355,6 @@ module.exports = class okx extends Exchange {
             }
         } else {
             if (pos !== undefined) {
-                contracts = this.parseNumber (contractsAbs);
                 if (side === 'net') {
                     if (Precise.stringGt (pos, '0')) {
                         side = 'long';


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16488#issuecomment-1397252076

```
p okx fetchPositions '["LTC/USDT"]'
Python v3.10.8
CCXT v2.6.45
okx.fetchPositions(['LTC/USDT'])
[{'collateral': 0.011379,
  'contractSize': None,
  'contracts': 0.068217105,
  'datetime': '2023-01-19T16:05:08.474Z',
  'entryPrice': 87.65,
  'hedged': False,
  'id': None,
  'info': {'adl': '1',
           'availPos': '0.068217105',
           'avgPx': '87.65',
           'baseBal': '',
           'baseBorrowed': '',
           'baseInterest': '',
           'bizRefId': '',
           'bizRefType': '',
           'cTime': '1673800452447',
           'ccy': 'LTC',
           'closeOrderAlgo': [],
           'deltaBS': '',
           'deltaPA': '',
           'gammaBS': '',
           'gammaPA': '',
           'imr': '',
           'instId': 'LTC-USDT',
           'instType': 'MARGIN',
           'interest': '0',
           'last': '83.71',
           'lever': '5',
           'liab': '-4.9885529365682356',
           'liabCcy': 'USDT',
           'liqPx': '76.89915240864799',
           'margin': '0.011379',
           'markPx': '83.69',
           'mgnMode': 'isolated',
           'mgnRatio': '2.800542789200504',
           'mmr': '0.002980375753715',
           'notionalUsd': '5.70908951745',
           'optVal': '',
           'pendingCloseOrdLiabVal': '0',
           'pos': '0.068217105',
           'posCcy': 'LTC',
           'posId': '534890895045840898',
           'posSide': 'net',
           'quoteBal': '',
           'quoteBorrowed': '',
           'quoteInterest': '',
           'spotInUseAmt': '',
           'spotInUseCcy': '',
           'thetaBS': '',
           'thetaPA': '',
           'tradeId': '94942277',
           'uTime': '1674144308474',
           'upl': '-0.0027694100743008',
           'uplRatio': '-0.2433790380789896',
           'usdPx': '',
           'vegaBS': '',
           'vegaPA': ''},
  'initialMargin': 1.14181790349,
  'initialMarginPercentage': 0.2,
  'leverage': 5.0,
  'liquidationPrice': 76.89915240864799,
  'maintenanceMargin': 0.002980375753715,
  'maintenanceMarginPercentage': 0.0005,
  'marginMode': 'isolated',
  'marginRatio': 0.2619,
  'markPrice': 83.69,
  'notional': 5.70908951745,
  'percentage': -24.33790380789896,
  'side': 'long',
  'symbol': 'LTC/USDT',
  'timestamp': 1674144308474,
  'unrealizedPnl': -0.0027694100743008}]
```
