### PR TITLE
force re-transpile mexc3

### DIFF
--- a/ts/src/mexc3.ts
+++ b/ts/src/mexc3.ts
@@ -4,6 +4,7 @@
 import mexc from './mexc.js';
 
 // ---------------------------------------------------------------------------
+// this is a dummy change to force re-transpile of mexc3's py/php-files. This line can be removed again on next change
 
 export default class mexc3 extends mexc {
     describe () {


### PR DESCRIPTION
Makes php/py-files to be in-sync again. Check:
https://github.com/ccxt/ccxt/blob/master/ts/src/mexc3.ts
https://github.com/ccxt/ccxt/blob/master/php/mexc3.php **[out-of-sync @ v3.0.43]**
https://github.com/ccxt/ccxt/blob/master/python/ccxt/mexc3.py **[out-of-sync @ v3.0.43]**
