### PR TITLE
Currencycom - fix margin

### DIFF
--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -459,7 +459,7 @@ export default class currencycom extends Exchange {
             const futures = false;
             const swap = (typeRaw === 'LEVERAGE');
             const type = swap ? 'swap' : 'spot';
-            const margin = undefined;
+            const margin = swap; // as we decided to set
             if (swap) {
                 symbol = symbol.replace (this.options['leverage_markets_suffix'], '');
                 symbol += ':' + quote;

--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -459,7 +459,7 @@ export default class currencycom extends Exchange {
             const futures = false;
             const swap = (typeRaw === 'LEVERAGE');
             const type = swap ? 'swap' : 'spot';
-            const margin = swap; // as we decided to set
+            const margin = undefined;
             if (swap) {
                 symbol = symbol.replace (this.options['leverage_markets_suffix'], '');
                 symbol += ':' + quote;


### PR DESCRIPTION
we had a mistake there. 
when it's a contract market, margin must be false, causing bug in tests.

moreover, currencycom doesnt have spot margin trading at all as it seems.