### PR TITLE
fix(bybit): spot order amount precision

### DIFF
--- a/js/bybit.js
+++ b/js/bybit.js
@@ -3497,6 +3497,14 @@ module.exports = class bybit extends Exchange {
     async createSpotOrder (symbol, type, side, amount, price = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const upperCaseType = type.toUpperCase ();
+        const request = {
+            'symbol': market['id'],
+            'side': this.capitalize (side),
+            'orderType': upperCaseType, // limit, market or limit_maker
+            'timeInForce': 'GTC', // FOK, IOC
+            // 'orderLinkId': 'string', // unique client order id, max 36 characters
+        };
         if ((type === 'market') && (side === 'buy')) {
             // for market buy it requires the amount of quote currency to spend
             if (this.options['createMarketBuyOrderRequiresPrice']) {
@@ -3509,18 +3517,12 @@ module.exports = class bybit extends Exchange {
                     const priceString = this.numberToString (price);
                     const quoteAmount = Precise.stringMul (amountString, priceString);
                     amount = (cost !== undefined) ? cost : this.parseNumber (quoteAmount);
+                    request['orderQty'] = this.costToPrecision (symbol, amount);
                 }
             }
+        } else {
+            request['orderQty'] = this.amountToPrecision (symbol, amount);
         }
-        const upperCaseType = type.toUpperCase ();
-        const request = {
-            'symbol': market['id'],
-            'side': this.capitalize (side),
-            'orderType': upperCaseType, // limit, market or limit_maker
-            'timeInForce': 'GTC', // FOK, IOC
-            'orderQty': this.amountToPrecision (symbol, amount),
-            // 'orderLinkId': 'string', // unique client order id, max 36 characters
-        };
         if ((upperCaseType === 'LIMIT') || (upperCaseType === 'LIMIT_MAKER')) {
             if (price === undefined) {
                 throw new InvalidOrder (this.id + ' createOrder requires a price argument for a ' + type + ' order');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17085

DEMO

```
 p bybit createSpotOrder "LTC/USDT" market buy 1 10 --sandbox
Python v3.10.9
CCXT v2.9.7
bybit.createSpotOrder(LTC/USDT,market,buy,1,10)
{'amount': None,
 'average': None,
 'clientOrderId': '1678293588780633',
 'cost': None,
 'datetime': '2023-03-08T16:39:48.790Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '1372020497786625280',
 'info': {'accountId': '551167',
          'createTime': '1678293588790',
          'execQty': '0',
          'orderCategory': '0',
          'orderId': '1372020497786625280',
          'orderLinkId': '1678293588780633',
          'orderPrice': '0',
          'orderQty': '10',
          'orderType': 'MARKET',
          'side': 'BUY',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1678293588790,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
```
p bybit createSpotOrder "LTC/USDT" market sell 0.2 --sandbox
Python v3.10.9
CCXT v2.9.7
bybit.createSpotOrder(LTC/USDT,market,sell,0.2)
{'amount': 0.2,
 'average': None,
 'clientOrderId': '1678293613070690',
 'cost': None,
 'datetime': '2023-03-08T16:40:13.080Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '1372020701545904640',
 'info': {'accountId': '551167',
          'createTime': '1678293613080',
          'execQty': '0',
          'orderCategory': '0',
          'orderId': '1372020701545904640',
          'orderLinkId': '1678293613070690',
          'orderPrice': '0',
          'orderQty': '0.2',
          'orderType': 'MARKET',
          'side': 'SELL',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': None,
 'reduceOnly': None,
 'remaining': 0.2,
 'side': 'sell',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1678293613080,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
```
 p bybit createSpotOrder "LTC/USDT" market buy 0.2 50 --sandbox
Python v3.10.9
CCXT v2.9.7
bybit.createSpotOrder(LTC/USDT,market,buy,0.2,50)
{'amount': None,
 'average': None,
 'clientOrderId': '1678293637115663',
 'cost': None,
 'datetime': '2023-03-08T16:40:37.124Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '1372020903241604352',
 'info': {'accountId': '551167',
          'createTime': '1678293637124',
          'execQty': '0',
          'orderCategory': '0',
          'orderId': '1372020903241604352',
          'orderLinkId': '1678293637115663',
          'orderPrice': '0',
          'orderQty': '10',
          'orderType': 'MARKET',
          'side': 'BUY',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1678293637124,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
