### PR TITLE
Binance: fetchMarkets, add option support

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -1962,7 +1962,7 @@ module.exports = class binance extends Exchange {
         let fees = this.fees;
         let linear = undefined;
         let inverse = undefined;
-        const strike = this.safeNumber (market, 'strikePrice');
+        const strike = this.safeString (market, 'strikePrice');
         let symbol = base + '/' + quote;
         if (contract) {
             if (swap) {
@@ -2025,7 +2025,7 @@ module.exports = class binance extends Exchange {
             'contractSize': contractSize,
             'expiry': expiry,
             'expiryDatetime': this.iso8601 (expiry),
-            'strike': strike,
+            'strike': this.parseNumber (strike),
             'optionType': this.safeStringLower (market, 'side'),
             'precision': {
                 'amount': this.safeInteger2 (market, 'quantityPrecision', 'quantityScale'),

--- a/js/binance.js
+++ b/js/binance.js
@@ -1962,7 +1962,7 @@ module.exports = class binance extends Exchange {
         let fees = this.fees;
         let linear = undefined;
         let inverse = undefined;
-        const strike = this.safeString (market, 'strikePrice');
+        const strike = this.safeInteger (market, 'strikePrice');
         let symbol = base + '/' + quote;
         if (contract) {
             if (swap) {
@@ -1970,7 +1970,7 @@ module.exports = class binance extends Exchange {
             } else if (future) {
                 symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
             } else if (option) {
-                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + strike + '-' + this.safeString (optionParts, 3);
+                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + this.numberToString (strike) + '-' + this.safeString (optionParts, 3);
             }
             contractSize = this.safeNumber2 (market, 'contractSize', 'unit', this.parseNumber ('1'));
             linear = settle === quote;

--- a/js/binance.js
+++ b/js/binance.js
@@ -880,7 +880,7 @@ module.exports = class binance extends Exchange {
             'precisionMode': DECIMAL_PLACES,
             // exchange-specific options
             'options': {
-                'fetchMarkets': [ 'spot', 'linear', 'inverse' ],
+                'fetchMarkets': [ 'spot', 'linear', 'inverse', 'option' ],
                 'fetchCurrencies': true, // this is a private call and it requires API keys
                 // 'fetchTradesMethod': 'publicGetAggTrades', // publicGetTrades, publicGetHistoricalTrades
                 'defaultTimeInForce': 'GTC', // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
@@ -1691,7 +1691,7 @@ module.exports = class binance extends Exchange {
          * @returns {[object]} an array of objects representing market data
          */
         let promises = [];
-        const fetchMarkets = this.safeValue (this.options, 'fetchMarkets', [ 'spot', 'linear', 'inverse' ]);
+        const fetchMarkets = this.safeValue (this.options, 'fetchMarkets', [ 'spot', 'linear', 'inverse', 'option' ]);
         for (let i = 0; i < fetchMarkets.length; i++) {
             const marketType = fetchMarkets[i];
             if (marketType === 'spot') {
@@ -1700,6 +1700,8 @@ module.exports = class binance extends Exchange {
                 promises.push (this.fapiPublicGetExchangeInfo (params));
             } else if (marketType === 'inverse') {
                 promises.push (this.dapiPublicGetExchangeInfo (params));
+            } else if (marketType === 'option') {
+                promises.push (this.eapiPublicGetExchangeInfo (params));
             } else {
                 throw new ExchangeError (this.id + ' fetchMarkets() this.options fetchMarkets "' + marketType + '" is not a supported market type');
             }
@@ -1708,9 +1710,11 @@ module.exports = class binance extends Exchange {
         const spotMarkets = this.safeValue (this.safeValue (promises, 0), 'symbols', []);
         const futureMarkets = this.safeValue (this.safeValue (promises, 1), 'symbols', []);
         const deliveryMarkets = this.safeValue (this.safeValue (promises, 2), 'symbols', []);
+        const optionMarkets = this.safeValue (this.safeValue (promises, 3), 'optionSymbols', []);
         let markets = spotMarkets;
         markets = this.arrayConcat (markets, futureMarkets);
         markets = this.arrayConcat (markets, deliveryMarkets);
+        markets = this.arrayConcat (markets, optionMarkets);
         //
         // spot / margin
         //
@@ -1860,6 +1864,59 @@ module.exports = class binance extends Exchange {
         //         ]
         //     }
         //
+        // options (eapi)
+        //
+        //     {
+        //         "timezone": "UTC",
+        //         "serverTime": 1675912490405,
+        //         "optionContracts": [
+        //             {
+        //                 "id": 1,
+        //                 "baseAsset": "SOL",
+        //                 "quoteAsset": "USDT",
+        //                 "underlying": "SOLUSDT",
+        //                 "settleAsset": "USDT"
+        //             },
+        //             ...
+        //         ],
+        //         "optionAssets": [
+        //             {"id":1,"name":"USDT"}
+        //         ],
+        //         "optionSymbols": [
+        //             {
+        //                 "contractId": 3,
+        //                 "expiryDate": 1677225600000,
+        //                 "filters": [
+        //                     {"filterType":"PRICE_FILTER","minPrice":"724.6","maxPrice":"919.2","tickSize":"0.1"},
+        //                     {"filterType":"LOT_SIZE","minQty":"0.01","maxQty":"1000","stepSize":"0.01"}
+        //                 ],
+        //                 "id": 2474,
+        //                 "symbol": "ETH-230224-800-C",
+        //                 "side": "CALL",
+        //                 "strikePrice": "800.00000000",
+        //                 "underlying": "ETHUSDT",
+        //                 "unit": 1,
+        //                 "makerFeeRate": "0.00020000",
+        //                 "takerFeeRate": "0.00020000",
+        //                 "minQty": "0.01",
+        //                 "maxQty": "1000",
+        //                 "initialMargin": "0.15000000",
+        //                 "maintenanceMargin": "0.07500000",
+        //                 "minInitialMargin": "0.10000000",
+        //                 "minMaintenanceMargin": "0.05000000",
+        //                 "priceScale": 1,
+        //                 "quantityScale": 2,
+        //                 "quoteAsset": "USDT"
+        //             },
+        //             ...
+        //         ],
+        //         "rateLimits": [
+        //             {"rateLimitType":"REQUEST_WEIGHT","interval":"MINUTE","intervalNum":1,"limit":400},
+        //             {"rateLimitType":"ORDERS","interval":"MINUTE","intervalNum":1,"limit":100},
+        //             {"rateLimitType":"ORDERS","interval":"SECOND","intervalNum":10,"limit":30}
+        //         ]
+        //     }
+        //
         if (this.options['adjustForTimeDifference']) {
             await this.loadTimeDifference ();
         }
@@ -1873,24 +1930,31 @@ module.exports = class binance extends Exchange {
     parseMarket (market) {
         let swap = false;
         let future = false;
+        let option = false;
+        const underlying = this.safeString (market, 'underlying');
         const id = this.safeString (market, 'symbol');
+        const optionParts = id.split ('-');
+        const optionBase = this.safeString (optionParts, 0);
         const lowercaseId = this.safeStringLower (market, 'symbol');
-        const baseId = this.safeString (market, 'baseAsset');
+        const baseId = this.safeString (market, 'baseAsset', optionBase);
         const quoteId = this.safeString (market, 'quoteAsset');
-        const settleId = this.safeString (market, 'marginAsset');
+        const settleId = this.safeString (market, 'marginAsset', 'USDT');
         const base = this.safeCurrencyCode (baseId);
         const quote = this.safeCurrencyCode (quoteId);
         const settle = this.safeCurrencyCode (settleId);
         const contractType = this.safeString (market, 'contractType');
-        const contract = ('contractType' in market);
-        const spot = !contract;
-        let expiry = this.safeInteger (market, 'deliveryDate');
+        let contract = ('contractType' in market);
+        let expiry = this.safeInteger2 (market, 'deliveryDate', 'expiryDate');
         if ((contractType === 'PERPETUAL') || (expiry === 4133404800000)) { // some swap markets do not have contract type, eg: BTCST
             expiry = undefined;
             swap = true;
+        } else if (underlying !== undefined) {
+            contract = true;
+            option = true;
         } else {
             future = true;
         }
+        const spot = !contract;
         const filters = this.safeValue (market, 'filters', []);
         const filtersByType = this.indexBy (filters, 'filterType');
         const status = this.safeString2 (market, 'status', 'contractStatus');
@@ -1898,14 +1962,17 @@ module.exports = class binance extends Exchange {
         let fees = this.fees;
         let linear = undefined;
         let inverse = undefined;
+        const strike = this.safeNumber (market, 'strikePrice');
         let symbol = base + '/' + quote;
         if (contract) {
             if (swap) {
                 symbol = symbol + ':' + settle;
             } else if (future) {
                 symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
+            } else if (option) {
+                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + strike + '-' + this.safeString (optionParts, 3);
             }
-            contractSize = this.safeNumber (market, 'contractSize', this.parseNumber ('1'));
+            contractSize = this.safeNumber2 (market, 'contractSize', 'unit', this.parseNumber ('1'));
             linear = settle === quote;
             inverse = settle === base;
             const feesType = linear ? 'linear' : 'inverse';
@@ -1929,6 +1996,9 @@ module.exports = class binance extends Exchange {
             unifiedType = 'swap';
         } else if (future) {
             unifiedType = 'future';
+        } else if (option) {
+            unifiedType = 'option';
+            active = undefined;
         }
         const entry = {
             'id': id,
@@ -1945,7 +2015,7 @@ module.exports = class binance extends Exchange {
             'margin': spot && isMarginTradingAllowed,
             'swap': swap,
             'future': future,
-            'option': false,
+            'option': option,
             'active': active,
             'contract': contract,
             'linear': linear,
@@ -1955,11 +2025,11 @@ module.exports = class binance extends Exchange {
             'contractSize': contractSize,
             'expiry': expiry,
             'expiryDatetime': this.iso8601 (expiry),
-            'strike': undefined,
-            'optionType': undefined,
+            'strike': strike,
+            'optionType': this.safeStringLower (market, 'side'),
             'precision': {
-                'amount': this.safeInteger (market, 'quantityPrecision'),
-                'price': this.safeInteger (market, 'pricePrecision'),
+                'amount': this.safeInteger2 (market, 'quantityPrecision', 'quantityScale'),
+                'price': this.safeInteger2 (market, 'pricePrecision', 'priceScale'),
                 'base': this.safeInteger (market, 'baseAssetPrecision'),
                 'quote': this.safeInteger (market, 'quotePrecision'),
             },
@@ -1969,8 +2039,8 @@ module.exports = class binance extends Exchange {
                     'max': undefined,
                 },
                 'amount': {
-                    'min': undefined,
-                    'max': undefined,
+                    'min': this.safeNumber (market, 'minQty'),
+                    'max': this.safeNumber (market, 'maxQty'),
                 },
                 'price': {
                     'min': undefined,

--- a/js/binance.js
+++ b/js/binance.js
@@ -2025,7 +2025,7 @@ module.exports = class binance extends Exchange {
             'contractSize': contractSize,
             'expiry': expiry,
             'expiryDatetime': this.iso8601 (expiry),
-            'strike': this.parseNumber (strike),
+            'strike': strike,
             'optionType': this.safeStringLower (market, 'side'),
             'precision': {
                 'amount': this.safeInteger2 (market, 'quantityPrecision', 'quantityScale'),


### PR DESCRIPTION
Added option support to fetchMarkets:
```
node examples/js/cli binance fetchMarkets
...
BTC-230224-21000-C | btc-230224-21000-c | BTC/USDT:USDT-230224-21000-C |       BTC |  USDT |   USDT |       BTC |    USDT |     USDT | option | false |  false | false |  false |   true |        |     true |   true |   false | 0.0004 | 0.0002 |            1 | 1677225600000 | 2023-02-24T08:00:00.000Z |  21000 |       call |                    {"amount":2,"price":0} |            {"leverage":{},"amount":{"min":0.01,"max":200},"price":{"min":576,"max":3286},"cost":{}}
BTC-230224-21000-P | btc-230224-21000-p | BTC/USDT:USDT-230224-21000-P |       BTC |  USDT |   USDT |       BTC |    USDT |     USDT | option | false |  false | false |  false |   true |        |     true |   true |   false | 0.0004 | 0.0002 |            1 | 1677225600000 | 2023-02-24T08:00:00.000Z |  21000 |        put |                    {"amount":2,"price":0} |              {"leverage":{},"amount":{"min":0.01,"max":200},"price":{"min":1,"max":3119},"cost":{}}
2655 objects
```