### PR TITLE
Okx: fetchOpenInterestHistory, add option support

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -5870,7 +5870,7 @@ export default class okx extends Exchange {
          * @description Retrieves the open interest history of a currency
          * @see https://www.okx.com/docs-v5/en/#rest-api-trading-data-get-contracts-open-interest-and-volume
          * @see https://www.okx.com/docs-v5/en/#rest-api-trading-data-get-options-open-interest-and-volume
-         * @param {string} symbol Unified CCXT currency code instead of a unified symbol
+         * @param {string} symbol Unified CCXT currency code or unified symbol
          * @param {string} timeframe "5m", "1h", or "1d" for option only "1d" or "8h"
          * @param {int|undefined} since The time in ms of the earliest record to retrieve as a unix timestamp
          * @param {int|undefined} limit Not used by okx, but parsed internally by CCXT
@@ -5885,8 +5885,15 @@ export default class okx extends Exchange {
             throw new BadRequest (this.id + ' fetchOpenInterestHistory cannot only use the 5m, 1h, and 1d timeframe');
         }
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        const currency = this.currency (symbol);
+        // handle unified currency code or symbol
+        let currency = undefined;
+        let market = undefined;
+        if (symbol in this.markets || symbol in this.markets_by_id) {
+            market = this.market (symbol);
+            currency = market['baseId'];
+        } else {
+            currency = this.currency (symbol);
+        }
         const request = {
             'ccy': currency['id'],
             'period': timeframe,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -5886,16 +5886,17 @@ export default class okx extends Exchange {
         }
         await this.loadMarkets ();
         // handle unified currency code or symbol
-        let currency = undefined;
+        let currencyId = undefined;
         let market = undefined;
         if (symbol in this.markets || symbol in this.markets_by_id) {
             market = this.market (symbol);
-            currency = market['baseId'];
+            currencyId = market['baseId'];
         } else {
-            currency = this.currency (symbol);
+            const currency = this.currency (symbol);
+            currencyId = currency['id'];
         }
         const request = {
-            'ccy': currency['id'],
+            'ccy': currencyId,
             'period': timeframe,
         };
         let type = undefined;

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -5885,6 +5885,7 @@ export default class okx extends Exchange {
             throw new BadRequest (this.id + ' fetchOpenInterestHistory cannot only use the 5m, 1h, and 1d timeframe');
         }
         await this.loadMarkets ();
+        const market = this.market (symbol);
         const currency = this.currency (symbol);
         const request = {
             'ccy': currency['id'],
@@ -5892,7 +5893,7 @@ export default class okx extends Exchange {
         };
         let type = undefined;
         let response = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchOpenInterestHistory', undefined, params);
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchOpenInterestHistory', market, params);
         if (type === 'option') {
             response = await this.publicGetRubikStatOptionOpenInterestVolume (this.extend (request, params));
         } else {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -5937,11 +5937,11 @@ export default class okx extends Exchange {
         // fetchOpenInterest
         //
         //     {
-        //         "instId": "BTC-USDT-SWAP",
-        //         "instType": "SWAP",
-        //         "oi": "2125419",
-        //         "oiCcy": "21254.19",
-        //         "ts": "1664005108969"
+        //         "instId": "BTC-USD-230520-25500-P",
+        //         "instType": "OPTION",
+        //         "oi": "300",
+        //         "oiCcy": "3",
+        //         "ts": "1684551166251"
         //     }
         //
         const id = this.safeString (interest, 'instId');
@@ -5963,9 +5963,8 @@ export default class okx extends Exchange {
             }
         } else {
             baseVolume = this.safeNumber (interest, 'oiCcy');
-            quoteVolume = this.safeNumber (interest, 'oi');
-            openInterestAmount = this.safeNumber (interest, 'oiCcy');
-            openInterestValue = this.safeNumber (interest, 'oi');
+            openInterestAmount = this.safeNumber (interest, 'oi');
+            openInterestValue = this.safeNumber (interest, 'oiCcy');
         }
         return {
             'symbol': this.safeSymbol (id),


### PR DESCRIPTION
Added option support to fetchOpenInterestHistory, adjusted parseOpenInterest based on this data: https://www.okx.com/markets/data-list
```
okx.fetchOpenInterestHistory (BTC, 1d, , 3)
2023-05-20T02:35:54.613Z iteration 0 passed in 367 ms

symbol | baseVolume | quoteVolume | openInterestAmount | openInterestValue |     timestamp |                 datetime
---------------------------------------------------------------------------------------------------------------------
       |    1121.75 |             |           19268.84 |                   | 1684339200000 | 2023-05-17T16:00:00.000Z
       |    2085.85 |             |           19898.72 |                   | 1684425600000 | 2023-05-18T16:00:00.000Z
       |    2787.71 |             |           18691.64 |                   | 1684512000000 | 2023-05-19T16:00:00.000Z
3 objects
```