### PR TITLE
Kucoinfutures fetchFundingRateHistory

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -3515,7 +3515,7 @@ module.exports = class kucoin extends Exchange {
         params = this.omit (params, 'version');
         let endpoint = '/api/' + version + '/' + this.implodeParams (path, params);
         if (api === 'webFront') {
-            endpoint = '/' + this.implodeParams (path, params)
+            endpoint = '/' + this.implodeParams (path, params);
         }
         const query = this.omit (params, this.extractParams (path));
         let endpart = '';

--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -3514,6 +3514,9 @@ module.exports = class kucoin extends Exchange {
         const version = this.safeString (params, 'version', defaultVersion);
         params = this.omit (params, 'version');
         let endpoint = '/api/' + version + '/' + this.implodeParams (path, params);
+        if (api === 'webFront') {
+            endpoint = '/' + this.implodeParams (path, params)
+        }
         const query = this.omit (params, this.extractParams (path));
         let endpart = '';
         headers = (headers !== undefined) ? headers : {};

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -2137,4 +2137,64 @@ module.exports = class kucoinfutures extends kucoin {
         }
         return tiers;
     }
+
+    async fetchFundingRateHistory (symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        /**
+         * @method
+         * @name okx#fetchFundingRateHistory
+         * @description fetches historical funding rate prices
+         * @param {string|undefined} symbol unified symbol of the market to fetch the funding rate history for
+         * @param {int|undefined} since not used by kucuoinfutures
+         * @param {int|undefined} limit the maximum amount of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure} to fetch
+         * @param {object} params extra parameters specific to the okx api endpoint
+         * @returns {[object]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
+         */
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        if (limit !== undefined) {
+            request['maxCount'] = limit;
+        }
+        const response = await this.webFrontGetContractSymbolFundingRates (this.extend (request, params));
+        //
+        //    {
+        //        success: true,
+        //        code: '200',
+        //        msg: 'success',
+        //        retry: false,
+        //        data: {
+        //            dataList: [
+        //                {
+        //                    symbol: 'XBTUSDTM',
+        //                    granularity: 28800000,
+        //                    timePoint: 1675108800000,
+        //                    value: 0.0001
+        //                },
+        //                ...
+        //            ],
+        //            hasMore: true
+        //        }
+        //    }
+        //
+        const data = this.safeValue (response, 'data');
+        const dataList = this.safeValue (data, 'dataList');
+        return this.parseFundingRateHistories (dataList, market, since, limit);
+    }
+
+    parseFundingRateHistory (info, market = undefined) {
+        const timestamp = this.safeNumber (info, 'timePoint');
+        const marketId = this.safeString (info, 'symbol');
+        return {
+            'info': info,
+            'symbol': this.safeSymbol (marketId, market),
+            'fundingRate': this.safeNumber (info, 'value'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+        };
+    }
 };

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -93,6 +93,7 @@ module.exports = class kucoinfutures extends kucoin {
                     'private': 'https://openapi-v2.kucoin.com',
                     'futuresPrivate': 'https://api-futures.kucoin.com',
                     'futuresPublic': 'https://api-futures.kucoin.com',
+                    'webFront': 'https://futures.kucoin.com/_api/web-front',
                 },
                 'test': {
                     'public': 'https://openapi-sandbox.kucoin.com',
@@ -167,6 +168,11 @@ module.exports = class kucoinfutures extends kucoin {
                         'orders/{orderId}': 1,
                         'orders': 4.44,
                         'stopOrders': 1,
+                    },
+                },
+                'webFront': {
+                    'get': {
+                        'contract/{symbol}/funding-rates': 1,
                     },
                 },
             },


### PR DESCRIPTION
fixes: #16549

I'm not sure where this endpoint comes from, it's talked about on #16549

----------------------

```
% kucoinfutures fetchFundingRateHistory BTC/USDT:USDT undefined 5
2023-01-30T22:33:43.986Z
Node.js: v18.4.0
CCXT v2.6.93
kucoinfutures.fetchFundingRateHistory (BTC/USDT:USDT, , 5)
2023-01-30T22:33:47.152Z iteration 0 passed in 1793 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
BTC/USDT:USDT |      0.0001 | 1674993600000 | 2023-01-29T12:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1675022400000 | 2023-01-29T20:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1675051200000 | 2023-01-30T04:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1675080000000 | 2023-01-30T12:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1675108800000 | 2023-01-30T20:00:00.000Z
5 objects
2023-01-30T22:33:47.152Z iteration 1 passed in 1793 ms
```