### PR TITLE
binance parseWsOrder add reduceOnly. 

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1455,6 +1455,7 @@ export default class binance extends binanceRest {
             'type': type,
             'timeInForce': timeInForce,
             'postOnly': undefined,
+            'reduceOnly': this.safeValue (order, 'R'),
             'side': side,
             'price': price,
             'stopPrice': stopPrice,


### PR DESCRIPTION
fixes: #17604

```
% binanceusdm watchOrders          
2023-05-04T02:56:25.527Z
Node.js: v18.15.0
CCXT v3.0.90
binanceusdm.watchOrders ()
       symbol |           id |                 clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | reduceOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT | 146660562460 | electron_9DScIS0pzl8VlFsJoyHW | 1683169001222 | 2023-05-04T02:56:41.222Z |                    | limit |         GTC |    false |       true | sell | 31000 |         0 |            0 |  0.046 |    0 |         |      0 |     0.046 |   open |     |     [] |   []
1 objects
```