### PR TITLE
feat(TS): improve types [ci deploy]

### DIFF
--- a/build/export-exchanges.js
+++ b/build/export-exchanges.js
@@ -409,7 +409,8 @@ async function exportEverything () {
     const flat = flatten (errorHierarchy['default'])
     flat.push ('error_hierarchy')
 
-    const staticExports = ['version', 'Exchange', 'exchanges', 'pro', 'Precise', 'functions', 'errors'] // missing  'exportExchanges' 
+    const typeExports = ['Market', 'Trade' , 'Fee', 'Ticker', 'OrderBook', 'Order', 'Transaction', 'Tickers', 'Currency', 'Balance', 'DepositAddress', 'WithdrawalResponse', 'DepositAddressResponse', 'OHLCV' ]
+    const staticExports = ['version', 'Exchange', 'exchanges', 'pro', 'Precise', 'functions', 'errors'].concat(typeExports)
 
     const fullExports  = staticExports.concat(ids)
 

--- a/ts/ccxt.ts
+++ b/ts/ccxt.ts
@@ -33,6 +33,7 @@ import { Exchange }  from './src/base/Exchange.js'
 import { Precise }   from './src/base/Precise.js'
 import * as functions from './src/base/functions.js'
 import * as errors   from './src/base/errors.js'
+import { Market, Trade , Fee, Ticker, OrderBook, Order, Transaction, Tickers, Currency, Balance, DepositAddress, WithdrawalResponse, DepositAddressResponse, OHLCV } from './src/base/types.js'
 
 //-----------------------------------------------------------------------------
 // this is updated by vss.js when building
@@ -406,6 +407,20 @@ export {
     Precise,
     functions,
     errors,
+    Market,
+    Trade,
+    Fee,
+    Ticker,
+    OrderBook,
+    Order,
+    Transaction,
+    Tickers,
+    Currency,
+    Balance,
+    DepositAddress,
+    WithdrawalResponse,
+    DepositAddressResponse,
+    OHLCV,
     ace,
     alpaca,
     ascendex,

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -1815,7 +1815,7 @@ export default class ascendex extends Exchange {
             const order = this.parseOrder (data[i], market);
             orders.push (order);
         }
-        return this.filterBySymbolSinceLimit (orders, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (orders, symbol, since, limit) as any;
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3117,7 +3117,7 @@ export default class Exchange {
         return this.safeValue (config, 'cost', 1);
     }
 
-    async fetchTicker (symbol: string, params = {}) {
+    async fetchTicker (symbol: string, params = {}): Promise<Ticker> {
         if (this.has['fetchTickers']) {
             await this.loadMarkets ();
             const market = this.market (symbol);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3163,19 +3163,19 @@ export default class Exchange {
         return this.cancelOrder (this.safeValue (order, 'id'), this.safeValue (order, 'symbol'), params);
     }
 
-    async fetchOrders (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<any> {
+    async fetchOrders (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<Order[]> {
         throw new NotSupported (this.id + ' fetchOrders() is not supported yet');
     }
 
-    async fetchOpenOrders (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<any> {
+    async fetchOpenOrders (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<Order[]> {
         throw new NotSupported (this.id + ' fetchOpenOrders() is not supported yet');
     }
 
-    async fetchClosedOrders (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<any> {
+    async fetchClosedOrders (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<Order[]> {
         throw new NotSupported (this.id + ' fetchClosedOrders() is not supported yet');
     }
 
-    async fetchMyTrades (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<any> {
+    async fetchMyTrades (symbol = undefined, since: number = undefined, limit: number = undefined, params = {}): Promise<Trade[]> {
         throw new NotSupported (this.id + ' fetchMyTrades() is not supported yet');
     }
 

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -144,7 +144,7 @@ import { OrderBook, IndexedOrderBook, CountedOrderBook } from './ws/OrderBook.js
 //
 
 // import types
-import {Market, Trade, Fee, Ticker} from './types'
+import {Market, Trade, Fee, Ticker, OHLCV} from './types'
 export {Market, Trade, Fee, Ticker} from './types'
 
 
@@ -1989,7 +1989,7 @@ export default class Exchange {
         };
     }
 
-    safeTrade (trade: Trade, market: object = undefined): Trade {
+    safeTrade (trade: object, market: object = undefined): Trade {
         const amount = this.safeString (trade, 'amount');
         const price = this.safeString (trade, 'price');
         let cost = this.safeString (trade, 'cost');
@@ -2188,7 +2188,7 @@ export default class Exchange {
         });
     }
 
-    async fetchOHLCV (symbol: string, timeframe = '1m', since: number = undefined, limit: number = undefined, params = {}) {
+    async fetchOHLCV (symbol: string, timeframe = '1m', since: number = undefined, limit: number = undefined, params = {}): Promise<OHLCV[]> {
         if (!this.has['fetchTrades']) {
             throw new NotSupported (this.id + ' fetchOHLCV() is not supported yet');
         }
@@ -2534,14 +2534,14 @@ export default class Exchange {
         } as any;
     }
 
-    parseOHLCVs (ohlcvs: object[], market: string = undefined, timeframe: string = '1m', since: number = undefined, limit: number = undefined) {
+    parseOHLCVs (ohlcvs: object[], market: string = undefined, timeframe: string = '1m', since: number = undefined, limit: number = undefined): OHLCV[] {
         const results = [];
         for (let i = 0; i < ohlcvs.length; i++) {
             results.push (this.parseOHLCV (ohlcvs[i], market));
         }
         const sorted = this.sortBy (results, 0);
         const tail = (since === undefined);
-        return this.filterBySinceLimit (sorted, since, limit, 0, tail);
+        return this.filterBySinceLimit (sorted, since, limit, 0, tail) as any;
     }
 
     parseLeverageTiers (response, symbols = undefined, marketIdKey = undefined) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -144,7 +144,7 @@ import { OrderBook, IndexedOrderBook, CountedOrderBook } from './ws/OrderBook.js
 //
 
 // import types
-import {Market, Trade, Fee, Ticker, OHLCV} from './types'
+import {Market, Trade, Fee, Ticker, OHLCV, Order} from './types'
 export {Market, Trade, Fee, Ticker} from './types'
 
 
@@ -1172,7 +1172,7 @@ export default class Exchange {
             return undefined;
         }
 
-        parseOrder (order, market = undefined) {
+        parseOrder (order, market = undefined): Order {
             return undefined;
         }
 
@@ -1894,7 +1894,7 @@ export default class Exchange {
         });
     }
 
-    parseOrders (orders: object, market: object = undefined, since: number = undefined, limit: number = undefined, params = {}) {
+    parseOrders (orders: object, market: object = undefined, since: number = undefined, limit: number = undefined, params = {}): Order[] {
         //
         // the value of orders is either a dict or a list
         //
@@ -1933,7 +1933,7 @@ export default class Exchange {
         results = this.sortBy (results, 'timestamp');
         const symbol = (market !== undefined) ? market['symbol'] : undefined;
         const tail = since === undefined;
-        return this.filterBySymbolSinceLimit (results, symbol, since, limit, tail);
+        return this.filterBySymbolSinceLimit (results, symbol, since, limit, tail) as Order[];
     }
 
     calculateFee (symbol: string, type: string, side: string, amount: number, price: number, takerOrMaker = 'taker', params = {}) {
@@ -3138,7 +3138,7 @@ export default class Exchange {
         throw new NotSupported (this.id + ' fetchTickers() is not supported yet');
     }
 
-    async fetchOrder (id: string, symbol: string = undefined, params = {}): Promise<any> {
+    async fetchOrder (id: string, symbol: string = undefined, params = {}): Promise<Order> {
         throw new NotSupported (this.id + ' fetchOrder() is not supported yet');
     }
 
@@ -3151,7 +3151,7 @@ export default class Exchange {
         return await this.fetchOrder (this.safeValue (order, 'id'), this.safeValue (order, 'symbol'), params);
     }
 
-    async createOrder (symbol, type, side, amount, price = undefined, params = {}): Promise<any> {
+    async createOrder (symbol, type, side, amount, price = undefined, params = {}): Promise<Order> {
         throw new NotSupported (this.id + ' createOrder() is not supported yet');
     }
 

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -1,6 +1,107 @@
+interface Dictionary<T> {
+    [key: string]: T;
+}
+/** Request parameters */
+// type Params = Dictionary<string | number | boolean | string[]>;
+
 export interface MinMax {
     min: number | undefined;
     max: number | undefined;
+}
+
+export interface Fee {
+    type?: 'taker' | 'maker' | string;
+    currency: string;
+    rate?: number;
+    cost: number;
+}
+
+export interface Market {
+    id: string;
+    symbol: string;
+    base: string;
+    quote: string;
+    baseId: string;
+    quoteId: string;
+    active?: boolean | undefined;
+    type?: string;
+    spot?: boolean;
+    margin?: boolean;
+    swap?: boolean;
+    future?: boolean;
+    option?: boolean;
+    contract?: boolean;
+    settle?: string | undefined;
+    settleId?: string | undefined;
+    contractSize?: number | undefined;
+    linear?: boolean | undefined;
+    inverse?: boolean | undefined;
+    expiry?: number | undefined;
+    expiryDatetime?: string | undefined;
+    strike?: number | undefined;
+    optionType?: string | undefined;
+    taker?: number | undefined;
+    maker?: number | undefined;
+    percentage?: boolean | undefined;
+    tierBased?: boolean | undefined;
+    feeSide?: string | undefined;
+    precision: {
+        amount: number | undefined,
+        price: number | undefined
+    };
+    limits: {
+        amount?: MinMax,
+        cost?: MinMax,
+        leverage?: MinMax,
+        price?: MinMax,
+    };
+    info: any;
+}
+
+export interface Trade {
+    amount: number;                  // amount of base currency
+    datetime: string;                // ISO8601 datetime with milliseconds;
+    id: string;                      // string trade id
+    info: any;                        // the original decoded JSON as is
+    order?: string;                  // string order id or undefined/None/null
+    price: number;                   // float price in quote currency
+    timestamp: number;               // Unix timestamp in milliseconds
+    type?: string;                   // order type, 'market', 'limit', ... or undefined/None/null
+    side: 'buy' | 'sell' | string;            // direction of the trade, 'buy' or 'sell'
+    symbol: string;                  // symbol in CCXT format
+    takerOrMaker: 'taker' | 'maker' | string; // string, 'taker' or 'maker'
+    cost: number;                    // total cost (including fees), `price * amount`
+    fee: Fee;
+}
+
+export interface Order {
+    id: string;
+    clientOrderId: string;
+    datetime: string;
+    timestamp: number;
+    lastTradeTimestamp: number;
+    status: 'open' | 'closed' | 'canceled' | string;
+    symbol: string;
+    type: string;
+    timeInForce?: string;
+    side: 'buy' | 'sell' | string;
+    price: number;
+    average?: number;
+    amount: number;
+    filled: number;
+    remaining: number;
+    cost: number;
+    trades: Trade[];
+    fee: Fee;
+    info: any;
+}
+
+export interface OrderBook {
+    asks: [number, number][];
+    bids: [number, number][];
+    datetime: string;
+    timestamp: number;
+    nonce: number;
 }
 
 export interface Ticker {
@@ -26,77 +127,63 @@ export interface Ticker {
     baseVolume?: number;
 }
 
-export interface Market {
-        id: string;
-        symbol: string;
-        base: string;
-        quote: string;
-        baseId: string;
-        quoteId: string;
-        active?: boolean | undefined;
-        type?: string;
-        spot?: boolean;
-        margin?: boolean;
-        swap?: boolean;
-        future?: boolean;
-        option?: boolean;
-        contract?: boolean;
-        settle?: string | undefined;
-        settleId?: string | undefined;
-        contractSize?: number | undefined;
-        linear?: boolean | undefined;
-        inverse?: boolean | undefined;
-        expiry?: number | undefined;
-        expiryDatetime?: string | undefined;
-        strike?: number | undefined;
-        optionType?: string | undefined;
-        taker?: number | undefined;
-        maker?: number | undefined;
-        percentage?: boolean | undefined;
-        tierBased?: boolean | undefined;
-        feeSide?: string | undefined;
-        precision: {
-            amount: number | undefined,
-            price: number | undefined
-        };
-        limits: {
-            amount?: MinMax,
-            cost?: MinMax,
-            leverage?: MinMax,
-            price?: MinMax,
-        };
-        info: any;
-}
-
-export interface OrderBook {
-    symbol: string;
-    asks: [number, number][];
-    bids: [number, number][];
-    datetime: string;
-    timestamp: number;
-    nonce: number;
-}
-
-export interface Fee {
-    type?: 'taker' | 'maker';
-    currency: string;
-    rate?: number | string;
-    cost: number | string;
-}
-
-export interface Trade {
-    amount: number | string;
-    datetime: string;
-    id: string;
+export interface Transaction {
     info: any;
-    order?: string;
-    price: number| string;
+    id: string;
+    txid?: string;
     timestamp: number;
-    type?: string;
-    side: 'buy' | 'sell' | string; // tmp
-    symbol: string;
-    takerOrMaker: 'taker' | 'maker' | string; // tmp
-    cost: number | string;
+    datetime: string;
+    address: string;
+    type: 'deposit' | 'withdrawal' | string;
+    amount: number;
+    currency: string;
+    status: 'pending' | 'ok' | string;
+    updated: number;
     fee: Fee;
-    fees?: Fee[];
 }
+
+export interface Tickers extends Dictionary<Ticker> {
+    info: any;
+}
+
+export interface Currency {
+    id: string;
+    code: string;
+    numericId?: number;
+    precision: number;
+}
+
+export interface Balance {
+    free: number;
+    used: number;
+    total: number;
+}
+
+export interface PartialBalances extends Dictionary<number> {
+}
+
+export interface Balances extends Dictionary<Balance> {
+    info: any;
+}
+
+export interface DepositAddress {
+    currency: string;
+    address: string;
+    status: string;
+    info: any;
+}
+
+export interface WithdrawalResponse {
+    info: any;
+    id: string;
+}
+
+export interface DepositAddressResponse {
+    currency: string;
+    address: string;
+    info: any;
+    tag?: string;
+}
+
+/** [ timestamp, open, high, low, close, volume ] */
+export type OHLCV = [number, number, number, number, number, number];

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -965,18 +965,6 @@ export default class bitfinex2 extends Exchange {
         return currencyId;
     }
 
-    async fetchOrder (id, symbol = undefined, params = {}) {
-        /**
-         * @method
-         * @name bitfinex2#fetchOrder
-         * @description fetches information on an order made by the user
-         * @param {string|undefined} symbol unified symbol of the market the order was made in
-         * @param {object} params extra parameters specific to the bitfinex2 api endpoint
-         * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
-         */
-        throw new NotSupported (this.id + ' fetchOrder() is not supported yet. Consider using fetchOpenOrder() or fetchClosedOrder() instead.');
-    }
-
     async fetchOrderBook (symbol, limit = undefined, params = {}) {
         /**
          * @method

--- a/ts/src/bitflyer.ts
+++ b/ts/src/bitflyer.ts
@@ -542,10 +542,10 @@ export default class bitflyer extends Exchange {
         const result = await (this as any).privatePostSendchildorder (this.extend (request, params));
         // { "status": - 200, "error_message": "Insufficient funds", "data": null }
         const id = this.safeString (result, 'child_order_acceptance_id');
-        return {
-            'info': result,
+        return this.safeOrder ({
             'id': id,
-        };
+            'info': result,
+        });
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/bitforex.ts
+++ b/ts/src/bitforex.ts
@@ -660,10 +660,10 @@ export default class bitforex extends Exchange {
         };
         const response = await (this as any).privatePostApiV1TradePlaceOrder (this.extend (request, params));
         const data = response['data'];
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': this.safeString (data, 'orderId'),
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -696,13 +696,13 @@ export default class bithumb extends Exchange {
         if (id === undefined) {
             throw new InvalidOrder (this.id + ' createOrder() did not return an order id');
         }
-        return {
+        return this.safeOrder ({
             'info': response,
             'symbol': symbol,
             'type': type,
             'side': side,
             'id': id,
-        };
+        }, market);
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -965,10 +965,10 @@ export default class bitso extends Exchange {
         }
         const response = await (this as any).privatePostOrders (this.extend (request, params));
         const id = this.safeString (response['payload'], 'oid');
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': id,
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/bitstamp1.ts
+++ b/ts/src/bitstamp1.ts
@@ -318,10 +318,10 @@ export default class bitstamp1 extends Exchange {
         };
         const response = await (this as any)[method] (this.extend (request, params));
         const id = this.safeString (response, 'id');
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': id,
-        };
+        });
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -1887,7 +1887,7 @@ export default class bittrex extends Exchange {
         }
         const response = await (this as any).privateGetExecutions (this.extend (request, params));
         const trades = this.parseTrades (response, market);
-        return this.filterBySymbolSinceLimit (trades, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (trades, symbol, since, limit) as any;
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/ts/src/bl3p.ts
+++ b/ts/src/bl3p.ts
@@ -366,10 +366,10 @@ export default class bl3p extends Exchange {
         }
         const response = await (this as any).privatePostMarketMoneyOrderAdd (this.extend (order, params));
         const orderId = this.safeString (response['data'], 'order_id');
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': orderId,
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/btcturk.ts
+++ b/ts/src/btcturk.ts
@@ -646,7 +646,7 @@ export default class btcturk extends Exchange {
         }
         const sorted = this.sortBy (results, 0);
         const tail = (since === undefined);
-        return this.filterBySinceLimit (sorted, since, limit, 0, tail);
+        return this.filterBySinceLimit (sorted, since, limit, 0, tail) as any;
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/ts/src/coincheck.ts
+++ b/ts/src/coincheck.ts
@@ -594,10 +594,10 @@ export default class coincheck extends Exchange {
         }
         const response = await (this as any).privatePostExchangeOrders (this.extend (request, params));
         const id = this.safeString (response, 'id');
-        return {
-            'info': response,
+        return this.safeOrder ({
             'id': id,
-        };
+            'info': response,
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/coinmate.ts
+++ b/ts/src/coinmate.ts
@@ -903,10 +903,10 @@ export default class coinmate extends Exchange {
         }
         const response = await this[method] (this.extend (request, params));
         const id = this.safeString (response, 'data');
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': id,
-        };
+        }, market);
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -1235,7 +1235,7 @@ export default class exmo extends Exchange {
             const trades = this.parseTrades (items, resultMarket, since, limit);
             result = this.arrayConcat (result, trades);
         }
-        return this.filterBySinceLimit (result, since, limit);
+        return this.filterBySinceLimit (result, since, limit) as any;
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
@@ -1450,7 +1450,7 @@ export default class exmo extends Exchange {
             const parsedOrders = this.parseOrders (response[marketId], market);
             orders = this.arrayConcat (orders, parsedOrders);
         }
-        return this.filterBySymbolSinceLimit (orders, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (orders, symbol, since, limit) as any;
     }
 
     parseOrder (order, market = undefined) {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3826,7 +3826,7 @@ export default class gate extends Exchange {
          * @param {string} params.marginMode 'cross' or 'isolated' - marginMode for type='margin', if not provided this.options['defaultMarginMode'] is used
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
-        return await this.fetchOrdersByStatus ('open', symbol, since, limit, params);
+        return await this.fetchOrdersByStatus ('open', symbol, since, limit, params) as any;
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
@@ -3843,7 +3843,7 @@ export default class gate extends Exchange {
          * @param {string} params.marginMode 'cross' or 'isolated' - marginMode for margin trading if not provided this.options['defaultMarginMode'] is used
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
-        return await this.fetchOrdersByStatus ('finished', symbol, since, limit, params);
+        return await this.fetchOrdersByStatus ('finished', symbol, since, limit, params) as any;
     }
 
     async fetchOrdersByStatus (status, symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -1264,7 +1264,7 @@ export default class hitbtc extends Exchange {
                 orders.push (order);
             }
         }
-        return this.filterBySinceLimit (orders, since, limit);
+        return this.filterBySinceLimit (orders, since, limit) as any;
     }
 
     async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/ts/src/independentreserve.ts
+++ b/ts/src/independentreserve.ts
@@ -701,10 +701,10 @@ export default class independentreserve extends Exchange {
         }
         request['volume'] = amount;
         const response = await this[method] (this.extend (request, params));
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': response['OrderGuid'],
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -691,7 +691,7 @@ export default class indodax extends Exchange {
         const response = await (this as any).privatePostOrderHistory (this.extend (request, params));
         let orders = this.parseOrders (response['return']['orders'], market);
         orders = this.filterBy (orders, 'status', 'closed');
-        return this.filterBySymbolSinceLimit (orders, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (orders, symbol, since, limit) as any;
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {

--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -727,10 +727,10 @@ export default class indodax extends Exchange {
         const result = await (this as any).privatePostTrade (this.extend (request, params));
         const data = this.safeValue (result, 'return', {});
         const id = this.safeString (data, 'order_id');
-        return {
+        return this.safeOrder ({
             'info': result,
             'id': id,
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/itbit.ts
+++ b/ts/src/itbit.ts
@@ -751,10 +751,10 @@ export default class itbit extends Exchange {
             'instrument': market['id'],
         };
         const response = await (this as any).privatePostWalletsWalletIdOrders (this.extend (request, params));
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': response['id'],
-        };
+        }, market);
     }
 
     async fetchOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -721,7 +721,7 @@ export default class lbank extends Exchange {
         const closed = this.filterBy (orders, 'status', 'closed');
         const canceled = this.filterBy (orders, 'status', 'cancelled'); // cancelled orders may be partially filled
         const allOrders = this.arrayConcat (closed, canceled);
-        return this.filterBySymbolSinceLimit (allOrders, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (allOrders, symbol, since, limit) as any;
     }
 
     async withdraw (code, amount, address, tag = undefined, params = {}) {

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -671,7 +671,7 @@ export default class lbank extends Exchange {
         if (numOrders === 1) {
             return orders[0];
         } else {
-            return orders;
+            return orders as any;
         }
     }
 

--- a/ts/src/lbank2.ts
+++ b/ts/src/lbank2.ts
@@ -1035,10 +1035,10 @@ export default class lbank2 extends Exchange {
         //      }
         //
         const result = this.safeValue (response, 'data', {});
-        return {
+        return this.safeOrder ({
             'id': this.safeString (result, 'order_id'),
             'info': result,
-        };
+        }, market);
     }
 
     parseOrderStatus (status) {

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -838,10 +838,10 @@ export default class luno extends Exchange {
             request['type'] = (side === 'buy') ? 'BID' : 'ASK';
         }
         const response = await this[method] (this.extend (request, params));
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': response['order_id'],
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/mercado.ts
+++ b/ts/src/mercado.ts
@@ -845,7 +845,7 @@ export default class mercado extends Exchange {
         const ordersRaw = this.safeValue (responseData, 'orders', []);
         const orders = this.parseOrders (ordersRaw, market, since, limit);
         const trades = this.ordersToTrades (orders);
-        return this.filterBySymbolSinceLimit (trades, market['symbol'], since, limit);
+        return this.filterBySymbolSinceLimit (trades, market['symbol'], since, limit) as any;
     }
 
     ordersToTrades (orders) {

--- a/ts/src/mercado.ts
+++ b/ts/src/mercado.ts
@@ -461,10 +461,10 @@ export default class mercado extends Exchange {
         }
         const response = await this[method] (this.extend (request, params));
         // TODO: replace this with a call to parseOrder for unification
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': response['response_data']['order']['order_id'].toString (),
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/okcoin.ts
+++ b/ts/src/okcoin.ts
@@ -3154,7 +3154,7 @@ export default class okcoin extends Exchange {
         //         }
         //     ]
         //
-        return this.parseMyTrades (response, market, since, limit, params);
+        return this.parseMyTrades (response, market, since, limit, params) as any;
     }
 
     async fetchOrderTrades (id, symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/ts/src/paymium.ts
+++ b/ts/src/paymium.ts
@@ -405,10 +405,10 @@ export default class paymium extends Exchange {
             request['price'] = price;
         }
         const response = await (this as any).privatePostUserOrders (this.extend (request, params));
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': response['uuid'],
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -837,7 +837,7 @@ export default class poloniex extends Exchange {
         //     ]
         //
         const result = this.parseTrades (response, market);
-        return this.filterBySinceLimit (result, since, limit);
+        return this.filterBySinceLimit (result, since, limit) as any;
     }
 
     parseOrderStatus (status) {

--- a/ts/src/pro/coinbasepro.ts
+++ b/ts/src/pro/coinbasepro.ts
@@ -318,6 +318,7 @@ export default class coinbasepro extends coinbaseproRest {
             'rate': feeRate,
             'cost': feeCost,
             'currency': feeCurrency,
+            'type': undefined,
         };
         return parsed;
     }

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -950,7 +950,7 @@ export default class whitebit extends Exchange {
             }
             results = this.sortBy2 (results, 'timestamp', 'id');
             const tail = (since === undefined);
-            return this.filterBySinceLimit (results, since, limit, 'timestamp', tail);
+            return this.filterBySinceLimit (results, since, limit, 'timestamp', tail) as any;
         }
     }
 

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -1111,7 +1111,7 @@ export default class yobit extends Exchange {
             }), market);
             result.push (trade);
         }
-        return this.filterBySymbolSinceLimit (result, market['symbol'], since, limit);
+        return this.filterBySymbolSinceLimit (result, market['symbol'], since, limit) as any;
     }
 
     async createDepositAddress (code, params = {}) {

--- a/ts/src/zaif.ts
+++ b/ts/src/zaif.ts
@@ -471,10 +471,10 @@ export default class zaif extends Exchange {
             'price': price,
         };
         const response = await (this as any).privatePostTrade (this.extend (request, params));
-        return {
+        return this.safeOrder ({
             'info': response,
             'id': response['return']['order_id'].toString (),
-        };
+        }, market);
     }
 
     async cancelOrder (id, symbol = undefined, params = {}) {


### PR DESCRIPTION

From now one, our types can be imported directly, for example:
```Javascript
import {Orderbook, Trade, OHLCV, Ticker} from 'ccxt'
```
