### PR TITLE
fix:php ccxt pro alias classes

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -960,7 +960,12 @@ class Transpiler {
 
         let bodyAsString = body.join ("\n")
 
+        const isAlias = bodyAsString.match ("'alias': true")
+        
         let header = this.createPHPClassHeader (className, baseClass, bodyAsString, async ? 'ccxt\\async' : 'ccxt')
+        if (isAlias && async) {
+            header = this.createPHPClassHeader (className, baseClass, bodyAsString, 'ccxt\\pro')
+        }    
 
         const errorImports = []
 


### PR DESCRIPTION
ccxt.pro php classes with aliases weren't extending the correct class.