### PR TITLE
krakenfutures - remove force stp type if stopPrice exists

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -813,7 +813,9 @@ export default class krakenfutures extends Exchange {
         if ((type === 'stp' || type === 'take_profit') && stopPrice === undefined) {
             throw new ArgumentsRequired (this.id + ' createOrder requires params.stopPrice when type is ' + type);
         }
-        if (postOnly) {
+        if (stopPrice !== undefined && type !== 'take_profit') {
+            type = 'stp';
+        } else if (postOnly) {
             type = 'postOnly';
         } else if (timeInForce === 'ioc') {
             type = 'ioc';

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -813,9 +813,7 @@ export default class krakenfutures extends Exchange {
         if ((type === 'stp' || type === 'take_profit') && stopPrice === undefined) {
             throw new ArgumentsRequired (this.id + ' createOrder requires params.stopPrice when type is ' + type);
         }
-        if (stopPrice !== undefined) {
-            type = 'stp';
-        } else if (postOnly) {
+        if (postOnly) {
             type = 'postOnly';
         } else if (timeInForce === 'ioc') {
             type = 'ioc';


### PR DESCRIPTION
I cannot create `take_profit` order because of forcing `type` to `stp` while having `stopPrice` param.

[docs](https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-send-order) says that `stopPrice` is `Required if orderType is stp or take_profit`. I think this `if` statement is not required there because if `type` is `limit` or `market` then `stopPrice` is simply omited.

This PR allows to create `take_profit` orders