### PR TITLE
okx: support authenticate for public ws ccxt/ccxt#16853

### DIFF
--- a/js/pro/okx.js
+++ b/js/pro/okx.js
@@ -305,6 +305,9 @@ module.exports = class okx extends okxRest {
         // 3. Data feeds will be delivered every 100ms (vs. every 200ms now)
         //
         const depth = this.safeString (options, 'depth', 'books');
+        if ((depth === 'books-l2-tbt') || (depth === 'books50-l2-tbt')) {
+            await this.authenticate ({ 'access': 'public' });
+        }
         const orderbook = await this.subscribe ('public', depth, symbol, params);
         return orderbook.limit ();
     }
@@ -520,7 +523,9 @@ module.exports = class okx extends okxRest {
 
     authenticate (params = {}) {
         this.checkRequiredCredentials ();
-        const url = this.urls['api']['ws']['private'];
+        const access = this.safeString (params, 'access', 'private');
+        params = this.omit (params, [ 'access' ]);
+        const url = this.urls['api']['ws'][access];
         const messageHash = 'authenticated';
         const client = this.client (url);
         let future = this.safeValue (client.subscriptions, messageHash);


### PR DESCRIPTION
fix: ccxt/ccxt#16853

Now we can call `await this.authenticate ({ 'access': 'public" })` to login the public connection.

```
$ python3 examples/py/cli.py okx watchOrderBook BTC/USDT 1 --verbose
connecting to wss://ws.okx.com:8443/ws/v5/public with timeout 10000 ms
connected
ping loop
sending ping
sending {'op': 'login', 'args': [{'apiKey': 'xx, 'passphrase': 'xx!', 'timestamp': 'xx', 'sign': 'xx'}]}
message pong
message {"event":"login", "msg" : "", "code": "0"}
sending {'op': 'subscribe', 'args': [{'channel': 'books50-l2-tbt', 'instId': 'BTC-USDT'}]}
message {"event":"error","msg":"Only users who're VIP4 and above can subscribe to books50-l2-tbt order book channels","code":"60030"}
```