### PR TITLE
fix(Krakenfutures): fix parseTicker

### DIFF
--- a/js/krakenfutures.js
+++ b/js/krakenfutures.js
@@ -510,8 +510,15 @@ module.exports = class krakenfutures extends Exchange {
         const percentage = Precise.stringMul (Precise.stringDiv (change, open), '100');
         const average = Precise.stringDiv (Precise.stringAdd (open, last), '2');
         const volume = this.safeString (ticker, 'vol24h');
-        const baseVolume = (!market['index'] && market['linear']) ? volume : undefined;
-        const quoteVolume = (!market['index'] && market['inverse']) ? volume : undefined;
+        let baseVolume = undefined;
+        let quoteVolume = undefined;
+        if (!market['index']) {
+            if (market['linear']) {
+                baseVolume = volume;
+            } else if (market['inverse']) {
+                quoteVolume = volume;
+            }
+        }
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,


### PR DESCRIPTION
DEMO

```
p krakenfutures fetchTicker "BTC/USD:BTC"
Python v3.10.9
CCXT v2.8.37
krakenfutures.fetchTicker(BTC/USD:BTC)
{'ask': 22983.5,
 'askVolume': 173.0,
 'average': 23470.0,
 'baseVolume': None,
 'bid': 22981.0,
 'bidVolume': 695.0,
 'change': -978.0,
 'close': 22981.0,
 'datetime': '2023-02-25T12:14:25.384Z',
 'high': None,
 'info': {'ask': '22983.5',
          'askSize': '173',
          'bid': '22981',
          'bidSize': '695',
          'fundingRate': '0.000000000355471816',
          'fundingRatePrediction': '0.000000000535301467',
          'indexPrice': '22979.44',
          'last': '22981.00000000',
          'lastSize': '696',
          'lastTime': '2023-02-25T12:14:25.384Z',
          'markPrice': '22983.2',
          'open24h': '23959',
          'openInterest': '24682474.00000000',
          'pair': 'XBT:USD',
          'postOnly': False,
          'suspended': False,
          'symbol': 'pi_xbtusd',
          'tag': 'perpetual',
          'vol24h': '17729086',
          'volumeQuote': '17729086'},
 'last': 22981.0,
 'low': None,
 'open': 23959.0,
 'percentage': -4.081973371175758,
 'previousClose': None,
 'quoteVolume': 17729086.0,
 'symbol': 'BTC/USD:BTC',
 'timestamp': 1677327265384,
 'vwap': None}
```
```
 p krakenfutures fetchTicker "BTC/USD:USD"  
Python v3.10.9
CCXT v2.8.37
krakenfutures.fetchTicker(BTC/USD:USD)
{'ask': 22978.0,
 'askVolume': 0.0606,
 'average': 23477.5,
 'baseVolume': 3008.2811,
 'bid': 22975.0,
 'bidVolume': 0.5796,
 'change': -979.0,
 'close': 22988.0,
 'datetime': '2023-02-25T12:13:38.585Z',
 'high': None,
 'info': {'ask': '22978',
          'askSize': '0.0606',
          'bid': '22975',
          'bidSize': '0.5796',
          'fundingRate': '0.156890745511661559',
          'fundingRatePrediction': '0.225717247691659008',
          'indexPrice': '22974.34',
          'last': '22988',
          'lastSize': '0.0005',
          'lastTime': '2023-02-25T12:13:38.585Z',
          'markPrice': '22977',
          'open24h': '23967',
          'openInterest': '685.82750000',
          'pair': 'XBT:USD',
          'postOnly': False,
          'suspended': False,
          'symbol': 'pf_xbtusd',
          'tag': 'perpetual',
          'vol24h': '3008.2811',
          'volumeQuote': '70320364.5672'},
 'last': 22988.0,
 'low': None,
 'open': 23967.0,
 'percentage': -4.084783243626653,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USD:USD',
 'timestamp': 1677327218585,
 'vwap': None}
```
