### PR TITLE
Okx: fetchTrades, add option support

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1570,6 +1570,23 @@ export default class okx extends Exchange {
         //         "ts": "1621446178316"
         //     }
         //
+        // option: fetchTrades
+        //
+        //     {
+        //         "fillVol": "0.46387625976562497",
+        //         "fwdPx": "26299.754935451125",
+        //         "indexPx": "26309.7",
+        //         "instFamily": "BTC-USD",
+        //         "instId": "BTC-USD-230526-26000-C",
+        //         "markPx": "0.042386283557554236",
+        //         "optType": "C",
+        //         "px": "0.0415",
+        //         "side": "sell",
+        //         "sz": "90",
+        //         "tradeId": "112",
+        //         "ts": "1683907480154"
+        //     }
+        //
         // private fetchMyTrades
         //
         //     {
@@ -1638,6 +1655,8 @@ export default class okx extends Exchange {
          * @method
          * @name okx#fetchTrades
          * @description get the list of most recent trades for a particular symbol
+         * @see https://www.okx.com/docs-v5/en/#rest-api-market-data-get-trades
+         * @see https://www.okx.com/docs-v5/en/#rest-api-public-data-get-option-trades
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int|undefined} since timestamp in ms of the earliest trade to fetch
          * @param {int|undefined} limit the maximum amount of trades to fetch
@@ -1649,10 +1668,15 @@ export default class okx extends Exchange {
         const request = {
             'instId': market['id'],
         };
-        if (limit !== undefined) {
-            request['limit'] = limit; // default 100
+        let response = undefined;
+        if (market['option']) {
+            response = await this.publicGetPublicOptionTrades (this.extend (request, params));
+        } else {
+            if (limit !== undefined) {
+                request['limit'] = limit; // default 100
+            }
+            response = await this.publicGetMarketTrades (this.extend (request, params));
         }
-        const response = await this.publicGetMarketTrades (this.extend (request, params));
         //
         //     {
         //         "code": "0",
@@ -1662,6 +1686,29 @@ export default class okx extends Exchange {
         //             {"instId":"ETH-BTC","side":"sell","sz":"0.03","px":"0.07068","tradeId":"15826756","ts":"1621446178066"},
         //             {"instId":"ETH-BTC","side":"buy","sz":"0.507","px":"0.07069","tradeId":"15826755","ts":"1621446175085"},
         //         ]
+        //     }
+        //
+        // option
+        //
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             {
+        //                 "fillVol": "0.46387625976562497",
+        //                 "fwdPx": "26299.754935451125",
+        //                 "indexPx": "26309.7",
+        //                 "instFamily": "BTC-USD",
+        //                 "instId": "BTC-USD-230526-26000-C",
+        //                 "markPx": "0.042386283557554236",
+        //                 "optType": "C",
+        //                 "px": "0.0415",
+        //                 "side": "sell",
+        //                 "sz": "90",
+        //                 "tradeId": "112",
+        //                 "ts": "1683907480154"
+        //             },
+        //         ],
+        //         "msg": ""
         //     }
         //
         const data = this.safeValue (response, 'data', []);


### PR DESCRIPTION
Added option support to fetchTrades:
```
okx.fetchTrades (BTC/USD:BTC-230526-26000-C)
2023-05-19T04:43:02.123Z iteration 0 passed in 364 ms

    timestamp |                 datetime |                     symbol |  id | order | type | takerOrMaker | side |  price | amount |               cost | fee | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
1677845638101 | 2023-03-03T12:13:58.101Z | BTC/USD:BTC-230526-26000-C |  13 |       |      |              | sell | 0.0465 |      2 |  43.01075268817204 |     |   []
1678202449945 | 2023-03-07T15:20:49.945Z | BTC/USD:BTC-230526-26000-C |  14 |       |      |              | sell |  0.039 |    800 |  20512.82051282051 |     |   []
1678202449945 | 2023-03-07T15:20:49.945Z | BTC/USD:BTC-230526-26000-C |  15 |       |      |              | sell |  0.039 |     66 | 1692.3076923076924 |     |   []
...
```