### PR TITLE
fix(bitfinex): parseTicker marketId

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -888,7 +888,7 @@ export default class bitfinex extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         const timestamp = this.safeTimestamp (ticker, 'timestamp');
-        const marketId = this.safeString (market, 'pair');
+        const marketId = this.safeString (ticker, 'pair');
         market = this.safeMarket (marketId, market);
         const symbol = market['symbol'];
         const last = this.safeString (ticker, 'last_price');


### PR DESCRIPTION
- We were using the wrong target to get the `marketId` 