### PR TITLE
fix(bybit): fetchPositions USDC

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7138,22 +7138,24 @@ export default class bybit extends Exchange {
         symbols = this.marketSymbols (symbols);
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         let settle = this.safeString (params, 'settleCoin');
+        let paramsOmitted = undefined;
         if (settle === undefined) {
-            [ settle, params ] = this.handleOptionAndParams (params, 'fetchPositions', 'settle', settle);
+            [ settle, paramsOmitted ] = this.handleOptionAndParams (params, 'fetchPositions', 'settle', settle);
         }
         const isUsdcSettled = settle === 'USDC';
-        const [ subType, query ] = this.handleSubTypeAndParams ('fetchPositions', undefined, params);
+        let subType = undefined;
+        [ subType, paramsOmitted ] = this.handleSubTypeAndParams ('fetchPositions', undefined, paramsOmitted);
         const isInverse = subType === 'inverse';
         const isLinearSettle = isUsdcSettled || (settle === 'USDT');
         if (isInverse && isLinearSettle) {
             throw new ArgumentsRequired (this.id + ' fetchPositions with inverse subType requires settle to not be USDT or USDC');
         }
         if ((enableUnifiedMargin || enableUnifiedAccount) && !isInverse) {
-            return await this.fetchUnifiedPositions (symbols, query);
+            return await this.fetchUnifiedPositions (symbols, params);
         } else if (isUsdcSettled) {
-            return await this.fetchUSDCPositions (symbols, query);
+            return await this.fetchUSDCPositions (symbols, paramsOmitted);
         } else {
-            return await this.fetchDerivativesPositions (symbols, query);
+            return await this.fetchDerivativesPositions (symbols, params);
         }
     }
 


### PR DESCRIPTION
DEMO

```
n bybit fetchPositions undefined '{"settle":"USDC"}' --sandbox
Debugger attached.
2023-04-24T10:04:18.953Z
Node.js: v18.14.0
CCXT v3.0.75
bybit.fetchPositions (, [object Object])
2023-04-24T10:04:24.219Z iteration 0 passed in 3788 ms

id |       symbol |     timestamp |                 datetime | lastUpdateTimestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice | notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | liquidationPrice | markPrice | lastPrice |  collateral | marginMode | side | percentage
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | BTC/USD:USDC | 1682329621162 | 2023-04-24T09:47:01.162Z |                     |    5.49670278 |     0.10054000014632772 |        0.24820998 |        0.004540000146327722 |    27335.9 |  54.6718 |       10 |       -0.0124 |     0.002 |            1 |      0.0045 |              0.1 |   27329.7 |           | 54.90740998 |      cross | long |           
1 objects
```
```
 bybit fetchPositions undefined  --sandbox 
Debugger attached.
2023-04-24T10:04:40.167Z
Node.js: v18.14.0
CCXT v3.0.75
bybit.fetchPositions ()
2023-04-24T10:04:42.278Z iteration 0 passed in 604 ms

id |        symbol |     timestamp |                 datetime | lastUpdateTimestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice | notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | liquidationPrice | markPrice | lastPrice | collateral | marginMode | side | percentage
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | LTC/USDT:USDT | 1682330464647 | 2023-04-24T10:01:04.647Z |                     |        0.8703 |                     0.1 |                   |                             |      87.03 |    8.703 |       10 |         0.014 |       0.1 |            1 |             |             0.01 |     87.17 |           |            |      cross | long |           
1 objects
2023-04-24T10:04:42.278Z iteration 1 passed in 604 ms
```
