### PR TITLE
fix(bitget): remove symbol requirement from fetchOpenOrders

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2948,7 +2948,7 @@ export default class bitget extends Exchange {
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
-        const request = { };
+        const request = {};
         let marketType = undefined;
         let query = undefined;
         let market = undefined;

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2939,6 +2939,7 @@ export default class bitget extends Exchange {
          * @see https://bitgetlimited.github.io/apidoc/en/spot/#get-order-list
          * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-all-open-order
          * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-plan-order-tpsl-list
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-open-order
          * @description fetch all unfilled currently open orders
          * @param {string} symbol unified market symbol
          * @param {int|undefined} since the earliest time in ms to fetch open orders for

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2936,6 +2936,9 @@ export default class bitget extends Exchange {
         /**
          * @method
          * @name bitget#fetchOpenOrders
+         * @see https://bitgetlimited.github.io/apidoc/en/spot/#get-order-list
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-all-open-order
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-plan-order-tpsl-list
          * @description fetch all unfilled currently open orders
          * @param {string} symbol unified market symbol
          * @param {int|undefined} since the earliest time in ms to fetch open orders for
@@ -2943,33 +2946,46 @@ export default class bitget extends Exchange {
          * @param {object} params extra parameters specific to the bitget api endpoint
          * @returns {[object]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        this.checkRequiredSymbol ('fetchOpenOrders', symbol);
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const request = { };
         let marketType = undefined;
         let query = undefined;
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['symbol'] = market['id'];
+        }
         [ marketType, query ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
-        const request = {
-            'symbol': market['id'],
-        };
-        let method = this.getSupportedMapping (marketType, {
-            'spot': 'privateSpotPostTradeOpenOrders',
-            'swap': 'privateMixGetOrderCurrent',
-            'future': 'privateMixGetOrderCurrent',
-        });
+        let response = undefined;
         const stop = this.safeValue (query, 'stop');
         if (stop) {
+            this.checkRequiredSymbol ('fetchOpenOrders', symbol);
+            query = this.omit (query, 'stop');
             if (marketType === 'spot') {
-                method = 'privateSpotPostPlanCurrentPlan';
                 if (limit !== undefined) {
                     request['pageSize'] = limit;
                 }
+                response = await this.privateSpotPostPlanCurrentPlan (this.extend (request, query));
             } else {
-                method = 'privateMixGetPlanCurrentPlan';
+                response = await this.privateMixGetPlanCurrentPlan (this.extend (request, query));
             }
-            query = this.omit (query, 'stop');
+        } else {
+            if (marketType === 'spot') {
+                response = await this.privateSpotPostTradeOpenOrders (this.extend (request, query));
+            } else {
+                if (market === undefined) {
+                    let subType = undefined;
+                    [ subType, params ] = this.handleSubTypeAndParams ('fetchOpenOrders', undefined, params);
+                    let productType = (subType === 'linear') ? 'UMCBL' : 'DMCBL';
+                    const sandboxMode = this.safeValue (this.options, 'sandboxMode', false);
+                    if (sandboxMode) {
+                        productType = 'S' + productType;
+                    }
+                    request['productType'] = productType;
+                }
+                response = await this.privateMixGetOrderCurrent (this.extend (request, query));
+            }
         }
-        let response = await this[method] (this.extend (request, query));
         //
         //  spot
         //     {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2982,8 +2982,10 @@ export default class bitget extends Exchange {
                         productType = 'S' + productType;
                     }
                     request['productType'] = productType;
+                    response = await this.privateMixGetOrderMarginCoinCurrent (this.extend (request, query));
+                } else {
+                    response = await this.privateMixGetOrderCurrent (this.extend (request, query));
                 }
-                response = await this.privateMixGetOrderCurrent (this.extend (request, query));
             }
         }
         //


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17880

```
✗ p bitget fetchOpenOrders                             
Python v3.10.9
CCXT v3.0.99
bitget.fetchOpenOrders()
[{'amount': 0.15,
  'average': None,
  'clientOrderId': 'cdd54d33-932e-4667-8fc4-24281704a3d3',
  'cost': 0.0,
  'datetime': '2023-05-11T10:58:32.372Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '1040509479714983936',
  'info': {'accountId': '3704614084',
           'cTime': '1683802712372',
           'clientOrderId': 'cdd54d33-932e-4667-8fc4-24281704a3d3',
           'enterPointSource': 'API',
           'feeDetail': '',
           'fillPrice': '0',
           'fillQuantity': '0.0000000000000000',
           'fillTotalAmount': '0.0000000000000000',
           'orderId': '1040509479714983936',
           'orderType': 'limit',
           'price': '40.0000000000000000',
           'quantity': '0.1500000000000000',
           'side': 'buy',
           'status': 'new',
           'symbol': 'LTCUSDT_SPBL'},
  'lastTradeTimestamp': None,
  'postOnly': None,
  'price': 40.0,
  'reduceOnly': None,
  'remaining': 0.15,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'timeInForce': None,
  'timestamp': 1683802712372,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
```
p bitget fetchOpenOrders "LTC/USDT"
Python v3.10.9
CCXT v3.0.99
bitget.fetchOpenOrders(LTC/USDT)
[{'amount': 0.15,
  'average': None,
  'clientOrderId': 'cdd54d33-932e-4667-8fc4-24281704a3d3',
  'cost': 0.0,
  'datetime': '2023-05-11T10:58:32.372Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '1040509479714983936',
  'info': {'accountId': '3704614084',
           'cTime': '1683802712372',
           'clientOrderId': 'cdd54d33-932e-4667-8fc4-24281704a3d3',
           'enterPointSource': 'API',
           'feeDetail': '',
           'fillPrice': '0',
           'fillQuantity': '0.0000000000000000',
           'fillTotalAmount': '0.0000000000000000',
           'orderId': '1040509479714983936',
           'orderType': 'limit',
           'price': '40.0000000000000000',
           'quantity': '0.1500000000000000',
           'side': 'buy',
           'status': 'new',
           'symbol': 'LTCUSDT_SPBL'},
  'lastTradeTimestamp': None,
  'postOnly': None,
  'price': 40.0,
  'reduceOnly': None,
  'remaining': 0.15,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'timeInForce': None,
  'timestamp': 1683802712372,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
```
 p bitget fetchOpenOrders --swap
Python v3.10.9
CCXT v3.0.99
bitget.fetchOpenOrders()
[{'amount': 0.1,
  'average': None,
  'clientOrderId': '1040509696667688960',
  'cost': 0.0,
  'datetime': '2023-05-11T10:59:24.097Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '1040509696638328833',
  'info': {'cTime': '1683802764097',
           'clientOid': '1040509696667688960',
           'enterPointSource': 'API',
           'fee': '0E-8',
           'filledAmount': '0.0000',
           'filledQty': '0.0',
           'holdMode': 'double_hold',
           'leverage': '3',
           'marginCoin': 'USDT',
           'marginMode': 'crossed',
           'orderId': '1040509696638328833',
           'orderType': 'limit',
           'posSide': 'long',
           'price': '50.00',
           'reduceOnly': False,
           'side': 'open_long',
           'size': '0.1',
           'state': 'new',
           'symbol': 'LTCUSDT_UMCBL',
           'timeInForce': 'normal',
           'totalProfits': '0E-8',
           'tradeSide': 'open_long',
           'uTime': '1683802764097'},
  'lastTradeTimestamp': 1683802764097,
  'postOnly': None,
  'price': 50.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'LTC/USDT:USDT',
  'timeInForce': None,
  'timestamp': 1683802764097,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
```
p bitget fetchOpenOrders "LTC/USDT:USDT"
Python v3.10.9
CCXT v3.0.99
bitget.fetchOpenOrders(LTC/USDT:USDT)
[{'amount': 0.1,
  'average': None,
  'clientOrderId': '1040509696667688960',
  'cost': 0.0,
  'datetime': '2023-05-11T10:59:24.097Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '1040509696638328833',
  'info': {'cTime': '1683802764097',
           'clientOid': '1040509696667688960',
           'enterPointSource': 'API',
           'fee': '0E-8',
           'filledAmount': '0.0000',
           'filledQty': '0.0',
           'holdMode': 'double_hold',
           'leverage': '3',
           'marginCoin': 'USDT',
           'marginMode': 'crossed',
           'orderId': '1040509696638328833',
           'orderType': 'limit',
           'posSide': 'long',
           'price': '50.00',
           'reduceOnly': False,
           'side': 'open_long',
           'size': '0.1',
           'state': 'new',
           'symbol': 'LTCUSDT_UMCBL',
           'timeInForce': 'normal',
           'totalProfits': '0E-8',
           'tradeSide': 'open_long',
           'uTime': '1683802764097'},
  'lastTradeTimestamp': 1683802764097,
  'postOnly': None,
  'price': 50.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopPrice': None,
  'symbol': 'LTC/USDT:USDT',
  'timeInForce': None,
  'timestamp': 1683802764097,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
