### PR TITLE
fix(binance): stream reconnect

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -107,18 +107,6 @@ module.exports = class binance extends binanceRest {
         return stream;
     }
 
-    onError (client, error) {
-        this.options['streamBySubscriptionsHash'] = {};
-        this.options['streamIndex'] = -1;
-        super.onError (client, error);
-    }
-
-    onClose (client, error) {
-        this.options['streamBySubscriptionsHash'] = {};
-        this.options['streamIndex'] = -1;
-        super.onClose (client, error);
-    }
-
     async watchOrderBook (symbol, limit = undefined, params = {}) {
         /**
          * @method


### PR DESCRIPTION
### Issue
When one client would error, all stream subscriptions of the exchange would reset. This was causing several issues:
- Same subscriptions would exist across several clients
- If watching a large amount of orderbooks, too many orderbooks would be refetched and a large queue of rest requests would be generated, filling up the RL Rest queue causing further errors.

### Solution 
This removes the current `onError` and `onClose` logic. This will make `streamBySubscriptionsHash` to persist therefore when the user reconnects the subscription will reconnect to the same stream and url.

### Alternative solution
We could also look at the subscriptions included in the client and remove those from `streamBySubscriptionsHash` however it feels like it just adds complexity without much benefit.