### PR TITLE
fix(bitmex): fetchMarkets

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -394,35 +394,28 @@ export default class bitmex extends Exchange {
             // so let's take the settlCurrency first and then adjust if needed
             let type = undefined;
             let future = false;
-            let prediction = false;
-            let index = false;
             let symbol = base + '/' + quote + ':' + settle;
             const expiryDatetime = this.safeString (market, 'expiry');
             const expiry = this.parse8601 (expiryDatetime);
             const inverse = this.safeValue (market, 'isInverse');
             const status = this.safeString (market, 'state');
             let active = status !== 'Unlisted';
+            let contract = true;
             if (swap) {
                 type = 'swap';
-            } else if (id.indexOf ('B_') >= 0) {
-                prediction = true;
-                type = 'prediction';
-                symbol = id;
             } else if (expiry !== undefined) {
                 future = true;
                 type = 'future';
                 symbol = symbol + '-' + this.yymmdd (expiry);
             } else {
-                index = true;
-                type = 'index';
-                symbol = id;
+                symbol = base + '/' + quote;
                 active = false;
+                contract = false;
             }
             const positionId = this.safeString2 (market, 'positionCurrency', 'underlying');
             const position = this.safeCurrencyCode (positionId);
             const positionIsQuote = (position === quote);
             const maxOrderQty = this.safeNumber (market, 'maxOrderQty');
-            const contract = !index;
             const initMargin = this.safeString (market, 'initMargin', '1');
             const maxLeverage = this.parseNumber (Precise.stringDiv ('1', initMargin));
             const multiplierString = Precise.stringAbs (this.safeString (market, 'multiplier'));
@@ -441,8 +434,6 @@ export default class bitmex extends Exchange {
                 'swap': swap,
                 'future': future,
                 'option': false,
-                'prediction': prediction,
-                'index': index,
                 'active': active,
                 'contract': contract,
                 'linear': contract ? !inverse : undefined,


### PR DESCRIPTION
- Fixes spot symbol, before was getting `ETH_USDT` as symbol instead of `ETH/USDT`
- Removed prediction and index that weren't being used and are not part of the market structure.