### PR TITLE
feat(gate): fetchMyTrades, replace swap endpoint

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -328,6 +328,7 @@ export default class gate extends Exchange {
                             '{settle}/orders': 1.5,
                             '{settle}/orders/{order_id}': 1.5,
                             '{settle}/my_trades': 1.5,
+                            '{settle}/my_trades_timerange': 1.5,
                             '{settle}/position_close': 1.5,
                             '{settle}/liquidates': 1.5,
                             '{settle}/price_orders': 1.5,
@@ -2788,7 +2789,7 @@ export default class gate extends Exchange {
         const method = this.getSupportedMapping (type, {
             'spot': 'privateSpotGetMyTrades',
             'margin': 'privateSpotGetMyTrades',
-            'swap': 'privateFuturesGetSettleMyTrades',
+            'swap': 'privateFuturesGetSettleMyTradesTimerange',
             'future': 'privateDeliveryGetSettleMyTrades',
         });
         const response = await this[method] (this.extend (request, params));


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/17938

DEMO
```
 p gate fetchMyTrades "BTC/USDT:USDT" 1684400330000 None '{"until":"1684400492000"}' --sandbox --swap --verbose     
Python v3.10.9
CCXT v3.0.106
gate.fetchMyTrades(BTC/USDT:USDT,1684400330000,None,{'until': '1684400492000'})

fetch Request: gate GET https://fx-api-testnet.gateio.ws/api/v4/futures/usdt/my_trades_timerange?contract=BTC_USDT&from=1684400330&to=1684400492 RequestHeaders: {'KEY': '15e2487aceea4e657569d59883f92dab', 'Timestamp': '1684400988', 'SIGN': '20fa785454fc06068a7d06c89975ba288350db2e80066479525fc9b2a9df1a23d42b7948117e95a83d8e71e5594b1bb5c22d9448219204309f66c878a5047b87', 'Content-Type': 'application/json', 'X-Gate-Channel-Id': 'ccxt', 'User-Agent': 'python-requests/2.28.1', 'Accept-Encoding': 'gzip, deflate'} RequestBody: None

fetch Response: gate GET https://fx-api-testnet.gateio.ws/api/v4/futures/usdt/my_trades_timerange?contract=BTC_USDT&from=1684400330&to=1684400492 200 ResponseHeaders: {'Date': 'Thu, 18 May 2023 09:09:48 GMT', 'Content-Type': 'application/json', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Server': 'openresty', 'Content-Encoding': 'gzip', 'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,DELETE,PUT', 'Access-Control-Allow-Headers': 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type', 'Access-Control-Max-Age': '1728000', 'Vary': 'Origin'} ResponseBody: [{"size":1,"role":"taker","contract":"BTC_USDT","text":"api","point_fee":"0","fee":"0.00136586","order_id":"","create_time":1684400331,"trade_id":"6963146","price":"27317.2"}]
[{'amount': 1.0,
  'cost': 2.73172,
  'datetime': '2023-05-18T08:58:51.000Z',
  'fee': None,
  'fees': [{'cost': '0.00136586', 'currency': 'USDT'},
           {'cost': '0', 'currency': 'GatePoint'}],
  'id': None,
  'info': {'contract': 'BTC_USDT',
           'create_time': '1684400331',
           'fee': '0.00136586',
           'order_id': '',
           'point_fee': '0',
           'price': '27317.2',
           'role': 'taker',
           'size': '1',
           'text': 'api',
           'trade_id': '6963146'},
  'order': None,
  'price': 27317.2,
  'side': 'buy',
  'symbol': 'BTC/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1684400331000,
  'type': None}]
```
