### PR TITLE
hitbtc: createDepositAddress () returns a DepositAddressResponse

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -1384,7 +1384,7 @@ export default class hitbtc extends Exchange {
         this.checkAddress (address);
         const tag = this.safeString (response, 'paymentId');
         return {
-            'currency': currency,
+            'currency': code,
             'address': address,
             'tag': tag,
             'info': response,


### PR DESCRIPTION
`createDepositAddress ()` returns a `Promise<DepositAddressResponse>`:

```
export interface DepositAddressResponse {
    currency: string;
    address: string;
    info: any;
    tag?: string;
}
```

However, hitbtc's `createDepositAddress ()` is putting a `Currency` object into the `currency` property so switch to the currency code.