### PR TITLE
bitget: patch returned order is defined

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2893,7 +2893,7 @@ export default class bitget extends Exchange {
             'symbol': market['id'],
             'orderId': id,
         };
-        const response = await this[method] (this.extend (request, query));
+        let response = await this[method] (this.extend (request, query));
         // spot
         //     {
         //       code: '00000',
@@ -2945,6 +2945,10 @@ export default class bitget extends Exchange {
         //       }
         //     }
         //
+        // response will be string after filled, see: ccxt/ccxt#17900
+        if (typeof response === 'string') {
+            response = JSON.parse (response);
+        }
         const data = this.safeValue (response, 'data');
         const first = this.safeValue (data, 0, data);
         return this.parseOrder (first, market);


### PR DESCRIPTION
fix ccxt/ccxt#17900

The response is string if order was filled.