### PR TITLE
bybit: remove exceptions.ws

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -106,12 +106,6 @@ export default class bybit extends bybitRest {
                 'ping': this.ping,
                 'keepAlive': 20000,
             },
-            'exceptions': {
-                'ws': {
-                    'exact': {
-                    },
-                },
-            },
         });
     }
 


### PR DESCRIPTION
For bybit ws error, we use `exceptions.exact` instead of `exceptions.ws`. In this PR, I remove `exceptions.ws`.