### PR TITLE
fix python: 3.7 types

### DIFF
--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -1,10 +1,11 @@
 import sys
-from typing import Union, Literal
+from typing import Union
 
 if sys.version_info.minor > 7:
-    from typing import TypedDict
+    from typing import TypedDict, Literal
 else:
     TypedDict = dict
+    from typing_extensions import Literal
 
 
 OrderSide = Literal['buy', 'sell']


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17498

```
/usr/local/bin/python3.7 examples/py/cli.py bybit fetchTime --sandbox
Python v3.7.16
CCXT v3.0.55
bybit.fetchTime()
1680778954568
```
```
 python3 examples/py/cli.py bybit fetchTime --sandbox
Python v3.10.9
CCXT v3.0.55
bybit.fetchTime()
1680778982727
```
