### PR TITLE
types.ts add uppercase type|undefined

### DIFF
--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -196,7 +196,11 @@ export type implicitReturnType = any;
 // must be an integer in other langs
 export type IndexType = number | string;
 
-export type Int = number;
+export type Int = number | undefined;
+
+export type String = string | undefined;
+
+export type Boolean = boolean | undefined;
 
 export type OrderSide = 'buy' | 'sell';
 


### PR DESCRIPTION
Used to replace declarations like `code: string = undefined` with `code: String = undefined` and will remove errors like `Type 'undefined' is not assignable to type 'string'.ts(2322)`

In the case of `Int`, I don't think that there's a single occurrence where we use `Int` and the argument can't also be `undefined`