### PR TITLE
Fix typo when creating postOnly order

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -816,7 +816,7 @@ export default class krakenfutures extends Exchange {
         if (stopPrice !== undefined && type !== 'take_profit') {
             type = 'stp';
         } else if (postOnly) {
-            type = 'postOnly';
+            type = 'post';
         } else if (timeInForce === 'ioc') {
             type = 'ioc';
         } else if (type === 'limit') {


### PR DESCRIPTION
The correct type is `post`, see here:
https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-send-order