### PR TITLE
bybit: update entry price ccxt/ccxt#17021

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -7111,7 +7111,7 @@ module.exports = class bybit extends Exchange {
         const tradeMode = this.safeInteger (position, 'tradeMode', 0);
         const marginMode = tradeMode ? 'isolated' : 'cross';
         let collateralString = this.safeString (position, 'positionBalance');
-        const entryPrice = this.omitZero (this.safeString (position, 'entryPrice'));
+        const entryPrice = this.omitZero (this.safeString2 (position, 'entryPrice', 'avgPrice'));
         const liquidationPrice = this.omitZero (this.safeString (position, 'liqPrice'));
         const leverage = this.safeString (position, 'leverage');
         if (liquidationPrice !== undefined) {


### PR DESCRIPTION
fix: ccxt/ccxt#17021

According to documentation, the `avgPrice` represent the average entry price (https://bybit-exchange.github.io/docs/v5/position). In this pr, I set entry price to this value.