### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y nodejs
 # Python 3
 RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip
 RUN pip3 install 'idna==2.9' --force-reinstall
-RUN pip3 install --upgrade setuptools
+RUN pip3 install --upgrade setuptools==65.7.0
 RUN pip3 install tox
 RUN pip3 install aiohttp
 RUN pip3 install cryptography


### PR DESCRIPTION
with newer setuptools,

```
 => ERROR [13/25] RUN pip3 install tox                                   1.9s
------                                                                               
 > [13/25] RUN pip3 install tox:                                              
#0 1.826 ERROR: Exception:                                                           
#0 1.826 Traceback (most recent call last):                                          
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/cli/base_command.py", line 186, in _main
#0 1.826     status = self.run(options, args)
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/commands/install.py", line 357, in run
#0 1.826     resolver.resolve(requirement_set)
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/legacy_resolve.py", line 177, in resolve
#0 1.826     discovered_reqs.extend(self._resolve_one(requirement_set, req))
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/legacy_resolve.py", line 333, in _resolve_one
#0 1.826     abstract_dist = self._get_abstract_dist_for(req_to_install)
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/legacy_resolve.py", line 270, in _get_abstract_dist_for
#0 1.826     skip_reason = self._check_skip_installed(req)
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/legacy_resolve.py", line 228, in _check_skip_installed
#0 1.826     req_to_install.check_if_exists(self.use_user_site)
#0 1.826   File "/usr/lib/python3/dist-packages/pip/_internal/req/req_install.py", line 443, in check_if_exists
#0 1.826     self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 514, in get_distribution
#0 1.826     dist = get_provider(dist)
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 386, in get_provider
#0 1.826     return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 956, in require
#0 1.826     needed = self.resolve(parse_requirements(requirements))
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 815, in resolve
#0 1.826     dist = self._resolve_dist(
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 844, in _resolve_dist
#0 1.826     env = Environment(self.entries)
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 1044, in __init__
#0 1.826     self.scan(search_path)
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 1077, in scan
#0 1.826     self.add(dist)
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 1096, in add
#0 1.826     dists.sort(key=operator.attrgetter('hashcmp'), reverse=True)
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 2631, in hashcmp
#0 1.826     self.parsed_version,
#0 1.826   File "/usr/local/lib/python3.8/dist-packages/pkg_resources/__init__.py", line 2685, in parsed_version
#0 1.826     raise packaging.version.InvalidVersion(f"{str(ex)} {info}") from None
#0 1.826 pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '0.23ubuntu1' (package: distro-info)
```