### PR TITLE
binance - rename option position

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6921,6 +6921,14 @@ export default class binance extends Exchange {
         if (side !== 'long') {
             quantity = Precise.stringMul ('-1', quantity);
         }
+        const optionSide = this.safeString (position, 'optionSide');
+        let optionType = undefined;
+        if (optionSide === 'CALL') {
+            optionType = 'call';
+        } else if (optionSide === 'PUT') {
+            optionType = 'put';
+        }
+        const strikePrice = this.safeNumber (position, 'strikePrice');
         const timestamp = this.safeInteger (position, 'time');
         return this.safePosition ({
             'info': position,
@@ -6946,6 +6954,8 @@ export default class binance extends Exchange {
             'marginRatio': undefined,
             'marginMode': undefined,
             'percentage': undefined,
+            'optionType': optionType,
+            'strikePrice': strikePrice,
         });
     }
 

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6886,12 +6886,12 @@ export default class binance extends Exchange {
         //
         const result = [];
         for (let i = 0; i < response.length; i++) {
-            result.push (this.parsePosition (response[i], market));
+            result.push (this.parseOptionPosition (response[i], market));
         }
         return this.filterByArray (result, 'symbol', symbols, false);
     }
 
-    parsePosition (position, market = undefined) {
+    parseOptionPosition (position, market = undefined) {
         //
         //     {
         //         "entryPrice": "27.70000000",

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6921,13 +6921,7 @@ export default class binance extends Exchange {
         if (side !== 'long') {
             quantity = Precise.stringMul ('-1', quantity);
         }
-        const optionSide = this.safeString (position, 'optionSide');
-        let optionType = undefined;
-        if (optionSide === 'CALL') {
-            optionType = 'call';
-        } else if (optionSide === 'PUT') {
-            optionType = 'put';
-        }
+        const optionSide = this.safeStringLower (position, 'optionSide');
         const strikePrice = this.safeNumber (position, 'strikePrice');
         const timestamp = this.safeInteger (position, 'time');
         return this.safePosition ({
@@ -6954,7 +6948,7 @@ export default class binance extends Exchange {
             'marginRatio': undefined,
             'marginMode': undefined,
             'percentage': undefined,
-            'optionType': optionType,
+            'optionType': optionSide,
             'strikePrice': strikePrice,
         });
     }


### PR DESCRIPTION
@lead I think that we should not mix options markets with regular derivatives markets (at least for now, until we have an unified scheme).
Options have different characteristics and different **mandatory** data you need to have in response structure (strike, call/put type ... ) which we don't have in our unified `position` structure which is primarily meant for regular derivatives market (swap & future).
At this moment, `parsePosition` is held by option's position parsing, which is not ideal imo, and at this stage we might rename it into `parseOptionPosition` with added two values -  optionType & strikePrice;