### PR TITLE
Run-tests :: options forwarding + old bug fix

### DIFF
--- a/js/test/test.js
+++ b/js/test/test.js
@@ -222,10 +222,6 @@ function getTestSymbol (exchange, symbols) {
 
 async function testExchange (exchange) {
 
-    if (sandbox || exchange.sandbox) {
-        exchange.setSandboxMode (true);
-    }
-
     await loadExchange (exchange);
 
     const codes = [
@@ -423,6 +419,10 @@ async function tryAllProxies (exchange, proxies) {
 //-----------------------------------------------------------------------------
 
 async function main () {
+
+    if (sandbox || exchange.sandbox) {
+        exchange.setSandboxMode (true);
+    }
 
     if (exchangeSymbol) {
 

--- a/keys.json
+++ b/keys.json
@@ -38,6 +38,5 @@
     "crex24":        { "skip": true },
     "btcex":         { "skip": true },
     "wazirx":        { "skipWs": true },
-    "deribit":       { "skipWs": true },
-    "theocean":      { "skip": true }
+    "deribit":       { "skipWs": true }
 }

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -462,7 +462,21 @@ def get_test_symbol(exchange, symbols):
     return symbol
 
 
-def get_exchange_code(exchange):
+def get_exchange_code(codes, exchange):
+    code = codes[0]
+    for i in range(0, len(codes)):
+        if codes[i] in exchange.currencies:
+            code = codes[i]
+    return code
+
+
+async def test_exchange(exchange, symbol=None):
+
+    dump(green('EXCHANGE: ' + exchange.id))
+    # delay = 2
+
+    # ..........................................................................
+    # public API
     codes = [
         'BTC',
         'ETH',
@@ -495,21 +509,6 @@ def get_exchange_code(exchange):
         'ZEC',
         'ZRX',
     ]
-
-    code = codes[0]
-    for i in range(0, len(codes)):
-        if codes[i] in exchange.currencies:
-            code = codes[i]
-    return code
-
-
-async def test_exchange(exchange, symbol=None):
-
-    dump(green('EXCHANGE: ' + exchange.id))
-    # delay = 2
-
-    # ..........................................................................
-    # public API
 
     code = get_exchange_code(exchange)
 

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -461,6 +461,7 @@ def get_test_symbol(exchange, symbols):
                 break
     return symbol
 
+
 def get_exchange_code(exchange):
     codes = [
         'BTC',
@@ -500,6 +501,7 @@ def get_exchange_code(exchange):
         if codes[i] in exchange.currencies:
             code = codes[i]
     return code
+
 
 async def test_exchange(exchange, symbol=None):
 

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -461,15 +461,7 @@ def get_test_symbol(exchange, symbols):
                 break
     return symbol
 
-
-async def test_exchange(exchange, symbol=None):
-
-    dump(green('EXCHANGE: ' + exchange.id))
-    # delay = 2
-
-    # ..........................................................................
-    # public API
-
+def get_exchange_code(exchange):
     codes = [
         'BTC',
         'ETH',
@@ -507,6 +499,17 @@ async def test_exchange(exchange, symbol=None):
     for i in range(0, len(codes)):
         if codes[i] in exchange.currencies:
             code = codes[i]
+    return code
+
+async def test_exchange(exchange, symbol=None):
+
+    dump(green('EXCHANGE: ' + exchange.id))
+    # delay = 2
+
+    # ..........................................................................
+    # public API
+
+    code = get_exchange_code(exchange)
 
     if not symbol:
         symbol = get_test_symbol(exchange, [
@@ -675,8 +678,9 @@ async def main():
                 exchange.set_sandbox_mode(True)
 
             if symbol:
+                code = get_exchange_code(exchange)
                 await load_exchange(exchange)
-                await test_symbol(exchange, symbol)
+                await test_symbol(exchange, symbol, code)
             else:
                 await try_all_proxies(exchange, proxies)
 

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -462,9 +462,9 @@ def get_test_symbol(exchange, symbols):
     return symbol
 
 
-def get_exchange_code(exchange, codes = None):
+def get_exchange_code(exchange, codes=None):
     if codes is None:
-        codes = ['BTC','ETH','XRP','LTC','BCH','EOS','BNB','BSV','USDT']
+        codes = ['BTC', 'ETH', 'XRP', 'LTC', 'BCH', 'EOS', 'BNB', 'BSV', 'USDT']
     code = codes[0]
     for i in range(0, len(codes)):
         if codes[i] in exchange.currencies:

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -462,7 +462,9 @@ def get_test_symbol(exchange, symbols):
     return symbol
 
 
-def get_exchange_code(codes, exchange):
+def get_exchange_code(exchange, codes = None):
+    if codes is None:
+        codes = ['BTC','ETH','XRP','LTC','BCH','EOS','BNB','BSV','USDT']
     code = codes[0]
     for i in range(0, len(codes)):
         if codes[i] in exchange.currencies:
@@ -510,7 +512,7 @@ async def test_exchange(exchange, symbol=None):
         'ZRX',
     ]
 
-    code = get_exchange_code(exchange)
+    code = get_exchange_code(exchange, codes)
 
     if not symbol:
         symbol = get_test_symbol(exchange, [

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -433,14 +433,15 @@ def get_test_symbol(exchange, symbols):
     return symbol
 
 
-def get_exchange_code(exchange, codes = None):
+def get_exchange_code(exchange, codes=None):
     if codes is None:
-        codes = ['BTC','ETH','XRP','LTC','BCH','EOS','BNB','BSV','USDT']
+        codes = ['BTC', 'ETH', 'XRP', 'LTC', 'BCH', 'EOS', 'BNB', 'BSV', 'USDT']
     code = codes[0]
     for i in range(0, len(codes)):
         if codes[i] in exchange.currencies:
             code = codes[i]
     return code
+
 
 def test_exchange(exchange, symbol=None):
 

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -366,7 +366,7 @@ def test_balance(exchange):
 # ------------------------------------------------------------------------------
 
 
-def test_symbol(exchange, symbol, code = None):
+def test_symbol(exchange, symbol, code=None):
     if not argv.privateOnly:
         run_public_tests(exchange, symbol, code)
 
@@ -432,6 +432,7 @@ def get_test_symbol(exchange, symbols):
                 break
     return symbol
 
+
 def get_exchange_code(exchange):
     codes = [
         'BTC',
@@ -471,6 +472,7 @@ def get_exchange_code(exchange):
         if codes[i] in exchange.currencies:
             code = codes[i]
     return code
+
 
 def test_exchange(exchange, symbol=None):
 

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -366,7 +366,7 @@ def test_balance(exchange):
 # ------------------------------------------------------------------------------
 
 
-def test_symbol(exchange, symbol, code):
+def test_symbol(exchange, symbol, code = None):
     if not argv.privateOnly:
         run_public_tests(exchange, symbol, code)
 
@@ -432,15 +432,7 @@ def get_test_symbol(exchange, symbols):
                 break
     return symbol
 
-
-def test_exchange(exchange, symbol=None):
-
-    dump(green('EXCHANGE: ' + exchange.id))
-    # delay = 2
-
-    # ..........................................................................
-    # public API
-
+def get_exchange_code(exchange):
     codes = [
         'BTC',
         'ETH',
@@ -478,6 +470,16 @@ def test_exchange(exchange, symbol=None):
     for i in range(0, len(codes)):
         if codes[i] in exchange.currencies:
             code = codes[i]
+    return code
+
+def test_exchange(exchange, symbol=None):
+
+    dump(green('EXCHANGE: ' + exchange.id))
+    # delay = 2
+
+    # ..........................................................................
+    # public API
+    code = get_exchange_code(exchange)
 
     if not symbol:
         symbol = get_test_symbol(exchange, [
@@ -646,8 +648,9 @@ def main():
                 exchange.set_sandbox_mode(True)
 
             if symbol:
+                code = get_exchange_code(exchange)
                 load_exchange(exchange)
-                test_symbol(exchange, symbol)
+                test_symbol(exchange, symbol, code)
             else:
                 try_all_proxies(exchange, proxies)
 

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -433,13 +433,14 @@ def get_test_symbol(exchange, symbols):
     return symbol
 
 
-def get_exchange_code(codes, exchange):
+def get_exchange_code(exchange, codes = None):
+    if codes is None:
+        codes = ['BTC','ETH','XRP','LTC','BCH','EOS','BNB','BSV','USDT']
     code = codes[0]
     for i in range(0, len(codes)):
         if codes[i] in exchange.currencies:
             code = codes[i]
     return code
-
 
 def test_exchange(exchange, symbol=None):
 
@@ -480,7 +481,7 @@ def test_exchange(exchange, symbol=None):
         'ZEC',
         'ZRX',
     ]
-    code = get_exchange_code(exchange)
+    code = get_exchange_code(exchange, codes)
 
     if not symbol:
         symbol = get_test_symbol(exchange, [

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -433,7 +433,21 @@ def get_test_symbol(exchange, symbols):
     return symbol
 
 
-def get_exchange_code(exchange):
+def get_exchange_code(codes, exchange):
+    code = codes[0]
+    for i in range(0, len(codes)):
+        if codes[i] in exchange.currencies:
+            code = codes[i]
+    return code
+
+
+def test_exchange(exchange, symbol=None):
+
+    dump(green('EXCHANGE: ' + exchange.id))
+    # delay = 2
+
+    # ..........................................................................
+    # public API
     codes = [
         'BTC',
         'ETH',
@@ -466,21 +480,6 @@ def get_exchange_code(exchange):
         'ZEC',
         'ZRX',
     ]
-
-    code = codes[0]
-    for i in range(0, len(codes)):
-        if codes[i] in exchange.currencies:
-            code = codes[i]
-    return code
-
-
-def test_exchange(exchange, symbol=None):
-
-    dump(green('EXCHANGE: ' + exchange.id))
-    # delay = 2
-
-    # ..........................................................................
-    # public API
     code = get_exchange_code(exchange)
 
     if not symbol:

--- a/run-tests.js
+++ b/run-tests.js
@@ -31,17 +31,33 @@ const keys = {
     '--php-async': false,    // run php async tests only
 }
 
+const exchangeSpecificFlags = {
+    '--sandbox': false,
+    '--verbose': false,
+    '--private': false,
+    '--privateOnly': false,
+}
+
 let exchanges = []
 let symbol = 'all'
 let maxConcurrency = 5 // Number.MAX_VALUE // no limit
 
 for (const arg of args) {
-    if (arg.startsWith ('--'))               { keys[arg] = true }
+    if (arg in exchangeSpecificFlags) { exchangeSpecificFlags[arg] = true }
+    else if (arg.startsWith ('--'))               { keys[arg] = true }
     else if (arg.includes ('/'))             { symbol = arg }
     else if (Number.isFinite (Number (arg))) { maxConcurrency = Number (arg) }
     else                                     { exchanges.push (arg) }
 }
 
+/*  --------------------------------------------------------------------------- */
+
+const exchangeOptions = []
+for (const key of Object.keys (exchangeSpecificFlags)) {
+    if (exchangeSpecificFlags[key]) {
+        exchangeOptions.push (key)
+    }
+}
 /*  --------------------------------------------------------------------------- */
 
 if (!exchanges.length) {
@@ -146,9 +162,12 @@ const sequentialMap = async (input, fn) => {
 const testExchange = async (exchange) => {
 
 /*  Run tests for all/selected languages (in parallel)     */
-
-    const args = [exchange, ...symbol === 'all' ? [] : symbol]
-        , allTests = [
+    let args = [exchange];
+    if (symbol !== undefined && symbol !== 'all') {
+        args.push(symbol);
+    }
+    args = args.concat(exchangeOptions)
+    const allTests = [
 
             { language: 'JavaScript',     key: '--js',           exec: ['node',      'js/test/test.js',           ...args] },
             { language: 'Python 3',       key: '--python',       exec: ['python3',   'python/ccxt/test/test_sync.py',  ...args] },


### PR DESCRIPTION
- continues https://github.com/ccxt/ccxt/pull/16711
- correctly forwards the newly added options (verbose, private, privateOnly)
- fix test_symbol call when symbol is provided
- fixes the old bug `...symbol === 'all` so now we can do this:

```
 node run-tests bybit --js --sandbox "BTC/USDT" --verbose
```
