### PR TITLE
fix(binance): increase default keep alive to 180000

### DIFF
--- a/js/pro/binance.js
+++ b/js/pro/binance.js
@@ -41,6 +41,9 @@ module.exports = class binance extends binanceRest {
                     },
                 },
             },
+            'streaming': {
+                'keepAlive': 180000,
+            },
             'options': {
                 'streamLimits': {
                     'spot': 50, // max 1024


### PR DESCRIPTION
This PR increases the default keep alive of binance streams to 3 minutes, to help the stability when connecting to multiple streams.

Binance spec for spot:
`The websocket server will send a ping frame every 3 minutes. If the websocket server does not receive a pong frame back from the connection within a 10 minute period, the connection will be disconnected. Unsolicited pong frames are allowed.`

Binace spec for for usdm, coinm and european options:
`The websocket server will send a ping frame every 5 minutes. If the websocket server does not receive a pong frame back from the connection within a 15 minute period, the connection will be disconnected. Unsolicited pong frames are allowed.`