### PR TITLE
Huobi: cancelAllOrders, trigger stop-loss and take-profit support

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -2383,9 +2383,7 @@ export default class huobi extends Exchange {
             }
             method = 'spotPrivateGetV1OrderMatchresults';
         } else {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol for ' + marketType + ' orders');
-            }
+            this.checkRequiredSymbol ('fetchMyTrades', symbol);
             request['contract'] = market['id'];
             request['trade_type'] = 0; // 0 all, 1 open long, 2 open short, 3 close short, 4 close long, 5 liquidate long positions, 6 liquidate short positions
             if (since !== undefined) {
@@ -3242,9 +3240,7 @@ export default class huobi extends Exchange {
                 request['order-id'] = id;
             }
         } else {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol for ' + marketType + ' orders');
-            }
+            this.checkRequiredSymbol ('fetchOrder', symbol);
             request['contract_code'] = market['id'];
             if (market['linear']) {
                 let marginMode = undefined;
@@ -3425,9 +3421,7 @@ export default class huobi extends Exchange {
     async fetchSpotOrdersByStates (states, symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         const method = this.safeString (this.options, 'fetchOrdersByStatesMethod', 'spot_private_get_v1_order_orders'); // spot_private_get_v1_order_history
         if (method === 'spot_private_get_v1_order_orders') {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOrders() requires a symbol argument');
-            }
+            this.checkRequiredSymbol ('fetchOrders', symbol);
         }
         await this.loadMarkets ();
         let market = undefined;
@@ -3499,9 +3493,7 @@ export default class huobi extends Exchange {
     }
 
     async fetchContractOrders (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchContractOrders() requires a symbol argument');
-        }
+        this.checkRequiredSymbol ('fetchContractOrders', symbol);
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
@@ -3841,9 +3833,7 @@ export default class huobi extends Exchange {
             params = this.omit (params, 'account-id');
             response = await this.spotPrivateGetV1OrderOpenOrders (this.extend (request, params));
         } else {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires a symbol for ' + marketType + ' orders');
-            }
+            this.checkRequiredSymbol ('fetchOpenOrders', symbol);
             if (limit !== undefined) {
                 request['page_size'] = limit;
             }
@@ -4775,9 +4765,7 @@ export default class huobi extends Exchange {
                 response = await this.spotPrivatePostV1OrderOrdersSubmitCancelClientOrder (this.extend (request, params));
             }
         } else {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol for ' + marketType + ' orders');
-            }
+            this.checkRequiredSymbol ('cancelOrder', symbol);
             const clientOrderId = this.safeString2 (params, 'client_order_id', 'clientOrderId');
             if (clientOrderId === undefined) {
                 request['order_id'] = id;
@@ -5003,6 +4991,8 @@ export default class huobi extends Exchange {
          * @description cancel all open orders
          * @param {string|undefined} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} params extra parameters specific to the huobi api endpoint
+         * @param {bool|undefined} params.stop *contract only* if the orders are stop trigger orders or not
+         * @param {bool|undefined} params.stopLossTakeProfit *contract only* if the orders are stop-loss or take-profit orders
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -5026,40 +5016,66 @@ export default class huobi extends Exchange {
             // 'direction': 'buy': // buy, sell
             // 'offset': 'open', // open, close
         };
-        let method = undefined;
+        let response = undefined;
         if (marketType === 'spot') {
             if (symbol !== undefined) {
-                market = this.market (symbol);
                 request['symbol'] = market['id'];
             }
-            method = 'spotPrivatePostV1OrderOrdersBatchCancelOpenOrders';
+            response = await this.spotPrivatePostV1OrderOrdersBatchCancelOpenOrders (this.extend (request, params));
         } else {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol for ' + marketType + ' orders');
+            this.checkRequiredSymbol ('cancelAllOrders', symbol);
+            if (market['future']) {
+                request['symbol'] = market['settleId'];
             }
-            const marketInner = this.market (symbol);
-            request['contract_code'] = marketInner['id'];
-            if (marketInner['linear']) {
+            request['contract_code'] = market['id'];
+            const stop = this.safeValue (params, 'stop');
+            const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+            params = this.omit (params, [ 'stop', 'stopLossTakeProfit' ]);
+            if (market['linear']) {
                 let marginMode = undefined;
                 [ marginMode, params ] = this.handleMarginModeAndParams ('cancelAllOrders', params);
                 marginMode = (marginMode === undefined) ? 'cross' : marginMode;
                 if (marginMode === 'isolated') {
-                    method = 'contractPrivatePostLinearSwapApiV1SwapCancelallall';
+                    if (stop) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapTriggerCancelall (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapTpslCancelall (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCancelall (this.extend (request, params));
+                    }
                 } else if (marginMode === 'cross') {
-                    method = 'contractPrivatePostLinearSwapApiV1SwapCrossCancelall';
+                    if (stop) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTriggerCancelall (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTpslCancelall (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossCancelall (this.extend (request, params));
+                    }
                 }
-            } else if (marketInner['inverse']) {
-                if (marketType === 'future') {
-                    method = 'contractPrivatePostApiV1ContractCancelall';
-                    request['symbol'] = marketInner['settleId'];
-                } else if (marketType === 'swap') {
-                    method = 'contractPrivatePostSwapApiV1SwapCancelall';
-                } else {
-                    throw new NotSupported (this.id + ' cancelAllOrders() does not support ' + marketType + ' markets');
+            } else if (market['inverse']) {
+                if (market['swap']) {
+                    if (stop) {
+                        response = await this.contractPrivatePostSwapApiV1SwapTriggerCancelall (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostSwapApiV1SwapTpslCancelall (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostSwapApiV1SwapCancelall (this.extend (request, params));
+                    }
+                } else if (market['future']) {
+                    if (stop) {
+                        response = await this.contractPrivatePostApiV1ContractTriggerCancelall (this.extend (request, params));
+                    } else if (stopLossTakeProfit) {
+                        response = await this.contractPrivatePostApiV1ContractTpslCancelall (this.extend (request, params));
+                    } else {
+                        response = await this.contractPrivatePostApiV1ContractCancelall (this.extend (request, params));
+                    }
                 }
+            } else {
+                throw new NotSupported (this.id + ' cancelAllOrders() does not support ' + marketType + ' markets');
             }
         }
-        const response = await this[method] (this.extend (request, params));
+        //
+        // spot
         //
         //     {
         //         code: 200,
@@ -5068,6 +5084,17 @@ export default class huobi extends Exchange {
         //             "failed-count": 0,
         //             "next-id": 5454600
         //         }
+        //     }
+        //
+        // future and swap
+        //
+        //     {
+        //         status: "ok",
+        //         data: {
+        //             errors: [],
+        //             successes: "1104754904426696704"
+        //         },
+        //         ts: "1683435723755"
         //     }
         //
         return response;
@@ -5729,9 +5756,7 @@ export default class huobi extends Exchange {
          * @param {object} params extra parameters specific to the huobi api endpoint
          * @returns {[object]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
          */
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchFundingRateHistory() requires a symbol argument');
-        }
+        this.checkRequiredSymbol ('fetchFundingRateHistory', symbol);
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
@@ -6283,9 +6308,7 @@ export default class huobi extends Exchange {
          * @param {object} params extra parameters specific to the huobi api endpoint
          * @returns {object} response from the exchange
          */
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
-        }
+        this.checkRequiredSymbol ('setLeverage', symbol);
         await this.loadMarkets ();
         const market = this.market (symbol);
         const [ marketType, query ] = this.handleMarketTypeAndParams ('setLeverage', market, params);
@@ -7424,9 +7447,7 @@ export default class huobi extends Exchange {
         marginMode = (marginMode === undefined) ? 'cross' : marginMode;
         let method = undefined;
         if (marginMode === 'isolated') {
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' borrowMargin() requires a symbol argument for isolated margin');
-            }
+            this.checkRequiredSymbol ('borrowMargin', symbol);
             const market = this.market (symbol);
             request['symbol'] = market['id'];
             method = 'privatePostMarginOrders';


### PR DESCRIPTION
Added trigger, stop-loss and take-profit support to huobi cancelAllOrders:

### trigger:
```
huobi cancelAllOrders BTC/USDT:USDT '{"stop":true}'

huobi.cancelAllOrders (BTC/USDT:USDT, [object Object])
2023-05-07T04:59:11.297Z iteration 0 passed in 351 ms

{
  status: 'ok',
  data: { errors: [], successes: '1104754125896065024' },
  ts: '1683435552322'
}
```

### stop-loss and take-profit:
```
huobi cancelAllOrders BTC/USDT:USDT '{"stopLossTakeProfit":true}'

huobi.cancelAllOrders (BTC/USDT:USDT, [object Object])
2023-05-07T05:02:02.733Z iteration 0 passed in 357 ms

{
  status: 'ok',
  data: { errors: [], successes: '1104754904426696704' },
  ts: '1683435723755'
}
```