### PR TITLE
fix kucoin deposit withdraw fee

### DIFF
--- a/js/src/kucoin.js
+++ b/js/src/kucoin.js
@@ -847,7 +847,7 @@ export default class kucoin extends Exchange {
         const networkCode = this.safeStringUpper(params, 'network');
         const network = this.networkCodeToId(networkCode, code);
         if (network !== undefined) {
-            request['chain'] = network;
+            request['chain'] = network.toLowerCase();
             params = this.omit(params, ['network']);
         }
         const response = await this.privateGetWithdrawalsQuotas(this.extend(request, params));

--- a/js/src/kucoin.js
+++ b/js/src/kucoin.js
@@ -847,7 +847,7 @@ export default class kucoin extends Exchange {
         const networkCode = this.safeStringUpper(params, 'network');
         const network = this.networkCodeToId(networkCode, code);
         if (network !== undefined) {
-            request['chain'] = network.toLowerCase();
+            request['chain'] = network;
             params = this.omit(params, ['network']);
         }
         const response = await this.privateGetWithdrawalsQuotas(this.extend(request, params));

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -854,7 +854,7 @@ export default class kucoin extends Exchange {
         const networkCode = this.safeStringUpper (params, 'network');
         const network = this.networkCodeToId (networkCode, code);
         if (network !== undefined) {
-            request['chain'] = network.toLowerCase();
+            request['chain'] = network.toLowerCase ();
             params = this.omit (params, [ 'network' ]);
         }
         const response = await this.privateGetWithdrawalsQuotas (this.extend (request, params));

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -854,7 +854,7 @@ export default class kucoin extends Exchange {
         const networkCode = this.safeStringUpper (params, 'network');
         const network = this.networkCodeToId (networkCode, code);
         if (network !== undefined) {
-            request['chain'] = network;
+            request['chain'] = network.toLowerCase();
             params = this.omit (params, [ 'network' ]);
         }
         const response = await this.privateGetWithdrawalsQuotas (this.extend (request, params));


### PR DESCRIPTION
Please check this, I think here may be missing a lowercase. I cannot use ETH here

`client.fetch_deposit_withdraw_fee("USDT", params={"network": "ETH"}) # ETH, eth does not work, only ERC20 can work here.`