### PR TITLE
hitbtc remove BIT mapping

### DIFF
--- a/js/hitbtc.js
+++ b/js/hitbtc.js
@@ -232,7 +232,6 @@ module.exports = class hitbtc extends Exchange {
                 'BCC': 'BCC', // initial symbol for Bitcoin Cash, now inactive
                 'BDP': 'BidiPass',
                 'BET': 'DAO.Casino',
-                'BIT': 'BitRewards',
                 'BOX': 'BOX Token',
                 'CPT': 'Cryptaur', // conflict with CPT = Contents Protocol https://github.com/ccxt/ccxt/issues/4920 and https://github.com/ccxt/ccxt/issues/6081
                 'GET': 'Themis',


### PR DESCRIPTION
Bitrewards was delisted and BITDAO was renamed to BIT as on other exchanges
<img width="133" alt="2023-02-17_14h39_11" src="https://user-images.githubusercontent.com/38309641/219644103-557ff4f8-660f-4686-ab4f-0a1d18546df0.png">
