### PR TITLE
poloniexfutures.fetchOpenOrders fix to fetch open orders

### DIFF
--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -1257,13 +1257,11 @@ export default class poloniexfutures extends Exchange {
         params = this.omit (params, [ 'stop', 'until', 'till' ]);
         if (status === 'closed') {
             status = 'done';
-        } else if (status === 'open') {
-            status = 'active';
         }
         const request = {};
         if (!stop) {
-            request['status'] = status;
-        } else if (status !== 'active') {
+            request['status'] = status === 'open' ? 'active' : 'done';
+        } else if (status !== 'open') {
             throw new BadRequest (this.id + ' fetchOrdersByStatus() can only fetch untriggered stop orders');
         }
         let market = undefined;
@@ -1279,15 +1277,62 @@ export default class poloniexfutures extends Exchange {
         }
         const method = stop ? 'privateGetStopOrders' : 'privateGetOrders';
         const response = await this[method] (this.extend (request, params));
+        // 
+        //    {
+        //        "code": "200000",
+        //        "data": {
+        //            "totalNum": 1,
+        //            "totalPage": 1,
+        //            "pageSize": 50,
+        //            "currentPage": 1,
+        //            "items": [
+        //                {
+        //                    "symbol": "ADAUSDTPERP",
+        //                    "leverage": "1",
+        //                    "hidden": false,
+        //                    "forceHold": false,
+        //                    "closeOrder": false,
+        //                    "type": "limit",
+        //                    "isActive": true,
+        //                    "createdAt": 1678936920000,
+        //                    "orderTime": 1678936920480905922,
+        //                    "price": "0.3",
+        //                    "iceberg": false,
+        //                    "stopTriggered": false,
+        //                    "id": "64128b582cc0710007a3c840",
+        //                    "value": "3",
+        //                    "timeInForce": "GTC",
+        //                    "updatedAt": 1678936920000,
+        //                    "side": "buy",
+        //                    "stopPriceType": "",
+        //                    "dealValue": "0",
+        //                    "dealSize": 0,
+        //                    "settleCurrency": "USDT",
+        //                    "stp": "",
+        //                    "filledValue": "0",
+        //                    "postOnly": false,
+        //                    "size": 1,
+        //                    "stop": "",
+        //                    "filledSize": 0,
+        //                    "reduceOnly": false,
+        //                    "marginType": 1,
+        //                    "cancelExist": false,
+        //                    "clientOid": "ba669f39-dfcc-4664-9801-a42d06e59c2e",
+        //                    "status": "open"
+        //                }
+        //            ]
+        //        }
+        //    }
+        //
         const responseData = this.safeValue (response, 'data', {});
         const orders = this.safeValue (responseData, 'items', []);
         const ordersLength = orders.length;
         const result = [];
-        if (status === 'done') {
-            for (let i = 0; i < ordersLength; i++) {
-                if (!orders[i]['cancelExist']) {
-                    result.push (orders[i]);
-                }
+        for (let i = 0; i < ordersLength; i++) {
+            const order = orders[i];
+            const orderStatus = this.safeString (order, 'status');
+            if (status === orderStatus) {
+                result.push (orders[i]);
             }
         }
         return this.parseOrders (result, market, since, limit);
@@ -1309,7 +1354,7 @@ export default class poloniexfutures extends Exchange {
          * @param {string|undefined} params.type limit, or market
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
-        return await this.fetchOrdersByStatus ('active', symbol, since, limit, params);
+        return await this.fetchOrdersByStatus ('open', symbol, since, limit, params);
     }
 
     async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {

--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -1277,7 +1277,7 @@ export default class poloniexfutures extends Exchange {
         }
         const method = stop ? 'privateGetStopOrders' : 'privateGetOrders';
         const response = await this[method] (this.extend (request, params));
-        // 
+        //
         //    {
         //        "code": "200000",
         //        "data": {


### PR DESCRIPTION
fixes: #17187

---------------

```
% ccxt poloniexfutures fetchOpenOrders 
2023-03-16T03:55:26.017Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.fetchOpenOrders ()
2023-03-16T03:55:48.090Z iteration 0 passed in 16904 ms

                      id |                        clientOrderId |        symbol |  type | timeInForce | postOnly | side | amount | price | stopPrice | cost | filled | remaining |     timestamp |                 datetime | fee | status | lastTradeTimestamp | average | trades | fees | reduceOnly | triggerPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
64128b582cc0710007a3c840 | ba669f39-dfcc-4664-9801-a42d06e59c2e | ADA/USDT:USDT | limit |         GTC |    false |  buy |      1 |   0.3 |           |    0 |      0 |         1 | 1678936920000 | 2023-03-16T03:22:00.000Z |  {} |   open |                    |         |     [] | [{}] |            |             
1 objects
2023-03-16T03:55:48.090Z iteration 1 passed in 16904 ms

% ccxt poloniexfutures fetchClosedOrders 
2023-03-16T03:56:43.285Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.fetchClosedOrders ()
2023-03-16T03:57:08.278Z iteration 0 passed in 21718 ms

                      id |                        clientOrderId |        symbol |   type | timeInForce | postOnly | side | amount |   price | stopPrice |   cost | filled | remaining |     timestamp |                 datetime | fee |   status | lastTradeTimestamp | average | trades | fees | reduceOnly | triggerPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
64126eb38c6919000737dcdc | d19e8fcb-2df4-44bc-afd4-67dd42048246 | ADA/USDT:USDT | market |         GTC |    false |  buy |      1 | 0.31783 |           | 3.1783 |      1 |         0 | 1678929587000 | 2023-03-16T01:19:47.000Z |  {} |   closed |                    | 0.31783 |     [] | [{}] |            |             
64127028417cec000778055d | c515851e-bddf-4545-819d-4c0269e32098 | ADA/USDT:USDT |  limit |         GTC |    false |  buy |      1 |    0.31 |           |      0 |      0 |         1 | 1678929960000 | 2023-03-16T01:26:00.000Z |  {} | canceled |                    |         |     [] | [{}] |            |             
64127f184cf0c70008873f47 | eb8290db-76ff-4cac-8a12-8086332826d5 | ADA/USDT:USDT |  limit |         GTC |    false |  buy |      1 |    0.31 |           |      0 |      0 |         1 | 1678933784000 | 2023-03-16T02:29:44.000Z |  {} | canceled |                    |         |     [] | [{}] |            |             
64127fbf4cf0c700088784de | 6ce70c82-9c6e-4d0d-8a6b-4f7d4ae1a07c | ADA/USDT:USDT |  limit |         GTC |    false |  buy |      1 |    0.31 |           |      0 |      0 |         1 | 1678933951000 | 2023-03-16T02:32:31.000Z |  {} | canceled |                    |         |     [] | [{}] |            |             
641280f887623d00071a4b4b | 77218bc6-ab10-42e0-b841-a97d620e4d69 | ADA/USDT:USDT | market |         GTC |    false |  buy |      1 | 0.32405 |           | 3.2405 |      1 |         0 | 1678934264000 | 2023-03-16T02:37:44.000Z |  {} |   closed |                    | 0.32405 |     [] | [{}] |            |             
641282a587623d00071b2bd6 | 849d600c-73b1-44a8-b6c5-d2b0e9b7138d | ADA/USDT:USDT | market |         GTC |    false |  buy |      1 | 0.32495 |           | 3.2495 |      1 |         0 | 1678934693000 | 2023-03-16T02:44:53.000Z |  {} |   closed |                    | 0.32495 |     [] | [{}] |            |             
641283e887623d00071bbfd2 | e6ec013c-c69a-4871-8712-63af33610a25 | ADA/USDT:USDT | market |         GTC |    false | sell |      3 |  0.3246 |           |  9.738 |      3 |         0 | 1678935016000 | 2023-03-16T02:50:16.000Z |  {} |   closed |                    |  0.3246 |     [] | [{}] |            |             
6412841d4cf0c7000889a43f | 9e9773f0-4e66-4662-90e8-b177d1c5b599 | ADA/USDT:USDT |  limit |         GTC |    false |  buy |      1 |    0.31 |           |      0 |      0 |         1 | 1678935069000 | 2023-03-16T02:51:09.000Z |  {} | canceled |                    |         |     [] | [{}] |            |             
8 objects
2023-03-16T03:57:08.278Z iteration 1 passed in 21718 ms

% ccxt poloniexfutures fetchOpenOrders  undefined undefined undefine
d '{"stop": "true"}'
2023-03-16T04:02:17.363Z
Node.js: v18.9.0
CCXT v3.0.10
poloniexfutures.fetchOpenOrders (, , , [object Object])
2023-03-16T04:02:23.893Z iteration 0 passed in 652 ms

                      id | clientOrderId |        symbol |  type | timeInForce | postOnly | side | amount | price | stopPrice | cost | filled | remaining |     timestamp |                 datetime | fee | status | lastTradeTimestamp | average | trades | fees | reduceOnly | triggerPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6412946114d83f000733f48a |               | ADA/USDT:USDT | limit |         GTC |    false | sell |     50 |  0.34 |      0.34 |    0 |      0 |        50 | 1678939233000 | 2023-03-16T04:00:33.000Z |  {} |   open |                    |         |     [] | [{}] |            |         0.34
1 objects
2023-03-16T04:02:23.893Z iteration 1 passed in 652 ms
```