### PR TITLE
gate: Add mapping for invalid stop order pricing

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -572,7 +572,7 @@ module.exports = class gate extends Exchange {
                     },
                 },
             },
-            // https://www.gate.io/docs/apiv4/en/index.html#label-list
+            // https://www.gate.io/docs/developers/apiv4/en/#label-list
             'exceptions': {
                 'exact': {
                     'INVALID_PARAM_VALUE': BadRequest,
@@ -665,6 +665,8 @@ module.exports = class gate extends Exchange {
                     'TOO_BUSY': ExchangeNotAvailable,
                     'CROSS_ACCOUNT_NOT_FOUND': ExchangeError,
                     'RISK_LIMIT_TOO_LOW': BadRequest, // {"label":"RISK_LIMIT_TOO_LOW","detail":"limit 1000000"}
+                    'AUTO_TRIGGER_PRICE_LESS_LAST': InvalidOrder,  // {"label":"AUTO_TRIGGER_PRICE_LESS_LAST","message":"invalid argument: Trigger.Price must < last_price"}
+                    'AUTO_TRIGGER_PRICE_GREATE_LAST': InvalidOrder, // {"label":"AUTO_TRIGGER_PRICE_GREATE_LAST","message":"invalid argument: Trigger.Price must > last_price"}
                 },
                 'broad': {},
             },


### PR DESCRIPTION
Creating a (in this case intentionally) invalid stop order currently causes a AUTO_TRIGGER_PRICE_GREATE_LAST. (or the corresponding AUTO_TRIGGER_PRICE_LESS_LAST error).

``` python
import ccxt
exchange = ccxt.gate({'apiKey': '<yourApiKey>', 'secret': '<yoursecret>' , 'options': {'defaultType': 'swap'}})
params = {
    'stopPrice': 249,
}
pair='ETH/USDT:USDT'
exchange.create_order(pair, 'limit', 'buy', 1, 249, params=params)
```


```
HTTPError                                 Traceback (most recent call last)
File [~/.pyenv/versions/3.10.8/envs/trade_3108/lib/python3.10/site-packages/ccxt/base/exchange.py:625](https://file+.vscode-resource.vscode-cdn.net/home/xmatt/devel/cryptos/stuff/~/.pyenv/versions/3.10.8/envs/trade_3108/lib/python3.10/site-packages/ccxt/base/exchange.py:625), in Exchange.fetch(self, url, method, headers, body)
    624     self.logger.debug("%s %s, Response: %s %s %s", method, url, http_status_code, headers, http_response)
--> 625     response.raise_for_status()
    627 except Timeout as e:

File [~/.pyenv/versions/3.10.8/envs/trade_3108/lib/python3.10/site-packages/requests/models.py:1021](https://file+.vscode-resource.vscode-cdn.net/home/xmatt/devel/cryptos/stuff/~/.pyenv/versions/3.10.8/envs/trade_3108/lib/python3.10/site-packages/requests/models.py:1021), in Response.raise_for_status(self)
   1020 if http_error_msg:
-> 1021     raise HTTPError(http_error_msg, response=self)

HTTPError: 400 Client Error: Bad Request for url: https://api.gateio.ws/api/v4/futures/usdt/price_orders

During handling of the above exception, another exception occurred:

ExchangeError                             Traceback (most recent call last)
[/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb](https://file+.vscode-resource.vscode-cdn.net/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb) Cell 29 in 2
     [16](vscode-notebook-cell:/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb#X40sZmlsZQ%3D%3D?line=15) params = {
     [17](vscode-notebook-cell:/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb#X40sZmlsZQ%3D%3D?line=16)     'stopPrice': 249,
     [18](vscode-notebook-cell:/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb#X40sZmlsZQ%3D%3D?line=17) }
     [19](vscode-notebook-cell:/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb#X40sZmlsZQ%3D%3D?line=18) pair='ETH[/USDT](https://file+.vscode-resource.vscode-cdn.net/USDT):USDT'
---> [20](vscode-notebook-cell:/home/xmatt/devel/cryptos/stuff/ccxt_gate.ipynb#X40sZmlsZQ%3D%3D?line=19) ct.create_order(pair, 'limit', 'buy', 1, 249, params=params)

File [~/.pyenv/versions/3.10.8/envs/trade_3108/lib/python3.10/site-packages/ccxt/gate.py:3137](https://file+.vscode-resource.vscode-cdn.net/home/xmatt/devel/cryptos/stuff/~/.pyenv/versions/3.10.8/envs/trade_3108/lib/python3.10/site-packages/ccxt/gate.py:3137), in gate.create_order(self, symbol, type, side, amount, price, params)
   3130     methodTail = 'PriceOrders'
...
   4823 feedback = self.id + ' ' + body
   4824 self.throw_exactly_matched_exception(self.exceptions['exact'], label, feedback)
-> 4825 raise ExchangeError(feedback)

ExchangeError: gateio {"label":"AUTO_TRIGGER_PRICE_GREATE_LAST","message":"invalid argument: Trigger.Price must > last_price"}

```

It's an error for sure, but should be mapped to `InvalidOrder`, not the generic `ExchangeError`.