### PR TITLE
Binance: fetchTicker, fetchTickers, add option support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3037,10 +3037,15 @@ export default class binance extends Exchange {
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
         await this.loadMarkets ();
-        const defaultType = this.safeString2 (this.options, 'fetchTickers', 'defaultType', 'spot');
-        const type = this.safeString (params, 'type', defaultType);
+        let type = undefined;
+        let market = undefined;
+        if (symbols !== undefined) {
+            const first = this.safeString (symbols, 0);
+            market = this.market (first);
+        }
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         let subType = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', undefined, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params);
         const query = this.omit (params, 'type');
         let defaultMethod = undefined;
         if (type === 'option') {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2704,6 +2704,7 @@ export default class binance extends Exchange {
         //     }
         //
         // coinm
+        //
         //     {
         //         baseVolume: '214549.95171161',
         //         closeTime: '1621965286847',
@@ -2723,7 +2724,32 @@ export default class binance extends Exchange {
         //         volume: '81990451',
         //         weightedAvgPrice: '38215.08713747'
         //     }
+        //
+        // eapi: fetchTicker, fetchTickers
+        //
+        //     {
+        //         "symbol": "ETH-230510-1825-C",
+        //         "priceChange": "-5.1",
+        //         "priceChangePercent": "-0.1854",
+        //         "lastPrice": "22.4",
+        //         "lastQty": "0",
+        //         "open": "27.5",
+        //         "high": "34.1",
+        //         "low": "22.4",
+        //         "volume": "6.83",
+        //         "amount": "201.44",
+        //         "bidPrice": "21.9",
+        //         "askPrice": "22.4",
+        //         "openTime": 1683614771898,
+        //         "closeTime": 1683695017784,
+        //         "firstTradeId": 12,
+        //         "tradeCount": 22,
+        //         "strikePrice": "1825",
+        //         "exercisePrice": "1845.95341176"
+        //     }
+        //
         // spot bidsAsks
+        //
         //     {
         //         "symbol":"ETHBTC",
         //         "bidPrice":"0.07466800",
@@ -2731,7 +2757,9 @@ export default class binance extends Exchange {
         //         "askPrice":"0.07466900",
         //         "askQty":"10.93540000"
         //     }
+        //
         // usdm bidsAsks
+        //
         //     {
         //         "symbol":"BTCUSDT",
         //         "bidPrice":"21321.90",
@@ -2740,7 +2768,9 @@ export default class binance extends Exchange {
         //         "askQty":"1.427",
         //         "time":"1673899207538"
         //     }
+        //
         // coinm bidsAsks
+        //
         //     {
         //         "symbol":"BTCUSD_PERP",
         //         "pair":"BTCUSD",
@@ -2770,20 +2800,20 @@ export default class binance extends Exchange {
             quoteVolume = this.safeString (ticker, 'volume');
         } else {
             baseVolume = this.safeString (ticker, 'volume');
-            quoteVolume = this.safeString (ticker, 'quoteVolume');
+            quoteVolume = this.safeString2 (ticker, 'quoteVolume', 'amount');
         }
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeString (ticker, 'highPrice'),
-            'low': this.safeString (ticker, 'lowPrice'),
+            'high': this.safeString2 (ticker, 'highPrice', 'high'),
+            'low': this.safeString2 (ticker, 'lowPrice', 'low'),
             'bid': this.safeString (ticker, 'bidPrice'),
             'bidVolume': this.safeString (ticker, 'bidQty'),
             'ask': this.safeString (ticker, 'askPrice'),
             'askVolume': this.safeString (ticker, 'askQty'),
             'vwap': this.safeString (ticker, 'weightedAvgPrice'),
-            'open': this.safeString (ticker, 'openPrice'),
+            'open': this.safeString2 (ticker, 'openPrice', 'open'),
             'close': last,
             'last': last,
             'previousClose': this.safeString (ticker, 'prevClosePrice'), // previous day close
@@ -2830,6 +2860,7 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/spot/en/#24hr-ticker-price-change-statistics         // spot
          * @see https://binance-docs.github.io/apidocs/futures/en/#24hr-ticker-price-change-statistics      // swap
          * @see https://binance-docs.github.io/apidocs/delivery/en/#24hr-ticker-price-change-statistics     // future
+         * @see https://binance-docs.github.io/apidocs/voptions/en/#24hr-ticker-price-change-statistics     // option
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} params extra parameters specific to the binance api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -2840,7 +2871,9 @@ export default class binance extends Exchange {
             'symbol': market['id'],
         };
         let method = 'publicGetTicker24hr';
-        if (market['linear']) {
+        if (market['option']) {
+            method = 'eapiPublicGetTicker';
+        } else if (market['linear']) {
             method = 'fapiPublicGetTicker24hr';
         } else if (market['inverse']) {
             method = 'dapiPublicGetTicker24hr';
@@ -2998,6 +3031,7 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/spot/en/#24hr-ticker-price-change-statistics         // spot
          * @see https://binance-docs.github.io/apidocs/futures/en/#24hr-ticker-price-change-statistics      // swap
          * @see https://binance-docs.github.io/apidocs/delivery/en/#24hr-ticker-price-change-statistics     // future
+         * @see https://binance-docs.github.io/apidocs/voptions/en/#24hr-ticker-price-change-statistics     // option
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the binance api endpoint
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -3009,7 +3043,9 @@ export default class binance extends Exchange {
         [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', undefined, params);
         const query = this.omit (params, 'type');
         let defaultMethod = undefined;
-        if (this.isLinear (type, subType)) {
+        if (type === 'option') {
+            defaultMethod = 'eapiPublicGetTicker';
+        } else if (this.isLinear (type, subType)) {
             defaultMethod = 'fapiPublicGetTicker24hr';
         } else if (this.isInverse (type, subType)) {
             defaultMethod = 'dapiPublicGetTicker24hr';


### PR DESCRIPTION
Added option support to fetchTicker and fetchTickers:
```
binance.fetchTicker (ETH/USDT:USDT-230510-1825-C)
2023-05-10T05:28:51.871Z iteration 0 passed in 696 ms

{
  symbol: 'ETH/USDT:USDT-230510-1825-C',
  timestamp: 1683696484023,
  datetime: '2023-05-10T05:28:04.023Z',
  high: 34.1,
  low: 15,
  bid: 14.6,
  bidVolume: undefined,
  ask: 21,
  askVolume: undefined,
  vwap: 24.120626151012893,
  open: 27.5,
  close: 15,
  last: 15,
  previousClose: undefined,
  change: -12.5,
  percentage: -0.4545,
  average: 21.25,
  baseVolume: 10.86,
  quoteVolume: 261.95,
  info: {
    symbol: 'ETH-230510-1825-C',
    priceChange: '-12.5',
    priceChangePercent: '-0.4545',
    lastPrice: '15',
    lastQty: '4',
    open: '27.5',
    high: '34.1',
    low: '15',
    volume: '10.86',
    amount: '261.95',
    bidPrice: '14.6',
    askPrice: '21',
    openTime: '1683614771898',
    closeTime: '1683696484023',
    firstTradeId: '12',
    tradeCount: '24',
    strikePrice: '1825',
    exercisePrice: '1844.43905882'
  }
}
```