### PR TITLE
fix(kucoin & mexc): removed commonCurrency BiFi->BIFIF

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -405,7 +405,6 @@ export default class kucoin extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'BIFI': 'BIFIF',
                 'EDGE': 'DADI', // https://github.com/ccxt/ccxt/issues/5756
                 'HOT': 'HOTNOW',
                 'TRY': 'Trias',

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -430,7 +430,6 @@ export default class mexc extends Exchange {
             },
             'commonCurrencies': {
                 'BEYONDPROTOCOL': 'BEYOND',
-                'BIFI': 'BIFIF',
                 'BYN': 'BeyondFi',
                 'COFI': 'COFIX', // conflict with CoinFi
                 'DFI': 'DfiStarter',


### PR DESCRIPTION
It looks like [coingecko](https://coinmarketcap.com/currencies/bifi/) no longer lists the currency as `BIFIF`, which was the original reason for this common currency https://github.com/ccxt/ccxt/pull/16413

fixes: #17478