### PR TITLE
fix(Bitfinex2): fetchTrades symbol parsing

### DIFF
--- a/js/bitfinex2.js
+++ b/js/bitfinex2.js
@@ -1227,7 +1227,7 @@ module.exports = class bitfinex2 extends Exchange {
         let takerOrMaker = undefined;
         let type = undefined;
         let fee = undefined;
-        let symbol = undefined;
+        let symbol = this.safeSymbol (undefined, market);
         const timestampIndex = isPrivate ? 2 : 1;
         const timestamp = this.safeInteger (trade, timestampIndex);
         if (isPrivate) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/16906

```
p bitfinex2 fetchTrades "BTC/USDT" None 2
Python v3.10.9
CCXT v2.8.17
bitfinex2.fetchTrades(BTC/USDT,None,2)
[{'amount': 5.91e-06,
  'cost': 0.14725356,
  'datetime': '2023-02-20T14:47:10.171Z',
  'fee': None,
  'fees': [],
  'id': '1310936180',
  'info': ['1310936180', '1676904430171', '0.00000591', '24916'],
  'order': None,
  'price': 24916.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1676904430171,
  'type': None},
 {'amount': 0.01762191,
  'cost': 439.24372866,
  'datetime': '2023-02-20T14:47:17.154Z',
  'fee': None,
  'fees': [],
  'id': '1310936182',
  'info': ['1310936182', '1676904437154', '-0.01762191', '24926'],
  'order': None,
  'price': 24926.0,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1676904437154,
  'type': None}]
```
