### PR TITLE
Add TypeScript types to a number of Exchange's market methods.

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -646,6 +646,8 @@ class Transpiler {
             // [ /:\s\w+(\s*\|\s*\w+)?(?=\s|,|\))/g, ""], // remove parameters type
             // array types: string[] or (string|number)[]
             // [ /:\s\(?\w+(\s*\|\s*\w+)?\)?\[]/g, ""], // remove parameters type
+            // generic types: Dictionary<Currency>
+            [ /:\s\w+\s*<\s*\w+\s*>/g, ""],
         ]
     }
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1197,7 +1197,7 @@ class Exchange {
         }
 
         if ($this->markets) {
-            $this->set_markets($this->markets);
+            $this->set_markets(array_values($this->markets));
         }
     }
 
@@ -1547,7 +1547,7 @@ class Exchange {
     public function load_markets($reload = false, $params = array()) {
         if (!$reload && $this->markets) {
             if (!$this->markets_by_id) {
-                return $this->set_markets($this->markets);
+                return $this->set_markets(array_values($this->markets));
             }
             return $this->markets;
         }
@@ -2348,11 +2348,11 @@ class Exchange {
         $this->markets_by_id = array();
         // handle marketId conflicts
         // we insert spot $markets first
-        $marketValues = $this->sort_by($this->to_array($markets), 'spot', true);
+        $marketValues = $this->sort_by($markets, 'spot', true);
         for ($i = 0; $i < count($marketValues); $i++) {
             $value = $marketValues[$i];
             if (is_array($this->markets_by_id) && array_key_exists($value['id'], $this->markets_by_id)) {
-                ($this->markets_by_id[$value['id']])[] = $value;
+                $this->markets_by_id[$value['id']][] = $value;
             } else {
                 $this->markets_by_id[$value['id']] = array( $value );
             }

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -446,11 +446,11 @@ class Exchange extends \ccxt\Exchange {
         $this->markets_by_id = array();
         // handle marketId conflicts
         // we insert spot $markets first
-        $marketValues = $this->sort_by($this->to_array($markets), 'spot', true);
+        $marketValues = $this->sort_by($markets, 'spot', true);
         for ($i = 0; $i < count($marketValues); $i++) {
             $value = $marketValues[$i];
             if (is_array($this->markets_by_id) && array_key_exists($value['id'], $this->markets_by_id)) {
-                ($this->markets_by_id[$value['id']])[] = $value;
+                $this->markets_by_id[$value['id']][] = $value;
             } else {
                 $this->markets_by_id[$value['id']] = array( $value );
             }

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -189,7 +189,7 @@ class Exchange(BaseExchange):
         if not reload:
             if self.markets:
                 if not self.markets_by_id:
-                    return self.set_markets(self.markets)
+                    return self.set_markets(list(self.markets.values()))
                 return self.markets
         currencies = None
         if self.has['fetchCurrencies'] is True:
@@ -618,11 +618,11 @@ class Exchange(BaseExchange):
         self.markets_by_id = {}
         # handle marketId conflicts
         # we insert spot markets first
-        marketValues = self.sort_by(self.to_array(markets), 'spot', True)
+        marketValues = self.sort_by(markets, 'spot', True)
         for i in range(0, len(marketValues)):
             value = marketValues[i]
             if value['id'] in self.markets_by_id:
-                (self.markets_by_id[value['id']]).append(value)
+                self.markets_by_id[value['id']].append(value)
             else:
                 self.markets_by_id[value['id']] = [value]
             market = self.deep_extend(self.safe_market(), {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -409,7 +409,7 @@ class Exchange(object):
                 setattr(self, key, settings[key])
 
         if self.markets:
-            self.set_markets(self.markets)
+            self.set_markets(list(self.markets.values()))
 
         # convert all properties from underscore notation foo_bar to camelcase notation fooBar
         cls = type(self)
@@ -1383,7 +1383,7 @@ class Exchange(object):
         if not reload:
             if self.markets:
                 if not self.markets_by_id:
-                    return self.set_markets(self.markets)
+                    return self.set_markets(list(self.markets.values()))
                 return self.markets
         currencies = None
         if self.has['fetchCurrencies'] is True:
@@ -1828,11 +1828,11 @@ class Exchange(object):
         self.markets_by_id = {}
         # handle marketId conflicts
         # we insert spot markets first
-        marketValues = self.sort_by(self.to_array(markets), 'spot', True)
+        marketValues = self.sort_by(markets, 'spot', True)
         for i in range(0, len(marketValues)):
             value = marketValues[i]
             if value['id'] in self.markets_by_id:
-                (self.markets_by_id[value['id']]).append(value)
+                self.markets_by_id[value['id']].append(value)
             else:
                 self.markets_by_id[value['id']] = [value]
             market = self.deep_extend(self.safe_market(), {


### PR DESCRIPTION
Add accurate types to a number of market related properties and methods.

`Exchange#setMarkets()` was a little complicated since it would actually accept an array and a dictionary and convert into an array in the method itself. However, attempting to use `setMarkets (markets: Market[] | Dictionary<Market>, ...)` to indicate this as a type would fail the transpiler as the type text would end up in the Python version.

Instead, I went with `setMarkets (markets: Market[],...)` and updated all callers that passed in a dictionary to convert it to an array before hand.