### PR TITLE
filterByLimit is descending by default

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1366,7 +1366,7 @@ export default class Exchange {
                     const first = array[0][key];
                     const last = array[arrayLength - 1][key];
                     if (first !== undefined && last !== undefined) {
-                        ascending = first < last;  // true if array is sorted in ascending order based on 'timestamp'
+                        ascending = first <= last;  // true if array is sorted in ascending order based on 'timestamp'
                     }
                 }
                 array = ascending ? this.arraySlice (array, -limit) : this.arraySlice (array, 0, limit);


### PR DESCRIPTION
fixes: #17919

-------------

As specified on the issue

> snippet from base exchange reveals that when array's first and last timestamp are the same the array is treated as descending by default due to first < last instead of first <= last which would make more sense, since ascending is the default when comparison is not possible.