### PR TITLE
feat(coinbase): add bid and ask to fetchTicker

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1340,20 +1340,26 @@ export default class coinbase extends Exchange {
         //     {
         //         "trades": [
         //             {
-        //                 "trade_id": "10209805",
-        //                 "product_id": "BTC-USDT",
-        //                 "price": "19381.27",
-        //                 "size": "0.1",
-        //                 "time": "2023-01-13T20:35:41.865970Z",
+        //                 "trade_id": "518078013",
+        //                 "product_id": "BTC-USD",
+        //                 "price": "28208.1",
+        //                 "size": "0.00659179",
+        //                 "time": "2023-04-04T23:05:34.492746Z",
         //                 "side": "BUY",
         //                 "bid": "",
         //                 "ask": ""
         //             }
-        //         ]
+        //         ],
+        //         "best_bid": "28208.61",
+        //         "best_ask": "28208.62"
         //     }
         //
         const data = this.safeValue (response, 'trades', []);
-        return this.parseTicker (data[0], market);
+        const ticker = this.parseTicker (data[0], market);
+        return this.extend (ticker, {
+            'bid': this.safeNumber (response, 'best_bid'),
+            'ask': this.safeNumber (response, 'best_ask'),
+        });
     }
 
     parseTicker (ticker, market = undefined) {


### PR DESCRIPTION
Update fetchTicker to include the bid and ask prices:
fixes: #17462
```
coinbase.fetchTicker (BTC/USD)
2023-04-05T00:54:32.757Z iteration 0 passed in 541 ms

{
  symbol: 'BTC/USD',
  timestamp: undefined,
  datetime: undefined,
  bid: '28486.57',
  ask: '28489.63',
  last: 28489.62,
  high: undefined,
  low: undefined,
  bidVolume: undefined,
  askVolume: undefined,
  vwap: undefined,
  open: undefined,
  close: 28489.62,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: undefined,
  quoteVolume: undefined,
  info: {
    trade_id: '518112499',
    product_id: 'BTC-USD',
    price: '28489.62',
    size: '0.00169189',
    time: '2023-04-05T00:54:33.324620Z',
    side: 'SELL',
    bid: '',
    ask: ''
  }
}
```