### PR TITLE
fix(coinex): fetchTradingFee market handling

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1124,7 +1124,7 @@ export default class coinex extends Exchange {
         //      }
         //
         const data = this.safeValue (response, 'data', {});
-        return this.parseTradingFee (data);
+        return this.parseTradingFee (data, market);
     }
 
     async fetchTradingFees (params = {}) {


### PR DESCRIPTION
```
 p coinex fetchTradingFee "ADA/USDT" 
Python v3.10.9
CCXT v3.0.102
coinex.fetchTradingFee(ADA/USDT)
{'info': {'maker_fee_rate': '0.002',
          'min_amount': '5',
          'name': 'ADAUSDT',
          'pricing_decimal': '4',
          'pricing_name': 'USDT',
          'taker_fee_rate': '0.002',
          'trading_decimal': '8',
          'trading_name': 'ADA'},
 'maker': 0.002,
 'percentage': True,
 'symbol': 'ADA/USDT',
 'taker': 0.002,
 'tierBased': True}
```
