### PR TITLE
fix(Bitfinex2): authenticate and watchOrders

### DIFF
--- a/js/pro/bitfinex2.js
+++ b/js/pro/bitfinex2.js
@@ -966,13 +966,15 @@ module.exports = class bitfinex2 extends bitfinex2Rest {
         } else {
             const parsed = this.parseWsOrder (data);
             orders.append (parsed);
+            const symbol = parsed['symbol'];
+            symbolIds[symbol] = true;
         }
         const name = 'orders';
         client.resolve (this.orders, name);
         const keys = Object.keys (symbolIds);
         for (let i = 0; i < keys.length; i++) {
             const symbol = keys[i];
-            const market = this.safeMarket (symbol);
+            const market = this.market (symbol);
             const messageHash = name + ':' + market['id'];
             client.resolve (this.orders, messageHash);
         }
@@ -1029,7 +1031,7 @@ module.exports = class bitfinex2 extends bitfinex2Rest {
         const clientOrderId = this.safeString (order, 1);
         const marketId = this.safeString (order, 3);
         const symbol = this.safeSymbol (marketId);
-        market = this.safeMarket (symbol);
+        market = this.safeMarket (marketId);
         let amount = this.safeNumber (order, 7);
         let side = 'buy';
         if (amount < 0) {

--- a/js/pro/bitfinex2.js
+++ b/js/pro/bitfinex2.js
@@ -841,7 +841,7 @@ module.exports = class bitfinex2 extends bitfinex2Rest {
     authenticate (params = {}) {
         const url = this.urls['api']['ws']['private'];
         const client = this.client (url);
-        const messageHash = 'authenticate';
+        const messageHash = 'authenticated';
         let future = this.safeValue (client.subscriptions, messageHash);
         if (future === undefined) {
             const nonce = this.milliseconds ();


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17101
Demo
```
p bitfinex2 watchOrders "LTC/USDT"   
Python v3.10.9
CCXT v2.9.10
bitfinex2.watchOrders(LTC/USDT)
[{'amount': 0.1,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-03-09T17:34:55.267Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '114945890678',
  'info': [114945890678,
           None,
           1678383295267,
           'tLTCUST',
           1678383295267,
           1678383295268,
           0.1,
           0.1,
           'EXCHANGE LIMIT',
           None,
           None,
           None,
           0,
           'ACTIVE',
           None,
           None,
           40,
           0,
           0,
           0,
           None,
           None,
           None,
           0,
           0,
           None,
           None,
           None,
           'API>BFX',
           None,
           None,
           {}],
  'lastTradeTimestamp': None,
  'postOnly': None,
  'price': 40.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'timeInForce': None,
  'timestamp': 1678383295267,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
