### PR TITLE
[bybit] Fix watch_ticker to use symbol in same way as other exchanges

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -175,7 +175,8 @@ export default class bybit extends bybitRest {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const messageHash = 'ticker:' + market['symbol'];
+        symbol = market['symbol'];
+        const messageHash = 'ticker:' + symbol;
         const url = this.getUrlByMarketType (symbol, false, params);
         params = this.cleanParams (params);
         const options = this.safeValue (this.options, 'watchTicker', {});


### PR DESCRIPTION
giving `market['id']` probably broke handleTicker