### PR TITLE
hollaex: patch parseInt ccxt/ccxt#17597

### DIFF
--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -1738,7 +1738,7 @@ export default class hollaex extends Exchange {
         const url = this.urls['api']['rest'] + path;
         if (api === 'private') {
             this.checkRequiredCredentials ();
-            const defaultExpires = this.safeInteger2 (this.options, 'api-expires', 'expires', parseInt ((this.timeout / 1000).toString ()));
+            const defaultExpires = this.safeInteger2 (this.options, 'api-expires', 'expires', this.parseToInt (this.timeout / 1000));
             const expires = this.sum (this.seconds (), defaultExpires);
             const expiresString = expires.toString ();
             let auth = method + path + expiresString;


### PR DESCRIPTION
fix ccxt/ccxt#17597

The current transpiler might return different when use `(a / b).toString()` in python.