### PR TITLE
fix client race condition - move client subscription check before connection and handle rollback

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -340,15 +340,17 @@ class Exchange(BaseExchange):
             return client.futures[message_hash]
         future = client.future(message_hash)
 
+        subscribed = client.subscriptions.get(subscribe_hash)
+
+        if not subscribed:
+            client.subscriptions[subscribe_hash] = subscription or True
+
         # base exchange self.open starts the aiohttp Session in an async context
         self.open()
         connected = client.connected if client.connected.done() \
             else asyncio.ensure_future(client.connect(self.session, backoff_delay))
 
         def after(fut):
-            if subscribe_hash not in client.subscriptions:
-                if subscribe_hash is not None:
-                    client.subscriptions[subscribe_hash] = subscription or True
                 # todo: decouple signing from subscriptions
                 options = self.safe_value(self.options, 'ws')
                 cost = self.safe_value(options, 'cost', 1)
@@ -359,10 +361,16 @@ class Exchange(BaseExchange):
                         try:
                             await client.send(message)
                         except ConnectionError as e:
+                            del client.subscriptions[subscribe_hash]
                             future.reject(e)
                     asyncio.ensure_future(send_message())
 
-        connected.add_done_callback(after)
+        if not subscribed:
+            try:
+                connected.add_done_callback(after)
+            except Exception as e:
+                del client.subscriptions[subscribe_hash]
+                future.reject(e)
 
         return future
 

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1209,6 +1209,12 @@ export default class Exchange {
             return client.futures[messageHash];
         }
         const future = client.future (messageHash);
+        // read and write subscription, this is done before connecting the client
+        // to avoid race conditions when other parts of the code read or write to the client.subscriptions
+        const clientSubscription = client.subscriptions[subscribeHash];
+        if (!clientSubscription) {
+            client.subscriptions[subscribeHash] = subscription || true;
+        }
         // we intentionally do not use await here to avoid unhandled exceptions
         // the policy is to make sure that 100% of promises are resolved or rejected
         // either with a call to client.resolve or client.reject with
@@ -1217,28 +1223,28 @@ export default class Exchange {
         // the following is executed only if the catch-clause does not
         // catch any connection-level exceptions from the client
         // (connection established successfully)
-        connected.then (() => {
-            if (!client.subscriptions[subscribeHash]) {
-                if (subscribeHash !== undefined) {
-                    client.subscriptions[subscribeHash] = subscription || true;
-                }
-                const options = this.safeValue (this.options, 'ws');
-                const cost = this.safeValue (options, 'cost', 1);
-                if (message) {
-                    if (this.enableRateLimit && client.throttle) {
-                        // add cost here |
-                        //               |
-                        //               V
-                        client.throttle (cost).then (() => {
-                            client.send (message);
-                        }).catch ((e) => { throw e });
-                    } else {
-                        client.send (message)
-                        .catch ((e) => { throw e });;
+        if (!clientSubscription) {
+            connected.then (() => {
+                    const options = this.safeValue (this.options, 'ws');
+                    const cost = this.safeValue (options, 'cost', 1);
+                    if (message) {
+                        if (this.enableRateLimit && client.throttle) {
+                            // add cost here |
+                            //               |
+                            //               V
+                            client.throttle (cost).then (() => {
+                                client.send (message);
+                            }).catch ((e) => { throw e });
+                        } else {
+                            client.send (message)
+                            .catch ((e) => { throw e });;
+                        }
                     }
-                }
-            }
-        })
+                }).catch ((e)=> {
+                    delete (client.subscriptions[subscribeHash])
+                    throw e
+            });
+        }
         return future;
     }
 


### PR DESCRIPTION
There was a race condition when other parts of the code read or write to client.subscriptions when caling watch(), however the subscription hadn´t been recorded yet as it waits for the client to be connected.

This PR moves the subscription to be created before the connection to avoid the race condition and adds a rollback in case the connection errors to delete the subscription