### PR TITLE
fix(bybit): parseTicker default type

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -1746,9 +1746,9 @@ module.exports = class bybit extends Exchange {
         //
         const timestamp = this.safeInteger (ticker, 'time');
         const marketId = this.safeString (ticker, 'symbol');
-        const marketType = (market !== undefined) ? market['type'] : 'linear';
-        market = this.safeMarket (marketId, market, undefined, marketType);
-        const symbol = this.safeSymbol (marketId, market, undefined, marketType);
+        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
+        market = this.safeMarket (marketId, market, undefined, defaultType);
+        const symbol = this.safeSymbol (marketId, market, undefined, defaultType);
         const last = this.safeString (ticker, 'lastPrice');
         const open = this.safeString (ticker, 'prevPrice24h');
         let percentage = this.safeString (ticker, 'price24hPcnt');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17054

```
Python v3.10.9
CCXT v2.8.93
bybit.fetchTickers()
{'10000NFT/USDT:USDT': {'ask': 0.0045,
                        'askVolume': 1606880.0,
                        'average': 0.0045725,
                        'baseVolume': 69163390.0,
                        'bid': 0.00449,
                        'bidVolume': 808280.0,
                        'change': -0.000145,
                        'close': 0.0045,
                        'datetime': None,
                        'high': 0.0047,
                        'info': {'ask1Price': '0.004500',
                                 'ask1Size': '1606880',
                                 'basisRate': '',
                                 'bid1Price': '0.004490',
                                 'bid1Size': '808280',
                                 'deliveryFeeRate': '',
                                 'deliveryTime': '0',
                                 'fundingRate': '0.0001',
                                 'highPrice24h': '0.004700',
                                 'indexPrice': '0.004488',
                                 'lastPrice': '0.004500',
                                 'lowPrice24h': '0.004455',
                                 'markPrice': '0.004496',
                                 'nextFundingTime': '1677974400000',
                                 'openInterest': '42939560',
                                 'openInterestValue': '193056.26',
                                 'predictedDeliveryPrice': '',
                                 'prevPrice1h': '0.004485',
                                 'prevPrice24h': '0.004645',
                                 'price24hPcnt': '-0.031216',
                                 'symbol': '10000NFTUSDT',
                                 'turnover24h': '316081.51527999',
                                 'volume24h': '69163390'},
                        'last': 0.0045,
                        'low': 0.004455,
                        'open': 0.004645,
                        'percentage': -3.1216,
                        'previousClose': None,
                        'quoteVolume': 316081.51527999,
                        'symbol': '10000NFT/USDT:USDT',
                        'timestamp': None,
                        'vwap': 0.004570069733134682},
```
```
Python v3.10.9
CCXT v2.8.93
bybit.fetchTickers() --spot
{'AAVE/USDT': {'ask': 0.0,
               'askVolume': 0.0,
               'average': 10000.0,
               'baseVolume': 0.0,
               'bid': 10000.0,
               'bidVolume': 0.057,
               'change': 0.0,
               'close': 10000.0,
               'datetime': None,
               'high': 10000.0,
               'info': {'ask1Price': '0',
                        'ask1Size': '0',
                        'bid1Price': '10000',
                        'bid1Size': '0.057',
                        'highPrice24h': '10000',
                        'lastPrice': '10000',
                        'lowPrice24h': '10000',
                        'prevPrice24h': '10000',
                        'price24hPcnt': '0',
                        'symbol': 'AAVEUSDT',
                        'turnover24h': '0',
                        'volume24h': '0'},
               'last': 10000.0,
               'low': 10000.0,
               'open': 10000.0,
               'percentage': 0.0,
               'previousClose': None,
               'quoteVolume': 0.0,
               'symbol': 'AAVE/USDT',
               'timestamp': None,
               'vwap': None},
```
