### PR TITLE
bitmex.parseLedgerEntry string math

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -955,9 +955,9 @@ export default class bitmex extends Exchange {
             'referenceAccount': referenceAccount,
             'type': type,
             'currency': code,
-            'amount': this.safeNumber (amount),
-            'before': this.safeNumber (before),
-            'after': this.safeNumber (after),
+            'amount': this.parseNumber (amount),
+            'before': this.parseNumber (before),
+            'after': this.parseNumber (after),
             'status': status,
             'fee': fee,
         };

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -911,9 +911,9 @@ export default class bitmex extends Exchange {
         const type = this.parseLedgerEntryType (this.safeString (item, 'transactType'));
         const currencyId = this.safeString (item, 'currency');
         const code = this.safeCurrencyCode (currencyId, currency);
-        let amount = this.safeNumber (item, 'amount');
+        let amount = this.safeString (item, 'amount');
         if (amount !== undefined) {
-            amount = amount / 100000000;
+            amount = Precise.stringDiv (amount, '100000000');
         }
         let timestamp = this.parse8601 (this.safeString (item, 'transactTime'));
         if (timestamp === undefined) {
@@ -922,23 +922,24 @@ export default class bitmex extends Exchange {
             // for unrealized pnl and other transactions without a timestamp
             timestamp = 0; // see comments above
         }
-        let feeCost = this.safeNumber (item, 'fee', 0);
+        let feeCost = this.safeString (item, 'fee', 0);
         if (feeCost !== undefined) {
-            feeCost = feeCost / 100000000;
+            feeCost = Precise.stringDiv (feeCost, '100000000');
         }
         const fee = {
-            'cost': feeCost,
+            'cost': this.parseNumber (feeCost),
             'currency': code,
         };
-        let after = this.safeNumber (item, 'walletBalance');
+        let after = this.safeString (item, 'walletBalance');
         if (after !== undefined) {
-            after = after / 100000000;
+            after = Precise.stringDiv (after, '100000000');
         }
-        const before = this.sum (after, -amount);
+        const negativeAmount = Precise.stringNeg (amount);
+        const before = Precise.stringAdd (after, negativeAmount);
         let direction = undefined;
-        if (amount < 0) {
+        if (Precise.stringLt (amount, '0')) {
             direction = 'out';
-            amount = Math.abs (amount);
+            amount = Precise.stringAbs (amount);
         } else {
             direction = 'in';
         }
@@ -954,9 +955,9 @@ export default class bitmex extends Exchange {
             'referenceAccount': referenceAccount,
             'type': type,
             'currency': code,
-            'amount': amount,
-            'before': before,
-            'after': after,
+            'amount': this.safeNumber (amount),
+            'before': this.safeNumber (before),
+            'after': this.safeNumber (after),
             'status': status,
             'fee': fee,
         };

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -922,7 +922,7 @@ export default class bitmex extends Exchange {
             // for unrealized pnl and other transactions without a timestamp
             timestamp = 0; // see comments above
         }
-        let feeCost = this.safeString (item, 'fee', 0);
+        let feeCost = this.safeString (item, 'fee');
         if (feeCost !== undefined) {
             feeCost = Precise.stringDiv (feeCost, '100000000');
         }


### PR DESCRIPTION
```
% bitmex fetchLedger                                           
Debugger listening on ws://127.0.0.1:59921/c0d54edd-6a2e-4949-93e2-824a10faddb7
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
(node:35296) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-03-13T23:52:44.889Z
Node.js: v18.9.0
CCXT v3.0.1
bitmex.fetchLedger ()
2023-03-13T23:52:50.352Z iteration 0 passed in 1966 ms

                                  id |     timestamp |                 datetime | direction | account |                          referenceId | referenceAccount |       type | currency |  amount | before |   after | status |                fee
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
db2bc8a7-0dc5-9d58-1b2e-0a078f0017b5 | 1664838369756 | 2022-10-03T23:06:09.756Z |        in | 1833101 | 342fe3bc-a048-4c57-b97d-7470752cce79 |                  | Conversion |      BTC | 0.00127 |      0 | 0.00127 |     ok | {"currency":"BTC"}
1 objects
2023-03-13T23:52:50.352Z iteration 1 passed in 1966 ms
```