### PR TITLE
Exhange#setMarkets: Currency.numericId is a number and not a string.

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1605,7 +1605,7 @@ export default class Exchange {
                     const currencyPrecision = this.safeValue2 (marketPrecision, 'base', 'amount', defaultCurrencyPrecision);
                     const currency = {
                         'id': this.safeString2 (market, 'baseId', 'base'),
-                        'numericId': this.safeString (market, 'baseNumericId'),
+                        'numericId': this.safeInteger (market, 'baseNumericId'),
                         'code': this.safeString (market, 'base'),
                         'precision': currencyPrecision,
                     };
@@ -1615,7 +1615,7 @@ export default class Exchange {
                     const currencyPrecision = this.safeValue2 (marketPrecision, 'quote', 'price', defaultCurrencyPrecision);
                     const currency = {
                         'id': this.safeString2 (market, 'quoteId', 'quote'),
-                        'numericId': this.safeString (market, 'quoteNumericId'),
+                        'numericId': this.safeInteger (market, 'quoteNumericId'),
                         'code': this.safeString (market, 'quote'),
                         'precision': currencyPrecision,
                     };


### PR DESCRIPTION
Currency is declared as

```
export interface Currency {
    id: string;
    code: string;
    numericId?: number;
    precision: number;
}
```

and all other references to `numericId` in the code use `safeInteger()`, so switch `Exhange#setMarkets()` to do the same.