### PR TITLE
Fix: Huobi fetch_markets 'spot' is False

### DIFF
--- a/python/ccxt/async_support/huobi.py
+++ b/python/ccxt/async_support/huobi.py
@@ -1418,7 +1418,7 @@ class huobi(Exchange):
             value = self.safe_value(types, type)
             if value is True:
                 promises.append(self.fetch_markets_by_type_and_sub_type(type, None, params))
-            else:
+            elif value is not False:
                 subKeys = list(value.keys())
                 for j in range(0, len(subKeys)):
                     subType = subKeys[j]


### PR DESCRIPTION
Current code raise error when exchange options are given like this.

```js
'options': {
  'fetchMarkets': {
      'types': {
          'spot': False,
          'future': {
              'linear': False,
              'inverse': False,
          },
          'swap': {
              'linear': True,
              'inverse': False,
          },
      },
  },
  // ...
}
```

There are three states for `value`, `True` | `False` | `object`.
It should be passed if `False`, or you'll get error when executing `value.keys()`.


