### PR TITLE
fix binance: parseOpenInterest

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -8072,7 +8072,7 @@ export default class binance extends Exchange {
     }
 
     parseOpenInterest (interest, market = undefined) {
-        const timestamp = this.safeInteger (interest, 'timestamp');
+        const timestamp = this.safeInteger2 (interest, 'timestamp', 'time');
         const id = this.safeString (interest, 'symbol');
         const amount = this.safeNumber2 (interest, 'sumOpenInterest', 'openInterest');
         const value = this.safeNumber2 (interest, 'sumOpenInterestValue', 'sumOpenInterestUsd');


### PR DESCRIPTION
some of the api response is using `time`