### PR TITLE
Binance: parseOrder, fix options bug

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3594,7 +3594,7 @@ module.exports = class binance extends Exchange {
         const id = this.safeString (order, 'orderId');
         let type = this.safeStringLower (order, 'type');
         const side = this.safeStringLower (order, 'side');
-        const fills = this.safeValue2 (order, 'fills', 'lastTrade', []);
+        const fills = this.safeValue (order, 'fills', []);
         const clientOrderId = this.safeString (order, 'clientOrderId');
         let timeInForce = this.safeString (order, 'timeInForce');
         if (timeInForce === 'GTX') {


### PR DESCRIPTION
Removed lastTrade from fills to fix a bug in parseOrder

![image](https://user-images.githubusercontent.com/83686770/219137893-732db9e5-58b7-466e-98bc-32205dc79b80.png)
