### PR TITLE
feat(okx): fetchOHLCV retrieve base volume

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1686,13 +1686,16 @@ export default class okx extends Exchange {
         //         "0" // candlestick state
         //     ]
         //
+        const res = this.handleMarketTypeAndParams ('fetchOHLCV', market, undefined);
+        const type = res[0];
+        const volumeIndex = (type === 'spot') ? 5 : 6;
         return [
             this.safeInteger (ohlcv, 0),
             this.safeNumber (ohlcv, 1),
             this.safeNumber (ohlcv, 2),
             this.safeNumber (ohlcv, 3),
             this.safeNumber (ohlcv, 4),
-            this.safeNumber (ohlcv, 6),
+            this.safeNumber (ohlcv, volumeIndex),
         ];
     }
 

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1675,13 +1675,15 @@ export default class okx extends Exchange {
     parseOHLCV (ohlcv, market = undefined) {
         //
         //     [
-        //         "1621447080000", // timestamp
-        //         "0.07073", // open
-        //         "0.07073", // high
-        //         "0.07064", // low
-        //         "0.07064", // close
-        //         "12.08863", // base volume
-        //         "0.854309" // quote volume
+        //         "1678928760000", // timestamp
+        //         "24341.4", // open
+        //         "24344", // high
+        //         "24313.2", // low
+        //         "24323", // close
+        //         "628", // contract volume
+        //         "2.5819", // base volume
+        //         "62800", // quote volume
+        //         "0" // candlestick state
         //     ]
         //
         return [
@@ -1690,7 +1692,7 @@ export default class okx extends Exchange {
             this.safeNumber (ohlcv, 2),
             this.safeNumber (ohlcv, 3),
             this.safeNumber (ohlcv, 4),
-            this.safeNumber (ohlcv, 5),
+            this.safeNumber (ohlcv, 6),
         ];
     }
 
@@ -1699,6 +1701,12 @@ export default class okx extends Exchange {
          * @method
          * @name okx#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-candlesticks
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-candlesticks-history
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-mark-price-candlesticks
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-mark-price-candlesticks-history
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-index-candlesticks
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-index-candlesticks-history
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int|undefined} since timestamp in ms of the earliest candle to fetch
@@ -1761,9 +1769,9 @@ export default class okx extends Exchange {
         //         "code": "0",
         //         "msg": "",
         //         "data": [
-        //             ["1621447080000","0.07073","0.07073","0.07064","0.07064","12.08863","0.854309"],
-        //             ["1621447020000","0.0708","0.0709","0.0707","0.07072","58.517435","4.143309"],
-        //             ["1621446960000","0.0707","0.07082","0.0707","0.07076","53.850841","3.810921"],
+        //             ["1678928760000","24341.4","24344","24313.2","24323","628","2.5819","62800","0"],
+        //             ["1678928700000","24324.1","24347.6","24321.7","24341.4","2565","10.5401","256500","1"],
+        //             ["1678928640000","24300.2","24324.1","24288","24324.1","3304","13.5937","330400","1"],
         //         ]
         //     }
         //


### PR DESCRIPTION
Adjusted fetchOHLCV to retrieve the base volume:
fixes: #17177
```
npm run cli.ts okx fetchOHLCV BTC/USD:BTC 1m undefined 3

okx.fetchOHLCV (BTC/USD:BTC, 1m, , 3)
2023-03-16T01:13:52.162Z iteration 0 passed in 345 ms

1678929060000 | 24322.1 | 24327.7 | 24311.2 | 24325.4 |   11.37
1678929120000 | 24334.6 |   24358 | 24334.6 | 24345.6 | 19.7338
1678929180000 | 24349.6 | 24353.8 | 24324.9 | 24324.9 |  3.3892
3 objects
```