### PR TITLE
feat: add docsify

### DIFF
--- a/wiki/_coverpage.md
+++ b/wiki/_coverpage.md
@@ -1,0 +1,14 @@
+![logo](https://user-images.githubusercontent.com/1294454/112665445-2008ec80-8e6c-11eb-9647-623a347ddade.png)
+
+# CCXT
+
+> CryptoCurrency eXchange Trading Library.
+
+- support for many cryptocurrency exchanges
+- fully implemented public and private APIs
+- optional normalized data for cross-exchange analytics and arbitrage
+- an out of the box unified API that is extremely easy to integrate
+- works in Node 10.4+, Python 3, PHP 8.1+, and web browsers
+
+[GitHub](https://github.com/ccxt/ccxt/)
+[Get Started](#Overview)

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,6 @@
+* [Supported Exchanges](Exchange-Markets.md)
+* [Exchanges By Country](Exchange-Markets-By-Country.md)
+* [Install](Install.md)
+* [Manual](Manual.md)
+* [Ccxt.pro](ccxt.pro.md)
+* [FAQ](FAQ.md)

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>ccxt - documentation</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="description" content="ccxt documen" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
+    />
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      window.$docsify = {
+        name: "ccxt",
+        repo: "ccxt/ccxt",
+        search: "auto",
+        homepage: 'Manual.md',
+        logo: 'https://user-images.githubusercontent.com/1294454/112665445-2008ec80-8e6c-11eb-9647-623a347ddade.png',
+        loadSidebar: true,
+        subMaxLevel: 3,
+        coverpage: true,
+        onlyCover: false,
+      };
+    </script>
+    <!-- Docsify v4 -->
+    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+    <!-- Plugins -->
+    <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-php.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-python.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
- Tried to implement docsify with no impact to current docs or build scripts

### How to test
- Install docsify: `npm i docsify-cli -g`
- Serve docs: `docsify serve wiki`

### Todo
- Deployment to https://docs.ccxt.com  Here are the deploy docs: (https://docsify.js.org/#/deploy) Would be happy to implement but couldn't found how we currently deploy.
- After merge need to update code blocks languages to lowercase for plugin to correctly highlight code. (i.e Python to python) 

### Screenshots
![image](https://user-images.githubusercontent.com/12142844/224522043-951ccd3a-6e1e-4264-9610-e2a4036bbc6d.png)
![image](https://user-images.githubusercontent.com/12142844/224522056-eb00e836-9f14-4b93-8759-f3320e1df6cb.png)
