### PR TITLE
Bitget: change fetchOpenInterest error type

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -637,7 +637,7 @@ export default class bitget extends Exchange {
                     '40016': PermissionDenied, // The user must bind the phone or Google
                     '40017': ExchangeError, // Parameter verification failed
                     '40018': PermissionDenied, // Invalid IP
-                    '40019': InvalidOrder, // {"code":"40019","msg":"Parameter QLCUSDT_SPBL cannot be empty","requestTime":1679196063659,"data":null}
+                    '40019': BadRequest, // {"code":"40019","msg":"Parameter QLCUSDT_SPBL cannot be empty","requestTime":1679196063659,"data":null}
                     '40102': BadRequest, // Contract configuration does not exist, please check the parameters
                     '40103': BadRequest, // Request method cannot be empty
                     '40104': ExchangeError, // Lever adjustment failure


### PR DESCRIPTION
Changed the error type for using fetchOpenInterest with an incompatible symbol from InvalidOrder to BadRequest
fixes: #17594

```
bitget.fetchOpenInterest (BTC/USD:BTC-230630)
2023-04-19T02:19:46.762Z iteration 0 passed in 269 ms

{
  symbol: 'BTC/USD:BTC-230630',
  openInterestAmount: 305.594,
  openInterestValue: undefined,
  timestamp: 1681870787704,
  datetime: '2023-04-19T02:19:47.704Z',
  info: {
    symbol: 'BTCUSD_DMCBL_230630',
    amount: '305.594',
    timestamp: '1681870787704'
  }
}
```

```
bitget.fetchOpenInterest (BTC/USD:BTC-221230)
BadRequest bitget {"code":"40019","msg":"Parameter BTCUSD_DMCBL_221230 cannot be empty","requestTime":1681870808775,"data":null}
---------------------------------------------------
[BadRequest] bitget {"code":"40019","msg":"Parameter BTCUSD_DMCBL_221230 cannot be empty","requestTime":1681870808775,"data":null}

    at throwExactlyMatchedException  …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2797  
    at handleErrors                  mnt/c/Users/Dan/Documents/GitHub/ccxt/js/src/bitget.js:4356   
    at                               …Users/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:754  
    at processTicksAndRejections     node:internal/process/task_queues:96
    at fetch2                        …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2439  
    at request                       …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2442  
    at fetchOpenInterest             mnt/c/Users/Dan/Documents/GitHub/ccxt/js/src/bitget.js:4125   
    at async run                     mnt/c/Users/Dan/Documents/GitHub/ccxt/examples/js/cli.js:295  

bitget {"code":"40019","msg":"Parameter BTCUSD_DMCBL_221230 cannot be empty","requestTime":1681870808775,"data":null}
```