### PR TITLE
bybit: add unified account apis

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -313,6 +313,7 @@ module.exports = class bybit extends Exchange {
                         'asset/v2/private/exchange/exchange-order-all': 1,
                         'unified/v3/private/account/borrow-history': 1,
                         'unified/v3/private/account/borrow-rate': 1,
+                        'unified/v3/private/account/info': 1,
                         'user/v3/private/frozen-sub-member': 10, // 5/s
                         'user/v3/private/query-sub-members': 5, // 10/s
                         'user/v3/private/query-api': 5, // 10/s
@@ -468,6 +469,7 @@ module.exports = class bybit extends Exchange {
                         'unified/v3/private/position/set-risk-limit': 2.5,
                         'unified/v3/private/position/trading-stop': 2.5,
                         'unified/v3/private/account/upgrade-unified-account': 2.5,
+                        'unified/v3/private/account/setMarginMode': 2.5,
                         // tax
                         'fht/compliance/tax/v3/private/registertime': 50,
                         'fht/compliance/tax/v3/private/create': 50,


### PR DESCRIPTION
Some apis in unified contract were missing, in this PR, I added these apis.

```BASH
$  node examples/js/cli bybit privateGetUnifiedV3PrivateAccountInfo
$  node examples/js/cli bybit privatePostUnifiedV3PrivateAccountSetMarginMode '{"setMarginMode":"REGULAR_MARGIN"}'
```