### PR TITLE
Typo in comment in line 134 fixed

### DIFF
--- a/js/base/functions/generic.js
+++ b/js/base/functions/generic.js
@@ -131,7 +131,7 @@ module.exports = {
 
         Returns an array:
         [
-            value1: { someKey: 'value1', anotherKey: 'anotherValue1' },
+            { someKey: 'value1', anotherKey: 'anotherValue1' },
         ]
     */
 


### PR DESCRIPTION
Function `filterBy` returns an array of objects like this: 
`[
            { someKey: 'value1', anotherKey: 'anotherValue1' },
 ]`

not this:
`[
            value1: { someKey: 'value1', anotherKey: 'anotherValue1' },
 ]`