### PR TITLE
coinex editOrder fix

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1995,7 +1995,7 @@ export default class coinex extends Exchange {
         }
         const request = {
             'market': market['id'],
-            'id': id,
+            'id': parseInt (id),
         };
         if (amount !== undefined) {
             request['amount'] = this.amountToPrecision (symbol, amount);


### PR DESCRIPTION
https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot003_trade022_modify_order
in case of `string` I get `{"code":2,"data":{},"message":"Invalid Parameter"}`, `number` working fine