### PR TITLE
gate: add price_type ccxt/ccxt#16749

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -3110,6 +3110,7 @@ module.exports = class gate extends Exchange {
          * @param {bool|undefined} params.reduceOnly *contract only* Indicates if this order is to reduce the size of a position
          * @param {bool|undefined} params.close *contract only* Set as true to close the position, with size set to 0
          * @param {bool|undefined} params.auto_size *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
+         * @param {int|undefined} params.price_type *contract only* 0 latest deal price, 1 mark price, 2 index price
          * @returns {object|undefined} [An order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();

--- a/js/gate.js
+++ b/js/gate.js
@@ -3264,9 +3264,14 @@ module.exports = class gate extends Exchange {
                         rule = (side === 'buy') ? 2 : 1;
                         triggerOrderPrice = this.priceToPrecision (symbol, takeProfitPrice);
                     }
+                    const priceType = this.safeInteger (params, 'price_type', 0);
+                    if (priceType < 0 || priceType > 2) {
+                        throw new BadRequest (this.id + ' createOrder () price_type should be 0 latest deal price, 1 mark price, 2 index price');
+                    }
+                    params = this.omit (params, [ 'price_type' ]);
                     request['trigger'] = {
                         // 'strategy_type': 0, // 0 = by price, 1 = by price gap, only 0 is supported currently
-                        'price_type': 0, // 0 latest deal price, 1 mark price, 2 index price
+                        'price_type': priceType, // 0 latest deal price, 1 mark price, 2 index price
                         'price': this.priceToPrecision (symbol, triggerOrderPrice), // price or gap
                         'rule': rule, // 1 means price_type >= price, 2 means price_type <= price
                         // 'expiration': expiration, how many seconds to wait for the condition to be triggered before cancelling the order


### PR DESCRIPTION
Fix ccxt/ccxt#16749

Add `price_type` in params.

```BASH
$ node examples/js/cli gateio createOrder ADA/USDT:USDT limit buy 1 0.02 '{"price_type":2,"stopLossPrice":1}' --verbose
Node.js: v14.17.0
CCXT v2.7.76
gateio.createOrder (ADA/USDT:USDT, limit, buy, 1, 0.02, [object Object])
fetch Request:
 gateio POST https://api.gateio.ws/api/v4/futures/usdt/price_orders 
RequestHeaders:
 {
  'X-Gate-Channel-Id': 'ccxt',
  KEY: 'xxxxxx',
  SIGN: 'xxxxxx',
  'Content-Type': 'application/json'
} 
RequestBody:
 {"initial":{"contract":"ADA_USDT","size":1,"price":"0.02"},"trigger":{"price_type":2,"price":"1","rule":1}} 

handleRestResponse:
 gateio POST https://api.gateio.ws/api/v4/futures/usdt/price_orders 201 Created 
ResponseHeaders:
 {
  'Access-Control-Allow-Headers': 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type',
  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,DELETE,PUT',
  'Access-Control-Max-Age': '1728000',
  Connection: 'keep-alive',
  'Content-Length': '15',
  'Content-Type': 'application/json',
  Server: 'openresty',
  Vary: 'Origin'
} 
ResponseBody:
 {"id":xxxxxx} 

2023-02-10T16:01:58.468Z iteration 0 passed in 70 ms

{
  id: 'xxxxxx',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'ADA/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: false,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  average: undefined,
  amount: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  fee: undefined,
  fees: [],
  trades: [],
  info: { id: 'xxxxxx' }
}
```

There are some other exchanges support different price type (last price / mark price / index price) in stop orders. Shall we consider to unify this in parameters?