### PR TITLE
Bitget: createOrder, market trigger order

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -2388,7 +2388,9 @@ module.exports = class bitget extends Exchange {
                 const triggerType = this.safeString (params, 'triggerType', 'market_price');
                 request['triggerType'] = triggerType;
                 request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
-                request['executePrice'] = this.priceToPrecision (symbol, price);
+                if (price !== undefined) {
+                    request['executePrice'] = this.priceToPrecision (symbol, price);
+                }
                 method = 'privateMixPostPlanPlacePlan';
             }
             if (isStopLossOrTakeProfit) {


### PR DESCRIPTION
Fixed a bug preventing market trigger orders:
fixes: #16755
```
node examples/js/cli bitget createOrder BTC/USDT:USDT market buy 0.001 undefined '{"triggerPrice":23000}'

{
  info: { clientOid: '1006745324109762560', orderId: '1006745324109762561' },
  id: '1006745324109762561',
  clientOrderId: '1006745324109762560',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  average: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: [],
  reduceOnly: undefined
}
```