### PR TITLE
fix(bybit): add symbol to fetchPositions

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -6820,6 +6820,7 @@ export default class bybit extends Exchange {
             const first = this.safeValue (symbols, 0);
             const market = this.market (first);
             settle = market['settle'];
+            request['symbol'] = market['id'];
         }
         if (enableUnified[1]) {
             request['settleCoin'] = settle;


### PR DESCRIPTION
```
p bybit fetchPositions '["ETH/USDT:USDT"]' --sandbox
Python v3.10.9
CCXT v3.0.24
bybit.fetchPositions(['ETH/USDT:USDT'])
[{'collateral': None,
  'contractSize': 1.0,
  'contracts': 0.0,
  'datetime': None,
  'entryPrice': None,
  'id': None,
  'info': {'activePrice': '',
           'avgPrice': '',
           'bustPrice': '',
           'createdTime': '',
           'cumRealisedPnl': '',
           'leverage': '10',
           'liqPrice': '',
           'markPrice': '',
           'positionIM': '',
           'positionIdx': '0',
           'positionMM': '',
           'positionValue': '',
           'riskId': '11',
           'riskLimitValue': '900000',
           'side': 'None',
           'size': '0',
           'stopLoss': '',
           'symbol': 'ETHUSDT',
           'takeProfit': '',
           'tpslMode': '',
           'tradeMode': '0',
           'trailingStop': '',
           'unrealisedPnl': '',
           'updatedTime': ''},
  'initialMargin': None,
  'initialMarginPercentage': None,
  'leverage': 10.0,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'side': None,
  'symbol': 'ETH/USDT:USDT',
  'timestamp': None,
  'unrealizedPnl': None}]
```
