### PR TITLE
Btcex: setMarginMode

### DIFF
--- a/js/btcex.js
+++ b/js/btcex.js
@@ -2088,12 +2088,15 @@ module.exports = class btcex extends Exchange {
          * @param {object} params extra parameters specific to the btcex api endpoint
          * @returns {object} response from the exchange
          */
+        this.checkRequiredSymbol ('setMarginMode', symbol);
         await this.signIn ();
         await this.loadMarkets ();
-        this.checkRequiredSymbol ('setMarginMode', symbol);
         const market = this.market (symbol);
-        if (market['type'] !== 'swap') {
+        if (!market['swap']) {
             throw new BadRequest (this.id + ' setMarginMode() supports swap contracts only');
+        }
+        if ((marginMode !== 'isolated') && (marginMode !== 'isolate') && (marginMode !== 'cross')) {
+            throw new BadRequest (this.id + ' marginMode must be either isolated or cross');
         }
         marginMode = (marginMode === 'isolated') ? 'isolate' : 'cross';
         const request = {


### PR DESCRIPTION
Added setMarginMode to Btcex:
```
btcex.setMarginMode (isolated, BTC/USDT:USDT)
2023-01-27T22:18:40.058Z iteration 0 passed in 4926 ms

{
  id: '1674857919',
  jsonrpc: '2.0',
  usIn: '1674857920070',
  usOut: '1674857920079',
  usDiff: '9',
  result: 'ok'
}
```