### PR TITLE
binance: patch ccxt/ccxt#16702

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -4537,8 +4537,10 @@ module.exports = class binance extends Exchange {
         const updated = this.safeInteger2 (transaction, 'successTime', 'updateTime');
         let type = this.safeString (transaction, 'type');
         if (type === undefined) {
-            const txType = this.safeString2 (transaction, 'transactionType', 'transferType');
-            type = (txType === '0') ? 'deposit' : 'withdrawal';
+            const txType = this.safeString (transaction, 'transactionType');
+            if (txType !== undefined) {
+                type = (txType === '0') ? 'deposit' : 'withdrawal';
+            }
             const legalMoneyCurrenciesById = this.safeValue (this.options, 'legalMoneyCurrenciesById');
             code = this.safeString (legalMoneyCurrenciesById, code, code);
         }


### PR DESCRIPTION
fix: ccxt/ccxt#16702

For binance parseTransaction, they didn't always return `transactionType` because of the separate api endpoints (withdraw / deposit history or use transactionType in query). We can probably add workaround to recognize whether it's deposit / withdrawal transaction, eg unlockConfirm for crypto deposit / applyTime for crypto withdrawal, but probably not a good idea. Or we can add type after `parseTransaction`, eg `tx['type'] = 'deposit`.

In this PR, I leaved `type` undefined if no transactionType in response first.

```
$  node examples/js/cli binance fetchDeposits USDT
helloworld | helloworld | helloworld | helloworld |     TRX | helloworld | helloworld |             |     |       |         |      |   8.8 |     USDT |      1 |         |    false |    
$  node examples/js/cli binance fetchDeposits USD
[]
$  node examples/js/cli binance fetchWithdrawals USDT
helloworld | helloworld | helloworld | helloworld |     TRX | helloworld | helloworld |             |     |       |         | |          8.8 |     USDT |     ok |         |    false | {"currency":"USDT","cost":0.8}
$  node examples/js/cli binance fetchWithdrawals USD
helloworld |      | helloworld | helloworld |         |         |           |             |     |       |         |      |  15 |      USD | Successful | helloworld |          | {"currency":"USD","cost":15}
```