### PR TITLE
fix(Bybit): timeframe parsing

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1977,7 +1977,6 @@ module.exports = class bybit extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const duration = this.parseTimeframe (timeframe);
         if (limit === undefined) {
             limit = 200; // default is 200 when requested with `since`
         }
@@ -1987,7 +1986,7 @@ module.exports = class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // max 1000, default 1000
         }
-        request['interval'] = duration;
+        request['interval'] = this.safeString (this.timeframes, timeframe, timeframe);
         let method = undefined;
         if (market['spot']) {
             request['category'] = 'spot';


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/pull/16563
 
```
p bybit fetchOHLCV "BTC/USDT:USDT" 1m None 2 --sandbox
Python v3.10.9
CCXT v2.8.66
bybit.fetchOHLCV(BTC/USDT:USDT,1m,None,2)
[[1677681900000, 23720.6, 24432.3, 21100.0, 23743.3, 6238.324],
 [1677681960000, 23743.3, 23755.9, 23549.0, 23755.9, 440.673]]
```
```
p bybit fetchOHLCV "BTC/USDT" 1m None 2 --sandbox 
Python v3.10.9
CCXT v2.8.66
bybit.fetchOHLCV(BTC/USDT,1m,None,2)
[[1677681900000, 23503.4, 23503.4, 23503.39, 23503.4, 0.027926],
 [1677681960000, 23503.4, 23503.4, 23503.39, 23503.4, 0.019678]]
```
```
p bybit fetchOHLCV "BTC/USDT" 1M None 2 --sandbox
Python v3.10.9
CCXT v2.8.66
bybit.fetchOHLCV(BTC/USDT,1M,None,2)
[[1675209600000, 17995.43, 40776.0, 10501.36, 17994.67, 57915.06379428],
 [1677628800000, 17994.67, 23759.8, 15236.67, 23503.4, 2980.110916]]
```
