### PR TITLE
coinbase: fix quote size for market buy order ccxt/ccxt#16918

### DIFF
--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -2059,7 +2059,7 @@ module.exports = class coinbase extends Exchange {
                         total = this.priceToPrecision (symbol, cost);
                     }
                 } else {
-                    total = this.amountToPrecision (symbol, amount);
+                    total = this.priceToPrecision (symbol, amount);
                 }
                 request['order_configuration'] = {
                     'market_market_ioc': {


### PR DESCRIPTION
fix ccxt/ccxt#16918
Based on coinbase documentation https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder, the `quote_size` should be **Amount of quote currency to spend on order.** => price precision.

In this PR, I update the the `quote_size`.