### PR TITLE
Bitget :: fix parseBalance

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2153,7 +2153,7 @@ module.exports = class bitget extends Exchange {
         //
         for (let i = 0; i < balance.length; i++) {
             const entry = balance[i];
-            const currencyId = this.safeString2 (entry, 'coinId', 'marginCoin');
+            const currencyId = this.safeString2 (entry, 'coinName', 'marginCoin');
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
             const frozen = this.safeString (entry, 'frozen');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16710

```
Python v3.10.8
CCXT v2.7.23
bitget.fetchBalance()
{'USDT': {'free': 33.12880076, 'total': 33.12880076, 'used': 0.0},
 'free': {'USDT': 33.12880076},
 'info': [{'available': '33.12880076',
           'bonus': '0',
           'btcEquity': '0.001957690452',
           'crossMaxAvailable': '17.2221341',
           'equity': '45.14880076',
           'fixedMaxAvailable': '17.2221341',
           'locked': '0',
           'marginCoin': 'USDT',
           'maxTransferOut': '5.2021341',
           'unrealizedPL': None,
           'usdtEquity': '45.148800767523'}],
 'total': {'USDT': 33.12880076},
 'used': {'USDT': 0.0}}
```
```
Python v3.10.8
CCXT v2.7.23
bitget.fetchBalance()
{'1INCH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 '1SQ': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ABBC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ABT': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ACA': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ACH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ACM': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ADA': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AERGO': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AFC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
```
