### PR TITLE
btcex ALT -> ArchLoot

### DIFF
--- a/ts/src/btcex.ts
+++ b/ts/src/btcex.ts
@@ -321,6 +321,7 @@ export default class btcex extends Exchange {
                 'createMarketBuyOrderRequiresPrice': true,
             },
             'commonCurrencies': {
+                'ALT': 'ArchLoot',
             },
         });
     }


### PR DESCRIPTION
https://www.coingecko.com/en/coins/archloot#markets conflict with https://www.coingecko.com/en/coins/aptoslaunch-token#markets