### PR TITLE
fix(gate): fetchOHLCV limit switched to 999

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2490,7 +2490,8 @@ export default class gate extends Exchange {
         if (since !== undefined) {
             const duration = this.parseTimeframe (timeframe);
             request['from'] = this.parseToInt (since / 1000);
-            const toTimestamp = this.sum (request['from'], ((limit - 1) * duration));
+            const distance = (limit - 1) * duration;
+            const toTimestamp = this.sum (request['from'], distance);
             const currentTimestamp = this.seconds ();
             const to = Math.min (toTimestamp, currentTimestamp);
             if (until !== undefined) {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2490,7 +2490,7 @@ export default class gate extends Exchange {
         if (since !== undefined) {
             const duration = this.parseTimeframe (timeframe);
             request['from'] = this.parseToInt (since / 1000);
-            const toTimestamp = this.sum (request['from'], limit * duration - 1);
+            const toTimestamp = this.sum (request['from'], ((limit - 1) * duration));
             const currentTimestamp = this.seconds ();
             const to = Math.min (toTimestamp, currentTimestamp);
             if (until !== undefined) {


### PR DESCRIPTION
fixes: #17464

```
% gateio fetchOHLCV BTC/USDT:USDT 1h 1667237607000           
2023-04-04T14:13:05.733Z
Node.js: v18.15.0
CCXT v3.0.45
gateio.fetchOHLCV (BTC/USDT:USDT, 1h, 1667237607000)
2023-04-04T14:13:15.142Z iteration 0 passed in 962 ms

1667239200000 | 20366.6 | 20458.9 | 20350.1 | 20421.4 |   4959474
1667242800000 | 20421.7 | 20425.3 | 20355.8 | 20361.8 |   5322304
...
1674428400000 | 22675.9 |   22771 | 22640.2 | 22701.5 |  11061770
1674432000000 | 22701.5 | 22701.5 | 22701.5 | 22701.5 |         0
1999 objects
2023-04-04T14:13:15.142Z iteration 1 passed in 962 ms
```
```
% gateio fetchOHLCV BTC/USDT 1h 1667237607000     
2023-04-04T14:26:11.000Z
Node.js: v18.15.0
CCXT v3.0.45
gateio.fetchOHLCV (BTC/USDT, 1h, 1667237607000)
2023-04-04T14:26:17.722Z iteration 0 passed in 794 ms

1667239200000 |    20374.3 |        20469.093 |         20355.3 |          20434.2 |    320.35900346
1667242800000 |    20434.3 |          20437.2 |         20361.9 |          20373.5 |  369.5507629134
...
1670828400000 |    16939.4 |            16944 |         16906.9 |          16923.4 |  704.9683613984
1670832000000 |    16924.9 |            16940 |         16903.8 |          16935.3 |  680.1622904878
999 objects
2023-04-04T14:26:17.722Z iteration 1 passed in 794 ms
```
```
 % gateio fetchOHLCV BTC/USDT 1h undefined 1000
2023-04-04T14:28:00.202Z
Node.js: v18.15.0
CCXT v3.0.45
gateio.fetchOHLCV (BTC/USDT, 1h, , 1000)
2023-04-04T14:28:05.737Z iteration 0 passed in 746 ms

1677020400000 | 24379.5 |    24447 | 24334.5 |   24447 |  152.9492711932
1677024000000 | 24446.9 |  24469.2 | 24268.1 |   24417 |  225.5292141858
...
1680613200000 | 28266.9 |    28395 | 28078.9 |   28110 |  477.2555655039
1680616800000 | 28111.9 |  28204.5 | 28083.1 | 28151.1 |  176.9188168476
1000 objects
2023-04-04T14:28:05.737Z iteration 1 passed in 746 ms
```