### PR TITLE
okx: Fix validation of posSide in setLeverage

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -4904,8 +4904,8 @@ module.exports = class okx extends Exchange {
             if (posSide === undefined) {
                 throw new ArgumentsRequired (this.id + ' setLeverage() requires a posSide argument for isolated margin');
             }
-            if (posSide !== 'long' && posSide !== 'short') {
-                throw new BadRequest (this.id + ' setLeverage() requires the posSide argument to be either "long" or "short"');
+            if (posSide !== 'long' && posSide !== 'short' && posSide !== 'net') {
+                throw new BadRequest (this.id + ' setLeverage() requires the posSide argument to be either "long", "short" or "net"');
             }
         }
         const response = await this.privatePostAccountSetLeverage (this.extend (request, params));


### PR DESCRIPTION
The following segment on the okx's setLeverage call is validating wrongly.

https://github.com/ccxt/ccxt/blob/f667f8e3705a5eb3541b41ec4721843c4211b969/js/okx.js#L4903C23-L4910

With the following account settings (position mode buy/sell) - "net" is an acceptable value to the setLeverage call - as that's valid depending on the account settings for position mode.

![image](https://user-images.githubusercontent.com/5024695/217340661-478f9c32-6609-42bf-80fe-22cfaca04e7e.png)

Doing exactly that setting on the exchange reveals that this should be an acceptable call.

![image](https://user-images.githubusercontent.com/5024695/217341367-8e8c751f-3efe-4225-8e77-4d8c31adafc3.png)

Unfortunately, i don't think it's possible to determine the mode without doing an additional call to `fetch_accounts()`.
So the best we can do here is to accept all 3, and let the exchange handle the failure.
