### PR TITLE
fix(bybit): v5 does not require symbol for spot trades

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5917,7 +5917,7 @@ export default class bybit extends Exchange {
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         if (enableUnifiedAccount && !isInverse) {
             const orderId = this.safeString (params, 'orderId');
-            if (orderId === undefined) {
+            if (orderId === undefined && type !== 'spot') {
                 this.checkRequiredSymbol ('fetchMyTrades', symbol);
             }
             return await this.fetchMyUnifiedTrades (symbol, since, limit, query);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17254

```
p bybit fetchMyTrades None None 1 --sandbox --spot          
Python v3.10.9
CCXT v3.0.23
bybit.fetchMyTrades(None,None,1)
[{'amount': 0.000197,
  'cost': 4.97516605,
  'datetime': '2023-03-15T12:38:31.104Z',
  'fee': {'cost': 1.97e-07, 'currency': 'USDT'},
  'fees': [{'cost': 1.97e-07, 'currency': 'USDT'}],
  'id': '2100000000014827766',
  'info': {'blockTradeId': '',
           'execFee': '0.000000197',
           'execId': '2100000000014827766',
           'execPrice': '25254.65',
           'execQty': '0.000197',
           'execTime': '1678883911104',
           'execType': 'UNKNOWN',
           'execValue': '4.97516605',
           'feeRate': '0.001',
           'indexPrice': '',
           'isMaker': False,
           'leavesQty': '0',
           'markIv': '',
           'markPrice': '',
           'orderId': '1376972480213685760',
           'orderLinkId': '1678883911092627',
           'orderPrice': '999999',
           'orderQty': '0',
           'orderType': 'Market',
           'side': 'Buy',
           'stopOrderType': 'UNKNOWN',
           'symbol': 'BTCUSDT',
           'tradeIv': '',
           'underlyingPrice': ''},
  'order': '1376972480213685760',
  'price': 25254.65,
  'side': 'buy',
  'symbol': 'BTC/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1678883911104,
  'type': 'market'}]
```
