### PR TITLE
Coinbase Fetch Ledger Fix

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -323,7 +323,7 @@ export default class coinbase extends Exchange {
         return await this.fetchAccountsV2 (params);
     }
 
-    async fetchAccountsV2 (params = {}) {
+    async fetchAccountsV2 (params = {}, list = []) {
         await this.loadMarkets ();
         const request = {
             'limit': 100,
@@ -374,7 +374,14 @@ export default class coinbase extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', []);
-        return this.parseAccounts (data, params);
+        list.push (data);
+        const pagination = this.safeValue (response, 'pagination', {});
+        const startingAfter = this.safeString (pagination, 'next_starting_after');
+        if (startingAfter !== undefined) {
+            params['starting_after'] = startingAfter;
+            this.fetchAccountsV2 (params, list);
+        }
+        return this.parseAccounts (list, params);
     }
 
     async fetchAccountsV3 (params = {}) {

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -385,7 +385,7 @@ export default class coinbase extends Exchange {
         }
     }
 
-    async fetchAccountsV3 (params = {}, list = []) {
+    async fetchAccountsV3 (params = {}) {
         const request = {
             'limit': 249,
         };
@@ -421,15 +421,15 @@ export default class coinbase extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'accounts', []);
-        list = list.concat (data);
-        const hasNext = this.safeValue (response, 'has_next', false);
-        if (hasNext) {
-            const cursor = this.safeString (response, 'cursor');
-            params['cursor'] = cursor;
-            return await this.fetchAccountsV3 (params, list);
-        } else {
-            return this.parseAccounts (list, params);
-        }
+        // list = list.concat (data);
+        // const hasNext = this.safeValue (response, 'has_next', false);
+        // if (hasNext) {
+        //     const cursor = this.safeString (response, 'cursor');
+        //     params['cursor'] = cursor;
+        //     return await this.fetchAccountsV3 (params, list);
+        // } else {
+        return this.parseAccounts (data, params);
+        // }
     }
 
     parseAccount (account) {

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -279,10 +279,10 @@ export default class coinbase extends Exchange {
                 ],
                 'createMarketBuyOrderRequiresPrice': true,
                 'advanced': true, // set to true if using any v3 endpoints from the advanced trade API
-                'fetchMarkets': 'fetchMarketsV2', // 'fetchMarketsV3' or 'fetchMarketsV2'
+                'fetchMarkets': 'fetchMarketsV3', // 'fetchMarketsV3' or 'fetchMarketsV2'
                 'fetchTicker': 'fetchTickerV3', // 'fetchTickerV3' or 'fetchTickerV2'
                 'fetchTickers': 'fetchTickersV3', // 'fetchTickersV3' or 'fetchTickersV2'
-                'fetchAccounts': 'fetchAccountsV2', // 'fetchAccountsV3' or 'fetchAccountsV2'
+                'fetchAccounts': 'fetchAccountsV3', // 'fetchAccountsV3' or 'fetchAccountsV2'
             },
         });
     }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -326,7 +326,7 @@ export default class coinbase extends Exchange {
 
     async fetchAccountsV2 (params = {}, list = []) {
         const request = {
-            'limit': 100,
+            'limit': 249,
         };
         const response = await this.v2PrivateGetAccounts (this.extend (request, params));
         //
@@ -387,7 +387,7 @@ export default class coinbase extends Exchange {
 
     async fetchAccountsV3 (params = {}, list = []) {
         const request = {
-            'limit': 100,
+            'limit': 249,
         };
         const response = await this.v3PrivateGetBrokerageAccounts (this.extend (request, params));
         //

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -385,7 +385,7 @@ export default class coinbase extends Exchange {
         }
     }
 
-    async fetchAccountsV3 (params = {}) {
+    async fetchAccountsV3 (params = {}, list = []) {
         const request = {
             'limit': 249,
         };
@@ -421,15 +421,15 @@ export default class coinbase extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'accounts', []);
-        // list = list.concat (data);
-        // const hasNext = this.safeValue (response, 'has_next', false);
-        // if (hasNext) {
-        //     const cursor = this.safeString (response, 'cursor');
-        //     params['cursor'] = cursor;
-        //     return await this.fetchAccountsV3 (params, list);
-        // } else {
-        return this.parseAccounts (data, params);
-        // }
+        list = list.concat (data);
+        const hasNext = this.safeValue (response, 'has_next', false);
+        if (hasNext) {
+            const cursor = this.safeString (response, 'cursor');
+            params['cursor'] = cursor;
+            return await this.fetchAccountsV3 (params, list);
+        } else {
+            return this.parseAccounts (list, params);
+        }
     }
 
     parseAccount (account) {


### PR DESCRIPTION
Coinbase Ledger fetches accounts based on V2 or V3 rest API. However, the this.loadAccounts() => this.fetchAccounts() => this.fetchAccountsV2() || this.fetchAccountsV3() only does one iterations of fetching the accounts list and not all of the accounts.

This fix ensures coinbase.fetchLedger(code) can actually fetch the ledger content for the actual code without error.

Additionally, loadmarket() was being called in three times during the fetchLedger(). Reduced loadmarkets to when fetchAccounts is conducted to reduce latency.