### PR TITLE
mercado removed invalid api doc link

### DIFF
--- a/js/mercado.js
+++ b/js/mercado.js
@@ -89,7 +89,6 @@ module.exports = class mercado extends Exchange {
                 'doc': [
                     'https://www.mercadobitcoin.com.br/api-doc',
                     'https://www.mercadobitcoin.com.br/trade-api',
-                    'https://api.mercadobitcoin.net/api/v4/docs/',
                 ],
             },
             'api': {


### PR DESCRIPTION
Visiting the link shows this in the browser

![](https://i.imgur.com/5bByVdw.png)