### PR TITLE
fix(bybit): createOrder v3 stopPrice [ci deploy]

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3821,7 +3821,7 @@ export default class bybit extends Exchange {
             request['timeInForce'] = 'ImmediateOrCancel';
         }
         let triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
-        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice');
+        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice', triggerPrice);
         const takeProfitTriggerPrice = this.safeNumber (params, 'takeProfitPrice');
         const stopLoss = this.safeNumber (params, 'stopLoss');
         const takeProfit = this.safeNumber (params, 'takeProfit');


### PR DESCRIPTION
relates to: https://github.com/ccxt/ccxt/issues/17456


```
p bybit createOrder "LTC/USDT:USDT" limit buy 0.2 30 '{"stopPrice":100, "positionIdx":1}'
Python v3.10.9
CCXT v3.0.63
bybit.createOrder(LTC/USDT:USDT,limit,buy,0.2,30,{'stopPrice': 100, 'positionIdx': 1})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '413bc263-ecd8-402e-b1fd-d358d44c3500',
 'info': {'orderId': '413bc263-ecd8-402e-b1fd-d358d44c3500', 'orderLinkId': ''},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
```
 p bybit createOrder "LTC/USDT:USDT" limit buy 0.2 30 '{"stopLoss":20, "takeProfit":"100", "positionIdx":1}'
Python v3.10.9
CCXT v3.0.63
bybit.createOrder(LTC/USDT:USDT,limit,buy,0.2,30,{'stopLoss': 20, 'takeProfit': '100', 'positionIdx': 1})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': 'b1fa8068-0b4a-4248-aaa7-8ce6f70da013',
 'info': {'orderId': 'b1fa8068-0b4a-4248-aaa7-8ce6f70da013', 'orderLinkId': ''},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
