### PR TITLE
gate: fix parse_order for spot orders

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -3693,14 +3693,16 @@ module.exports = class gate extends Exchange {
         let remaining = this.parseNumber (Precise.stringAbs (remainingString));
         // handle spot market buy
         const account = this.safeString (order, 'account'); // using this instead of market type because of the conflicting ids
-        if ((account === 'spot') && (type === 'market') && (side === 'buy')) {
+        if (account === 'spot') {
             const averageString = this.safeString (order, 'avg_deal_price');
             average = this.parseNumber (averageString);
-            filled = Precise.stringDiv (filledString, averageString);
-            remaining = Precise.stringDiv (remainingString, averageString);
-            price = undefined; // arrives as 0
-            cost = amount;
-            amount = Precise.stringDiv (amount, averageString);
+            if ((type === 'market') && (side === 'buy')) {
+                filled = Precise.stringDiv (filledString, averageString);
+                remaining = Precise.stringDiv (remainingString, averageString);
+                price = undefined; // arrives as 0
+                cost = amount;
+                amount = Precise.stringDiv (amount, averageString);
+            }
         }
         return this.safeOrder ({
             'id': this.safeString (order, 'id'),


### PR DESCRIPTION
Current order parsing on gate is broken.
```
{
    "id": "276266839423",
    "clientOrderId": "apiv4",
    "timestamp": 1675936898746,
    "datetime": "2023-02-09T10:01:38.746Z",
    "lastTradeTimestamp": 1675936898746,
    "status": "closed",
    "symbol": "BTC/USDT",
    "type": "limit",
    "timeInForce": "GTC",
    "postOnly": False,
    "reduceOnly": None,
    "side": "buy",
    "price": 22727.4,
    "stopPrice": None,
    "triggerPrice": None,
    "average": 20.45466,   <-- this is supposed to be avg_deal_price - not cost.
    "amount": 0.0009,
    "cost": 20.45466,
    "filled": 0.0009,
    "remaining": 0.0,
    "fee": {
        "currency": "BTC",
        "cost": 1.8e-06
    },
    "fees": [
        {
            "currency": "BTC",
            "cost": 1.8e-06
        }
    ],
    "trades": [],
    "info": {
        "id": "276266839423",
        "text": "apiv4",
        "create_time": "1675936898",
        "update_time": "1675936898",
        "create_time_ms": "1675936898746",
        "update_time_ms": "1675936898746",
        "status": "closed",
        "currency_pair": "BTC_USDT",
        "type": "limit",
        "account": "spot",
        "side": "buy",
        "amount": "0.0009",
        "price": "22727.4",
        "time_in_force": "gtc",
        "iceberg": "0",
        "left": "0",
        "fill_price": "20.45466",
        "filled_total": "20.45466",
        "avg_deal_price": "22727.4",
        "fee": "0.0000018",
        "fee_currency": "BTC",
        "point_fee": "0",
        "gt_fee": "0",
        "gt_maker_fee": "0",
        "gt_taker_fee": "0.0015",
        "gt_discount": True,
        "rebated_fee": "0",
        "rebated_fee_currency": "USDT"
    }
}

```

New format:
```
{"id": "276266839423",
 "clientOrderId": "apiv4",
 "timestamp": 1675936898746,
 "datetime": "2023-02-09T10:01:38.746Z",
 "lastTradeTimestamp": 1675936898746,
 "status": "closed",
 "symbol": "BTC/USDT",
 "type": "limit",
 "timeInForce": "GTC",
 "postOnly": False,
 "reduceOnly": None,
 "side": "buy",
 "price": 22727.4,
 "stopPrice": None,
 "triggerPrice": None,
 "average": 22727.4,
 "amount": 0.0009,
 "cost": 20.45466,
 "filled": 0.0009,
 "remaining": 0.0,
 "fee": {"currency": "BTC", "cost": 1.8e-06},
 "fees": [{"currency": "BTC", "cost": 1.8e-06}],
 "trades": [],
 "info": {"id": "276266839423",
  "text": "apiv4",
  "create_time": "1675936898",
  "update_time": "1675936898",
  "create_time_ms": "1675936898746",
  "update_time_ms": "1675936898746",
  "status": "closed",
  "currency_pair": "BTC_USDT",
  "type": "limit",
  "account": "spot",
  "side": "buy",
  "amount": "0.0009",
  "price": "22727.4",
  "time_in_force": "gtc",
  "iceberg": "0",
  "left": "0",
  "fill_price": "20.45466",
  "filled_total": "20.45466",
  "avg_deal_price": "22727.4",
  "fee": "0.0000018",
  "fee_currency": "BTC",
  "point_fee": "0",
  "gt_fee": "0",
  "gt_maker_fee": "0",
  "gt_taker_fee": "0.0015",
  "gt_discount": True,
  "rebated_fee": "0",
  "rebated_fee_currency": "USDT"}}
```

I also performed a market sell - just to do a "regression test" of some sorts ...

```
{'id': '276402737296',
 'clientOrderId': '3',
 'timestamp': 1675963721000,
 'datetime': '2023-02-09T17:28:41.000Z',
 'lastTradeTimestamp': 1675963721000,
 'status': 'closed',
 'symbol': 'SOL/USDT',
 'type': 'market',
 'timeInForce': 'FOK',
 'postOnly': False,
 'reduceOnly': None,
 'side': 'sell',
 'price': 22.52,
 'stopPrice': None,
 'triggerPrice': None,
 'average': 22.52,
 'amount': 0.4529,
 'cost': 10.199308,
 'filled': 0.4529,
 'remaining': 0.0,
 'fee': None,
 'fees': [],
 'trades': [],
 'info': {'id': '276402737296',
  'text': '3',
  'create_time': '1675963721',
  'update_time': '1675963721',
  'create_time_ms': '1675963721000',
  'update_time_ms': '1675963721000',
  'status': 'closed',
  'currency_pair': 'SOL_USDT',
  'type': 'market',
  'account': 'spot',
  'side': 'sell',
  'amount': '0.4529',
  'price': '0',
  'time_in_force': 'fok',
  'iceberg': '0',
  'left': '0.0000',
  'fill_price': '10.199308',
  'filled_total': '10.199308',
  'avg_deal_price': '22.52',
  'fee': '0',
  'fee_currency': 'USDT',
  'point_fee': '0.020398616',
  'gt_fee': '0',
  'gt_maker_fee': '0',
  'gt_taker_fee': '0',
  'gt_discount': False,
  'rebated_fee': '0',
  'rebated_fee_currency': 'SOL'}}
```

corresponding on exchange:
![image](https://user-images.githubusercontent.com/5024695/217909467-d1fe56eb-dc96-4969-b3a5-823b6af8fece.png)

