### PR TITLE
[binance] Normalize symbol in `watchTrades()`

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -433,7 +433,7 @@ module.exports = class binance extends binanceRest {
         };
         const trades = await this.watch (url, messageHash, this.extend (request, query), messageHash, subscribe);
         if (this.newUpdates) {
-            limit = trades.getLimit (symbol, limit);
+            limit = trades.getLimit (market['symbol'], limit);
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }


### PR DESCRIPTION
Use the unified symbol to index the trade cache in `watchTrades()`. Not doing this results in a bug when watching trades on Binance with the "legacy" futures symbols:

```python
import asyncio

from ccxt.pro import binanceusdm  # type: ignore[import]


async def main() -> None:
    client = binanceusdm(config={"newUpdates": True})

    symbols = ["BTC/USDT", "BTC/USDT:USDT"]

    await client.load_markets()

    for symbol in symbols:
        print(f"Trade IDs for {symbol}:")
        for _ in range(5):
            trades = await client.watch_trades(symbol)
            print([t["id"] for t in trades])

    await client.close()


if __name__ == "__main__":
    asyncio.run(main())
```

Results (notice the repeated trades on the first symbol):
```
Trade IDs for BTC/USDT:
['3225593406']
['3225593406', '3225593407']
['3225593406', '3225593407', '3225593408']
['3225593406', '3225593407', '3225593408', '3225593409']
['3225593406', '3225593407', '3225593408', '3225593409', '3225593410']
Trade IDs for BTC/USDT:USDT:
['3225593406', '3225593407', '3225593408', '3225593409', '3225593410', '3225593411']
['3225593412', '3225593413', '3225593414', '3225593415', '3225593416', '3225593417', '3225593418', '3225593419', '3225593420']
['3225593421', '3225593422', '3225593423', '3225593424', '3225593425', '3225593426', '3225593427', '3225593428', '3225593429']
['3225593430']
['3225593431', '3225593432']
```

Thanks @m-gentil for finding the bug!