### PR TITLE
binance pro parseTrade string math

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -574,7 +574,7 @@ module.exports = class binance extends binanceRest {
             takerOrMaker = trade['m'] ? 'maker' : 'taker';
         }
         let fee = undefined;
-        const feeCost = this.safeFloat (trade, 'n');
+        const feeCost = this.safeString (trade, 'n');
         if (feeCost !== undefined) {
             const feeCurrencyId = this.safeString (trade, 'N');
             const feeCurrencyCode = this.safeCurrencyCode (feeCurrencyId);
@@ -584,7 +584,7 @@ module.exports = class binance extends binanceRest {
             };
         }
         const type = this.safeStringLower (trade, 'o');
-        return {
+        return this.safeTrade ({
             'info': trade,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -598,7 +598,7 @@ module.exports = class binance extends binanceRest {
             'amount': amount,
             'cost': cost,
             'fee': fee,
-        };
+        });
     }
 
     handleTrade (client, message) {

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -550,15 +550,15 @@ module.exports = class binance extends binanceRest {
         }
         const id = this.safeString2 (trade, 't', 'a');
         const timestamp = this.safeInteger (trade, 'T');
-        const price = this.safeFloat2 (trade, 'L', 'p');
-        let amount = this.safeFloat (trade, 'q');
+        const price = this.safeString2 (trade, 'L', 'p');
+        let amount = this.safeString (trade, 'q');
         if (isTradeExecution) {
-            amount = this.safeFloat (trade, 'l', amount);
+            amount = this.safeString (trade, 'l', amount);
         }
-        let cost = this.safeFloat (trade, 'Y');
+        let cost = this.safeString (trade, 'Y');
         if (cost === undefined) {
             if ((price !== undefined) && (amount !== undefined)) {
-                cost = price * amount;
+                cost = Precise.stringMul (price, amount);
             }
         }
         const marketId = this.safeString (trade, 's');


### PR DESCRIPTION
```
% binanceusdm watchMyTrades
2023-01-31T23:43:11.849Z
Node.js: v18.4.0
CCXT v2.7.23
binanceusdm.watchMyTrades ()
    timestamp |                 datetime |        symbol |        id |       order |   type | takerOrMaker | side |    price | amount |  cost |                                 fee
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1675208619460 | 2023-01-31T23:43:39.460Z | FTM/USDT:USDT | 586580897 | 14031594961 | market |        taker | sell | 0.547500 |      2 | 1.095 | {"cost":0.000438,"currency":"USDT"}
1 objects
```