### PR TITLE
kucoinfutures stopPrice order bug fix

### DIFF
--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1030,18 +1030,18 @@ module.exports = class kucoinfutures extends kucoin {
          * @param {float} amount the amount of currency to trade
          * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
          * @param {object} params  Extra parameters specific to the exchange API endpoint
-         * @param {float} params.leverage Leverage size of the order
-         * @param {float} params.stopPrice The price a stop order is triggered at
-         * @param {float} params.triggerPrice price to trigger stop orders
+         * @param {float} params.triggerPrice The price a trigger order is triggered at
          * @param {float} params.stopLossPrice price to trigger stop-loss orders
          * @param {float} params.takeProfitPrice price to trigger take-profit orders
-         * @param {string} params.stop 'up' or 'down', the direction the stopPrice is triggered from, requires stopPrice
-         * @param {string} params.stopPriceType  TP, IP or MP, defaults to MP: Mark Price
          * @param {bool} params.reduceOnly A mark to reduce the position size only. Set to false by default. Need to set the position size when reduceOnly is true.
          * @param {string} params.timeInForce GTC, GTT, IOC, or FOK, default is GTC, limit orders only
          * @param {string} params.postOnly Post only flag, invalid when timeInForce is IOC or FOK
+         * ----------------- Exchange Specific Parameters -----------------
+         * @param {float} params.leverage Leverage size of the order
          * @param {string} params.clientOid client order id, defaults to uuid if not passed
          * @param {string} params.remark remark for the order, length cannot exceed 100 utf8 characters
+         * @param {string} params.stop 'up' or 'down', the direction the stopPrice is triggered from, requires stopPrice. down: Triggers when the price reaches or goes below the stopPrice. up: Triggers when the price reaches or goes above the stopPrice.
+         * @param {string} params.stopPriceType  TP, IP or MP, defaults to MP: Mark Price
          * @param {bool} params.closeOrder set to true to close position
          * @param {bool} params.forceHold A mark to forcely hold the funds for an order, even though it's an order to reduce the position size. This helps the order stay on the order book and not get canceled when the position size changes. Set to false by default.
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
@@ -1068,28 +1068,20 @@ module.exports = class kucoinfutures extends kucoin {
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
         const isStopLoss = stopLossPrice !== undefined;
         const isTakeProfit = takeProfitPrice !== undefined;
-        const stop = this.safeString (params, 'stop');
-        const stopPriceType = this.safeString (params, 'stopPriceType', 'MP');
         if (stopPrice) {
-            if (stop === undefined) {
-                request['stop'] = (side === 'buy') ? 'down' : 'up';
-            }
+            request['stop'] = (side === 'buy') ? 'up' : 'down';
             request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
-            request['stopPriceType'] = stopPriceType;
+            request['stopPriceType'] = 'MP';
         } else if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
-                if (stop === undefined) {
-                    request['stop'] = (side === 'buy') ? 'up' : 'down';
-                }
+                request['stop'] = (side === 'buy') ? 'down' : 'up';
                 request['stopPrice'] = this.priceToPrecision (symbol, stopLossPrice);
             } else {
-                if (stop === undefined) {
-                    request['stop'] = (side === 'buy') ? 'down' : 'up';
-                }
+                request['stop'] = (side === 'buy') ? 'up' : 'down';
                 request['stopPrice'] = this.priceToPrecision (symbol, takeProfitPrice);
             }
             request['reduceOnly'] = true;
-            request['stopPriceType'] = stopPriceType;
+            request['stopPriceType'] = 'MP';
         }
         const uppercaseType = type.toUpperCase ();
         const timeInForce = this.safeStringUpper (params, 'timeInForce');
@@ -1115,7 +1107,7 @@ module.exports = class kucoinfutures extends kucoin {
                 throw new ArgumentsRequired (this.id + ' createOrder() requires a visibleSize parameter for iceberg orders');
             }
         }
