### PR TITLE
Bitget: fetchCanceledOrders

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2954,11 +2954,9 @@ module.exports = class bitget extends Exchange {
         this.checkRequiredSymbol ('fetchClosedOrders', symbol);
         const market = this.market (symbol);
         const response = await this.fetchCanceledAndClosedOrders (symbol, since, limit, params);
-        const data = this.safeValue (response, 'data');
-        const orderList = this.safeValue (data, 'orderList', data);
         const result = [];
-        for (let i = 0; i < orderList.length; i++) {
-            const entry = orderList[i];
+        for (let i = 0; i < response.length; i++) {
+            const entry = response[i];
             const status = this.parseOrderStatus (this.safeString2 (entry, 'state', 'status'));
             if (status === 'closed') {
                 result.push (entry);
@@ -2984,11 +2982,9 @@ module.exports = class bitget extends Exchange {
         this.checkRequiredSymbol ('fetchCanceledOrders', symbol);
         const market = this.market (symbol);
         const response = await this.fetchCanceledAndClosedOrders (symbol, since, limit, params);
-        const data = this.safeValue (response, 'data');
-        const orderList = this.safeValue (data, 'orderList', data);
         const result = [];
-        for (let i = 0; i < orderList.length; i++) {
-            const entry = orderList[i];
+        for (let i = 0; i < response.length; i++) {
+            const entry = response[i];
             const status = this.parseOrderStatus (this.safeString2 (entry, 'state', 'status'));
             if (status === 'canceled') {
                 result.push (entry);
@@ -3146,7 +3142,8 @@ module.exports = class bitget extends Exchange {
         //         "requestTime":1627354109502
         //     }
         //
-        return response;
+        const data = this.safeValue (response, 'data');
+        return this.safeValue (data, 'orderList', data);
     }
 
     async fetchLedger (code = undefined, since = undefined, limit = undefined, params = {}) {


### PR DESCRIPTION
Added fetchCanceledOrders to Bitget, also:
- added fields to parseOrderStatus
- adjusted fetchClosedOrders to only return closed orders
- added checkRequiredSymbol to required methods

replaces: #15064
```
bitget.fetchCanceledOrders (BTC/USDT:USDT)
2023-02-04T07:55:58.891Z iteration 0 passed in 299 ms

                id |      clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |        symbol |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining |   status | fee | trades | fees | reduceOnly
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
954564352813969409 | 954564352868495360 | 1663311797348 | 2022-09-16T07:03:17.348Z |      1663312536072 | BTC/USDT:USDT | limit |             |          |  buy | 18000 |           |              |         |    0 |  0.004 |      0 |     0.004 | canceled |     |     [] |   [] |
954568553644306433 | 954568553677860864 | 1663312798899 | 2022-09-16T07:19:58.899Z |      1663312809425 | BTC/USDT:USDT | limit |             |          |  buy | 18000 |           |              |         |    0 |  0.004 |      0 |     0.004 | canceled |     |     [] |   [] |
959123019139788801 | 959123019185926144 | 1664398668094 | 2022-09-28T20:57:48.094Z |      1664398985312 | BTC/USDT:USDT | limit |             |          |  buy | 18000 |           |              |         |    0 |  0.003 |      0 |     0.003 | canceled |     |     [] |   [] |
3 objects
```