### PR TITLE
base - NUMBER CONSTANTS

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -45,13 +45,13 @@ const ROUND_UP = 2;
 const ROUND_DOWN = 3;
 
 // digits counting mode
-const DECIMAL_PLACES = 0;
-const SIGNIFICANT_DIGITS = 1;
-const TICK_SIZE = 2;
+const DECIMAL_PLACES = 2;
+const SIGNIFICANT_DIGITS = 3;
+const TICK_SIZE = 4;
 
 // padding mode
-const NO_PADDING = 0;
-const PAD_WITH_ZERO = 1;
+const NO_PADDING = 5;
+const PAD_WITH_ZERO = 6;
 
 class Exchange {
 

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -12,15 +12,15 @@
 //
 //          decimalToPrecision ('123.456', ROUND, 2, DECIMAL_PLACES)
 
-const ROUND = 0;                // rounding mode
-const TRUNCATE = 1;
+const TRUNCATE = 0;                // rounding mode
+const ROUND = 1;
 const ROUND_UP = 2;
 const ROUND_DOWN = 3;
-const DECIMAL_PLACES = 0;        // digits counting mode
-const SIGNIFICANT_DIGITS = 1;
-const TICK_SIZE = 2;
-const NO_PADDING = 0;             // zero-padding mode
-const PAD_WITH_ZERO = 1;
+const DECIMAL_PLACES = 2;        // digits counting mode
+const SIGNIFICANT_DIGITS = 3;
+const TICK_SIZE = 4;
+const NO_PADDING = 5;             // zero-padding mode
+const PAD_WITH_ZERO = 6;
 const precisionConstants = {
     ROUND,
     TRUNCATE,


### PR DESCRIPTION
So, this PR corrects the numbers of constants. However, to be clear, I am not aware of what negative impact this PR might have (i.e. userland codes might break, whoever have `this.precisionMode === 1` or like such direct comparisons in js/php).
I avoided to change python (because of most coverage) so, i've adjusted js/php toward the python values.