### PR TITLE
Binance, Bybit: fetchOHLCV inverse markets volume

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2988,7 +2988,7 @@ export default class binance extends Exchange {
         //         "0.02500000",  // close
         //         "22.19000000", // volume
         //         1591478579999, // close time
-        //         "0.55490906",  // quote asset volume
+        //         "0.55490906",  // quote asset volume, base asset volume for dapi
         //         40,            // number of trades
         //         "10.92900000", // taker buy base asset volume
         //         "0.27336462",  // taker buy quote asset volume
@@ -3030,13 +3030,14 @@ export default class binance extends Exchange {
         //         "closeTime": 1677097200000
         //     }
         //
+        const volumeIndex = (market['inverse']) ? 7 : 5;
         return [
             this.safeInteger2 (ohlcv, 0, 'closeTime'),
             this.safeNumber2 (ohlcv, 1, 'open'),
             this.safeNumber2 (ohlcv, 2, 'high'),
             this.safeNumber2 (ohlcv, 3, 'low'),
             this.safeNumber2 (ohlcv, 4, 'close'),
-            this.safeNumber2 (ohlcv, 5, 'volume'),
+            this.safeNumber2 (ohlcv, volumeIndex, 'volume'),
         ];
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1952,13 +1952,14 @@ export default class bybit extends Exchange {
         //         "2.4343353100000003"
         //     ]
         //
+        const volumeIndex = (market['inverse']) ? 6 : 5;
         return [
             this.safeInteger (ohlcv, 0),
             this.safeNumber (ohlcv, 1),
             this.safeNumber (ohlcv, 2),
             this.safeNumber (ohlcv, 3),
             this.safeNumber (ohlcv, 4),
-            this.safeNumber (ohlcv, 5),
+            this.safeNumber (ohlcv, volumeIndex),
         ];
     }
 


### PR DESCRIPTION
Update fetchOHLCV on Binance and Bybit to return the correct volume for inverse markets:
fixes: #17279
### Binance fetchOHLCV:
```
binance.fetchOHLCV (BTC/USD:BTC, 1m, , 3)
2023-03-21T20:57:30.911Z iteration 0 passed in 467 ms

1679432100000 | 28151.7 |   28157 | 28147.6 | 28147.6 | 21.41177992
1679432160000 | 28147.6 | 28147.6 | 28142.3 | 28146.2 | 12.71666411
1679432220000 | 28146.1 | 28146.1 |   28144 | 28144.1 |  10.2324702
3 objects
```

### Bybit fetchOHLCV:
```
bybit.fetchOHLCV (BTC/USD:BTC, 1m, , 3)
2023-03-21T20:57:35.348Z iteration 0 passed in 256 ms

1679432100000 |   28153 | 28165.5 | 28150.5 |   28152 | 6.57921134
1679432160000 |   28152 |   28153 | 28142.5 | 28152.5 | 5.64614585
1679432220000 | 28152.5 | 28153.5 | 28135.5 | 28135.5 | 2.61354273
3 objects
```