### PR TITLE
Btcex: fetchOrder, swap support

### DIFF
--- a/js/btcex.js
+++ b/js/btcex.js
@@ -1144,13 +1144,6 @@ module.exports = class btcex extends Exchange {
         const averageString = this.safeString (order, 'average_price');
         const amountString = this.safeString (order, 'amount');
         const filledString = this.safeString (order, 'filled_amount');
-        let lastTradeTimestamp = undefined;
-        if (filledString !== undefined) {
-            const isFilledPositive = Precise.stringGt (filledString, '0');
-            if (isFilledPositive) {
-                lastTradeTimestamp = lastUpdate;
-            }
-        }
         const status = this.parseOrderStatus (this.safeString (order, 'order_state'));
         const marketId = this.safeString (order, 'instrument_name');
         market = this.safeMarket (marketId, market);
@@ -1164,27 +1157,26 @@ module.exports = class btcex extends Exchange {
                 'currency': market['base'],
             };
         }
-        const type = this.safeString (order, 'order_type');
         // injected in createOrder
         const trades = this.safeValue (order, 'trades');
-        const timeInForce = this.parseTimeInForce (this.safeString (order, 'time_in_force'));
-        const stopPrice = this.safeValue (order, 'trigger_price');
-        const postOnly = this.safeValue (order, 'post_only');
+        const stopPrice = this.safeNumber (order, 'trigger_price');
         return this.safeOrder ({
             'info': order,
             'id': id,
             'clientOrderId': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'lastTradeTimestamp': lastTradeTimestamp,
+            'lastTradeTimestamp': lastUpdate,
             'symbol': market['symbol'],
-            'type': type,
-            'timeInForce': timeInForce,
-            'postOnly': postOnly,
+            'type': this.safeString (order, 'order_type'),
+            'timeInForce': this.parseTimeInForce (this.safeString (order, 'time_in_force')),
+            'postOnly': this.safeValue (order, 'post_only'),
             'side': side,
-            'price': priceString,
+            'price': this.parseNumber (priceString),
             'stopPrice': stopPrice,
             'triggerPrice': stopPrice,
+            'stopLossPrice': this.safeNumber (order, 'stop_loss_price'),
+            'takeProfitPrice': this.safeNumber (order, 'take_profit_price'),
             'amount': amountString,
             'cost': undefined,
             'average': averageString,
@@ -1197,6 +1189,7 @@ module.exports = class btcex extends Exchange {
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {
+        await this.signIn ();
         await this.loadMarkets ();
         const request = {
             'order_id': id,


### PR DESCRIPTION
Fixed an error with fetchOrder for swap orders, added stopLossPrice and takeProfitPrice to parseOrder:
```
btcex.fetchOrder (365003891281453056)
2023-01-27T21:28:47.044Z iteration 0 passed in 4913 ms

{
  info: {
    kind: 'perpetual',
    direction: 'buy',
    amount: '0.001',
    price: '14000',
    advanced: 'usdt',
    source: 'api',
    mmp: false,
    rpl: '0',
    version: '1',
    order_id: '365003891281453056',
    custom_order_id: '-',
    order_state: 'open',
    instrument_name: 'BTC-USDT-PERPETUAL',
    show_name: 'BTCUSDT Perp',
    filled_amount: '0',
    average_price: '0',
    order_type: 'limit',
    time_in_force: 'GTC',
    post_only: false,
    reduce_only: false,
    condition_type: 'NORMAL',
    trigger_touch: false,
    trigger_price_type: '1',
    stop_loss_price: '13000',
    stop_loss_type: '1',
    take_profit_price: '0',
    take_profit_type: '1',
    creation_timestamp: '1674854109133',
    last_update_timestamp: '1674854109283',
    show_zero_rpl: false,
    cascade_type: '0',
    first_deal_time: '0',
    position_side: 'LONG'
  },
  id: '365003891281453056',
  clientOrderId: undefined,
  timestamp: 1674854109133,
  datetime: '2023-01-27T21:15:09.133Z',
  lastTradeTimestamp: 1674854109283,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 14000,
  stopPrice: undefined,
  triggerPrice: undefined,
  stopLossPrice: 13000,
  takeProfitPrice: 0,
  amount: 0.001,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 0.001,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: [],
  reduceOnly: undefined
}
```