### PR TITLE
[binance] URL encode RSA signatures

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -6546,7 +6546,7 @@ module.exports = class binance extends Exchange {
             }
             let signature = undefined;
             if (this.secret.indexOf ('PRIVATE KEY') > -1) {
-                signature = this.rsa (query, this.secret);
+                signature = this.encodeURIComponent (this.rsa (query, this.secret));
             } else {
                 signature = this.hmac (this.encode (query), this.encode (this.secret));
             }


### PR DESCRIPTION
Somehow, the fix in #16530 is no longer working.

Binance requires to url-encode the base64 representation of the RSA request signature, and CCXT is not doing it correctly.

See documentation:

> 2.4 - Since the signature may contain / and =, this could cause issues with sending the request. So the signature has to be URL encoded.

https://binance-docs.github.io/apidocs/spot/en/#signed-trade-user_data-and-margin-endpoint-security