### PR TITLE
fix(bybit): remove isUnifiedMarginEnabled from ws

### DIFF
--- a/js/pro/bybit.js
+++ b/js/pro/bybit.js
@@ -783,7 +783,8 @@ module.exports = class bybit extends bybitRest {
             symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
         }
-        const isUnifiedMargin = await this.isUnifiedMarginEnabled ();
+        const unified = await this.isUnifiedEnabled ();
+        const isUnifiedMargin = this.safeValue (unified, 0, false);
         const url = this.getUrlByMarketType (symbol, true, isUnifiedMargin, method, params);
         await this.authenticate (url);
         const topicByMarket = {
@@ -899,7 +900,8 @@ module.exports = class bybit extends bybitRest {
             symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
         }
-        const isUnifiedMargin = await this.isUnifiedMarginEnabled ();
+        const unified = await this.isUnifiedEnabled ();
+        const isUnifiedMargin = this.safeValue (unified, 0, false);
         const url = this.getUrlByMarketType (undefined, true, isUnifiedMargin, method, params);
         await this.authenticate (url);
         const topicsByMarket = {
@@ -1164,7 +1166,8 @@ module.exports = class bybit extends bybitRest {
          */
         const method = 'watchBalance';
         const messageHash = 'balances';
-        const isUnifiedMargin = await this.isUnifiedMarginEnabled ();
+        const unified = await this.isUnifiedEnabled ();
+        const isUnifiedMargin = this.safeValue (unified, 0, false);
         const url = this.getUrlByMarketType (undefined, true, isUnifiedMargin, method, params);
         await this.authenticate (url);
         const topicByMarket = {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17007
- TODO: Add v5 support 

DEMO
```
 p bybit watchOrders --swap  --sandbox          
Python v3.10.9
CCXT v2.8.65
bybit.watchOrders()
[{'amount': 0.1,
  'average': 97.67,
  'clientOrderId': None,
  'cost': 9.767,
  'datetime': '2023-03-01T12:17:31.940Z',
  'fee': {'cost': 0.0058602, 'currency': 'USDT'},
  'fees': [{'cost': 0.0058602, 'currency': 'USDT'}],
  'filled': 0.1,
  'id': 'a97e7d68-1c4a-4de1-9805-0c37d9d480b5',
  'info': {'avgPrice': '97.67',
           'blockTradeId': '',
           'cancelType': 'UNKNOWN',
           'closeOnTrigger': False,
           'createdTime': '1677673051940',
           'cumExecFee': '0.0058602',
           'cumExecQty': '0.1',
           'cumExecValue': '9.767',
           'lastExecPrice': '97.67',
           'lastExecQty': '0.1',
           'leavesQty': '0',
           'leavesValue': '0',
           'orderId': 'a97e7d68-1c4a-4de1-9805-0c37d9d480b5',
           'orderLinkId': '',
           'orderStatus': 'Filled',
           'orderType': 'Market',
           'positionIdx': 1,
           'price': '102.54',
           'qty': '0.1',
           'reduceOnly': False,
           'rejectReason': 'EC_NoError',
           'side': 'Buy',
           'slTriggerBy': 'UNKNOWN',
           'stopLoss': '0.00',
           'stopOrderType': 'UNKNOWN',
           'symbol': 'LTCUSDT',
           'takeProfit': '0.00',
           'timeInForce': 'ImmediateOrCancel',
           'tpTriggerBy': 'UNKNOWN',
           'triggerBy': 'UNKNOWN',
           'triggerDirection': 0,
           'triggerPrice': '0.00',
           'updatedTime': '1677673051943'},
  'lastTradeTimestamp': None,
  'postOnly': False,
  'price': 102.54,
  'reduceOnly': None,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopPrice': None,
  'symbol': 'LTC/USDT:USDT',
  'timeInForce': 'IOC',
  'timestamp': 1677673051940,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```
