### PR TITLE
Coinbase: cancelOrders, BadRequest

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -2075,8 +2075,7 @@ module.exports = class coinbase extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const rawSide = this.safeString (order, 'side');
-        const side = (rawSide !== undefined) ? rawSide.toLowerCase () : undefined;
+        const side = this.safeStringLower (order, 'side');
         return this.safeOrder ({
             'info': order,
             'id': this.safeString (order, 'order_id'),
@@ -2153,9 +2152,11 @@ module.exports = class coinbase extends Exchange {
         //     }
         //
         const orders = this.safeValue (response, 'results', []);
-        const success = this.safeValue (orders, 'success');
-        if (success !== true) {
-            throw new BadRequest (this.id + ' cancelOrders() has failed, check your arguments and parameters');
+        for (let i = 0; i < orders.length; i++) {
+            const success = this.safeValue (orders[i], 'success');
+            if (success !== true) {
+                throw new BadRequest (this.id + ' cancelOrders() has failed, check your arguments and parameters');
+            }
         }
         return this.parseOrders (orders, market);
     }


### PR DESCRIPTION
Fixed a bug with cancelOrders, it was throwing a BadRequest error for all requests:
```
coinbase.cancelOrders (0ad120de-f285-4414-aa79-6fe0b06f8a2e)
2023-01-21T19:57:53.762Z iteration 0 passed in 636 ms

                                  id | clientOrderId | timestamp | datetime | lastTradeTimestamp | symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | filled | remaining | cost | average | status | fee | trades | fees | reduceOnly
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0ad120de-f285-4414-aa79-6fe0b06f8a2e |               |           |          |                    |        |      |             |          |      |       |           |              |        |        |           |      |         |        |  {} |     [] | [{}] |
1 objects
```