### PR TITLE
fix: parsePrecision

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3419,6 +3419,9 @@ export default class Exchange {
             return undefined;
         }
         const precisionNumber = parseInt (precision);
+        if (precisionNumber === 0) {
+            return '1';
+        }
         let parsedPrecision = '0.';
         for (let i = 0; i < precisionNumber - 1; i++) {
             parsedPrecision = parsedPrecision + '0';


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17284

Demo

```
✗ n bitget parsePrecision "0"         
CCXT v3.0.26
bitget.parsePrecision (0)
2023-03-21T11:24:03.224Z iteration 0 passed in 0 ms

'1'
```
```
 n bitget parsePrecision "1"
CCXT v3.0.26
bitget.parsePrecision (1)

'0.1'
```
```
n bitget parsePrecision "2"
Debugger attached.
2023-03-21T11:24:43.054Z
Node.js: v18.14.0
CCXT v3.0.26
bitget.parsePrecision (2)
2023-03-21T11:24:44.288Z iteration 0 passed in 0 ms

'0.01'
```
