### PR TITLE
Fix fetchOHLCV

### DIFF
--- a/js/kraken.js
+++ b/js/kraken.js
@@ -860,7 +860,7 @@ module.exports = class kraken extends Exchange {
         const market = this.market (symbol);
         const request = {
             'pair': market['id'],
-            'interval': this.safeNumber (this.timeframes, timeframe, timeframe),
+            'interval': this.safeInteger (this.timeframes, timeframe, timeframe),
         };
         if (since !== undefined) {
             request['since'] = parseInt ((since - 1) / 1000);

--- a/js/kucoinfutures.js
+++ b/js/kucoinfutures.js
@@ -553,7 +553,7 @@ module.exports = class kucoinfutures extends kucoin {
         const marketId = market['id'];
         const request = {
             'symbol': marketId,
-            'granularity': this.safeNumber (this.timeframes, timeframe, timeframe),
+            'granularity': this.safeInteger (this.timeframes, timeframe, timeframe),
         };
         const duration = this.parseTimeframe (timeframe) * 1000;
         let endAt = this.milliseconds ();

--- a/js/poloniexfutures.js
+++ b/js/poloniexfutures.js
@@ -690,7 +690,7 @@ module.exports = class poloniexfutures extends Exchange {
         const marketId = market['id'];
         const request = {
             'symbol': marketId,
-            'granularity': this.safeNumber (this.timeframes, timeframe, timeframe),
+            'granularity': this.safeInteger (this.timeframes, timeframe, timeframe),
         };
         const duration = this.parseTimeframe (timeframe) * 1000;
         let endAt = this.milliseconds ();


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16767

```
 p kraken fetchOHLCV "BTC/USDT" 1m None 1          
Python v3.10.9
CCXT v2.7.53
kraken.fetchOHLCV(BTC/USDT,1m,None,1)
[[1675773240000, 22983.9, 22983.9, 22983.9, 22983.9, 0.00087729]]
```
```
 p kucoinfutures fetchOHLCV "BTC/USDT:USDT" 1m None 1
Python v3.10.9
CCXT v2.7.53
kucoinfutures.fetchOHLCV(BTC/USDT:USDT,1m,None,1)
[[1675773360000, 22987.0, 22987.0, 22986.0, 22987.0, 423.0]]
```
```
p poloniexfutures fetchOHLCV "BTC/USDT:USDT" 1m None 1
Python v3.10.9
CCXT v2.7.53
poloniexfutures.fetchOHLCV(BTC/USDT:USDT,1m,None,1)
[[1675773360000, 22980.4, 22986.4, 22980.4, 22986.4, 10.0]]
```
