### PR TITLE
Exchange#safeOrder: remove no-op code.

### DIFF
--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -1195,11 +1195,8 @@ module.exports = class Exchange {
             // timeInForce is not undefined here
             postOnly = timeInForce === 'PO';
         }
-        let timestamp = this.safeInteger (order, 'timestamp');
+        const timestamp = this.safeInteger (order, 'timestamp');
         let datetime = this.safeString (order, 'datetime');
-        if (timestamp === undefined) {
-            timestamp = this.parse8601 (timestamp);
-        }
         if (datetime === undefined) {
             datetime = this.iso8601 (timestamp);
         }


### PR DESCRIPTION
The code being modified is

```
        let timestamp = this.safeInteger (order, 'timestamp');
        let datetime = this.safeString (order, 'datetime');
        if (timestamp === undefined) {
            timestamp = this.parse8601 (timestamp);
        }
```

If `datetime` is `undefined` then calling `this.parse8601(undefined)` also returns `undefined`.

Thinking if the code should change `===` to `!==, then if `datetime` is a defined value, then it'll be an integer. But `this.parse8601` will return `undefined` if it isn't passed a string:

```
const parse8601 = (x) => {
    if (typeof x !== 'string' || !x) {
        return undefined;
    }
```

So the code being deleted has no value.