### PR TITLE
ndax: patch parseInt

### DIFF
--- a/ts/src/pro/ndax.ts
+++ b/ts/src/pro/ndax.ts
@@ -271,7 +271,7 @@ export default class ndax extends ndaxRest {
                 const duration = parseInt (interval) * 1000;
                 const timestamp = this.safeInteger (ohlcv, 0);
                 const parsed = [
-                    parseInt (((timestamp / duration) * duration).toString ()),
+                    this.parseToInt ((timestamp / duration) * duration),
                     this.safeFloat (ohlcv, 3),
                     this.safeFloat (ohlcv, 1),
                     this.safeFloat (ohlcv, 2),


### PR DESCRIPTION
use `parseToInt` instead of `parseInt`