### PR TITLE
probit fetchCurrencies fix

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -414,7 +414,22 @@ export default class probit extends Exchange {
             const name = this.safeString (displayName, 'en-us');
             const platforms = this.safeValue (currency, 'platform', []);
             const platformsByPriority = this.sortBy (platforms, 'priority');
-            const platform = this.safeValue (platformsByPriority, 0, {});
+            let platform = undefined;
+            for (let j = 0; j < platformsByPriority.length; i++) {
+                const currentPlatform = platformsByPriority[j];
+                const currentDepositSuspended = this.safeValue (currentPlatform, 'deposit_suspended');
+                const currentWithdrawalSuspended = this.safeValue (currentPlatform, 'withdrawal_suspended');
+                const currentDeposit = !currentDepositSuspended;
+                const currentWithdraw = !currentWithdrawalSuspended;
+                const currentActive = currentDeposit && currentWithdraw;
+                if (currentActive) {
+                    platform = currentPlatform;
+                    break;
+                }
+            }
+            if (platform === undefined) {
+                platform = this.safeValue (platformsByPriority, 0, {});
+            }
             const depositSuspended = this.safeValue (platform, 'deposit_suspended');
             const withdrawalSuspended = this.safeValue (platform, 'withdrawal_suspended');
             const deposit = !depositSuspended;


### PR DESCRIPTION
In current version `fetchCurrencies` select the `platform` with the highest priority (by probit opinion). This `platform` can be not `active`, so the data will be not relevant.
For example now for USDT the highest `priority` (1) is for EOS `platform` and probit return in API that `deposit` and `withdraw` is suspended:

```
{
    id: 'EOS',
    priority: '1',
    deposit: false,
    withdrawal: false,
    currency_id: 'USDT',
    precision: '18',
    min_confirmation_count: '1',
    require_destination_tag: true,
    allow_withdrawal_destination_tag: true,
    display_name: { name: [Object], destinationTag: [Object] },
    min_deposit_amount: '0',
    min_withdrawal_amount: '0',
    withdrawal_fee: [ [Object] ],
    deposit_fee: {},
    suspended_reason: '',
    deposit_suspended: true,
    withdrawal_suspended: true,
    platform_currency_display_name: { name: [Object], destinationTag: [Object] }
  }
```

And next `platform` with the same `priority` (1) for USDT is ETH, `deposits` and `withdrawals` are not suspended:

 ```
{
    id: 'ETH',
    priority: '1',
    deposit: true,
    withdrawal: true,
    currency_id: 'USDT',
    precision: '6',
    min_confirmation_count: '15',
    require_destination_tag: false,
    allow_withdrawal_destination_tag: false,
    display_name: { name: [Object] },
    min_deposit_amount: '0',
    min_withdrawal_amount: '1',
    withdrawal_fee: [ [Object], [Object] ],
    deposit_fee: {},
    suspended_reason: 'wallet_maintenance',
    deposit_suspended: false,
    withdrawal_suspended: false,
    platform_currency_display_name: { name: [Object] }
  }
```

In this version at first we find first `active` `platform` with the highest `priority` and then parse data from this `platform`.  If all platforms not `active` we will parse data from the first `platform` with the highest `priority` (as it is current version).

It's not ideal, but I think it's the best option until `networks` won't be ready for probit.
