### PR TITLE
Gemini :: fix sandbox markets loading

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -418,6 +418,9 @@ module.exports = class gemini extends Exchange {
     async fetchUSDTMarkets (params = {}) {
         // these markets can't be scrapped and fetchMarketsFrom api does an extra call
         // to load market ids which we don't need here
+        if ('test' in this.urls) {
+            return []; // sandbox does not have usdt markets
+        }
         const fetchUsdtMarkets = this.safeValue (this.options, 'fetchUsdtMarkets', []);
         const result = [];
         for (let i = 0; i < fetchUsdtMarkets.length; i++) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16649

```
p gemini fetchTicker "BTC/USD" --sandbox
Python v3.10.8
CCXT v2.6.98
gemini.fetchTicker(BTC/USD)
{'ask': 22961.61,
 'askVolume': None,
 'average': None,
 'baseVolume': 2891.98282391,
 'bid': 22961.6,
 'bidVolume': None,
 'change': None,
 'close': 22938.11,
 'datetime': '2023-01-27T11:53:28.000Z',
 'high': None,
 'info': {'ask': '22961.61',
          'bid': '22961.60',
          'last': '22938.11',
          'volume': {'BTC': '2891.98282391',
                     'USD': '66336620.1329582101',
                     'timestamp': '1674820408000'}},
 'last': 22938.11,
 'low': None,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 66336620.13295821,
 'symbol': 'BTC/USD',
 'timestamp': 1674820408000,
 'vwap': 22938.11}
```
