### PR TITLE
Coinbase: fetchOHLCV

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -2086,7 +2086,7 @@ module.exports = class coinbase extends Exchange {
         const end = this.seconds ().toString ();
         const request = {
             'product_id': market['id'],
-            'granularity': this.timeframes[timeframe],
+            'granularity': this.safeString (this.timeframes, timeframe, timeframe),
             'end': end,
         };
         if (since !== undefined) {


### PR DESCRIPTION
Added fetchOHLCV to coinbase using the advanced trade api:

```
coinbase.fetchOHLCV (BTC/USDT)
2023-01-20T06:40:25.827Z iteration 0 passed in 553 ms

1674178860000 | 21097.15 | 21105.68 | 21096.89 | 21105.68 | 0.78632033
1674178920000 | 21106.35 |  21109.1 | 21099.42 | 21099.42 | 0.50407881
1674178980000 |  21099.7 | 21103.18 | 21099.29 | 21100.97 |  0.6353758
...
1674196680000 | 20977.85 | 20977.85 | 20969.96 |  20975.4 | 1.64268065
1674196740000 | 20977.72 | 20983.87 | 20977.72 | 20981.37 | 0.97858316
1674196800000 | 20979.71 | 20979.71 | 20975.44 | 20975.44 | 0.36140214
297 objects
```