### PR TITLE
binance: fix fetchOpenInterestHistory

### DIFF
--- a/js/src/binance.js
+++ b/js/src/binance.js
@@ -8084,7 +8084,7 @@ export default class binance extends Exchange {
         //      ...
         //  ]
         //
-        return this.parseOpenInterests(response, symbol, since, limit);
+        return this.parseOpenInterests(response, market, since, limit);
     }
     async fetchOpenInterest(symbol, params = {}) {
         /**

--- a/js/src/binance.js
+++ b/js/src/binance.js
@@ -8084,7 +8084,7 @@ export default class binance extends Exchange {
         //      ...
         //  ]
         //
-        return this.parseOpenInterests(response, market, since, limit);
+        return this.parseOpenInterests(response, symbol, since, limit);
     }
     async fetchOpenInterest(symbol, params = {}) {
         /**

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -8003,7 +8003,7 @@ export default class binance extends Exchange {
         //      ...
         //  ]
         //
-        return this.parseOpenInterests (response, symbol, since, limit);
+        return this.parseOpenInterests (response, market, since, limit);
     }
 
     async fetchOpenInterest (symbol: string, params = {}) {


### PR DESCRIPTION
The `market` object is not being passed into `parseOpenInterests`