### PR TITLE
feat(Binance): add mark/index stream to watchOHLCV

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -68,7 +68,7 @@ module.exports = class binance extends binanceRest {
                     'name': 'ticker', // ticker or miniTicker or bookTicker
                 },
                 'watchOHLCV': {
-                    'name': 'kline', // or indexPriceKline or markPriceKline
+                    'name': 'kline', // or indexPriceKline or markPriceKline (coin-m futures)
                 },
                 'watchBalance': {
                     'fetchBalanceSnapshot': false, // or true

--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -713,7 +713,6 @@ module.exports = class binance extends binanceRest {
         if (event === 'indexPriceKline') {
             // indexPriceKline doesn't have the _PERP suffix
             marketId = this.safeString (message, 'ps');
-            marketId = marketId + '_PERP';
         }
         const lowercaseMarketId = marketId.toLowerCase ();
         const interval = this.safeString (kline, 'i');


### PR DESCRIPTION
- Added mark and index channels (coin m only)

Demo
```
 p binance watchOHLCV "BTC/USD:BTC" 1m None None '{"name":"markPriceKline"}'
Python v3.10.9
CCXT v2.8.21
binance.watchOHLCV(BTC/USD:BTC,1m,None,None,{'name': 'markPriceKline'})
[[1676983920000,
  24640.43371725,
  24642.40737222,
  24640.43371725,
  24642.12105643,
  0.0]]
```

```
 binance watchOHLCV "BTC/USD:BTC" 5m None None '{"name":"indexPriceKline"}' 
Python v3.10.9
CCXT v2.8.21
binance.watchOHLCV(BTC/USD:BTC,5m,None,None,{'name': 'indexPriceKline'})
[[1676984700000, 24641.47731579, 24643.52742105, 24631.939, 24631.939, 0.0]]
[[1676984700000,
  24641.47731579,
  24643.52742105,
  24630.58531579,
  24630.58531579,
  0.0]]
```
```
n binance watchOHLCV "BTC/USDT:USDT"          
Debugger attached.
2023-02-21T13:04:21.998Z
Node.js: v18.14.0
CCXT v2.8.21
binance.watchOHLCV (BTC/USDT:USDT)
1676984640000 | 24641.1 | 24649.4 | 24641.1 | 24647.7 | 139.99
1 objects
1676984640000 | 24641.1 | 24649.4 | 24641.1 | 24647.7 | 140.236
```
```
 binance watchOHLCV "BTC/USDT"     
Debugger attached.
2023-02-21T13:04:46.107Z
Node.js: v18.14.0
CCXT v2.8.21
binance.watchOHLCV (BTC/USDT)
1676984640000 | 24643.72 | 24650.82 | 24633.24 | 24635.12 | 189.46801
1 objects
```
