### PR TITLE
fix(Phemex): sandbox v2

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -85,6 +85,7 @@ export default class phemex extends Exchange {
                 'logo': 'https://user-images.githubusercontent.com/1294454/85225056-221eb600-b3d7-11ea-930d-564d2690e3f6.jpg',
                 'test': {
                     'v1': 'https://testnet-api.phemex.com/v1',
+                    'v2': 'https://testnet-api.phemex.com/',
                     'public': 'https://testnet-api.phemex.com/exchange/public',
                     'private': 'https://testnet-api.phemex.com',
                 },


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17437

```
 p phemex fetchTicker "BTC/USDT:USDT" --sandbox 
Python v3.10.9
CCXT v3.0.48
phemex.fetchTicker(BTC/USDT:USDT)
{'ask': None,
 'askVolume': None,
 'average': None,
 'baseVolume': 254663.756,
 'bid': None,
 'bidVolume': None,
 'change': None,
 'close': 28361.3,
 'datetime': '2023-04-02T09:03:27.386Z',
 'high': 28826.0,
 'info': {'closeRp': '28361.3',
          'fundingRateRr': '0.0001',
          'highRp': '28826',
          'indexPriceRp': '28381.66760289',
          'lowRp': '28031.9',
          'markPriceRp': '28362.964989445',
          'openInterestRv': '383.807',
          'openRp': '28441.2',
          'predFundingRateRr': '0.0001',
          'symbol': 'BTCUSDT',
          'timestamp': '1680426207386369867',
          'turnoverRv': '7232926387.6955',
          'volumeRq': '254663.756'},
 'last': 28361.3,
 'low': 28031.9,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 7232926387.6955,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1680426207386,
 'vwap': 28401.86802120165}
```
