### PR TITLE
gate remove TON mapping

### DIFF
--- a/js/gate.js
+++ b/js/gate.js
@@ -424,7 +424,6 @@ module.exports = class gate extends Exchange {
                 'RAI': 'Rai Reflex Index', // conflict with RAI Finance
                 'SBTC': 'Super Bitcoin',
                 'TNC': 'Trinity Network Credit',
-                'TON': 'TONToken',
                 'VAI': 'VAIOT',
             },
             'requiredCredentials': {


### PR DESCRIPTION
https://www.gate.io/article/29890
Probably old TON (TONToken) was delisted and now TON is https://www.coingecko.com/en/coins/toncoin#markets like on other exchanges