### PR TITLE
[gateio] Fix bugs in watchOrderBook

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -188,7 +188,10 @@ module.exports = class gate extends gateRest {
         const storedOrderBook = this.safeValue (this.orderbooks, symbol);
         const nonce = this.safeInteger (storedOrderBook, 'nonce');
         if (nonce === undefined) {
-            const cacheLength = storedOrderBook.cache.length;
+            let cacheLength = 0;
+            if (storedOrderBook !== undefined) {
+                cacheLength = storedOrderBook.cache.length;
+            }
             const snapshotDelay = this.handleOption ('watchOrderBook', 'snapshotDelay', 10);
             const waitAmount = isSpot ? snapshotDelay : 0;
             if (cacheLength === waitAmount) {

--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -193,7 +193,7 @@ module.exports = class gate extends gateRest {
             const waitAmount = isSpot ? snapshotDelay : 0;
             if (cacheLength === waitAmount) {
                 // max limit is 100
-                const subscription = client.subscriptions[channel];
+                const subscription = client.subscriptions[messageHash];
                 const limit = this.safeInteger (subscription, 'limit');
                 this.spawn (this.loadOrderBook, client, messageHash, symbol, limit);
             }
@@ -880,7 +880,7 @@ module.exports = class gate extends gateRest {
             'balance': this.handleBalanceSubscription,
             'order_book': this.handleOrderBookSubscription,
         };
-        const id = this.safeString (message, 'id');
+        const id = this.safeInteger (message, 'id');
         const subscriptionsById = this.indexBy (client.subscriptions, 'id');
         const subscription = this.safeValue (subscriptionsById, id);
         if (subscription !== undefined) {


### PR DESCRIPTION
Bug 1: in `handleOrderBook()`, we try to index `client.subscriptions` by `channel`, which is something like `spot.order_book_update`, while we should use `messageHash` (something like `orderbook:BTC/USDT`).

Bug 2: in `handleOrderBookSubscription`, we index `client.subscriptions` by a _string_ id, but the keys are actually integers.