### PR TITLE
handleIsContractAndParams implementation

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3147,6 +3147,32 @@ export default class Exchange {
         return [ type, params ];
     }
 
+    handleIsContractAndParams (methodName, market = undefined, params = {}): any {
+        const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
+        const defaultIsContract = this.safeValue2 (this.options, 'isContract', 'defaultIsContract', false);
+        const methodOptions = this.safeValue (this.options, methodName);
+        let methodType = defaultType;
+        let methodIsContract = defaultIsContract;
+        if (methodOptions !== undefined) {
+            if (typeof methodOptions === 'string') {
+                methodType = methodOptions;
+                methodIsContract = methodOptions;
+            } else {
+                methodType = this.safeString2 (methodOptions, 'defaultType', 'type', methodType);
+                methodIsContract = this.safeString2 (methodOptions, 'isContract', 'defaultIsContract', methodIsContract);
+            }
+        }
+        const marketType = (market === undefined) ? methodType : market['type'];
+        let isContract = (market === undefined) ? methodIsContract : market['contract'];
+        const type = this.safeString2 (params, 'defaultType', 'type', marketType);
+        isContract = this.safeString2 (params, 'defaultIsContract', 'isContract', isContract);
+        params = this.omit (params, [ 'defaultType', 'type', 'isContract', 'defaultIsContract' ]);
+        return [
+            (type !== 'spot' && type !== 'margin') || isContract,
+            params,
+        ];
+    }
+
     handleSubTypeAndParams (methodName, market = undefined, params = {}, defaultValue = undefined) {
         let subType = undefined;
         // if set in params, it takes precedence


### PR DESCRIPTION
@kroitor @carlosmiei @frosty00 

Let me know what you think. We'll probably need something like this for XT Websockets, it gets split in spot and contract markets. My logic is that it should be enough to just provide the defaultType, since doing that is valid other places in the library and users are more used to that, but providing a defaultType of `'swap'` and calling `fetchTickers` (for example), will result in future tickers as well, so I think that there should be a way to specify that the default is for the contract endpoint, but also accept the defaultType values.