### PR TITLE
cli.py -  unicode support

### DIFF
--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -105,7 +105,7 @@ async def main():
     keys_file = keys_local if os.path.exists(keys_local) else keys_global
 
     # load the api keys and other settings from a JSON config
-    with open(keys_file) as file:
+    with open(keys_file, encoding="utf-8") as file:
         keys = json.load(file)
 
     config = {


### PR DESCRIPTION
it didnt support unicode chars in keys.json (for some valid reasons we should be able to have them in keys files).
