### PR TITLE
fix(bybit): USDC market orders v1

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3235,7 +3235,7 @@ export default class bybit extends Exchange {
         }
         const id = this.safeString (order, 'orderId');
         const type = this.safeStringLower (order, 'orderType');
-        const price = this.safeString (order, 'price', 'orderPrice');
+        const price = this.safeString2 (order, 'price', 'orderPrice');
         const amount = this.safeString2 (order, 'qty', 'orderQty');
         const cost = this.safeString (order, 'cumExecValue');
         const filled = this.safeString (order, 'cumExecQty');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3966,9 +3966,9 @@ export default class bybit extends Exchange {
         params = this.omit (params, [ 'stopPrice', 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'postOnly', 'clientOrderId', 'stopLoss', 'takeProfit' ]);
         let response = undefined;
         if (market['option']) {
-            response = this.privatePostOptionUsdcOpenapiPrivateV1PlaceOrder (this.extend (request, params));
+            response = await this.privatePostOptionUsdcOpenapiPrivateV1PlaceOrder (this.extend (request, params));
         } else {
-            response = this.privatePostPerpetualUsdcOpenapiPrivateV1PlaceOrder (this.extend (request, params));
+            response = await this.privatePostPerpetualUsdcOpenapiPrivateV1PlaceOrder (this.extend (request, params));
         }
         //
         //     {


### PR DESCRIPTION
- API permits market orders

DEMO

```
p bybit createOrder "SOL/USD:USDC" market buy 0.1
Python v3.10.9
CCXT v3.0.95
bybit.createOrder(SOL/USD:USDC,market,buy,0.1)
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': '2023-05-06T13:54:40.522Z',
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '4cfcc9e9-14e6-4cb7-b1dd-7053f4e4d1d8',
 'info': {'basePrice': '0.000',
          'createdAt': '1683381280522466',
          'iv': '0',
          'mmp': False,
          'orderId': '4cfcc9e9-14e6-4cb7-b1dd-7053f4e4d1d8',
          'orderLinkId': '',
          'orderPrice': '23.070',
          'orderQty': '0.10000000',
          'orderStatus': 'Created',
          'orderType': 'Market',
          'side': 'Buy',
          'slTriggerBy': 'UNKNOWN',
          'stopLoss': '0.000',
          'symbol': 'SOLPERP',
          'takeProfit': '0.000',
          'timeInForce': 'ImmediateOrCancel',
          'tpTriggerBy': 'UNKNOWN',
          'triggerPrice': '0.000'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 23.07,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'SOL/USD:USDC',
 'takeProfitPrice': None,
 'timeInForce': 'IOC',
 'timestamp': 1683381280522,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}

```
