### PR TITLE
fix(binance): postOnly Orders [ci deploy]

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3204,6 +3204,10 @@ export default class Exchange {
         throw new NotSupported (this.id + ' cancelOrder() is not supported yet');
     }
 
+    async cancelAllOrders (symbol: string = undefined, params = {}): Promise<any> {
+        throw new NotSupported (this.id + ' cancelAllOrders() is not supported yet');
+    }
+
     async cancelUnifiedOrder (order, params = {}) {
         return this.cancelOrder (this.safeValue (order, 'id'), this.safeValue (order, 'symbol'), params);
     }
@@ -3244,7 +3248,7 @@ export default class Exchange {
         throw new NotSupported (this.id + ' fetchWithdrawals() is not supported yet');
     }
 
-    parseLastPrice (price, market = undefined) {
+    parseLastPrice (price, market = undefined): any {
         throw new NotSupported (this.id + ' parseLastPrice() is not supported yet');
     }
 
@@ -3313,7 +3317,7 @@ export default class Exchange {
         throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
     }
 
-    handleWithdrawTagAndParams (tag, params) {
+    handleWithdrawTagAndParams (tag, params): any {
         if (typeof tag === 'object') {
             params = this.extend (tag, params);
             tag = undefined;

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4080,6 +4080,10 @@ export default class binance extends Exchange {
                 request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
             }
         }
+        // remove timeInForce from params because PO is only used by this.isPostOnly and it's not a valid value for Binance
+        if (this.safeString (params, 'timeInForce') === 'PO') {
+            params = this.omit (params, [ 'timeInForce' ]);
+        }
         const requestParams = this.omit (params, [ 'quoteOrderQty', 'cost', 'stopPrice', 'test', 'type', 'newClientOrderId', 'clientOrderId', 'postOnly' ]);
         const response = await this[method] (this.extend (request, requestParams));
         return this.parseOrder (response, market);

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3569,6 +3569,10 @@ export default class binance extends Exchange {
                 request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
             }
         }
+        // remove timeInForce from params because PO is only used by this.isPostOnly and it's not a valid value for Binance
+        if (this.safeString (params, 'timeInForce') === 'PO') {
+            params = this.omit (params, [ 'timeInForce' ]);
+        }
         const requestParams = this.omit (params, [ 'quoteOrderQty', 'cost', 'stopPrice', 'newClientOrderId', 'clientOrderId', 'postOnly' ]);
         const response = await (this as any).privatePostOrderCancelReplace (this.extend (request, requestParams));
         //


### PR DESCRIPTION


Demo:

```
 p binanceusdm createOrder "LTC/USDT:USDT" limit buy 0.2 50 '{"timeInForce":"PO"}' --sandbox

Python v3.10.9
CCXT v3.0.22
binanceusdm.createOrder(LTC/USDT:USDT,limit,buy,0.2,50,{'timeInForce': 'PO'})
{'amount': 0.2,
 'average': None,
 'clientOrderId': 'akNDVlw7kI2x28U5fnJ2yk',
 'cost': 0.0,
 'datetime': '2023-03-19T16:43:38.764Z',
 'fee': {'cost': None, 'currency': None, 'rate': None},
 'fees': [{'cost': None, 'currency': None, 'rate': None}],
 'filled': 0.0,
 'id': '529493011',
 'info': {'avgPrice': '0.00000',
          'clientOrderId': 'akNDVlw7kI2x28U5fnJ2yk',
          'closePosition': False,
          'cumQty': '0',
          'cumQuote': '0',
          'executedQty': '0',
          'orderId': '529493011',
          'origQty': '0.200',
          'origType': 'LIMIT',
          'positionSide': 'BOTH',
          'price': '50',
          'priceProtect': False,
          'reduceOnly': False,
          'side': 'BUY',
          'status': 'NEW',
          'stopPrice': '0',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTX',
          'type': 'LIMIT',
          'updateTime': '1679244218764',
          'workingType': 'CONTRACT_PRICE'},
 'lastTradeTimestamp': None,
 'postOnly': True,
 'price': 50.0,
 'reduceOnly': False,
 'remaining': 0.2,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT:USDT',
 'timeInForce': 'PO',
 'timestamp': 1679244218764,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
```
 p binanceusdm createOrder "LTC/USDT:USDT" limit buy 0.2 50 --sandbox  
Python v3.10.9
CCXT v3.0.22
binanceusdm.createOrder(LTC/USDT:USDT,limit,buy,0.2,50)
{'amount': 0.2,
 'average': None,
 'clientOrderId': 'Kc82SgC9LuYwJ3bYfeqqiE',
 'cost': 0.0,
 'datetime': '2023-03-19T16:44:04.568Z',
 'fee': {'cost': None, 'currency': None, 'rate': None},
 'fees': [{'cost': None, 'currency': None, 'rate': None}],
 'filled': 0.0,
 'id': '529493230',
 'info': {'avgPrice': '0.00000',
          'clientOrderId': 'Kc82SgC9LuYwJ3bYfeqqiE',
          'closePosition': False,
          'cumQty': '0',
          'cumQuote': '0',
          'executedQty': '0',
          'orderId': '529493230',
          'origQty': '0.200',
          'origType': 'LIMIT',
          'positionSide': 'BOTH',
          'price': '50',
          'priceProtect': False,
          'reduceOnly': False,
          'side': 'BUY',
          'status': 'NEW',
          'stopPrice': '0',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC',
          'type': 'LIMIT',
          'updateTime': '1679244244568',
          'workingType': 'CONTRACT_PRICE'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': False,
 'remaining': 0.2,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT:USDT',
 'timeInForce': 'GTC',
 'timestamp': 1679244244568,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
```
p binance createOrder "LTC/USDT" limit buy 0.2 50  
Python v3.10.9
CCXT v3.0.22
binance.createOrder(LTC/USDT,limit,buy,0.2,50)
{'amount': 0.2,
 'average': None,
 'clientOrderId': 'x-R4BD3S823852d2d2fa25bff50d85b5',
 'cost': 0.0,
 'datetime': '2023-03-19T16:48:08.484Z',
 'fee': {'cost': None, 'currency': None, 'rate': None},
 'fees': [{'cost': None, 'currency': None, 'rate': None}],
 'filled': 0.0,
 'id': '3385428233',
 'info': {'clientOrderId': 'x-R4BD3S823852d2d2fa25bff50d85b5',
          'cummulativeQuoteQty': '0.00000000',
          'executedQty': '0.00000000',
          'fills': [],
          'orderId': '3385428233',
          'orderListId': '-1',
          'origQty': '0.20000000',
          'price': '50.00000000',
          'selfTradePreventionMode': 'NONE',
          'side': 'BUY',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC',
          'transactTime': '1679244488484',
          'type': 'LIMIT',
          'workingTime': '1679244488484'},
 'lastTradeTimestamp': 1679244488484,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': 0.2,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1679244488484,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
```
p binance createOrder "LTC/USDT" limit buy 0.2 50 '{"timeInForce":"PO"}' 
Python v3.10.9
CCXT v3.0.22
binance.createOrder(LTC/USDT,limit,buy,0.2,50,{'timeInForce': 'PO'})
{'amount': 0.2,
 'average': None,
 'clientOrderId': 'x-R4BD3S82c5c12b58c6f6a0a7618847',
 'cost': 0.0,
 'datetime': '2023-03-19T16:48:36.686Z',
 'fee': {'cost': None, 'currency': None, 'rate': None},
 'fees': [{'cost': None, 'currency': None, 'rate': None}],
 'filled': 0.0,
 'id': '3385431570',
 'info': {'clientOrderId': 'x-R4BD3S82c5c12b58c6f6a0a7618847',
          'cummulativeQuoteQty': '0.00000000',
          'executedQty': '0.00000000',
          'orderId': '3385431570',
          'orderListId': '-1',
          'origQty': '0.20000000',
          'price': '50.00000000',
          'selfTradePreventionMode': 'NONE',
          'side': 'BUY',
          'status': 'NEW',
          'symbol': 'LTCUSDT',
          'timeInForce': 'GTC',
          'transactTime': '1679244516686',
          'type': 'LIMIT_MAKER',
          'workingTime': '1679244516686'},
 'lastTradeTimestamp': 1679244516686,
 'postOnly': True,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': 0.2,
 'side': 'buy',
 'status': 'open',
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': 'GTC',
 'timestamp': 1679244516686,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
