### PR TITLE
huobi: safeCurrencyCode ()'s second argument is a Currency

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -5272,7 +5272,7 @@ export default class huobi extends Exchange {
             for (let j = 0; j < currencies.length; j++) {
                 const currency = currencies[j];
                 const currencyId = this.safeString (currency, 'currency');
-                const code = this.safeCurrencyCode (currencyId, 'currency');
+                const code = this.safeCurrencyCode (currencyId);
                 symbolRates[code] = {
                     'currency': code,
                     'rate': this.safeNumber (currency, 'actual-rate'),
@@ -5334,7 +5334,7 @@ export default class huobi extends Exchange {
             for (let j = 0; j < currencies.length; j++) {
                 const currency = currencies[j];
                 const currencyId = this.safeString (currency, 'currency');
-                const code = this.safeCurrencyCode (currencyId, 'currency');
+                const code = this.safeCurrencyCode (currencyId);
                 rates[code] = {
                     'currency': code,
                     'rate': this.safeNumber (currency, 'actual-rate'),


### PR DESCRIPTION
`safeCurrencyCode ()` really takes a Currency object as its second argument, not a currency code.

Since `fetchBorrowRatesPerSymbol ()` and `fetchBorrowRates ()` don't have a Currency object available, drop the `'currency'` argument to `safeCurrencyCode ()`.