### PR TITLE
Wavesexchange :: fix fetchTicker

### DIFF
--- a/js/wavesexchange.js
+++ b/js/wavesexchange.js
@@ -770,17 +770,31 @@ module.exports = class wavesexchange extends Exchange {
         //           "timestamp":1640232379124
         //       }
         //
+        //  fetch ticker
+        //
+        //       {
+        //           firstPrice: '21749',
+        //           lastPrice: '22000',
+        //           volume: '0.73747149',
+        //           quoteVolume: '16409.44564928645471',
+        //           high: '23589.999941',
+        //           low: '21010.000845',
+        //           weightedAveragePrice: '22250.955964',
+        //           txsCount: '148',
+        //           volumeWaves: '0.0000000000680511203072'
+        //       }
+        //
         const timestamp = this.safeInteger (ticker, 'timestamp');
         const marketId = this.safeString (ticker, 'symbol');
         market = this.safeMarket (marketId, market, '/');
         const symbol = market['symbol'];
-        const last = this.safeString (ticker, '24h_close');
-        const low = this.safeString (ticker, '24h_low');
-        const high = this.safeString (ticker, '24h_high');
-        const vwap = this.safeString (ticker, '24h_vwap');
-        const baseVolume = this.safeString (ticker, '24h_volume');
-        const quoteVolume = this.safeString (ticker, '24h_priceVolume');
-        const open = this.safeString (ticker, '24h_open');
+        const last = this.safeString2 (ticker, '24h_close', 'lastPrice');
+        const low = this.safeString2 (ticker, '24h_low', 'low');
+        const high = this.safeString2 (ticker, '24h_high', 'high');
+        const vwap = this.safeString2 (ticker, '24h_vwap', 'weightedAveragePrice');
+        const baseVolume = this.safeString2 (ticker, '24h_volume', 'volume');
+        const quoteVolume = this.safeString2 (ticker, '24h_priceVolume', 'quoteVolume');
+        const open = this.safeString2 (ticker, '24h_open', 'firstPrice');
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
@@ -845,7 +859,8 @@ module.exports = class wavesexchange extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         const ticker = this.safeValue (data, 0, {});
-        return this.parseTicker (ticker, market);
+        const dataTicker = this.safeValue (ticker, 'data', {});
+        return this.parseTicker (dataTicker, market);
     }
 
     async fetchTickers (symbols = undefined, params = {}) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16554

```
p wavesexchange fetchTicker 'BTC/USDT'
Python v3.10.8
CCXT v2.6.47
wavesexchange.fetchTicker(BTC/USDT)
{'ask': None,
 'askVolume': None,
 'average': 21874.5,
 'baseVolume': 0.73747149,
 'bid': None,
 'bidVolume': None,
 'change': 251.0,
 'close': 22000.0,
 'datetime': None,
 'high': 23589.999941,
 'info': {'firstPrice': '21749',
          'high': '23589.999941',
          'lastPrice': '22000',
          'low': '21010.000845',
          'quoteVolume': '16409.44564928645471',
          'txsCount': '148',
          'volume': '0.73747149',
          'volumeWaves': '0.0000000000680687631777',
          'weightedAveragePrice': '22250.955964'},
 'last': 22000.0,
 'low': 21010.000845,
 'open': 21749.0,
 'percentage': 1.154076049473539,
 'previousClose': None,
 'quoteVolume': 16409.445649286456,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': 22250.955964}
```
```
p wavesexchange fetchTickers '["BTC/USDT"]'
Python v3.10.8
CCXT v2.6.47
wavesexchange.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': None,
              'askVolume': None,
              'average': 21874.5,
              'baseVolume': 0.73747149,
              'bid': None,
              'bidVolume': None,
              'change': 251.0,
              'close': 22000.0,
              'datetime': '2023-01-20T15:32:23.422Z',
              'high': 23589.999941,
              'info': {'24h_close': '22000',
                       '24h_high': '23589.999941',
                       '24h_low': '21010.000845',
                       '24h_open': '21749',
                       '24h_priceVolume': '16409.445649',
                       '24h_volume': '0.73747149',
                       '24h_vwap': '22250.955964',
                       'amountAssetCirculatingSupply': '20999999.43918778',
                       'amountAssetDecimals': '8',
                       'amountAssetID': '8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS',
                       'amountAssetMaxSupply': '20999999.96000264',
                       'amountAssetName': 'WBTC',
                       'amountAssetTotalSupply': '20999999.96000264',
                       'priceAssetCirculatingSupply': '67635792.524480',
                       'priceAssetDecimals': '6',
                       'priceAssetID': '34N9YcEETLWn93qYQ64EsP1x89tSruJU44RrEMSXXEPJ',
                       'priceAssetMaxSupply': 'infinite',
                       'priceAssetName': 'USDT',
                       'priceAssetTotalSupply': '67635825.124481',
                       'symbol': 'BTC/USDT',
                       'timestamp': '1674228743422'},
              'last': 22000.0,
              'low': 21010.000845,
              'open': 21749.0,
              'percentage': 1.154076049473539,
              'previousClose': None,
              'quoteVolume': 16409.445649,
              'symbol': 'BTC/USDT',
              'timestamp': 1674228743422,
              'vwap': 22250.955964}}
```
