### PR TITLE
fix(types): python3.7 support [ci deploy]

### DIFF
--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -1,6 +1,11 @@
 import sys
 import enum
-from typing import TypedDict, Union
+from typing import Union
+
+if sys.version_info.minor > 7:
+    from typing import TypedDict
+else:
+    TypedDict = dict
 
 if sys.version_info.minor >= 11:
     StrEnum = enum.StrEnum


### PR DESCRIPTION
DEMO
```
 python3.7 examples/py/cli.py phemex fetchBalance --sandbox
Python v3.7.16
CCXT v3.0.44
phemex.fetchBalance()
{'ANKR': {'free': 1298.7, 'total': 1298.7, 'used': 0.0},
 'BTC': {'free': 0.00252845, 'total': 0.00252845, 'used': 0.0},
 'LTC': {'free': 0.44568387, 'total': 0.44568387, 'used': 0.0},
 'USDT': {'free': 4767.40631089, 'total': 4777.40631089, 'used': 10.0},
 'datetime': '2023-03-28T17:25:51.664Z',
 'free': {'ANKR': 1298.7,
          'BTC': 0.00252845,
          'LTC': 0.44568387,
          'USDT': 4767.40631089},
 'info': {'code': '0',
          'data': [{'balanceEv': '252845',
                    'currency': 'BTC',
                    'lastUpdateTimeNs': '1657612336937678848',
                    'lockedTradingBalanceEv': '0',
                    'lockedWithdrawEv': '0',
                    'walletVid': '0'},
                   {'balanceEv': '477740631089',
                    'currency': 'USDT',
                    'lastUpdateTimeNs': '1680024351664299812',
                    'lockedTradingBalanceEv': '1000000000',
                    'lockedWithdrawEv': '0',
                    'walletVid': '0'},
                   {'balanceEv': '44568387',
                    'currency': 'LTC',
                    'lastUpdateTimeNs': '1679992688870751841',
                    'lockedTradingBalanceEv': '0',
                    'lockedWithdrawEv': '0',
                    'walletVid': '0'},
```
