### PR TITLE
Woo :: fix createMarketBuyRequiresPrice

### DIFF
--- a/js/woo.js
+++ b/js/woo.js
@@ -766,6 +766,8 @@ module.exports = class woo extends Exchange {
                     } else {
                         request['order_amount'] = this.costToPrecision (symbol, cost);
                     }
+                } else {
+                    request['order_amount'] = this.costToPrecision (symbol, amount);
                 }
             } else {
                 request['order_quantity'] = this.amountToPrecision (symbol, amount);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16801

```
 n woo createOrder "LTC/USDT" market buy 5 --sandbox
Debugger attached.
2023-02-10T15:06:37.323Z
Node.js: v17.9.0
CCXT v2.7.76
woo.createOrder (LTC/USDT, market, buy, 5)
2023-02-10T15:06:43.118Z iteration 0 passed in 2233 ms

{
  id: '54053140',
  clientOrderId: '0',
  timestamp: 1676041603064,
  datetime: '2023-02-10T15:06:43.064Z',
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'LTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  average: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: 5,
  trades: [],
  fee: { cost: undefined, currency: undefined },
  info: {
    success: true,
    timestamp: '1676041603.064',
    order_id: '54053140',
    order_type: 'MARKET',
    order_price: null,
    order_quantity: null,
    order_amount: '5',
    client_order_id: '0'
  },
  fees: [ { cost: undefined, currency: undefined } ]
}
2023-02-10T15:06:43.118Z iteration 1 passed in 2233 ms
```
