### PR TITLE
fix incorrect content in dist/cjs/package.json [ci deploy]

### DIFF
--- a/dist/cjs/package.json
+++ b/dist/cjs/package.json
@@ -1,1 +1,1 @@
-{ type: commonjs }
+{ "type": "commonjs" }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ export default [
         transformMixedEsModules: true,
         dynamicRequireTargets: ["**/js/src/static_dependencies/**/*.cjs"],
       }),
-      execute("echo { \"type\": \"commonjs\" } > ./dist/cjs/package.json") // this is needed to make node treat files inside dist/cjs as CJS modules
+      execute("echo '{ \"type\": \"commonjs\" }' > ./dist/cjs/package.json") // this is needed to make node treat files inside dist/cjs as CJS modules
     ],
     onwarn: ( warning, next ) => {
       if ( warning.message.indexOf('is implicitly using "default" export mode') > -1 ) return;


### PR DESCRIPTION
update the `dist/cjs/package.json` file.

My project is written using TypeScript, Jest, and Babel. After upgrading to ccxt 3.0.71, the unit tests consistently fail with the following error message:

```
Cannot find module './cjs/ccxt.js' from 'node_modules/ccxt/dist/ccxt.cjs'
```

I believe that updating the `dist/cjs/package.json` file will resolve this issue.