### PR TITLE
huobi createOrder default stopOperator for stop orders

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -4167,10 +4167,8 @@ export default class huobi extends Exchange {
                 throw new ArgumentsRequired (this.id + ' createOrder() requires a stopPrice or a stop-price parameter for a stop order');
             }
         } else {
-            const stopOperator = this.safeString (params, 'operator');
-            if (stopOperator === undefined) {
-                throw new ArgumentsRequired (this.id + ' createOrder() requires an operator parameter "gte" or "lte" for a stop order');
-            }
+            const defaultOperator = (side === 'sell') ? 'lte' : 'gte';
+            const stopOperator = this.safeString (params, 'operator', defaultOperator);
             params = this.omit (params, [ 'stopPrice', 'stop-price' ]);
             request['stop-price'] = this.priceToPrecision (symbol, stopPrice);
             request['operator'] = stopOperator;


### PR DESCRIPTION
```
% huobi createOrder ADA/USDT limit sell 28 0.36 '{"stopPrice": 0.36}'
2023-05-03T04:42:03.552Z
Node.js: v18.15.0
CCXT v3.0.83
huobi.createOrder (ADA/USDT, limit, sell, 28, 0.36, [object Object])
2023-05-03T04:42:06.810Z iteration 0 passed in 956 ms

{
  info: { status: 'ok', data: '791340579590349' },
  id: '791340579590349',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  price: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  trades: undefined,
  fee: undefined,
  clientOrderId: undefined,
  average: undefined
}
2023-05-03T04:42:06.810Z iteration 1 passed in 956 ms

samgermain@Sams-MBP ccxt % huobi fetchOpenOrders
(node:12831) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-05-03T04:42:22.654Z
Node.js: v18.15.0
CCXT v3.0.83
huobi.fetchOpenOrders ()
2023-05-03T04:42:25.499Z iteration 0 passed in 744 ms

             id |                                  clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining | status |                          fee | trades |                           fees | reduceOnly
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
791340579590349 | AA03022abc826934e4-e5ee-4429-b8e1-a4190777a218 | 1683088926755 | 2023-05-03T04:42:06.755Z |                    | ADA/USDT | stop |             |          | sell |  0.36 |      0.36 |         0.36 |         |    0 |     28 |      0 |        28 |   open | {"cost":0,"currency":"USDT"} |     [] | [{"cost":0,"currency":"USDT"}] |           
1 objects
2023-05-03T04:42:25.499Z iteration 1 passed in 744 ms
```

```
 % py huobi createOrder ADA/USDT limit buy 21 0.5 '{"stopPrice": 0.5}'
Python v3.11.2
CCXT v3.0.83
huobi.createOrder(ADA/USDT,limit,buy,21,0.5,{'stopPrice': 0.5})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'filled': None,
 'id': '791340722719622',
 'info': {'data': '791340722719622', 'status': 'ok'},
 'lastTradeTimestamp': None,
 'price': None,
 'remaining': None,
 'side': None,
 'status': None,
 'symbol': None,
 'timestamp': None,
 'trades': None,
 'type': None}
samgermain@Sams-MBP ccxt % huobi fetchOpenOrders                                              
(node:13868) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-05-03T04:54:29.388Z
Node.js: v18.15.0
CCXT v3.0.83
huobi.fetchOpenOrders ()
2023-05-03T04:54:32.563Z iteration 0 passed in 748 ms

             id |                                  clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining | status |                         fee | trades |                          fees | reduceOnly
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
791340722719622 | AA03022abc8c8cbc4b-1cb8-4b4d-88a5-6ea8f8b37330 | 1683089640128 | 2023-05-03T04:54:00.128Z |                    | ADA/USDT | stop |             |          |  buy |   0.5 |       0.5 |          0.5 |         |    0 |     21 |      0 |        21 |   open | {"cost":0,"currency":"ADA"} |     [] | [{"cost":0,"currency":"ADA"}] |           
1 objects
2023-05-03T04:54:32.563Z iteration 1 passed in 748 ms
```