### PR TITLE
Binance: update python option examples [ci skip]

### DIFF
--- a/examples/py/async-binance-cancel-option-order.py
+++ b/examples/py/async-binance-cancel-option-order.py
@@ -20,16 +20,19 @@ async def main():
         # 'verbose': True,  # for debug output
     })
     await exchange.load_markets()
-    market_id = 'ETH-221028-1700-C'
+    market_id = 'ETH-230214-1525-C'
+    symbol = 'ETH/USDT:USDT-230214-1525-C'
     order_id = 4612100534317768959
     try:
-        response = await exchange.eapiPrivateDeleteOrder({
-            'symbol': market_id,
-            'orderId': order_id,
-        })
+        response = await exchange.cancel_order(order_id, symbol)
+        # Implicit API:
+        # response = await exchange.eapiPrivateDeleteOrder({
+        #     'symbol': market_id,
+        #     'orderId': order_id,
+        # })
         pprint(response)
     except Exception as e:
-        print('eapiPrivateDeleteOrder() failed')
+        print('cancel_order() failed')
         print(e)
     await exchange.close()
 

--- a/examples/py/async-binance-create-option-order.py
+++ b/examples/py/async-binance-create-option-order.py
@@ -20,21 +20,28 @@ async def main():
         # 'verbose': True,  # for debug output
     })
     await exchange.load_markets()
+    symbol = 'ETH/USDT:USDT-221028-1700-C'
+    order_type = 'limit'
+    side = 'buy'
+    amount = 1
+    price = 2.1
     try:
-        response = await exchange.eapiPrivatePostOrder({
-            # ETH/USDT call option strike 1700 USDT expiry on 2022-10-28
-            'symbol': 'ETH-221028-1700-C',
-            'side': 'BUY',
-            'type': 'LIMIT',
-            'quantity': 1,
-            'price': 2.1,
-        })
+        response = await exchange.create_order(symbol, order_type, side, amount, price)
+        # Implicit API:
+        # response = await exchange.eapiPrivatePostOrder({
+        #     # ETH/USDT call option strike 1700 USDT expiry on 2022-10-28
+        #     'symbol': 'ETH-221028-1700-C',
+        #     'side': 'BUY',
+        #     'type': 'LIMIT',
+        #     'quantity': 1,
+        #     'price': 2.1,
+        # })
         pprint(response)
     except ccxt.InsufficientFunds as e:
-        print('eapiPrivatePostOrder() failed - not enough funds')
+        print('create_order() failed - not enough funds')
         print(e)
     except Exception as e:
-        print('eapiPrivatePostOrder() failed')
+        print('create_order() failed')
         print(e)
     await exchange.close()
 

--- a/examples/py/async-binance-fetch-option-OHLCV.py
+++ b/examples/py/async-binance-fetch-option-OHLCV.py
@@ -21,19 +21,22 @@ async def main():
     })
     await exchange.load_markets()
     market_id = 'ETH-221028-1700-C'
+    symbol = 'ETH/USDT:USDT-221028-1700-C'
     timeframe = '1m'
     since = 1592317127349
     limit = 10
     try:
-        response = await exchange.eapiPublicGetKlines({
-            'symbol': market_id,
-            'interval': timeframe,
-            # 'startTime': since,  # optional
-            # 'limit': limit,  # optional
-        })
+        response = await exchange.fetch_OHLCV(symbol, timeframe, since, limit)
+        # Implicit API:
+        # response = await exchange.eapiPublicGetKlines({
+        #     'symbol': market_id,
+        #     'interval': timeframe,
+        #     # 'startTime': since,  # optional
+        #     # 'limit': limit,  # optional
+        # })
         pprint(response)
     except Exception as e:
-        print('eapiPublicGetKlines() failed')
+        print('fetch_OHLCV() failed')
         print(e)
     await exchange.close()
 

