### PR TITLE
deepExtend checks if value is undefined

### DIFF
--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -237,7 +237,9 @@ module.exports = {
                     out[k] = deepExtend (out[k], x[k]);
                 }
             } else {
-                out = x;
+                if (x !== undefined) {
+                    out = x;
+                }
             }
         }
         return out;

--- a/js/test/base/functions/test.generic.js
+++ b/js/test/base/functions/test.generic.js
@@ -43,7 +43,7 @@ function testDeepExtend() {
             c: { test1: 123, test2: 222 }
         },
         f: [{ 'foo': 'bar' }],
-        g: undefined,
+        g: 123,
         c: 5,
         e: { one: 1, two: 2 },
         h: /abc/g,

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -889,7 +889,9 @@ class Exchange {
                     $out[$k] = static::deep_extend(isset($out[$k]) ? $out[$k] : array(), $v);
                 }
             } else {
-                $out = $arg;
+                if ($arg !== null) {
+                    $out = $arg;
+                }
             }
         }
         return $out;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -959,7 +959,8 @@ class Exchange(object):
                 for key in arg:
                     result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
             else:
-                result = arg
+                if arg is not None:
+                    result = arg
         return result
 
     @staticmethod


### PR DESCRIPTION
When deepExtend is combining two objects, a value of `undefined/None/null` in the second object, will not replace a defined value in the first object.

For example:

**object1**

```
{
    "key1": "value1",
    "key2": undefined,
    "key3": {
        "key4": "value2"
    },
    "key5": undefined,
    "key6": {
        "key7": "value3"
    },
}
```

**object2**

```
{
    "key1": "value4",
    "key2": undefined,
    "key3": undefined,


    "key5": "value5",
    "key6": {
        "key7": undefined
    },
}
```

**exchange.deepExtend (object1, object2)**

```
{
    "key1": "value1",
    "key2": undefined,
    "key3": {
        "key4": "value2"       
    },                         
    "key5": "value5",
    "key6": {        
        "key7": "value3"
    },
}
```