### PR TITLE
Align bybit fetchOrder for futures to other exchanges

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3477,6 +3477,9 @@ module.exports = class bybit extends Exchange {
             };
             const result = await this.fetchOrders (symbol, undefined, undefined, this.extend (request, params));
             const length = result.length;
+            if (length === 0) {
+                throw new OrderNotFound ('Order ' + id + ' does not exist.');
+            }
             if (length > 1) {
                 throw new InvalidOrder (this.id + ' returned more than one order');
             }


### PR DESCRIPTION
Align bybit fetchOrder for swap to behavior of other exchanges, which raise an `OrderNotFound` exception if an order was not found.
Until now, bybit return(ed) None - which is unexpected, and kindof invalidates the purpose of the `OrderNotFound` exception.

``` python
import ccxt
exchange = ccxt.bybit({'apiKey': '<yourApiKey>', 'secret': '<yoursecret>', 'options': {'defaultType': 'swap'}})
res = exchange.fetch_order('invalidOrder', 'XRP/USDT:USDT)
print(res)
```