### PR TITLE
[Binance-USDM] Update error codes

### DIFF
--- a/ts/src/binancecoinm.ts
+++ b/ts/src/binancecoinm.ts
@@ -31,6 +31,14 @@ export default class binancecoinm extends binance {
                 'defaultSubType': 'inverse',
                 'leverageBrackets': undefined,
             },
+            // https://binance-docs.github.io/apidocs/futures/en/#error-codes
+            'exceptions': {
+                'exact': {
+                    '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
+                    '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
+                    '-5028': InvalidOrder, // {"code":-5022,"msg":"Timestamp for this request is outside of the ME recvWindow."}
+                }
+            }
         });
     }
 

--- a/ts/src/binancecoinm.ts
+++ b/ts/src/binancecoinm.ts
@@ -31,14 +31,6 @@ export default class binancecoinm extends binance {
                 'defaultSubType': 'inverse',
                 'leverageBrackets': undefined,
             },
-            // https://binance-docs.github.io/apidocs/futures/en/#error-codes
-            'exceptions': {
-                'exact': {
-                    '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
-                    '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
-                    '-5028': InvalidOrder, // {"code":-5022,"msg":"Timestamp for this request is outside of the ME recvWindow."}
-                }
-            }
         });
     }
 

--- a/ts/src/binanceusdm.ts
+++ b/ts/src/binanceusdm.ts
@@ -2,6 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import binance from './binance.js';
+import { InvalidOrder } from './base/errors.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -38,7 +39,7 @@ export default class binanceusdm extends binance {
             // https://binance-docs.github.io/apidocs/futures/en/#error-codes
             'exceptions': {
                 'exact': {
-                    '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
+                    '-5021': InvalidOrder, // {"code":-502,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
                     '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
                     '-5028': InvalidOrder, // {"code":-5028,"msg":"Timestamp for this request is outside of the ME recvWindow."}
                 },

--- a/ts/src/binanceusdm.ts
+++ b/ts/src/binanceusdm.ts
@@ -40,7 +40,7 @@ export default class binanceusdm extends binance {
                 'exact': {
                     '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
                     '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
-                    '-5028': InvalidOrder, // {"code":-5022,"msg":"Timestamp for this request is outside of the ME recvWindow."}
+                    '-5028': InvalidOrder, // {"code":-5028,"msg":"Timestamp for this request is outside of the ME recvWindow."}
                 },
             },
         });

--- a/ts/src/binanceusdm.ts
+++ b/ts/src/binanceusdm.ts
@@ -35,6 +35,14 @@ export default class binanceusdm extends binance {
                 'marginTypes': {},
                 'marginModes': {},
             },
+            // https://binance-docs.github.io/apidocs/futures/en/#error-codes
+            'exceptions': {
+                'exact': {
+                    '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
+                    '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
+                    '-5028': InvalidOrder, // {"code":-5022,"msg":"Timestamp for this request is outside of the ME recvWindow."}
+                },
+            },
         });
     }
 


### PR DESCRIPTION
I accidentally modified the js file in my previous PR https://github.com/ccxt/ccxt/pull/17566. So the change was never applied. 

This PR also makes sure that only the binanceusdm file is edited:
 Code -5021 will be overridden since it differs between spot and USDM) 
 Code -5022 and -5028 are unique to usdm futures