### PR TITLE
krakenfutures: fix signing for private endpoints

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1990,7 +1990,7 @@ export default class krakenfutures extends Exchange {
         }
         const url = this.urls['api'][api] + query;
         if (api === 'private' || access === 'private') {
-            const auth = postData + '/api/' + endpoint; // 1
+            const auth = postData + '/api/' + (api === 'private' ? endpoint : api + '/' + endpoint); // 1
             const hash = this.hash (this.encode (auth), sha256, 'binary'); // 2
             const secret = this.base64ToBinary (this.secret); // 3
             const signature = this.hmac (hash, secret, sha512, 'base64'); // 4-5


### PR DESCRIPTION
Currently using private, non derivatives endpoints like `historyGetOrders` will throw `401 Unauthorized {"reason":"You are not authorized to access this endpoint.","status":"unauthorized"}` error because of improper auth signing.

For endpoint `https://futures.kraken.com/api/history/v2/orders` path should be `history/v2/orders` but is `v2/orders` for now.

This PR will fix this problem
