### PR TITLE
Fix wrong mexc "has" flags

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -33,8 +33,6 @@ export default class mexc extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': undefined,
                 'createDepositAddress': undefined,
-                'createLimitOrder': undefined,
-                'createMarketOrder': undefined,
                 'createOrder': true,
                 'createReduceOnlyOrder': true,
                 'deposit': undefined,


### PR DESCRIPTION
Fix wrong mexc "has" flags
mexc has both createLimitOrder, as well as createMarketOrder()`