### PR TITLE
Bitmex : authenticate ws fix

### DIFF
--- a/js/pro/bitmex.js
+++ b/js/pro/bitmex.js
@@ -585,7 +585,7 @@ module.exports = class bitmex extends bitmexRest {
                 }
             }
         }
-        return await future;
+        return future;
     }
 
     handleAuthenticationMessage (client, message) {

--- a/js/pro/bitmex.js
+++ b/js/pro/bitmex.js
@@ -592,8 +592,7 @@ module.exports = class bitmex extends bitmexRest {
         const authenticated = this.safeValue (message, 'success', false);
         if (authenticated) {
             // we resolve the future here permanently so authentication only happens once
-            const future = this.safeValue (client.futures, 'authenticated');
-            future.resolve (true);
+            client.resolve (message, 'authenticated');
         } else {
             const error = new AuthenticationError (this.json (message));
             client.reject (error, 'authenticated');


### PR DESCRIPTION
- authentication was broken in Python, this pr fixes it

```
Python v3.10.9
CCXT v2.8.14
bitmex.watchOrders(BTC/USD:BTC)
[{'amount': 200.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-02-18T14:25:10.405Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': 'a53c28f0-4088-4360-a27c-7c332c771d2d',
  'info': {'account': 395724,
           'cumQty': 0,
           'currency': 'USD',
           'leavesQty': 200,
           'ordStatus': 'New',
           'ordType': 'Limit',
           'orderID': 'a53c28f0-4088-4360-a27c-7c332c771d2d',
           'orderQty': 200,
           'price': 11000,
           'settlCurrency': 'XBt',
           'side': 'Buy',
           'stopPx': None,
           'symbol': 'XBTUSD',
           'text': 'Amended orderQty price: CCXT\nCCXT',
           'timeInForce': 'GoodTillCancel',
           'timestamp': '2023-02-18T14:25:10.405Z',
           'transactTime': '2023-02-18T14:25:10.405Z',
           'workingIndicator': True},
```
