### PR TITLE
binance: update postOnly in editOrder

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3074,18 +3074,16 @@ module.exports = class binance extends Exchange {
         const clientOrderId = this.safeString2 (params, 'newClientOrderId', 'clientOrderId');
         const initialUppercaseType = type.toUpperCase ();
         let uppercaseType = initialUppercaseType;
-        const isMarketOrder = initialUppercaseType === 'MARKET';
-        const isLimitOrder = initialUppercaseType === 'LIMIT';
-        const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
+        const postOnly = this.isPostOnly (initialUppercaseType === 'MARKET', initialUppercaseType === 'LIMIT_MAKER', params);
         if (postOnly) {
             uppercaseType = 'LIMIT_MAKER';
         }
         request['type'] = uppercaseType;
         const stopPrice = this.safeNumber (params, 'stopPrice');
         if (stopPrice !== undefined) {
-            if (isMarketOrder) {
+            if (uppercaseType === 'MARKET') {
                 uppercaseType = 'STOP_LOSS';
-            } else if (isLimitOrder) {
+            } else if (uppercaseType === 'LIMIT') {
                 uppercaseType = 'STOP_LOSS_LIMIT';
             }
         }
@@ -3113,7 +3111,7 @@ module.exports = class binance extends Exchange {
         let priceIsRequired = false;
         let stopPriceIsRequired = false;
         let quantityIsRequired = false;
-        if (isMarketOrder) {
+        if (uppercaseType === 'MARKET') {
             const quoteOrderQty = this.safeValue (this.options, 'quoteOrderQty', true);
             if (quoteOrderQty) {
                 const quoteOrderQty = this.safeValue2 (params, 'quoteOrderQty', 'cost');
@@ -3131,7 +3129,7 @@ module.exports = class binance extends Exchange {
             } else {
                 quantityIsRequired = true;
             }
-        } else if (isLimitOrder) {
+        } else if (uppercaseType === 'LIMIT') {
             priceIsRequired = true;
             timeInForceIsRequired = true;
             quantityIsRequired = true;

--- a/js/binance.js
+++ b/js/binance.js
@@ -3072,18 +3072,20 @@ module.exports = class binance extends Exchange {
             // ALLOW_FAILURE - new order placement will be attempted even if cancel request fails.
         };
         const clientOrderId = this.safeString2 (params, 'newClientOrderId', 'clientOrderId');
-        const postOnly = this.safeValue (params, 'postOnly', false);
-        if (postOnly) {
-            type = 'LIMIT_MAKER';
-        }
         const initialUppercaseType = type.toUpperCase ();
         let uppercaseType = initialUppercaseType;
+        const isMarketOrder = initialUppercaseType === 'MARKET';
+        const isLimitOrder = initialUppercaseType === 'LIMIT';
+        const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
+        if (postOnly) {
+            uppercaseType = 'LIMIT_MAKER';
+        }
         request['type'] = uppercaseType;
         const stopPrice = this.safeNumber (params, 'stopPrice');
         if (stopPrice !== undefined) {
-            if (uppercaseType === 'MARKET') {
+            if (isMarketOrder) {
                 uppercaseType = 'STOP_LOSS';
-            } else if (uppercaseType === 'LIMIT') {
+            } else if (isLimitOrder) {
                 uppercaseType = 'STOP_LOSS_LIMIT';
             }
         }
@@ -3111,7 +3113,7 @@ module.exports = class binance extends Exchange {
         let priceIsRequired = false;
         let stopPriceIsRequired = false;
         let quantityIsRequired = false;
-        if (uppercaseType === 'MARKET') {
+        if (isMarketOrder) {
             const quoteOrderQty = this.safeValue (this.options, 'quoteOrderQty', true);
             if (quoteOrderQty) {
                 const quoteOrderQty = this.safeValue2 (params, 'quoteOrderQty', 'cost');
@@ -3129,7 +3131,7 @@ module.exports = class binance extends Exchange {
             } else {
                 quantityIsRequired = true;
             }
-        } else if (uppercaseType === 'LIMIT') {
+        } else if (isLimitOrder) {
             priceIsRequired = true;
             timeInForceIsRequired = true;
             quantityIsRequired = true;


### PR DESCRIPTION
IMHO, it might be better to check `timeInForce` and `postOnly` (in `isPostOnly`) when edit order.

```BASH
$ node examples/js/cli binance createOrder HOOK/USDT limit sell 1 10
$ node examples/js/cli binance editOrder '"xxxxxx"' HOOK/USDT limit sell 1 10.1 '{"postOnly":true}' # => will change order id
$ python3 examples/py/cli.py binance editOrder 'xxxxxx' HOOK/USDT limit sell 1 10.5 # => will change order id
```