### PR TITLE
Bitfinex pro string math

### DIFF
--- a/ts/src/pro/bitfinex.ts
+++ b/ts/src/pro/bitfinex.ts
@@ -351,13 +351,13 @@ export default class bitfinex extends bitfinexRest {
             const orderbook = this.orderbooks[symbol];
             if (isRaw) {
                 const id = this.safeString (message, 1);
-                const price = this.safeFloat (message, 2);
+                const price = this.safeString (message, 2);
                 const size = (message[3] < 0) ? -message[3] : message[3];
                 const side = (message[3] < 0) ? 'asks' : 'bids';
                 const bookside = orderbook[side];
                 // price = 0 means that you have to remove the order from your book
-                const amount = (price > 0) ? size : 0;
-                bookside.store (price, amount, id);
+                const amount = Precise.stringGt (price, '0') ? size : 0;
+                bookside.store (this.parseNumber (price), amount, id);
             } else {
                 const size = (message[3] < 0) ? -message[3] : message[3];
                 const side = (message[3] < 0) ? 'asks' : 'bids';

--- a/ts/src/pro/bitfinex.ts
+++ b/ts/src/pro/bitfinex.ts
@@ -167,16 +167,12 @@ export default class bitfinex extends bitfinexRest {
             id = this.safeString (trade, tradeLength - 4);
         }
         const timestamp = this.safeTimestamp (trade, tradeLength - 3);
-        const price = this.safeFloat (trade, tradeLength - 2);
-        let amount = this.safeFloat (trade, tradeLength - 1);
+        const price = this.safeString (trade, tradeLength - 2);
+        let amount = this.safeString (trade, tradeLength - 1);
         let side = undefined;
         if (amount !== undefined) {
-            side = (amount > 0) ? 'buy' : 'sell';
-            amount = Math.abs (amount);
-        }
-        let cost = undefined;
-        if ((price !== undefined) && (amount !== undefined)) {
-            cost = price * amount;
+            side = Precise.stringGt (amount, '0') ? 'buy' : 'sell';
+            amount = Precise.stringAbs (amount);
         }
         const seq = this.safeString (trade, 2);
         const parts = seq.split ('-');
@@ -187,7 +183,7 @@ export default class bitfinex extends bitfinexRest {
         const symbol = this.safeSymbol (marketId, market);
         const takerOrMaker = undefined;
         const orderId = undefined;
-        return {
+        return this.safeTrade ({
             'info': trade,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -199,9 +195,9 @@ export default class bitfinex extends bitfinexRest {
             'side': side,
             'price': price,
             'amount': amount,
-            'cost': cost,
+            'cost': undefined,
             'fee': undefined,
-        };
+        });
     }
 
     handleTicker (client, message, subscription) {


### PR DESCRIPTION
### typescript

#### watchTrades

```
% bitfinex watchTrades BTC/USDT
2023-03-25T04:21:40.087Z
Node.js: v18.15.0
CCXT v3.0.33
bitfinex.watchTrades (BTC/USDT)
    timestamp |                 datetime |   symbol | id | order | type | takerOrMaker | side | price |     amount |          cost | fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27546 |     0.0011 |       30.3006 |     |   []
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27547 |     0.0011 |       30.3017 |     |   []
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27548 |     0.0011 |       30.3028 |     |   []
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27549 |     0.0011 |       30.3039 |     |   []
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27550 |     0.0011 |        30.305 |     |   []
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27551 | 0.13214463 | 3640.71670113 |     |   []
1679717568000 | 2023-03-25T04:12:48.000Z | BTC/USDT |    |       |      |              | sell | 27552 |  0.1442696 |  3974.9160192 |     |   []
1679717569000 | 2023-03-25T04:12:49.000Z | BTC/USDT |    |       |      |              | sell | 27541 |     0.0011 |       30.2951 |     |   []
1679717569000 | 2023-03-25T04:12:49.000Z | BTC/USDT |    |       |      |              | sell | 27543 |     0.0011 |       30.2973 |     |   []
1679717592000 | 2023-03-25T04:13:12.000Z | BTC/USDT |    |       |      |              |  buy | 27554 | 0.00006524 |    1.79762296 |     |   []
1679717616000 | 2023-03-25T04:13:36.000Z | BTC/USDT |    |       |      |              |  buy | 27560 | 0.00011417 |     3.1465252 |     |   []
1679717644000 | 2023-03-25T04:14:04.000Z | BTC/USDT |    |       |      |              |  buy | 27553 | 0.00011608 |    3.19835224 |     |   []
1679717672000 | 2023-03-25T04:14:32.000Z | BTC/USDT |    |       |      |              | sell | 27549 | 0.00009362 |    2.57913738 |     |   []
1679717697000 | 2023-03-25T04:14:57.000Z | BTC/USDT |    |       |      |              |  buy | 27554 | 0.00006042 |    1.66481268 |     |   []
1679717700000 | 2023-03-25T04:15:00.000Z | BTC/USDT |    |       |      |              | sell | 27550 | 0.00008676 |      2.390238 |     |   []
1679717725000 | 2023-03-25T04:15:25.000Z | BTC/USDT |    |       |      |              |  buy | 27556 | 0.00007717 |    2.12649652 |     |   []
1679717743000 | 2023-03-25T04:15:43.000Z | BTC/USDT |    |       |      |              | sell | 27557 | 0.00008928 |    2.46028896 |     |   []
1679717862000 | 2023-03-25T04:17:42.000Z | BTC/USDT |    |       |      |              |  buy | 27555 | 0.00010237 |    2.82080535 |     |   []
1679717885000 | 2023-03-25T04:18:05.000Z | BTC/USDT |    |       |      |              |  buy | 27558 | 0.00008569 |    2.36144502 |     |   []
1679717905000 | 2023-03-25T04:18:25.000Z | BTC/USDT |    |       |      |              |  buy | 27559 | 0.00009685 |    2.66908915 |     |   []
1679717922000 | 2023-03-25T04:18:42.000Z | BTC/USDT |    |       |      |              | sell | 27548 | 0.00011542 |    3.17959016 |     |   []
1679717942000 | 2023-03-25T04:19:02.000Z | BTC/USDT |    |       |      |              |  buy | 27555 | 0.00011245 |    3.09855975 |     |   []
1679717963000 | 2023-03-25T04:19:23.000Z | BTC/USDT |    |       |      |              |  buy | 27559 | 0.00008083 |    2.22759397 |     |   []
1679717984000 | 2023-03-25T04:19:44.000Z | BTC/USDT |    |       |      |              |  buy | 27559 | 0.00010719 |    2.95404921 |     |   []
1679717989000 | 2023-03-25T04:19:49.000Z | BTC/USDT |    |       |      |              | sell | 27556 |  0.0001052 |     2.8988912 |     |   []
1679718001000 | 2023-03-25T04:20:01.000Z | BTC/USDT |    |       |      |              | sell | 27557 |  0.0000926 |     2.5517782 |     |   []
1679718025000 | 2023-03-25T04:20:25.000Z | BTC/USDT |    |       |      |              |  buy | 27557 | 0.00010923 |    3.01005111 |     |   []
1679718049000 | 2023-03-25T04:20:49.000Z | BTC/USDT |    |       |      |              |  buy | 27560 | 0.00006265 |      1.726634 |     |   []
1679718072000 | 2023-03-25T04:21:12.000Z | BTC/USDT |    |       |      |              |  buy | 27558 | 0.00008552 |    2.35676016 |     |   []
1679718096000 | 2023-03-25T04:21:36.000Z | BTC/USDT |    |       |      |              |  buy | 27559 |  0.0000843 |     2.3232237 |     |   []
30 objects
    timestamp |                 datetime |   symbol |         id | order | type | takerOrMaker | side | price |     amount |       cost | fee | fees
----------------------------------------------------------------------------------------------------------------------------------------------------
1679718118000 | 2023-03-25T04:21:58.000Z | BTC/USDT | 1338106086 |       |      |              |  buy | 27561 | 0.00007762 | 2.13928482 |     |   []
1 objects
```

#### watchTicker

```
% bitfinex watchTicker BTC/USDT
2023-03-25T04:22:56.311Z
Node.js: v18.15.0
CCXT v3.0.33
bitfinex.watchTicker (BTC/USDT)
{
  symbol: 'BTC/USDT',
  timestamp: 1679718189461,
  datetime: '2023-03-25T04:23:09.461Z',
  high: 28329,
  low: 27000,
  bid: 27558,
  bidVolume: undefined,
  ask: 27559,
  askVolume: undefined,
  vwap: undefined,
  open: 28208,
  close: 27559,
  last: 27559,
  previousClose: undefined,
  change: -649,
  percentage: -0.02300766,
  average: undefined,
  baseVolume: 433.76692329,
  quoteVolume: undefined,
  info: [
          252706, 27558,
     15.88166384, 27559,
     13.25556578,  -649,
     -0.02300766, 27559,
    433.76692329, 28329,
           27000
  ]
}
```

### python3

#### watchTrades

```
% python3 examples/py/cli.py bitfinex watchTrades BTC/USDT
Python v3.9.6
CCXT v3.0.33
bitfinex.watchTrades(BTC/USDT)
[{'amount': 0.01758682,
  'cost': 484.67517238,
  'datetime': '2023-03-25T04:23:59.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106115-tBTCUST', 1679718239, 27559, 0.01758682],
  'order': None,
  'price': 27559.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718239000,
  'type': None},
 {'amount': 0.01806,
  'cost': 497.71554,
  'datetime': '2023-03-25T04:23:59.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106114-tBTCUST', 1679718239, 27559, 0.01806],
  'order': None,
  'price': 27559.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718239000,
  'type': None},
 {'amount': 0.00011789,
  'cost': 3.25128831,
  'datetime': '2023-03-25T04:24:21.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106122-tBTCUST', 1679718261, 27579, 0.00011789],
  'order': None,
  'price': 27579.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718261000,
  'type': None},
 {'amount': 7.637e-05,
  'cost': 2.10597912,
  'datetime': '2023-03-25T04:25:01.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106130-tBTCUST', 1679718301, 27576, -7.637e-05],
  'order': None,
  'price': 27576.0,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718301000,
  'type': None},
 {'amount': 0.00011209,
  'cost': 3.09177847,
  'datetime': '2023-03-25T04:25:23.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106132-tBTCUST', 1679718323, 27583, 0.00011209],
  'order': None,
  'price': 27583.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718323000,
  'type': None},
 {'amount': 9.999e-05,
  'cost': 2.75802417,
  'datetime': '2023-03-25T04:25:44.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106139-tBTCUST', 1679718344, 27583, 9.999e-05],
  'order': None,
  'price': 27583.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718344000,
  'type': None},
 {'amount': 8.504e-05,
  'cost': 2.34565832,
  'datetime': '2023-03-25T04:26:09.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106143-tBTCUST', 1679718369, 27583, 8.504e-05],
  'order': None,
  'price': 27583.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718369000,
  'type': None},
 {'amount': 0.00099712,
  'cost': 27.50455808,
  'datetime': '2023-03-25T04:26:18.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106147-tBTCUST', 1679718378, 27584, 0.00099712],
  'order': None,
  'price': 27584.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718378000,
  'type': None},
 {'amount': 0.00070288,
  'cost': 19.38753904,
  'datetime': '2023-03-25T04:26:18.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106146-tBTCUST', 1679718378, 27583, 0.00070288],
  'order': None,
  'price': 27583.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718378000,
  'type': None},
 {'amount': 5.712e-05,
  'cost': 1.5756552,
  'datetime': '2023-03-25T04:26:21.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106150-tBTCUST', 1679718381, 27585, 5.712e-05],
  'order': None,
  'price': 27585.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718381000,
  'type': None},
 {'amount': 2.88e-06,
  'cost': 0.07944192,
  'datetime': '2023-03-25T04:26:21.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106149-tBTCUST', 1679718381, 27584, 2.88e-06],
  'order': None,
  'price': 27584.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718381000,
  'type': None},
 {'amount': 7.983e-05,
  'cost': 2.20211055,
  'datetime': '2023-03-25T04:26:44.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106156-tBTCUST', 1679718404, 27585, 7.983e-05],
  'order': None,
  'price': 27585.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718404000,
  'type': None},
 {'amount': 0.00010142,
  'cost': 2.7976707,
  'datetime': '2023-03-25T04:27:07.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106160-tBTCUST', 1679718427, 27585, 0.00010142],
  'order': None,
  'price': 27585.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718427000,
  'type': None},
 {'amount': 8.061e-05,
  'cost': 2.22362685,
  'datetime': '2023-03-25T04:27:32.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106164-tBTCUST', 1679718452, 27585, 8.061e-05],
  'order': None,
  'price': 27585.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718452000,
  'type': None},
 {'amount': 0.00068,
  'cost': 18.7578,
  'datetime': '2023-03-25T04:27:42.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106166-tBTCUST', 1679718462, 27585, 0.00068],
  'order': None,
  'price': 27585.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718462000,
  'type': None},
 {'amount': 0.001,
  'cost': 27.589,
  'datetime': '2023-03-25T04:27:43.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106169-tBTCUST', 1679718463, 27589, 0.001],
  'order': None,
  'price': 27589.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718463000,
  'type': None},
 {'amount': 0.001,
  'cost': 27.586,
  'datetime': '2023-03-25T04:27:43.000Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': ['1338106168-tBTCUST', 1679718463, 27586, 0.001],
  'order': None,
  'price': 27586.0,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1679718463000,
  'type': None},
  ```

#### watchTicker

```
% python3 examples/py/cli.py bitfinex watchTicker BTC/USDT
Python v3.9.6
CCXT v3.0.33
bitfinex.watchTicker(BTC/USDT)
{'ask': 27600.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 433.80956103,
 'bid': 27598.0,
 'bidVolume': None,
 'change': -610.0,
 'close': 27598.0,
 'datetime': '2023-03-25T04:29:46.775Z',
 'high': 28329.0,
 'info': [209471,
          27598,
          15.12365906,
          27600,
          16.66082624,
          -610,
          -0.02162507,
          27598,
          433.80956103,
          28329,
          27000],
 'last': 27598.0,
 'low': 27000.0,
 'open': 28208.0,
 'percentage': -0.02162507,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1679718586775,
 'vwap': None}
 ```