### PR TITLE
fix(kraken): watchOrderbook handleDeltas [ci deploy]

### DIFF
--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -525,13 +525,10 @@ export default class kraken extends krakenRest {
     handleDeltas (bookside, deltas, timestamp = undefined) {
         for (let j = 0; j < deltas.length; j++) {
             const delta = deltas[j];
-            const price = parseFloat (delta[0]);
-            const amount = parseFloat (delta[1]);
+            const price = this.parseNumber (delta[0]);
+            const amount = this.parseNumber (delta[1]);
             const oldTimestamp = timestamp ? timestamp : 0;
-            const calcMul = delta[2] * 1000;
-            const calcStr = this.numberToString (calcMul);
-            const calc = this.numberToString (parseFloat (calcStr));
-            timestamp = Math.max (oldTimestamp, parseInt (calc));
+            timestamp = Math.max (oldTimestamp, this.parseToInt (parseFloat (delta[2]) * 1000));
             bookside.store (price, amount);
         }
         return timestamp;


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17210

Demo

```
p kraken watchOrderBook "LTC/USDT"
Python v3.10.9
CCXT v3.0.13
kraken.watchOrderBook(LTC/USDT)
{'asks': [[78.14998, 10.0], [78.19518, 17.52186544], [78.23, 0.29402267], [78.24386, 1.99], [78.27135, 22.43565746], [78.28553, 109.0254], [78.2905, 13.338964], [78.29898, 30.22853121], [78.34869, 138.56130812], [78.41683, 25.079812]],
 'bids': [[78.11874, 30.0], [78.10927, 1.99], [78.10919, 10.0], [78.10907, 15.40385028], [78.10906, 1.99], [78.10886, 10.0], [78.10874, 30.0], [78.09472, 3.17480061], [78.09292, 12.75704371], [78.08043, 2.04543345]],
 'datetime': '2023-03-16T18:02:40.773Z',
 'nonce': None,
 'symbol': 'LTC/USDT',
 'timestamp': 1678989760773}
{'asks': [[78.14998, 10.0], [78.19518, 17.52186544], [78.23, 0.29402267], [78.24386, 1.99], [78.27135, 22.43565746], [78.28553, 109.0254], [78.2905, 13.338964], [78.29898, 30.22853121], [78.34869, 138.56130812], [78.41683, 25.079812]],
 'bids': [[78.11874, 30.0], [78.10927, 1.99], [78.10919, 10.0], [78.10907, 15.40385028], [78.10906, 1.99], [78.10886, 10.0], [78.10874, 30.0], [78.09292, 12.75704371], [78.08043, 2.04543345], [78.07962, 10.0]],
 'datetime': '2023-03-16T18:02:40.855Z',
 'nonce': None,
 'symbol': 'LTC/USDT',
 'timestamp': 1678989760855}
{'asks': [[78.14998, 10.0], [78.19518, 17.52186544], [78.23, 0.29402267], [78.24386, 1.99], [78.27135, 22.43565746], [78.28553, 109.0254], [78.2905, 13.338964], [78.29898, 30.22853121], [78.34869, 138.56130812], [78.41683, 25.079812]],
 'bids': [[78.11912, 3.17480061], [78.11874, 30.0], [78.10927, 1.99], [78.10919, 10.0], [78.10907, 15.40385028], [78.10906, 1.99], [78.10886, 10.0], [78.10874, 30.0], [78.09292, 12.75704371], [78.08043, 2.04543345]],
 'datetime': '2023-03-16T18:02:40.856Z',
 'nonce': None,
 'symbol': 'LTC/USDT',
 'timestamp': 1678989760856}
{'asks': [[78.14998, 10.0], [78.23, 0.29402267], [78.24386, 1.99], [78.27135, 22.43565746], [78.28553, 109.0254], [78.2905, 13.338964], [78.29898, 30.22853121], [78.34869, 138.56130812], [78.41683, 25.079812], [78.41684, 6.77932846]],
 'bids': [[78.11912, 3.17480061], [78.11874, 30.0], [78.10927, 1.99], [78.10919, 10.0], [78.10907, 15.40385028], [78.10906, 1.99], [78.10874, 30.0], [78.09292, 12.75704371], [78.08043, 2.04543345], [78.07962, 10.0]],
 'datetime': '2023-03-16T18:02:40.862Z',
 'nonce': None,
 'symbol': 'LTC/USDT',
 'timestamp': 1678989760862}
```
