### PR TITLE
bitget cancelOrders, fetchOpenOrders edits

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2619,11 +2619,8 @@ export default class bitget extends Exchange {
         this.checkRequiredSymbol ('cancelOrders', symbol);
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const type = this.safeString (params, 'type', market['type']);
-        if (type === undefined) {
-            throw new ArgumentsRequired (this.id + " cancelOrders() requires a type parameter (one of 'spot', 'swap').");
-        }
-        params = this.omit (params, 'type');
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('cancelOrders', market, params);
         const request = {};
         let method = undefined;
         if (type === 'spot') {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -174,6 +174,7 @@ export default class bitget extends Exchange {
                             'trade/batch-orders': 4,
                             'trade/cancel-order': 2,
                             'trade/cancel-batch-orders': 4,
+                            'trade/cancel-batch-orders-v2': 4,
                             'trade/orderInfo': 1,
                             'trade/open-orders': 1,
                             'trade/history': 1,
@@ -2202,6 +2203,7 @@ export default class bitget extends Exchange {
             'new': 'open',
             'init': 'open',
             'not_trigger': 'open',
+            'partial_fill': 'open',
             'triggered': 'closed',
             'full_fill': 'closed',
             'filled': 'closed',
@@ -2625,11 +2627,9 @@ export default class bitget extends Exchange {
         const request = {};
         let method = undefined;
         if (type === 'spot') {
-            method = 'apiPostOrderOrdersBatchcancel';
-            request['method'] = 'batchcancel';
-            const jsonIds = this.json (ids);
-            const parts = jsonIds.split ('"');
-            request['order_ids'] = parts.join ('');
+            method = 'privateSpotPostTradeCancelBatchOrdersV2';
+            request['symbol'] = market['id'];
+            request['orderIds'] = ids;
         } else if (type === 'swap') {
             method = 'privateMixPostOrderCancelBatchOrders';
             request['symbol'] = market['id'];
@@ -2641,18 +2641,17 @@ export default class bitget extends Exchange {
         //     spot
         //
         //     {
-        //         "status": "ok",
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": "1680008815965",
         //         "data": {
-        //             "success": [
-        //                 "673451224205135872",
-        //             ],
-        //             "failed": [
+        //             "resultList": [
         //                 {
-        //                 "err-msg": "invalid record",
-        //                 "order-id": "673451224205135873",
-        //                 "err-code": "base record invalid"
-        //                 }
-        //             ]
+        //                     "orderId": "1024598257429823488",
+        //                     "clientOrderId": "876493ce-c287-4bfc-9f4a-8b1905881313"
+        //                 },
+        //             ],
+        //             "failed": []
         //         }
         //     }
         //
@@ -2862,7 +2861,7 @@ export default class bitget extends Exchange {
             }
             query = this.omit (query, 'stop');
         }
-        const response = await this[method] (this.extend (request, query));
+        let response = await this[method] (this.extend (request, query));
         //
         //  spot
         //     {
@@ -2966,6 +2965,9 @@ export default class bitget extends Exchange {
         //         }
         //     }
         //
+        if (typeof response === 'string') {
+            response = JSON.parse (response);
+        }
         let data = this.safeValue (response, 'data', []);
         if (!Array.isArray (data)) {
             data = this.safeValue (data, 'orderList', []);


### PR DESCRIPTION
`cancelOrders:`
there is no `apiPostOrderOrdersBatchcancel` method but https://bitgetlimited.github.io/apidoc/en/spot/#cancel-order-in-batch-v2-single-instruments works fine

`fetchOpenOrders:`
in some strange cases response is string not object:
`await exchange.fetchOpenOrders('CYCLUB/USDT');`

```
ResponseBody:
 {"code":"00000","msg":"success","requestTime":1680010262116,"data":[{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024550609058451458","clientOrderId":"de6a6d29-607e-48e5-84e2-aebbc09364c0","price":"0.000136460000","quantity":"644699.126600000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679997821106"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024547900079132673","clientOrderId":"2485dbca-3ac1-4463-887c-7dffc6fbc384","price":"0.000135090000","quantity":"73950.699300000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679997175235"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024519969445433348","clientOrderId":"3a59010d-992f-4021-831f-1e3bb039f415","price":"0.000133120000","quantity":"379984.795500000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679990516053"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024519792668102657","clientOrderId":"e6fb8427-f721-43bc-8e31-b49c8c8757c7","price":"0.000133040000","quantity":"49952.468300000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679990473906"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024491895043575809","clientOrderId":"822284a4-cea8-4efd-88b6-a234d442888a","price":"0.000132180000","quantity":"63060.102800000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679983822594"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024491859358437377","clientOrderId":"63abf367-881e-467f-ae34-da009856500c","price":"0.000132170000","quantity":"65047.235500000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679983814086"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1024491812503867393","clientOrderId":"e69f68ef-9cf4-4202-9c94-7f889e2121b2","price":"0.000132170000","quantity":"58675.840700000000","orderType":"limit","side":"buy","status":"init","fillPrice":"0.000000000000","fillQuantity":"0.000000000000","fillTotalAmount":"0.000000000000","enterPointSource":"API","feeDetail":"","cTime":"1679983802915"},{"accountId":"5988738802","symbol":"CYCLUBUSDT_SPBL","orderId":"1023857428348194817","clientOrderId":"2eb2a2d3-6318-4b58-94e8-ae408638ddab","price":"0.000131620000","quantity":"1317918.611800000000","orderType":"limit","side":"buy","status":"partial_fill","fillPrice":"0.000131620000","fillQuantity":"1279186.713300000000","fillTotalAmount":"168.366555204546","enterPointSource":"API","feeDetail":"{\"CYCLUB\":{\"deduction\":false,\"feeCoinCode\":\"CYCLUB\",\"totalDeductionFee\":0,\"totalFee\":-1279.186713300000}}","cTime":"1679832553946"}]}
```

`console.log(typeof response);`
`string`

Usually type is `object`. As understood, `string` appears if you have some partitially filled orders, maybe it also needed to have several open orders.