### PR TITLE
base - async fetch currecnies

### DIFF
--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -270,7 +270,7 @@ class Exchange extends \ccxt\Exchange {
 
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
 
-    public function filter_by_limit(mixed $array, ?int $limit = null, int|string $key = 'timestamp') {
+    public function filter_by_limit(array $array, ?int $limit = null, int|string $key = 'timestamp') {
         if ($this->valueIsDefined ($limit)) {
             $arrayLength = count($array);
             if ($arrayLength > 0) {
@@ -288,7 +288,7 @@ class Exchange extends \ccxt\Exchange {
         return $array;
     }
 
-    public function filter_by_since_limit(mixed $array, ?int $since = null, ?int $limit = null, int|string $key = 'timestamp') {
+    public function filter_by_since_limit(array $array, ?int $since = null, ?int $limit = null, int|string $key = 'timestamp') {
         $sinceIsDefined = $this->valueIsDefined ($since);
         $parsedArray = $this->to_array($array);
         if ($sinceIsDefined) {


### PR DESCRIPTION
during tests it revealed this forgotten issue.
typically, if exchange has implemented `fetchCurrencies`, it's React\Promise\PromiseInterface . however, if derived exchange does not have implemented it, then async exchange defaults to sync exchange's `fetchCurrencies` which did not return promise interface.
So, here I added override in async exchange base