### PR TITLE
Fix TypeScript emitting updated types into Exchange.d.ts.

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -130,7 +130,7 @@ import { Precise } from './Precise.js'
 
 //-----------------------------------------------------------------------------
 import WsClient from './ws/WsClient.js';
-import Future from './ws/Future.js';
+import { createFuture, Future } from './ws/Future.js';
 import { OrderBook as WsOrderBook, IndexedOrderBook, CountedOrderBook } from './ws/OrderBook.js';
 
 // ----------------------------------------------------------------------------
@@ -1117,9 +1117,9 @@ export default class Exchange {
         return undefined;
     }
 
-    spawn (method, ... args) {
-        const future = Future ()
-        method.apply (this, args).then ((future as any).resolve).catch ((future as any).reject)
+    spawn (method, ... args): Future {
+        const future = createFuture ()
+        method.apply (this, args).then (future.resolve).catch (future.reject)
         return future
     }
 

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -1,6 +1,6 @@
 import { RequestTimeout, NetworkError ,NotSupported, BaseError } from '../../base/errors.js';
 import { inflateSync, gunzipSync } from '../../static_dependencies/fflake/browser.js';
-import Future from './Future.js';
+import { createFuture } from './Future.js';
 
 import {
     isNode,
@@ -68,12 +68,12 @@ export default class Client {
         }
         Object.assign (this, deepExtend (defaults, config))
         // connection-related Future
-        this.connected = Future ()
+        this.connected = createFuture ()
     }
 
     future (messageHash) {
         if (!(messageHash in this.futures)) {
-            this.futures[messageHash] = Future ()
+            this.futures[messageHash] = createFuture ()
         }
         const future = this.futures[messageHash]
         if (messageHash in this.rejections) {
@@ -261,7 +261,7 @@ export default class Client {
             this.log (new Date (), 'sending', message)
         }
         message = (typeof message === 'string') ? message : JSON.stringify (message)
-        const future = Future ()
+        const future = createFuture ()
         if (isNode) {
             function onSendComplete (error) {
                 if (error) {

--- a/ts/src/base/ws/Future.ts
+++ b/ts/src/base/ws/Future.ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
 
-interface Future extends Promise<unknown> {
+export interface Future extends Promise<unknown> {
     resolve(value: unknown): void;
     reject(reason?: any): void;
 }
 
-export default function Future (): Future {
+export function createFuture (): Future {
 
     let resolve = undefined
         , reject = undefined

--- a/ts/src/static_dependencies/fflake/browser.js
+++ b/ts/src/static_dependencies/fflake/browser.js
@@ -971,6 +971,7 @@ function AsyncCmpStrm(opts, cb) {
 // zlib footer: -4 to -0 is Adler32
 /**
  * Streaming DEFLATE compression
+ * @type Class
  */
 var Deflate = /*#__PURE__*/ (function () {
     function Deflate(opts, cb) {
@@ -1000,6 +1001,7 @@ var Deflate = /*#__PURE__*/ (function () {
 export { Deflate };
 /**
  * Asynchronous streaming DEFLATE compression
+ * @type Class
  */
 var AsyncDeflate = /*#__PURE__*/ (function () {
     function AsyncDeflate(opts, cb) {
@@ -1034,6 +1036,7 @@ export function deflateSync(data, opts) {
 }
 /**
  * Streaming DEFLATE decompression
+ * @type Class
  */
 var Inflate = /*#__PURE__*/ (function () {
     /**
@@ -1074,10 +1077,12 @@ var Inflate = /*#__PURE__*/ (function () {
 }());
 export { Inflate };
 /**
+ * @type Class
  * Asynchronous streaming DEFLATE decompression
  */
 var AsyncInflate = /*#__PURE__*/ (function () {
     /**
+     * @type Class
      * Creates an asynchronous inflation stream
      * @param cb The callback to call whenever data is deflated
      */
@@ -1115,6 +1120,7 @@ export function inflateSync(data, out = undefined) {
 // before you yell at me for not just using extends, my reason is that TS inheritance is hard to workerize.
 /**
  * Streaming GZIP compression
+ * @type Class
  */
 var Gzip = /*#__PURE__*/ (function () {
     function Gzip(opts, cb) {
@@ -1188,6 +1194,7 @@ export function gzipSync(data, opts) {
 }
 /**
  * Streaming GZIP decompression
+ * @type Class
  */
 var Gunzip = /*#__PURE__*/ (function () {
     /**
@@ -1224,6 +1231,7 @@ var Gunzip = /*#__PURE__*/ (function () {
 }());
 export { Gunzip };
 /**
+ * @type Class
  * Asynchronous streaming GZIP decompression
  */
 var AsyncGunzip = /*#__PURE__*/ (function () {
@@ -1266,6 +1274,7 @@ export function gunzipSync(data, out = undefined) {
     return inflt(data.subarray(gzs(data), -8), out || new u8(gzl(data)));
 }
 /**
+ * @type Class
  * Streaming Zlib compression
  */
 var Zlib = /*#__PURE__*/ (function () {
@@ -1338,6 +1347,7 @@ export function zlibSync(data, opts) {
 }
 /**
  * Streaming Zlib decompression
+ * @type Class
  */
 var Unzlib = /*#__PURE__*/ (function () {
     /**
@@ -1373,6 +1383,7 @@ var Unzlib = /*#__PURE__*/ (function () {
 }());
 export { Unzlib };
 /**
+ * @type Class
  * Asynchronous streaming Zlib decompression
  */
 var AsyncUnzlib = /*#__PURE__*/ (function () {
@@ -1419,10 +1430,12 @@ export { gzip as compress, AsyncGzip as AsyncCompress };
 // Default algorithm for compression (used because having a known output size allows faster decompression)
 export { gzipSync as compressSync, Gzip as Compress };
 /**
+ * @type Class
  * Streaming GZIP, Zlib, or raw DEFLATE decompression
  */
 var Decompress = /*#__PURE__*/ (function () {
     /**
+     * @type Class
      * Creates a decompression stream
      * @param cb The callback to call whenever data is decompressed
      */
@@ -1467,6 +1480,7 @@ var Decompress = /*#__PURE__*/ (function () {
 export { Decompress };
 /**
  * Asynchronous streaming GZIP, Zlib, or raw DEFLATE decompression
+ * @type Class
  */
 var AsyncDecompress = /*#__PURE__*/ (function () {
     /**
@@ -1559,10 +1573,12 @@ var dutf8 = function (d) {
     }
 };
 /**
+ * @type Class
  * Streaming UTF-8 decoding
  */
 var DecodeUTF8 = /*#__PURE__*/ (function () {
     /**
+     * @type Class
      * Creates a UTF-8 decoding stream
      * @param cb The callback to call whenever data is decoded
      */
@@ -1611,6 +1627,7 @@ var DecodeUTF8 = /*#__PURE__*/ (function () {
 export { DecodeUTF8 };
 /**
  * Streaming UTF-8 encoding
+ * @type Class
  */
 var EncodeUTF8 = /*#__PURE__*/ (function () {
     /**
@@ -1777,6 +1794,7 @@ var wzf = function (o, b, c, d, e) {
 };
 /**
  * A pass-through stream to keep data uncompressed in a ZIP archive.
+ * @type Class
  */
 var ZipPassThrough = /*#__PURE__*/ (function () {
     /**
@@ -1823,6 +1841,7 @@ export { ZipPassThrough };
 /**
  * Streaming DEFLATE compression for ZIP archives. Prefer using AsyncZipDeflate
  * for better performance
+ * @type Class
  */
 var ZipDeflate = /*#__PURE__*/ (function () {
     /**
@@ -1862,6 +1881,7 @@ var ZipDeflate = /*#__PURE__*/ (function () {
 export { ZipDeflate };
 /**
  * Asynchronous streaming DEFLATE compression for ZIP archives
+ * @type Class
  */
 var AsyncZipDeflate = /*#__PURE__*/ (function () {
     /**
@@ -1898,6 +1918,7 @@ export { AsyncZipDeflate };
 // TODO: Better tree shaking
 /**
  * A zippable archive to which files can incrementally be added
+ * @type Class
  */
 var Zip = /*#__PURE__*/ (function () {
     /**
@@ -2189,6 +2210,7 @@ export function zipSync(data, opts) {
 }
 /**
  * Streaming pass-through decompression for ZIP archives
+ * @type Class
  */
 var UnzipPassThrough = /*#__PURE__*/ (function () {
     function UnzipPassThrough() {
@@ -2203,6 +2225,7 @@ export { UnzipPassThrough };
 /**
  * Streaming DEFLATE decompression for ZIP archives. Prefer AsyncZipInflate for
  * better performance.
+ * @type Class
  */
 var UnzipInflate = /*#__PURE__*/ (function () {
     /**
@@ -2227,10 +2250,12 @@ var UnzipInflate = /*#__PURE__*/ (function () {
 }());
 export { UnzipInflate };
 /**
+ * @type Class
  * Asynchronous streaming DEFLATE decompression for ZIP archives
  */
 var AsyncUnzipInflate = /*#__PURE__*/ (function () {
     /**
+     * @type Class
      * Creates a DEFLATE decompression that can be used in ZIP archives
      */
     function AsyncUnzipInflate(_, sz) {
@@ -2258,6 +2283,7 @@ var AsyncUnzipInflate = /*#__PURE__*/ (function () {
 export { AsyncUnzipInflate };
 /**
  * A ZIP archive decompression stream that emits files as they are discovered
+ * @type Class
  */
 var Unzip = /*#__PURE__*/ (function () {
     /**

--- a/ts/src/static_dependencies/jsencrypt/lib/jsbn/jsbn.ts
+++ b/ts/src/static_dependencies/jsencrypt/lib/jsbn/jsbn.ts
@@ -20,8 +20,11 @@ const lplim = (1 << 26) / lowprimes[lowprimes.length - 1];
 //#endregion
 
 // (public) Constructor
+/**
+ * @type Class
+ */
 export class BigInteger {
-    constructor(a:number|number[]|string, b?:number|SecureRandom, c?:number|SecureRandom) {
+    public constructor(a:number|number[]|string, b?:number|SecureRandom, c?:number|SecureRandom) {
         if (a != null) {
             if ("number" == typeof a) {
                 this.fromNumber(a, b, c);

--- a/ts/src/static_dependencies/jsencrypt/lib/jsrsasign/asn1-1.0.js
+++ b/ts/src/static_dependencies/jsencrypt/lib/jsrsasign/asn1-1.0.js
@@ -94,6 +94,7 @@ if (typeof KJUR.asn1 == "undefined" || !KJUR.asn1) KJUR.asn1 = {};
 
 /**
  * ASN1 utilities class
+ * @type Class
  * @name KJUR.asn1.ASN1Util
  * @class ASN1 utilities class
  * @since asn1 1.0.2


### PR DESCRIPTION
In 4464bc8877 `fix: ws client send` has this change:

```
--- a/ts/src/base/ws/Future.ts
+++ b/ts/src/base/ws/Future.ts
@@ -1,6 +1,11 @@
 // @ts-nocheck
 
-export default function Future () {
+interface Future extends Promise<unknown> {
+    resolve(value: unknown): void;
+    reject(reason?: any): void;
+}
+
+export default function Future (): Future {
```

When trying to emit `js/src/base/Exchange.d.ts`, `tsc` won't update it because there's this new error:

```
ts/src/base/Exchange.ts:1120:5 - error TS4053: Return type of public method from exported class has or is using name 'Future' from external module "/Users/blair/Code/Cryptocurrency-Reference/ccxt.git/ts/src/base/ws/Future" but cannot be named.

1120     spawn (method, ... args) {
```

The simple fix is to declare `spawn` to return `Promise<unknown>`.

A more complicated fix would be to export the `Future` type itself and rename the current default export of `Future` to something like `newFuture`. Let me know if you want that.