### PR TITLE
feat: add 1:1 CommonJS structure instead of bundle [ci skip]

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -37,3 +37,6 @@ exchanges.cfg
 /ts/
 /js/src/test/
 /js/src/pro/test/
+
+# Ignore cjs bundle
+dist/ccxt.bundle.cjs

--- a/build/vss.js
+++ b/build/vss.js
@@ -51,6 +51,7 @@ async function vssEverything () {
     vss ('./js/ccxt.js',                                 "const version = '{version}'", version)
     vss ('./dist/ccxt.browser.js',                       "const version = '{version}'", version)
     vss ('./dist/cjs/ccxt.js',                           "const version = '{version}'", version)
+    vss ('./dist/ccxt.bundle.cjs',                       "const version = '{version}'", version)
     vss ('./php/Exchange.php',                           "$version = '{version}'",      version)
     vss ('./php/async/Exchange.php',                     "VERSION = '{version}'",       version)
     vss ('./php/async/Exchange.php',                     "$version = '{version}'",      version)

--- a/build/vss.js
+++ b/build/vss.js
@@ -50,7 +50,7 @@ async function vssEverything () {
     vss ('./ts/ccxt.ts',                                 "const version = '{version}'", version)
     vss ('./js/ccxt.js',                                 "const version = '{version}'", version)
     vss ('./dist/ccxt.browser.js',                       "const version = '{version}'", version)
-    vss ('./dist/ccxt.bundle.cjs',                       "const version = '{version}'", version)
+    vss ('./dist/cjs/ccxt.js',                           "const version = '{version}'", version)
     vss ('./php/Exchange.php',                           "$version = '{version}'",      version)
     vss ('./php/async/Exchange.php',                     "VERSION = '{version}'",       version)
     vss ('./php/async/Exchange.php',                     "$version = '{version}'",      version)

--- a/dist/ccxt.cjs
+++ b/dist/ccxt.cjs
@@ -1,4 +1,4 @@
-const ccxt = require('./ccxt.bundle.cjs');
+const ccxt = require('./cjs/ccxt.js');
 
 // this is needed because we use default and named exports
 // in the esm version

--- a/dist/cjs/ccxt.js
+++ b/dist/cjs/ccxt.js
@@ -1,0 +1,1 @@
+// will be built later

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,12 @@
         "ololog": "1.1.155",
         "replace-in-file": "^6.3.5",
         "rollup": "^2.70.1",
+        "rollup-plugin-execute": "1.1.1",
         "ts-node": "^10.9.1",
         "typescript": "4.7.4"
       },
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=15.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4572,6 +4573,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-execute": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-execute/-/rollup-plugin-execute-1.1.1.tgz",
+      "integrity": "sha512-isCNR/VrwlEfWJMwsnmt5TBRod8dW1IjVRxcXCBrxDmVTeA1IXjzeLSS3inFBmRD7KDPlo38KSb2mh5v5BoWgA==",
+      "dev": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9078,6 +9085,12 @@
       "requires": {
         "fsevents": "~2.3.2"
       }
+    },
+    "rollup-plugin-execute": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-execute/-/rollup-plugin-execute-1.1.1.tgz",
+      "integrity": "sha512-isCNR/VrwlEfWJMwsnmt5TBRod8dW1IjVRxcXCBrxDmVTeA1IXjzeLSS3inFBmRD7KDPlo38KSb2mh5v5BoWgA==",
+      "dev": true
     },
     "run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "ololog": "1.1.155",
     "replace-in-file": "^6.3.5",
     "rollup": "^2.70.1",
