### PR TITLE
okx: add v5/trade/order-algo

### DIFF
--- a/js/okx.js
+++ b/js/okx.js
@@ -2641,7 +2641,12 @@ module.exports = class okx extends Exchange {
         const method = this.safeString (params, 'method', defaultMethod);
         const stop = this.safeValue (params, 'stop');
         if (stop) {
-            throw new NotSupported (this.id + ' fetchOrder() does not support stop orders, use fetchOpenOrders() fetchCanceledOrders() or fetchClosedOrders()');
+            method = 'privateGetTradeOrderAlgo';
+            if (clientOrderId !== undefined) {
+                request['algoClOrdId'] = clientOrderId;
+            } else {
+                request['algoId'] = id;
+            }
         } else {
             if (clientOrderId !== undefined) {
                 request['clOrdId'] = clientOrderId;
@@ -2693,6 +2698,58 @@ module.exports = class okx extends Exchange {
         //             }
         //         ],
         //         "msg": ""
+        //     }
+        //
+        // Algo order
+        //     {
+        //         "code":"0",
+        //         "msg":"",
+        //         "data":[
+        //             {
+        //                 "instType":"FUTURES",
+        //                 "instId":"BTC-USD-200329",
+        //                 "ordId":"123445",
+        //                 "ccy":"BTC",
+        //                 "clOrdId":"",
+        //                 "algoId":"1234",
+        //                 "sz":"999",
+        //                 "closeFraction":"",
+        //                 "ordType":"oco",
+        //                 "side":"buy",
+        //                 "posSide":"long",
+        //                 "tdMode":"cross",
+        //                 "tgtCcy": "",
+        //                 "state":"effective",
+        //                 "lever":"20",
+        //                 "tpTriggerPx":"",
+        //                 "tpTriggerPxType":"",
+        //                 "tpOrdPx":"",
+        //                 "slTriggerPx":"",
+        //                 "slTriggerPxType":"",
+        //                 "triggerPx":"99",
+        //                 "triggerPxType":"last",
+        //                 "ordPx":"12",
+        //                 "actualSz":"",
+        //                 "actualPx":"",
+        //                 "actualSide":"",
+        //                 "pxVar":"",
+        //                 "pxSpread":"",
+        //                 "pxLimit":"",
+        //                 "szLimit":"",
+        //                 "tag": "adadadadad",
+        //                 "timeInterval":"",
+        //                 "callbackRatio":"",
+        //                 "callbackSpread":"",
+        //                 "activePx":"",
+        //                 "moveTriggerPx":"",
+        //                 "reduceOnly": "false",
+        //                 "triggerTime":"1597026383085",
+        //                 "last": "16012",
+        //                 "failCode": "",
+        //                 "algoClOrdId": "",
+        //                 "cTime":"1597026383000"
+        //             }
+        //         ]
         //     }
         //
         const data = this.safeValue (response, 'data', []);

--- a/js/okx.js
+++ b/js/okx.js
@@ -245,6 +245,7 @@ module.exports = class okx extends Exchange {
                         'trade/fills-history': 2,
                         'trade/orders-algo-pending': 1,
                         'trade/orders-algo-history': 1,
+                        'trade/order-algo': 1,
                         'account/subaccount/balances': 10,
                         'asset/subaccount/bills': 5 / 3,
                         'users/subaccount/list': 10,

--- a/js/okx.js
+++ b/js/okx.js
@@ -2638,7 +2638,7 @@ module.exports = class okx extends Exchange {
         const clientOrderId = this.safeString2 (params, 'clOrdId', 'clientOrderId');
         const options = this.safeValue (this.options, 'fetchOrder', {});
         const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrder');
-        const method = this.safeString (params, 'method', defaultMethod);
+        let method = this.safeString (params, 'method', defaultMethod);
         const stop = this.safeValue (params, 'stop');
         if (stop) {
             method = 'privateGetTradeOrderAlgo';
@@ -2654,7 +2654,7 @@ module.exports = class okx extends Exchange {
                 request['ordId'] = id;
             }
         }
-        const query = this.omit (params, [ 'method', 'clOrdId', 'clientOrderId' ]);
+        const query = this.omit (params, [ 'method', 'clOrdId', 'clientOrderId', 'stop' ]);
         const response = await this[method] (this.extend (request, query));
         //
         // Spot and Swap


### PR DESCRIPTION
fix: ccxt/ccxt#17019

Changes:
* Add api
* Update fetchOrder (https://www.okx.com/docs-v5/en/#rest-api-trade-cancel-advance-algo-order)

TODO:
- [ ] check and update other methods related to algo orders (with `algoClOrdId` param)

@carlosmiei there is no order id param for `GET /api/v5/trade/order-algo`, shall we take id as `algoId`? 