### PR TITLE
bitso: use currency rather than currency code for parseLedger ()

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1496,7 +1496,7 @@ export default class Exchange {
         };
     }
 
-    safeLedgerEntry (entry: object, currency: string = undefined) {
+    safeLedgerEntry (entry: object, currency: object = undefined) {
         currency = this.safeCurrency (undefined, currency);
         let direction = this.safeString (entry, 'direction');
         let before = this.safeString (entry, 'before');
@@ -2635,7 +2635,7 @@ export default class Exchange {
         return this.filterBySymbolSinceLimit (result, symbol, since, limit, tail) as Trade[];
     }
 
-    parseTransactions (transactions, currency: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    parseTransactions (transactions, currency: object = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         transactions = this.toArray (transactions);
         let result = [];
         for (let i = 0; i < transactions.length; i++) {
@@ -2648,7 +2648,7 @@ export default class Exchange {
         return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
     }
 
-    parseTransfers (transfers, currency: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    parseTransfers (transfers, currency: object = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         transfers = this.toArray (transfers);
         let result = [];
         for (let i = 0; i < transfers.length; i++) {
@@ -2661,7 +2661,7 @@ export default class Exchange {
         return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
     }
 
-    parseLedger (data, currency: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    parseLedger (data, currency: object = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         let result = [];
         const arrayData = this.toArray (data);
         for (let i = 0; i < arrayData.length; i++) {

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -216,7 +216,8 @@ export default class bitso extends Exchange {
         //     }
         //
         const payload = this.safeValue (response, 'payload', []);
-        return this.parseLedger (payload, code, since, limit);
+        const currency = this.safeCurrency (code);
+        return this.parseLedger (payload, currency, since, limit);
     }
 
     parseLedgerEntryType (type) {

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -368,7 +368,8 @@ export default class timex extends Exchange {
         //         }
         //     ]
         //
-        return this.parseTransactions (response, code, since, limit);
+        const currency = this.safeCurrency (code);
+        return this.parseTransactions (response, currency, since, limit);
     }
 
     async fetchWithdrawals (code: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -403,7 +404,8 @@ export default class timex extends Exchange {
         //         }
         //     ]
         //
-        return this.parseTransactions (response, code, since, limit);
+        const currency = this.safeCurrency (code);
+        return this.parseTransactions (response, currency, since, limit);
     }
 
     getCurrencyByAddress (address) {


### PR DESCRIPTION
`fetchLedger ()` calls `this.parseLedger ()` with a `string` currency code.

But note that `parseLedger` is defined to take a `string` but it actually behaves as though the `currency` argument is a `Currency` by the `currency['code']`

```
    parseLedger (data, currency: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
...
...
        const code = (currency !== undefined) ? currency['code'] : undefined;
```

A follow up commit can fix the `parseLedger ()`.

So fix bitso's use here by passing a `Currency` to `parseLedger ()`.