### PR TITLE
Poloniexfutures parse order cost

### DIFF
--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -901,18 +901,20 @@ export default class poloniexfutures extends Exchange {
         };
         const response = await (this as any).privateDeleteOrdersOrderId (this.extend (request, params));
         //
-        //   {
-        //       code: "200000",
-        //       data: {
-        //           cancelledOrderIds: [
+        //    {
+        //        code: "200000",
+        //        data: {
+        //            cancelledOrderIds: [
         //                "619714b8b6353000014c505a",
-        //           ],
-        //           cancelFailedOrders: [
-        //              {
-        //                  orderId: "63a9c5c2b9e7d70007eb0cd5", orderState: "2"}
-        //          ],
-        //       },
-        //   }
+        //            ],
+        //            cancelFailedOrders: [
+        //                {
+        //                    orderId: "63a9c5c2b9e7d70007eb0cd5",
+        //                    orderState: "2"
+        //                }
+        //            ],
+        //        },
+        //    }
         //
         const data = this.safeValue (response, 'data');
         const cancelledOrderIds = this.safeValue (data, 'cancelledOrderIds');
@@ -920,29 +922,7 @@ export default class poloniexfutures extends Exchange {
         if (cancelledOrderIdsLength === 0) {
             throw new InvalidOrder (this.id + ' cancelOrder() order already cancelled');
         }
-        return {
-            'id': this.safeString (cancelledOrderIds, 0),
-            'clientOrderId': undefined,
-            'timestamp': undefined,
-            'datetime': undefined,
-            'lastTradeTimestamp': undefined,
-            'symbol': undefined,
-            'type': undefined,
-            'side': undefined,
-            'price': undefined,
-            'amount': undefined,
-            'cost': undefined,
-            'average': undefined,
-            'filled': undefined,
-            'remaining': undefined,
-            'status': undefined,
-            'fee': undefined,
-            'trades': undefined,
-            'timeInForce': undefined,
-            'postOnly': undefined,
-            'stopPrice': undefined,
-            'info': response,
-        };
+        return this.parseOrder (data);
     }
 
     async fetchPositions (symbols = undefined, params = {}) {
@@ -1357,27 +1337,130 @@ export default class poloniexfutures extends Exchange {
             request['order-id'] = id;
         }
         const response = await this[method] (this.extend (request, params));
+        //
+        //    {
+        //        "code": "200000",
+        //        "data": {
+        //            "symbol": "ADAUSDTPERP",
+        //            "leverage": "1",
+        //            "hidden": false,
+        //            "forceHold": false,
+        //            "closeOrder": false,
+        //            "type": "market",
+        //            "isActive": false,
+        //            "createdAt": 1678929587000,
+        //            "orderTime": 1678929587248115582,
+        //            "iceberg": false,
+        //            "stopTriggered": false,
+        //            "id": "64126eb38c6919000737dcdc",
+        //            "value": "3.1783",
+        //            "timeInForce": "GTC",
+        //            "updatedAt": 1678929587000,
+        //            "side": "buy",
+        //            "stopPriceType": "",
+        //            "dealValue": "3.1783",
+        //            "dealSize": 1,
+        //            "settleCurrency": "USDT",
+        //            "trades": [
+        //                {
+        //                    "feePay": "0.00158915",
+        //                    "tradeId": "64126eb36803eb0001ff99bc"
+        //                }
+        //            ],
+        //            "endAt": 1678929587000,
+        //            "stp": "",
+        //            "filledValue": "3.1783",
+        //            "postOnly": false,
+        //            "size": 1,
+        //            "stop": "",
+        //            "filledSize": 1,
+        //            "reduceOnly": false,
+        //            "marginType": 1,
+        //            "cancelExist": false,
+        //            "clientOid": "d19e8fcb-2df4-44bc-afd4-67dd42048246",
+        //            "status": "done"
+        //        }
+        //    }
+        //
         const market = (symbol !== undefined) ? this.market (symbol) : undefined;
         const responseData = this.safeValue (response, 'data');
         return this.parseOrder (responseData, market);
     }
 
     parseOrder (order, market = undefined) {
+        //
+        // createOrder
+        //
+        //    {
+        //        code: "200000",
+        //        data: {
+        //            orderId: "619717484f1d010001510cde",
+        //        },
+        //    }
+        //
+        // fetchOrder
+        //    
+        //    {
+        //        "symbol": "ADAUSDTPERP",
+        //        "leverage": "1",
+        //        "hidden": false,
+        //        "forceHold": false,
+        //        "closeOrder": false,
+        //        "type": "market",
+        //        "isActive": false,
+        //        "createdAt": 1678929587000,
+        //        "orderTime": 1678929587248115582,
+        //        "iceberg": false,
+        //        "stopTriggered": false,
+        //        "id": "64126eb38c6919000737dcdc",
+        //        "value": "3.1783",
+        //        "timeInForce": "GTC",
+        //        "updatedAt": 1678929587000,
+        //        "side": "buy",
+        //        "stopPriceType": "",
+        //        "dealValue": "3.1783",
+        //        "dealSize": 1,
+        //        "settleCurrency": "USDT",
+        //        "trades": [
+        //            {
+        //                "feePay": "0.00158915",
+        //                "tradeId": "64126eb36803eb0001ff99bc"
+        //            }
+        //        ],
+        //        "endAt": 1678929587000,
+        //        "stp": "",
+        //        "filledValue": "3.1783",
+        //        "postOnly": false,
+        //        "size": 1,
+        //        "stop": "",
+        //        "filledSize": 1,
+        //        "reduceOnly": false,
+        //        "marginType": 1,
+        //        "cancelExist": false,
+        //        "clientOid": "d19e8fcb-2df4-44bc-afd4-67dd42048246",
+        //        "status": "done"
+        //    }
+        //
+        // cancelOrder
+        //
+        //    {
+        //        cancelledOrderIds: [
+        //            "619714b8b6353000014c505a",
+        //        ],
+        //        cancelFailedOrders: [
+        //            {
+        //                orderId: "63a9c5c2b9e7d70007eb0cd5",
+        //                orderState: "2"
+        //            }
+        //        ],
+        //    },
+        //
         const marketId = this.safeString (order, 'symbol');
         market = this.safeMarket (marketId, market);
-        const symbol = market['symbol'];
-        const orderId = this.safeString (order, 'id');
-        const type = this.safeString (order, 'type');
         const timestamp = this.safeInteger (order, 'createdAt');
-        const datetime = this.iso8601 (timestamp);
-        const price = this.safeString (order, 'price');
         // price is zero for market order
         // omitZero is called in safeOrder2
-        const side = this.safeString (order, 'side');
         const feeCurrencyId = this.safeString (order, 'feeCurrency');
-        const feeCurrency = this.safeCurrencyCode (feeCurrencyId);
-        const feeCost = this.safeNumber (order, 'fee');
-        const amount = this.safeString (order, 'size');
         const filled = this.safeString (order, 'dealSize');
         const rawCost = this.safeString2 (order, 'dealFunds', 'filledValue');
         const leverage = this.safeString (order, 'leverage');
@@ -1397,34 +1480,33 @@ export default class poloniexfutures extends Exchange {
         const isActive = this.safeValue (order, 'isActive', false);
         const cancelExist = this.safeValue (order, 'cancelExist', false);
         let status = isActive ? 'open' : 'closed';
-        status = cancelExist ? 'canceled' : status;
-        const fee = {
-            'currency': feeCurrency,
-            'cost': feeCost,
-        };
-        const clientOrderId = this.safeString (order, 'clientOid');
-        const timeInForce = this.safeString (order, 'timeInForce');
-        const stopPrice = this.safeNumber (order, 'stopPrice');
-        const postOnly = this.safeValue (order, 'postOnly');
+        let id = this.safeString (order, 'id');
+        if ('cancelledOrderIds' in order) {
+            const cancelledOrderIds = this.safeValue (order, 'cancelledOrderIds');
+            id = this.safeString (cancelledOrderIds, 0);
+        }
         return this.safeOrder ({
-            'id': orderId,
-            'clientOrderId': clientOrderId,
-            'symbol': symbol,
-            'type': type,
-            'timeInForce': timeInForce,
-            'postOnly': postOnly,
-            'side': side,
-            'amount': amount,
-            'price': price,
-            'stopPrice': stopPrice,
+            'info': order,
+            'id': id,
+            'clientOrderId': this.safeString (order, 'clientOid'),
+            'symbol': this.safeString (market, 'symbol'),
+            'type': this.safeString (order, 'type'),
+            'timeInForce': this.safeString (order, 'timeInForce'),
+            'postOnly': this.safeValue (order, 'postOnly'),
+            'side': this.safeString (order, 'side'),
+            'amount': this.safeString (order, 'size'),
+            'price': this.safeString (order, 'price'),
+            'stopPrice': this.safeNumber (order, 'stopPrice'),
             'cost': cost,
             'filled': filled,
             'remaining': undefined,
             'timestamp': timestamp,
-            'datetime': datetime,
-            'fee': fee,
-            'status': status,
-            'info': order,
+            'datetime': this.iso8601 (timestamp),
+            'fee': {
+                'currency': this.safeCurrencyCode (feeCurrencyId),
+                'cost': this.safeNumber (order, 'fee'),
+            },
+            'status': cancelExist ? 'canceled' : status,
             'lastTradeTimestamp': undefined,
             'average': average,
             'trades': undefined,

--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -1463,8 +1463,6 @@ export default class poloniexfutures extends Exchange {
         const feeCurrencyId = this.safeString (order, 'feeCurrency');
         const filled = this.safeString (order, 'dealSize');
         const rawCost = this.safeString2 (order, 'dealFunds', 'filledValue');
-        const leverage = this.safeString (order, 'leverage');
-        const cost = Precise.stringDiv (rawCost, leverage);
         let average = undefined;
         if (Precise.stringGt (filled, '0')) {
             const contractSize = this.safeString (market, 'contractSize');
@@ -1496,15 +1494,15 @@ export default class poloniexfutures extends Exchange {
             'side': this.safeString (order, 'side'),
             'amount': this.safeString (order, 'size'),
             'price': this.safeString (order, 'price'),
-            'stopPrice': this.safeNumber (order, 'stopPrice'),
-            'cost': cost,
+            'stopPrice': this.safeString (order, 'stopPrice'),
+            'cost': this.safeString (order, 'dealValue'),
             'filled': filled,
             'remaining': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'fee': {
                 'currency': this.safeCurrencyCode (feeCurrencyId),
-                'cost': this.safeNumber (order, 'fee'),
+                'cost': this.safeString (order, 'fee'),
             },
             'status': cancelExist ? 'canceled' : status,
             'lastTradeTimestamp': undefined,

--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -1399,7 +1399,7 @@ export default class poloniexfutures extends Exchange {
         //    }
         //
         // fetchOrder
-        //    
+        //
         //    {
         //        "symbol": "ADAUSDTPERP",
         //        "leverage": "1",
@@ -1477,7 +1477,7 @@ export default class poloniexfutures extends Exchange {
         // bool
         const isActive = this.safeValue (order, 'isActive', false);
         const cancelExist = this.safeValue (order, 'cancelExist', false);
-        let status = isActive ? 'open' : 'closed';
+        const status = isActive ? 'open' : 'closed';
         let id = this.safeString (order, 'id');
         if ('cancelledOrderIds' in order) {
             const cancelledOrderIds = this.safeValue (order, 'cancelledOrderIds');


### PR DESCRIPTION
fixes: #17185

---------------------

```
2023-03-16T02:44:44.972Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.createOrder (ADA/USDT:USDT, market, buy, 1)
2023-03-16T02:44:53.604Z iteration 0 passed in 758 ms

{
  id: '641282a587623d00071b2bd6',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  stopPrice: undefined,
  info: { code: '200000', data: { orderId: '641282a587623d00071b2bd6' } }
}
2023-03-16T02:44:53.604Z iteration 1 passed in 758 ms
```

```
2023-03-16T02:45:50.129Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.fetchOrder (641282a587623d00071b2bd6)
2023-03-16T02:45:57.401Z iteration 0 passed in 707 ms

{
  info: {
    symbol: 'ADAUSDTPERP',
    leverage: '1',
    hidden: false,
    forceHold: false,
    closeOrder: false,
    type: 'market',
    isActive: false,
    createdAt: '1678934693000',
    orderTime: '1678934693703173899',
    iceberg: false,
    stopTriggered: false,
    id: '641282a587623d00071b2bd6',
    value: '3.2495',
    timeInForce: 'GTC',
    updatedAt: '1678934693000',
    side: 'buy',
    stopPriceType: '',
    dealValue: '3.2495',
    dealSize: '1',
    settleCurrency: 'USDT',
    trades: [ { feePay: '0.00162475', tradeId: '641282a56803eb0001ffe947' } ],
    endAt: '1678934693000',
    stp: '',
    filledValue: '3.2495',
    postOnly: false,
    size: '1',
    stop: '',
    filledSize: '1',
    reduceOnly: false,
    marginType: '1',
    cancelExist: false,
    clientOid: '849d600c-73b1-44a8-b6c5-d2b0e9b7138d',
    status: 'done'
  },
  id: '641282a587623d00071b2bd6',
  clientOrderId: '849d600c-73b1-44a8-b6c5-d2b0e9b7138d',
  symbol: 'ADA/USDT:USDT',
  type: 'market',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  amount: 1,
  price: 0.32495,
  stopPrice: undefined,
  cost: 3.2495,
  filled: 1,
  remaining: 0,
  timestamp: 1678934693000,
  datetime: '2023-03-16T02:44:53.000Z',
  fee: { currency: undefined, cost: undefined },
  status: 'closed',
  lastTradeTimestamp: undefined,
  average: 0.32495,
  trades: [],
  fees: [ { currency: undefined, cost: undefined } ],
  reduceOnly: undefined,
  triggerPrice: undefined
}
2023-03-16T02:45:57.401Z iteration 1 passed in 707 ms
```

```
2023-03-16T02:51:05.549Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.createOrder (ADA/USDT:USDT, limit, buy, 1, 0.31)
2023-03-16T02:51:09.338Z iteration 0 passed in 712 ms

{
  id: '6412841d4cf0c7000889a43f',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  stopPrice: undefined,
  info: { code: '200000', data: { orderId: '6412841d4cf0c7000889a43f' } }
}
2023-03-16T02:51:09.338Z iteration 1 passed in 712 ms
```

```
2023-03-16T02:51:53.031Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.cancelOrder (6412841d4cf0c7000889a43f)
2023-03-16T02:51:55.215Z iteration 0 passed in 682 ms

{
  id: '6412841d4cf0c7000889a43f',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  stopPrice: undefined,
  info: {
    code: '200000',
    data: {
      cancelFailedOrders: [],
      cancelledOrderIds: [ '6412841d4cf0c7000889a43f' ]
    }
  }
}
2023-03-16T02:51:55.215Z iteration 1 passed in 682 ms
```