### PR TITLE
mexc: parse trade-side as bool not string

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1280,7 +1280,7 @@ export default class mexc extends Exchange {
                 costString = this.safeString (trade, 'quoteQty');
                 const isBuyer = this.safeValue (trade, 'isBuyer');
                 const isMaker = this.safeValue (trade, 'isMaker');
-                const buyerMaker = this.safeString2 (trade, 'isBuyerMaker', 'm');
+                const buyerMaker = this.safeValue2 (trade, 'isBuyerMaker', 'm');
                 if (isMaker !== undefined) {
                     takerOrMaker = isMaker ? 'maker' : 'taker';
                 }


### PR DESCRIPTION
raw response was parsed as string instead of bool, which marks all trades as 'sell'. See relevant transpiled python-snippet below:
```
buyerMaker = self.safe_string_2(trade, 'isBuyerMaker', 'm')  # bug
...
if buyerMaker is not None:
    side = 'sell' if buyerMaker else 'buy'
```