-        params = this.omit (params, [ 'timeInForce', 'stop', 'stopPrice', 'stopPriceType', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice' ]); // Time in force only valid for limit orders, exchange error when gtc for market orders
+        params = this.omit (params, [ 'timeInForce', 'stopPrice', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice' ]); // Time in force only valid for limit orders, exchange error when gtc for market orders
         const response = await this.futuresPrivatePostOrders (this.extend (request, params));
         //
         //    {

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -1074,10 +1074,10 @@ module.exports = class kucoinfutures extends kucoin {
             request['stopPriceType'] = 'MP';
         } else if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
-                request['stop'] = (side === 'buy') ? 'down' : 'up';
+                request['stop'] = (side === 'buy') ? 'up' : 'down';
                 request['stopPrice'] = this.priceToPrecision (symbol, stopLossPrice);
             } else {
-                request['stop'] = (side === 'buy') ? 'up' : 'down';
+                request['stop'] = (side === 'buy') ? 'down' : 'up';
                 request['stopPrice'] = this.priceToPrecision (symbol, takeProfitPrice);
             }
             request['reduceOnly'] = true;


### PR DESCRIPTION
Previously trigger orders were being triggered immediately, because the parameter `stop` was set to the opposite value that it should have been set to

fixes: #16442

----------------------------------

## Testing

```
% kucoinfutures createOrder BTC/USDT:USDT market buy 1 undefined '{"stopPrice": "22951"}'
Debugger attached.
2023-01-24T17:02:47.724Z
Node.js: v18.4.0
CCXT v2.6.70
kucoinfutures.createOrder (BTC/USDT:USDT, market, buy, 1, , [object Object])
2023-01-24T17:02:50.173Z iteration 0 passed in 554 ms

{
  id: '63d00f3a84120200014adfa1',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  info: { code: '200000', data: { orderId: '63d00f3a84120200014adfa1' } }
}
2023-01-24T17:02:50.173Z iteration 1 passed in 554 ms

Waiting for the debugger to disconnect...
sam@Sams-Mac-mini ccxt % kucoinfutures fetchOrder 63d00f3a84120200014adfa1
Debugger attached.
2023-01-24T17:03:10.207Z
Node.js: v18.4.0
CCXT v2.6.70
kucoinfutures.fetchOrder (63d00f3a84120200014adfa1)
2023-01-24T17:03:12.606Z iteration 0 passed in 789 ms

{
  id: '63d00f3a84120200014adfa1',
  clientOrderId: '4eff52e1-be4c-4dbf-8218-a77574d9bda0',
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  amount: 1,
  price: undefined,
  stopPrice: 22951,
  triggerPrice: 22951,
  cost: 0,
  filled: 0,
  remaining: 1,
  timestamp: 1674579770000,
  datetime: '2023-01-24T17:02:50.000Z',
  fee: { currency: undefined, cost: undefined },
  status: 'open',
  info: {
    id: '63d00f3a84120200014adfa1',
    symbol: 'XBTUSDTM',
    type: 'market',
    side: 'buy',
    price: null,
    size: 1,
    value: '0',
    dealValue: '0',
    dealSize: 0,
    stp: '',
    stop: 'up',
    stopPriceType: 'MP',
    stopTriggered: false,
    stopPrice: '22951',
    timeInForce: 'GTC',
    postOnly: false,
    hidden: false,
    iceberg: false,
    leverage: '1',
    forceHold: false,
    closeOrder: false,
    visibleSize: null,
    clientOid: '4eff52e1-be4c-4dbf-8218-a77574d9bda0',
    remark: null,
    tags: 'ccxtfutures',
    isActive: true,
    cancelExist: false,
    createdAt: 1674579770000,
    updatedAt: 1674579770000,
    endAt: null,
    orderTime: null,
    settleCurrency: 'USDT',
    status: 'open',
    filledValue: '0',
    filledSize: 0,
    reduceOnly: false
  },
  lastTradeTimestamp: undefined,
  average: undefined,
  trades: [],
  fees: [ { currency: undefined, cost: undefined } ],
  reduceOnly: undefined
}
2023-01-24T17:03:12.606Z iteration 1 passed in 789 ms
```