### PR TITLE
php pro proxy[http/scoks/ssh mode] support

### DIFF
--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -45,6 +45,7 @@ class Exchange extends \ccxt\Exchange {
     public $reloadingMarkets = null;
     public $tokenBucket;
     public $throttle;
+    public $asyncproxy = false;
 
     public $streaming = array(
         'keepAlive' => 30000,
@@ -58,8 +59,10 @@ class Exchange extends \ccxt\Exchange {
     public function __construct($options = array()) {
         parent::__construct($options);
         /*
-        composer require clue/http-proxy-react
-        $proxy = new \Clue\React\HttpProxy\ProxyConnector('127.0.0.1:38700');
+        composer require clue/http-proxy-react clue/socks-react clue/reactphp-ssh-proxy
+        $proxy = new \Clue\React\HttpProxy\ProxyConnector('127.0.0.1:38700');  // http proxy
+        $proxy = new \Clue\React\Socks\Client('socks://127.0.0.1:38700');  // socks proxy
+        $proxy = new \Clue\React\SshProxy\SshSocksConnector('ssh://127.0.0.1:38700');  // ssh proxy
         $connector = new React\Socket\Connector(array(
             'tcp' => $proxy,
             'timeout' => 3.0,
@@ -76,12 +79,13 @@ class Exchange extends \ccxt\Exchange {
         $context = array(
             'timeout' => $this->timeout
         );
-        if(isset($options['myproxy']) && !empty($options['myproxy'])) {
+        if(isset($options['asyncproxy']) && !empty($options['asyncproxy'])) {
             $context = array(
                 'timeout' => $this->timeout,
                 'tcp' => $options['myproxy'],
                 'dns' => false,
             );
+            $this->asyncproxy = $options['asyncproxy'];
         }
         $connector = new React\Socket\Connector(Loop::get(), $context);
         if ($this->browser === null) {

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -57,9 +57,33 @@ class Exchange extends \ccxt\Exchange {
 
     public function __construct($options = array()) {
         parent::__construct($options);
-        $connector = new React\Socket\Connector(Loop::get(), array(
-            'timeout' => $this->timeout,
+        /*
+        composer require clue/http-proxy-react
+        $proxy = new \Clue\React\HttpProxy\ProxyConnector('127.0.0.1:38700');
+        $connector = new React\Socket\Connector(array(
+            'tcp' => $proxy,
+            'timeout' => 3.0,
+            'dns' => false,
         ));
+        $connector->connect('tls://google.com:443')->then(function (React\Socket\ConnectionInterface $connection) {
+            $connection->write("GET / HTTP/1.1\r\nHost: google.com\r\nConnection: close\r\n\r\n");
+            $connection->on('data', function ($chunk) {
+                echo '连接谷歌测试成功' . PHP_EOL;
+            });
+        }, function (Exception $e) {
+            echo 'Error: ' . $e->getMessage() . PHP_EOL;
+        });*/
+        $context = array(
+            'timeout' => $this->timeout
+        );
+        if(isset($options['myproxy']) && !empty($options['myproxy'])) {
+            $context = array(
+                'timeout' => $this->timeout,
+                'tcp' => $options['myproxy'],
+                'dns' => false,
+            );
+        }
+        $connector = new React\Socket\Connector(Loop::get(), $context);
         if ($this->browser === null) {
             $this->browser = (new React\Http\Browser(Loop::get(), $connector))->withRejectErrorResponse(false);
         }

--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -47,6 +47,7 @@ class Client {
     public $lastPong = null;
     public $ping = null;
     public $verbose = false; // verbose output
+    public $asyncproxy = false;
     public $gunzip = false;
     public $inflate = false;
     public $throttle = null;
@@ -132,7 +133,15 @@ class Client {
         }
 
         $this->connected = new Future();
-        $connector = new React\Socket\Connector();
+        if(!$this->asyncproxy) {
+            $connector = new React\Socket\Connector();
+        } else {
+            $context = array(
+                'tcp' => $this->asyncproxy,
+                'dns' => false,
+            );
+            $connector = new React\Socket\Connector(Loop::get(), $context);
+        }
         if ($this->noOriginHeader) {
             $this->connector = new NoOriginHeaderConnector(Loop::get(), $connector);
         } else {

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -58,6 +58,7 @@ trait ClientTrait {
                 'log' => array($this, 'log'),
                 'verbose' => $this->verbose,
                 'throttle' => new Throttle($this->tokenBucket),
+                'asyncproxy' => $this->asyncproxy,
             ), $this->streaming, $ws_options);
             $this->clients[$url] = new Client($url, $on_message, $on_error, $on_close, $on_connected, $options);
         }


### PR DESCRIPTION
1.composer require clue/http-proxy-react clue/socks-react clue/reactphp-ssh-proxy
2.use:
$exchange = new '\\ccxt\\pro\\' . $exchange_id(
            ['apiKey' => 'xxx', 'secret' => 'xxx', 'asyncproxy' => new \Clue\React\HttpProxy\ProxyConnector('127.0.0.1:38700')]
        );