### PR TITLE
bitflyer: fix markets conflict

### DIFF
--- a/js/bitflyer.js
+++ b/js/bitflyer.js
@@ -134,6 +134,13 @@ module.exports = class bitflyer extends Exchange {
         return this.parse8601 (year + '-' + month + '-' + day + 'T00:00:00Z');
     }
 
+    safeMarket (marketId = undefined, market = undefined, delimiter = undefined, marketType = undefined) {
+        // Bitflyer has a different type of conflict in markets, because
+        // some of their ids (ETH/BTC and BTC/JPY) are duplicated in US, EU and JP.
+        // Since they're the same we just need to return one
+        return super.safeMarket (marketId, market, delimiter, 'spot');
+    }
+
     async fetchMarkets (params = {}) {
         /**
          * @method


### PR DESCRIPTION
Hello, thanks for this so useful library.

Bitflyer has a different type of conflict in markets, because some of their ids (ETH/BTC and BTC/JPY) are duplicated in US, EU and JP. This problem appears when calling methods that use `safeMarket` internally (e.g. `fetchOrders`, `fetchOrder`).

A manner that follows the solution in [bithumb](https://github.com/ccxt/ccxt/blob/master/js/bithumb.js#L170) solves this problem.

before:
```
> (async () => { const res = await bitflyer.fetchOrder("XXXXXXXX", "BTC/JPY"); console.log(res);})();

> (node:2834) UnhandledPromiseRejectionWarning: ArgumentsRequired: bitflyer safeMarket() requires a fourth argument for BTC_JPY to disambiguate between different markets with the same market id
    at bitflyer.safeMarket (/ccxt/js/base/Exchange.js:2195:31)
    at bitflyer.safeSymbol (/ccxt/js/base/Exchange.js:2882:23)
    at bitflyer.parseOrder (/ccxt/js/bitflyer.js:594:29)
    at bitflyer.parseOrders (/ccxt/js/base/Exchange.js:1258:49)
    at bitflyer.fetchOrders (/ccxt/js/bitflyer.js:652:27)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async bitflyer.fetchOrder (/ccxt/js/bitflyer.js:705:24)
    at async REPL3:1:28
(Use `node --trace-warnings ...` to show where the warning was created)

```

after:
```
> (async () => { const res = await bitflyer.fetchOrder("XXXXXXXX", "BTC/JPY"); console.log(res);})();
> {
  id: 'XXXXXXXX',
  clientOrderId: undefined,
  info: {
    ...
  },
  ...
}
```