### PR TITLE
Exchange: add types from pre-TypeScript conversion ccxt.d.ts.

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -194,11 +194,11 @@ export default class Exchange {
     apiKey: string;
     secret: string;
     uid: string;
-    login         = undefined
+    login:string;
     password: string;
-    privateKey    = undefined // a "0x"-prefixed hexstring private key for a wallet
-    walletAddress = undefined // a wallet address "0x"-prefixed hexstring
-    token         = undefined // reserved for HTTP auth in some cases
+    privateKey: string;// a "0x"-prefixed hexstring private key for a wallet
+    walletAddress: string; // a wallet address "0x"-prefixed hexstring
+    token: string; // reserved for HTTP auth in some cases
 
     balance      = {}
     orderbooks   = {}
@@ -265,11 +265,11 @@ export default class Exchange {
         leverage?: MinMax,
         price?: MinMax,
     };
-    fees = undefined
-    markets_by_id: Dictionary<any> = undefined
+    fees: object;
+    markets_by_id: Dictionary<any> = undefined;
     symbols: string[] = undefined;
-    ids: string[] = undefined
-    currencies: Dictionary<Currency> = undefined
+    ids: string[] = undefined;
+    currencies: Dictionary<Currency> = undefined;
 
     baseCurrencies = undefined
     quoteCurrencies = undefined
@@ -296,9 +296,9 @@ export default class Exchange {
 
     marketsByAltname = undefined
 
-    name = undefined
+    name:string = undefined
 
-    lastRestRequestTimestamp = undefined
+    lastRestRequestTimestamp:number;
 
     targetAccount = undefined
 

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -188,14 +188,14 @@ export default class Exchange {
     timeout       = 10000 // milliseconds
     verbose       = false
     debug         = false
-    userAgent     = undefined
+    userAgent: { 'User-Agent': string } | false = undefined;
     twofa         = undefined // two-factor authentication (2FA)
 
     apiKey: string;
     secret: string;
     uid: string;
     login         = undefined
-    password
+    password: string;
     privateKey    = undefined // a "0x"-prefixed hexstring private key for a wallet
     walletAddress = undefined // a wallet address "0x"-prefixed hexstring
     token         = undefined // reserved for HTTP auth in some cases
@@ -252,10 +252,10 @@ export default class Exchange {
         walletAddress: boolean;
         token: boolean;
     };
-    rateLimit = undefined
+    rateLimit: number = undefined; // milliseconds
     tokenBucket = undefined
     throttle = undefined
-    enableRateLimit = undefined
+    enableRateLimit: boolean = undefined;
 
     httpExceptions = undefined
 
@@ -267,7 +267,7 @@ export default class Exchange {
     };
     fees = undefined
     markets_by_id: Dictionary<any> = undefined
-    symbols = undefined
+    symbols: string[] = undefined;
     ids: string[] = undefined
     currencies: Dictionary<Currency> = undefined
 
@@ -284,15 +284,15 @@ export default class Exchange {
 
     commonCurrencies = undefined
 
-    hostname = undefined
+    hostname: string = undefined;
 
-    precisionMode = undefined
+    precisionMode: number = undefined;
     paddingMode = undefined
 
     exceptions = {}
     timeframes: Dictionary<number | string> = {}
 
-    version = undefined
+    version: string = undefined;
 
     marketsByAltname = undefined
 


### PR DESCRIPTION
Review the pre-TypeScript `ccxt.d.ts` and declare the variables in the newer `Exchange.ts` with those types where they didn't have them.

Add semicolons also. I can remove these if you like.