### PR TITLE
fix:php ArrayCache use in watchOrders and watchTrades

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1469,6 +1469,7 @@ class Transpiler {
                 'IndexType': 'int|string',
                 'Int': 'int',
                 'object': 'array',
+                'object[]': 'mixed',
                 'OrderType': 'string',
                 'OrderSide': 'string',
             }

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -852,6 +852,9 @@ class Exchange {
     }
 
     public static function to_array($object) {
+        if ($object instanceof \JsonSerializable) {
+            $object = $object->jsonSerialize();
+        }
         return array_values($object);
     }
 
@@ -2132,7 +2135,7 @@ class Exchange {
 
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
 
-    public function filter_by_limit(array $array, ?int $limit = null, int|string $key = 'timestamp') {
+    public function filter_by_limit(mixed $array, ?int $limit = null, int|string $key = 'timestamp') {
         if ($this->valueIsDefined ($limit)) {
             $arrayLength = count($array);
             if ($arrayLength > 0) {
@@ -2150,7 +2153,7 @@ class Exchange {
         return $array;
     }
 
-    public function filter_by_since_limit(array $array, ?int $since = null, ?int $limit = null, int|string $key = 'timestamp') {
+    public function filter_by_since_limit(mixed $array, ?int $since = null, ?int $limit = null, int|string $key = 'timestamp') {
         $sinceIsDefined = $this->valueIsDefined ($since);
         $parsedArray = $this->to_array($array);
         if ($sinceIsDefined) {
@@ -2166,7 +2169,7 @@ class Exchange {
         return $this->filterByLimit ($parsedArray, $limit, $key);
     }
 
-    public function filter_by_value_since_limit(array $array, int|string $field, $value = null, ?int $since = null, ?int $limit = null, $key = 'timestamp') {
+    public function filter_by_value_since_limit(mixed $array, int|string $field, $value = null, ?int $since = null, ?int $limit = null, $key = 'timestamp') {
         $valueIsDefined = $this->valueIsDefined ($value);
         $sinceIsDefined = $this->valueIsDefined ($since);
         $parsedArray = $this->to_array($array);
@@ -3359,7 +3362,7 @@ class Exchange {
         );
     }
 
-    public function parse_ohlcvs(array $ohlcvs, mixed $market = null, string $timeframe = '1m', ?int $since = null, ?int $limit = null) {
+    public function parse_ohlcvs(mixed $ohlcvs, mixed $market = null, string $timeframe = '1m', ?int $since = null, ?int $limit = null) {
         $results = array();
         for ($i = 0; $i < count($ohlcvs); $i++) {
             $results[] = $this->parse_ohlcv($ohlcvs[$i], $market);


### PR DESCRIPTION
### The issue
There was an error in php in `watchOrders` and `watchTrades`  when trying to pass anArrayCache to `filterByValueSinceLimit`

### How to reproduce?
`npm run cli.php alpaca watchOrders`

### What?
- change the transpiler to convert object[] to a php mixed type so filterByValueSinceLimit can accept the ArrayCache
- Change `to_array` in php to first call jsonSerialize if object is jsonSerializable as if it not the call to `array_values` would fail

### Alternatives
I tried instead of using a mixed type to use `\ArrayAccess&\Countable` but would fail in certain cases, so dicided to use `mixed`