### PR TITLE
Bybit: fetchSpotOHLCV, since and limit adjustments

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1953,8 +1953,10 @@ module.exports = class bybit extends Exchange {
         if (since !== undefined) {
             // startTime isn't working, emulated since using endTime
             // request['startTime'] = since;
-            const millisecondDuration = Precise.stringMul (this.parseTimeframe (timeframe).toString (), '1000');
-            const emulatedSince = Precise.stringAdd (since.toString (), (Precise.stringMul (limit.toString (), millisecondDuration)));
+            const duration = this.parseTimeframe (timeframe).toString ();
+            const millisecondDuration = Precise.stringMul (duration, '1000');
+            const timeFromSince = Precise.stringMul (limit.toString (), millisecondDuration);
+            const emulatedSince = Precise.stringAdd (since.toString (), timeFromSince);
             const emulatedSinceAdjustDurationError = Precise.stringSub (emulatedSince, millisecondDuration);
             request['endTime'] = this.parseNumber (emulatedSinceAdjustDurationError);
         }

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1952,7 +1952,7 @@ module.exports = class bybit extends Exchange {
         const now = this.seconds ();
         let sinceTimestamp = undefined;
         if (limit === undefined) {
-            limit = 200; // default is 200 when requested with `since`
+            limit = 1000; // default is 1000 when requested with `since`
         }
         if (since === undefined) {
             sinceTimestamp = now - limit * duration;
@@ -1960,7 +1960,7 @@ module.exports = class bybit extends Exchange {
             sinceTimestamp = parseInt (since / 1000);
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // max 200, default 200
+            request['limit'] = limit; // max 1000, default 1000
         }
         request['interval'] = timeframe;
         request['from'] = sinceTimestamp;
@@ -2064,6 +2064,10 @@ module.exports = class bybit extends Exchange {
          * @method
          * @name bybit#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://bybit-exchange.github.io/docs/spot/v3/#t-querykline
+         * @see https://bybit-exchange.github.io/docs/derivativesV3/contract/#t-dv_querykline
+         * @see https://bybit-exchange.github.io/docs/derivativesV3/contract/#t-dv_markpricekline
+         * @see https://bybit-exchange.github.io/docs/derivativesV3/contract/#t-dv_indexpricekline
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int|undefined} since timestamp in ms of the earliest candle to fetch

--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1896,7 +1896,6 @@ module.exports = class bybit extends Exchange {
 
     parseSpotOHLCV (ohlcv, market = undefined) {
         //
-        // spot
         //     {
         //         "t": "1666759020000",
         //         "s": "AAVEUSDT",
@@ -1951,15 +1950,15 @@ module.exports = class bybit extends Exchange {
         };
         let limitString = undefined;
         if (limit !== undefined) {
-            limitString = limit.toString ();
+            limitString = this.numberToString (limit);
         } else {
             limitString = '1000';
         }
         if (since !== undefined) {
             // request['startTime'] = since;
             // startTime isn't working, emulated since using endTime
-            since = since.toString ();
-            const duration = this.parseTimeframe (timeframe).toString ();
+            since = this.numberToString (since);
+            const duration = this.numberToString (this.parseTimeframe (timeframe));
             const millisecondDuration = Precise.stringMul (duration, '1000');
             const timeFromSince = Precise.stringMul (limitString, millisecondDuration);
             const emulatedSince = Precise.stringAdd (since, timeFromSince);
@@ -1975,19 +1974,19 @@ module.exports = class bybit extends Exchange {
         //         "retCode": 0,
         //         "retMsg": "OK",
         //         "result": {
-        //         "list": [
-        //             {
-        //             "t": 1659430380000,
-        //             "s": "BTCUSDT",
-        //             "sn": "BTCUSDT",
-        //             "c": "21170.14",
-        //             "h": "21170.14",
-        //             "l": "21127.86",
-        //             "o": "21127.86",
-        //             "v": "0.907276"
-        //             }
-        //         ]
-        //         },
+        //             "list": [
+        //                 {
+        //                     "t": 1659430380000,
+        //                     "s": "BTCUSDT",
+        //                     "sn": "BTCUSDT",
+        //                     "c": "21170.14",
+        //                     "h": "21170.14",
+        //                     "l": "21127.86",
+        //                     "o": "21127.86",
+        //                     "v": "0.907276"
+        //                 },
+        //             ]
+        //         }
         //         "retExtInfo": {},
         //         "time": 1659430400353
         //     }


### PR DESCRIPTION
Changed the default limit to 1000 and emulated since on fetchSpotOHLCV:
fixes: #16551
```
bybit.fetchOHLCV (BTC/USDT, 5m, 1672531200000, 200)
2023-01-20T23:30:49.853Z iteration 0 passed in 551 ms

1672531200000 |  16541.8 | 16543.48 | 16527.84 | 16535.15 | 16.245772
1672531500000 | 16535.15 |    16539 | 16523.48 | 16525.98 |  6.070775
1672531800000 | 16525.98 | 16529.87 | 16518.68 | 16519.77 |  5.411939
...
1672590300000 | 16570.25 | 16577.35 | 16568.71 | 16576.32 |  3.247477
1672590600000 | 16576.32 | 16578.99 | 16569.49 | 16576.16 |  9.742067
1672590900000 | 16576.16 | 16577.56 | 16569.53 | 16570.99 |  5.725733
200 objects
```