### PR TITLE
Disable fetchPositions() for Binance US

### DIFF
--- a/python/ccxt/binanceus.py
+++ b/python/ccxt/binanceus.py
@@ -46,6 +46,8 @@ class binanceus(binance):
                 'CORS': None,
                 'spot': True,
                 'margin': None,
+                'fetc
+                'fetchPositions': None,
                 'swap': None,
                 'future': None,
                 'option': None,


### PR DESCRIPTION
https://github.com/ccxt/ccxt/issues/16688 describes why `fetchPositions()` does not work for `binanceus`

This change indicates to developers that the method is not supported for this class.