### PR TITLE
binance: add self trade prevention

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3217,6 +3217,7 @@ module.exports = class binance extends Exchange {
             'PENDING_CANCEL': 'canceling', // currently unused
             'REJECTED': 'rejected',
             'EXPIRED': 'expired',
+            'EXPIRED_IN_MATCH': 'expired',
         };
         return this.safeString (statuses, status, status);
     }

--- a/js/binance.js
+++ b/js/binance.js
@@ -776,6 +776,7 @@ module.exports = class binance extends Exchange {
                         'account': 10,
                         'myTrades': 10,
                         'rateLimit/order': 20,
+                        'myPreventedMatches': 1,
                     },
                     'post': {
                         'order/oco': 1,


### PR DESCRIPTION
binance support self trade prevention (https://binance-docs.github.io/apidocs/spot/en/#query-prevented-matches-user_data). In this PR, I made some changes for this.

* add api
* add order status