### PR TITLE
fix(bitget): handle future markets

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2151,11 +2151,11 @@ export default class bitget extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOHLCV', market, params);
-        const until = this.safeInteger2 (query, 'until', 'till');
+        const until = this.safeInteger2 (params, 'until', 'till');
         if (limit === undefined) {
             limit = 100;
         }
+        const marketType = market['spot'] ? 'spot' : 'swap';
         const timeframes = this.options['timeframes'][marketType];
         const selectedTimeframe = this.safeString (timeframes, timeframe, timeframe);
         const duration = this.parseTimeframe (timeframe);
@@ -2186,7 +2186,7 @@ export default class bitget extends Exchange {
                 }
             }
         }
-        const ommitted = this.omit (query, [ 'until', 'till' ]);
+        const ommitted = this.omit (params, [ 'until', 'till' ]);
         const extended = this.extend (request, ommitted);
         let response = undefined;
         if (market['spot']) {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1627,18 +1627,18 @@ export default class bitget extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
-        const method = this.getSupportedMapping (marketType, {
-            'spot': 'publicSpotGetMarketDepth',
-            'swap': 'publicMixGetMarketDepth',
-        });
         const request = {
             'symbol': market['id'],
         };
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this[method] (this.extend (request, query));
+        let response = undefined;
+        if (market['spot']) {
+            response = await this.publicSpotGetMarketDepth (this.extend (request, params));
+        } else {
+            response = await this.publicMixGetMarketDepth (this.extend (request, params));
+        }
         //
         //     {
         //       code: '00000',
@@ -1746,12 +1746,13 @@ export default class bitget extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
-        const method = this.getSupportedMapping (marketType, {
-            'spot': 'publicSpotGetMarketTicker',
-            'swap': 'publicMixGetMarketTicker',
-        });
-        const response = await this[method] (this.extend (request, query));
+        let response = undefined;
+        const extended = this.extend (request, params);
+        if (market['spot']) {
+            response = await this.publicSpotGetMarketTicker (extended);
+        } else {
+            response = await this.publicMixGetMarketTicker (extended);
+        }
         //
         //     {
         //         code: '00000',
@@ -1795,12 +1796,8 @@ export default class bitget extends Exchange {
             market = this.market (symbol);
         }
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
-        const method = this.getSupportedMapping (type, {
-            'spot': 'publicSpotGetMarketTickers',
-            'swap': 'publicMixGetMarketTickers',
-        });
         const request = {};
-        if (method === 'publicMixGetMarketTickers') {
+        if (type !== 'spot') {
             let subType = undefined;
             [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', undefined, params);
             let productType = (subType === 'linear') ? 'UMCBL' : 'DMCBL';
@@ -1809,7 +1806,13 @@ export default class bitget extends Exchange {
             }
             request['productType'] = productType;
         }
-        const response = await this[method] (this.extend (request, params));
+        const extended = this.extend (request, params);
+        let response = undefined;
+        if (type === 'spot') {
+            response = await this.publicSpotGetMarketTickers (extended);
+        } else {
+            response = await this.publicMixGetMarketTickers (extended);
+        }
         //
         // spot
         //
@@ -1972,12 +1975,13 @@ export default class bitget extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTrades', market, params);
-        const method = this.getSupportedMapping (marketType, {
-            'spot': 'publicSpotGetMarketFills',
-            'swap': 'publicMixGetMarketFills',
-        });
-        const response = await this[method] (this.extend (request, query));
+        const extended = this.extend (request, params);
+        let response = undefined;
+        if (market['spot']) {
+            response = await this.publicSpotGetMarketFills (extended);
+        } else {
+            response = await this.publicMixGetMarketFills (extended);
+        }
         //
         //     {
         //       code: '00000',
@@ -2148,10 +2152,6 @@ export default class bitget extends Exchange {
             'symbol': market['id'],
         };
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOHLCV', market, params);
-        const method = this.getSupportedMapping (marketType, {
-            'spot': 'publicSpotGetMarketCandles',
-            'swap': 'publicMixGetMarketCandles',
-        });
         const until = this.safeInteger2 (query, 'until', 'till');
         if (limit === undefined) {
             limit = 100;
@@ -2171,7 +2171,7 @@ export default class bitget extends Exchange {
             if (until !== undefined) {
                 request['before'] = until;
             }
-        } else if (market['swap']) {
+        } else if (market['contract']) {
             request['granularity'] = selectedTimeframe;
             const now = this.milliseconds ();
             if (since === undefined) {
@@ -2187,7 +2187,13 @@ export default class bitget extends Exchange {
             }
         }
         const ommitted = this.omit (query, [ 'until', 'till' ]);
-        const response = await this[method] (this.extend (request, ommitted));
+        const extended = this.extend (request, ommitted);
+        let response = undefined;
+        if (market['spot']) {
+            response = await this.publicSpotGetMarketCandles (extended);
+        } else {
+            response = await this.publicMixGetMarketCandles (extended);
+        }
         //  [ ["1645911960000","39406","39407","39374.5","39379","35.526","1399132.341"] ]
         const data = this.safeValue (response, 'data', response);
         return this.parseOHLCVs (data, market, timeframe, since, limit);
@@ -2448,6 +2454,7 @@ export default class bitget extends Exchange {
         let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeOrders',
             'swap': 'privateMixPostOrderPlaceOrder',
+            'future': 'privateMixPostOrderPlaceOrder',
         });
         const exchangeSpecificTifParam = this.safeStringN (params, [ 'force', 'timeInForceValue', 'timeInForce' ]);
         let postOnly = undefined;
@@ -2590,6 +2597,7 @@ export default class bitget extends Exchange {
         let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostPlanModifyPlan',
             'swap': 'privateMixPostPlanModifyPlan',
+            'future': 'privateMixPostPlanModifyPlan',
         });
         if (triggerPrice !== undefined) {
             // default triggerType to market price for unification
@@ -2668,6 +2676,7 @@ export default class bitget extends Exchange {
         let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeCancelOrder',
             'swap': 'privateMixPostOrderCancelOrder',
+            'future': 'privateMixPostOrderCancelOrder',
         });
         const request = {
             'symbol': market['id'],
@@ -2715,7 +2724,7 @@ export default class bitget extends Exchange {
             method = 'privateSpotPostTradeCancelBatchOrdersV2';
             request['symbol'] = market['id'];
             request['orderIds'] = ids;
-        } else if (type === 'swap') {
+        } else {
             method = 'privateMixPostOrderCancelBatchOrders';
             request['symbol'] = market['id'];
             request['marginCoin'] = market['quote'];
@@ -2848,6 +2857,7 @@ export default class bitget extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeOrderInfo',
             'swap': 'privateMixGetOrderDetail',
+            'future': 'privateMixGetOrderDetail',
         });
         const request = {
             'symbol': market['id'],
@@ -2933,6 +2943,7 @@ export default class bitget extends Exchange {
         let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeOpenOrders',
             'swap': 'privateMixGetOrderCurrent',
+            'future': 'privateMixGetOrderCurrent',
         });
         const stop = this.safeValue (query, 'stop');
         if (stop) {
@@ -3127,6 +3138,7 @@ export default class bitget extends Exchange {
         let method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeHistory',
             'swap': 'privateMixGetOrderHistory',
+            'future': 'privateMixGetOrderHistory',
         });
         const stop = this.safeValue (params, 'stop');
         if (stop) {
@@ -3429,6 +3441,7 @@ export default class bitget extends Exchange {
         const method = this.getSupportedMapping (marketType, {
             'spot': 'privateSpotPostTradeFills',
             'swap': 'privateMixGetOrderFills',
+            'future': 'privateMixGetOrderFills',
         });
         const request = {
             'symbol': market['id'],


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17547

```
p bitget fetchTicker "BTC/USD:BTC-230929" 
Python v3.10.9
CCXT v3.0.62
bitget.fetchTicker(BTC/USD:BTC-230929)
{'ask': 31085.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 31.645,
 'bid': 31081.5,
 'bidVolume': None,
 'change': None,
 'close': 31084.5,
 'datetime': '2023-04-13T14:44:23.465Z',
 'high': 31117.5,
 'info': {'askSz': '0.074',
          'baseVolume': '31.645',
          'bestAsk': '31085',
          'bestBid': '31081.5',
          'bidSz': '0.092',
          'chgUtc': '0.01762',
          'fundingRate': '0',
          'high24h': '31117.5',
          'holdingAmount': '27.442',
          'indexPrice': '30433.890588',
          'last': '31084.5',
          'low24h': '30300',
          'openUtc': '30540',
          'priceChangePercent': '0.01529',
          'quoteVolume': '971959.3705',
          'symbol': 'BTCUSD_DMCBL_230929',
          'timestamp': '1681397063465',
          'usdtVolume': '971959.3705'},
 'last': 31084.5,
 'low': 30300.0,
 'open': None,
 'percentage': 1.529,
 'previousClose': None,
 'quoteVolume': 971959.3705,
 'symbol': 'BTC/USD:BTC-230929',
 'timestamp': 1681397063465,
 'vwap': 30714.46896824143}
```
```
p bitget fetchOrderBook "BTC/USD:BTC-230929" 5
Python v3.10.9
CCXT v3.0.62
bitget.fetchOrderBook(BTC/USD:BTC-230929,5)
{'asks': [[31057.5, 0.084],
          [31058.5, 0.087],
          [31062.0, 0.067],
          [31063.0, 0.134],
          [31063.5, 0.052]],
 'bids': [[31052.5, 0.099],
          [31051.0, 0.157],
          [31048.5, 0.083],
          [31048.0, 0.064],
          [31047.5, 0.141]],
 'datetime': '2023-04-13T14:44:46.469Z',
 'nonce': None,
 'symbol': 'BTC/USD:BTC-230929',
 'timestamp': 1681397086469}
```
```
 p bitget fetchOHLCV "BTC/USD:BTC-230929" 1h None 5         
Python v3.10.9
CCXT v3.0.62
bitget.fetchOHLCV(BTC/USD:BTC-230929,1h,None,5)
[[1681383600000, 30884.5, 30917.0, 30814.0, 30824.0, 1.072],
 [1681387200000, 30824.0, 30979.5, 30812.5, 30951.0, 1.196],
 [1681390800000, 30951.0, 31001.5, 30833.0, 30846.5, 2.065],
 [1681394400000, 30846.5, 31117.5, 30836.0, 31061.5, 1.284]]
```
```
p bitget fetchTrades "BTC/USD:BTC-230929" 1
Python v3.10.9
CCXT v3.0.62
bitget.fetchTrades(BTC/USD:BTC-230929,1)
[{'amount': 0.002,
  'cost': 6.438735432361e-08,
  'datetime': '2023-04-13T14:49:46.186Z',
  'fee': None,
  'fees': [],
  'id': '1030420810474119169',
  'info': {'price': '31062.0',
           'side': 'sell',
           'size': '0.002',
           'symbol': 'BTCUSD_DMCBL_230929',
           'timestamp': '1681397386186',
           'tradeId': '1030420810474119169'},
  'order': None,
  'price': 31062.0,
  'side': 'sell',
  'symbol': 'BTC/USD:BTC-230929',
  'takerOrMaker': None,
  'timestamp': 1681397386186,
  'type': None}]
```
