### PR TITLE
bybit: patch fetchMarketLeverageTiers ccxt/ccxt#17055

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -7974,106 +7974,28 @@ module.exports = class bybit extends Exchange {
 
     parseMarketLeverageTiers (info, market) {
         //
-        //    Linear
-        //    [
-        //        {
-        //            id: '11',
-        //            symbol: 'ETHUSDT',
-        //            limit: '800000',
-        //            maintain_margin: '0.01',
-        //            starting_margin: '0.02',
-        //            section: [
-        //                '1',  '2',  '3',
-        //                '5',  '10', '15',
-        //                '25'
-        //            ],
-        //            is_lowest_risk: '1',
-        //            created_at: '2022-02-04 23:30:33.555252',
-        //            updated_at: '2022-02-04 23:30:33.555254',
-        //            max_leverage: '50'
-        //        },
-        //        ...
-        //    ]
-        //
-        //    Inverse
-        //    [
-        //        {
-        //            id: '180',
-        //            is_lowest_risk: '0',
-        //            section: [
-        //                '1', '2', '3',
-        //                '4', '5', '7',
-        //                '8', '9'
-        //            ],
-        //            symbol: 'ETHUSDH22',
-        //            limit: '30000',
-        //            max_leverage: '9',
-        //            starting_margin: '11',
-        //            maintain_margin: '5.5',
-        //            coin: 'ETH',
-        //            created_at: '2021-04-22T15:00:00Z',
-        //            updated_at: '2021-04-22T15:00:00Z'
-        //        }
-        //        ...
-        //    ]
-        //
-        // usdc swap
-        //
-        //    {
-        //        "riskId":"10001",
-        //        "symbol":"BTCPERP",
-        //        "limit":"1000000",
-        //        "startingMargin":"0.0100",
-        //        "maintainMargin":"0.0050",
-        //        "isLowestRisk":true,
-        //        "section":[
-        //           "1",
-        //           "2",
-        //           "3",
-        //           "5",
-        //           "10",
-        //           "25",
-        //           "50",
-        //           "100"
-        //        ],
-        //        "maxLeverage":"100.00"
-        //    }
-        //
-        // Unified Margin
-        //
-        //     [
-        //         {
-        //             "id": 1,
-        //             "symbol": "BTCUSDT",
-        //             "limit": "2000000",
-        //             "maintainMargin": "0.005",
-        //             "initialMargin": "0.01",
-        //             "section": [
-        //                 "1",
-        //                 "3",
-        //                 "5",
-        //                 "10",
-        //                 "25",
-        //                 "50",
-        //                 "80"
-        //             ],
-        //             "isLowestRisk": 1,
-        //             "maxLeverage": "100.00"
-        //         }
-        //     ]
+        //     {
+        //         "id": 1,
+        //         "symbol": "BTCUSD",
+        //         "riskLimitValue": "150",
+        //         "maintenanceMargin": "0.5",
+        //         "initialMargin": "1",
+        //         "isLowestRisk": 1,
+        //         "maxLeverage": "100.00"
+        //     }
         //
         let minNotional = 0;
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const item = info[i];
-            const maxNotional = this.safeNumber (item, 'limit');
+            const maxNotional = this.safeNumber (item, 'riskLimitValue');
             tiers.push ({
                 'tier': this.sum (i, 1),
                 'currency': market['base'],
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
-                'maintenanceMarginRate': this.safeNumber2 (item, 'maintain_margin', 'maintainMargin'),
-                'maxLeverage': this.safeNumber2 (item, 'max_leverage', 'maxLeverage'),
+                'maintenanceMarginRate': this.safeNumber (item, 'maintenanceMargin'),
+                'maxLeverage': this.safeNumber (item, 'maxLeverage'),
                 'info': item,
             });
             minNotional = maxNotional;


### PR DESCRIPTION
fix ccxt/ccxt#17055

```BASH
$ node examples/js/cli bybit fetchMarketLeverageTiers ETH/USDT:USDT

tier | currency | minNotional | maxNotional | maintenanceMarginRate | maxLeverage
---------------------------------------------------------------------------------
   1 |      ETH |           0 |      900000 |                 0.005 |         100
   2 |      ETH |      900000 |     1500000 |                  0.01 |          50
   3 |      ETH |     1500000 |     3000000 |                 0.015 |       36.37
   4 |      ETH |     3000000 |     4500000 |                  0.02 |       28.58
   5 |      ETH |     4500000 |     6000000 |                 0.025 |       23.53
   6 |      ETH |     6000000 |     7500000 |                  0.03 |          20
   7 |      ETH |     7500000 |     9000000 |                 0.035 |        17.4
   8 |      ETH |     9000000 |    10500000 |                  0.04 |       15.39
   9 |      ETH |    10500000 |    16000000 |                 0.045 |        13.8
  10 |      ETH |    16000000 |    18000000 |                  0.05 |        12.5
  11 |      ETH |    18000000 |    20000000 |                 0.055 |       11.43
  12 |      ETH |    20000000 |    22000000 |                  0.06 |       10.53
  13 |      ETH |    22000000 |    24000000 |                 0.065 |        9.76
  14 |      ETH |    24000000 |    26000000 |                  0.07 |         9.1
  15 |      ETH |    26000000 |    28000000 |                 0.075 |        8.52
  16 |      ETH |    28000000 |    30000000 |                  0.08 |           8
  17 |      ETH |    30000000 |    32000000 |                 0.085 |        7.55
  18 |      ETH |    32000000 |    34000000 |                  0.09 |        7.15
  19 |      ETH |    34000000 |    36000000 |                 0.095 |        6.78
  20 |      ETH |    36000000 |    38000000 |                   0.1 |        6.46
  21 |      ETH |    38000000 |    40000000 |                 0.105 |        6.16
  22 |      ETH |    40000000 |    42000000 |                  0.11 |        5.89
  23 |      ETH |    42000000 |    44000000 |                 0.115 |        5.64
  24 |      ETH |    44000000 |    46000000 |                  0.12 |        5.41
  25 |      ETH |    46000000 |    48000000 |                 0.125 |         5.2
  26 |      ETH |    48000000 |    50000000 |                  0.13 |           5
  27 |      ETH |    50000000 |    60000000 |                  0.18 |        3.33
  28 |      ETH |    60000000 |    75000000 |                   0.3 |           2
  29 |      ETH |    75000000 |   100000000 |                  0.42 |        1.43
  30 |      ETH |   100000000 |   200000000 |                   0.6 |           1
30 objects

```