--- a/examples/py/async-binance-fetch-option-order.py
+++ b/examples/py/async-binance-fetch-option-order.py
@@ -21,15 +21,20 @@ async def main():
     })
     await exchange.load_markets()
     market_id = 'ETH-221028-1700-C'
+    symbol = 'ETH/USDT:USDT-221028-1700-C'
+    since = 1677102900000
+    limit = 10
     order_id = 4612098335294532880
     try:
-        response = await exchange.eapiPrivateGetOpenOrders({
-            # 'symbol': market_id,  # optional
-            # 'orderId': order_id,  # optional
-        })
+        response = await exchange.fetch_open_orders(symbol, since, limit)
+        # Implicit API:
+        # response = await exchange.eapiPrivateGetOpenOrders({
+        #     # 'symbol': market_id,  # optional
+        #     # 'orderId': order_id,  # optional
+        # })
         pprint(response)
     except Exception as e:
-        print('eapiPrivateGetOpenOrders() failed')
+        print('fetch_open_orders() failed')
         print(e)
     await exchange.close()
 

--- a/examples/py/async-binance-fetch-option-orderbook.py
+++ b/examples/py/async-binance-fetch-option-orderbook.py
@@ -21,15 +21,18 @@ async def main():
     })
     await exchange.load_markets()
     market_id = 'ETH-221028-1500-C'
+    symbol = 'ETH/USDT:USDT-221028-1500-C'
     limit = 10
     try:
-        response = await exchange.eapiPublicGetDepth({
-            'symbol': market_id,
-            # 'limit': limit,  # optional
-        })
+        response = await exchange.fetch_order_book(symbol, limit)
+        # Implicit API:
+        # response = await exchange.eapiPublicGetDepth({
+        #     'symbol': market_id,
+        #     # 'limit': limit,  # optional
+        # })
         pprint(response)
     except Exception as e:
-        print('eapiPublicGetDepth() failed')
+        print('fetch_order_book() failed')
         print(e)
     await exchange.close()
 

--- a/examples/py/async-binance-fetch-option-position.py
+++ b/examples/py/async-binance-fetch-option-position.py
@@ -21,13 +21,16 @@ async def main():
     })
     await exchange.load_markets()
     market_id = 'ETH-221028-1700-C'
+    symbol = 'ETH/USDT:USDT-221028-1700-C'
     try:
-        response = await exchange.eapiPrivateGetPosition({
-            # 'symbol': market_id,  # optional
-        })
+        response = await exchange.fetch_position(symbol)
+        # Implicit API:
+        # response = await exchange.eapiPrivateGetPosition({
+        #     # 'symbol': market_id,  # optional
+        # })
         pprint(response)
     except Exception as e:
-        print('eapiPrivateGetPosition() failed')
+        print('fetch_position() failed')
         print(e)
     await exchange.close()
 

--- a/examples/py/async-binance-fetch-option-ticker.py
+++ b/examples/py/async-binance-fetch-option-ticker.py
@@ -21,13 +21,16 @@ async def main():
     })
     await exchange.load_markets()
     market_id = 'ETH-221028-1700-C'
+    symbol = 'ETH/USDT:USDT-221028-1700-C'
     try:
-        response = await exchange.eapiPublicGetTicker({
-            # 'symbol': market_id,  # optional
-        })
+        response = await exchange.fetch_ticker(symbol)
+        # Implicit API:
+        # response = await exchange.eapiPublicGetTicker({
+        #     # 'symbol': market_id,  # optional
+        # })
         pprint(response)
     except Exception as e:
-        print('eapiPublicGetTicker() failed')
+        print('fetch_ticker() failed')
         print(e)
     await exchange.close()
 

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -27,7 +27,7 @@ export default class binance extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': true,
-                'option': undefined,
+                'option': true,
                 'addMargin': true,
                 'borrowMargin': true,
                 'cancelAllOrders': true,


### PR DESCRIPTION
Updated the python examples for binance option markets to include unified methods, and set option to true on binance.
closes: #11008