### PR TITLE
bitstamp parseTrade fix

### DIFF
--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -846,7 +846,8 @@ export default class bitstamp extends Exchange {
         }
         const feeCostString = this.safeString (trade, 'fee');
         const feeCurrency = market['quote'];
-        priceString = this.safeString (trade, rawMarketId, priceString);
+        const priceId = (rawMarketId !== undefined) ? rawMarketId : market['marketId'];
+        priceString = this.safeString(trade, priceId, priceString);
         amountString = this.safeString (trade, market['baseId'], amountString);
         costString = this.safeString (trade, market['quoteId'], costString);
         symbol = market['symbol'];

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -847,7 +847,7 @@ export default class bitstamp extends Exchange {
         const feeCostString = this.safeString (trade, 'fee');
         const feeCurrency = market['quote'];
         const priceId = (rawMarketId !== undefined) ? rawMarketId : market['marketId'];
-        priceString = this.safeString(trade, priceId, priceString);
+        priceString = this.safeString (trade, priceId, priceString);
         amountString = this.safeString (trade, market['baseId'], amountString);
         costString = this.safeString (trade, market['quoteId'], costString);
         symbol = market['symbol'];


### PR DESCRIPTION
now when we try to call `fetchMyTrades` with `symbol`, `price` is `undefined`:

`await exchange.fetchMyTrades ('BTC/USD');`
```
{
    id: '248276265',
    info: {
      id: 248276265,
      datetime: '2022-09-21 17:59:54.915000',
      type: '2',
      fee: '0.04886',
      btc: '-0.00310029',
      usd: '61.07881329',
      btc_usd: 19701,
      eur: 0,
      order_id: 1535787903991815
    },
    timestamp: 1663783194915,
    datetime: '2022-09-21T17:59:54.915Z',
    symbol: 'BTC/USD',
    order: '1535787903991815',
    type: undefined,
    side: 'sell',
    takerOrMaker: undefined,
    price: undefined,
    amount: 0.00310029,
    cost: 61.07881329,
    fee: { cost: 0.04886, currency: 'USD' },
    fees: [ [Object] ]
  }
```
