### PR TITLE
Bybit balance fix

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -2931,7 +2931,6 @@ module.exports = class bybit extends Exchange {
          */
         await this.loadMarkets ();
         const request = {};
-        // let method = 'privateGetAssetV3PrivateTransferAccountCoinsBalanceQuery';
         let method = undefined;
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         let type = undefined;


### PR DESCRIPTION
- New tests v3 normal
```
➜  ccxt git:(bybit-balance-fix) ✗ n bybit fetchBalance
bybit.fetchBalance ()
2023-03-03T15:23:50.123Z iteration 0 passed in 3276 ms

{
  info: {
    retCode: '0',
    retMsg: 'OK',
    result: {
      list: [
        {
          coin: 'BTC',
          equity: '0',
          walletBalance: '0',
          positionMargin: '0',
          availableBalance: '0',
```

```
 n bybit fetchBalance '{"type":"funding"}'

  USDT: { free: 96.3, used: 0, total: 96.3 },
  BUSD: { free: 90, used: 0, total: 90 },
  free: { USDT: 96.3, BUSD: 0 },
  used: { USDT: 0, BUSD: 0 },
  total: { USDT: 96.3, BUSD: 0 }
}
2023-03-03T15:24:15.698Z iteration 1 passed in 1239 ms
```

```
 n bybit fetchBalance --spot

  free: {
    BNB: 0.168,
    BUSD: 44.5,
    DOGE: 0.0495,
    ETHF: 0.00535025,
    ETHW: 0.00535025,
    LTC: 0.34657607,
    USDT: 35
  },
  used: { BNB: 0, BUSD: 0, DOGE: 0, ETHF: 0, ETHW: 0, LTC: 0, USDT: 0 },
  total: {
    BNB: 0.168,
    BUSD: 44.5,
    DOGE: 0.0495,
    ETHF: 0.00535025,
    ETHW: 0.00535025,
    LTC: 0.34657607,
    USDT: 35
  }
}
2023-03-03T15:25:56.450Z iteration 1 passed in 1251 ms

```

================= V3 unified margin ================
```
 n bybit fetchBalance --spot --sandbox
  BTC: { free: 0.00989628418, used: 0, total: 0.00989628418 },
  EOS: { free: 2000, used: 0, total: 2000 },
  ETH: { free: 0.07825167, used: 0, total: 0.07825167 },
  LTC: { free: 0.8587062381, used: 0, total: 0.8587062381 },
  USDC: { free: 45000, used: 0, total: 45000 },
  USDT: { free: 29667.73682712754, used: 0, total: 29667.73682712754 },
  XRP: { free: 10000, used: 0, total: 10000 },
  free: {
    BTC: 0.00989628418,
    EOS: 2000,
    ETH: 0.07825167,
    LTC: 0.8587062381,
    USDC: 45000,
    USDT: 29667.73682712754,
    XRP: 10000
  },
  used: { BTC: 0, EOS: 0, ETH: 0, LTC: 0, USDC: 0, USDT: 0, XRP: 0 },
  total: {
    BTC: 0.00989628418,
    EOS: 2000,
    ETH: 0.07825167,
    LTC: 0.8587062381,
    USDC: 45000,
    USDT: 29667.73682712754,
    XRP: 10000
  }
}
2023-03-03T15:27:46.709Z iteration 1 passed in 1114 ms
```

```
 n bybit fetchBalance --sandbox          

  BTC: { free: 0.19999059, used: 0, total: 0.19999059 },
  ETH: { free: 1.13638128, used: 0, total: 1.13638128 },
  EOS: { free: 0, used: 0, total: 0 },
  XRP: { free: 0, used: 0, total: 0 },
  USDT: { free: 0, used: 0, total: 0 },
  DOT: { free: 0, used: 0, total: 0 },
  LTC: { free: 0, used: 0, total: 0 },
  BIT: { free: 0, used: 0, total: 0 },
  USDC: { free: 0, used: 0, total: 0 },
  ADA: { free: 0, used: 0, total: 0 },
  MANA: { free: 0, used: 0, total: 0 },
  free: {
    BTC: 0.19999059,
    ETH: 1.13638128,
    EOS: 0,
    XRP: 0,
    USDT: 0,
    DOT: 0,
    LTC: 0,
    BIT: 0,
    USDC: 0,
    ADA: 0,
    MANA: 0
  },
  used: {
    BTC: 0,
    ETH: 0,
    EOS: 0,
    XRP: 0,
    USDT: 0,
    DOT: 0,
    LTC: 0,
    BIT: 0,
    USDC: 0,
    ADA: 0,
    MANA: 0
  },
  total: {
    BTC: 0.19999059,
    ETH: 1.13638128,
    EOS: 0,
    XRP: 0,
    USDT: 0,
    DOT: 0,
    LTC: 0,
    BIT: 0,
    USDC: 0,
    ADA: 0,
    MANA: 0
  }
}
2023-03-03T15:28:11.873Z iteration 1 passed in 1125 ms
```

```
n bybit fetchBalance '{"type":"funding"}' --sandbox
Debugger attached.
2023-03-03T15:28:42.048Z
Node.js: v18.14.0
CCXT v2.8.82
bybit.fetchBalance ([object Object])
2023-03-03T15:28:45.130Z iteration 0 passed in 1080 ms

{
  info: {
    retCode: '0',
    retMsg: 'success',
    result: {
      memberId: '551166',
      accountType: 'FUND',
      balance: [
        {
          coin: 'USDT',
          transferBalance: '2',
          walletBalance: '2',
          bonus: ''
        }
      ]
    },
    retExtInfo: {},
    time: '1677857325073'
  },
  USDT: { free: 2, used: 0, total: 2 },
  free: { USDT: 2 },
  used: { USDT: 0 },
  total: { USDT: 2 }
}
2023-03-03T15:28:45.130Z iteration 1 passed in 1080 ms
```
================== V5 unified ======================================
```
 n bybit fetchBalance --spot --sandbox          
Debugger attached.
2023-03-03T15:30:44.526Z
Node.js: v19.5.0
CCXT v2.8.82
bybit.fetchBalance ()
2023-03-03T15:30:47.742Z iteration 0 passed in 1224 ms

{
  info: {
    retCode: '0',
    retMsg: 'OK',
    result: { balances: [] },
    retExtInfo: {},
    time: '1677857447698'
  },
  free: {},
  used: {},
  total: {}
}
2023-03-03T15:30:47.742Z iteration 1 passed in 1224 ms
```

```
n bybit fetchBalance --sandbox          

  BTC: { free: 0, used: 0, total: 0 },
  ETH: { free: 0, used: 0, total: 0 },
  EOS: { free: 0, used: 0, total: 0 },
  XRP: { free: 0, used: 0, total: 0 },
  USDT: { free: 0, used: 0, total: 0 },
  DOT: { free: 0, used: 0, total: 0 },
  LTC: { free: 0, used: 0, total: 0 },
  BIT: { free: 0, used: 0, total: 0 },
  USDC: { free: 0, used: 0, total: 0 },
  ADA: { free: 0, used: 0, total: 0 },
  MANA: { free: 0, used: 0, total: 0 },
}
2023-03-03T15:31:00.408Z iteration 1 passed in 911 ms

```

```
 n bybit fetchBalance '{"type":"funding"}' --sandbox
Debugger attached.
2023-03-03T15:31:29.779Z
Node.js: v19.5.0
CCXT v2.8.82
bybit.fetchBalance ([object Object])
2023-03-03T15:31:32.741Z iteration 0 passed in 920 ms

{
  info: {
    retCode: '0',
    retMsg: 'success',
    result: {
      memberId: '452265',
      accountType: 'FUND',
      balance: [
        {
          coin: 'BTC',
          transferBalance: '0.2',
          walletBalance: '0.2',
          bonus: ''
        }
      ]
    },
    retExtInfo: {},
    time: '1677857492686'
  },
  BTC: { free: 0.2, used: 0, total: 0.2 },
  free: { BTC: 0.2 },
  used: { BTC: 0 },
  total: { BTC: 0.2 }
}
2023-03-03T15:31:32.741Z iteration 1 passed in 920 ms
```