### PR TITLE
poloniex.fetchTrades: side added for public trades

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -800,7 +800,7 @@ export default class poloniex extends Exchange {
         const marketId = this.safeString (trade, 'symbol');
         market = this.safeMarket (marketId, market, '_');
         const symbol = market['symbol'];
-        const side = this.safeStringLower (trade, 'side');
+        const side = this.safeStringLower2 (trade, 'side', 'takerSide');
         let fee = undefined;
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'quantity');


### PR DESCRIPTION
Added mapping for unified (public) `fetch_trades()`.