+    "rollup-plugin-execute": "1.1.1",
     "ts-node": "^10.9.1",
     "typescript": "4.7.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import json from "@rollup/plugin-json";
 import execute from 'rollup-plugin-execute';
 
 export default {
-  inlineDynamicImports: true,
+  preserveModules: true,
   input: "./js/ccxt.js",
   output: [
     {
@@ -17,6 +17,10 @@ export default {
       transformMixedEsModules: true,
       dynamicRequireTargets: ["**/js/src/static_dependencies/**/*.cjs"],
     }),
-    execute("echo '{ \"type\": \"commonjs\" }' > ./dist/cjs/package.json")
-  ]
+    execute("echo '{ \"type\": \"commonjs\" }' > ./dist/cjs/package.json") // this is needed to make node treat files inside dist/cjs as CJS modules
+  ],
+  onwarn: ( warning, next ) => {
+    if ( warning.message.indexOf('is implicitly using "default" export mode') > -1 ) return;
+    next( warning );
+},
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,13 @@
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
+import execute from 'rollup-plugin-execute';
 
 export default {
   inlineDynamicImports: true,
   input: "./js/ccxt.js",
   output: [
     {
-      file: "./dist/ccxt.bundle.cjs",
+      dir: "./dist/cjs/",
       format: "cjs",
     }
   ],
@@ -15,7 +16,7 @@ export default {
     commonjs({
       transformMixedEsModules: true,
       dynamicRequireTargets: ["**/js/src/static_dependencies/**/*.cjs"],
-
     }),
+    execute("echo '{ \"type\": \"commonjs\" }' > ./dist/cjs/package.json")
   ]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,25 +2,44 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import execute from 'rollup-plugin-execute';
 
-export default {
-  preserveModules: true,
-  input: "./js/ccxt.js",
-  output: [
-    {
-      dir: "./dist/cjs/",
-      format: "cjs",
-    }
-  ],
-  plugins: [
-    json(),
-    commonjs({
-      transformMixedEsModules: true,
-      dynamicRequireTargets: ["**/js/src/static_dependencies/**/*.cjs"],
-    }),
-    execute("echo '{ \"type\": \"commonjs\" }' > ./dist/cjs/package.json") // this is needed to make node treat files inside dist/cjs as CJS modules
-  ],
-  onwarn: ( warning, next ) => {
-    if ( warning.message.indexOf('is implicitly using "default" export mode') > -1 ) return;
-    next( warning );
-},
-};
+export default [
+  {
+    preserveModules: true,
+    input: "./js/ccxt.js",
+    output: [
+      {
+        dir: "./dist/cjs/",
+        format: "cjs",
+      }
+    ],
+    plugins: [
+      json(),
+      commonjs({
+        transformMixedEsModules: true,
+        dynamicRequireTargets: ["**/js/src/static_dependencies/**/*.cjs"],
+      }),
+      execute("echo '{ \"type\": \"commonjs\" }' > ./dist/cjs/package.json") // this is needed to make node treat files inside dist/cjs as CJS modules
+    ],
+    onwarn: ( warning, next ) => {
+      if ( warning.message.indexOf('is implicitly using "default" export mode') > -1 ) return;
+      next( warning );
+    },
+  },
+  {
+    inlineDynamicImports: true,
+    input: "./js/ccxt.js",
+    output: [
+      {
+        file: "./dist/ccxt.bundle.cjs",
+        format: "cjs",
+      },
+    ],
+    plugins: [
+      json(),
+      commonjs({
+        transformMixedEsModules: true,
+        dynamicRequireTargets: ["**/js/src/static_dependencies/**/*.cjs"],
+      }),
+    ],
+  }
+];

--- a/test-commonjs.cjs
+++ b/test-commonjs.cjs
@@ -1,4 +1,5 @@
 const ccxt = require ('./dist/ccxt.cjs');
+const ccxtBundle = require ('./dist/ccxt.bundle.cjs');
 const log = require ('ololog');
 const ansi = require ('ansicolor').nice;
 const assert = require ('assert');
@@ -16,11 +17,18 @@ process.on ('unhandledRejection', (e) => {
 const symbol = 'BTC/USDT:USDT';
 async function main() {
     try {
+        // test cjs version
         const exchange = new ccxt.bybit({});
         const ticker = await exchange.fetchTicker(symbol);
         assert(ticker !== undefined);
         assert(ticker['symbol'] === symbol);
         log.bright.green('[CJS Code] OK');
+        // test cjs bundle version
+        const exchangeBundle = new ccxtBundle.bybit({});
+        const tickeBundle = await exchangeBundle.fetchTicker(symbol);
+        assert(tickeBundle !== undefined);
+        assert(tickeBundle['symbol'] === symbol);
+        log.bright.green('[CJS Bundle Code] OK');
         process.exit(0);
     } catch (e) {
         log.bright.red('[CJS Code] Error: ' + e);

--- a/test-commonjs.cjs
+++ b/test-commonjs.cjs
@@ -1,4 +1,4 @@
-const ccxt = require ('./dist/ccxt.bundle.cjs');
+const ccxt = require ('./dist/ccxt.cjs');
 const log = require ('ololog');
 const ansi = require ('ansicolor').nice;
 const assert = require ('assert');
@@ -11,7 +11,7 @@ process.on ('unhandledRejection', (e) => {
 });
 
 // ----------------------------------------------------------------------------
-// Simple test just to make sure that the CJS bundle works
+// Simple test just to make sure that the CJS code works
 
 const symbol = 'BTC/USDT:USDT';
 async function main() {
@@ -20,10 +20,10 @@ async function main() {
         const ticker = await exchange.fetchTicker(symbol);
         assert(ticker !== undefined);
         assert(ticker['symbol'] === symbol);
-        log.bright.green('[CJS Bundle] OK');
+        log.bright.green('[CJS Code] OK');
         process.exit(0);
     } catch (e) {
-        log.bright.red('[CJS Bundle] Error: ' + e);
+        log.bright.red('[CJS Code] Error: ' + e);
         process.exit (1);
     }
 }


### PR DESCRIPTION
- Instead of `ccxt.bundle.cjs` we now have a `dist/cjs/` folder with the same structure as `js/` and `ts/` 