### PR TITLE
huobi fetchFundingRateHistory

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -5401,7 +5401,7 @@ export default class huobi extends Exchange {
                 'datetime': this.iso8601 (timestamp),
             });
         }
-        const sorted = this.sortBy (rates, 'timestamp');
+        const sorted = this.sortBy (rates, 'timestamp', true);
         return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit);
     }
 

--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -5401,8 +5401,8 @@ export default class huobi extends Exchange {
                 'datetime': this.iso8601 (timestamp),
             });
         }
-        const sorted = this.sortBy (rates, 'timestamp', true);
-        return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit);
+        const sorted = this.sortBy (rates, 'timestamp');
+        return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit, true);
     }
 
     parseFundingRate (contract, market = undefined) {


### PR DESCRIPTION
fixes: #15905

```
% huobi fetchFundingRateHistory BTC/USDT:USDT undefined 5         
2023-04-28T20:19:28.316Z
Node.js: v18.15.0
CCXT v3.0.80
huobi.fetchFundingRateHistory (BTC/USDT:USDT, , 5)
2023-04-28T20:19:31.341Z iteration 0 passed in 474 ms

       symbol |          fundingRate |     timestamp |                 datetime
-------------------------------------------------------------------------------
BTC/USDT:USDT |               0.0001 | 1682582400000 | 2023-04-27T08:00:00.000Z
BTC/USDT:USDT |               0.0001 | 1682611200000 | 2023-04-27T16:00:00.000Z
BTC/USDT:USDT | 0.000035338731538801 | 1682640000000 | 2023-04-28T00:00:00.000Z
BTC/USDT:USDT |  0.00003192576787035 | 1682668800000 | 2023-04-28T08:00:00.000Z
BTC/USDT:USDT |               0.0001 | 1682697600000 | 2023-04-28T16:00:00.000Z
5 objects
2023-04-28T20:19:31.341Z iteration 1 passed in 474 ms
```
```
% huobi fetchFundingRateHistory ETH/USD:ETH undefined 5
2023-04-28T20:19:54.952Z
Node.js: v18.15.0
CCXT v3.0.80
huobi.fetchFundingRateHistory (ETH/USD:ETH, , 5)
2023-04-28T20:19:57.914Z iteration 0 passed in 575 ms

     symbol |           fundingRate |     timestamp |                 datetime
------------------------------------------------------------------------------
ETH/USD:ETH | -0.000203611171295381 | 1682582400000 | 2023-04-27T08:00:00.000Z
ETH/USD:ETH | -0.000084301548263399 | 1682611200000 | 2023-04-27T16:00:00.000Z
ETH/USD:ETH |  0.000041627453813905 | 1682640000000 | 2023-04-28T00:00:00.000Z
ETH/USD:ETH |  0.000005526917263024 | 1682668800000 | 2023-04-28T08:00:00.000Z
ETH/USD:ETH |  0.000013688329846651 | 1682697600000 | 2023-04-28T16:00:00.000Z
5 objects
2023-04-28T20:19:57.914Z iteration 1 passed in 575 ms
```