### PR TITLE
Adjust php build_ohlcvc limit to javascript

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -707,9 +707,7 @@ class Exchange {
         if (!is_numeric($since)) {
             $since = PHP_INT_MIN;
         }
-        if (!is_numeric($limits)) {
-            $limits = PHP_INT_MAX;
-        }
+        $limits = is_numeric($limits) ? ($limits + 1) : PHP_INT_MAX;
         $ms = static::parse_timeframe($timeframe) * 1000;
         $ohlcvs = array();
         list(/* $timestamp */, /* $open */, $high, $low, $close, $volume) = array(0, 1, 2, 3, 4, 5);


### PR DESCRIPTION
Assume that trades is the following array: `trades = [1,2,3,4,5];`

When setting the limit value in javascript to 3, the following trades are used: `1, 2, 3, 4`
When setting the $limit value in PHP to 3, the following trades were used: `1, 2, 3`

This PR adjusts the behaviour of PHP to match the behaviour of javascript.

Python already uses the same trades as javascript
