### PR TITLE
bybit: set endTime when since is not empty

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2260,6 +2260,12 @@ export default class bybit extends Exchange {
         params = this.omit (params, [ 'endTime', 'till', 'until' ]);
         if (endTime !== undefined) {
             request['endTime'] = endTime;
+        } else {
+            if (since !== undefined) {
+                // end time is required when since is not empty
+                const fundingInterval = 60 * 60 * 8 * 1000;
+                request['endTime'] = since + limit * fundingInterval;
+            }
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2235,12 +2235,15 @@ export default class bybit extends Exchange {
          */
         this.checkRequiredSymbol ('fetchFundingRateHistory', symbol);
         await this.loadMarkets ();
+        if (limit === undefined) {
+            limit = 200;
+        }
         const request = {
             // 'category': '', // Product type. linear,inverse
             // 'symbol': '', // Symbol name
             // 'startTime': 0, // The start timestamp (ms)
             // 'endTime': 0, // The end timestamp (ms)
-            // 'limit': 0, // Limit for data size per page. [1, 200]. Default: 200
+            'limit': limit, // Limit for data size per page. [1, 200]. Default: 200
         };
         const market = this.market (symbol);
         symbol = market['symbol'];
@@ -2266,9 +2269,6 @@ export default class bybit extends Exchange {
                 const fundingInterval = 60 * 60 * 8 * 1000;
                 request['endTime'] = since + limit * fundingInterval;
             }
-        }
-        if (limit !== undefined) {
-            request['limit'] = limit;
         }
         const response = await this.publicGetV5MarketFundingHistory (this.extend (request, params));
         //


### PR DESCRIPTION
fix https://github.com/ccxt/ccxt/issues/15990

Bybit will return `Time is invalid` if `startTime` is set and `endTime` is empty. In this PR, I fix this issue.

```
$ node examples/js/cli bybit fetchFundingRateHistory ETH/USDT:USDT 'undefined' 10 '{"endTime":1673063081000}' --test
2023-04-05T09:37:02.032Z iteration 0 passed in 171 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
ETH/USDT:USDT |      0.0001 | 1672790400000 | 2023-01-04T00:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672819200000 | 2023-01-04T08:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672848000000 | 2023-01-04T16:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672876800000 | 2023-01-05T00:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672905600000 | 2023-01-05T08:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672934400000 | 2023-01-05T16:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672963200000 | 2023-01-06T00:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1672992000000 | 2023-01-06T08:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673020800000 | 2023-01-06T16:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673049600000 | 2023-01-07T00:00:00.000Z


$ node examples/js/cli bybit fetchFundingRateHistory ETH/USDT:USDT 1673063081000 10 --test
2023-04-05T09:35:44.501Z iteration 0 passed in 269 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
ETH/USDT:USDT |      0.0001 | 1673078400000 | 2023-01-07T08:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673107200000 | 2023-01-07T16:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673136000000 | 2023-01-08T00:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673164800000 | 2023-01-08T08:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673193600000 | 2023-01-08T16:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673222400000 | 2023-01-09T00:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673251200000 | 2023-01-09T08:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673280000000 | 2023-01-09T16:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673308800000 | 2023-01-10T00:00:00.000Z
ETH/USDT:USDT |      0.0001 | 1673337600000 | 2023-01-10T08:00:00.000Z

```