### PR TITLE
Binance: fetchOHLCV, add option support

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -2936,13 +2936,30 @@ module.exports = class binance extends Exchange {
         //         ]
         //     ]
         //
+        // options
+        //
+        //     {
+        //         "open": "32.2",
+        //         "high": "32.2",
+        //         "low": "32.2",
+        //         "close": "32.2",
+        //         "volume": "0",
+        //         "interval": "5m",
+        //         "tradeCount": 0,
+        //         "takerVolume": "0",
+        //         "takerAmount": "0",
+        //         "amount": "0",
+        //         "openTime": 1677096900000,
+        //         "closeTime": 1677097200000
+        //     }
+        //
         return [
-            this.safeInteger (ohlcv, 0),
-            this.safeNumber (ohlcv, 1),
-            this.safeNumber (ohlcv, 2),
-            this.safeNumber (ohlcv, 3),
-            this.safeNumber (ohlcv, 4),
-            this.safeNumber (ohlcv, 5),
+            this.safeInteger2 (ohlcv, 0, 'closeTime'),
+            this.safeNumber2 (ohlcv, 1, 'open'),
+            this.safeNumber2 (ohlcv, 2, 'high'),
+            this.safeNumber2 (ohlcv, 3, 'low'),
+            this.safeNumber2 (ohlcv, 4, 'close'),
+            this.safeNumber2 (ohlcv, 5, 'volume'),
         ];
     }
 
@@ -2999,7 +3016,9 @@ module.exports = class binance extends Exchange {
             request['endTime'] = until;
         }
         let method = 'publicGetKlines';
-        if (price === 'mark') {
+        if (market['option']) {
+            method = 'eapiPublicGetKlines';
+        } else if (price === 'mark') {
             if (market['inverse']) {
                 method = 'dapiPublicGetMarkPriceKlines';
             } else {
@@ -3022,6 +3041,25 @@ module.exports = class binance extends Exchange {
         //         [1591478520000,"0.02501300","0.02501800","0.02500000","0.02500000","22.19000000",1591478579999,"0.55490906",40,"10.92900000","0.27336462","0"],
         //         [1591478580000,"0.02499600","0.02500900","0.02499400","0.02500300","21.34700000",1591478639999,"0.53370468",24,"7.53800000","0.18850725","0"],
         //         [1591478640000,"0.02500800","0.02501100","0.02500300","0.02500800","154.14200000",1591478699999,"3.85405839",97,"5.32300000","0.13312641","0"],
+        //     ]
+        //
+        // options (eapi)
+        //
+        //     [
+        //         {
+        //             "open": "32.2",
+        //             "high": "32.2",
+        //             "low": "32.2",
+        //             "close": "32.2",
+        //             "volume": "0",
+        //             "interval": "5m",
+        //             "tradeCount": 0,
+        //             "takerVolume": "0",
+        //             "takerAmount": "0",
+        //             "amount": "0",
+        //             "openTime": 1677096900000,
+        //             "closeTime": 1677097200000
+        //         }
         //     ]
         //
         return this.parseOHLCVs (response, market, timeframe, since, limit);


### PR DESCRIPTION
Added option support to fetchOHLCV:
```
binance.fetchOHLCV (ETH/USDT:USDT-230224-1600-C, 5m, , 3)
2023-02-22T22:01:47.329Z iteration 0 passed in 610 ms

1677102900000 | 30.5 | 30.5 |   30 | 30.5 | 0.01
1677103200000 | 30.5 | 30.5 | 30.5 | 30.5 |    0
1677103500000 | 30.5 | 30.5 | 30.5 | 30.5 |    0
3 objects
```