### PR TITLE
ccxt.js removed require "./js/therock.js"

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -142,7 +142,6 @@ const exchanges = {
     'probit':                  require ('./js/probit.js'),
     'ripio':                   require ('./js/ripio.js'),
     'stex':                    require ('./js/stex.js'),
-    'therock':                 require ('./js/therock.js'),
     'tidex':                   require ('./js/tidex.js'),
     'timex':                   require ('./js/timex.js'),
     'tokocrypto':              require ('./js/tokocrypto.js'),


### PR DESCRIPTION
Fixes this error

```
node:internal/modules/cjs/loader:949
  throw err;
  ^

Error: Cannot find module './js/therock.js'
Require stack:
- /Users/sam/Documents/dev/ccxt/ccxt/ccxt.js
- /Users/sam/Documents/dev/ccxt/ccxt/examples/js/cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:946:15)
    at Module._load (node:internal/modules/cjs/loader:787:27)
    at Module.require (node:internal/modules/cjs/loader:1012:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/sam/Documents/dev/ccxt/ccxt/ccxt.js:145:32)
    at Module._compile (node:internal/modules/cjs/loader:1112:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1166:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:834:12)
    at Module.require (node:internal/modules/cjs/loader:1012:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/sam/Documents/dev/ccxt/ccxt/ccxt.js',
    '/Users/sam/Documents/dev/ccxt/ccxt/examples/js/cli.js'
  ]
}

```