### PR TITLE
bithumb ALT -> ArchLoot

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -161,6 +161,7 @@ export default class bithumb extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'ALT': 'ArchLoot',
                 'FTC': 'FTC2',
                 'SOC': 'Soda Coin',
             },


### PR DESCRIPTION
https://www.coingecko.com/en/coins/archloot#markets conflict with https://www.coingecko.com/en/coins/aptoslaunch-token#markets