### PR TITLE
Huobi: cancelOrders, trigger, stop-loss and take-profit support

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -4869,6 +4869,8 @@ export default class huobi extends Exchange {
          * @param {[string]} ids order ids
          * @param {string|undefined} symbol unified market symbol, default is undefined
          * @param {object} params extra parameters specific to the huobi api endpoint
+         * @param {bool|undefined} params.stop *contract only* if the orders are stop trigger orders or not
+         * @param {bool|undefined} params.stopLossTakeProfit *contract only* if the orders are stop-loss or take-profit orders
          * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -4880,7 +4882,7 @@ export default class huobi extends Exchange {
         [ marketType, params ] = this.handleMarketTypeAndParams ('cancelOrders', market, params);
         const request = {
             // spot -----------------------------------------------------------
-            // 'order-ids': ids.jsoin (','), // max 50
+            // 'order-ids': ids.join (','), // max 50
             // 'client-order-ids': ids.join (','), // max 50
             // contracts ------------------------------------------------------
             // 'order_id': id, // comma separated, max 10
@@ -4888,7 +4890,7 @@ export default class huobi extends Exchange {
             // 'contract_code': market['id'],
             // 'symbol': market['settleId'],
         };
-        let method = undefined;
+        let response = undefined;
         if (marketType === 'spot') {
             let clientOrderIds = this.safeValue2 (params, 'client-order-id', 'clientOrderId');
             clientOrderIds = this.safeValue2 (params, 'client-order-ids', 'clientOrderIds', clientOrderIds);
@@ -4906,31 +4908,10 @@ export default class huobi extends Exchange {
                 }
                 params = this.omit (params, [ 'client-order-id', 'client-order-ids', 'clientOrderId', 'clientOrderIds' ]);
             }
-            method = 'spotPrivatePostV1OrderOrdersBatchcancel';
+            response = await this.spotPrivatePostV1OrderOrdersBatchcancel (this.extend (request, params));
         } else {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol for ' + marketType + ' orders');
-            }
-            const marketInner = this.market (symbol);
-            request['contract_code'] = marketInner['id'];
-            if (marketInner['linear']) {
-                let marginMode = undefined;
-                [ marginMode, params ] = this.handleMarginModeAndParams ('cancelOrders', params);
-                marginMode = (marginMode === undefined) ? 'cross' : marginMode;
-                if (marginMode === 'isolated') {
-                    method = 'contractPrivatePostLinearSwapApiV1SwapCancel';
-                } else if (marginMode === 'cross') {
-                    method = 'contractPrivatePostLinearSwapApiV1SwapCrossCancel';
-                }
-            } else if (marketInner['inverse']) {
-                if (marketInner['future']) {
-                    method = 'contractPrivatePostApiV1ContractCancel';
-                    request['symbol'] = marketInner['settleId'];
-                } else if (marketInner['swap']) {
-                    method = 'contractPrivatePostSwapApiV1SwapCancel';
-                } else {
-                    throw new NotSupported (this.id + ' cancelOrders() does not support ' + marketType + ' markets');
-                }
             }
             let clientOrderIds = this.safeString2 (params, 'client_order_id', 'clientOrderId');
             clientOrderIds = this.safeString2 (params, 'client_order_ids', 'clientOrderIds', clientOrderIds);
@@ -4940,8 +4921,57 @@ export default class huobi extends Exchange {
                 request['client_order_id'] = clientOrderIds;
                 params = this.omit (params, [ 'client_order_id', 'client_order_ids', 'clientOrderId', 'clientOrderIds' ]);
             }
+            if (market['future']) {
+                request['symbol'] = market['settleId'];
+            } else {
+                request['contract_code'] = market['id'];
+            }
+            const stop = this.safeValue (params, 'stop');
+            const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+            params = this.omit (params, [ 'stop', 'stopLossTakeProfit' ]);
+            if (market['linear']) {
+                let marginMode = undefined;
+                [ marginMode, params ] = this.handleMarginModeAndParams ('cancelOrders', params);
+                marginMode = (marginMode === undefined) ? 'cross' : marginMode;
+                if (marginMode === 'isolated') {
+                    if (stop) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapTriggerCancel (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapTpslCancel (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCancel (this.extend (request, params));
+                    }
+                } else if (marginMode === 'cross') {
+                    if (stop) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTriggerCancel (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTpslCancel (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossCancel (this.extend (request, params));
+                    }
+                }
+            } else if (market['inverse']) {
+                if (market['swap']) {
+                    if (stop) {
+                        response = await this.contractPrivatePostSwapApiV1SwapTriggerCancel (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostSwapApiV1SwapTpslCancel (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostSwapApiV1SwapCancel (this.extend (request, params));
+                    }
+                } else if (market['future']) {
+                    if (stop) {
+                        response = await this.contractPrivatePostApiV1ContractTriggerCancel (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostApiV1ContractTpslCancel (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostApiV1ContractCancel (this.extend (request, params));
+                    }
+                }
+            } else {
+                throw new NotSupported (this.id + ' cancelOrders() does not support ' + marketType + ' markets');
+            }
         }
-        const response = await this[method] (this.extend (request, params));
         //
         // spot
         //
@@ -4976,7 +5006,7 @@ export default class huobi extends Exchange {
         //         }
         //     }
         //
-        // contracts
+        // future and swap
         //
         //     {
         //         "status": "ok",


### PR DESCRIPTION
Add trigger, stop-loss and take-profit support to huobi cancelOrders:

### trigger:
```
huobi cancelOrders '["1104734381883920384"]' BTC/USDT:USDT '{"stop":true}'

huobi.cancelOrders (1104734381883920384, BTC/USDT:USDT, [object Object])
2023-05-07T03:42:07.519Z iteration 0 passed in 361 ms

{
  status: 'ok',
  data: { errors: [], successes: '1104734381883920384' },
  ts: '1683430928489'
}
```

### stop-loss and take-profit:
```
huobi cancelOrders '["1104735204588261376"]' BTC/USDT:USDT '{"stopLossTakeProfit":true}'

huobi.cancelOrders (1104735204588261376, BTC/USDT:USDT, [object Object])
2023-05-07T03:44:30.760Z iteration 0 passed in 425 ms

{
  status: 'ok',
  data: { errors: [], successes: '1104735204588261376' },
  ts: '1683431071714'
}
```