### PR TITLE
Fix React\Http\Browser::request() compatibility by replace null body value with empty string

### DIFF
--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -94,7 +94,7 @@ class Exchange extends \ccxt\Exchange {
             $this->lastRestRequestTimestamp = $this->milliseconds();
 
             try {
-                $result = React\Async\await($this->browser->request($method, $url, $headers, $body));
+                $result = React\Async\await($this->browser->request($method, $url, $headers, $body ?? ''));
             } catch (Exception $e) {
                 $message = $e->getMessage();
                 if (strpos($message, 'timed out') !== false) { // no way to determine this easily https://github.com/clue/reactphp-buzz/issues/146


### PR DESCRIPTION
`null` `$body` value on `ccxt\async\Exchange::fetch()` will throw  `InvalidArgumentException` with message **"Invalid request body given"** upon `React\Http\Browser::request()`
see: https://github.com/reactphp/http/blob/1.x/src/Message/Request.php#L48-L54