### PR TITLE
Binance: fetchPosition, options

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -6697,7 +6697,7 @@ module.exports = class binance extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['option']) {
-            throw new BadRequest (this.id + ' fetchPosition() only supports option markets');
+            throw new NotSupported (this.id + ' fetchPosition() supports option markets only');
         }
         const request = {
             'symbol': market['id'],


### PR DESCRIPTION
Added fetchPosition for options:
```
binance.fetchPosition (ETH/USDT:USDT-230218-1650-C)
2023-02-17T07:53:10.124Z iteration 0 passed in 577 ms

{
  info: {
    entryPrice: '34.20000000',
    symbol: 'ETH-230218-1650-C',
    side: 'LONG',
    quantity: '0.50000000',
    reducibleQty: '0.50000000',
    markValue: '16.150000000',
    ror: '-0.0555',
    unrealizedPNL: '-0.950000000',
    markPrice: '32.3',
    strikePrice: '1650.00000000',
    positionCost: '17.10000000',
    expiryDate: '1676707200000',
    priceScale: '1',
    quantityScale: '2',
    optionSide: 'CALL',
    quoteAsset: 'USDT',
    time: '1676620390487'
  },
  id: undefined,
  symbol: 'ETH/USDT:USDT-230218-1650-C',
  entryPrice: 34.2,
  markPrice: 32.3,
  notional: 16.15,
  collateral: 17.1,
  unrealizedPnl: -0.95,
  side: 'long',
  contracts: 0.5,
  contractSize: undefined,
  timestamp: 1676620390487,
  datetime: '2023-02-17T07:53:10.487Z',
  hedged: undefined,
  maintenanceMargin: undefined,
  maintenanceMarginPercentage: undefined,
  initialMargin: undefined,
  initialMarginPercentage: undefined,
  leverage: undefined,
  liquidationPrice: undefined,
  marginRatio: undefined,
  marginMode: undefined,
  percentage: undefined
}
```