### PR TITLE
Woo :: fix swap market orders

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -751,7 +751,7 @@ module.exports = class woo extends Exchange {
         }
         if (isMarket) {
             // for market buy it requires the amount of quote currency to spend
-            if (orderSide === 'BUY') {
+            if (market['spot'] && orderSide === 'BUY') {
                 const cost = this.safeNumber (params, 'cost');
                 if (this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true)) {
                     if (cost === undefined) {


### PR DESCRIPTION

```
 p woo createOrder "LTC/USDT" market buy 5 1 --sandbox
Python v3.10.9
CCXT v2.7.52
woo.createOrder(LTC/USDT,market,buy,5,1)
{'amount': None,
 'average': None,
 'clientOrderId': '0',
 'cost': 5.0,
 'datetime': '2023-02-07T10:39:27.213Z',
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '54018823',
 'info': {'client_order_id': '0',
          'order_amount': '5',
          'order_id': '54018823',
          'order_price': None,
          'order_quantity': None,
          'order_type': 'MARKET',
          'success': True,
          'timestamp': '1675766367.213'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'IOC',
 'timestamp': 1675766367213,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
```
p woo createOrder "LTC/USDT:USDT" market buy 0.1 --sandbox
Python v3.10.9
CCXT v2.7.52
woo.createOrder(LTC/USDT:USDT,market,buy,0.1)
{'amount': 0.1,
 'average': None,
 'clientOrderId': '0',
 'cost': None,
 'datetime': '2023-02-07T10:40:07.402Z',
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '54018826',
 'info': {'client_order_id': '0',
          'order_amount': None,
          'order_id': '54018826',
          'order_price': None,
          'order_quantity': '0.1',
          'order_type': 'MARKET',
          'success': True,
          'timestamp': '1675766407.402'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT:USDT',
 'timeInForce': 'IOC',
 'timestamp': 1675766407402,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
```
 p woo createOrder "LTC/USDT" limit buy 0.2 50 --sandbox 
Python v3.10.9
CCXT v2.7.52
woo.createOrder(LTC/USDT,limit,buy,0.2,50)
{'amount': 0.2,
 'average': None,
 'clientOrderId': '0',
 'cost': None,
 'datetime': '2023-02-07T10:40:46.795Z',
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '54018827',
 'info': {'client_order_id': '0',
          'order_amount': None,
          'order_id': '54018827',
          'order_price': '50',
          'order_quantity': '0.2',
          'order_type': 'LIMIT',
          'success': True,
          'timestamp': '1675766446.795'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': None,
 'timestamp': 1675766446795,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
