### PR TITLE
Revert "fix(kucoin & mexc): removed commonCurrency BiFi->BIFIF"

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -405,6 +405,7 @@ export default class kucoin extends Exchange {
                 },
             },
             'commonCurrencies': {
+                'BIFI': 'BIFIF',
                 'EDGE': 'DADI', // https://github.com/ccxt/ccxt/issues/5756
                 'HOT': 'HOTNOW',
                 'TRY': 'Trias',

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -428,6 +428,7 @@ export default class mexc extends Exchange {
             },
             'commonCurrencies': {
                 'BEYONDPROTOCOL': 'BEYOND',
+                'BIFI': 'BIFIF',
                 'BYN': 'BeyondFi',
                 'COFI': 'COFIX', // conflict with CoinFi
                 'DFI': 'DfiStarter',


### PR DESCRIPTION
https://www.coingecko.com/en/coins/bifi#markets and https://www.coingecko.com/en/coins/beefy-finance#markets are tokens with the same ticker. So one of them was renamed to BIFIF (naming like on Gate.io https://www.gate.io/trade/BIFIF_USDT). Now we have two different tokens with the same naming.

This reverts commit 7b88615733ee604f41f53c1f6567da400dcf7a32.