### PR TITLE
fix(Bitfinex2): await client send

### DIFF
--- a/js/pro/bitfinex2.js
+++ b/js/pro/bitfinex2.js
@@ -58,7 +58,7 @@ module.exports = class bitfinex2 extends bitfinex2Rest {
         const checksum = this.safeValue (this.options, 'checksum', true);
         if (checksum && !client.subscriptions[messageHash]['checksum'] && (channel === 'book')) {
             client.subscriptions[messageHash]['checksum'] = true;
-            client.send ({
+            await client.send ({
                 'event': 'conf',
                 'flags': 131072,
             });


### PR DESCRIPTION
Demo
```
p bitfinex2 watchTrades "BTC/USDT"   
Python v3.10.9
CCXT v2.8.17
bitfinex2.watchTrades(BTC/USDT)
[{'amount': 0.0006848,
  'cost': 16.9960512,
  'datetime': '2023-02-20T16:28:24.596Z',
  'fee': None,
  'fees': [],
  'id': '1310985056',
  'info': [1310985056, 1676910504596, -0.0006848, 24819],
  'order': None,
  'price': 24819.0,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1676910504596,
  'type': None},
 {'amount': 6e-05,
  'cost': 1.48932,
  'datetime': '2023-02-20T16:28:21.300Z',
  'fee': None,
  'fees': [],
  'id': '1310985053',
  'info': [1310985053, 1676910501300, 6e-05, 24822],
  'order': None,
  'price': 24822.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1676910501300,
  'type': None},
```
