### PR TITLE
fix(phemex): watchOrders

### DIFF
--- a/ts/src/pro/phemex.ts
+++ b/ts/src/pro/phemex.ts
@@ -924,8 +924,9 @@ export default class phemex extends phemexRest {
             }
         }
         [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params);
+        const isUSDTSettled = this.safeString (params, 'settle') === 'USDT';
         if (symbol === undefined) {
-            messageHash = (params['settle'] === 'USDT') ? (messageHash + 'perpetual') : (messageHash + type);
+            messageHash = (isUSDTSettled) ? (messageHash + 'perpetual') : (messageHash + type);
         }
         const orders = await this.subscribePrivate (type, messageHash, params);
         if (this.newUpdates) {
@@ -1522,6 +1523,6 @@ export default class phemex extends phemexRest {
             future = this.watch (url, messageHash, message);
             client.subscriptions[messageHash] = future;
         }
-        return future;
+        return await future;
     }
 }


### PR DESCRIPTION
- we're not awaiting the manually created authenticate future, only the future returned automatically by making `authenticate` an async method
- usdt `settle` handling was also broken in Python

DEMO
````
Python v3.10.9
CCXT v3.0.81
phemex.watchOrders()
[{'amount': 0.000301,
  'average': 41387.63,
  'clientOrderId': '7956e0be-e8be-93a0-2887-ca504d85cda2',
  'cost': 12.48,
  'datetime': '2022-04-20T08:16:57.606Z',
  'fee': {'cost': 3.1e-07, 'currency': None},
  'fees': [{'cost': 3.1e-07, 'currency': None}],
  'filled': 0.000301,
  'id': '34a4b1a8-ac3a-4580-b3e6-a6d039f27195',
  'info': {'action': 'New',
           'activity_id': 0,
           'avgPriceEp': 4138763000000,
           'baseCurrency': 'BTC',
           'baseQtyEv': 0,
           'bizError': 0,
           'clOrdID': '7956e0be-e8be-93a0-2887-ca504d85cda2',
           'createTimeNs': 1650442617606017583,
           'cumBaseQtyEv': 30100,
           'cumFeeEv': 31,
           'cumQuoteQtyEv': 1245767663,
           'cxlRejReason': 0,
           'execPriceEp': 4138763000000,
           'feeCurrency': 'BTC',
           'leavesBaseQtyEv': 0,
           'leavesQuoteQtyEv': 0,
           'maker_fee_rate_er': 0,
           'ordStatus': 'Filled',
           'ordType': 'Market',
           'orderID': '34a4b1a8-ac3a-4580-b3e6-a6d039f27195',
           'pegOffsetValueEp': 0,
           'priceEp': 4549022000000,
           'qtyType': 'ByQuote',
           'quoteCurrency': 'USDT',
           'quoteQtyEv': 1248000000,
           'side': 'Buy',
           'stopPxEp': 0,
           'symbol': 'sBTCUSDT',
           'taker_fee_rate_er': 0,
           'timeInForce': 'ImmediateOrCancel',
           'tradeType': 'Trade',
           'transactTimeNs': 1650442617609928764,
           'triggerTimeNs': 0,
           'userID': 2647224},
  'lastTradeTimestamp': None,
  'postOnly': False,
  'price': 45490.22,
  'reduceOnly': None,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'timeInForce': 'IOC',
  'timestamp': 1650442617606,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'},
 {'amount': None,
```
