### PR TITLE
fix(bybit): v5 uta spot market buy

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3315,7 +3315,7 @@ export default class bybit extends Exchange {
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         const accounts = await this.isUnifiedEnabled ();
-        const isUnifiedAccount = this.safeValue (accounts, 0, false);
+        const isUnifiedAccount = this.safeValue (accounts, 1, false);
         if (isUnifiedAccount) {
             throw new NotSupported (this.id + ' fetchOrder() does not support unified account. Please consider using fetchOpenOrders() or fetchClosedOrders()');
         }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3417,7 +3417,6 @@ export default class bybit extends Exchange {
             'symbol': market['id'],
             'side': this.capitalize (side),
             'orderType': this.capitalize (lowerCaseType), // limit or market
-
             // 'timeInForce': 'GTC', // IOC, FOK, PostOnly
             // 'takeProfit': 123.45, // take profit price, only take effect upon opening the position
             // 'stopLoss': 123.45, // stop loss price, only take effect upon opening the position

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3417,7 +3417,7 @@ export default class bybit extends Exchange {
             'symbol': market['id'],
             'side': this.capitalize (side),
             'orderType': this.capitalize (lowerCaseType), // limit or market
-            'qty': this.amountToPrecision (symbol, amount),
+
             // 'timeInForce': 'GTC', // IOC, FOK, PostOnly
             // 'takeProfit': 123.45, // take profit price, only take effect upon opening the position
             // 'stopLoss': 123.45, // stop loss price, only take effect upon opening the position
@@ -3447,6 +3447,24 @@ export default class bybit extends Exchange {
             request['category'] = 'option';
         } else {
             throw new NotSupported (this.id + ' createOrder does not allow inverse market orders for ' + symbol + ' markets');
+        }
+        if (market['spot'] && (type === 'market') && (side === 'buy')) {
+            // for market buy it requires the amount of quote currency to spend
+            if (this.options['createMarketBuyOrderRequiresPrice']) {
+                const cost = this.safeNumber (params, 'cost');
+                params = this.omit (params, 'cost');
+                if (price === undefined && cost === undefined) {
+                    throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
+                } else {
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    const quoteAmount = Precise.stringMul (amountString, priceString);
+                    amount = (cost !== undefined) ? cost : this.parseNumber (quoteAmount);
+                    request['qty'] = this.costToPrecision (symbol, amount);
+                }
+            }
+        } else {
+            request['qty'] = this.amountToPrecision (symbol, amount);
         }
         const isMarket = lowerCaseType === 'market';
         const isLimit = lowerCaseType === 'limit';

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3314,6 +3314,11 @@ export default class bybit extends Exchange {
         }
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
+        const accounts = await this.isUnifiedEnabled ();
+        const isUnifiedAccount = this.safeValue (accounts, 0, false);
+        if (isUnifiedAccount) {
+            throw new NotSupported (this.id + ' fetchOrder() does not support unified account. Please consider using fetchOpenOrders() or fetchClosedOrders()');
+        }
         if (type === 'spot') {
             // only spot markets have a dedicated endpoint for fetching a order
             const request = {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17164

DEMO
```
p bybit createOrder "BTC/USDT" market buy 7 1 --sandbox                 
Python v3.10.9
CCXT v3.0.4
bybit.createOrder(BTC/USDT,market,buy,7,1)
{'amount': None,
 'average': None,
 'clientOrderId': '1678790796730675',
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '1376191380340086272',
 'info': {'orderId': '1376191380340086272', 'orderLinkId': '1678790796730675'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
```
p bybit createOrder "BTC/USDT" market sell 0.001 --sandbox
Python v3.10.9
CCXT v3.0.4
bybit.createOrder(BTC/USDT,market,sell,0.001)
{'amount': None,
 'average': None,
 'clientOrderId': '1678790813297818',
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '1376191519314155008',
 'info': {'orderId': '1376191519314155008', 'orderLinkId': '1678790813297818'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
```
 p bybit createOrder "BTC/USDT:USDT" market buy 0.001 --sandbox 
Python v3.10.9
CCXT v3.0.4
bybit.createOrder(BTC/USDT:USDT,market,buy,0.001)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '3a5c67ba-f24e-47e7-93e4-2ae7a61217f2',
 'info': {'orderId': '3a5c67ba-f24e-47e7-93e4-2ae7a61217f2', 'orderLinkId': ''},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
```
p bybit createOrder "BTC/USDT:USDT" market sell 0.001 --sandbox
Python v3.10.9
CCXT v3.0.4
bybit.createOrder(BTC/USDT:USDT,market,sell,0.001)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '38723d7c-c727-4d2d-8402-558a35eef5a1',
 'info': {'orderId': '38723d7c-c727-4d2d-8402-558a35eef5a1', 'orderLinkId': ''},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
