### PR TITLE
bybit: Add PARTIALLY_FILLED_CANCELLED to bybit order stati

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3205,6 +3205,7 @@ module.exports = class bybit extends Exchange {
             'PENDING_CANCEL': 'open',
             'PENDING_NEW': 'open',
             'REJECTED': 'rejected',
+            'PARTIALLY_FILLED_CANCELLED': 'canceled',
             // v3 contract / unified margin
             'Created': 'open',
             'New': 'open',


### PR DESCRIPTION
As shown in https://bybit-exchange.github.io/docs/spot/v3/#currency-currency-coin and https://github.com/ccxt/ccxt/issues/16600 - orders can have a status of PARTIALLY_FILLED_CANCELLED  - which should be mapped to an appropriate ccxt status.

I assume canceled is the right status, as i know from other exchanges that a canceled order can still be partially filled.