### PR TITLE
bithumb fetchTickers fix

### DIFF
--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -433,10 +433,10 @@ module.exports = class bithumb extends Exchange {
             const currencyIds = Object.keys (tickers);
             for (let j = 0; j < currencyIds.length; j++) {
                 const currencyId = currencyIds[j];
-                const market = this.safeMarket (currencyId);
                 const ticker = data[currencyId];
                 const base = this.safeCurrencyCode (currencyId);
                 const symbol = base + '/' + quote;
+                const market = this.safeMarket (symbol);
                 ticker['date'] = timestamp;
                 result[symbol] = this.parseTicker (ticker, market);
             }

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -441,7 +441,7 @@ module.exports = class bithumb extends Exchange {
                 result[symbol] = this.parseTicker (ticker, market);
             }
         }
-        return result;
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     async fetchTicker (symbol, params = {}) {

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -399,46 +399,49 @@ module.exports = class bithumb extends Exchange {
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols);
-        const response = await this.publicGetTickerAll (params);
-        //
-        //     {
-        //         "status":"0000",
-        //         "data":{
-        //             "BTC":{
-        //                 "opening_price":"9045000",
-        //                 "closing_price":"9132000",
-        //                 "min_price":"8938000",
-        //                 "max_price":"9168000",
-        //                 "units_traded":"4619.79967497",
-        //                 "acc_trade_value":"42021363832.5187",
-        //                 "prev_closing_price":"9041000",
-        //                 "units_traded_24H":"8793.5045804",
-        //                 "acc_trade_value_24H":"78933458515.4962",
-        //                 "fluctate_24H":"530000",
-        //                 "fluctate_rate_24H":"6.16"
-        //             },
-        //             "date":"1587710878669"
-        //         }
-        //     }
-        //
-        const result = {};
-        const data = this.safeValue (response, 'data', {});
-        const timestamp = this.safeInteger (data, 'date');
-        const tickers = this.omit (data, 'date');
-        const ids = Object.keys (tickers);
-        for (let i = 0; i < ids.length; i++) {
-            const id = ids[i];
-            const market = this.safeMarket (id);
-            const symbol = market['symbol'];
-            const ticker = tickers[id];
-            const isArray = Array.isArray (ticker);
-            if (!isArray) {
+        const result = [];
+        const quoteCurrencies = this.safeValue (this.options, 'quoteCurrencies', {});
+        const quotes = Object.keys (quoteCurrencies);
+        for (let i = 0; i < quotes.length; i++) {
+            const quote = quotes[i];
+            const method = 'publicGetTickerALL' + quote;
+            const response = await this[method] (params);
+            //
+            //     {
+            //         "status":"0000",
+            //         "data":{
+            //             "BTC":{
+            //                 "opening_price":"9045000",
+            //                 "closing_price":"9132000",
+            //                 "min_price":"8938000",
+            //                 "max_price":"9168000",
+            //                 "units_traded":"4619.79967497",
+            //                 "acc_trade_value":"42021363832.5187",
+            //                 "prev_closing_price":"9041000",
+            //                 "units_traded_24H":"8793.5045804",
+            //                 "acc_trade_value_24H":"78933458515.4962",
+            //                 "fluctate_24H":"530000",
+            //                 "fluctate_rate_24H":"6.16"
+            //             },
+            //             "date":"1587710878669"
+            //         }
+            //     }
+            //
+            const data = this.safeValue (response, 'data', {});
+            const timestamp = this.safeInteger (data, 'date');
+            const tickers = this.omit (data, 'date');
+            const currencyIds = Object.keys (tickers);
+            for (let j = 0; j < currencyIds.length; j++) {
+                const currencyId = currencyIds[j];
+                const market = this.safeMarket (currencyId);
+                const ticker = data[currencyId];
+                const base = this.safeCurrencyCode (currencyId);
+                const symbol = base + '/' + quote;
                 ticker['date'] = timestamp;
                 result[symbol] = this.parseTicker (ticker, market);
             }
         }
-        return this.filterByArray (result, 'symbol', symbols);
+        return result;
     }
 
     async fetchTicker (symbol, params = {}) {

--- a/js/bithumb.js
+++ b/js/bithumb.js
@@ -399,7 +399,7 @@ module.exports = class bithumb extends Exchange {
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         await this.loadMarkets ();
-        const result = [];
+        const result = {};
         const quoteCurrencies = this.safeValue (this.options, 'quoteCurrencies', {});
         const quotes = Object.keys (quoteCurrencies);
         for (let i = 0; i < quotes.length; i++) {


### PR DESCRIPTION
https://apidocs.bithumb.com/reference/%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C-all

now we use only this https://api.bithumb.com/public/ticker/ALL response which is equal to https://api.bithumb.com/public/ticker/ALL_KRW

We also need to parse https://api.bithumb.com/public/ticker/ALL_BTC to get all pairs