### PR TITLE
feat(bybit): fetchCurrencies enhancement

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1280,6 +1280,11 @@ export default class bybit extends Exchange {
             const chains = this.safeValue (currency, 'chains', []);
             const networks = {};
             let minPrecision = undefined;
+            let minWithdrawFeeString = undefined;
+            let minWithdrawString = undefined;
+            let minDepositString = undefined;
+            let deposit = false;
+            let withdraw = false;
             for (let j = 0; j < chains.length; j++) {
                 const chain = chains[j];
                 const networkId = this.safeString (chain, 'chain');
@@ -1287,23 +1292,37 @@ export default class bybit extends Exchange {
                 const precision = this.parseNumber (this.parsePrecision (this.safeString (chain, 'minAccuracy')));
                 minPrecision = (minPrecision === undefined) ? precision : Math.min (minPrecision, precision);
                 const depositAllowed = this.safeInteger (chain, 'chainDeposit') === 1;
+                deposit = (depositAllowed) ? depositAllowed : deposit;
                 const withdrawAllowed = this.safeInteger (chain, 'chainWithdraw') === 1;
+                withdraw = (withdrawAllowed) ? withdrawAllowed : withdraw;
+                const withdrawFeeString = this.safeString (chain, 'withdrawFee');
+                if (withdrawFeeString !== undefined) {
+                    minWithdrawFeeString = (minWithdrawFeeString === undefined) ? withdrawFeeString : Precise.stringMin (withdrawFeeString, minWithdrawFeeString);
+                }
+                const minNetworkWithdrawString = this.safeString (chain, 'withdrawMin');
+                if (minNetworkWithdrawString !== undefined) {
+                    minWithdrawString = (minWithdrawString === undefined) ? minNetworkWithdrawString : Precise.stringMin (minNetworkWithdrawString, minWithdrawString);
+                }
+                const minNetworkDepositString = this.safeString (chain, 'depositMin');
+                if (minNetworkDepositString !== undefined) {
+                    minDepositString = (minDepositString === undefined) ? minNetworkDepositString : Precise.stringMin (minNetworkDepositString, minDepositString);
+                }
                 networks[networkCode] = {
                     'info': chain,
                     'id': networkId,
                     'network': networkCode,
-                    'active': undefined,
+                    'active': depositAllowed && withdrawAllowed,
                     'deposit': depositAllowed,
                     'withdraw': withdrawAllowed,
-                    'fee': this.safeNumber (chain, 'withdrawFee'),
+                    'fee': this.parseNumber (withdrawFeeString),
                     'precision': precision,
                     'limits': {
                         'withdraw': {
-                            'min': this.safeNumber (chain, 'withdrawMin'),
+                            'min': this.parseNumber (minNetworkWithdrawString),
                             'max': undefined,
                         },
                         'deposit': {
-                            'min': this.safeNumber (chain, 'depositMin'),
+                            'min': this.parseNumber (minNetworkDepositString),
                             'max': undefined,
                         },
                     },
@@ -1314,14 +1333,22 @@ export default class bybit extends Exchange {
                 'code': code,
                 'id': currencyId,
                 'name': name,
-                'active': undefined,
-                'deposit': undefined,
-                'withdraw': undefined,
-                'fee': undefined,
+                'active': deposit && withdraw,
+                'deposit': deposit,
+                'withdraw': withdraw,
+                'fee': this.parseNumber (minWithdrawFeeString),
                 'precision': minPrecision,
                 'limits': {
                     'amount': {
                         'min': undefined,
+                        'max': undefined,
+                    },
+                    'withdraw': {
+                        'min': this.parseNumber (minWithdrawString),
+                        'max': undefined,
+                    },
+                    'deposit': {
+                        'min': this.parseNumber (minDepositString),
                         'max': undefined,
                     },
                 },


### PR DESCRIPTION
Added information to `fetchCurrencies`

I'll check `fetchCurrencies` on several exchanges so I need to clarify some moments about `fetchCurrencies` for the future.
When we fill `result[code]` we consider that:
`deposit` - `true` if at least one network allows to deposit;
`withdraw` - `true` if at least one network allows to withdraw;
`fee` - it's the minimum available withdrawal fee among all `networks`.

About `active` there is some moment that I want understand.
For example on some exchange USDT have only 2 networks (ERC20 and TRC20).
In TRC20 `deposit` is enabled and `withdraw` is disabled. 
In ERC20 network on the contrary `deposit` is disabled and `withdraw` enabled.
What we consider in this case? `Active` is `true` in this case? (meaning that we can deposit only through TRC20 and withdraw only through ERC20).
 