### PR TITLE
Pro - Check if `newUpdates` is being set

### DIFF
--- a/js/pro/base/Exchange.js
+++ b/js/pro/base/Exchange.js
@@ -15,7 +15,7 @@ const BaseExchange = require ("../../base/Exchange")
 module.exports = class Exchange extends BaseExchange {
     constructor (options = {}) {
         super (options);
-        this.newUpdates = options.newUpdates || true;
+        this.newUpdates = options.hasOwnProperty('newUpdates') ? options.newUpdates : true;
     }
 
     inflate (data) {


### PR DESCRIPTION
There seems to be a mistake in the code resulting in it being impossible to set the `newUpdates` flag to false. This oneliner resolves that issue by first checking if the key in the options object has been defined. 
