### PR TITLE
feat(xt): remove bigInt usage

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2210,11 +2210,11 @@ export default class xt extends Exchange {
         const stop = this.safeValue (params, 'stop');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
         if (stop) {
-            request['entrustId'] = this.convertToBigInt (id);
+            request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
-            request['profitId'] = this.convertToBigInt (id);
+            request['profitId'] = id;
         } else {
-            request['orderId'] = this.convertToBigInt (id);
+            request['orderId'] = id;
         }
         if (stop) {
             params = this.omit (params, 'stop');
@@ -2880,11 +2880,11 @@ export default class xt extends Exchange {
         const stop = this.safeValue (params, 'stop');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
         if (stop) {
-            request['entrustId'] = this.convertToBigInt (id);
+            request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
-            request['profitId'] = this.convertToBigInt (id);
+            request['profitId'] = id;
         } else {
-            request['orderId'] = this.convertToBigInt (id);
+            request['orderId'] = id;
         }
         if (stop) {
             params = this.omit (params, 'stop');


### PR DESCRIPTION
- Actually XT accepts stringified Ids so we don't need to use BigInt anymore

```
n xt fetchOrder "'224800111094488704'" "XRP/USDT:USDT"           
Debugger attached.
2023-05-05T15:10:02.557Z
Node.js: v18.14.0
CCXT v3.0.93
xt.fetchOrder (224800111094488704, XRP/USDT:USDT)
2023-05-05T15:10:04.338Z iteration 0 passed in 375 ms

{
  info: {
    orderId: '224800111094488704',
    clientOrderId: null,
    symbol: 'xrp_usdt',
    orderType: 'LIMIT',
    orderSide: 'BUY',
    positionSide: 'LONG',
    timeInForce: 'GTC',
    closePosition: false,
    price: '0.5',
    origQty: '2',
    avgPrice: '0.4623',
    executedQty: '2',
    marginFrozen: '0.506',
    remark: null,
    triggerProfitPrice: null,
    triggerStopPrice: null,
    sourceId: null,
    sourceType: 'DEFAULT',
    forceClose: false,
    closeProfit: null,
    state: 'FILLED',
    createdTime: '1683298523259',
    updatedTime: '1683298523259'
  },
  id: '224800111094488704',
  clientOrderId: undefined,
  timestamp: 1683298523259,
  datetime: '2023-05-05T14:55:23.259Z',
  lastTradeTimestamp: 1683298523259,
  symbol: 'XRP/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 0.5,
  stopPrice: undefined,
  stopLoss: undefined,
  takeProfit: undefined,
  amount: 20,
  filled: 20,
  remaining: 0,
  cost: 92.46,
  average: 0.4623,
  status: 'closed',
  fee: { currency: undefined, cost: undefined },
  trades: [],
  fees: [ { currency: undefined, cost: undefined } ],
  reduceOnly: undefined,
  triggerPrice: undefined
}
2023-05-05T15:10:04.338Z iteration 1 passed in 375 ms
```
```

```
p xt cancelOrder "224803888728464256" "XRP/USDT:USDT"  --verbose
Python v3.10.9
CCXT v3.0.93
xt.cancelOrder(224803888728464256,XRP/USDT:USDT)

{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '224803888728464256',
 'info': {'error': None,
          'msgInfo': 'success',
          'result': '224803888728464256',
          'returnCode': '0'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLoss': None,
 'stopPrice': None,
 'symbol': 'XRP/USDT:USDT',
 'takeProfit': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
