### PR TITLE
fix(phemex): v2 sandbox url

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -86,7 +86,7 @@ export default class phemex extends Exchange {
                 'logo': 'https://user-images.githubusercontent.com/1294454/85225056-221eb600-b3d7-11ea-930d-564d2690e3f6.jpg',
                 'test': {
                     'v1': 'https://testnet-api.phemex.com/v1',
-                    'v2': 'https://testnet-api.phemex.com/',
+                    'v2': 'https://testnet-api.phemex.com',
                     'public': 'https://testnet-api.phemex.com/exchange/public',
                     'private': 'https://testnet-api.phemex.com',
                 },


### PR DESCRIPTION
DEMO
```
n phemex fetchFundingRateHistory "BTC/USDT:USDT" --sandbox          
2023-05-09T13:10:09.243Z
Node.js: v18.14.0
CCXT v3.0.98
phemex.fetchFundingRateHistory (BTC/USDT:USDT)
2023-05-09T13:10:12.369Z iteration 0 passed in 650 ms

       symbol | fundingRate |     timestamp |                 datetime
----------------------------------------------------------------------
BTC/USDT:USDT |      0.0001 | 1680739200000 | 2023-04-06T00:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1680768000000 | 2023-04-06T08:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1680796800000 | 2023-04-06T16:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1680825600000 | 2023-04-07T00:00:00.000Z
BTC/USDT:USDT |      0.0001 | 1680854400000 | 2023-04-07T08:00:00.000Z
```
