### PR TITLE
fix(bitfinex2): checksum when length < 25

### DIFF
--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -667,10 +667,16 @@ export default class bitfinex2 extends bitfinex2Rest {
         const asks = book['asks'];
         // pepperoni pizza from bitfinex
         for (let i = 0; i < depth; i++) {
-            stringArray.push (this.numberToString (bids[i][0]));
-            stringArray.push (this.numberToString (bids[i][1]));
-            stringArray.push (this.numberToString (asks[i][0]));
-            stringArray.push (this.numberToString (-asks[i][1]));
+            const bid = this.safeValue (bids, i);
+            const ask = this.safeValue (asks, i);
+            if (bid !== undefined) {
+                stringArray.push (this.numberToString (bids[i][0]));
+                stringArray.push (this.numberToString (bids[i][1]));
+            }
+            if (ask !== undefined) {
+                stringArray.push (this.numberToString (asks[i][0]));
+                stringArray.push (this.numberToString (-asks[i][1]));
+            }
         }
         const payload = stringArray.join (':');
         const localChecksum = this.crc32 (payload, true);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17833
- Following the same approach as the original reference: https://gist.github.com/prdn/b9c9c24fb1bb38604dcd1e94ee89dd9e

-Demo
```
p bitfinex2 watchOrderBook "SUI/USDT"
Python v3.10.9
CCXT v3.0.97
bitfinex2.watchOrderBook(SUI/USDT)
{'asks': [[1.154, 173.16, 1.0], [1.1546, 987.69, 2.0], [1.1556, 815.0, 1.0], [1.156, 864.3, 1.0], [1.1585, 2587.19, 1.0], [1.1612, 4302.29, 1.0], [1.1663, 38.73545202, 1.0], [1.1664, 8566.21, 1.0], [1.1833, 8443.45, 1.0], [1.39, 5.0, 1.0], [1.49, 7900.0, 1.0], [40.0, 13.0, 1.0], [1000000.0, 1.0, 1.0]],
 'bids': [[1.1532, 173.27, 1.0], [1.1528, 433.33, 1.0], [1.152, 4335.25645009, 1.0], [1.1517, 1422.48, 2.0], [1.1515, 815.0, 1.0], [1.1511, 2283.17003498, 2.0], [1.151, 1379.0, 1.0], [1.1496, 2607.16, 1.0], [1.1491, 5505.0, 1.0], [1.1488, 3411.0, 1.0], [1.1475, 4353.24, 1.0], [1.1474, 2095.0, 1.0], [1.1441, 1379.0, 1.0], [1.1415, 8752.18, 1.0], [1.1373, 688.0, 1.0], [1.1326, 8821.01, 1.0], [1.13, 187.0, 1.0], [1.1186, 343.0, 1.0], [1.1, 600.0, 1.0], [1.096, 343.0, 1.0], [1.0812, 343.0, 1.0], [1.0704, 343.0, 1.0], [1.0512, 174.771704, 1.0], [1.0415, 343.0, 1.0], [1.0112, 100.0, 1.0]],
 'datetime': None,
 'nonce': None,
 'symbol': None,
 'timestamp': None}
{'asks': [[1.154, 173.16, 1.0], [1.1546, 987.69, 2.0], [1.1556, 815.0, 1.0], [1.156, 864.3, 1.0], [1.1585, 2587.19, 1.0], [1.1612, 4302.29, 1.0], [1.1663, 38.73545202, 1.0], [1.1664, 8566.21, 1.0], [1.1833, 8443.45, 1.0], [1.39, 5.0, 1.0], [1.49, 7900.0, 1.0], [40.0, 13.0, 1.0], [1000000.0, 1.0, 1.0]],
 'bids': [[1.1532, 173.27, 1.0], [1.1528, 433.33, 1.0], [1.152, 4335.25645009, 1.0], [1.1517, 1422.48, 2.0], [1.1515, 815.0, 1.0], [1.1511, 2283.17003498, 2.0], [1.151, 1379.0, 1.0], [1.1496, 2607.16, 1.0], [1.1491, 5505.0, 1.0], [1.1488, 3411.0, 1.0], [1.1475, 4353.24, 1.0], [1.1474, 2095.0, 1.0], [1.1441, 1379.0, 1.0], [1.1415, 8752.18, 1.0], [1.1373, 688.0, 1.0], [1.1326, 8821.01, 1.0], [1.13, 187.0, 1.0], [1.1186, 343.0, 1.0], [1.1, 600.0, 1.0], [1.096, 343.0, 1.0], [1.0812, 343.0, 1.0], [1.0704, 343.0, 1.0], [1.0415, 343.0, 1.0], [1.0112, 100.0, 1.0]],
 'datetime': None,
 'nonce': None,
 'symbol': None,
 'timestamp': None}
{'asks': [[1.154, 173.16, 1.0], [1.1546, 987.69, 2.0], [1.1556, 815.0, 1.0], [1.156, 864.3, 1.0], [1.1585, 2587.19, 1.0], [1.1612, 4302.29, 1.0], [1.1663, 38.73545202, 1.0], [1.1664, 8566.21, 1.0], [1.1833, 8443.45, 1.0], [1.39, 5.0, 1.0], [1.49, 7900.0, 1.0], [40.0, 13.0, 1.0], [1000000.0, 1.0, 1.0]],
 'bids': [[1.1532, 173.27, 1.0], [1.1528, 433.33, 1.0], [1.152, 4335.25645009, 1.0], [1.1517, 1422.48, 2.0], [1.1515, 815.0, 1.0], [1.1511, 2283.17003498, 2.0], [1.151, 1379.0, 1.0], [1.1496, 2607.16, 1.0], [1.1491, 5505.0, 1.0], [1.1488, 3411.0, 1.0], [1.1475, 4353.24, 1.0], [1.1474, 2095.0, 1.0], [1.1441, 1379.0, 1.0], [1.1415, 8752.18, 1.0], [1.1373, 688.0, 1.0], [1.1326, 8821.01, 1.0], [1.13, 187.0, 1.0], [1.1186, 343.0, 1.0], [1.1, 600.0, 1.0], [1.096, 343.0, 1.0], [1.0812, 343.0, 1.0], [1.0704, 343.0, 1.0], [1.0112, 100.0, 1.0]],
 'datetime': None,
 'nonce': None,
 'symbol': None,
 'timestamp': None}
```
