### PR TITLE
bybit: update timestamp of position

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7216,7 +7216,7 @@ export default class bybit extends Exchange {
         let maintenanceMarginString = this.safeString (position, 'positionMM');
         let timestamp = this.parse8601 (this.safeString (position, 'updated_at'));
         if (timestamp === undefined) {
-            timestamp = this.safeInteger (position, 'updatedAt');
+            timestamp = this.safeIntegerN (position, ['updatedTime', 'updatedAt']);
         }
         // default to cross of USDC margined positions
         const tradeMode = this.safeInteger (position, 'tradeMode', 0);

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7216,7 +7216,7 @@ export default class bybit extends Exchange {
         let maintenanceMarginString = this.safeString (position, 'positionMM');
         let timestamp = this.parse8601 (this.safeString (position, 'updated_at'));
         if (timestamp === undefined) {
-            timestamp = this.safeIntegerN (position, ['updatedTime', 'updatedAt']);
+            timestamp = this.safeIntegerN (position, [ 'updatedTime', 'updatedAt' ]);
         }
         // default to cross of USDC margined positions
         const tradeMode = this.safeInteger (position, 'tradeMode', 0);


### PR DESCRIPTION
The timestamp is missing after parse position. The `fetchPosition` works because the timestamp will be assigned.