### PR TITLE
Huobi :: update transfer

### DIFF
--- a/js/huobi.js
+++ b/js/huobi.js
@@ -966,12 +966,6 @@ module.exports = class huobi extends Exchange {
                 'broker': {
                     'id': 'AA03022abc',
                 },
-                'accountsByType': {
-                    'spot': 'pro',
-                    'funding': 'pro',
-                    'future': 'futures',
-                    'swap': 'swap',
-                },
                 'accountsById': {
                     'spot': 'spot',
                     'margin': 'margin',

--- a/js/huobi.js
+++ b/js/huobi.js
@@ -5142,6 +5142,11 @@ module.exports = class huobi extends Exchange {
         };
         const fromIdFuture = this.safeString (futuresAccounts, fromAccount, fromAccount);
         const toIdFuture = this.safeString (futuresAccounts, toAccount, toAccount);
+        const isFromSpot = (fromAccount === 'spot') || (fromAccount === 'pro');
+        const isToSpot = (toAccount === 'spot') || (toAccount === 'pro');
+        if (!isFromSpot && !isToSpot) {
+            throw new BadRequest (this.id + ' transfer() can only transfer between spot and futures accounts or vice versa');
+        }
         const fromOrToFuturesAccount = (fromIdFuture === 'futures') || (toIdFuture === 'futures');
         if (fromOrToFuturesAccount) {
             let type = fromIdFuture + '-to-' + toIdFuture;


### PR DESCRIPTION
- Fixed the typo in the endpoint name
- Added transfers between the different swap accounts (linear, linear isolated and inverse)

Demo: 

```
p huobi transfer USDT 1 swap spot          
Python v3.10.8
CCXT v2.6.84
huobi.transfer(USDT,1,swap,spot)
{'amount': 1,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': 'linear-swap',
 'id': '659623908',
 'info': {'code': '200',
          'data': '659623908',
          'message': 'Succeed',
          'print-log': True,
          'success': True},
 'status': None,
 'timestamp': None,
 'toAccount': 'spot'}
 ```

```
p huobi transfer USDT 1 spot swap
Python v3.10.8
CCXT v2.6.84
huobi.transfer(USDT,1,spot,swap)
{'amount': 1,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': 'spot',
 'id': '659623916',
 'info': {'code': '200',
          'data': '659623916',
          'message': 'Succeed',
          'print-log': True,
          'success': True},
 'status': None,
 'timestamp': None,
 'toAccount': 'linear-swap'}
 ```

```
p huobi transfer USDT 1 spot swap '{"symbol":"ADA/USDT:USDT"}'
Python v3.10.8
CCXT v2.6.84
huobi.transfer(USDT,1,spot,swap,{'symbol': 'ADA/USDT:USDT'})
{'amount': 1,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': 'spot',
 'id': '659623924',
 'info': {'code': '200',
          'data': '659623924',
          'message': 'Succeed',
          'print-log': True,
          'success': True},
 'status': None,
 'timestamp': None,
 'toAccount': 'linear-swap'}
 ```

```
 p huobi transfer USDT 1 swap spot '{"symbol":"ADA/USDT:USDT"}' --verbose
Python v3.10.8
CCXT v2.6.84
huobi.transfer(USDT,1,swap,spot,{'symbol': 'ADA/USDT:USDT'})
{'amount': 1,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': 'linear-swap',
 'id': '659623933',
 'info': {'code': '200',
          'data': '659623933',
          'message': 'Succeed',
          'print-log': True,
          'success': True},
 'status': None,
 'timestamp': None,
 'toAccount': 'spot'}
 ```

```
 n huobi transfer LTC .00007 spot swap '{"subType":"inverse"}' --verbose
CCXT v2.6.84
huobi.transfer (LTC, 0.00007, spot, swap, [object Object])

2023-01-25T18:53:52.330Z iteration 0 passed in 1775 ms

{
  info: {
    code: '200',
    data: '659623998',
    message: 'Succeed',
    success: true,
    'print-log': true
  },
  id: '659623998',
  timestamp: undefined,
  datetime: undefined,
  currency: 'LTC',
  amount: 0.00007,
  fromAccount: 'spot',
  toAccount: 'swap',
  status: undefined
}
2023-01-25T18:53:52.330Z iteration 1 passed in 1775 ms
```
