### PR TITLE
Coinbase Pro: Add bidVolume and askVolume to watchTicker

### DIFF
--- a/js/pro/coinbasepro.js
+++ b/js/pro/coinbasepro.js
@@ -585,20 +585,22 @@ module.exports = class coinbasepro extends coinbaseproRest {
         //
         //     {
         //         type: 'ticker',
-        //         sequence: 12042642428,
-        //         product_id: 'BTC-USD',
-        //         price: '9380.55',
-        //         open_24h: '9450.81000000',
-        //         volume_24h: '9611.79166047',
-        //         low_24h: '9195.49000000',
-        //         high_24h: '9475.19000000',
-        //         volume_30d: '327812.00311873',
-        //         best_bid: '9380.54',
-        //         best_ask: '9380.55',
-        //         side: 'buy',
-        //         time: '2020-02-01T01:40:16.253563Z',
-        //         trade_id: 82062566,
-        //         last_size: '0.41969131'
+        //         sequence: 7388547310,
+        //         product_id: 'BTC-USDT',
+        //         price: '22345.67',
+        //         open_24h: '22308.13',
+        //         volume_24h: '470.21123644',
+        //         low_24h: '22150',
+        //         high_24h: '22495.15',
+        //         volume_30d: '25713.98401605',
+        //         best_bid: '22345.67',
+        //         best_bid_size: '0.10647825',
+        //         best_ask: '22349.68',
+        //         best_ask_size: '0.03131702',
+        //         side: 'sell',
+        //         time: '2023-03-04T03:37:20.799258Z',
+        //         trade_id: 11586478,
+        //         last_size: '0.00352175'
         //     }
         //
         const type = this.safeString (ticker, 'type');
@@ -616,9 +618,9 @@ module.exports = class coinbasepro extends coinbaseproRest {
             'high': this.safeNumber (ticker, 'high_24h'),
             'low': this.safeNumber (ticker, 'low_24h'),
             'bid': this.safeNumber (ticker, 'best_bid'),
-            'bidVolume': undefined,
+            'bidVolume': this.safeNumber (ticker, 'best_bid_size'),
             'ask': this.safeNumber (ticker, 'best_ask'),
-            'askVolume': undefined,
+            'askVolume': this.safeNumber (ticker, 'best_ask_size'),
             'vwap': undefined,
             'open': this.safeNumber (ticker, 'open_24h'),
             'close': last,


### PR DESCRIPTION
Added bidVolume and askVolume to watchTicker:
fixes: #17037
```
coinbasepro.watchTicker (BTC/USDT)
{
  symbol: 'BTC/USDT',
  timestamp: 1677901319841,
  datetime: '2023-03-04T03:41:59.841Z',
  high: 22495.15,
  low: 22150,
  bid: 22343.35,
  bidVolume: 0.10650708,
  ask: 22346.82,
  askVolume: 0.0313213,
  vwap: undefined,
  open: 22308.13,
  close: 22343.35,
  last: 22343.35,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: 470.88162625,
  quoteVolume: undefined,
  info: {
    type: 'ticker',
    sequence: 7388553636,
    product_id: 'BTC-USDT',
    price: '22343.35',
    open_24h: '22308.13',
    volume_24h: '470.88162625',
    low_24h: '22150',
    high_24h: '22495.15',
    volume_30d: '25714.65440586',
    best_bid: '22343.35',
    best_bid_size: '0.10650708',
    best_ask: '22346.82',
    best_ask_size: '0.03132130',
    side: 'sell',
    time: '2023-03-04T03:41:59.841714Z',
    trade_id: 11586506,
    last_size: '0.00349292'
  }
}
```