### PR TITLE
coinex - watchOrderBook - allow multiple subscriptions

### DIFF
--- a/js/pro/coinex.js
+++ b/js/pro/coinex.js
@@ -427,6 +427,7 @@ module.exports = class coinex extends coinexRest {
          * @method
          * @name coinex#watchOrderBook
          * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot004_websocket017_depth_subscribe_multi
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures002_websocket011_depth_subscribe_multi
          * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int|undefined} limit the maximum amount of order book entries to return

--- a/js/pro/coinex.js
+++ b/js/pro/coinex.js
@@ -465,7 +465,7 @@ module.exports = class coinex extends coinexRest {
             'params': Object.values (watchOrderBookSubscriptions),
         };
         this.options['watchOrderBookSubscriptions'] = watchOrderBookSubscriptions;
-        const subscriptionHash = this.hashMessage (this.json (watchOrderBookSubscriptions));
+        const subscriptionHash = this.hash (this.encode (this.json (watchOrderBookSubscriptions)));
         const request = this.deepExtend (subscribe, params);
         const orderbook = await this.watch (url, messageHash, request, subscriptionHash, request);
         return orderbook.limit ();


### PR DESCRIPTION
Allows to subscribe simultaneously to several symbols. Previously was unsubscribing and subscribing and therefore only watching the latest symbol.