### PR TITLE
bybit: patch fetchTransfers ccxt/ccxt#16945

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -6916,7 +6916,7 @@ module.exports = class bybit extends Exchange {
         const request = {};
         if (code !== undefined) {
             currency = this.safeCurrencyCode (code);
-            request['coin'] = currency['id'];
+            request['coin'] = currency;
         }
         if (since !== undefined) {
             request['startTime'] = since;
@@ -7091,7 +7091,7 @@ module.exports = class bybit extends Exchange {
         //      }
         //
         const currencyId = this.safeString (transfer, 'coin');
-        const timestamp = this.safeTimestamp (transfer, 'timestamp');
+        const timestamp = this.safeInteger (transfer, 'timestamp');
         const fromAccountId = this.safeString2 (transfer, 'fromAccountType', 'from_account_type');
         const toAccountId = this.safeString2 (transfer, 'toAccountType', 'to_account_type');
         const accountIds = this.safeValue (this.options, 'accountsById', {});


### PR DESCRIPTION
fix ccxt/ccxt#16945

```
$ node examples/js/cli bybit fetchTransfers USDT --verbose
Node.js: v14.17.0
CCXT v2.8.32
bybit.fetchTransfers (USDT)
fetch Request:
 bybit GET https://api.bybit.com/asset/v3/private/transfer/inter-transfer/list/query?api_key=xxxx&coin=USDT&recv_window=5000&timestamp=xxxx&sign=xxxx 
RequestHeaders:
 {} 
RequestBody:
 undefined 

handleRestResponse:
 bybit GET https://api.bybit.com/asset/v3/private/transfer/inter-transfer/list/query?api_key=xxxx&coin=USDT&recv_window=5000&timestamp=xxxx&sign=xxxx 200 OK 

                                               id |     timestamp |                 datetime | currency |   amount | fromAccount |  toAccount | status
------------------------------------------------------------------------------------------------------------------------------------------------------
selfTransfer_ahloha | xxxxxxxxxxxxxxxxxxxxx | 2023-01-16T00:00:0.000Z |     USDT |        1 |        spot | investment |     ok
```