### PR TITLE
Tests python :: restore orders line

### DIFF
--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -288,6 +288,7 @@ async def test_orders(exchange, symbol):
         await asyncio.sleep(delay)
         # dump(green(exchange.id), green(symbol), 'fetching orders...')
         try:
+            orders = await exchange.fetch_orders(symbol)
             for order in orders:
                 test_order(exchange, order, symbol, int(time.time() * 1000))
             dump(green(exchange.id), green(symbol), 'fetched', green(len(orders)), 'orders')

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -259,6 +259,7 @@ def test_orders(exchange, symbol):
         time.sleep(delay)
         # dump(green(exchange.id), green(symbol), 'fetching orders...')
         try:
+            orders = exchange.fetch_orders(symbol)
             for order in orders:
                 test_order(exchange, order, symbol, int(time.time() * 1000))
             dump(green(exchange.id), green(symbol), 'fetched', green(len(orders)), 'orders')


### PR DESCRIPTION

```
node run-tests huobi --python-async --privateOnly
Testing { exchanges: ["huobi"], symbol: "all", keys: { '--js': false, '--php': false, '--python': false, '--python-async': true, '--php-async': false }, exchangeSpecificFlags: { '--sandbox': false, '--verbose': false, '--private': false, '--privateOnly': true }, maxConcurrency: 5 } (run-tests.js:274)
[100%] Testing huobi OK (testExchange @ run-tests.js:191)
All done, 1 succeeded (run-tests.js:295)
```
```
.js:295)
➜  ccxt git:(fix-orders-test) ✗ node run-tests huobi --python --privateOnly --verbose 
Testing { exchanges: ["huobi"], symbol: "all", keys: { '--js': false, '--php': false, '--python': true, '--python-async': false, '--php-async': false }, exchangeSpecificFlags: { '--sandbox': false, '--verbose': true, '--private': false, '--privateOnly': true }, maxConcurrency: 5 } (run-tests.js:274)
[100%] Testing huobi OK (testExchange @ run-tests.js:191)
```
```
.js:295)
➜  ccxt git:(fix-orders-test) ✗ node run-tests huobi --python-async --privateOnly --verbose
Testing { exchanges: ["huobi"], symbol: "all", keys: { '--js': false, '--php': false, '--python': false, '--python-async': true, '--php-async': false }, exchangeSpecificFlags: { '--sandbox': false, '--verbose': true, '--private': false, '--privateOnly': true }, maxConcurrency: 5 } (run-tests.js:274)
```
