### PR TITLE
fix(bigone): fetchBalance

### DIFF
--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -770,8 +770,12 @@ export default class bigone extends Exchange {
         await this.loadMarkets ();
         const type = this.safeString (params, 'type', '');
         params = this.omit (params, 'type');
-        const method = 'privateGet' + this.capitalize (type) + 'Accounts';
-        const response = await this[method] (params);
+        let response = undefined;
+        if (type === 'funding' || type === 'fund') {
+            response = await this.privateGetFundAccounts (params);
+        } else {
+            response = await this.privateGetAccounts (params);
+        }
         //
         //     {
         //         "code":0,


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17643


```
Python v3.10.9
CCXT v3.0.74
bigone.fetchBalance({'type': 'funding'})
{'1INCH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE3L': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE3S': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE5L': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE5S': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ABBC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
```
```
Python v3.10.9
CCXT v3.0.74
bigone.fetchBalance()
{'1INCH': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE3L': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE3S': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE5L': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'AAVE5S': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ABBC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ACA': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ADA': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ADA3L': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ADA3S': {'free': 0.0, 'total': 0.0, 'used': 0.0},
```
