### PR TITLE
bitget.fetchMarkets contract size is 1

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -1040,7 +1040,7 @@ module.exports = class bitget extends Exchange {
             'inverse': inverse,
             'taker': this.safeNumber (market, 'takerFeeRate'),
             'maker': this.safeNumber (market, 'makerFeeRate'),
-            'contractSize': this.safeNumber (market, 'sizeMultiplier'),
+            'contractSize': 1,
             'expiry': expiry,
             'expiryDatetime': expiryDatetime,
             'strike': undefined,


### PR DESCRIPTION
fixes: #16157

```
% bitget fetchMarkets | condense
2023-02-25T01:51:40.553Z
Node.js: v18.9.0
CCXT v2.8.32
bitget.fetchMarkets ()
2023-02-25T01:51:42.294Z iteration 0 passed in 482 ms
                 id |             symbol |     base | quote | settle |   baseId | quoteId | settleId |   type |  spot | margin |  swap | future | option | active | contract | linear | inverse |  taker |  maker | contractSize |        expiry |       expiryDatetime | strike | optionType |                          precision |                                                                          limits
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       TRXUSDT_SPBL |           TRX/USDT |      TRX |  USDT |        |      TRX |    USDT |          |   spot |  true |  false | false |  false |  false |   true |    false |        |         |  0.002 |  0.002 |            1 |               |                      |        |            | {"amount":0.0001,"price":0.000001} |          {"leverage":{},"amount":{"min":1,"max":0},"price":{},"cost":{"min":5}}
...
      ETHPERP_CMCBL |       ETH/USD:USDC |      ETH |   USD |   USDC |      ETH |     USD |     USDC |   swap | false |  false |  true |  false |  false |   true |     true |   true |   false | 0.0006 | 0.0002 |            1 |               |                      |        |            |       {"amount":0.01,"price":0.01} |                      {"leverage":{},"amount":{"min":0.01},"price":{},"cost":{}}
635 objects
2023-02-25T01:51:42.294Z iteration 1 passed in 482 ms
```