### PR TITLE
fix(bybit): createMarketBuyOrderRequiresPrice

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3497,6 +3497,8 @@ export default class bybit extends Exchange {
                     amount = (cost !== undefined) ? cost : this.parseNumber (quoteAmount);
                     request['qty'] = this.costToPrecision (symbol, amount);
                 }
+            } else {
+                request['qty'] = this.costToPrecision (symbol, amount);
             }
         } else {
             request['qty'] = this.amountToPrecision (symbol, amount);
@@ -3601,6 +3603,8 @@ export default class bybit extends Exchange {
                     amount = (cost !== undefined) ? cost : this.parseNumber (quoteAmount);
                     request['orderQty'] = this.costToPrecision (symbol, amount);
                 }
+            } else {
+                request['orderQty'] = this.costToPrecision (symbol, amount);
             }
         } else {
             request['orderQty'] = this.amountToPrecision (symbol, amount);


### PR DESCRIPTION
DEMO

```
 ✗ n bybit createMarketBuyOrder "LTC/USDT" 0.3 --sandbox          
Debugger attached.
2023-04-12T10:27:55.858Z
Node.js: v18.14.0
CCXT v3.0.61
bybit.createMarketBuyOrder (LTC/USDT, 0.3)
2023-04-12T10:27:59.647Z iteration 0 passed in 1464 ms

{
  info: { orderId: '1397200504615977984', orderLinkId: '1681295279505838' },
  id: '1397200504615977984',
  clientOrderId: '1681295279505838',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
2023-04-12T10:27:59.647Z iteration 1 passed in 1464 ms
```