### PR TITLE
reenable fetchTickers on binance.us

### DIFF
--- a/js/binanceus.js
+++ b/js/binanceus.js
@@ -48,7 +48,6 @@ module.exports = class binanceus extends binance {
                 'swap': undefined,
                 'future': undefined,
                 'option': undefined,
-                'fetchTickers': false,
             },
         });
     }


### PR DESCRIPTION
binance.us does have fetch-tickers just fine.

```
> node ./examples/js/cli.js binanceus fetchTickers

2023-01-29T13:48:59.806Z
Node.js: v16.19.0
CCXT v2.7.8
binanceus.fetchTickers ()
2023-01-29T13:49:01.163Z iteration 0 passed in 725 ms

{
  'BTC/USD': {
    symbol: 'BTC/USD',
    timestamp: 1675000140647,
    datetime: '2023-01-29T13:49:00.647Z',
    high: 23641.6,
    low: 22934.73,
    bid: 23564.39,
    bidVolume: 0.020353,
    ask: 23571.62,
    askVolume: 0.007513,
    vwap: 23235.3536,
    open: 22963.11,
    close: 23571.62,
    last: 23571.62,
    previousClose: 22962.96,
    change: 608.51,
    percentage: 2.65,
    average: 23267.365,
    baseVolume: 3123.532947,
    quoteVolume: 72576392.5888,
    info: {
      symbol: 'BTCUSD',
      priceChange: '608.5100',
      priceChangePercent: '2.650',
      weightedAvgPrice: '23235.3536',
      prevClosePrice: '22962.9600',
      lastPrice: '23571.6200',
      lastQty: '0.00650000',
      bidPrice: '23564.3900',
      bidQty: '0.02035300',
      askPrice: '23571.6200',
      askQty: '0.00751300',
      openPrice: '22963.1100',
      highPrice: '23641.6000',
      lowPrice: '22934.7300',
      volume: '3123.53294700',
      quoteVolume: '72576392.5888',
      openTime: '1674913740647',
      closeTime: '1675000140647',
      firstId: '64127245',
      lastId: '64209452',
      count: '82208'
    }
  },
  'ETH/USD': {
.....
```

closes #16614