### PR TITLE
Binance spot trailing fix and examples

### DIFF
--- a/examples/php/binance-spot-trailing.php
+++ b/examples/php/binance-spot-trailing.php
@@ -1,0 +1,75 @@
+<?php
+
+$root = dirname(dirname(dirname(__FILE__)));
+
+include $root . '/ccxt.php';
+
+date_default_timezone_set('UTC');
+
+echo 'CCXT v' . \ccxt\Exchange::VERSION . "\n";
+
+$exchange = new \ccxt\binance(array(
+    'apiKey' => 'YOUR_API_KEY',
+    'secret' => 'YOUR_SECRET_KEY',
+    // 'verbose' => true, // uncomment if debug output is needed
+));
+
+// You can read more about spot trailing orders here:
+// https://github.com/binance/binance-spot-api-docs/blob/master/faqs/trailing-stop-faq.md
+
+// Example 1: Spot : trailing spot loss
+function example_1($exchange) {
+    $markets = $exchange->load_markets(true);
+
+    // create STOP_LOSS_LIMIT BUY with a trailing stop of 5%.
+    $symbol = 'LTC/USDT';
+    $type = 'STOP_LOSS_LIMIT';
+    $side = 'buy';
+    $amount = 0.4;
+    $price = 25;
+    $params = array(
+        'trailingDelta' => 500, // 5% in BIPS
+    );
+    $create_order = $exchange->create_order($symbol, $type, $side, $amount, $price, $params);
+    
+    print_r('Create order id:' . $create_order['id']);
+    
+    // cancel created order
+    $canceled_order = $exchange->cancel_order($create_order['id'] . $symbol);
+    print_r ($canceled_order);
+}
+
+// -----------------------------------------------------------------------------------------
+
+// Example 2: Spot : TAKE_PROFIT_LIMIT BUY order
+function example_2($exchange) {
+    $markets = $exchange->load_markets(true);
+
+    // create STOP_LOSS_LIMIT BUY with a trailing stop of 5%.
+    $symbol = 'LTC/USDT';
+    $type = 'TAKE_PROFIT_LIMIT';
+    $side = 'buy';
+    $amount = 0.2;
+    $price = 70;
+    $params = array(
+        'trailingDelta' => 250, // 2.5% in BIPS
+    );
+
+    $create_order = $exchange->create_order($symbol, $type, $side, $amount, $price, $params);
+    
+    print_r('Create order id:' . $create_order['id']);
+    
+    // cancel created order
+    $canceled_order = $exchange->cancel_order($create_order['id'], $symbol);
+    print_r ($canceled_order);
+}
+// -----------------------------------------------------------------------------------------
+
+function main($exchange) {
+    example_1($exchange);
+    example_2($exchange);
+}
+
+main($exchange)
+
+?>

--- a/examples/py/binance-spot-trailing.py
+++ b/examples/py/binance-spot-trailing.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import os
+from random import randint
+import sys
+from pprint import pprint
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(root + '/python')
+
+import ccxt.async_support as ccxt  # noqa: E402
+
+
+print('CCXT Version:', ccxt.__version__)
+
+exchange = ccxt.binance({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_SECRET_KEY',
+})
+
+exchange = ccxt.binance({
+    'apiKey': os.environ['BINANCE_APIKEY'],
+    'secret': os.environ['BINANCE_SECRET'],
+})
+
+# You can read more about spot trailing orders here:
+# https://github.com/binance/binance-spot-api-docs/blob/master/faqs/trailing-stop-faq.md
+
+# Example 1: Spot : trailing spot loss
+async def example_1():
+    markets = await exchange.load_markets(True)
+
+    # create STOP_LOSS_LIMIT BUY with a trailing stop of 5%.
+    symbol = 'LTC/USDT'
+    type = 'STOP_LOSS_LIMIT'
+    side = 'buy'
+    amount = 0.4
+    price = 25
+    params = {
+        'trailingDelta':  500, # 5% in BIPS
+    }
+    exchange.verbose = True
+    create_order = await exchange.create_order(symbol, type, side, amount, price, params)
+    print('Create order id:', create_order['id'])
+
+    # cancel created order
+    canceled_order = await exchange.cancel_order(create_order['id'], symbol)
+    print(canceled_order)
+
+    await exchange.close()
+
+# -------------------------------------------------------------------------------------------
+
+# Example 2: Spot : TAKE_PROFIT_LIMIT BUY order
+async def example_2():
+    markets = await exchange.load_markets(True)
+
+    # create TAKE_PROFIT_LIMIT BUY with a trailing stop of 5%.
+    symbol = 'LTC/USDT'
+    type = 'TAKE_PROFIT_LIMIT'
+    side = 'buy'
+    amount = 0.2
+    price = 70
+    params = {
+        'trailingDelta':  250 # 2.5% in BIPS
+    }
+    exchange.verbose = True
+    create_order = await exchange.create_order(symbol, type, side, amount, price, params)
+    print('Create order id:', create_order['id'])
+
+    # cancel created order
+    canceled_order = await exchange.cancel_order(create_order['id'], symbol)
+    print(canceled_order)
+
+    await exchange.close()
+
+# -------------------------------------------------------------------------------------------
+
+async def main():
+    try:
+        # await example_1()
+        await example_2()
+    except Exception as e:
+        print(e)
+    await exchange.close()
+    
+    
+
+
+asyncio.run(main())

