### PR TITLE
bigone - fix

### DIFF
--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -1138,7 +1138,7 @@ export default class bigone extends Exchange {
 
     nonce () {
         const exchangeTimeCorrection = this.safeInteger (this.options, 'exchangeMillisecondsCorrection', 0) * 1000000;
-        return this.microseconds () * 1000 + exchangeTimeCorrection;
+        return this.sum (this.microseconds () * 1000, exchangeTimeCorrection);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
after  much time spent on this, and even vague bigone response, i've found out that ReactPhp has some inner issue, which can't read the response, which is otherwise readable in regular php curl request.
the issue turns out to be our incorrectly sent request in php, however, the exception that is readable in regular php:
```    [8] => ResponseBody:
    [9] => {"code":40004,"message":"strconv.ParseInt: parsing \"1680510127264783000-100000000\": invalid syntax"}
```
was otherwise unreadable in reactPhp Browser's response
									
						