### PR TITLE
alpaca - po fix

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -185,7 +185,7 @@ export default class alpaca extends Exchange {
                     'GNSS', // Genesis
                     'ERSX', // ErisX
                 ],
-                'defaultTimeInForce': 'gtc', // fok, gtc, ioc
+                'defaultTimeInForce': 'gtc', // gtc, ioc
                 'clientOrderId': 'ccxt_{id}',
             },
             'exceptions': {
@@ -533,8 +533,13 @@ export default class alpaca extends Exchange {
             request['limit_price'] = this.priceToPrecision (symbol, price);
         }
         const defaultTIF = this.safeString (this.options, 'defaultTimeInForce');
-        request['time_in_force'] = this.safeString (params, 'timeInForce', defaultTIF);
-        params = this.omit (params, [ 'timeInForce', 'triggerPrice' ]);
+        const tif = this.safeString2 (params, 'timeInForce', 'time_in_force', defaultTIF);
+        const postOnly = this.safeValue (params, 'postOnly', tif === 'PO');
+        if (postOnly) {
+            throw new NotSupported (this.id + ' createOrder() does not support postOnly orders');
+        }
+        request['time_in_force'] = tif;
+        params = this.omit (params, [ 'postOnly', 'timeInForce', 'time_in_force', 'triggerPrice' ]);
         const clientOrderIdprefix = this.safeString (this.options, 'clientOrderId');
         const uuid = this.uuid ();
         const parts = uuid.split ('-');


### PR DESCRIPTION
as opposed to upcoming unified approach, this PR is "in-place" fix for po/tif for alpaca ( https://alpaca.markets/docs/crypto/orders/#:~:text=We%20only%20support%20gtc%20and%20ioc%20time%20in%20force%20options%20for%20crypto%20orders )