### PR TITLE
chore: update error codes for binanceusdm.ts [ccxt-pro]

### DIFF
--- a/ts/src/binanceusdm.ts
+++ b/ts/src/binanceusdm.ts
@@ -39,7 +39,7 @@ export default class binanceusdm extends binance {
             // https://binance-docs.github.io/apidocs/futures/en/#error-codes
             'exceptions': {
                 'exact': {
-                    '-5021': InvalidOrder, // {"code":-502,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
+                    '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
                     '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
                     '-5028': InvalidOrder, // {"code":-5028,"msg":"Timestamp for this request is outside of the ME recvWindow."}
                 },

--- a/ts/src/pro/binanceusdm.ts
+++ b/ts/src/pro/binanceusdm.ts
@@ -2,6 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import binance from './binance.js';
+import { InvalidOrder } from './base/errors.js';
 
 // ---------------------------------------------------------------------------
 
@@ -16,6 +17,14 @@ export default class binanceusdm extends binance {
             'options': {
                 'fetchMarkets': [ 'linear' ],
                 'defaultSubType': 'linear',
+            },
+            // https://binance-docs.github.io/apidocs/futures/en/#error-codes
+            'exceptions': {
+                'exact': {
+                    '-5021': InvalidOrder, // {"code":-5021,"msg":"Due to the order could not be filled immediately, the FOK order has been rejected."}
+                    '-5022': InvalidOrder, // {"code":-5022,"msg":"Due to the order could not be executed as maker, the Post Only order will be rejected."}
+                    '-5028': InvalidOrder, // {"code":-5028,"msg":"Timestamp for this request is outside of the ME recvWindow."}
+                },
             },
         });
     }

--- a/ts/src/pro/binanceusdm.ts
+++ b/ts/src/pro/binanceusdm.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import binance from './binance.js';
-import { InvalidOrder } from './base/errors.js';
+import { InvalidOrder } from '../base/errors.js';
 
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
In https://github.com/ccxt/ccxt/pull/17640, I updated the error codes for binance-usdm. This change must also be added to the `pro/binanceusdm.ts` file.

Are there any plans to remove this redundancy?