### PR TITLE
xt.parseTrade trades are all buyer for spot

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1854,6 +1854,9 @@ export default class xt extends Exchange {
             side = (bidOrAsk === 'BID') ? 'buy' : 'sell';
         }
         const buyerMaker = this.safeValue (trade, 'b');
+        if (buyerMaker !== undefined) {
+            side = 'buy';
+        }
         let takerOrMaker = this.safeStringLower (trade, 'takerMaker');
         if (buyerMaker !== undefined) {
             takerOrMaker = buyerMaker ? 'maker' : 'taker';


### PR DESCRIPTION
We return `maker` or `taker` based on whether the buyer is a taker or a maker, so it makes sense to set the side to buy for all orders where we use the field `takerOrMaker`

```
% ccxt xt fetchTrades BTC/USDT | condense
2023-05-08T00:47:07.754Z
Node.js: v18.15.0
CCXT v3.0.94
xt.fetchTrades (BTC/USDT)
2023-05-08T00:47:12.864Z iteration 0 passed in 465 ms
                id |     timestamp |                 datetime |   symbol | order | type | side | takerOrMaker |    price |   amount |          cost | fee | fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------
225673442148522370 | 1683506741418 | 2023-05-08T00:45:41.418Z | BTC/USDT |       |      |  buy |        taker | 28580.94 | 0.003221 |   92.05920774 |  {} | [{}]
...
225673823473670529 | 1683506832333 | 2023-05-08T00:47:12.333Z | BTC/USDT |       |      |  buy |        maker | 28576.26 | 0.003136 |   89.61515136 |  {} | [{}]
200 objects
2023-05-08T00:47:12.864Z iteration 1 passed in 465 ms
```