### PR TITLE
Coinbase: advanced trade examples

### DIFF
--- a/examples/py/coinbase-cancel-order.py
+++ b/examples/py/coinbase-cancel-order.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.coinbase({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    # 'verbose': True,  # for debug output
+})
+
+order_id = '04204eaf-94d6-444a-b9b7-2f8a485311f6'
+# order_ids = ['04204eaf-94d6-444a-b9b7-2f8a485311f6', '7c13a059-d235-46e1-ab43-6794a5836db9']
+
+try:
+    cancel_order = exchange.cancel_order(order_id)
+    # cancel_orders = exchange.cancel_orders(order_ids)
+    pprint(cancel_order)
+    # pprint(cancel_orders)
+except Exception as err:
+    print(err)

--- a/examples/py/coinbase-create-order.py
+++ b/examples/py/coinbase-create-order.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.coinbase({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    # 'verbose': True,  # for debug output
+})
+
+symbol = 'BTC/USDT'
+order_type = 'limit'
+side = 'buy'
+amount = 0.0003
+order_price = 13500
+stop_params = {
+    'triggerPrice': 15000
+}
+
+try:
+    limit_order = exchange.create_order(symbol, order_type, side, amount, order_price)
+    # stop_order = exchange.create_order(symbol, order_type, side, amount, order_price, stop_params)
+    pprint(limit_order)
+    # pprint(stop_order)
+except Exception as err:
+    print(err)

--- a/examples/py/coinbase-fetch-OHLCV.py
+++ b/examples/py/coinbase-fetch-OHLCV.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.coinbase({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    # 'verbose': True,  # for debug output
+})
+
+symbol = 'BTC/USDT'
+timeframe = '1m'
+since = None
+limit = None  # not used by coinbase
+
+try:
+    # Max 300 Candles
+    candles = exchange.fetch_ohlcv(symbol, timeframe, since, limit)
+    pprint(candles)
+except Exception as err:
+    print(err)

--- a/examples/py/coinbase-fetch-order.py
+++ b/examples/py/coinbase-fetch-order.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.coinbase({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    # 'verbose': True,  # for debug output
+})
+
+order_id = '04204eaf-94d6-444a-b9b7-2f8a485311f6'
+symbol = 'BTC/USDT'
+since = None
+limit = 3
+
+try:
+    fetch_order = exchange.fetch_order(order_id, symbol)
+    # fetch_orders = exchange.fetch_orders(symbol, since, limit)
+    # fetch_open_orders = exchange.fetch_open_orders(symbol, since, limit)
+    pprint(fetch_order)
+    # pprint(fetch_orders)
+    # pprint(fetch_open_orders)
+except Exception as err:
+    print(err)

--- a/examples/py/coinbase-fetch-ticker.py
+++ b/examples/py/coinbase-fetch-ticker.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.coinbase({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    # some markets are not supported with v2 like BTC/USDT
+    'options': {'fetchTicker': 'fetchTickerV3', 'fetchTickers': 'fetchTickersV3'}  # for selecting previous versions
+    # 'verbose': True,  # for debug output
+})
+
+symbols = ['BTC/USDT', 'ETH/USDT']
+symbol = 'BTC/USDT'
+
+try:
+    tickers = exchange.fetch_tickers(symbols)
+    ticker = exchange.fetch_ticker(symbol)
+    pprint(tickers)
+    pprint(ticker)
+except Exception as err:
+    print(err)

--- a/examples/py/coinbase-fetch-trades.py
+++ b/examples/py/coinbase-fetch-trades.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt  # noqa: E402
+
+# -----------------------------------------------------------------------------
+
+print('CCXT Version:', ccxt.__version__)
+
+# -----------------------------------------------------------------------------
+
+exchange = ccxt.coinbase({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_API_SECRET',
+    # 'verbose': True,  # for debug output
+})
+
+symbol = 'BTC/USDT'
+since = None  # not used by coinbase
+limit = 3
+
+try:
+    trades = exchange.fetch_trades(symbol, since, limit)
+    my_trades = exchange.fetch_my_trades(symbol, since, limit)
+    pprint(trades)
+    pprint(my_trades)
+except Exception as err:
+    print(err)


### PR DESCRIPTION
Added python examples for coinbase advanced trade:
- createOrder
- cancelOrder, cancelOrders
- fetchOrder, fetchOrders. fetchOrdersByStatus
- fetchTicker, fetchTickers
- fetchTrades, fetchMyTrades
- fetchOHLCV