### PR TITLE
badsymbol error stringify

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2581,6 +2581,8 @@ module.exports = class Exchange {
                     }
                 }
                 return markets[0];
+            } else {
+                throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
             }
         }
         throw new BadSymbol (this.id + ' does not have market symbol ' + this.json (symbol));

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2586,10 +2586,7 @@ module.exports = class Exchange {
             }
         }
         let symbolValue = symbol;
-        if (symbolValue === undefined) {
-            symbolValue = '';
-        }
-        else if (this.isObject (symbolValue) || Array.isArray(symbolValue)) {
+        if (this.isObject (symbolValue) || Array.isArray(symbolValue)) {
             symbolValue = this.json (symbolValue);
         }
         throw new BadSymbol (this.id + ' does not have market symbol ' + symbolValue);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2583,7 +2583,7 @@ module.exports = class Exchange {
                 return markets[0];
             }
         }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        throw new BadSymbol (this.id + ' does not have market symbol ' + this.json (symbol));
     }
 
     handleWithdrawTagAndParams (tag, params) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2585,7 +2585,14 @@ module.exports = class Exchange {
                 throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
             }
         }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + this.json (symbol));
+        let symbolValue = symbol;
+        if (symbolValue === undefined) {
+            symbolValue = '';
+        }
+        else if (this.isObject (symbolValue) || Array.isArray(symbolValue)) {
+            symbolValue = this.json (symbolValue);
+        }
+        throw new BadSymbol (this.id + ' does not have market symbol ' + symbolValue);
     }
 
     handleWithdrawTagAndParams (tag, params) {

--- a/js/binance.js
+++ b/js/binance.js
@@ -1464,6 +1464,7 @@ module.exports = class binance extends Exchange {
                     return this.markets[futuresSymbol];
                 }
             }
+            throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
         }
         throw new BadSymbol (this.id + ' does not have market symbol ' + this.json (symbol));
     }

--- a/js/binance.js
+++ b/js/binance.js
@@ -1465,7 +1465,7 @@ module.exports = class binance extends Exchange {
                 }
             }
         }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        throw new BadSymbol (this.id + ' does not have market symbol ' + this.json (symbol));
     }
 
     costToPrecision (symbol, cost) {

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -29,6 +29,7 @@ from ccxt.base.errors import NotSupported
 from ccxt.base.errors import BadSymbol
 from ccxt.base.errors import NullResponse
 from ccxt.base.errors import InvalidOrder
+from ccxt.base.errors import InvalidAddress
 from ccxt.base.decimal_to_precision import TRUNCATE, ROUND, TICK_SIZE, DECIMAL_PLACES
 
 # -----------------------------------------------------------------------------

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -29,7 +29,6 @@ from ccxt.base.errors import NotSupported
 from ccxt.base.errors import BadSymbol
 from ccxt.base.errors import NullResponse
 from ccxt.base.errors import InvalidOrder
-from ccxt.base.errors import InvalidAddress
 from ccxt.base.decimal_to_precision import TRUNCATE, ROUND, TICK_SIZE, DECIMAL_PLACES
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
1) some cases ends up with `[BadSymbol] binance does not have market symbol [object Object]` ( full msg is: `[BadSymbol] binance does not have market symbol {"isBrowser":false,"isElectron":false,"isWebWorker":false,"isNode":true,"isWindows":true,"truncate":1,..`, so incorrect argument is passed, but it's another issue/another PR)
2) in python  `"InvalidAddress" is not defined`