--- a/js/binance.js
+++ b/js/binance.js
@@ -3613,9 +3613,18 @@ module.exports = class binance extends Exchange {
             request['timeInForce'] = 'GTX';
         }
         if (stopPriceIsRequired) {
-            if (stopPrice === undefined) {
-                throw new InvalidOrder (this.id + ' createOrder() requires a stopPrice extra param for a ' + type + ' order');
+            if (market['contract']) {
+                if (stopPrice === undefined) {
+                    throw new InvalidOrder (this.id + ' createOrder() requires a stopPrice extra param for a ' + type + ' order');
+                }
             } else {
+                // check for delta price as well
+                const trailingDelta = this.safeValue (params, 'trailingDelta');
+                if (trailingDelta === undefined && stopPrice === undefined) {
+                    throw new InvalidOrder (this.id + ' createOrder() requires a stopPrice or trailingDelta param for a ' + type + ' order');
+                }
+            }
+            if (stopPrice !== undefined) {
                 request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
             }
         }


### PR DESCRIPTION
- Spot trailing orders were not possible because we always required the `stopPrice` instead.
- Examples in PHP and Python
- fixes https://github.com/ccxt/ccxt/issues/16632
Demo:

```
 p binance createOrder "LTC/USDT" "STOP_LOSS_LIMIT" buy 0.4 25 '{"trailingDelta":500}' 
Python v3.10.8
CCXT v2.6.89
binance.createOrder(LTC/USDT,STOP_LOSS_LIMIT,buy,0.4,25,{'trailingDelta': 500})
{'amount': 0.4,
 'average': None,
 'clientOrderId': 'x-R4BD3S82930ad4f0a4f5d7573d37df',
 'cost': 0.0,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '3285685415',
 'info': {'clientOrderId': 'x-R4BD3S82930ad4f0a4f5d7573d37df',
          'cummulativeQuoteQty': '0.00000000',
          'executedQty': '0.00000000',
          'orderId': '3285685415',
          'orderListId': '-1',
          'origQty': '0.40000000',
          'price': '25.00000000',
          'selfTradePreventionMode': 'NONE',
          'side': 'BUY',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC',
          'trailingDelta': '500',
          'trailingTime': '1674732039797',
          'transactTime': '1674732039797',
          'type': 'STOP_LOSS_LIMIT',
          'workingTime': '-1'},
 'lastTradeTimestamp': 1674732039797,
 'postOnly': False,
 'price': 25.0,
 'reduceOnly': None,
 'remaining': 0.4,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': -1,
 'trades': [],
 'triggerPrice': None,
 'type': 'stop_loss_limit'}
```
```
 p binance createOrder "LTC/USDT" market buy 0.4 25                          
Python v3.10.8
CCXT v2.6.89
binance.createOrder(LTC/USDT,market,buy,0.4,25)
{'amount': 0.113,
 'average': 88.21,
 'clientOrderId': 'x-R4BD3S82462642a60a6fc081c6acb',
 'cost': 9.96773,
 'datetime': '2023-01-26T11:21:23.959Z',
 'fee': {'cost': 2.458e-05, 'currency': 'BNB'},
 'fees': [{'cost': 2.458e-05, 'currency': 'BNB'}],
 'filled': 0.113,
 'id': '3285685742',
 'info': {'clientOrderId': 'x-R4BD3S82462642a60a6fc081c6acb',
          'cummulativeQuoteQty': '9.96773000',
          'executedQty': '0.11300000',
          'fills': [{'commission': '0.00002458',
                     'commissionAsset': 'BNB',
                     'price': '88.21000000',
                     'qty': '0.11300000',
                     'tradeId': '270996564'}],
          'orderId': '3285685742',
          'orderListId': '-1',
          'origQty': '0.11300000',
          'price': '0.00000000',
          'selfTradePreventionMode': 'NONE',
          'side': 'BUY',
          'status': 'FILLED',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC',
          'transactTime': '1674732083959',
          'type': 'MARKET',
          'workingTime': '1674732083959'},
 'lastTradeTimestamp': 1674732083959,
 'postOnly': False,
 'price': 88.21,
 'reduceOnly': None,
 'remaining': 0.0,
 'side': 'buy',
 'status': 'closed',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1674732083959,
 'trades': [{'amount': 0.113,
             'cost': 9.96773,
             'datetime': None,
             'fee': {'cost': 2.458e-05, 'currency': 'BNB'},
             'fees': [{'cost': 2.458e-05, 'currency': 'BNB'}],
             'id': '270996564',
             'info': {'commission': '0.00002458',
                      'commissionAsset': 'BNB',
                      'price': '88.21000000',
                      'qty': '0.11300000',
                      'tradeId': '270996564'},
             'order': None,
             'price': 88.21,
             'side': None,
             'symbol': 'LTC/USDT',
             'takerOrMaker': None,
             'timestamp': None,
             'type': None}],
 'triggerPrice': None,
 'type': 'market'}
```
```
p binance createOrder "LTC/USDT" limit buy 0.4 25
Python v3.10.8
CCXT v2.6.89
binance.createOrder(LTC/USDT,limit,buy,0.4,25)
{'amount': 0.4,
 'average': None,
 'clientOrderId': 'x-R4BD3S82e5ced410457f5a738ebcfd',
 'cost': 0.0,
 'datetime': '2023-01-26T11:22:14.829Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '3285686105',
 'info': {'clientOrderId': 'x-R4BD3S82e5ced410457f5a738ebcfd',
          'cummulativeQuoteQty': '0.00000000',
          'executedQty': '0.00000000',
          'fills': [],
          'orderId': '3285686105',
          'orderListId': '-1',
          'origQty': '0.40000000',
          'price': '25.00000000',
          'selfTradePreventionMode': 'NONE',
          'side': 'BUY',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC',
          'transactTime': '1674732134829',
          'type': 'LIMIT',
          'workingTime': '1674732134829'},
 'lastTradeTimestamp': 1674732134829,
 'postOnly': False,
 'price': 25.0,
 'reduceOnly': None,
 'remaining': 0.4,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1674732134829,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```

```
p binance createOrder "ADA/USDT:USDT" limit buy 25 0.2
Python v3.10.8
CCXT v2.6.89
binance.createOrder(ADA/USDT:USDT,limit,buy,25,0.2)
{'amount': 25.0,
 'average': None,
 'clientOrderId': 'Xt6NYn6R9zuykz03KfyJUk',
 'cost': 0.0,
 'datetime': '2023-01-26T11:25:24.818Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '28923760314',
 'info': {'avgPrice': '0.00000',
          'clientOrderId': 'Xt6NYn6R9zuykz03KfyJUk',
          'closePosition': False,
          'cumQty': '0',
          'cumQuote': '0',
          'executedQty': '0',
          'orderId': '28923760314',
          'origQty': '25',
          'origType': 'LIMIT',
          'positionSide': 'BOTH',
          'price': '0.20000',
          'priceProtect': False,
          'reduceOnly': False,
          'side': 'BUY',
          'status': 'NEW',
          'stopPrice': '0',
          'symbol': 'ADAUSDT',
          'timeInForce': 'GTC',
          'type': 'LIMIT',
          'updateTime': '1674732324818',
          'workingType': 'CONTRACT_PRICE'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 0.2,
 'reduceOnly': False,
 'remaining': 25.0,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'ADA/USDT:USDT',
 'timeInForce': 'GTC',
 'timestamp': 1674732324818,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
```
p binance createOrder "ADA/USDT:USDT" limit buy 10 0.2 '{"stopPrice":0.6}'  
Python v3.10.8
CCXT v2.6.89
binance.createOrder(ADA/USDT:USDT,limit,buy,10,0.2,{'stopPrice': 0.6})
{'amount': 10.0,
 'average': None,
 'clientOrderId': 'TrkRzIC5Sef9FbvWJWgFfl',
 'cost': 0.0,
 'datetime': '2023-01-26T11:26:29.019Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '28923781522',
 'info': {'avgPrice': '0.00000',
          'clientOrderId': 'TrkRzIC5Sef9FbvWJWgFfl',
          'closePosition': False,
          'cumQty': '0',
          'cumQuote': '0',
          'executedQty': '0',
          'orderId': '28923781522',
          'origQty': '10',
          'origType': 'STOP',
          'positionSide': 'BOTH',
          'price': '0.20000',
          'priceProtect': False,
          'reduceOnly': False,
          'side': 'BUY',
          'status': 'NEW',
          'stopPrice': '0.60000',
          'symbol': 'ADAUSDT',
          'timeInForce': 'GTC',
          'type': 'STOP',
          'updateTime': '1674732389019',
          'workingType': 'CONTRACT_PRICE'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 0.2,
 'reduceOnly': False,
 'remaining': 10.0,
 'side': 'buy',
 'status': 'open',
 'stopPrice': 0.6,
 'symbol': 'ADA/USDT:USDT',
 'timeInForce': 'GTC',
 'timestamp': 1674732389019,
 'trades': [],
 'triggerPrice': 0.6,
 'type': 'stop'}
```
