### PR TITLE
ignore binance in test

### DIFF
--- a/ts/src/test/base/functions/test.binanceMarkets.ts
+++ b/ts/src/test/base/functions/test.binanceMarkets.ts
@@ -108,6 +108,7 @@ defaultOptions = defaultOptions['binance']
         defaultOptions['agent'] = new HttpsProxyAgent (defaultOptions.httpProxy)
     }
     for (const test of cases) {
+        // @ts-ignore
         const binance = new ccxt.binance (Object.assign ({}, defaultOptions, {
             options: {
                 defaultType: test.defaultType,


### PR DESCRIPTION
If didn't export `binance` from exchanges (`exchanges.cfg`), the `tsc` command always throw `error TS2339: Property 'binance' does not exist on type......`

We might need to ignore this line (maybe have another solution for this).