### PR TITLE
Gate: fetchTrades add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2647,6 +2647,7 @@ export default class gate extends Exchange {
             'margin': 'publicSpotGetTrades',
             'swap': 'publicFuturesGetSettleTrades',
             'future': 'publicDeliveryGetSettleTrades',
+            'option': 'publicOptionsGetTrades',
         });
         if (limit !== undefined) {
             request['limit'] = limit; // default 100, max 1000
@@ -2680,6 +2681,18 @@ export default class gate extends Exchange {
         //              create_time: "1634673380.182",
         //              contract: "ADA_USDT",
         //              price: "2.10486",
+        //         }
+        //     ]
+        //
+        // option
+        //
+        //     [
+        //         {
+        //             "size": -5,
+        //             "id": 25,
+        //             "create_time": 1682378573,
+        //             "contract": "ETH_USDT-20230526-2000-P",
+        //             "price": "209.1"
         //         }
         //     ]
         //
@@ -2895,6 +2908,16 @@ export default class gate extends Exchange {
         //         "size": 100,
         //         "price": "100.123",
         //         "role": "taker"
+        //     }
+        //
+        // option rest
+        //
+        //     {
+        //         "size": -5,
+        //         "id": 25,
+        //         "create_time": 1682378573,
+        //         "contract": "ETH_USDT-20230526-2000-P",
+        //         "price": "209.1"
         //     }
         //
         const id = this.safeString (trade, 'id');


### PR DESCRIPTION
Added option support to fetchTrades:
```
gate.fetchTrades (ETH/USDT:USDT-230526-2000-P, , 3)
2023-05-12T05:04:02.400Z iteration 0 passed in 202 ms

id |     timestamp |                 datetime |                      symbol | order | type | side | takerOrMaker | price | amount |   cost | fee | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------
23 | 1682378509000 | 2023-04-24T23:21:49.000Z | ETH/USDT:USDT-230526-2000-P |       |      | sell |              | 208.3 |      6 | 1249.8 |     |   []
24 | 1682378541000 | 2023-04-24T23:22:21.000Z | ETH/USDT:USDT-230526-2000-P |       |      | sell |              | 208.5 |      6 |   1251 |     |   []
25 | 1682378573000 | 2023-04-24T23:22:53.000Z | ETH/USDT:USDT-230526-2000-P |       |      | sell |              | 209.1 |      5 | 1045.5 |     |   []
3 objects
```