### PR TITLE
Gate :: fix watchBalance

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -873,7 +873,7 @@ module.exports = class gate extends gateRest {
         }
     }
 
-    handleBalanceSubscription (client, message) {
+    handleBalanceSubscription (client, message, subscription = undefined) {
         this.balance = {};
     }
 


### PR DESCRIPTION

```
p gate watchBalance  --verbose
Python v3.10.8
CCXT v2.7.12
gate.watchBalance()
{'LTC': {'free': 0.071923787481, 'total': 0.071923787481, 'used': 0.0},
 'USDT': {'free': 1548.1798434349148, 'total': 1548.1798434349148, 'used': 0.0},
 'free': {'LTC': 0.071923787481, 'USDT': 1548.1798434349148},
 'total': {'LTC': 0.071923787481, 'USDT': 1548.1798434349148},
 'used': {'LTC': 0.0, 'USDT': 0.0}}
```
