### PR TITLE
fix: ws client send

### DIFF
--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -196,12 +196,13 @@ class Client {
     }
 
     public function send($data) {
-        $message = is_string($data) ? $data : Exchange::json($data);
-        if ($this->verbose) {
-            echo date('c'), ' sending ', $message, "\n";
-        }
-        $this->connection->send($message);
-        return null;
+        return React\Async\async(function () use ($data) {
+            $message = is_string($data) ? $data : Exchange::json($data);
+            if ($this->verbose) {
+                echo date('c'), ' sending ', $message, "\n";
+            }
+            return $this->connection->send($message);
+        })();
     }
 
     public function close() {

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -109,10 +109,10 @@ trait ClientTrait {
                             //               |
                             //               V
                             \call_user_func($client->throttle, $cost)->then(function ($result) use ($client, $message) {
-                                $client->send($message);
+                                Async\await($client->send($message));
                             });
                         } else {
-                            $client->send($message);
+                            Async\await($client->send($message));
                         }
                     }
                 }

--- a/python/ccxt/async_support/base/ws/aiohttp_client.py
+++ b/python/ccxt/async_support/base/ws/aiohttp_client.py
@@ -73,10 +73,10 @@ class AiohttpClient(Client):
         # if connecting to a non-existent endpoint
         return session.ws_connect(self.url, autoping=False, autoclose=False, headers=self.options.get('headers')).__aenter__()
 
-    def send(self, message):
+    async def send(self, message):
         if self.verbose:
             self.log(iso8601(milliseconds()), 'sending', message)
-        return self.connection.send_str(message if isinstance(message, str) else json.dumps(message, separators=(',', ':')))
+        return await self.connection.send_str(message if isinstance(message, str) else json.dumps(message, separators=(',', ':')))
 
     async def close(self, code=1000):
         if self.verbose:

--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -180,7 +180,7 @@ class Client(object):
     def closed(self):
         raise NotSupported('closed() not implemented')
 
-    def send(self, message):
+    async def send(self, message):
         raise NotSupported('send() not implemented')
 
     async def close(self, code=1000):

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1233,7 +1233,8 @@ export default class Exchange {
                             client.send (message);
                         }).catch ((e) => { throw e });
                     } else {
-                        client.send (message);
+                        client.send (message)
+                        .catch ((e) => { throw e });;
                     }
                 }
             }

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -261,7 +261,6 @@ export default class Client {
             this.log (new Date (), 'sending', message)
         }
         message = (typeof message === 'string') ? message : JSON.stringify (message)
-        this.connection.send (message, )
         const future = Future ()
         if (isNode) {
             function onSendComplete (error) {

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -256,12 +256,27 @@ export default class Client {
         }
     }
 
-    send (message) {
+    async send (message) {
         if (this.verbose) {
             this.log (new Date (), 'sending', message)
         }
         message = (typeof message === 'string') ? message : JSON.stringify (message)
-        this.connection.send (message)
+        this.connection.send (message, )
+        const future = Future ()
+        if (isNode) {
+            function onSendComplete (error) {
+                if (error) {
+                    future.reject (error)
+                } else {
+                    future.resolve (null)
+                }
+            }
+            this.connection.send (message, {}, onSendComplete)
+        } else {
+            this.connection.send (message)
+            future.resolve (null)
+        }
+        return future
     }
 
     close () {

--- a/ts/src/base/ws/Future.ts
+++ b/ts/src/base/ws/Future.ts
@@ -1,6 +1,11 @@
 // @ts-nocheck
 
-export default function Future () {
+interface Future extends Promise<unknown> {
+    resolve(value: unknown): void;
+    reject(reason?: any): void;
+}
+
+export default function Future (): Future {
 
     let resolve = undefined
         , reject = undefined


### PR DESCRIPTION
Problems
- In node the callback for client.send was not being used
- `client.send` was returning null in JS and php but returning a promise in python

This PR solves for: 
- Add future type to Typescript
- Add callback to Node ws `client.send()`
- Unifies client.send