### PR TITLE
fix(gate): reset correctly orderbook after invalid nonce error

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -186,7 +186,7 @@ module.exports = class gate extends gateRest {
         const marketId = this.safeString (delta, 's');
         const symbol = this.safeSymbol (marketId, undefined, '_', marketType);
         const messageHash = 'orderbook:' + symbol;
-        const storedOrderBook = this.safeValue (this.orderbooks, symbol);
+        const storedOrderBook = this.safeValue (this.orderbooks, symbol, this.orderBook ({}));
         const nonce = this.safeInteger (storedOrderBook, 'nonce');
         if (nonce === undefined) {
             let cacheLength = 0;
@@ -209,6 +209,8 @@ module.exports = class gate extends gateRest {
             this.handleDelta (storedOrderBook, delta);
         } else {
             const error = new InvalidNonce (this.id + ' orderbook update has a nonce bigger than u');
+            delete client.subscriptions[messageHash];
+            delete this.orderbooks[symbol];
             client.reject (error, messageHash);
         }
         client.resolve (storedOrderBook, messageHash);


### PR DESCRIPTION
This PR fixes an error in gate, where after an invalidNonce error the user would have to call exchange.close() to call watchOrderBook again.

To test:
 - comment line 206 to 209 in pro/gate.js
 - comment `throw e` in line 313 of `cli.js`

 Expected result:
 Received orderbook, then receive invalidNonce error, then receive new orderbook