### PR TITLE
Exchange: restore semantics of timestamp, datetime in safeOrder

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1206,8 +1206,8 @@ module.exports = class Exchange {
         return this.extend (order, {
             'id': this.safeString (order, 'id'),
             'clientOrderId': this.safeString (order, 'clientOrderId'),
-            'timestamp': datetime,
-            'datetime': timestamp,
+            'timestamp': timestamp,
+            'datetime': datetime,
             'symbol': symbol,
             'type': this.safeString (order, 'type'),
             'side': side,


### PR DESCRIPTION
Commit https://github.com/ccxt/ccxt/commit/ab0c133464091fb21991d277ccf051677b5b7968 swapped the `timestamp` and `datetime` fields, breaking the timestamp parsing in clients. If this is unintended, the change should be reverted.