### PR TITLE
Websocket Client - arrayBuffer decode take into account byte length

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -278,7 +278,7 @@ export default class Client {
             if (typeof message === 'string') {
                 arrayBuffer = utf8.decode (message)
             } else {
-                arrayBuffer = new Uint8Array (message.buffer.slice (message.byteOffset))
+                arrayBuffer = new Uint8Array (message.buffer.slice (message.byteOffset, message.byteOffset + message.byteLength))
             }
             if (this.gunzip) {
                 arrayBuffer = gunzipSync (arrayBuffer)


### PR DESCRIPTION
This PR changes the decode of the arrayBuffers received by Websocket client to take into account the byte length of the messageEvent. The bug was found with issue #17413 where the bytelength received on some messages was sometimes less than the total message therefore causing the decode to fail.
