### PR TITLE
bybit: update fetchOrders

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4743,7 +4743,7 @@ export default class bybit extends Exchange {
             request['endTime'] = endTime;
         } else {
             if (since !== undefined) {
-                throw new BadRequest (this.id + ' fetchOrders() required both startTime and endTime.');
+                throw new BadRequest (this.id + ' fetchOrders() requires until/endTime when since is provided.');
             }
         }
         const response = await this.privateGetV5OrderHistory (this.extend (request, params));

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4694,6 +4694,8 @@ export default class bybit extends Exchange {
             // 'orderFilter', Conditional order or active order
             // 'limit': number, Data quantity per page: Max data value per page is 50, and default value at 20.
             // 'cursor', API pass-through. accountType + category + cursor +. If inconsistent, the following should be returned: The account type does not match the service inquiry.
+            // 'startTime': 0, // The start timestamp (ms) Support UTA only temporarily startTime and endTime must be passed together If not passed, query the past 7 days data by default
+            // 'endTime': 0, // The end timestamp (ms)
         };
         let market = undefined;
         if (symbol === undefined) {
@@ -4730,6 +4732,19 @@ export default class bybit extends Exchange {
         }
         if (limit !== undefined) {
             request['limit'] = limit;
+        }
+        if (since !== undefined) {
+            request['startTime'] = since;
+        }
+        const until = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
+        const endTime = this.safeInteger (params, 'endTime', until); // exchange-specific in milliseconds
+        params = this.omit (params, [ 'endTime', 'till', 'until' ]);
+        if (endTime !== undefined) {
+            request['endTime'] = endTime;
+        } else {
+            if (since !== undefined) {
+                throw new BadRequest (this.id + ' fetchOrders() required both startTime and endTime.');
+            }
         }
         const response = await this.privateGetV5OrderHistory (this.extend (request, params));
         //


### PR DESCRIPTION
Bybit added `startTime` and `endTime` in v5 order/history endpoint (only works for UTA account, and 7 days limit). In this PR, I made relevant changes for fetchOrders.