### PR TITLE
Bitfinex2 :: fix symbol

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1181,26 +1181,6 @@ module.exports = class bitfinex2 extends Exchange {
         return this.parseTicker (ticker, market);
     }
 
-    parseSymbol (marketId) {
-        if (marketId === undefined) {
-            return marketId;
-        }
-        marketId = marketId.replace ('t', '');
-        let baseId = undefined;
-        let quoteId = undefined;
-        if (marketId.indexOf (':') >= 0) {
-            const parts = marketId.split (':');
-            baseId = parts[0];
-            quoteId = parts[1];
-        } else {
-            baseId = marketId.slice (0, 3);
-            quoteId = marketId.slice (3, 6);
-        }
-        const base = this.safeCurrencyCode (baseId);
-        const quote = this.safeCurrencyCode (quoteId);
-        return base + '/' + quote;
-    }
-
     parseTrade (trade, market = undefined) {
         //
         // fetchTrades (public)
@@ -1252,7 +1232,7 @@ module.exports = class bitfinex2 extends Exchange {
         const timestamp = this.safeInteger (trade, timestampIndex);
         if (isPrivate) {
             const marketId = trade[1];
-            symbol = this.parseSymbol (marketId);
+            symbol = this.safeSymbol (marketId);
             orderId = this.safeString (trade, 3);
             const maker = this.safeInteger (trade, 8);
             takerOrMaker = (maker === 1) ? 'maker' : 'taker';
@@ -1432,7 +1412,7 @@ module.exports = class bitfinex2 extends Exchange {
     parseOrder (order, market = undefined) {
         const id = this.safeString (order, 0);
         const marketId = this.safeString (order, 3);
-        const symbol = this.parseSymbol (marketId);
+        const symbol = this.safeSymbol (marketId);
         // https://github.com/ccxt/ccxt/issues/6686
         // const timestamp = this.safeTimestamp (order, 5);
         const timestamp = this.safeInteger (order, 5);


### PR DESCRIPTION
- fix `parseSymbol` calls
- indirectly fixes `parseOrder` and `parseTicker` 

```
 p bitfinex2 fetchOpenOrders "LTC/USDT:USDT"
Python v3.10.8
CCXT v2.6.47
bitfinex2.fetchOpenOrders(LTC/USDT:USDT)
[{'amount': 0.1,
  'average': None,
  'clientOrderId': '1674229133389',
  'cost': 0.0,
  'datetime': 1674229133391,
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '111933382091',
  'info': ['111933382091',
           None,
           '1674229133389',
           'tLTCF0:USTF0',
           '1674229133389',
           '1674229133391',
           '0.1',
           '0.1',
           'LIMIT',
           None,
           None,
           None,
           '0',
           'ACTIVE',
           None,
           None,
           '30',
           '0',
           '0',
           '0',
           None,
           None,
           None,
           '0',
           '0',
           None,
           None,
           None,
           'API>BFX',
           None,
           None,
           {'$F33': '10', 'lev': '10'}],
  'lastTradeTimestamp': None,
  'postOnly': False,
  'price': 30.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'LTC/USDT:USDT',
  'timeInForce': 'GTC',
  'timestamp': '2023-01-20T15:38:53.391Z',
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```
```
p bitfinex2 fetchTicker "BTC/USDT"
Python v3.10.8
CCXT v2.6.47
bitfinex2.fetchTicker(BTC/USDT)
{'ask': 20979.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 384.35554539,
 'bid': 20978.0,
 'bidVolume': None,
 'change': 211.0,
 'close': 21132.0,
 'datetime': '2023-01-20T15:47:22.132Z',
 'high': 21238.0,
 'info': ['20978',
          '32.34463692',
          '20979',
          '28.46535905',
          '211',
          '0.0101',
          '21132',
          '384.35554539',
          '21238',
          '20799'],
 'last': 21132.0,
 'low': 20799.0,
 'open': 20921.0,
 'percentage': 1.01,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1674229642132,
 'vwap': None}
```

```
 p bitfinex2 fetchTicker "BTC/USDT:USDT"
Python v3.10.8
CCXT v2.6.47
bitfinex2.fetchTicker(BTC/USDT:USDT)
{'ask': 21121.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 482.65576167,
 'bid': 21120.0,
 'bidVolume': None,
 'change': 183.0,
 'close': 21115.0,
 'datetime': '2023-01-20T15:47:57.169Z',
 'high': 21250.0,
 'info': ['21120',
          '14.93888328',
          '21121',
          '22.05466692',
          '183',
          '0.0087',
          '21115',
          '482.65576167',
          '21250',
          '20808'],
 'last': 21115.0,
 'low': 20808.0,
 'open': 20932.0,
 'percentage': 0.87,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1674229677169,
 'vwap': None}