### PR TITLE
bitbns: removed empty timeframes object

### DIFF
--- a/js/bitbns.js
+++ b/js/bitbns.js
@@ -60,8 +60,6 @@ module.exports = class bitbns extends Exchange {
                 'transfer': false,
                 'withdraw': false,
             },
-            'timeframes': {
-            },
             'hostname': 'bitbns.com',
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/117201933-e7a6e780-adf5-11eb-9d80-98fc2a21c3d6.jpg',


### PR DESCRIPTION
Related to an error on https://github.com/ccxt/ccxt/pull/14007