### PR TITLE
[binance] In `create_order()`, set `uppercaseType` correctly

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3467,7 +3467,7 @@ module.exports = class binance extends Exchange {
                 type = 'LIMIT_MAKER';
             }
         }
-        let uppercaseType = initialUppercaseType;
+        let uppercaseType = type.toUpperCase ();
         let stopPrice = undefined;
         if (isStopLoss) {
             stopPrice = stopLossPrice;


### PR DESCRIPTION
This is necessary in the case in which we set `type = 'LIMIT_MAKER'` on the line before, otherwise that value would be ignored.