### PR TITLE
package.json: set node version to 15.0.0 in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     }
   },
   "engines": {
-    "node": ">=10.4.0"
+    "node": ">=15.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com"


### PR DESCRIPTION
AbortController was supported after 15.0.0 (https://nodejs.org/docs/latest-v15.x/api/globals.html#globals_class_abortcontroller). If user use the version before that, they'll see error `AbortController is not constructor`.

In this PR, I update nodejs version in package.json