### PR TITLE
Btcex: fetchOpenInterest

### DIFF
--- a/js/btcex.js
+++ b/js/btcex.js
@@ -2486,12 +2486,13 @@ module.exports = class btcex extends Exchange {
         //
         const marketId = this.safeString (interest, 'ticker_id');
         market = this.safeMarket (marketId, market);
+        const openInterest = this.safeNumber (interest, 'open_interest');
         return {
             'info': interest,
             'symbol': market['symbol'],
-            'baseVolume': this.safeNumber (interest, 'open_interest'),
+            'baseVolume': openInterest,
             'quoteVolume': undefined,
-            'openInterestAmount': this.safeNumber (interest, 'open_interest'), // in base currency
+            'openInterestAmount': openInterest, // in base currency
             'openInterestValue': undefined,
             'timestamp': undefined,
             'datetime': undefined,


### PR DESCRIPTION
Added fetchOpenInterest to Btcex:
```
btcex.fetchOpenInterest (BTC/USDT:USDT)
2023-01-30T23:44:55.936Z iteration 0 passed in 2273 ms

{
  info: {
    ticker_id: 'BTC-USDT-PERPETUAL',
    base_currency: 'BTC',
    target_currency: 'USDT',
    last_price: '22798.5',
    base_volume: '186531.42800000000039518',
    target_volume: '4324519918.31350473128259182',
    bid: '22798',
    ask: '22798.5',
    high: '23800',
    low: '22476',
    product_type: 'perpetual',
    open_interest: '24853.508',
    index_price: '22790.5',
    index_name: 'BTC-USDT',
    index_currency: 'BTC',
    start_timestamp: '1631004005882',
    funding_rate: '0.00012',
    next_funding_rate_timestamp: '1675123200000',
    contract_type: 'Quanto',
    contract_price: '22798.5',
    contract_price_currency: 'USDT'
  },
  symbol: 'BTC/USDT:USDT',
  baseVolume: 24853.508,
  quoteVolume: undefined,
  openInterestAmount: 24853.508,
  openInterestValue: undefined,
  timestamp: undefined,
  datetime: undefined
}
```