### PR TITLE
fix(Gate): watchOrders without symbol

### DIFF
--- a/js/pro/gate.js
+++ b/js/pro/gate.js
@@ -756,7 +756,7 @@ module.exports = class gate extends gateRest {
         });
         const channel = typeId + '.orders';
         let messageHash = 'orders';
-        let payload = [ '!all' ];
+        let payload = [ '!' + 'all' ];
         if (symbol !== undefined) {
             messageHash += ':' + market['id'];
             payload = [ market['id'] ];


### PR DESCRIPTION

Demo

```
p gate watchOrders          
Python v3.10.9
CCXT v2.8.54
gate.watchOrders()
[{'amount': 0.8115005863091737,
  'average': 2.46457,
  'clientOrderId': 'apiv4',
  'cost': 2.0,
  'datetime': '2023-02-28T09:10:43.326Z',
  'fee': {'cost': 0.00162300116, 'currency': 'TONCOIN'},
  'fees': [{'cost': 0.00162300116, 'currency': 'TONCOIN'}],
  'filled': 0.81150058,
  'id': '286740192758',
  'info': {'account': 'spot',
           'amount': '2',
           'avg_deal_price': '2.46457',
           'create_time': '1677575443',
           'create_time_ms': '1677575443326',
           'currency_pair': 'TONCOIN_USDT',
           'event': 'finish',
           'fee': '0.00162300116',
           'fee_currency': 'TONCOIN',
           'filled_total': '1.9999999844506',
           'gt_fee': '0',
           'id': '286740192758',
           'left': '0.0000000155494',
           'point_fee': '0',
           'price': '0',
           'rebated_fee': '0',
           'rebated_fee_currency': 'TONCOIN',
           'side': 'buy',
           'text': 'apiv4',
           'time_in_force': 'ioc',
           'type': 'market',
           'update_time': '1677575443',
           'update_time_ms': '1677575443326',
           'user': 10406147},
  'lastTradeTimestamp': 1677575443326,
  'postOnly': False,
  'price': 2.46457,
  'reduceOnly': None,
  'remaining': 6.309173608e-09,
  'side': 'buy',
  'status': 'closed',
  'stopPrice': None,
  'symbol': 'TONCOIN/USDT',
  'timeInForce': 'IOC',
  'timestamp': 1677575443326,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```