### PR TITLE
bybit - fetchOrders - fix #16822

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4515,28 +4515,18 @@ module.exports = class bybit extends Exchange {
     async fetchDerivativesOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
         await this.loadMarkets ();
         let market = undefined;
-        let settle = undefined;
         const request = {
             // 'symbol': market['id'],
-            // 'order_id': 'string'
-            // 'order_link_id': 'string', // unique client order id, max 36 characters
-            // 'symbol': market['id'], // default BTCUSD
-            // 'order': 'desc', // asc
-            // 'page': 1,
-            // 'limit': 20, // max 50
-            // 'order_status': 'Created,New'
-            // conditional orders ---------------------------------------------
-            // 'stop_order_id': 'string',
-            // 'stop_order_status': 'Untriggered',
+            // 'orderId': 'string'
+            // 'orderLinkId': 'string', // unique client order id, max 36 characters
+            // 'orderStatus': 'Created,New'
+            // 'orderFilter': 'StopOrder', // 'Order' or 'StopOrder'
+            // 'limit': 20, // Limit for data size per page. [1, 50]. Default: 20
+            // 'cursor': 'string', // used for pagination
         };
         if (symbol !== undefined) {
             market = this.market (symbol);
-            settle = market['settle'];
             request['symbol'] = market['id'];
-        }
-        [ settle, params ] = this.handleOptionAndParams (params, 'cancelAllOrders', 'settle', settle);
-        if (settle !== undefined) {
-            request['settleCoin'] = settle;
         }
         const isStop = this.safeValue (params, 'stop', false);
         params = this.omit (params, [ 'stop' ]);


### PR DESCRIPTION
We were passing settleCoin as a parameter when it was not a parameter of this end point, and was throwing an error. This PR removes the parameter to allow the endpoint to be called succesfully.

Ref: https://bybit-exchange.github.io/docs/derivatives/contract/order-list