### PR TITLE
bybit: patch fetchClosedOrders ccxt/ccxt#16984

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -4704,7 +4704,7 @@ module.exports = class bybit extends Exchange {
         if (enableUnifiedMargin) {
             request['orderStatus'] = 'Canceled';
         } else {
-            request['orderStatus'] = 'Filled,Canceled';
+            request['orderStatus'] = 'Cancelled';
         }
         return await this.fetchOrders (symbol, since, limit, this.extend (request, params));
     }


### PR DESCRIPTION
fix ccxt/ccxt#16984

Bybit had renamed `Canceled` status to `Cancelled` in some apis (contract v3). In this PR, I fix this (also did this in uta PR https://github.com/ccxt/ccxt/pull/16699).