### PR TITLE
feat(Binance): support different ids in editOrder

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -3357,11 +3357,14 @@ module.exports = class binance extends Exchange {
         const request = {
             'symbol': market['id'],
             'side': side.toUpperCase (),
-            'cancelOrderId': id,
             'cancelReplaceMode': 'STOP_ON_FAILURE',
             // STOP_ON_FAILURE - If the cancel request fails, the new order placement will not be attempted.
             // ALLOW_FAILURE - new order placement will be attempted even if cancel request fails.
         };
+        const cancelId = this.safeString2 (params, 'cancelNewClientOrderId', 'cancelOrigClientOrderId');
+        if (cancelId === undefined) {
+            request['cancelOrderId'] = id; // user can provide either cancelOrderId, cancelOrigClientOrderId or cancelOrigClientOrderId
+        }
         const clientOrderId = this.safeString2 (params, 'newClientOrderId', 'clientOrderId');
         const initialUppercaseType = type.toUpperCase ();
         let uppercaseType = initialUppercaseType;


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16887
Demo

```
n binance editOrder undefined "LTC/USDT" limit buy 0.5 24 '{"cancelOrigClientOrderId":"newid1"}' --sandbox
Debugger attached.
2023-02-18T14:48:56.661Z
Node.js: v18.14.0
CCXT v2.8.14
binance.editOrder (, LTC/USDT, limit, buy, 0.5, 24, [object Object])
2023-02-18T14:48:59.092Z iteration 0 passed in 1057 ms

{
  info: {
    symbol: 'LTCUSDT',
    orderId: '1971887',
    orderListId: '-1',
    clientOrderId: 'x-R4BD3S82fe27880fb0c741408f089f',
    transactTime: '1676731738998',
    price: '24.00000000',
    origQty: '0.50000000',
    executedQty: '0.00000000',
    cummulativeQuoteQty: '0.00000000',
    status: 'NEW',
    timeInForce: 'GTC',
    type: 'LIMIT',
    side: 'BUY',
    workingTime: '1676731738998',
    fills: [],
    selfTradePreventionMode: 'NONE'
  },
  id: '1971887',
  clientOrderId: 'x-R4BD3S82fe27880fb0c741408f089f',
  timestamp: 1676731738998,
  datetime: '2023-02-18T14:48:58.998Z',
  lastTradeTimestamp: 1676731738998,
  symbol: 'LTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: undefined,
  side: 'buy',
  price: 24,
  triggerPrice: undefined,
  amount: 0.5,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 0.5,
  status: 'open',
  fee: { currency: undefined, cost: undefined, rate: undefined },
  trades: [],
  fees: [ { currency: undefined, cost: undefined, rate: undefined } ],
  stopPrice: undefined
}
2023-02-18T14:48:59.092Z iteration 1 passed in 1057 ms
```


```
n binance editOrder "1971643" "LTC/USDT" limit buy 0.5 23 '{"newClientOrderId":"newid1"}' --sandbox
Debugger attached.
2023-02-18T14:47:15.562Z
Node.js: v18.14.0
CCXT v2.8.14
binance.editOrder (1971643, LTC/USDT, limit, buy, 0.5, 23, [object Object])
2023-02-18T14:47:17.727Z iteration 0 passed in 800 ms

{
  info: {
    symbol: 'LTCUSDT',
    orderId: '1971746',
    orderListId: '-1',
    clientOrderId: 'newid1',
    transactTime: '1676731637639',
    price: '23.00000000',
    origQty: '0.50000000',
    executedQty: '0.00000000',
    cummulativeQuoteQty: '0.00000000',
    status: 'NEW',
    timeInForce: 'GTC',
    type: 'LIMIT',
    side: 'BUY',
    workingTime: '1676731637639',
    fills: [],
    selfTradePreventionMode: 'NONE'
  },
  id: '1971746',
  clientOrderId: 'newid1',
  timestamp: 1676731637639,
  datetime: '2023-02-18T14:47:17.639Z',
  lastTradeTimestamp: 1676731637639,
  symbol: 'LTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: undefined,
  side: 'buy',
  price: 23,
  triggerPrice: undefined,
  amount: 0.5,
  cost: 0,
  average: undefined,
  filled: 0,
  remaining: 0.5,
  status: 'open',
  fee: { currency: undefined, cost: undefined, rate: undefined },
  trades: [],
  fees: [ { currency: undefined, cost: undefined, rate: undefined } ],
  stopPrice: undefined
}
```