### PR TITLE
fix(kucoin): watchOrders timestamp

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -577,7 +577,7 @@ export default class kucoin extends kucoinRest {
         const amount = this.safeString (order, 'size');
         const rawType = this.safeString (order, 'type');
         const status = this.parseWsOrderStatus (rawType);
-        const timestamp = this.safeIntegerProduct (order, 'orderTime', 0.000001);
+        const timestamp = this.safeInteger (order, 'orderTime');
         const marketId = this.safeString (order, 'symbol');
         market = this.safeMarket (marketId, market);
         const symbol = market['symbol'];


### PR DESCRIPTION
DEMO

```
n kucoin watchOrders                         
Debugger attached.
2023-03-30T09:24:45.481Z
Node.js: v18.14.0
CCXT v3.0.44
kucoin.watchOrders ()
  symbol |                       id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | reduceOnly
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
LTC/USDT | 6425556521d9050001246d0b | ec2f65c2-ff49-44e7-9f38-242dfc396cec | 1680168293470 | 2023-03-30T09:24:53.470Z |                    | market |         IOC |          | sell |       |           |              |    0.1 |      |         |    0.1 |         0 | closed |     |     [] |   [] |  
```
