### PR TITLE
poloniex parseTransaction unification

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -2080,9 +2080,11 @@ export default class poloniex extends Exchange {
             'txid': txid,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
+            'comment': undefined,
             'fee': {
                 'currency': code,
                 'cost': this.parseNumber (feeCostString),
+                'rate': undefined,
             },
         };
     }


### PR DESCRIPTION
### TS

```
% poloniex fetchTransactions
(node:52399) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-04-19T20:42:42.634Z
Node.js: v18.15.0
CCXT v3.0.72
poloniex.fetchTransactions ()
2023-04-19T20:42:44.414Z iteration 0 passed in 273 ms

       id | currency |     amount | network |                                      address | addressTo | addressFrom | tag | tagTo | tagFrom | status |       type | updated |                                                                                    txid |     timestamp |                 datetime | comment |                            fee
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
151217950 |     USDT |         12 |         |           TUrByWNCeWscMB2vc1mLMMMRcr2xL4wuRH |           |             |     |       |         |     ok |    deposit |         |                        c5c501752e9854d382ab62aecec2fe1a208b7dd0dcd1e32bc1c75c72164e319d | 1677368643000 | 2023-02-25T23:44:03.000Z |         |            {"currency":"USDT"}
 16999399 |      SOL | 0.58411738 |         | 44vNZdutGhRi3Xq1fJLNxWXRdxszgZ4KsyUPV858kuUo |           |             |     |       |         |     ok | withdrawal |         | U3di1w4JUo4CwdsmjybQSf5AT7GPetUAWWSmJ1CPgNES5kxFdN9GntFPz3c9wX3biQM9Fp1uLgaZXnuXR6iv4tK | 1680989565000 | 2023-04-08T21:32:45.000Z |         | {"currency":"SOL","cost":0.01}
151498765 |     USDC |  13.072887 |         |   0xa1aa7d526c082bec0649edb5499832c08125d30d |           |             |     |       |         |     ok |    deposit |         |                      0x2ef27cff9a301c91f452baed03864a955ef27a37f0aa664c819620ad51659e1d | 1681866508000 | 2023-04-19T01:08:28.000Z |         |            {"currency":"USDC"}
3 objects
2023-04-19T20:42:44.414Z iteration 1 passed in 273 ms
```

### Python

```
% py poloniex fetchTransactions
Python v3.11.2
CCXT v3.0.72
poloniex.fetchTransactions()
[{'address': 'TUrByWNCeWscMB2vc1mLMMMRcr2xL4wuRH',
  'addressFrom': None,
  'addressTo': None,
  'amount': 12.0,
  'comment': None,
  'currency': 'USDT',
  'datetime': '2023-02-25T23:44:03.000Z',
  'fee': {'cost': None, 'currency': 'USDT', 'rate': None},
  'id': '151217950',
  'info': {'address': 'TUrByWNCeWscMB2vc1mLMMMRcr2xL4wuRH',
           'amount': '12.00000000',
           'confirmations': '0',
           'currency': 'USDTTRON',
           'depositNumber': '151217950',
           'status': 'COMPLETED',
           'timestamp': '1677368643',
           'txid': 'c5c501752e9854d382ab62aecec2fe1a208b7dd0dcd1e32bc1c75c72164e319d'},
  'network': None,
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp': 1677368643000,
  'txid': 'c5c501752e9854d382ab62aecec2fe1a208b7dd0dcd1e32bc1c75c72164e319d',
  'type': 'deposit',
  'updated': None},
 {'address': '44vNZdutGhRi3Xq1fJLNxWXRdxszgZ4KsyUPV858kuUo',
  'addressFrom': None,
  'addressTo': None,
  'amount': 0.58411738,
  'comment': None,
  'currency': 'SOL',
  'datetime': '2023-04-08T21:32:45.000Z',
  'fee': {'cost': 0.01, 'currency': 'SOL', 'rate': None},
  'id': '16999399',
  'info': {'address': '44vNZdutGhRi3Xq1fJLNxWXRdxszgZ4KsyUPV858kuUo',
           'amount': '0.59411738',
           'currency': 'SOL',
           'fee': '0.01000000',
           'ipAddress': '108.60.186.150',
           'paymentID': '',
           'status': 'COMPLETED',
           'timestamp': '1680989565',
           'txid': 'U3di1w4JUo4CwdsmjybQSf5AT7GPetUAWWSmJ1CPgNES5kxFdN9GntFPz3c9wX3biQM9Fp1uLgaZXnuXR6iv4tK',
           'withdrawalRequestsId': '16999399'},
  'network': None,
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp': 1680989565000,
  'txid': 'U3di1w4JUo4CwdsmjybQSf5AT7GPetUAWWSmJ1CPgNES5kxFdN9GntFPz3c9wX3biQM9Fp1uLgaZXnuXR6iv4tK',
  'type': 'withdrawal',
  'updated': None},
 {'address': '0xa1aa7d526c082bec0649edb5499832c08125d30d',
  'addressFrom': None,
  'addressTo': None,
  'amount': 13.072887,
  'comment': None,
  'currency': 'USDC',
  'datetime': '2023-04-19T01:08:28.000Z',
  'fee': {'cost': None, 'currency': 'USDC', 'rate': None},
  'id': '151498765',
  'info': {'address': '0xa1aa7d526c082bec0649edb5499832c08125d30d',
           'amount': '13.07288700',
           'confirmations': '64',
           'currency': 'USDC',
           'depositNumber': '151498765',
           'status': 'COMPLETED',
           'timestamp': '1681866508',
           'txid': '0x2ef27cff9a301c91f452baed03864a955ef27a37f0aa664c819620ad51659e1d'},
  'network': None,
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp': 1681866508000,
  'txid': '0x2ef27cff9a301c91f452baed03864a955ef27a37f0aa664c819620ad51659e1d',
  'type': 'deposit',
  'updated': None}]
```