### PR TITLE
krakenfutures transfer remove amountToPrecision

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1923,7 +1923,7 @@ export default class krakenfutures extends Exchange {
         const currency = this.currency (code);
         let method = 'privatePostTransfer';
         const request = {
-            'amount': this.currencyToPrecision (code, amount),
+            'amount': amount,
         };
         if (fromAccount === 'spot') {
             throw new BadRequest (this.id + ' transfer does not yet support transfers from spot');


### PR DESCRIPTION
You're actually able to transfer really small amounts on krakenfutures

```
% krakenfutures transfer XRP 0.001 XRP/USD:XRP cash
2023-05-10T18:46:31.590Z
Node.js: v18.15.0
CCXT v3.0.97
krakenfutures.transfer (XRP, 0.001, XRP/USD:XRP, cash)
2023-05-10T18:46:32.991Z iteration 0 passed in 723 ms

{
  info: { result: 'success', serverTime: '2023-05-10T18:46:33.098Z' },
  id: undefined,
  timestamp: 1683744393098,
  datetime: '2023-05-10T18:46:33.098Z',
  currency: 'XRP',
  amount: 0.001,
  fromAccount: 'XRP/USD:XRP',
  toAccount: 'cash',
  status: 'success'
}
2023-05-10T18:46:32.991Z iteration 1 passed in 723 ms
```