### PR TITLE
bithumb: use currency code rather than currency object

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -975,7 +975,7 @@ export default class bithumb extends Exchange {
             'address': address,
             'currency': currency['id'],
         };
-        if (currency === 'XRP' || currency === 'XMR' || currency === 'EOS' || currency === 'STEEM') {
+        if (code === 'XRP' || code === 'XMR' || code === 'EOS' || code === 'STEEM') {
             const destination = this.safeString (params, 'destination');
             if ((tag === undefined) && (destination === undefined)) {
                 throw new ArgumentsRequired (this.id + ' ' + code + ' withdraw() requires a tag argument or an extra destination param');


### PR DESCRIPTION
In the line

```
        if (currency === 'XRP' || currency === 'XMR' || currency === 'EOS' || currency === 'STEEM') {
```

will never match because `currency` is a `Currency` object, as can be seen by getting the object above:

```
        const currency = this.currency (code);
```

So switch to the code itself.
