### PR TITLE
zonda parseLedgerEntry amount returned as number

### DIFF
--- a/js/zonda.js
+++ b/js/zonda.js
@@ -1003,7 +1003,7 @@ module.exports = class zonda extends Exchange {
             'referenceAccount': undefined,
             'type': this.parseLedgerEntryType (this.safeString (item, 'type')),
             'currency': this.safeCurrencyCode (currencyId),
-            'amount': amount,
+            'amount': this.parseNumber (amount),
             'before': this.safeNumber (fundsBefore, 'total'),
             'after': this.safeNumber (fundsAfter, 'total'),
             'status': 'ok',


### PR DESCRIPTION
```
Testing { exchanges: ["zonda"], symbol: "all", keys: { '--js': true, '--php': false, '--python': false, '--python-async': true, '--php-async': true, '--python-sync': true, '--php-sync': true }, maxConcurrency: 5 } (run-tests.js:255)
[100%] Testing zonda OK (testExchange @ run-tests.js:172)
All done, 1 succeeded (run-tests.js:276)
```

```
2023-01-24T13:11:31.619Z
Node.js: v18.4.0
CCXT v2.6.70
zonda.fetchLedger (ZRX)
2023-01-24T13:11:33.730Z iteration 0 passed in 1261 ms

                                  id | direction | account | referenceId | referenceAccount |        type | currency | amount | before | after | status |     timestamp |                 datetime | fee
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
748c07cf-e5cc-4eff-b0af-cd3511be65e7 |        in |         |             |                  | transaction |      ZRX |      0 |        |     0 |     ok | 1655854488020 | 2022-06-21T23:34:48.020Z |    
1 objects
2023-01-24T13:11:33.730Z iteration 1 passed in 1261 ms
```