### PR TITLE
Kucoin cancel all margin orders

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -496,6 +496,10 @@ module.exports = class kucoin extends Exchange {
                 'networksById': {
                     'BEP20': 'BSC',
                 },
+                'marginModes': {
+                    'isolated': 'MARGIN_ISOLATED_TRADE',
+                    'cross': 'MARGIN_TRADE',
+                },
             },
         });
     }
@@ -1583,24 +1587,26 @@ module.exports = class kucoin extends Exchange {
          * @description cancel all open orders
          * @param {string|undefined} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} params extra parameters specific to the kucoin api endpoint
-         * @param {bool} params.stop true if cancelling all stop orders
-         * @param {string} params.tradeType The type of trading, "TRADE" for Spot Trading, "MARGIN_TRADE" for Margin Trading
+         * @param {bool} params.stop *invalid for isolated margin* true if cancelling all stop orders
+         * @param {string} params.marginMode 'cross' or 'isolated'
          * @param {string} params.orderIds *stop orders only* Comma seperated order IDs
          * @returns Response from the exchange
          */
         await this.loadMarkets ();
         const request = {};
-        let market = undefined;
-        if (symbol !== undefined) {
-            market = this.market (symbol);
-            request['symbol'] = market['id'];
-        }
-        let method = 'privateDeleteOrders';
         const stop = this.safeValue (params, 'stop');
-        if (stop) {
-            method = 'privateDeleteStopOrderCancel';
+        const [ marginMode, query ] = this.handleMarginModeAndParams ('cancelAllOrders', params);
+        if (symbol !== undefined) {
+            request['symbol'] = this.marketId (symbol);
         }
-        return await this[method] (this.extend (request, params));
+        if (marginMode !== undefined) {
+            request['tradeType'] = this.options['marginModes'][marginMode];
+            if (marginMode === 'isolated' && stop) {
+                throw new BadRequest (this.id + ' cancelAllOrders does not support isolated margin for stop orders');
+            }
+        }
+        const method = stop ? 'privateDeleteStopOrderCancel' : 'privateDeleteOrders';
+        return await this[method] (this.extend (request, query));
     }
 
     async fetchOrdersByStatus (status, symbol = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
# spot 

```
 kucoin cancelAllOrders                        
Debugger listening on ws://127.0.0.1:62070/da61ac9a-bcc3-4838-861b-4e983ab6fff5
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2023-01-20T20:27:03.036Z
Node.js: v18.4.0
CCXT v2.6.44
kucoin.cancelAllOrders ()
2023-01-20T20:27:06.126Z iteration 0 passed in 603 ms

{
  code: '200000',
  data: { cancelledOrderIds: [ '63caf912cf1b7e0001d149dc' ] }
}
2023-01-20T20:27:06.126Z iteration 1 passed in 603 ms
```

# cross margin

```
% kucoin cancelAllOrders undefined '{"marginMode": "cross"}'
2023-01-20T21:07:36.922Z
Node.js: v18.4.0
CCXT v2.6.44
kucoin.cancelAllOrders (, [object Object])
2023-01-20T21:07:40.274Z iteration 0 passed in 554 ms

{
  code: '200000',
  data: {
    cancelledOrderIds: [
      '63cadcc5525aef000142a2dd',
      'vs9f6ou9e76b78os000n0it0',
      'vs9f6ou9e864rgq8000t4qnm',
      'vs9f6ou9h4b2j7ma000logb8',
      'vs9f6ouairdb78os000n146g'
    ]
  }
}
2023-01-20T21:07:40.274Z iteration 1 passed in 554 ms
```

# isolated margin

```
% kucoin cancelAllOrders undefined '{"marginMode": "isolated"}'
Debugger listening on ws://127.0.0.1:62733/16bbaa84-f6eb-43e3-bbb1-22b421632f73
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
2023-01-20T21:09:06.757Z
Node.js: v18.4.0
CCXT v2.6.44
kucoin.cancelAllOrders (, [object Object])
2023-01-20T21:09:09.837Z iteration 0 passed in 456 ms

{
  code: '200000',
  data: { cancelledOrderIds: [ '63c962cc17f8760001ca008c' ] }
}
2023-01-20T21:09:09.837Z iteration 1 passed in 456 ms
```