### PR TITLE
fix(phemex): ws authenticate [ci deploy]

### DIFF
--- a/ts/src/pro/phemex.ts
+++ b/ts/src/pro/phemex.ts
@@ -1101,8 +1101,8 @@ export default class phemex extends phemexRest {
                 'id': time,
                 'method': this.handleAuthenticate,
             };
-            this.spawn (this.watch, url, messageHash, request, messageHash, subscription);
+            this.watch (url, messageHash, request, messageHash, subscription);
         }
-        return await future;
+        return future;
     }
 }


### PR DESCRIPTION

DEMO
```
p phemex watchOrders --sandbox                                
Python v3.10.9
CCXT v3.0.40
phemex.watchOrders()
[{'amount': 10000000.0,
  'average': None,
  'clientOrderId': 'ccxt2022137452b8660c46a7',
  'cost': 1000000000.0,
  'datetime': '2023-03-28T17:25:51.664Z',
  'fee': {'cost': 0.0, 'currency': None},
  'fees': [{'cost': 0.0, 'currency': None}],
  'filled': 0.0,
  'id': '1877d35a-af89-4576-9190-34dcc0f18fb8',
  'info': {'action': 'New',
           'activity_id': 0,
           'avgPriceEp': 0,
           'baseCurrency': 'ANKR',
           'baseQtyEv': 10000000,
           'bizError': 0,
           'clOrdID': 'ccxt2022137452b8660c46a7',
           'createTimeNs': 1680024351664299812,
           'cumBaseQtyEv': 0,
           'cumFeeEv': 0,
           'cumQuoteQtyEv': 0,
           'cxlRejReason': 0,
           'execPriceEp': 0,
           'feeCurrency': 'ANKR',
           'leavesBaseQtyEv': 10000000,
           'leavesQuoteQtyEv': 1000000000,
           'maker_fee_rate_er': 0,
           'ordStatus': 'New',
           'ordType': 'Limit',
           'orderID': '1877d35a-af89-4576-9190-34dcc0f18fb8',
           'pegOffsetValueEp': 0,
           'priceEp': 1000000,
           'qtyType': 'ByBase',
           'quoteCurrency': 'USDT',
           'quoteQtyEv': 1000000000,
           'side': 'Buy',
           'stopPxEp': 0,
           'symbol': 'sANKRUSDT',
           'taker_fee_rate_er': 0,
           'timeInForce': 'GoodTillCancel',
           'tradeType': 'Trade',
           'transactTimeNs': 1680024351666426827,
           'triggerTimeNs': 0,
           'userID': 940666},
```
