### PR TITLE
Fix buildOHLCVC js and python functions

### DIFF
--- a/js/src/base/functions/misc.js
+++ b/js/src/base/functions/misc.js
@@ -50,8 +50,8 @@ const buildOHLCVC = (trades, timeframe = '1m', since = -Infinity, limit = Infini
     const ms = parseTimeframe(timeframe) * 1000;
     const ohlcvs = [];
     const [timestamp, /* open */ , high, low, close, volume, count] = [0, 1, 2, 3, 4, 5, 6];
-    const oldest = Math.min(trades.length - 1, limit);
-    for (let i = 0; i <= oldest; i++) {
+    const oldest = Math.min(trades.length, limit);
+    for (let i = 0; i < oldest; i++) {
         const trade = trades[i];
         if (trade.timestamp < since) {
             continue;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1497,7 +1497,7 @@ class Exchange(object):
         ohlcvs = []
         (timestamp, open, high, low, close, volume, count) = (0, 1, 2, 3, 4, 5, 6)
         num_trades = len(trades)
-        oldest = (num_trades - 1) if limit is None else min(num_trades - 1, limit)
+        oldest = num_trades if limit is None else min(num_trades, limit)
         for i in range(0, oldest):
             trade = trades[i]
             if (since is not None) and (trade['timestamp'] < since):


### PR DESCRIPTION
In the build_ohlcvc python function candles were only generated when there are more than two trades

range() ommits the stop (`list(range(0,0))` returns `[]`, `list(range(0,1))` return `[0]`)

This PR fixes this so also a candle with only one trade is generated

Closes https://github.com/ccxt/ccxt/issues/17720