### PR TITLE
chore: changelog update [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ script:
       echo "Publishing";
       npm config set git-tag-version=false && NPM_VERSION=$(npm version patch);
       npm run vss && npm run copy-python-files;
-      npm list -g standard-version --depth=0 || npm install -g standard-version@9.5.0;
-      standard-version --skip.bump --skip.commit --skip.tag;
+      ./change.sh > CHANGELOG.md;
       env COMMIT_MESSAGE=${NPM_VERSION:1} GITHUB_TOKEN=${GITHUB_TOKEN} SHOULD_TAG=${SHOULD_DEPLOY} ./build/push.sh;
       cd python && env PYPI_TOKEN=${PYPI_TOKEN} ./deploy.sh && cd ..;
     else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,626 +1,1862 @@
-# Changelog
+## 3.1.3 (2023-05-20)
+
+*  typo [c43ebdd45f](https://github.com/ccxt/ccxt/commits/c43ebdd45f7fcd9e7b2df80e79939e9b7af98daf)
+*  add docs [decf252a6a](https://github.com/ccxt/ccxt/commits/decf252a6a6f096e945f1c5f088e3eab6319e3e1)
+*  cr fixes [7cae1791a8](https://github.com/ccxt/ccxt/commits/7cae1791a8d0d8585d2ad65c6c556cc5b828308b)
+*  bybit: add new position apis [acf316c367](https://github.com/ccxt/ccxt/commits/acf316c367eaadb735fd078d98516dd97243cd5b)
+*  3.1.3 [8941337921](https://github.com/ccxt/ccxt/commits/89413379218f29ab391e69fddf3012d56f6956b6)
+
+
+## 3.1.2 (2023-05-19)
+
+*  add build script [07d3512254](https://github.com/ccxt/ccxt/commits/07d35122549442a580acecc5561cc01d09d2cf8c)
+*  build all if not PR [0038354a5e](https://github.com/ccxt/ccxt/commits/0038354a5eca61724f7a98a0f3f8822686265f56)
+*  dummy changes [557674b790](https://github.com/ccxt/ccxt/commits/557674b790bfdb4c21a7ea42f356ad99710c25b2)
+*  update diff [a384125875](https://github.com/ccxt/ccxt/commits/a3841258756fb6a3273ab0e573cbc5e4cd998e45)
+*  dry code [2fec193110](https://github.com/ccxt/ccxt/commits/2fec193110b7b30dfdd30f3c132898abaa15924f)
+*  update ws command [5ac36f1dec](https://github.com/ccxt/ccxt/commits/5ac36f1dec881626960c3768fed964adbaa0d873)
+*  minor rename [f07038cead](https://github.com/ccxt/ccxt/commits/f07038cead55b1950ffd03ea9d881e3343a74af4)
+*  feat(binance): editOrder, add swap and future support [2c94f10d5a](https://github.com/ccxt/ccxt/commits/2c94f10d5a4f17158e1baff1254de07037ebc194)
+*  update build.sh [8a36b1469d](https://github.com/ccxt/ccxt/commits/8a36b1469d37ace6aa1f627e9884dd09d41fcf5b)
+*  update script [edb9172d72](https://github.com/ccxt/ccxt/commits/edb9172d72fa6942cd1331341334536220a65874)
+*  update script [1768278df2](https://github.com/ccxt/ccxt/commits/1768278df28b78bda29c81f63896c5cbcba7a059)
+*  update regex [cea995a6d1](https://github.com/ccxt/ccxt/commits/cea995a6d1aa11be00662b62f6c3ac3202ba6a7c)
+*  update specific tests running [ba3316f9d5](https://github.com/ccxt/ccxt/commits/ba3316f9d53c5b787187998de79ae5cebdb15619)
+*  update empty check [912bacc1cf](https://github.com/ccxt/ccxt/commits/912bacc1cfdf08d187d8c3c144ecfbf314d8da1e)
+*  handle tests running [836673b05c](https://github.com/ccxt/ccxt/commits/836673b05c2a76cf76519ceb6437f55108472ab6)
+*  base file modified (dummy) [bbe645898d](https://github.com/ccxt/ccxt/commits/bbe645898d1b7d61adad6fe770542fa1357fecff)
+*  revert changes [b0b13e38e7](https://github.com/ccxt/ccxt/commits/b0b13e38e77c8166a777b55b23d976e1050135f9)
+*  revert bybit [0100aca24c](https://github.com/ccxt/ccxt/commits/0100aca24cf1b73c6b7bfbc7b287abf57b09bb4e)
+*  revert [71170dd77e](https://github.com/ccxt/ccxt/commits/71170dd77e9c17515f275b9e235b24fef6d8b5ee)
+*  feat(okx): fetchTrades, add option support [5bc7d50709](https://github.com/ccxt/ccxt/commits/5bc7d5070997abbd0fded0b92374508509740529)
+*  add initial checks [8a8fd9155b](https://github.com/ccxt/ccxt/commits/8a8fd9155b827618b8869291ed863c9f5702a8b5)
+*  split into editSpotOrder and editContractOrder [e5cd4423d5](https://github.com/ccxt/ccxt/commits/e5cd4423d52331dddd32374802c9ba53c23e01f7)
+*  3.1.2 [321dc7d81d](https://github.com/ccxt/ccxt/commits/321dc7d81d8c4acfbe1d7560ed6eb2fc19abfdc8)
+
+
+## 3.1.1 (2023-05-18)
+
+*  Bump guzzlehttp/psr7 from 2.4.3 to 2.5.0 [6a0d7e3347](https://github.com/ccxt/ccxt/commits/6a0d7e3347a354813770c46f2c858cdce0cd5789)
+*  Bump react/http from 1.8.0 to 1.9.0 [35d39e686b](https://github.com/ccxt/ccxt/commits/35d39e686bc016b362a7a84488563459a1f7b982)
+*  bitget: patch returned order is defined [3065168c00](https://github.com/ccxt/ccxt/commits/3065168c00ecda7d9e4898b8f0f6c0c51919b79f)
+*  feat(gate): fetchMyTrades, replace swap endpoint [db9a269e28](https://github.com/ccxt/ccxt/commits/db9a269e288e1285f4aab29b836e3879249f39b8)
+*  Fix field name [e04e623b92](https://github.com/ccxt/ccxt/commits/e04e623b92c7446f4d250b325d2530f7a0be2871)
+*  fix(whitebit): nonce granularity [22f07e6112](https://github.com/ccxt/ccxt/commits/22f07e6112d92f5fda3411fe8632e3d11452ad27)
+*  3.1.0 [a7f22b4d79](https://github.com/ccxt/ccxt/commits/a7f22b4d797888528b05dbc0b157519e72d2dc41)
+*  3.1.1 [a9d315b103](https://github.com/ccxt/ccxt/commits/a9d315b1035d7ca111e284861a268237926e65c6)
+
+
+## 3.0.107 (2023-05-18)
+
+*  precision mode instance methods [c272ce9dd9](https://github.com/ccxt/ccxt/commits/c272ce9dd9ba5000a1e02a76e80f8137b0f69451)
+*  transpile str [598ea094a9](https://github.com/ccxt/ccxt/commits/598ea094a9f7d1c8d3a071beb47812d953672a91)
+*  rename methods [bdcdf7c2bf](https://github.com/ccxt/ccxt/commits/bdcdf7c2bf17c8b1c36c5f0bfaf382ee1a9e61f5)
+*  transpiler rename [6b81e8c370](https://github.com/ccxt/ccxt/commits/6b81e8c37025e98d9088aaed6cc97d0d1d62a5a6)
+*  bitget: fix apis limit rule, add missing apis [7ca06583d0](https://github.com/ccxt/ccxt/commits/7ca06583d03ff4c19abb2dd8490ac5fbd13892e8)
+*  bitget: add broker apis [d0973f8819](https://github.com/ccxt/ccxt/commits/d0973f88196071f50edb7491153a524f10fa5ef3)
+*  bitget: add margin apis [70edf98738](https://github.com/ccxt/ccxt/commits/70edf9873833a7b3fabc2051dc6b6c0d4d5d2e54)
+*  bitget: add future copytrading apis [337982dc96](https://github.com/ccxt/ccxt/commits/337982dc96caeb2a8aab4c4858c1b7221421daf9)
+*  3.0.107 [bff895d700](https://github.com/ccxt/ccxt/commits/bff895d7001cb764652d702c8a74fb6cea0d178f)
+
+
+## 3.0.106 (2023-05-17)
+
+*  fix build [293fd0ed30](https://github.com/ccxt/ccxt/commits/293fd0ed309dee8336174fb09d49f74e1cb228b0)
+*  fix watchTickers [d87767d631](https://github.com/ccxt/ccxt/commits/d87767d6316ce782b65014258e6d408d3eddcfb5)
+*  fix canceled orders and py wathMyTrades [2f445a4f5a](https://github.com/ccxt/ccxt/commits/2f445a4f5a3f6bfd36d7b2d4ea565f621837b09d)
+*  fix watchMyTrades [4e9e6b8223](https://github.com/ccxt/ccxt/commits/4e9e6b82238f17e3950ef0c556bdd92631e0a05f)
+*  merge main [39bc303242](https://github.com/ccxt/ccxt/commits/39bc3032421db164ef278df3445e6bee797eb331)
+*  move to typescript and small fix [6dfbd8d078](https://github.com/ccxt/ccxt/commits/6dfbd8d078977dde40ecd121b5f40e6999d9eb54)
+*  remove change to bitpanda.js [0306583976](https://github.com/ccxt/ccxt/commits/03065839761d496446f71a68685d736e56150502)
+*  bitpanda pr comments [d19d79edf1](https://github.com/ccxt/ccxt/commits/d19d79edf1bdf317b27298235abff033a345e846)
+*  fix orderbook timestamp [95ea966df6](https://github.com/ccxt/ccxt/commits/95ea966df6c8fff731d5f58c53e02310cb46ad9f)
+*  typo [72a20def7d](https://github.com/ccxt/ccxt/commits/72a20def7d5753757166a61ef79c9195c3a7a0eb)
+*  ticker ts [19803060bf](https://github.com/ccxt/ccxt/commits/19803060bf583c3c1cd8acccac023b74c156f253)
+*  fix handledelta [614f9df3f6](https://github.com/ccxt/ccxt/commits/614f9df3f6282162573af9402c8f87efb448e7ce)
+*  fix test.php [6d8a61e655](https://github.com/ccxt/ccxt/commits/6d8a61e6557fb1d363050590f12dddcdf8e87f57)
+*  xt parseTransaction fixes [0d7300c9de](https://github.com/ccxt/ccxt/commits/0d7300c9de0a974fcf9b42c5e66e6671ec231071)
+*  xt error mapping [77ba889469](https://github.com/ccxt/ccxt/commits/77ba8894698d9a660c6ee04ad6094df373cac78b)
+*  bitget: add 7 apis /api/user/* [fcad762e49](https://github.com/ccxt/ccxt/commits/fcad762e49d150bdb176e4fea93b57042ad6d905)
+*  3.0.106 [1cfbabb6a3](https://github.com/ccxt/ccxt/commits/1cfbabb6a327e9f1fc2aa2b27775c68c2dd204df)
+
+
+## 3.0.105 (2023-05-16)
+
+*  New and deleted files do not commiting to ccxt git repository [f7ddd552df](https://github.com/ccxt/ccxt/commits/f7ddd552df379236843751a47014851d5e11761f)
+*  take care about possible file renames [03be2cf019](https://github.com/ccxt/ccxt/commits/03be2cf019b19565d87e59e86e01f501c8ca3c33)
+*  typo in the command [722567273e](https://github.com/ccxt/ccxt/commits/722567273e040532f2ec892eaf8723fafb4048f0)
+*  bybit fetchCurrencies enhancement [18f2f2a241](https://github.com/ccxt/ccxt/commits/18f2f2a241be8198ea784f8688674d9573376ab8)
+*  comment out manual git add [e938ec6115](https://github.com/ccxt/ccxt/commits/e938ec611530d5736e0d889dabbc3f00abd90ab3)
+*  filterByLimit is descending by default [abef77fc2c](https://github.com/ccxt/ccxt/commits/abef77fc2c446811b2a96dec82840bd91ed73558)
+*  bitget: update transfer / withdraw to v2 api [9d6430ffca](https://github.com/ccxt/ccxt/commits/9d6430ffca7a0bcecca6abeebf97b3fbd646e157)
+*  improve withdraw [b267b4e7a1](https://github.com/ccxt/ccxt/commits/b267b4e7a1d828a0e809b30520a66fc41f97ad45)
+*  3.0.105 [f81b0b41be](https://github.com/ccxt/ccxt/commits/f81b0b41be76b54eddb36bfa0b24e04f8b519361)
+
+
+## 3.0.104 (2023-05-15)
+
+*  fix(phemex): ping pong handling [ae0aea8569](https://github.com/ccxt/ccxt/commits/ae0aea856985609ebacdd0a375758575fb9e7743)
+*  3.0.104 [2b47ba1fb2](https://github.com/ccxt/ccxt/commits/2b47ba1fb2938afb53ba79d60a63b6bc07373e9a)
+
+
+## 3.0.103 (2023-05-14)
+
+*  bitget: ws subscribe stop orders channel 'ordersAlgo' [01b43bed9a](https://github.com/ccxt/ccxt/commits/01b43bed9a27458ccea2a77ee66dc155ec55839d)
+*  feat(kucoinfutures): fetchPosition [9d687fc41a](https://github.com/ccxt/ccxt/commits/9d687fc41ac57047f9b13abef4bf21b57f9228ad)
+*  revert js file [3ca6f3f0a9](https://github.com/ccxt/ccxt/commits/3ca6f3f0a9787fa6a4f5f54e090e947079c866f9)
+*  add ts version [83bb38474d](https://github.com/ccxt/ccxt/commits/83bb38474d3323d1be56021d3c8e2f75356d8f66)
+*  update parseWsOrder [7ab0a772b5](https://github.com/ccxt/ccxt/commits/7ab0a772b53f10e9d971fb01a3937e916ef57723)
+*  fix(coinex): fetchTradingFee market handling [390603c0ab](https://github.com/ccxt/ccxt/commits/390603c0ab53d03c426bfec406599a2b0490aa60)
+*  fix(gate): fix status for partial orders and canceled orders [6218c59564](https://github.com/ccxt/ccxt/commits/6218c59564e30ad738091c4d184870f3bc4eb482)
+*  fix(bitfinex): parseTicker marketId [b2f72e0429](https://github.com/ccxt/ccxt/commits/b2f72e0429b85385b3fcfa17a2f1de5bf2cea22b)
+*  3.0.103 [1836f1a75c](https://github.com/ccxt/ccxt/commits/1836f1a75c24363978e4bb4d48cf20970d19dc9c)
+
+
+## 3.0.102 (2023-05-13)
+
+*  coinmate parseTransaction unification [b65ea3b7b4](https://github.com/ccxt/ccxt/commits/b65ea3b7b450978edf486a49eefbc6eaf3c26ccb)
+*  precision tests [1cc60eba97](https://github.com/ccxt/ccxt/commits/1cc60eba97544fa74be2d6501de4cbb06c48adcc)
+*  market fixes [a6e33f88ba](https://github.com/ccxt/ccxt/commits/a6e33f88baa04ec00b2fbad7918d9656b0cd881f)
+*  comprehensive updates for market tests [b8a186c8a6](https://github.com/ccxt/ccxt/commits/b8a186c8a6e9795770d8999d03ae211785872ecb)
+*  further updates for currency & markets [088fbfc78d](https://github.com/ccxt/ccxt/commits/088fbfc78dd69c86d807c9d01bc3471965d49bfd)
+*  extra updates for markets & currencies [946f63bca5](https://github.com/ccxt/ccxt/commits/946f63bca50ef0779ee14f8f6145ae68af8aaf5b)
+*  revert [87eba78dce](https://github.com/ccxt/ccxt/commits/87eba78dcee5d8d58d6a14c9cc6c6dee78ccb830)
+*  ws tests [1bdec9bb43](https://github.com/ccxt/ccxt/commits/1bdec9bb4300fdf6e1931307dd374ec49287a3db)
+*  lint py [5b220f1cdc](https://github.com/ccxt/ccxt/commits/5b220f1cdc8b4e536f7602718de29ca8715dd497)
+*  remove syntax contribute odd comment [440635c0e7](https://github.com/ccxt/ccxt/commits/440635c0e72a532719461890b12dacfb7e38283b)
+*  newlines [be46a2e3fd](https://github.com/ccxt/ccxt/commits/be46a2e3fd686630b0d38241619c1b2a500c0d60)
+*  lint [c00559024b](https://github.com/ccxt/ccxt/commits/c00559024b8ab075117fc46ffc959415af7a6ceb)
+*  structures [fed4dd74bd](https://github.com/ccxt/ccxt/commits/fed4dd74bdc22083b92e2a259875ffffb1d9ad8b)
+*  update all tests [93f540f568](https://github.com/ccxt/ccxt/commits/93f540f568534af4414eef8902b5dfc1ece58509)
+*  lint & comments [263ac99296](https://github.com/ccxt/ccxt/commits/263ac99296d6a43cfae409e205d935c45f8563e4)
+*  timestamps [77225c8883](https://github.com/ccxt/ccxt/commits/77225c8883c1b8c1f53f42014b0a791e19251942)
+*  fix transpilation  and conditions [9b0e0b4015](https://github.com/ccxt/ccxt/commits/9b0e0b4015aa185783a9522ec127ff3e394b35fc)
+*  stringified changes [ddef3a623f](https://github.com/ccxt/ccxt/commits/ddef3a623f0cfbb323e0513f5de0de2773fbb5aa)
+*  fix tests [3491062c81](https://github.com/ccxt/ccxt/commits/3491062c81ec9126520156a6486f42b0d7c659db)
+*  updated detail tests [37ed1d5977](https://github.com/ccxt/ccxt/commits/37ed1d5977008dffbbd7dad19a351c51b59208c0)
+*  fixed for all properties in tests [55ae68510a](https://github.com/ccxt/ccxt/commits/55ae68510ae9bbb3cfa3b5960261bde1fc768c03)
+*  full update & fixes for all exchanges [dfbb72422b](https://github.com/ccxt/ccxt/commits/dfbb72422b2cd0ed1484fa8bc8c7f6e914118269)
+*  transpiler fixes [01a99db0ae](https://github.com/ccxt/ccxt/commits/01a99db0ae4cd43f0fa393eb17ad63cf03b58bb8)
+*  status fix [988d8d7d09](https://github.com/ccxt/ccxt/commits/988d8d7d09fc4246e818e9ae134d9c2483f247a5)
+*  settleId [67928ff158](https://github.com/ccxt/ccxt/commits/67928ff158e8392d51d11d6b6086f2f721ab963e)
+*  revert timex [b2812163a5](https://github.com/ccxt/ccxt/commits/b2812163a5aa33615a19ee4a3669e1debaaebec4)
+*  temporary WS tests remove [c7efa98658](https://github.com/ccxt/ccxt/commits/c7efa98658205aa886f2fceb68e79dca85fa5538)
+*  fix pro parts [7aa0c283bd](https://github.com/ccxt/ccxt/commits/7aa0c283bdf84e60f2fd6ba8cfb6786828d590b0)
+*  temp disable ws [5301f386ee](https://github.com/ccxt/ccxt/commits/5301f386eea14eb6fcd7c872c4c99ec67f69609f)
+*  temp disable php async [30db2fbf16](https://github.com/ccxt/ccxt/commits/30db2fbf1686629743763b5d6b2e5aeb3b5933a3)
+*  update tests [3ab0aa6e35](https://github.com/ccxt/ccxt/commits/3ab0aa6e35050a3e689d5eb080ef06cce0fd6dd3)
+*  isinteger fix [49f64a8129](https://github.com/ccxt/ccxt/commits/49f64a8129589b136391599d5ecd8ba8b6241d39)
+*  fee undefined check [0b9ee20ddc](https://github.com/ccxt/ccxt/commits/0b9ee20ddc3f253f4b8c6590bd37298bbe95c8bd)
+*  update  tests php & manager [8360480399](https://github.com/ccxt/ccxt/commits/83604803994caad63044143fe7deb4592f49532b)
+*  async fetch currencies when emulated [efdc33660d](https://github.com/ccxt/ccxt/commits/efdc33660d271d22723b9a6e1c1eae31547ffcf5)
+*  update tests [b0d8c6b4cc](https://github.com/ccxt/ccxt/commits/b0d8c6b4cc5e7e54c5c9456e156189a6040d4a9e)
+*  has close py [6df7fbe52f](https://github.com/ccxt/ccxt/commits/6df7fbe52fb135175db8a46780683ae4c82e7493)
+*  shared method [2ff1063de4](https://github.com/ccxt/ccxt/commits/2ff1063de4b55094f6a9eb1233b7e3d8ae426795)
+*  revert [a6d49953ef](https://github.com/ccxt/ccxt/commits/a6d49953ef9aa14f41a6548d3a117c60f202a54b)
+*  last reverts [307acc4269](https://github.com/ccxt/ccxt/commits/307acc4269bfab06b9a52b3c408d95b006769375)
+*  minor edits [050a82c005](https://github.com/ccxt/ccxt/commits/050a82c005e7dea950e3ec3574baff77e35c6d91)
+*  recode catch assertions [8ae5543a8f](https://github.com/ccxt/ccxt/commits/8ae5543a8f523ed334f3dd491c0f8431bae4d198)
+*  currencies fix [085c6d97bf](https://github.com/ccxt/ccxt/commits/085c6d97bf0401d2bc5fd442c6655ce29db884a0)
+*  comma fix [534409810f](https://github.com/ccxt/ccxt/commits/534409810f1cdd66b67f5149487c191e34e92a50)
+*  digifinex [0e441a7637](https://github.com/ccxt/ccxt/commits/0e441a76379866580ca084fdca02583b9df48912)
+*  change implementation [d3e7dee696](https://github.com/ccxt/ccxt/commits/d3e7dee696509c69cd9513827098010768146136)
+*  xt parseMarket fixes [10824add6f](https://github.com/ccxt/ccxt/commits/10824add6f613c1820238e95b37d3168c4970362)
+*  xt fetchOrderBook limit [f216904b9b](https://github.com/ccxt/ccxt/commits/f216904b9b1e21a9f8841f6f270615431c4b5f34)
+*  feat(gate): fetchTrades add option support [5c5202be89](https://github.com/ccxt/ccxt/commits/5c5202be8949c9938e1b9b5074a6b27c0161579b)
+*  binance: add porfolio margin apis [f618a374c2](https://github.com/ccxt/ccxt/commits/f618a374c2745f5689a0290c71afc99feb7ee231)
+*  feat(xt): add networkError [0883f5518a](https://github.com/ccxt/ccxt/commits/0883f5518ac8d213d577aebfbf33ef397db52a7c)
+*  obj [c8487630e0](https://github.com/ccxt/ccxt/commits/c8487630e07fdcffe0d36ca81ca52c4aae825656)
+*  fix(huobi): fetchBalance:  add unified account support [387246ba93](https://github.com/ccxt/ccxt/commits/387246ba9341cede1c039850f4a6113ad6fd4288)
+*  fix build: add safeCurrencyStructure snake case [4fe1efd2b6](https://github.com/ccxt/ccxt/commits/4fe1efd2b69530d716f4cf635ac78009e8b564a0)
+*  assertTimestamp checks [b0144b87dd](https://github.com/ccxt/ccxt/commits/b0144b87ddf2bd2b59e6759995f422e98ccca66f)
+*  ascendex parseOrder fix [9725c2ddde](https://github.com/ccxt/ccxt/commits/9725c2dddefe84d67712e18574a907a584ae6c50)
+*  ascendex linting [e5a42b629b](https://github.com/ccxt/ccxt/commits/e5a42b629bb9090b7f8afb4e0cdc00e8918f297a)
+*  feat(kucoinfutures): add missing endpoints [807b4b2f82](https://github.com/ccxt/ccxt/commits/807b4b2f82d9760f3313dba51759564011808c69)
+*  3.0.102 [4adc5fb370](https://github.com/ccxt/ccxt/commits/4adc5fb370bb71f95c6336fd4945d2d2266b6a81)
+
+
+## 3.0.101 (2023-05-12)
+
+*  move client subscription check and handle rollback [b5a07c1841](https://github.com/ccxt/ccxt/commits/b5a07c1841c5e29b5c24fcdffaf6d06b950cff28)
+*  python lint [e7b321a8f9](https://github.com/ccxt/ccxt/commits/e7b321a8f96a4d159245e845f547b4bba174d063)
+*  fix(bitget): remove symbol requirement from fetchOpenOrders [af604319e7](https://github.com/ccxt/ccxt/commits/af604319e794533f5caf3e290381df5fa7632a36)
+*  update endpoint [c26e49e11f](https://github.com/ccxt/ccxt/commits/c26e49e11f09341624e299192fd2442d5049a88a)
+*  update endpoint [98c72a1b9d](https://github.com/ccxt/ccxt/commits/98c72a1b9df8af50a6a1c96827ddab392c1dc65b)
+*  update syntax [57777dde95](https://github.com/ccxt/ccxt/commits/57777dde955923b63b48afb2344af9f249221aa2)
+*  xt new endpoints [f9d4a8a37c](https://github.com/ccxt/ccxt/commits/f9d4a8a37cd52a650a0e60e64c9e9d99a242fc8c)
+*  probit fetchCurrencies network precision fix [51e431fb5b](https://github.com/ccxt/ccxt/commits/51e431fb5b18045417109519f4215d2175992476)
+*  xt more endpoints [98e3bf8f54](https://github.com/ccxt/ccxt/commits/98e3bf8f54d16880c6a4624571afff2177a4bc31)
+*  binance: add new fapis [727e6b5383](https://github.com/ccxt/ccxt/commits/727e6b53838fef6a63fb54e647401a19851511ea)
+*  feat(xt): add transfer [a1cd339772](https://github.com/ccxt/ccxt/commits/a1cd339772b33d174129562361a5e946e39ee1bf)
+*  add errors [34f9173ebf](https://github.com/ccxt/ccxt/commits/34f9173ebfff503dc7b660df4136719b0849d7ae)
+*  fix timeout import [72f55e6f92](https://github.com/ccxt/ccxt/commits/72f55e6f9210d549dd45be29c64e1339526b9e9e)
+*  udpate transfer flag [35bd6b29e4](https://github.com/ccxt/ccxt/commits/35bd6b29e462340a03ed4264e841389cf7ce24ff)
+*  xt fetchCurrencies enhancement [49168fa193](https://github.com/ccxt/ccxt/commits/49168fa1938ff3397c7112baa27e5d9a80c6d71a)
+*  xt fetchCurrencies fix [db5f6a1e90](https://github.com/ccxt/ccxt/commits/db5f6a1e902c99d6bf2e0c6181c25aeabb8e7d59)
+*  fix(coinbase): fetchOrders, fetchOrdersByStatus, fix since [fb444e5627](https://github.com/ccxt/ccxt/commits/fb444e562784ec949a7b034909fd095ea9cc5b52)
+*  3.0.101 [8865624bcc](https://github.com/ccxt/ccxt/commits/8865624bcccc95647cb989b66b8e7ff9147e708d)
+
+
+## 3.0.100 (2023-05-11)
+
+*  no Origin Header [b2a44f35de](https://github.com/ccxt/ccxt/commits/b2a44f35de07f24651821470a50e7c7a3e3a5184)
+*  Exchange.js unified currency structure [4b4fabd962](https://github.com/ccxt/ccxt/commits/4b4fabd96202ef6bf0cd6e3121d809f9a4cfe6d7)
+*  exchange.setMarkets comment [9ebc574cf0](https://github.com/ccxt/ccxt/commits/9ebc574cf0758f8a0d87772856ab321553767b74)
+*  currencyStructure in py/php [ae02eb42ff](https://github.com/ccxt/ccxt/commits/ae02eb42ffbf5ba9b959244101e5159477586134)
+*  exchange.currencyStructure removed address and limits["amount"/"cost"/"price"] [66686493a4](https://github.com/ccxt/ccxt/commits/66686493a40d2019310ce6c24a87cd61656e01ae)
+*  removed upperCaseId and lowerCaseId from exchange.currencyStructure [0ab104ff2e](https://github.com/ccxt/ccxt/commits/0ab104ff2e658aaf5fe99b60ea2d3d6a6ebf73b9)
+*  fix(coinex): parse cfx deposit address correctly. fix #17197 [a1f3e31db4](https://github.com/ccxt/ccxt/commits/a1f3e31db4be3def7061ebed2cb9e414cd84235a)
+*  exchange.ts currencyStructure fees and networks are empty object by default [0386c8af8f](https://github.com/ccxt/ccxt/commits/0386c8af8f0bef0e16d6faa511cd2318fe11e699)
+*  update typescript [631cbac2f0](https://github.com/ccxt/ccxt/commits/631cbac2f0098ea37f97a30f82a6a8efaa4fecf3)
+*  last fixes [c63918f978](https://github.com/ccxt/ccxt/commits/c63918f978847c1637f647e1b037039e59ec897e)
+*  fix php [c5fc33cb39](https://github.com/ccxt/ccxt/commits/c5fc33cb393fcc6d72721b5c022db026b3f097b6)
+*  remove use strict [5e400994a0](https://github.com/ccxt/ccxt/commits/5e400994a0e98c76065fa90d46eaa7f2217985ce)
+*  remove `margin` field [3416b15c50](https://github.com/ccxt/ccxt/commits/3416b15c5049ef82540f5d52aa98c48170c96abe)
+*  coinex new endpoint [65a9ebf0ea](https://github.com/ccxt/ccxt/commits/65a9ebf0ead7da49676115c6da4b5ae8afa0d10b)
+*  krakenfutures transfer remove amountToPrecision [52ff437c8b](https://github.com/ccxt/ccxt/commits/52ff437c8b036da52931ca7040b9c7a756fbf9c6)
+*  feat(binance): update python option examples [a6aa9daa5b](https://github.com/ccxt/ccxt/commits/a6aa9daa5b88107c4005aa42d00abf72877109be)
+*  feat(cryptocom): add since to cryptocom [5b5e18c790](https://github.com/ccxt/ccxt/commits/5b5e18c79037ecb1c443aa8f0515aa158851f9a1)
+*  missing await [f0402bc2d3](https://github.com/ccxt/ccxt/commits/f0402bc2d3db4d83b0fd7defcacd4944a84c991d)
+*  add untill param [4fe5d0d003](https://github.com/ccxt/ccxt/commits/4fe5d0d0033cf17bcfd0e1ff6a4e0e3d2749df2b)
+*  3.0.100 [d9144b0884](https://github.com/ccxt/ccxt/commits/d9144b0884bef66a54944250011f0338e08bd479)
+
+
+## 3.0.99 (2023-05-10)
+
+*  bitmart integer [6fe0454bf1](https://github.com/ccxt/ccxt/commits/6fe0454bf1c7de56e54680980b43073214eb596f)
+*  update bitmart [75aeeb96f8](https://github.com/ccxt/ccxt/commits/75aeeb96f8ba8ef9311ccd6ec948723869d095b5)
+*  coinbasepro: handle error message for ws [abc0d20791](https://github.com/ccxt/ccxt/commits/abc0d20791d47bbce973f2950b72ad9d3244531d)
+*  bybit: remove exceptions.ws [9e6827c899](https://github.com/ccxt/ccxt/commits/9e6827c899095454db80c99c72b12724b753f1fc)
+*  mexc error remapping [a37be6492b](https://github.com/ccxt/ccxt/commits/a37be6492b9b80b4e86dd8276014873f7b99b3d3)
+*  fix import [a3166b3c36](https://github.com/ccxt/ccxt/commits/a3166b3c36428257d7c9d69169b41f2c1ca9e5ce)
+*  fix(phemex): v2 sandbox url [a1ca7c573d](https://github.com/ccxt/ccxt/commits/a1ca7c573dd9da3e8f8aa079b5a69fb331141210)
+*  feat(binance): fetchTicker, fetchTickers, add option support [bbfb7c2bbc](https://github.com/ccxt/ccxt/commits/bbfb7c2bbc6a413b750f3e7832402f0fc38fca7e)
+*  bybit: add publicGetV5InsLoanEnsureTokensConvert & privateGetV5InsLoanLtvConvert [4fcb2340f5](https://github.com/ccxt/ccxt/commits/4fcb2340f515962fd0e10171d883c557ba36abcc)
+*  binance: add sapiGetPortfolioAssetIndexPrice [7b569b29c7](https://github.com/ccxt/ccxt/commits/7b569b29c72027378c50bb30acfb32ab95009de6)
+*  bybit: update fetchOpenInterestHistory [ac3e0d82f0](https://github.com/ccxt/ccxt/commits/ac3e0d82f09dad29c414f5ec4a3aeeb782d07980)
+*  handleMarketType properly [1d99c24604](https://github.com/ccxt/ccxt/commits/1d99c2460413fc45ec3c250632b68b7028f3f41d)
+*  fix until param [23daf0709a](https://github.com/ccxt/ccxt/commits/23daf0709a6bf9297a2ac243ef01491d4e7d96e6)
+*  3.0.99 [f463e06231](https://github.com/ccxt/ccxt/commits/f463e062319b10f6d3728b4a75977819145eb509)
+
+
+## 3.0.98 (2023-05-09)
+
+*  change ArgumentsRequired error to checkRequiredSymbol [7abaf5da98](https://github.com/ccxt/ccxt/commits/7abaf5da98802dd2b705d4bd17851fb57827a34e)
+*  add sample exchange [3427e5a705](https://github.com/ccxt/ccxt/commits/3427e5a70512e311a59b07751982e896d9133d8a)
+*  fix:php array cache fix [11e1db051c](https://github.com/ccxt/ccxt/commits/11e1db051c9698e80123cca2c8e50ace70e53923)
+*  fix proxy key [45aa868217](https://github.com/ccxt/ccxt/commits/45aa868217a15c45de50f0cb533dd5cddc130f0c)
+*  fix(Coinex): Required positionId for reduceOnly orders [ddc896516d](https://github.com/ccxt/ccxt/commits/ddc896516da6ccac99fc1b7dac64957385add727)
+*  improve error message [755982ac65](https://github.com/ccxt/ccxt/commits/755982ac65e4f7cf0c5af03dfce1959e22123bb1)
+*  fix spot cancelOrders [b159a80570](https://github.com/ccxt/ccxt/commits/b159a80570d82adcc5789127bb32db51586fa092)
+*  fix(bitfinex2): checksum when length < 25 [916da4a1bc](https://github.com/ccxt/ccxt/commits/916da4a1bca536f65557c7e74627f4f0b0665a92)
+*  mixed fix [99bf906d4e](https://github.com/ccxt/ccxt/commits/99bf906d4e903302ca2a6db269e90378d3175870)
+*  mixed limit [97d515c0fd](https://github.com/ccxt/ccxt/commits/97d515c0fd1baade799f14df3cdbacfa18df4938)
+*  Update Exchange.php [bfdf53c941](https://github.com/ccxt/ccxt/commits/bfdf53c941c7ecc7853a69ddeb733a86c285c59d)
+*  3.0.98 [d83028c379](https://github.com/ccxt/ccxt/commits/d83028c379d27f6a3d94377c9ccd946b6ceda9f5)
+
+
+## 3.0.97 (2023-05-08)
+
+*  Fix build_ohlcvc with single trade [670590779e](https://github.com/ccxt/ccxt/commits/670590779ee3205bc3c24beae2b41d5c5028bde8)
+*  Fix javascript limit parameter [d3ceb23f64](https://github.com/ccxt/ccxt/commits/d3ceb23f64861652c24e75564af474f5c71c0f43)
+*  update buildohlcv [38965b3a95](https://github.com/ccxt/ccxt/commits/38965b3a951dc6fce032734a106c888146a8545e)
+*  revert js file [d9cd944e64](https://github.com/ccxt/ccxt/commits/d9cd944e64455718a792bf8cca67bcc982ff3588)
+*  fix: transpile python IndexType [b8c8efa672](https://github.com/ccxt/ccxt/commits/b8c8efa672e47da3aca6bf352bd9030823a89272)
+*  fix typo [bf18d63795](https://github.com/ccxt/ccxt/commits/bf18d63795a781902fbc2c92058387d6ffffae5f)
+*  fix(deribit): fix #17729 [2a5d61af37](https://github.com/ccxt/ccxt/commits/2a5d61af37235ca85f72bbbab2440685c68a4d39)
+*  3.0.97 [ab85336c0c](https://github.com/ccxt/ccxt/commits/ab85336c0c8afdc0e85fcd5cbc2a6972ce81653a)
+
+
+## 3.0.96 (2023-05-06)
+
+*  probit: add @see [d2a7843ad2](https://github.com/ccxt/ccxt/commits/d2a7843ad260ae0a5cf4370b1d6134d995640d77)
+*  conditional [a30d0c3196](https://github.com/ccxt/ccxt/commits/a30d0c3196e0637176e1fc0a326ca5933b15f66a)
+*  remove margin [a7db017d45](https://github.com/ccxt/ccxt/commits/a7db017d45180507e2eaaac2aafe48ca78623121)
+*  fix(bybit): USDC market orders v1 [820be62ebf](https://github.com/ccxt/ccxt/commits/820be62ebf929c84e49208315b68b36d695eff55)
+*  add missing await [f1fb77eed9](https://github.com/ccxt/ccxt/commits/f1fb77eed9d9a231fd1d072bd0c85116127af509)
+*  fix parseOrder [ed97d9b511](https://github.com/ccxt/ccxt/commits/ed97d9b5118cbd1bdfffd48d1faae74be30326d1)
+*  safeString bug [c0d632a887](https://github.com/ccxt/ccxt/commits/c0d632a88727ccf4a29bd38fe77e629e3e99f2f5)
+*  3.0.96 [2ac8b87c10](https://github.com/ccxt/ccxt/commits/2ac8b87c10f20d43bd69abace7783692a8019fc4)
+
+
+## 3.0.95 (2023-05-06)
+
+*  feat(xt): remove bigInt usage [f7e29983cd](https://github.com/ccxt/ccxt/commits/f7e29983cd91321ed2b9fbace8719e4b009cec01)
+*  fix(xt): php signing [780f453cd7](https://github.com/ccxt/ccxt/commits/780f453cd73abe6a7144c67318a0434b9152540d)
+*  fix another occurence [c58bdf603c](https://github.com/ccxt/ccxt/commits/c58bdf603c4172c3b88580914951a49299e8cf9c)
+*  3.0.95 [776809323d](https://github.com/ccxt/ccxt/commits/776809323d3ad485efc8a77a149ab4b2759a40e6)
+
+
+## 3.0.94 (2023-05-05)
+
+*  probit fetxhCurrencies fix [ae4afd1f71](https://github.com/ccxt/ccxt/commits/ae4afd1f71dc363107556917bb9d271681fb859a)
+*  bitget timeframes [cdc0b05f08](https://github.com/ccxt/ccxt/commits/cdc0b05f08922f318aa91c8b072efe552bba41b7)
+*  bitget timeframes UTC [29bf83c8b4](https://github.com/ccxt/ccxt/commits/29bf83c8b4f0083e0d8ddf15c9b78568e6200538)
+*  add currencies [d41b604d79](https://github.com/ccxt/ccxt/commits/d41b604d7925743f5f273fdd593bba5533490c88)
+*  add jsdoc [5f6343018b](https://github.com/ccxt/ccxt/commits/5f6343018bd1c5560ba153dcf3da474d0dd6ebd2)
+*  fix limit [a85860a69a](https://github.com/ccxt/ccxt/commits/a85860a69af26ff8e9b9a8469c5e1ec6b788bead)
+*  off by one [6026811c09](https://github.com/ccxt/ccxt/commits/6026811c09297b6bfde11941dac6dab393e953a3)
+*  fix since bug [5a16e7a759](https://github.com/ccxt/ccxt/commits/5a16e7a759c3928d07131b98354abe316d0534ef)
+*  fix loop [00e35cb877](https://github.com/ccxt/ccxt/commits/00e35cb877032f37bf872fac64ed22cf2334fe93)
+*  fix(whitebit): signing [08249c79b6](https://github.com/ccxt/ccxt/commits/08249c79b6a4680acf0da4f186aa2fc8ce10f6f1)
+*  3.0.94 [7a8ee5b846](https://github.com/ccxt/ccxt/commits/7a8ee5b84625b0d7ce1f11f89766b1b5304ed1dd)
+
+
+## 3.0.93 (2023-05-05)
+
+*  huobi fetchCurrencies fix [12f116a146](https://github.com/ccxt/ccxt/commits/12f116a1464238f05939c4ff2b1f6d8548f88f41)
+*  huobi linting [ee00e33b72](https://github.com/ccxt/ccxt/commits/ee00e33b723974cad164dad83876afee46a0dd00)
+*  bitmex better support for spot markets [f266a23ffa](https://github.com/ccxt/ccxt/commits/f266a23ffa3d2e8da8ed059de08d1bc7d29c9b17)
+*  bitmex spot build [dc60bede85](https://github.com/ccxt/ccxt/commits/dc60bede85eb523f5024255237f37666bb735696)
+*  bitmex spot build [6687302336](https://github.com/ccxt/ccxt/commits/668730233692d03e1a8a58b9d4df2e42407f057e)
+*  stex: add @see [216029e70e](https://github.com/ccxt/ccxt/commits/216029e70e609f8f8ef06fe69419a25bd4d0031d)
+*  3.0.93 [4f4a4d07c5](https://github.com/ccxt/ccxt/commits/4f4a4d07c55c1c2be2f5aa8327800e3613b476c3)
+
+
+## 3.0.92 (2023-05-04)
+
+*  bitget: add position v2 apis [4d8fe5c825](https://github.com/ccxt/ccxt/commits/4d8fe5c825dbfd68cf8bb249248fc802f7f63afe)
+*  binancne parseWsOrder add reduceOnly. fixes: #17604 [c86ad77d41](https://github.com/ccxt/ccxt/commits/c86ad77d4191b1fa444c9453a1642e4e4e477815)
+*  fix filterByLimit [c287cbbe7f](https://github.com/ccxt/ccxt/commits/c287cbbe7f434d06db96895fbabdc355e56cc46c)
+*  fix python version [50aee899cc](https://github.com/ccxt/ccxt/commits/50aee899cc1f7878c65e11b18f7f46d766db4a26)
+*  fix python syntax [9db20c184b](https://github.com/ccxt/ccxt/commits/9db20c184b84b7ceee10e67f9d67c678005c5b37)
+*  fix(XT): fix active market [610ef9d83b](https://github.com/ccxt/ccxt/commits/610ef9d83bc61964ecdc489c73e6fae161276e08)
+*  feat(Phemex): add USD support to fetchFundingRateHistory [6cf872ae3d](https://github.com/ccxt/ccxt/commits/6cf872ae3d53317ca266e17722cce833cc661c0a)
+*  feat: transpile filterBySinceLimit/Value [67e4500de0](https://github.com/ccxt/ccxt/commits/67e4500de01d1eb5a06cc00a86b00bf3f86fb261)
+*  fix python syntax [92aeb753d5](https://github.com/ccxt/ccxt/commits/92aeb753d5ead45d0016ea4584e2ef229e01ab73)
+*  fix(huobi): fetchOHLCV since/limit usage [7718c84e8e](https://github.com/ccxt/ccxt/commits/7718c84e8e3d13491182c630f459f2c6f4436ac8)
+*  build: disable btcmarkets [ci deploy] [62f6149059](https://github.com/ccxt/ccxt/commits/62f6149059398336e98b646e0c4ef7ac728a98ee)
+*  currencycom type [52fc4081cb](https://github.com/ccxt/ccxt/commits/52fc4081cb8701f01c0673459d8d562af7595a17)
+*  3.0.92 [b33e6a936d](https://github.com/ccxt/ccxt/commits/b33e6a936da0900cbee422ff1b6d52f9a079824b)
+
+
+## 3.0.91 (2023-05-04)
+
+*  feat(krakenfutures): websockets implementation [8968cc96af](https://github.com/ccxt/ccxt/commits/8968cc96afa34fc972563eba1c15965f779d31e5)
+*  krakenfutures sockets response comments [7a2c111ec7](https://github.com/ccxt/ccxt/commits/7a2c111ec7a54d64ad4063c31e53fc30c68bca75)
+*  krakenfutures fetchTicker & fetchTickers works [7972c9231b](https://github.com/ccxt/ccxt/commits/7972c9231b1dd323f62d46e477ce4f6eab08a63e)
+*  krakenfutures.watchTrades [993bdbf763](https://github.com/ccxt/ccxt/commits/993bdbf763f4d19518b771ee0e306bd2a588701b)
+*  krakenfutures handleOrderBook [eefc07dbdd](https://github.com/ccxt/ccxt/commits/eefc07dbdd3f849948dc8021ebd2da28dd80afb8)
+*  krakenfutures parseWsMyTrade [a24ec0d477](https://github.com/ccxt/ccxt/commits/a24ec0d4776d8a744d5c34ba77bb1d6652e8aedd)
+*  krakenfutures handleMyTrade [09eb912fc5](https://github.com/ccxt/ccxt/commits/09eb912fc55886d27984b8c11e498f373a93b626)
+*  krakenfutures parseWsOrder [0b839943e0](https://github.com/ccxt/ccxt/commits/0b839943e0c50814d12edcf1b3d8bf009af80e52)
+*  krakenfutures handleOrder [3e2db13968](https://github.com/ccxt/ccxt/commits/3e2db13968bcab67d0791ed51580ddf678ad9182)
+*  krakenfutures handleBalance [2809bdf1f8](https://github.com/ccxt/ccxt/commits/2809bdf1f89223672ff254d5bbc515d0708e34af)
+*  krakenfutures watchOrderBook fixes [82f9806e43](https://github.com/ccxt/ccxt/commits/82f9806e43394a96f8f1afcc88280a2c425d5feb)
+*  krakenfutures remove extra authenticate calls [e31f206dd9](https://github.com/ccxt/ccxt/commits/e31f206dd9103ce0c4ca17fddb7adf1535603583)
+*  krakenfutures authentication fixes [bbd57bace0](https://github.com/ccxt/ccxt/commits/bbd57bace09f469c86383df0803fa58ceb6ad877)
+*  krakenfutures update authentication [39e0ad6aba](https://github.com/ccxt/ccxt/commits/39e0ad6abaebfd2bb04351846580642f38fff5b9)
+*  krakenfutures update authentication [86e042593b](https://github.com/ccxt/ccxt/commits/86e042593baadf34fd4763135ddc6264aa174d91)
+*  krakenfutures: update authentication [dbeedc82fa](https://github.com/ccxt/ccxt/commits/dbeedc82fa5396b226e0dcd775010a5330c134c8)
+*  krakenfutures.pro: removed onPong [e15d7adae6](https://github.com/ccxt/ccxt/commits/e15d7adae6ddbbb1a6a5cd6d43dd6d268bbe04e8)
+*  krakenfutures watchOrders fix [ffcaecbaaf](https://github.com/ccxt/ccxt/commits/ffcaecbaafa4331223289cde9cfb831a5cceacd3)
+*  krakenfutures watchMyTrades fix [51dfeb2567](https://github.com/ccxt/ccxt/commits/51dfeb2567e5e4e9d71cda4d62540e60df2d123e)
+*  krakenfutures watchBalance fixes [4f1f8f70bb](https://github.com/ccxt/ccxt/commits/4f1f8f70bb732323e3a2de212aed2488f8c8fff1)
+*  removed any type definitions [84ef8a07a1](https://github.com/ccxt/ccxt/commits/84ef8a07a16b324ce71fb3410613fdbc415411eb)
+*  krakenfutures.pro minor change [4eac509e71](https://github.com/ccxt/ccxt/commits/4eac509e71749f2edc0e85bd2da093bcadffd5c7)
+*  krakenfutures.pro watchTicker method in options update [b2aa704bf0](https://github.com/ccxt/ccxt/commits/b2aa704bf0fdfb489cf5bc3ebb9f36eba658ac9c)
+*  krakenfutures update streaming.keepAlive [9ab53881bb](https://github.com/ccxt/ccxt/commits/9ab53881bbafa9e20d75a1d10e911b0ec878a26e)
+*  krakenfutures.pro subscribePrivate minor change for python [a7c5d7d430](https://github.com/ccxt/ccxt/commits/a7c5d7d43099bbedf4e786576f58901f9b560569)
+*  krakenfutures watchBalance argument type update [7512aff0b8](https://github.com/ccxt/ccxt/commits/7512aff0b8f1bbcb9d26f09ae08a298d934ea024)
+*  krakenfutures removed custom ping [bb3314513d](https://github.com/ccxt/ccxt/commits/bb3314513d8dac59ad8bc0207da0252491d1a7fc)
+*  fix multiple subscriptions [c5f1f8e790](https://github.com/ccxt/ccxt/commits/c5f1f8e790c5052f853c2e9472f7db96c83e9d69)
+*  add pro flag [e249ce59da](https://github.com/ccxt/ccxt/commits/e249ce59da47652c7b89945c3bec130ec1baf967)
+*  krakenfutures handleOrders only resolves if number of orders is > 1 [0b6fab45d3](https://github.com/ccxt/ccxt/commits/0b6fab45d3866af2d0a4c04fba012082117dd192)
+*  add test url [d873afb9c2](https://github.com/ccxt/ccxt/commits/d873afb9c20d9f201100f41637da7c4326c73310)
+*  Fix typo when creating postOnly order [219434be8f](https://github.com/ccxt/ccxt/commits/219434be8f06e12c9082ca9b6ae207a9f9dc4c60)
+*  add info [ccade9109f](https://github.com/ccxt/ccxt/commits/ccade9109f088cf1420b7833a405c816d8ef88f2)
+*  feat(binance): fetchCanceledOrders [ac565e3ae2](https://github.com/ccxt/ccxt/commits/ac565e3ae221b5cf018527582806c6323dc14200)
+*  huobi createOrder default stopOperator for stop orders [bf7e61bc9e](https://github.com/ccxt/ccxt/commits/bf7e61bc9e3138c0e9082e70a44eab42c8afbc07)
+*  align ascii [950fe0a914](https://github.com/ccxt/ccxt/commits/950fe0a9140391db3de5e76222db056c9eb9e6e3)
+*  one space [8e64bc80ee](https://github.com/ccxt/ccxt/commits/8e64bc80eedf16d9526dc0694b94981371a495cf)
+*  fix messageHash [1092518528](https://github.com/ccxt/ccxt/commits/109251852806ee4720fbb4611f1c9f4f8d31fb1d)
+*  use append instead of push [f7e7862957](https://github.com/ccxt/ccxt/commits/f7e7862957a45552163c3318fec4e0492eb91b4e)
+*  order and balances fixes [47e5d6bd99](https://github.com/ccxt/ccxt/commits/47e5d6bd996cf6f1c59db87133ec94738bff8efe)
+*  update keepAlive [7a96303768](https://github.com/ccxt/ccxt/commits/7a963037688c71556f762f6ae57550ca06295a01)
+*  CR fixes [c7106498a3](https://github.com/ccxt/ccxt/commits/c7106498a3ea816bbe702f748959f248b369563a)
+*  fix limit [40c7fe441e](https://github.com/ccxt/ccxt/commits/40c7fe441ef3d12543af25ba940521891f53e960)
+*  add handlePostOnly [f58ee3a1c0](https://github.com/ccxt/ccxt/commits/f58ee3a1c0dd0aa4740341759a112eb86336433f)
+*  Await transaction helper [7df1d74540](https://github.com/ccxt/ccxt/commits/7df1d7454018b1c8c22c1209eea1ad1822b6c5f5)
+*  fix build [90ac261d89](https://github.com/ccxt/ccxt/commits/90ac261d89e283e9d161d98ec3ec659bad304fc0)
+*  apply changes to TS [91a146fde5](https://github.com/ccxt/ccxt/commits/91a146fde534838a0f0dbf90188fed1a28485103)
+*  revert [d1fc37caf7](https://github.com/ccxt/ccxt/commits/d1fc37caf78cd96acf8a22cf0b387bf608a0651b)
+*  fix(binance): fetchCanceledOrders options support [ff87330285](https://github.com/ccxt/ccxt/commits/ff873302858343a318ba01697fee9b0dfd8e4496)
+*  bitget fetchOHLCV docstring @see [6bd390740a](https://github.com/ccxt/ccxt/commits/6bd390740a2e13a99b3e1ec17607e589f2b735be)
+*  3.0.91 [f53eaed881](https://github.com/ccxt/ccxt/commits/f53eaed881150cb3484b0c399cd7c0caf70477ac)
+
+
+## 3.0.90 (2023-05-03)
+
+*  ascii art change [b396ef0097](https://github.com/ccxt/ccxt/commits/b396ef009794f9ac832e579508fc5cd804a95944)
+*  3.0.90 [dd7e6181cc](https://github.com/ccxt/ccxt/commits/dd7e6181ccee085ef2ab3ca2e0aba1c050699509)
+
+
+## 3.0.89 (2023-05-02)
+
+*  Build: fix __init__ inside abstract/ [2b0e65e1f2](https://github.com/ccxt/ccxt/commits/2b0e65e1f2cc3efd206346241a4a2016e270fc36)
+*  3.0.89 [5f2c3e4219](https://github.com/ccxt/ccxt/commits/5f2c3e4219b6ff1013ec5410e7397cd3ea24d209)
+
+
+## 3.0.88 (2023-05-02)
+
+*  filterBySinceLimit and filterByValueSinceLimit both sort before filtering [62f7ace6d0](https://github.com/ccxt/ccxt/commits/62f7ace6d0c4ee3622d1368d38c09febfd6d3c20)
+*  filterBy.*Limit results in descending order [27411222be](https://github.com/ccxt/ccxt/commits/27411222be99cf91832b574c6e616fc7ef9f182b)
+*  filterBy.*Limit chooses order of to filter limit by based on the > values of first and last records timestamp value, tested filterByValueSinceLimit, which works [ba30d9e3d2](https://github.com/ccxt/ccxt/commits/ba30d9e3d23d799799de411de94a2675fa240b80)
+*  filterBy.*Limit removed tail argument [ffc43f7100](https://github.com/ccxt/ccxt/commits/ffc43f7100aec2c8285874d0f6b3a6977b865d9f)
+*  exchange.filterBy.*Limit checks array length > 0 [d5c56382a0](https://github.com/ccxt/ccxt/commits/d5c56382a08d648bbcd357f98b21ad429ad1021c)
+*  filterBy.*Limit: moved limit logic to its own method and filter by key instead of timestamp [0dc65b104b](https://github.com/ccxt/ccxt/commits/0dc65b104b36c63127a794a11eb03b6d6a92c4b3)
+*  Update huobi.ts [8791093453](https://github.com/ccxt/ccxt/commits/879109345305dad4a4a71f26b21aee48bf317e91)
+*  fix huobi linting [437dd14e36](https://github.com/ccxt/ccxt/commits/437dd14e36b4c08c05c550d6d359e5c005e99043)
+*  remove functools [86d10623a4](https://github.com/ccxt/ccxt/commits/86d10623a45fd6e4d1c9a51646bfdf25734bb99e)
+*  add init [48b38089a2](https://github.com/ccxt/ccxt/commits/48b38089a2d31450bc6ff9687c9495be06fe149e)
+*  3.0.88 [5800b15546](https://github.com/ccxt/ccxt/commits/5800b15546edf9b0f3ecead6e7edcfe249b9f1a3)
+
+
+## 3.0.87 (2023-05-02)
+
+*  fix strings [0fdc973f1e](https://github.com/ccxt/ccxt/commits/0fdc973f1e1a1d33b852aaa094fda587fe89dbd9)
+*  add networks key [61f979bc9f](https://github.com/ccxt/ccxt/commits/61f979bc9f271fa6b43ae74cc2ed4e2df30a190e)
+*  add files [45d3fdccf5](https://github.com/ccxt/ccxt/commits/45d3fdccf5d4887223f4c3179b887e37d177a5c9)
+*  add cost to python api definitions [fb138ac263](https://github.com/ccxt/ccxt/commits/fb138ac2632a410a7f1c2a154a43d60c55073407)
+*  minor edit to exchange.py [67d978db8f](https://github.com/ccxt/ccxt/commits/67d978db8f4237336eca51be102b22142e7cb4de)
+*  implement python method descriptor protocol [fed159dd09](https://github.com/ccxt/ccxt/commits/fed159dd098e95a2627ade22818a86118571c1ac)
+*  remove redundant context argument [4c689ad15d](https://github.com/ccxt/ccxt/commits/4c689ad15dc3949ec56522b8577c73b4fe6b45ef)
+*  create abstract directory [e9e1508bb8](https://github.com/ccxt/ccxt/commits/e9e1508bb8a67204e42b955c4e58c5a1837f769d)
+*  add cost to php definitions [3c23ee00b9](https://github.com/ccxt/ccxt/commits/3c23ee00b9edfc401364c9900f25a1d246b7ecf7)
+*  add cost to php definitions [1cb64eba42](https://github.com/ccxt/ccxt/commits/1cb64eba427aeb68a00eb921363e138594aa18b7)
+*  fix(kucoinfutures): adjust parseOrder cost [b7d78fe603](https://github.com/ccxt/ccxt/commits/b7d78fe60381dabd574fc830cb1bafed377ff4ba)
+*  bitget: add p2p apis [7e26e9af18](https://github.com/ccxt/ccxt/commits/7e26e9af18e4fca70bfbfda9c6ae39f930b90119)
+*  okx: add apis [20be62858c](https://github.com/ccxt/ccxt/commits/20be62858cafa3813c0f52a0d4d9bceb08b99dbe)
+*  add abstract files [ci deploy] [3524793962](https://github.com/ccxt/ccxt/commits/3524793962bf8acb3525cdfd3f8830885706fb3c)
+*  manually add those abstract files [ci deploy] [debec1220f](https://github.com/ccxt/ccxt/commits/debec1220f84378b06dfe3919e21a12c236a74f0)
+*  3.0.87 [23f6ce9dfa](https://github.com/ccxt/ccxt/commits/23f6ce9dfaaf94a3d490fb8f705c37dd2424a68e)
+
+
+## 3.0.86 (2023-05-01)
+
+*  feat(xt): add adjustForTimeDifference option [91f776b8bf](https://github.com/ccxt/ccxt/commits/91f776b8bffb201eff18ee036bac64cc424997b2)
+*  fix(phemex): fix market loading inside setPositionMode [0662fd5fa6](https://github.com/ccxt/ccxt/commits/0662fd5fa6cefc52b485b474b1f5e345d32d6fab)
+*  fix(xt): add adjustForTimeDifference inside options [9a0dd95b64](https://github.com/ccxt/ccxt/commits/9a0dd95b64b44e388cf625a6123116ed0e40dc07)
+*  ccxt.pro manual removed duplicate watchOrders, fixes: #17735 [2bfcfba5bd](https://github.com/ccxt/ccxt/commits/2bfcfba5bd51989bd91d18a9f5256a55bb29b63e)
+*  3.0.86 [389154615a](https://github.com/ccxt/ccxt/commits/389154615a47f2876154e22d9a1644a42ac53901)
+
+
+## 3.0.85 (2023-05-01)
+
+*  bithumb: use currency code rather than currency object [a20e21598d](https://github.com/ccxt/ccxt/commits/a20e21598d32fea5897e64c795365a98c27da44c)
+*  bitso: use currency rather than currency code for parseLedger () [6cea958260](https://github.com/ccxt/ccxt/commits/6cea958260e7b831e38069f37b68de34bc6fac9e)
+*  fix currency type annotation [93bd74589c](https://github.com/ccxt/ccxt/commits/93bd74589c55a8592e1374d528b6999e1e65e7ce)
+*  hitbtc: createDepositAddress () returns a DepositAddressResponse [173ced629a](https://github.com/ccxt/ccxt/commits/173ced629a4cfb0510d1fbd074ff67cd03a19072)
+*  3.0.85 [d88c1853d2](https://github.com/ccxt/ccxt/commits/d88c1853d230e04664cab99edf7c3a4a9791e169)
+
+
+## 3.0.84 (2023-04-30)
+
+*  kucoin parseOrder fix [13ce2b2033](https://github.com/ccxt/ccxt/commits/13ce2b2033f81bed128186dcfecf36a59d1170e6)
+*  lint fix [dcc45f932d](https://github.com/ccxt/ccxt/commits/dcc45f932dc8b95a02c4b61c32afe11bf10cc45a)
+*  Update zb.ts [da9304e741](https://github.com/ccxt/ccxt/commits/da9304e741096be92e599f18cac657e8cb4556e1)
+*  whitebit linear inverse [4d007dc732](https://github.com/ccxt/ccxt/commits/4d007dc732151a141ba1a90dfeb75f680ec1df72)
+*  whitebit [19ace461aa](https://github.com/ccxt/ccxt/commits/19ace461aa14119f27e652d189cfeba9464a19f4)
+*  chagne bybit to gate [1e46911334](https://github.com/ccxt/ccxt/commits/1e469113348bc7c5bef6a300c81a5c4dd8330f5a)
+*  revert [c39db2c60b](https://github.com/ccxt/ccxt/commits/c39db2c60b82f4376b21a9b2e210dcbae13952c3)
+*  zaif: add @see [0eb70a559b](https://github.com/ccxt/ccxt/commits/0eb70a559ba832c335997f356fa97882bf44e8ef)
+*  yobit: add @see [b9c28decb4](https://github.com/ccxt/ccxt/commits/b9c28decb49a4c299227f15f520fadbd5c0b7ab7)
+*  wazirx: add @see [b5f7553a6a](https://github.com/ccxt/ccxt/commits/b5f7553a6a05add33d1e91f7527ba7c1ef995f3f)
+*  tokocrypto: add @see [a917436842](https://github.com/ccxt/ccxt/commits/a91743684245fbaedd91f3e9cc27c324178aecaf)
+*  revert file [07929cdf17](https://github.com/ccxt/ccxt/commits/07929cdf17b14e76d0762fd2d82a8c2f7a50501b)
+*  fix status handling [6ff788bd80](https://github.com/ccxt/ccxt/commits/6ff788bd8065674777d8697555d7a456b8fcd417)
+*  fix(bitget): watchOrders multiple spot sub [4dc555213e](https://github.com/ccxt/ccxt/commits/4dc555213e441d4f0a22a3a8d5db96772407abdb)
+*  fix OrderType and OrderSide [db503145eb](https://github.com/ccxt/ccxt/commits/db503145ebdc1ada0961c97ff7daef42924202c7)
+*  huobi: safeCurrencyCode ()'s second argument is a Currency [5092e5650c](https://github.com/ccxt/ccxt/commits/5092e5650c72809ebb2546efdb95514555a71774)
+*  3.0.84 [3169e3b469](https://github.com/ccxt/ccxt/commits/3169e3b469c9724b919a4bf3ec18109d0607dccc)
+
+
+## 3.0.83 (2023-04-29)
+
+*  feat(binance): fetchPosition [2577cf6f3e](https://github.com/ccxt/ccxt/commits/2577cf6f3e476650bd1575872de25c8f2d52d314)
+*  add option support to fetchPositions [9634d116d3](https://github.com/ccxt/ccxt/commits/9634d116d3fb55474fbc8a8bb2f2e01d13d8c286)
+*  fix number of processes spawned close #17703 [7c6b2b7c51](https://github.com/ccxt/ccxt/commits/7c6b2b7c51efd403bb07fd720c3378e4628911c2)
+*  fix number of processes spawned close #17703 [e17dde6750](https://github.com/ccxt/ccxt/commits/e17dde6750b50bda33e99223f9456430d6ec154f)
+*  delist buda [a809853a07](https://github.com/ccxt/ccxt/commits/a809853a0796ec6695316ea9fb7b9b7d0ff463fe)
+*  delist flowbtc (now part of ndax) [2d6ed358e6](https://github.com/ccxt/ccxt/commits/2d6ed358e62e2f26b751b890e2027715e4d54ceb)
+*  certify xt [ab3d0d5db2](https://github.com/ccxt/ccxt/commits/ab3d0d5db22e7dde3fb96f4736af1eedfea515a9)
+*  delist ripio pro [d057f4ec04](https://github.com/ccxt/ccxt/commits/d057f4ec04654f79816776b3308a4b6c5603efa1)
+*  3.0.83 [2a2da061e5](https://github.com/ccxt/ccxt/commits/2a2da061e59242736d4b18b4080e7f4c3d4244f1)
+
+
+## 3.0.82 (2023-04-28)
+
+*  adjust sl/tp order responses [3d5e15024a](https://github.com/ccxt/ccxt/commits/3d5e15024a62fd1fa2e9b821afcd09da380de1ce)
+*  fix(phemex): watchOrders auth flow [5a53e1e91f](https://github.com/ccxt/ccxt/commits/5a53e1e91f4c33bf4c792ed8cbee90ab36f5cd1f)
+*  3.0.82 [4f0178838e](https://github.com/ccxt/ccxt/commits/4f0178838ec838c9431c682384fe8f1bfa71d177)
+
+
+## 3.0.81 (2023-04-28)
+
+*  [bybit] Fix watch_ticker messageHash to be consistent [2df89275fb](https://github.com/ccxt/ccxt/commits/2df89275fb7856b80e5d39c39c048863b40b811d)
+*  [base] .calculate_fee not to return quote currency when feeSide=base [956a916236](https://github.com/ccxt/ccxt/commits/956a91623655be210706c6c096ddcb2e82898f1b)
+*  woo: update watchOrders price & filled [0eec3b1d78](https://github.com/ccxt/ccxt/commits/0eec3b1d78e43fd5d6facf9f290865d7a382bf00)
+*  delist zb.com https://www.zb.com/help/notices/proclamation/1972 [a5d128f90b](https://github.com/ccxt/ccxt/commits/a5d128f90bada033992a383128149c6e8c507dbf)
+*  upbit: add @see [a3efcb1822](https://github.com/ccxt/ccxt/commits/a3efcb18223cd7365e8e5cd915719ff0ca9e6c92)
+*  minor edit to generateImplicitAPI [7d591c690b](https://github.com/ccxt/ccxt/commits/7d591c690b408008a2466895df11f17c01daa19d)
+*  zonda: add @see [07eceb375c](https://github.com/ccxt/ccxt/commits/07eceb375cde42d7ac0e915f21b92716b3251da0)
+*  Fix URLs for sandbox [b60d653b63](https://github.com/ccxt/ccxt/commits/b60d653b63cbe40e01693d1e84f954ac18dde2bc)
+*  add safeOrder [f4fb29eca6](https://github.com/ccxt/ccxt/commits/f4fb29eca6ce69bb5374aef4a2d9ac88c8a6ec4f)
+*  fix comment [301444ac31](https://github.com/ccxt/ccxt/commits/301444ac319508003d76be2a727781007bc63600)
+*  remove assingment [c5fdc520b5](https://github.com/ccxt/ccxt/commits/c5fdc520b506d25ffa2078be599bcbe163116c2d)
+*  chore: route bybit through eu proxy [62b2dbfe3b](https://github.com/ccxt/ccxt/commits/62b2dbfe3b5e2912147947bb67fb7447702d83cb)
+*  3.0.81 [87df05a853](https://github.com/ccxt/ccxt/commits/87df05a85333ade911201e7b5df6ccfcb7ea4d00)
+
+
+## 3.0.80 (2023-04-27)
+
+*  fix: import [b3e70eabdc](https://github.com/ccxt/ccxt/commits/b3e70eabdca735be8cdd4905856b215d8a6f0bad)
+*  fix(webpack): webworkers usage [bc63ad905c](https://github.com/ccxt/ccxt/commits/bc63ad905c5db0c1b3ff1ad62e3eabeb48126c3a)
+*  3.0.80 [7da46c41c0](https://github.com/ccxt/ccxt/commits/7da46c41c0c64636191dba90b761d3a3910651d2)
+
+
+## 3.0.79 (2023-04-27)
+
+*  yobit fix arr [28e80821ac](https://github.com/ccxt/ccxt/commits/28e80821ac8a460e635070d9005bed2f61cce798)
+*  length [f58069b79f](https://github.com/ccxt/ccxt/commits/f58069b79f0a11433f8a7e63b3728bb412401924)
+*  coinbasepro.fetchOHLCV limit behavior fix when since is not on a timeframe boundary [995b9becd2](https://github.com/ccxt/ccxt/commits/995b9becd2c9e1351b0b04c6abcbe9b126e4ea47)
+*  mexc:add createDepositAddress [d13f0746f0](https://github.com/ccxt/ccxt/commits/d13f0746f043697156f7899a89155f85c198e807)
+*  poloniex error mapping [e00f1b5005](https://github.com/ccxt/ccxt/commits/e00f1b50051d6c21d40d21d6e602aee5f9656c2c)
+*  Fix TypeScript emitting updated types into Exchange.d.ts. [c1e766101c](https://github.com/ccxt/ccxt/commits/c1e766101c1540da5c8ab97a6b50e68c2917aab9)
+*  add image to appveyor [492de46fe1](https://github.com/ccxt/ccxt/commits/492de46fe1da4b7eaa3c14df9a9b5773de232a63)
+*  mexc:update has createDepositAddress [6053fcf122](https://github.com/ccxt/ccxt/commits/6053fcf1220fea71ffbc0b26fd1dca060a96f6b0)
+*  mexc:createDepositAddress&fetchDepositAddressesByNetwork add networkCode [c92b1a09aa](https://github.com/ccxt/ccxt/commits/c92b1a09aa9d8929bd0bd0ef3ac1545c6f22c134)
+*  required network argument [77bb962799](https://github.com/ccxt/ccxt/commits/77bb962799a6158466e2f476a7bf8c250f7786b2)
+*  fix ts emitTypes [fa59f73e93](https://github.com/ccxt/ccxt/commits/fa59f73e93c03967c150d5fb91b8d741fdf91fd7)
+*  fix(deribit): duplicated spot markets [ff58bd3871](https://github.com/ccxt/ccxt/commits/ff58bd387127eeac4f57f65ec328b01b79cd2477)
+*  revert [1d905744e0](https://github.com/ccxt/ccxt/commits/1d905744e0f209ab770a9205a94b4af51a90cc11)
+*  fix constant [410cbdc688](https://github.com/ccxt/ccxt/commits/410cbdc688d1a5bda91e180b42d7855778413d8d)
+*  specifically one test [eaa44c0741](https://github.com/ccxt/ccxt/commits/eaa44c0741ee1fee855dcf68332f2ae60acccc36)
+*  3.0.79 [9ca600c294](https://github.com/ccxt/ccxt/commits/9ca600c2943b8a74a6809323f12f2e805f719869)
+
+
+## 3.0.78 (2023-04-26)
+
+*  okx fetchCurrencies fix [bd5ac3611a](https://github.com/ccxt/ccxt/commits/bd5ac3611adbed8a20bf35146ff260829d0c9c20)
+*  3.0.78 [7d4d8d1130](https://github.com/ccxt/ccxt/commits/7d4d8d113059b384466d5649396ce1bfdb9e4ceb)
+
+
+## 3.0.77 (2023-04-25)
+
+*  phemex fetchTickers [8d6dee6e6f](https://github.com/ccxt/ccxt/commits/8d6dee6e6f3b5ed0745af19659003531c7d11eab)
+*  fix(ascendex): ascendex.fetchClosedOrders v2, fixes #17639 [6fe0aec274](https://github.com/ccxt/ccxt/commits/6fe0aec274f267bb4729d2832191665f3cb23973)
+*  feat(binance): add option support to transfer [2f7a4522af](https://github.com/ccxt/ccxt/commits/2f7a4522afa4cadd41c61d32dac4fd9c07f29e49)
+*  cr fixes [b80c0dbd2d](https://github.com/ccxt/ccxt/commits/b80c0dbd2d164e38811e6fe5acdeb73140789774)
+*  disable btctradeua [e2f56158fc](https://github.com/ccxt/ccxt/commits/e2f56158fc58cf4356d6b77d4af46b05974ba439)
+*  3.0.77 [5bf607fd25](https://github.com/ccxt/ccxt/commits/5bf607fd250a5d0398faa11b9d2cc2e6280b01b2)
+
+
+## 3.0.76 (2023-04-24)
+
+*  fix(bigone): fetchBalance [07ff6e6ad9](https://github.com/ccxt/ccxt/commits/07ff6e6ad98a28d9698af3f57cc9c48d6c3a30e4)
+*  fix(bybit): fetchPositions USDC [50eb47ab36](https://github.com/ccxt/ccxt/commits/50eb47ab36dd29f3a20d5cd68914828df7568c56)
+*  feat(Deribit): add spot markets [d561ecffb0](https://github.com/ccxt/ccxt/commits/d561ecffb0e7f4ca894a6285f0aa1c3d2c097dcc)
+*  3.0.76 [38e52d3588](https://github.com/ccxt/ccxt/commits/38e52d35880026b8fd55a36882af94682b47454a)
+
+
+## 3.0.75 (2023-04-23)
+
+*  test cleanup [393672f108](https://github.com/ccxt/ccxt/commits/393672f108213eb75a4b1489de76a5572492a588)
+*  error dir [766bb96c75](https://github.com/ccxt/ccxt/commits/766bb96c758af98059a1b178d7b770f46f1bf95c)
+*  js move [26906c0dc5](https://github.com/ccxt/ccxt/commits/26906c0dc50cc0abcd154fe1854e5cf2244dd848)
+*  ledger fixes [506b9cde45](https://github.com/ccxt/ccxt/commits/506b9cde4594dd06caf5e2fc2e808131abb6ec7f)
+*  different changes across langs [71ffb6f335](https://github.com/ccxt/ccxt/commits/71ffb6f3357c3e90e0119eab3f31c2511d41eeaa)
+*  php & js tests [f404d90880](https://github.com/ccxt/ccxt/commits/f404d90880d1ae463d9ff2ce7b4ad7aad1b217e3)
+*  test py/php/js [6066bec8d4](https://github.com/ccxt/ccxt/commits/6066bec8d498bb9efb097fd2a67657f7ef25cb87)
+*  py & php [a4cc995fa5](https://github.com/ccxt/ccxt/commits/a4cc995fa5c4ddf633f91f5435c1dac0f5a6bcb3)
+*  final touches to tests [0634d82964](https://github.com/ccxt/ccxt/commits/0634d829643cf89eae2afd3b5416feefb21ba3a5)
+*  test updates [b0378b2923](https://github.com/ccxt/ccxt/commits/b0378b2923bbbfba09eca8341a34c680f90ba0e4)
+*  py/php [6d344596cb](https://github.com/ccxt/ccxt/commits/6d344596cba7a31828d025e76a401db4f36ea3e9)
+*  fix lint [6378841ca2](https://github.com/ccxt/ccxt/commits/6378841ca220fc32a596cb0d1c4b50bd3a45f0ff)
+*  cli args as members [5b05f45f39](https://github.com/ccxt/ccxt/commits/5b05f45f3979563bd3a1cfce3fa5c7c878bc7311)
+*  cli args rename [b349744ee1](https://github.com/ccxt/ccxt/commits/b349744ee1b20b6dfa48281b1f6dc238fb6d48a0)
+*  py whitespaces fix [ab04baf3de](https://github.com/ccxt/ccxt/commits/ab04baf3de5a0dd44929683e17318a58100eefb4)
+*  ts fixes [1307328c5e](https://github.com/ccxt/ccxt/commits/1307328c5ef7c0d1c71889cf07c383041503bdee)
+*  add info [d30ac851d1](https://github.com/ccxt/ccxt/commits/d30ac851d1f605948e4be739ffb21c17d8770edc)
+*  make eslint work [d6fe424ba3](https://github.com/ccxt/ccxt/commits/d6fe424ba321e7534ff01ad7a339a30ec881162f)
+*  rename method [48e1ac345d](https://github.com/ccxt/ccxt/commits/48e1ac345d09e6a8907e677004a1841aeecad795)
+*  fix transpilation [80b0b559ee](https://github.com/ccxt/ccxt/commits/80b0b559ee913ffc6f821f483c1fa8d541ed12bd)
+*  add exchange.close [ed5447662f](https://github.com/ccxt/ccxt/commits/ed5447662f8e8834de6e0814f7abe1df979c1181)
+*  add close [7bc1bd4b49](https://github.com/ccxt/ccxt/commits/7bc1bd4b495e592dedcf8f9f908262141afe9713)
+*  lint [20c3009e65](https://github.com/ccxt/ccxt/commits/20c3009e6594a8a7a7d49b524924a51442fc610c)
+*  yobit url length [a62a6636b4](https://github.com/ccxt/ccxt/commits/a62a6636b40ae88c83bc893511192fe42b68c6f4)
+*  remove reason from RT [6da71e2266](https://github.com/ccxt/ccxt/commits/6da71e2266aa8a8474e40880e079c531279c3fcc)
+*  feat(phemex): add fetchFundingRateHistory [1876ec8313](https://github.com/ccxt/ccxt/commits/1876ec8313fe78a3a96a0ceb3e5647c734043b77)
+*  add flag [fdc2b20eb2](https://github.com/ccxt/ccxt/commits/fdc2b20eb2cb1c47c07b1c71f44090e212cdd3a6)
+*  fix extend [26d7428fe2](https://github.com/ccxt/ccxt/commits/26d7428fe2ec5dbb68cbd7fd21b5cd7dbf7ab7b8)
+*  value set [c2a0533c27](https://github.com/ccxt/ccxt/commits/c2a0533c27fd77b267590411a1002b752f3da847)
+*  fix(gemini): pro authenticate [5ee45dd7df](https://github.com/ccxt/ccxt/commits/5ee45dd7df53aa6b29d16678a545246cb5731c93)
+*  chore: remove changes from wrong file [3ed5dd3ae8](https://github.com/ccxt/ccxt/commits/3ed5dd3ae8e38f47e08cb3efe5f7b4d7955ff21d)
+*  chore: add changes to correct file [793db9563b](https://github.com/ccxt/ccxt/commits/793db9563b660ef97566d4cfc2f26d7eff3db239)
+*  chore: update comment [585b4844df](https://github.com/ccxt/ccxt/commits/585b4844df155e85395cbc43e09d781569350d8e)
+*  chore: add missing import [f5d5a0d4b6](https://github.com/ccxt/ccxt/commits/f5d5a0d4b69f70f301af8964cee0704fde0e0c69)
+*  fix test: protect access [156285dc23](https://github.com/ccxt/ccxt/commits/156285dc236f931ebeac1b53b533c5de2848db46)
+*  3.0.75 [03bff55039](https://github.com/ccxt/ccxt/commits/03bff55039974084eba3f18de79ecfb996b5bc53)
+
+
+## 3.0.74 (2023-04-21)
+
+*  fix: ws client send [4464bc8877](https://github.com/ccxt/ccxt/commits/4464bc88773666dedb892498ec821bc64fae91eb)
+*  python: fix urlencode bug #17550 [eabdfaf43b](https://github.com/ccxt/ccxt/commits/eabdfaf43be552248e7cc67d65acc605f098c15c)
+*  remove unnecessary line [08e31c0a18](https://github.com/ccxt/ccxt/commits/08e31c0a18175cd0a7762fb6fe456b2cb729f662)
+*  poloniex parseTransaction unification [0d3aa2f59e](https://github.com/ccxt/ccxt/commits/0d3aa2f59eef23fd613240e39315a6c3ca4ea622)
+*  novadax parseTransaction unification [e8149dc5c7](https://github.com/ccxt/ccxt/commits/e8149dc5c72dac91ff06c4e9b519191c131e850d)
+*  Fix watch_order_book bug on testnet spot [509a73b1a4](https://github.com/ccxt/ccxt/commits/509a73b1a4e1582b23e53abae3e9d0371bc11121)
+*  Transpiler compatible [3ab7cb2536](https://github.com/ccxt/ccxt/commits/3ab7cb253602df448e34e362153207ef957fec5e)
+*  Transpiler compatible (blank line) [5733ffc505](https://github.com/ccxt/ccxt/commits/5733ffc5059c3fd34b6c60be3ea770d3897d7e50)
+*  gate.io promo [955fd2503d](https://github.com/ccxt/ccxt/commits/955fd2503da9bf88715bb0b7bbf396ab3fa24c8a)
+*  gate.io promo [00de51d5ce](https://github.com/ccxt/ccxt/commits/00de51d5cee0c16da0547e1a2d508a89223429c9)
+*  review [3f762dcef7](https://github.com/ccxt/ccxt/commits/3f762dcef7aa85fad1ab2bed78bed399bb171d40)
+*  fix(phemex): fetchOHLCV [a0917fdbed](https://github.com/ccxt/ccxt/commits/a0917fdbed6e7093227445d976a8dc941ef526ec)
+*  fix incorrect content in dist/cjs/package.json [ed1d9c77bc](https://github.com/ccxt/ccxt/commits/ed1d9c77bc5e89f171a30c503d343131760144a8)
+*  add await to watch [499b3adc18](https://github.com/ccxt/ccxt/commits/499b3adc18b7b76b53d56e62f5822e2101223b4f)
+*  3.0.74 [89b3c2a9a2](https://github.com/ccxt/ccxt/commits/89b3c2a9a23a2a1b70b00fdd202692c7eeb800ce)
+
+
+## 3.0.73 (2023-04-20)
+
+*  gate add methods to has [f678df7987](https://github.com/ccxt/ccxt/commits/f678df7987dbbee5046fa3d3bc5d9b57ff4863fa)
+*  bitmart: patch parseInt [af890bf535](https://github.com/ccxt/ccxt/commits/af890bf535b0ee0299e2d404942ace3ce7e0e34a)
+*  woo parseTransaction unification [17301722d1](https://github.com/ccxt/ccxt/commits/17301722d12b29e808d575d7b15a4d4b85dcd424)
+*  3.0.73 [12bc081af0](https://github.com/ccxt/ccxt/commits/12bc081af0f3b5844d14b7e3af987eb9054511e9)
+
+
+## 3.0.72 (2023-04-19)
+
+*  feat(bitget): change fetchOpenInterest error type [026e199bf9](https://github.com/ccxt/ccxt/commits/026e199bf96cca54c3b367ab8031a81c83ad8cc9)
+*  hollaex: patch parseInt ccxt/ccxt#17597 [200b4c09d7](https://github.com/ccxt/ccxt/commits/200b4c09d76c0a647454187edd6cff039157d49c)
+*  bittrex: patch parseInt [0d0c883496](https://github.com/ccxt/ccxt/commits/0d0c8834969012ae3dbfe4eb64da0a0cf1709b96)
+*  ndax: patch parseInt [e05ea1f8dd](https://github.com/ccxt/ccxt/commits/e05ea1f8dd801143294fddbf07d58a10b31ac2d4)
+*  3.0.72 [03c427fb58](https://github.com/ccxt/ccxt/commits/03c427fb5872944306d2cab6079054ca8b0c0913)
+
+
+## 3.0.71 (2023-04-18)
+
+*  update args [69453031f6](https://github.com/ccxt/ccxt/commits/69453031f64b97312d660e9cf2f948e912637c9e)
+*  py/php test transpile [1977f4181d](https://github.com/ccxt/ccxt/commits/1977f4181d0c753828acdf8b3c4d13041fec7705)
+*  php update [7617839358](https://github.com/ccxt/ccxt/commits/76178393588de36b20e825200842b798e1e3730a)
+*  test  update [4e15e5d84f](https://github.com/ccxt/ccxt/commits/4e15e5d84f432d8228243e8c5c6dec1221f69b53)
+*  update for php [e6b3ef50f6](https://github.com/ccxt/ccxt/commits/e6b3ef50f68c1f67ad66053c64f2a77679fdd7e8)
+*  python rebuild [9c52d50977](https://github.com/ccxt/ccxt/commits/9c52d50977ef18a0fd380e31369a400a7802a4f3)
+*  py & php [e02e14c6d7](https://github.com/ccxt/ccxt/commits/e02e14c6d78bf78a74e5dc6498b1ccd0aec01ab5)
+*  transpiler update [28ed440dfc](https://github.com/ccxt/ccxt/commits/28ed440dfc24193f30b5a358e205824b19add9b1)
+*  return [9db8a8d78d](https://github.com/ccxt/ccxt/commits/9db8a8d78dada639ad6cbb4936568f2f34043fe4)
+*  return [745ca38663](https://github.com/ccxt/ccxt/commits/745ca38663b62b5894d967f009a4e4b3942c05d8)
+*  return [81f22526dd](https://github.com/ccxt/ccxt/commits/81f22526dd4e742233a7dcd9d75eb065c539e21c)
+*  fix syntaxes [a459d699da](https://github.com/ccxt/ccxt/commits/a459d699da79698114e6bd17f82d1d5abb4652ee)
+*  fixes [3b36369456](https://github.com/ccxt/ccxt/commits/3b363694567ea700d879c4f5c703e4cb7999505a)
+*  fixes [81e49fa78c](https://github.com/ccxt/ccxt/commits/81e49fa78c34f7fbac0b7b382f7c30d8e1f90868)
+*  fixes [321749e502](https://github.com/ccxt/ccxt/commits/321749e502f432c44473f429a4901a96708d84ea)
+*  updates [54cf966a96](https://github.com/ccxt/ccxt/commits/54cf966a9666ab38e7006433be7c209092974db2)
+*  fix all issues & corrected imports in py/php [f8874af74b](https://github.com/ccxt/ccxt/commits/f8874af74b279cd4ab24f8666201acc39bd7cef0)
+*  php update [26a02a05e2](https://github.com/ccxt/ccxt/commits/26a02a05e2671f611ec19440457b1c43ed2af2c8)
+*  fix py [b42b710699](https://github.com/ccxt/ccxt/commits/b42b7106994172e3c86a0dfae046ee2d3a96d8ae)
+*  syntax [4f4069e134](https://github.com/ccxt/ccxt/commits/4f4069e134efe9b94391c9cdb3a63785afe1656d)
+*  fix array/object [dac2ae0497](https://github.com/ccxt/ccxt/commits/dac2ae0497892b85e0ed8dbbc53dd82d01949169)
+*  removal of info check [f5f68d39c6](https://github.com/ccxt/ccxt/commits/f5f68d39c651703c124ac62d3c034f5424bc2dec)
+*  info test removal [7cac2f290b](https://github.com/ccxt/ccxt/commits/7cac2f290b8f43eb0ece82a4a294ad4625f0e5e9)
+*  fix assert [24a0ce0f33](https://github.com/ccxt/ccxt/commits/24a0ce0f3360af41f096a030fe1f15c4790930ca)
+*  comment [a09a892b30](https://github.com/ccxt/ccxt/commits/a09a892b3069007eedf16f325c7552ca33a71410)
+*  variable name [7dbe6978a6](https://github.com/ccxt/ccxt/commits/7dbe6978a62aa0a7a009efd6f59aa2a244c5fd56)
+*  fix php [c7e43420bf](https://github.com/ccxt/ccxt/commits/c7e43420bfb54395b77d93c573226ee9ca732f6c)
+*  fix array in [a6f59991df](https://github.com/ccxt/ccxt/commits/a6f59991df17a8e2781b6abf8aa89af51ba93a65)
+*  fix string ts [85fab379d5](https://github.com/ccxt/ccxt/commits/85fab379d547a35bce4c7c43a98287245faa768d)
+*  revert [199f5ba7a0](https://github.com/ccxt/ccxt/commits/199f5ba7a0a4d21a5e50deb736386e69d01516b2)
+*  updates [6029e62621](https://github.com/ccxt/ccxt/commits/6029e626214529e7ab15578cb90d8201e221ef5c)
+*  fix unused imports [620711f7de](https://github.com/ccxt/ccxt/commits/620711f7dec756561ccbe35d7f62dcf94ce248af)
+*  revert [ac8ad8ce7d](https://github.com/ccxt/ccxt/commits/ac8ad8ce7d73a03e00269c80c094fc9091fa8f70)
+*  revert [40fe312d1b](https://github.com/ccxt/ccxt/commits/40fe312d1bc23dedeb4e242cd1ecec06ccfce621)
+*  merge master [c5a33d7134](https://github.com/ccxt/ccxt/commits/c5a33d7134757c4db1976955f6739f9bd049db71)
+*  change required & base methods [772d8d8b5e](https://github.com/ccxt/ccxt/commits/772d8d8b5e7dc90e89ba966657b23f9d99db9e79)
+*  # Conflicts: #	js/test/test.js [6adc72247d](https://github.com/ccxt/ccxt/commits/6adc72247de38c7a4a52e7e1faa2ab9ee9ef2d66)
+*  merge master [c887fc8f2c](https://github.com/ccxt/ccxt/commits/c887fc8f2c3d03948dba5756caed8f595fbf1cdc)
+*  temp python update [946d14ba3a](https://github.com/ccxt/ccxt/commits/946d14ba3abb1c9fdf2bfddc8e2ba15ebf4535dc)
+*  feat(phemex):websockets support USDT using hedged perpetual API, fix #16909 [086f9ae3fe](https://github.com/ccxt/ccxt/commits/086f9ae3fedd5f18813ae2312c2447ca40a33090)
+*  python completed async [9d56cf7f02](https://github.com/ccxt/ccxt/commits/9d56cf7f02148939a28a8e9f0606a63a3c191709)
+*  python complete async & sync [b434b1a44b](https://github.com/ccxt/ccxt/commits/b434b1a44b64a982da4755d5c0d90d3d192f673a)
+*  fix transpile [9e4bba8654](https://github.com/ccxt/ccxt/commits/9e4bba86542f55ba7a106d4bd84287e7df65c369)
+*  fix php lint [9546245f6d](https://github.com/ccxt/ccxt/commits/9546245f6d346b5aaa74228d1229c1c78525bf46)
+*  update py & js & php [6a47206c8e](https://github.com/ccxt/ccxt/commits/6a47206c8efa34b4ea5b01cf5d32be87cac25e15)
+*  php fixes [ed1b99bc44](https://github.com/ccxt/ccxt/commits/ed1b99bc445c07034bc51a2d7c25772562caed76)
+*  fix all [1220b5f772](https://github.com/ccxt/ccxt/commits/1220b5f772a87377ac7797fd59273e119fac56c5)
+*  comment [0bdd9d49cb](https://github.com/ccxt/ccxt/commits/0bdd9d49cb4288c92f54fbdb9eeb299d8def372a)
+*  rename [03b2f129b7](https://github.com/ccxt/ccxt/commits/03b2f129b71234676abb6b8ee2220f5a575764b3)
+*  orderbook [aeeeeb9839](https://github.com/ccxt/ccxt/commits/aeeeeb98399cd9e8ab4539812bc66332e3d27492)
+*  minor [02ff34af5d](https://github.com/ccxt/ccxt/commits/02ff34af5d802517b89fe972191504776c66879e)
+*  without module, builds fail [ea58ca285b](https://github.com/ccxt/ccxt/commits/ea58ca285b150b6dfbf3c0ae8e84dfd8ea7c3fed)
+*  qa & transpiler [89b435b432](https://github.com/ccxt/ccxt/commits/89b435b4328a003a14bfbbbe463187375c8244c0)
+*  revert [3dcd05a892](https://github.com/ccxt/ccxt/commits/3dcd05a89278d72f7b7b6841ac067b50f99ea756)
+*  assert fix [c82c70ba4e](https://github.com/ccxt/ccxt/commits/c82c70ba4e375e721a1d296e71a328328ed38c3d)
+*  vwap high [b0c686bcae](https://github.com/ccxt/ccxt/commits/b0c686bcae956e0ceb625af9f273a7efb1a0e55d)
+*  fix [563c4ca261](https://github.com/ccxt/ccxt/commits/563c4ca2613bdc46b04b9f74bf01d25f9dec297f)
+*  updates [ce5e279c68](https://github.com/ccxt/ccxt/commits/ce5e279c686e769149fd8e63e7227a56b2c44c87)
+*  tests updates [2fe848ae9b](https://github.com/ccxt/ccxt/commits/2fe848ae9b53225d4e3995f370b20f0a571cb9f7)
+*  binance  added [138502c3d4](https://github.com/ccxt/ccxt/commits/138502c3d40f213511fb43be1ed09d0aae091779)
+*  fix error import [02e19637a9](https://github.com/ccxt/ccxt/commits/02e19637a943834dd6ece487a7fc993e0a8988b7)
+*  add extra config [62f8cd0a29](https://github.com/ccxt/ccxt/commits/62f8cd0a2921821fa01c6bd8bea1b962a61236a9)
+*  add node threads to transpile tests [4f69274bbf](https://github.com/ccxt/ccxt/commits/4f69274bbfa3e4393fdda4e121ad636f176733e9)
+*  lint [4874e972bd](https://github.com/ccxt/ccxt/commits/4874e972bdb2e2b9691842cdfc5f45544946c358)
+*  update [98e2bf3d95](https://github.com/ccxt/ccxt/commits/98e2bf3d95f61351f55116e0334d2d95acb36618)
+*  using thread pool [75ea149f72](https://github.com/ccxt/ccxt/commits/75ea149f72059f38289edb833d5f8bcf99a192ab)
+*  update package lock [02ba412ff6](https://github.com/ccxt/ccxt/commits/02ba412ff627714826cdc88527397fa413ccc3e6)
+*  minor keys update [196d9ede74](https://github.com/ccxt/ccxt/commits/196d9ede7427c47851a95757727cf41af027d8e8)
+*  rename [1e2fc24396](https://github.com/ccxt/ccxt/commits/1e2fc24396083da630f6f5b067e32cb1d5caf011)
+*  fix lint & qa checks [7e659bc1b9](https://github.com/ccxt/ccxt/commits/7e659bc1b969e6207aee2321dc44f75ec60692e0)
+*  fix fetchCurrencies syntax [434ca3cbf2](https://github.com/ccxt/ccxt/commits/434ca3cbf2110187b5c9af00a320f93ac0341571)
+*  lint [d9739aca2a](https://github.com/ccxt/ccxt/commits/d9739aca2a9fd7433aef235a5d94ecbcc5feb3f7)
+*  update tests names [afc07255ed](https://github.com/ccxt/ccxt/commits/afc07255ed273e2b671905d44af2da6024eb867a)
+*  fix markets var [faeeaaa6e4](https://github.com/ccxt/ccxt/commits/faeeaaa6e4f3f16b0503691bcb82b81b404e5ad9)
+*  bitmex & markets [3bbc8128ee](https://github.com/ccxt/ccxt/commits/3bbc8128ee1744eb8767e04fad650c0cce23bed7)
+*  correct json [7db4a0fe88](https://github.com/ccxt/ccxt/commits/7db4a0fe88a201e3e94728129491414fdd67cdef)
+*  minor [f73094b25f](https://github.com/ccxt/ccxt/commits/f73094b25f23c26e0d2fff636bb4e04d70f65edb)
+*  merge master [6420203f95](https://github.com/ccxt/ccxt/commits/6420203f9590322f909e36cdc0c73ea96e252dd1)
+*  update into TS [b90d317f71](https://github.com/ccxt/ccxt/commits/b90d317f71a83316f7c02baf1b41910c83bcc423)
+*  move [43169047e3](https://github.com/ccxt/ccxt/commits/43169047e3c116e2cf763126f48a31bcf8ebc4f0)
+*  add files [3dd910015d](https://github.com/ccxt/ccxt/commits/3dd910015d4966ce1b2e1bebd9ce95b808d2f7df)
+*  updates [a2cd990007](https://github.com/ccxt/ccxt/commits/a2cd990007d631156097cf4ee6eee70e04bef02d)
+*  renamed vars [7e49ab50ac](https://github.com/ccxt/ccxt/commits/7e49ab50ac049a95b6bbbcd8a422e41b9f1db36a)
+*  tranpiler [ef47dd87a6](https://github.com/ccxt/ccxt/commits/ef47dd87a63d85382661b36789b3883cc17ea6ef)
+*  minor [603a48a96d](https://github.com/ccxt/ccxt/commits/603a48a96d6ce9019a0f5a4d2d4df988cf759f30)
+*  minor [54dd109ba1](https://github.com/ccxt/ccxt/commits/54dd109ba16bde99cd6b221bab80bd2dcd4741ab)
+*  revert [0fff3d61d5](https://github.com/ccxt/ccxt/commits/0fff3d61d5ecbd84b74f8463fff74582a296aab9)
+*  url [947198f66a](https://github.com/ccxt/ccxt/commits/947198f66aaf579fce8ad7042a9dd95877ed6c59)
+*  fix types [f0e2ca5790](https://github.com/ccxt/ccxt/commits/f0e2ca5790525b12e9f5a1cd9b1b13d819baac77)
+*  several fixes [9e08a83750](https://github.com/ccxt/ccxt/commits/9e08a837507160432efcbb455992969973474c54)
+*  remove extra [f0a0922ced](https://github.com/ccxt/ccxt/commits/f0a0922cedf92a70696e76780b1c6ec04de5ed24)
+*  preciseNs [8a5f16120c](https://github.com/ccxt/ccxt/commits/8a5f16120c75e1e5289453f68825113a5b7f8113)
+*  fix import [914fde7988](https://github.com/ccxt/ccxt/commits/914fde79884fe0fc01de9516bb454d295bb347dc)
+*  import & cjs fixes [ea73502b48](https://github.com/ccxt/ccxt/commits/ea73502b48e308ca9deea58c80468cc5b50ae7e3)
+*  errorshierarchy fixes [43ee858f60](https://github.com/ccxt/ccxt/commits/43ee858f60a287f0b7e097ca442fdc3360172fbd)
+*  final test polishing [762047c5db](https://github.com/ccxt/ccxt/commits/762047c5db28d602c1d96fb3ab987d520751d99d)
+*  filenames fix [ca4e44d5eb](https://github.com/ccxt/ccxt/commits/ca4e44d5eba6345b6b363f9f617c946eac5a3d60)
+*  ts edits & transpiler [812c9880a2](https://github.com/ccxt/ccxt/commits/812c9880a2232691c3bd09740bb8d9fe289230cc)
+*  revert [172684d3e5](https://github.com/ccxt/ccxt/commits/172684d3e5752345e028eb5d9e658ce949b73308)
+*  replace var with method name [529a1f5ae4](https://github.com/ccxt/ccxt/commits/529a1f5ae4675a56eb3c46717a7ee83731ca0892)
+*  remove temp folders [4875a44a7f](https://github.com/ccxt/ccxt/commits/4875a44a7f4774f2ee101d50f1369b816e742943)
+*  fix & add [e4509ddb5a](https://github.com/ccxt/ccxt/commits/e4509ddb5a1b82daac037196c1baa91fe36d4e74)
+*  file path fix [5550ba6a23](https://github.com/ccxt/ccxt/commits/5550ba6a2337cc3f4eda9fc7ee051931c0bfe20f)
+*  fix ts [445e2a5814](https://github.com/ccxt/ccxt/commits/445e2a581409e64453e19ca6d4ac61da5cc53a27)
+*  PRO js fix [99d86d5bbf](https://github.com/ccxt/ccxt/commits/99d86d5bbf4f84ae81847699bee1fbec77130295)
+*  fix module error [2a1e7328e6](https://github.com/ccxt/ccxt/commits/2a1e7328e69c691153d405bfdd7510d26daed7a5)
+*  fix import [9a51b69a5f](https://github.com/ccxt/ccxt/commits/9a51b69a5f441169e8b8461b35e71ecd515ce743)
+*  Delete test_shared_methods.py [9efe7617b6](https://github.com/ccxt/ccxt/commits/9efe7617b691276558a3649d1533a63822aa4464)
+*  fix python imports & transpiler [b34e39c999](https://github.com/ccxt/ccxt/commits/b34e39c9992c08c1aeaa969b7aea3ae1b1b5c27d)
+*  fetchOHLCV fix [fc36031832](https://github.com/ccxt/ccxt/commits/fc3603183258deeddb314a2ab93da0cff55a44c4)
+*  rename helper methods [19fb9faeb2](https://github.com/ccxt/ccxt/commits/19fb9faeb2e85c1a5b902c60f181c039a3891658)
+*  remove console.log [b11d4f965f](https://github.com/ccxt/ccxt/commits/b11d4f965fecbf06688b79811f2ad7da21476d37)
+*  some fixes [fb5b26f746](https://github.com/ccxt/ccxt/commits/fb5b26f74682f27dca7ce07d49d4503dc8c9ad1b)
+*  duplicate removal [ad6bab6270](https://github.com/ccxt/ccxt/commits/ad6bab6270bbe460b4a75178a8228682c2e6986a)
+*  fix verbosity [4c5a110549](https://github.com/ccxt/ccxt/commits/4c5a110549cce86a13989b86934b72d4cf6a3c37)
+*  update [a4ab230f60](https://github.com/ccxt/ccxt/commits/a4ab230f607e99b5a8ef2c49e1c96b1637e6ef8d)
+*  missing [26cea88c54](https://github.com/ccxt/ccxt/commits/26cea88c548a2f9e1595e3dc046dcd656dabc56b)
+*  comment two spaces [9ec2eb39cb](https://github.com/ccxt/ccxt/commits/9ec2eb39cbba71a31e805a59aaa7db29f3ba2f25)
+*  add python preamble [ab7018ec9e](https://github.com/ccxt/ccxt/commits/ab7018ec9ea654a57296eee0c1b16fc3fd74893c)
+*  checkout php files [96b1d5fb8c](https://github.com/ccxt/ccxt/commits/96b1d5fb8c49ae61e068f84aeea207533dabeaba)
+*  restore python files [352f07b828](https://github.com/ccxt/ccxt/commits/352f07b8288602fe2e3f0a84aeb305430f32a08e)
+*  restore test_async [460ce285e1](https://github.com/ccxt/ccxt/commits/460ce285e1adea03ed15b783d89a3f8cb09d9f04)
+*  emptyclass rename & adding php instance vars [105a5fde02](https://github.com/ccxt/ccxt/commits/105a5fde024067b376826458e2b7698a3dea07ae)
+*  fix build [5ebacaf031](https://github.com/ccxt/ccxt/commits/5ebacaf0312fac15b7bf91589b064a9c07bcf26c)
+*  fix fatal errors [962b459d21](https://github.com/ccxt/ccxt/commits/962b459d211bd92925f2e0a4431a41c509d1f69b)
+*  message logs [a2ddc4577d](https://github.com/ccxt/ccxt/commits/a2ddc4577d4638b9bc01d3fb2a43d581474ceb6d)
+*  line replace [260a957d8c](https://github.com/ccxt/ccxt/commits/260a957d8ce98c267ce8d0b445b9b46f3a19797d)
+*  id change [13a20db80f](https://github.com/ccxt/ccxt/commits/13a20db80fe5c41ae0a9f4da424ee8da1a631aa9)
+*  update ts tests path [c0cc15bd06](https://github.com/ccxt/ccxt/commits/c0cc15bd06a3602c488f54c079227e6cd7b7bc73)
+*  rename [a466cf8f59](https://github.com/ccxt/ccxt/commits/a466cf8f59d6e39b9e6f6763fd23efcf1871fa1a)
+*  ts update [eaf856b943](https://github.com/ccxt/ccxt/commits/eaf856b943cd6678dcbea6a4874efb87275edba6)
+*  remove files [f784f23940](https://github.com/ccxt/ccxt/commits/f784f2394053e93fbec4f8b824405e2799ba3f2e)
+*  missing move [7d632782d6](https://github.com/ccxt/ccxt/commits/7d632782d613cdff179d778609f1e2d028462d20)
+*  php reorg finished [75720384c1](https://github.com/ccxt/ccxt/commits/75720384c10618f4732b297daa859fd96c4f65b2)
+*  python reorg [6eec6f64b2](https://github.com/ccxt/ccxt/commits/6eec6f64b2b11f48d84e140dfceed24fd3666c24)
+*  import fix [8066c2b72c](https://github.com/ccxt/ccxt/commits/8066c2b72ce07e723796bfd98df5008d92600b6f)
+*  improve message [5f56c483f6](https://github.com/ccxt/ccxt/commits/5f56c483f645c4df0e3c6e5a0f9fb182810e60c0)
+*  remove [dc89e5badb](https://github.com/ccxt/ccxt/commits/dc89e5badb62244217522f38a281cdd1b6cbdb30)
+*  git mv [8f3c37bb2d](https://github.com/ccxt/ccxt/commits/8f3c37bb2dc63548047106359225dfb14182b6e0)
+*  revert php files [52504ab9a3](https://github.com/ccxt/ccxt/commits/52504ab9a3246bcf7d2c06e85bf0af2e1442e900)
+*  restore test_async [15dda18d44](https://github.com/ccxt/ccxt/commits/15dda18d445114eec649b6c37e0db166b2a137be)
+*  tests base path update [32f466cc4a](https://github.com/ccxt/ccxt/commits/32f466cc4aa846302be1a340f662dd13dbdb5d72)
+*  fix python test_async [bcf33b248d](https://github.com/ccxt/ccxt/commits/bcf33b248d38266fed343c9cac2e216db6d6b787)
+*  indentation [c64db34a5d](https://github.com/ccxt/ccxt/commits/c64db34a5dd18663fe4296f7df7c8d955dc81192)
+*  fix test.fetchOHLCV [b8400c67a7](https://github.com/ccxt/ccxt/commits/b8400c67a76340d0f02e3adef3a6e61f19bac07a)
+*  pro tests update path [802273295e](https://github.com/ccxt/ccxt/commits/802273295efaf0ae753577a4cc9315ef3ec743fe)
+*  update fetchTickers [9e5c9839d8](https://github.com/ccxt/ccxt/commits/9e5c9839d8fcac2512b493a03fffce0156982abd)
+*  update test_sync [d9cf3fb456](https://github.com/ccxt/ccxt/commits/d9cf3fb456df4a6aa9b18c25d4056f82417d23f5)
+*  improve read from env keys [9d005293a1](https://github.com/ccxt/ccxt/commits/9d005293a1b5f5e54f6d6783d0fadd3619d1ce0d)
+*  rename method_Tester [6236af8943](https://github.com/ccxt/ccxt/commits/6236af8943713903e4d27a24e9fb6d78261b7313)
+*  move signin [dfef9c4dd1](https://github.com/ccxt/ccxt/commits/dfef9c4dd110fa0ea19f5dbb8fe25b74bff0d0a6)
+*  minor change [c14129edfd](https://github.com/ccxt/ccxt/commits/c14129edfdb9b56ca4ab0d0eb1ede083b317eb62)
+*  info and error handling [882ad71843](https://github.com/ccxt/ccxt/commits/882ad71843f92f385f93e2b9eec52c97755372a9)
+*  update test.ts [9757c9288f](https://github.com/ccxt/ccxt/commits/9757c9288fde51111244a2838b60f4dcd42901b7)
+*  tests fix [66c0a2e14a](https://github.com/ccxt/ccxt/commits/66c0a2e14ae0d6c8e5bcd31127e83120de717325)
+*  revert public tests [7913a1d9b5](https://github.com/ccxt/ccxt/commits/7913a1d9b55d7e7c0f67b9693a6ad7c9803f3dd9)
+*  remove exchange[method] [17989ddbb0](https://github.com/ccxt/ccxt/commits/17989ddbb0b296161b3f1d66e3fe518ec82dc1ec)
+*  fix fetchOrderBooks [ab75bab35c](https://github.com/ccxt/ccxt/commits/ab75bab35c6308860e5aa0934174eec32333fe33)
+*  fix coinex and auth error exception [dfd9e3a926](https://github.com/ccxt/ccxt/commits/dfd9e3a926baadb6fa3a32d9e8a9996f4b16bf07)
+*  fix get_exchange_prop [05df5ddbeb](https://github.com/ccxt/ccxt/commits/05df5ddbeba941785c69573c6c0f095b5592874c)
+*  remove emitTypes [fd69ef5504](https://github.com/ccxt/ccxt/commits/fd69ef5504be58d647c5a39a1b82ade99e8458f4)
+*  fix syntax [bea74a7a4b](https://github.com/ccxt/ccxt/commits/bea74a7a4be1723bccdf6f6cf51e2ace5bc27145)
+*  fix proxy func name [f7c295ca82](https://github.com/ccxt/ccxt/commits/f7c295ca82eecc981ed65ed3f1dec65ef0d5e7d3)
+*  fix binance [13cd1655b1](https://github.com/ccxt/ccxt/commits/13cd1655b17f3b70e7968203ceb4a5b69168e291)
+*  fix test ts/js [f6b6bc0922](https://github.com/ccxt/ccxt/commits/f6b6bc092239c13644234693be05a55e84c033ed)
+*  tf key fix [0b2e5ce089](https://github.com/ccxt/ccxt/commits/0b2e5ce0897aa69bb6253517335946bbc1f0a756)
+*  message comment [bfef69d502](https://github.com/ccxt/ccxt/commits/bfef69d50291be5b959ffdf3a977696e5ea12b28)
+*  update exit code [1acdf2d557](https://github.com/ccxt/ccxt/commits/1acdf2d557c843763d07e796116d787b149b100e)
+*  lint [b08b435ed7](https://github.com/ccxt/ccxt/commits/b08b435ed7fbf6b8ba5c0383fda992f9039fe5ec)
+*  fix binance tests [a6d4f7c10b](https://github.com/ccxt/ccxt/commits/a6d4f7c10b4a2b15610dbd77b209f578be33a148)
+*  typo [0a7ab90f76](https://github.com/ccxt/ccxt/commits/0a7ab90f767d2ff7288f44c556e73ffbbaf41d13)
+*  typo [7f1796c0b3](https://github.com/ccxt/ccxt/commits/7f1796c0b3fdc27c3397fb6b635780ec3530a975)
+*  protect access [b11de2b429](https://github.com/ccxt/ccxt/commits/b11de2b429be3cd3b508c5e40f98a05161afcee2)
+*  enable ws [85a61aea12](https://github.com/ccxt/ccxt/commits/85a61aea12f4171cc50f2c2febfadc9cecaef23e)
+*  WS tests update [ea92758a37](https://github.com/ccxt/ccxt/commits/ea92758a3749a09c188795e98b38b9d56e3fdb3d)
+*  fix indentation [e1baaad157](https://github.com/ccxt/ccxt/commits/e1baaad157a4449f802c928867c34b15b95578aa)
+*  remove unnecessary error message [80beacc922](https://github.com/ccxt/ccxt/commits/80beacc922ecc7c07081eaf500eef36b291a6214)
+*  restore ws exchanges [677858804e](https://github.com/ccxt/ccxt/commits/677858804eada0f799e51f0acf8ae6cd5736beee)
+*  fix coinbase watchOrderBook [6abf0e377d](https://github.com/ccxt/ccxt/commits/6abf0e377d712dc35b3458c13b96ccb15fb4ddb5)
+*  fix bitget watchOrderBook [18c91e9c43](https://github.com/ccxt/ccxt/commits/18c91e9c43a6dadcb0f114149e9a2a033a0a6cd1)
+*  update test trade [da20a23824](https://github.com/ccxt/ccxt/commits/da20a2382462ef44f42a6079b40ecfa0fae29a33)
+*  remove hardcoded id [d0aab1b782](https://github.com/ccxt/ccxt/commits/d0aab1b7820b4696e60f84af0d61d15a4964371a)
+*  fix imports [85b6f6a02f](https://github.com/ccxt/ccxt/commits/85b6f6a02f2c91802a8bcb34714d0bee5dc4be5c)
+*  small improvement [c7b6bd6ed2](https://github.com/ccxt/ccxt/commits/c7b6bd6ed214a75c331b95403cc1a9fc40d97d71)
+*  fix test_trade [b26bc82794](https://github.com/ccxt/ccxt/commits/b26bc8279406360cf9e90cf885cf1fb7b0c4a690)
+*  fix test_watch_ohlcv [426d10b357](https://github.com/ccxt/ccxt/commits/426d10b3574f0c5227ab3de8874117f95098bccd)
+*  update push.sh [47fff71335](https://github.com/ccxt/ccxt/commits/47fff71335a2721b21e165a26cbf703cefcb93b1)
+*  xt fixes [942e9c8231](https://github.com/ccxt/ccxt/commits/942e9c82318cd5a6af56cfe45465900d1c35ce7c)
+*  add is active [f762c8c87f](https://github.com/ccxt/ccxt/commits/f762c8c87f13a9f386ed02086213a726d3b0dbd3)
+*  orderbook string [19cd4020f1](https://github.com/ccxt/ccxt/commits/19cd4020f1da8f8f8dc94f7d1b38716d0ee0965e)
+*  feate(wazirx): update rateLimit weights [00bd722d6a](https://github.com/ccxt/ccxt/commits/00bd722d6a0a0245466e11566e70d5ddec71ac29)
+*  feat(idex): change rateLimit [6f88f3306d](https://github.com/ccxt/ccxt/commits/6f88f3306dd8c508d4d9fcf5ad69d02c50205b61)
+*  fix binance: parseOpenInterest [fb2770047e](https://github.com/ccxt/ccxt/commits/fb2770047ef633af3a361757583df711ac2ba350)
+*  fetchTransactions rename [987830ef6c](https://github.com/ccxt/ccxt/commits/987830ef6c1912d5999a57fa3a1af4e63fcb96d4)
+*  string concatenations [e8394135a7](https://github.com/ccxt/ccxt/commits/e8394135a7da1b4972c734e65fbfc9ff734a78f2)
+*  ticker structure test [4b4c76630d](https://github.com/ccxt/ccxt/commits/4b4c76630def5f493acc7288cbc10927be5adda1)
+*  export tests removal [10e58d8974](https://github.com/ccxt/ccxt/commits/10e58d89744562127ff820b05acb946e102ba146)
+*  fix build [099652d84a](https://github.com/ccxt/ccxt/commits/099652d84a7c8f85ffc2dbde0389a5f117aca3b3)
+*  update package.json [d8d7969bf3](https://github.com/ccxt/ccxt/commits/d8d7969bf30cb844bfad3ed781c37dc6ca86d7bb)
+*  restore package.lock [1d1dd3cd14](https://github.com/ccxt/ccxt/commits/1d1dd3cd143ea9bafd92781def60c58c2b10c592)
+*  revert [c13cfa9e2f](https://github.com/ccxt/ccxt/commits/c13cfa9e2fad8b4bd340268f6f19c43e02723fa1)
+*  add tests to push.sh [4ff85cc534](https://github.com/ccxt/ccxt/commits/4ff85cc534e38805b3ceea2f805fcb1778833d55)
+*  fix mercado & paymium [630bdc7106](https://github.com/ccxt/ccxt/commits/630bdc71064b59352ac54c1dc1d3ce8ffe7ac32d)
+*  Skip Exchanges [baf0339d3c](https://github.com/ccxt/ccxt/commits/baf0339d3c1a86b866698876b9a6b18637d33271)
+*  Skip delta [3d4db04199](https://github.com/ccxt/ccxt/commits/3d4db0419952661ccca5ee75dd747c3a926dc656)
+*  update push.sh [42ad8fa4bc](https://github.com/ccxt/ccxt/commits/42ad8fa4bcd94b88a3934c55c30d404267e72f1d)
+*  remove folder [f90688bf4a](https://github.com/ccxt/ccxt/commits/f90688bf4aba838473fcee9530dec1e60e28109a)
+*  revert [e0c30e9372](https://github.com/ccxt/ccxt/commits/e0c30e93720685edde7a24cf90633ce036d5c772)
+*  3.0.71 [93bbee40c8](https://github.com/ccxt/ccxt/commits/93bbee40c80903c83be2561c39c344922d4353ce)
+
+
+## 3.0.70 (2023-04-18)
+
+*  kucoin: add hf apis [96511c8d43](https://github.com/ccxt/ccxt/commits/96511c8d43e513b14053213d776088a052e16665)
+*  kucoin: update hf cost [07f9305cc2](https://github.com/ccxt/ccxt/commits/07f9305cc20679c97873218767ffd3a443415dcf)
+*  fix xt: logo [784e367639](https://github.com/ccxt/ccxt/commits/784e3676398ddb1e706e2619b694cececd4fa7bc)
+*  fix mexc intervals [6606a1922d](https://github.com/ccxt/ccxt/commits/6606a1922dc6f828ae2e48e6a01fe93c7148172b)
+*  xt logo fix [e0105ca15f](https://github.com/ccxt/ccxt/commits/e0105ca15faeae9fb3de70b87fe0edf19e00bd27)
+*  xt logo fix [9e9f08bdc4](https://github.com/ccxt/ccxt/commits/9e9f08bdc41c52428945b67aca3b56005491d65d)
+*  3.0.70 [a4b0b95831](https://github.com/ccxt/ccxt/commits/a4b0b958318136e8df4088393a006b587160b8fa)
+
+
+## 3.0.69 (2023-04-17)
+
+*  feat(XT): New Exchange Implementation [8bfc736c65](https://github.com/ccxt/ccxt/commits/8bfc736c652d0ca6836a6d3364a19d3d768c2185)
+*  update previous implementation [d2d5c2b6a0](https://github.com/ccxt/ccxt/commits/d2d5c2b6a07180c124039b86ca9dbdc64cdaf079)
+*  start private methods [4943a65694](https://github.com/ccxt/ccxt/commits/4943a6569405709cc2e6a73f02b173f6c42df408)
+*  Added the remaining API endpoints [ae67633462](https://github.com/ccxt/ccxt/commits/ae67633462499cfca4603afaa3cbeb33d9e6c070)
+*  change implementation to typescript [a322463e1e](https://github.com/ccxt/ccxt/commits/a322463e1e5dc1fed55a569d5213419c203fb985)
+*  xt: createOrder [9d1dde32df](https://github.com/ccxt/ccxt/commits/9d1dde32df56162e39586e8c9108310eccb1e626)
+*  Verify precisionMode as DECIMAL_PLACES [83e9c539af](https://github.com/ccxt/ccxt/commits/83e9c539af4b0bbdca1d45265bed0f9937f68520)
+*  xt: fetchBalance [3948367fde](https://github.com/ccxt/ccxt/commits/3948367fde35f4463ee30c42c7db9738f172bd02)
+*  xt: fetchOrder [16ac356803](https://github.com/ccxt/ccxt/commits/16ac35680302e0bcd88ca6b4e02cc72cd9015050)
+*  xt: fetchOrders [9dadd03776](https://github.com/ccxt/ccxt/commits/9dadd03776f45f38b78b89b91ece36524d89ede5)
+*  xt: fetchOrdersByStatus, fetchOpenOrders, fetchClosedOrders, fetchCanceledOrders [52d59ebbe9](https://github.com/ccxt/ccxt/commits/52d59ebbe93341609ffd395d4ac9609f96a83097)
+*  xt: cancelOrder [75b682609e](https://github.com/ccxt/ccxt/commits/75b682609e908055d5a673057ab04b75aec70193)
+*  xt: cancelAllOrders [d11e3b7f3e](https://github.com/ccxt/ccxt/commits/d11e3b7f3eaa3f8bc6fad8b1a82c2b0d28feac68)
+*  xt: cancelOrders [1bb875ad86](https://github.com/ccxt/ccxt/commits/1bb875ad868d7aee2c485247fe41b4f719ede4f8)
+*  xt: fetchMyTrades [a9da336c98](https://github.com/ccxt/ccxt/commits/a9da336c98e19c7cc129be2a928bdeb41e869e96)
+*  xt: fetchBidsAsks [ba6da3dfef](https://github.com/ccxt/ccxt/commits/ba6da3dfef97bbe658981d33397cf7647f7e797a)
+*  update to new typescript specifications [775a8e591a](https://github.com/ccxt/ccxt/commits/775a8e591a98969f30c6e6aa539180d93bcb0035)
+*  xt: fetchLedger [853b59faba](https://github.com/ccxt/ccxt/commits/853b59faba1dbce44e8fac4617f66ad4a506cf28)
+*  xt: fetchDepositAddress [4ff72f59eb](https://github.com/ccxt/ccxt/commits/4ff72f59ebd54f6b91713e39e4f04f542ca6fa86)
+*  xt: fetchDeposits [ab912058b1](https://github.com/ccxt/ccxt/commits/ab912058b1929ce2cafe0871ed1ab0d346dd045a)
+*  xt: withdraw [91a45851ae](https://github.com/ccxt/ccxt/commits/91a45851ae76cd32d76e2b1001803baa8bafa441)
+*  xt: fetchWithdrawals [f413e77465](https://github.com/ccxt/ccxt/commits/f413e77465de90f5a1762b7fb02a486cb2964ed0)
+*  xt: setLeverage [cd2ee487e1](https://github.com/ccxt/ccxt/commits/cd2ee487e1350d557af34e1c81f2f125c9fbb141)
+*  update fetchOrder swap and future comments [c59ea5a63a](https://github.com/ccxt/ccxt/commits/c59ea5a63ab381c48408d65c2cf3bda6985097bf)
+*  adjust taker and maker fees [e0fec6354d](https://github.com/ccxt/ccxt/commits/e0fec6354d82400bfcf40ba65611020c76241208)
+*  xt: addMargin, reduceMargin [1741985eda](https://github.com/ccxt/ccxt/commits/1741985eda660c18581b748c3865e6073ff34cb5)
+*  xt: fetchLeverageTiers [7d76aec089](https://github.com/ccxt/ccxt/commits/7d76aec089e439c059f554394d77a0bfe2a635b6)
+*  xt: fetchFundingRateHistory [b1c10259bd](https://github.com/ccxt/ccxt/commits/b1c10259bd95daef294b1a5ae94e448aeffe1b15)
+*  change await responses from ternaries to if statements [9a94e6404f](https://github.com/ccxt/ccxt/commits/9a94e6404fc25f1393a956ce5a0a68251ab961b2)
+*  xt: fetchFundingRate [a86827379c](https://github.com/ccxt/ccxt/commits/a86827379c8ac1c69b9b0a4612fead319604f4e6)
+*  xt: fetchFundingHistory [c83a6bbb86](https://github.com/ccxt/ccxt/commits/c83a6bbb86cb0ef61747271f2ce89205ad143dec)
+*  add exceptions [20989d7f90](https://github.com/ccxt/ccxt/commits/20989d7f9013d4cba96019198b6e9e893a718ca3)
+*  xt: fetchPosition, fetchPositions [b32b7c7a1e](https://github.com/ccxt/ccxt/commits/b32b7c7a1e28730373d2d5a1ae589a88b916d5cb)
+*  xt: fetchOHLCV set volumeIndex for inverse and linear [fe08e4ff4b](https://github.com/ccxt/ccxt/commits/fe08e4ff4b498f021cbb37567e17a482313e466c)
+*  add false methods to 'has' [669aa7ea18](https://github.com/ccxt/ccxt/commits/669aa7ea18afac9b75952c13f7ad184497d61d03)
+*  remove abstract file [81f7bfe1f1](https://github.com/ccxt/ccxt/commits/81f7bfe1f1292914b3feb6ca53a28cb969294961)
+*  update abstract [81e2cebd24](https://github.com/ccxt/ccxt/commits/81e2cebd244640ff1baa8692e74772c893c6f4c8)
+*  networks, remove exchange ids that are the same as unified ids [7f67c19bc7](https://github.com/ccxt/ccxt/commits/7f67c19bc7988d718ea407b0dee8b2c36d9f81e4)
+*  remove accidentally added files [51c255c616](https://github.com/ccxt/ccxt/commits/51c255c6166759860d4bd08e78f17ab7fdad019c)
+*  add back accidentally deleted files [461922af11](https://github.com/ccxt/ccxt/commits/461922af1125fe8a8e82968d7adcc486ddc26c55)
+*  remove pro files [1594ebbc75](https://github.com/ccxt/ccxt/commits/1594ebbc7585e9081f99fcf83003e03b142b1e6d)
+*  revert removing pro files [667bfae9bf](https://github.com/ccxt/ccxt/commits/667bfae9bf71a9c6d7b37bcec3120ac48e3c6f87)
+*  add back missing lines from pro files [6476f2c7ba](https://github.com/ccxt/ccxt/commits/6476f2c7ba4879dfff00a2840f8b0d7818054ce6)
+*  add int types to method signatures [79c4ffdb9d](https://github.com/ccxt/ccxt/commits/79c4ffdb9db104aee1bf8e028f413a919ce4d5de)
+*  fetchOrderBook, remove limit for spot [6e738e6620](https://github.com/ccxt/ccxt/commits/6e738e662035626d334ca34aa77e94957635b056)
+*  fetchOrderBook, use safeInteger with timestamp [cd55e05d3a](https://github.com/ccxt/ccxt/commits/cd55e05d3a3911713fd1a503ae47836bf7905195)
+*  fetchTickers, remove symbols NotSupported error [83d9969569](https://github.com/ccxt/ccxt/commits/83d99695691e186a0b0d11cc5ce2c2f76269f0b9)
+*  parseTrade, use safeTrade, change some values to strings [cf2dcb8986](https://github.com/ccxt/ccxt/commits/cf2dcb8986b5eb80750fa39b7e30a009527112a9)
+*  parsePosition, add safePosition [de0fb4330e](https://github.com/ccxt/ccxt/commits/de0fb4330ecc70a2586e7e775510096d52e15996)
+*  createOrder, fix issues, split into spot and contract [4cc2e2be18](https://github.com/ccxt/ccxt/commits/4cc2e2be18eba98770a08b8a7875768ea71a1b4e)
+*  parseMarket, set precisions to use safeInteger [22047e80d4](https://github.com/ccxt/ccxt/commits/22047e80d4c2d2c1d993ad63c6854d958e00fb28)
+*  fetchBalance, handleMarketTypeAndParams [b29248a054](https://github.com/ccxt/ccxt/commits/b29248a054f6c391f0b7173e1dba490f295b8138)
+*  fetchBalance, adjust future and swap conditional response [0af501c714](https://github.com/ccxt/ccxt/commits/0af501c7148afcaa536a2f40f0463814c35ce9b3)
+*  add handleMarketTypeAndParams check to multiple methods [240ed3b4f5](https://github.com/ccxt/ccxt/commits/240ed3b4f58d7978faa4ef058b2e80942673af0d)
+*  cancelOrder, add isContractResponse variable [bb18d0007f](https://github.com/ccxt/ccxt/commits/bb18d0007faf3d8b9afb99152d4e2c603da8c7d6)
+*  fetchBidsAsks, fetchTickers, remove symbols request [a8211b4dda](https://github.com/ccxt/ccxt/commits/a8211b4dda971ad41f5a914ab2f9ef9648f7d3ba)
+*  withdraw, adjust method signature [25aa5a4a30](https://github.com/ccxt/ccxt/commits/25aa5a4a305c373528276b3299e35267ff6c4075)
+*  fetchFundingHistory, change since check to !== [563f6afc81](https://github.com/ccxt/ccxt/commits/563f6afc813e8d81da96d159f8339e93e51cde8f)
+*  fetchDepositAddress, require network [98e6a4a327](https://github.com/ccxt/ccxt/commits/98e6a4a327eca6bb1b7fd5cbc40c94bf3cc06a2e)
+*  createContractOrder, trigger, stopLoss and takeProfit orders [580f466d08](https://github.com/ccxt/ccxt/commits/580f466d08e48202d11ad89dbc0c02f518f337f5)
+*  fix cancelOrder BigInt issue [8e53f613a9](https://github.com/ccxt/ccxt/commits/8e53f613a9ad139eaeaf5d4a7e614fd315f13797)
+*  missing method [3b6e0532e7](https://github.com/ccxt/ccxt/commits/3b6e0532e7cba17b96918e15c5a57648f2a98430)
+*  fetchOrder, add convertToBigInt [02a36bb919](https://github.com/ccxt/ccxt/commits/02a36bb919e6bdfdc4f156eca792f84496a58dd1)
+*  fix trading amount [dd7f14ed86](https://github.com/ccxt/ccxt/commits/dd7f14ed863e175ee877f56caaaed6db3840f82c)
+*  [Binance] Modify error codes [74aee84699](https://github.com/ccxt/ccxt/commits/74aee84699b7e88407fb7ffd66af56f3131a2305)
+*  adjust ratelimit weights [ba74deeaf8](https://github.com/ccxt/ccxt/commits/ba74deeaf8af5d1a79ffebb18f1b6ae0c876fce1)
+*  feat(examples): add html example for ccxt pro [7b70b29eb0](https://github.com/ccxt/ccxt/commits/7b70b29eb0667dccbab4a9dc9065a66a72b23f34)
+*  fix(examples): fix html examples [c986874ca7](https://github.com/ccxt/ccxt/commits/c986874ca7eb2f9f806e29ad9396968eb8f63120)
+*  build: patch php extends for ccxt pro ccxt/ccxt#17573 [a14844cc63](https://github.com/ccxt/ccxt/commits/a14844cc63d6005dfee70e8fb9775df34b239f50)
+*  declare dynamic props [cb21b1c61c](https://github.com/ccxt/ccxt/commits/cb21b1c61c3ceb2f06ca0f3d8d597901814589e9)
+*  add cost [8b469e6112](https://github.com/ccxt/ccxt/commits/8b469e611276c38477d3fa874d438e25a38370ae)
+*  add logo [9f060f50a8](https://github.com/ccxt/ccxt/commits/9f060f50a8502d40ee9ceaa2025032dc31e5ed10)
+*  3.0.69 [7345d6c74f](https://github.com/ccxt/ccxt/commits/7345d6c74f5c04c4eb03c35b4d6da5b24e23aac0)
+
+
+## 3.0.68 (2023-04-17)
+
+*  fix python and php [38bd30349d](https://github.com/ccxt/ccxt/commits/38bd30349d81d97ea3093206d23b82961d57ac82)
+*  restore await [3bd53d6619](https://github.com/ccxt/ccxt/commits/3bd53d6619a48507332e11f8bf2c64348a40b5ab)
+*  3.0.68 [27f9fd4317](https://github.com/ccxt/ccxt/commits/27f9fd431718116efd449f7b8d0b970ef652f988)
+
+
+## 3.0.67 (2023-04-16)
+
+*  poloniex.fetchTrades: side added for public trades [9268abf47b](https://github.com/ccxt/ccxt/commits/9268abf47b2a963337a6fcfcdf3b2f515f7f7d3e)
+*  3.0.67 [4b633cf407](https://github.com/ccxt/ccxt/commits/4b633cf407cb094d56648516004b6f60f80bb68d)
+
+
+## 3.0.66 (2023-04-15)
+
+*  fix(bybit): createOrder v3 stopPrice [40defccc6f](https://github.com/ccxt/ccxt/commits/40defccc6fed6a7aeef43c7092cd67659cde842f)
+*  3.0.66 [8932b6eac2](https://github.com/ccxt/ccxt/commits/8932b6eac2f05e670b300819affe5b150e2a72ac)
+
+
+## 3.0.65 (2023-04-15)
+
+*  types.ts formatting [d050618b91](https://github.com/ccxt/ccxt/commits/d050618b912ee14a73ecf087fc0c0aeba50e7df7)
+*  fix(binance): fetchOpenInterestHistory [dac3b3211a](https://github.com/ccxt/ccxt/commits/dac3b3211a2ea0ea94dd511386e1ff0674854aab)
+*  revert file [5a73c705a1](https://github.com/ccxt/ccxt/commits/5a73c705a1263e227b7923bfc5721942bb70bca6)
+*  fix fetchOpenInterestHistory [f454818270](https://github.com/ccxt/ccxt/commits/f4548182706e9418ceb815bb0c68b867ecf1d79c)
+*  3.0.65 [c9b4b7d407](https://github.com/ccxt/ccxt/commits/c9b4b7d4075f6905835331c427afb316b89c5633)
+
+
+## 3.0.64 (2023-04-14)
+
+*  handlepostonly [ba50a060aa](https://github.com/ccxt/ccxt/commits/ba50a060aabc3d234573fae10d222ee8aba09562)
+*  fix(okx): protect withdraw [1dae682b65](https://github.com/ccxt/ccxt/commits/1dae682b653860bdd9275e31530e78e3c21e1bb3)
+*  fix php: WS client [d46217bb29](https://github.com/ccxt/ccxt/commits/d46217bb2956490e2a68d766be0e9e8a0e4d4f16)
+*  3.0.64 [beb0fcfe94](https://github.com/ccxt/ccxt/commits/beb0fcfe945e34957110556478359cc7e3676db2)
+
+
+## 3.0.63 (2023-04-14)
+
+*  fix deribit [06162c540c](https://github.com/ccxt/ccxt/commits/06162c540cd003c114eb7ea052890203b77db861)
+*  refix deribit [2fcdf6a462](https://github.com/ccxt/ccxt/commits/2fcdf6a4629882baa0515a1016d24afa27cba5e2)
+*  refix deribit [5fbd475892](https://github.com/ccxt/ccxt/commits/5fbd4758921cca880b78d36c40b3013cecaa898e)
+*  fix(binance): notional spot testnet [33d122573f](https://github.com/ccxt/ccxt/commits/33d122573f416b62e33dbbf138ac1993567ce6e4)
+*  fix(bitget): handle future markets [aaa2cebe54](https://github.com/ccxt/ccxt/commits/aaa2cebe5407929a39efd31fe0e183fc4b7ad365)
+*  fix fetchOHLCV [2f95dbd31a](https://github.com/ccxt/ccxt/commits/2f95dbd31a1241b44c2714067edfce860921ab9e)
+*  fix(gemini): signing [4a65759fe4](https://github.com/ccxt/ccxt/commits/4a65759fe4c3bb1686ede475485a5f264c489900)
+*  3.0.63 [9658dc4526](https://github.com/ccxt/ccxt/commits/9658dc4526075431335762c36896678ff771f96d)
+
+
+## 3.0.62 (2023-04-12)
+
+*  woo: make some apis public [e602afdc1c](https://github.com/ccxt/ccxt/commits/e602afdc1c66e3fa39a861c043603b062be335f4)
+*  fix(deribit): authenticate ws [e88770b1f0](https://github.com/ccxt/ccxt/commits/e88770b1f08edeed4870582124daada0527e9a80)
+*  fix cli [415cd157b2](https://github.com/ccxt/ccxt/commits/415cd157b213c718012a190eb77c79f4db931bed)
+*  fix(poloniex): fix fetchTransactionsHelper [f4cb341186](https://github.com/ccxt/ccxt/commits/f4cb341186aecdb763c3d89b0419464919a6a070)
+*  fix(bybit): createMarketBuyOrderRequiresPrice [494863020a](https://github.com/ccxt/ccxt/commits/494863020a07bb2fe707acebba41049b714ee77e)
+*  3.0.62 [8869ea3dd2](https://github.com/ccxt/ccxt/commits/8869ea3dd239ab3a91013f47b5cae738409fbabb)
+
+
+## 3.0.61 (2023-04-11)
+
+*  bybit: update fetchBalance ccxt/ccxt#17520 [15f68b6276](https://github.com/ccxt/ccxt/commits/15f68b6276e6012361dc3a758aaecff86ac34d6f)
+*  mexc: add new api (capital/transfer/tranId) [5adf94403e](https://github.com/ccxt/ccxt/commits/5adf94403e832e09df11994d9700662af0bc791a)
+*  fix key_exists: exception handling [ab91ff1b41](https://github.com/ccxt/ccxt/commits/ab91ff1b4188b923487be20a3b97ae4c5b4c48d6)
+*  minor edits [547eaadfff](https://github.com/ccxt/ccxt/commits/547eaadfffd47c04ca7aa699c01edab2f3309ce1)
+*  throw on failed onMessage call [b66bf50179](https://github.com/ccxt/ccxt/commits/b66bf501795d0e87167a1707c518b19a5354d424)
+*  remove unused import [ci deploy] [5d498078b0](https://github.com/ccxt/ccxt/commits/5d498078b0afc2e7a1700dc36a03f1f426e7dc1a)
+*  minor edit [18fe730061](https://github.com/ccxt/ccxt/commits/18fe730061336b03eb45c8ee5578e0c589764a03)
+*  pass build [ci deploy] [a0ba3abdba](https://github.com/ccxt/ccxt/commits/a0ba3abdbacb59a2b1a85206de6fd1c0ffbd0d95)
+*  3.0.61 [dcc87b9a26](https://github.com/ccxt/ccxt/commits/dcc87b9a26de56ad3bf20593c5ad4bd9906fff11)
+
+
+## 3.0.60 (2023-04-10)
+
+*  revert changes [8c5d9f67f4](https://github.com/ccxt/ccxt/commits/8c5d9f67f4ef24b3bfce281779f0d4c5eeb594fc)
+*  bybit: update editOrder [465a131123](https://github.com/ccxt/ccxt/commits/465a1311234c693cf3ea0e8e58a285c0330d4216)
+*  mexc: use market id ccxt/ccxt#17515 [1e74b958b2](https://github.com/ccxt/ccxt/commits/1e74b958b29e120f8802fce2b6dbb5859755ced8)
+*  fix(bitget): canceledAndClosed default [d303a79918](https://github.com/ccxt/ccxt/commits/d303a799188d6d0f71d21bb9572b0e9c97a1e2cc)
+*  revert [16f5b3bbc9](https://github.com/ccxt/ccxt/commits/16f5b3bbc98458de94aecff0963f41401a0182b4)
+*  refactor key_exists [a46f277bf1](https://github.com/ccxt/ccxt/commits/a46f277bf11459d070a0beab3650f453c056231e)
+*  refactor refactor [246cca33de](https://github.com/ccxt/ccxt/commits/246cca33de400658e4ca1e69bb6e78ca36e47646)
+*  3.0.60 [fa5bcf3294](https://github.com/ccxt/ccxt/commits/fa5bcf3294e0dc86639b9aa67b5966e638f403ba)
+
+
+## 3.0.59 (2023-04-10)
+
+*  [krakenfutures] sign url generation for python [8ae8ff37d2](https://github.com/ccxt/ccxt/commits/8ae8ff37d20ef1a69190bb77ddb7a7c724064e0e)
+*  3.0.59 [50794fa1b2](https://github.com/ccxt/ccxt/commits/50794fa1b26f3fbb200725c6a6e657454a2cb3a7)
+
+
+## 3.0.58 (2023-04-09)
+
+*  fixes #17508 [598d6d7a49](https://github.com/ccxt/ccxt/commits/598d6d7a493825071c83c9724fe053925d0a2141)
+*  restore [ed5aa2c47c](https://github.com/ccxt/ccxt/commits/ed5aa2c47c771e05fce81b7939c3aef03f99b919)
+*  fixes [b3f3290ede](https://github.com/ccxt/ccxt/commits/b3f3290edeab9887328386cd7e25a568d80bcd9e)
+*  3.0.58 [acabbba6d0](https://github.com/ccxt/ccxt/commits/acabbba6d0dad104ff94fcf8d07cdea269f4db4c)
+
+
+## 3.0.57 (2023-04-09)
+
+*  bitrue has watchOrderBook [330d6d78fd](https://github.com/ccxt/ccxt/commits/330d6d78fdc1e66214eff643cc58e8fb2ac5f11f)
+*  add OrderSide type hint [d8ddfa7e12](https://github.com/ccxt/ccxt/commits/d8ddfa7e12e537f17cfbc191d4a0fb58ca55bbcc)
+*  fix types [df850e4646](https://github.com/ccxt/ccxt/commits/df850e4646d4f45739e581e815ae5660d78f2203)
+*  3.0.57 [ecee20a8d4](https://github.com/ccxt/ccxt/commits/ecee20a8d4ca1df328a9ae7921d5304718f08009)
+
+
+## 3.0.56 (2023-04-06)
+
+*  bybit: set endTime when since is not empty [90b79d386d](https://github.com/ccxt/ccxt/commits/90b79d386db0afbdc8f53f054a7c74a529ae56de)
+*  bybit: update limit [02014405ae](https://github.com/ccxt/ccxt/commits/02014405ae9263a220a3b48538496463618a162c)
+*  binance docstring @see [f5d0faef03](https://github.com/ccxt/ccxt/commits/f5d0faef032ee571f75d2cbfb8d7012ad296f244)
+*  bybit: update fetchOrders [c078e1ceb6](https://github.com/ccxt/ccxt/commits/c078e1ceb6ff29ae75e7678534fb10806474e293)
+*  bybit: omit prices when create order [6835082c26](https://github.com/ccxt/ccxt/commits/6835082c26432553785e247bbcd6a8a24334d602)
+*  improve error message [619d15faf8](https://github.com/ccxt/ccxt/commits/619d15faf8657de6466c370343f9478619929113)
+*  fix python: 3.7 types [41f909dd39](https://github.com/ccxt/ccxt/commits/41f909dd39d994412499f2bcfae01f66e17ea1c4)
+*  3.0.56 [af1cee2342](https://github.com/ccxt/ccxt/commits/af1cee2342687fc42403d4affdc1b911854fb2c0)
+
+
+## 3.0.55 (2023-04-06)
+
+*  fix deposit withdraw fee [5c01be388f](https://github.com/ccxt/ccxt/commits/5c01be388fe7f481700149ca7b06e65a1fd85aae)
+*  fix in ts instead of js [04b711f1e7](https://github.com/ccxt/ccxt/commits/04b711f1e78479fa23ca2bbed9e7c40c65cea185)
+*  linting [137d88248a](https://github.com/ccxt/ccxt/commits/137d88248a1d2f4732e288f95a74c99f1d7e9105)
+*  PO okx [aa996e6d5a](https://github.com/ccxt/ccxt/commits/aa996e6d5a085d9e552a8011fcb8fc245b77a4f5)
+*  last commit [b997fa6f6b](https://github.com/ccxt/ccxt/commits/b997fa6f6b07ce99b8cb2682ba6efbe0971f7f3a)
+*  PO kucoin [8086d41419](https://github.com/ccxt/ccxt/commits/8086d41419949749d6c36abb4c2de1f003056f77)
+*  PO kucoin [1d09e6c76f](https://github.com/ccxt/ccxt/commits/1d09e6c76f8340f4d9faa96466e637fff36a1eac)
+*  fix condition [7b7d7551f9](https://github.com/ccxt/ccxt/commits/7b7d7551f96a973d75d23e37fa5518a2024fb57f)
+*  Fix wrong mexc "has" flags [1fa7fafc1c](https://github.com/ccxt/ccxt/commits/1fa7fafc1cd8622ea8bbd6ba966e9579c47692f4)
+*  binance.fetchTrades add until and fetchTradesMethod param, docstring [d38a9d00df](https://github.com/ccxt/ccxt/commits/d38a9d00df4bb05be179db896b92eec380b24961)
+*  3.0.55 [90fdc94f58](https://github.com/ccxt/ccxt/commits/90fdc94f583b0e59b753900c76fe10d55ea4ae86)
+
+
+## 3.0.54 (2023-04-05)
+
+*  po bitget [a5190b867c](https://github.com/ccxt/ccxt/commits/a5190b867c3931418d931872f698de69155ed8bd)
+*  PO bitmart [86dd79d7ea](https://github.com/ccxt/ccxt/commits/86dd79d7eae2e9935915c1d108edc455b9db0291)
+*  feat(coinbase): add bid and ask to fetchTicker [fc9ffc1189](https://github.com/ccxt/ccxt/commits/fc9ffc118948dca1a194f8db1da95725b5fa08fd)
+*  woo: patch ccxt/ccxt#17453 [445be1fc17](https://github.com/ccxt/ccxt/commits/445be1fc17196711da80e8b1e53607d8a451e4d1)
+*  woo: update editOrder [5e86c6adfb](https://github.com/ccxt/ccxt/commits/5e86c6adfbef6c3f9e4d0bac969e3abe5ef20506)
+*  bitget: update spot apis [90dc4cc63c](https://github.com/ccxt/ccxt/commits/90dc4cc63c57dbc3ab50aa8b521af53a112ab263)
+*  bitget: update mix apis [d3b8dc0645](https://github.com/ccxt/ccxt/commits/d3b8dc0645a224880e1f8f3443827161ec47f424)
+*  bitget: add fetchMarketLeverageTiers [012131f093](https://github.com/ccxt/ccxt/commits/012131f0939830956eeb345987ded90221078872)
+*  3.0.54 [16a0587475](https://github.com/ccxt/ccxt/commits/16a0587475fff0e02e2bc9c9a665e690135e79d7)
+
+
+## 3.0.53 (2023-04-04)
+
+*  polish examples [6bd33de01e](https://github.com/ccxt/ccxt/commits/6bd33de01e948b4d788b588faad60f01e454d865)
+*  manually added transpiled files [f43a4867de](https://github.com/ccxt/ccxt/commits/f43a4867de7a38fa515781af151e86c56b1a5410)
+*  console.log commas [8d7338b103](https://github.com/ccxt/ccxt/commits/8d7338b103d197e4bc80b1111d2550d55ffb5101)
+*  change [458da89697](https://github.com/ccxt/ccxt/commits/458da8969788f7f2d7f9834a442bda68d43ecc4a)
+*  fixes [2727e74277](https://github.com/ccxt/ccxt/commits/2727e7427762d4e31ad8db4284cbff939e06105d)
+*  fix [4ce780e0cb](https://github.com/ccxt/ccxt/commits/4ce780e0cb5eab2dcffb582279a689a416aeb168)
+*  refix [5b59568e02](https://github.com/ccxt/ccxt/commits/5b59568e0200003d8f4f0947ec390f9f5145a7de)
+*  tsconfig [3675014bda](https://github.com/ccxt/ccxt/commits/3675014bdaaeaea3c403a3ed9776bdd1a8984b3f)
+*  bitfinex2 withdraw edits [2aa9268c41](https://github.com/ccxt/ccxt/commits/2aa9268c4126715b24a6a06c4953e7b828268f75)
+*  bitfinex2 transaction status [f1d70b486b](https://github.com/ccxt/ccxt/commits/f1d70b486b6048ad7e28fe5e86fb1461b87da691)
+*  bitfinex2 string withdraw id [3e938f0152](https://github.com/ccxt/ccxt/commits/3e938f0152d3f2d68e3c6075ba0d942580f920d0)
+*  bitfinex2 transaction status [e0fc4730a2](https://github.com/ccxt/ccxt/commits/e0fc4730a249278a837a7cf69fee979d39f402e4)
+*  local changes [ce5d643ca8](https://github.com/ccxt/ccxt/commits/ce5d643ca8bf4eb293543620c6cfb56c2968c5c3)
+*  transpiler fixes [92c2ebcb96](https://github.com/ccxt/ccxt/commits/92c2ebcb962283693e0dd49c849f262cafb6693d)
+*  final touches [42543ea2cc](https://github.com/ccxt/ccxt/commits/42543ea2cc1d6c21992fc71ba50664f09d0142e5)
+*  hitbtc includeFee [c4b45b9408](https://github.com/ccxt/ccxt/commits/c4b45b9408d337693523d0ad8073e317ae7722a7)
+*  hitbtc3 includeFee [5f3c80d3c7](https://github.com/ccxt/ccxt/commits/5f3c80d3c73c0523c82a46fdcba402e07f0a956d)
+*  coinex editOrder fix [ad555fc5de](https://github.com/ccxt/ccxt/commits/ad555fc5debd6b62029c1f3537a0bb3a249add57)
+*  fix(poloniex): poloniex transfer update to new response format [ec1b451236](https://github.com/ccxt/ccxt/commits/ec1b45123683900f7d157be907dab8ec84e872e6)
+*  bybit: omit tp/sl and triggerPrice [69f8752352](https://github.com/ccxt/ccxt/commits/69f8752352233cd605c866cc1d3702d1bbc5c968)
+*  bybit: update [fd6bc9ddc8](https://github.com/ccxt/ccxt/commits/fd6bc9ddc8171a78e7545329f41fc50f5dd79b48)
+*  latoken AccountSuspended error [52e7c53903](https://github.com/ccxt/ccxt/commits/52e7c53903881de19e58755de3115bd0c84c091c)
+*  fix(gate): fetchOHLCV to argument has 1 subtracted from limit, fixes: #17464 [8305fc4170](https://github.com/ccxt/ccxt/commits/8305fc417033ad51b9675f3cf1d4361634c5eff8)
+*  fix ts examples build [0c7c485c29](https://github.com/ccxt/ccxt/commits/0c7c485c29ecea620627416afc7dd80296137a45)
+*  restore files [dfcb0619ac](https://github.com/ccxt/ccxt/commits/dfcb0619ac89918fe04c2484a79a348a642a75e5)
+*  restore and add examples [35dd2d6654](https://github.com/ccxt/ccxt/commits/35dd2d66545ec6001365840bb6de8d12ac9e5504)
+*  add to push [9172e223d1](https://github.com/ccxt/ccxt/commits/9172e223d186641bbfb1e1c7e4aab466f5eddc9c)
+*  restore files [a5afa70caf](https://github.com/ccxt/ccxt/commits/a5afa70caf6d2f3f0189c93b786784fc0f862be6)
+*  remove generated files [2ff15ed8e4](https://github.com/ccxt/ccxt/commits/2ff15ed8e4c69f82b213c6c2b63a0dda9afbae3b)
+*  fix build [68557dc9b9](https://github.com/ccxt/ccxt/commits/68557dc9b9150f8323da5cfad74dbe94a5ec8768)
+*  remove things [71e67bf40f](https://github.com/ccxt/ccxt/commits/71e67bf40f1efc3553bd77bea21fdbf7d00231f9)
+*  remove comments [1d6b1bdb8a](https://github.com/ccxt/ccxt/commits/1d6b1bdb8a0adf30248e635fc6fcc73604d90819)
+*  3.0.53 [2718e197a6](https://github.com/ccxt/ccxt/commits/2718e197a6abf11cb1ac3a28e4248c60a591abbe)
+
+
+## 3.0.52 (2023-04-04)
+
+*  poloniex handleErrors [6ff5c4de1e](https://github.com/ccxt/ccxt/commits/6ff5c4de1ea95884b7c440287ceeb451d33871bd)
+*  poloniex remove unused [2e90831519](https://github.com/ccxt/ccxt/commits/2e908315194cc682871a57da9154de5f8f9cd6b5)
+*  3.0.52 [9fd23d22cd](https://github.com/ccxt/ccxt/commits/9fd23d22cd7e346a07c0c0b8c20ad1ea50cea07d)
+
+
+## 3.0.51 (2023-04-03)
+
+*  coinex has editOrder [d54b6b88fb](https://github.com/ccxt/ccxt/commits/d54b6b88fb555e3ddbd0e00ba71ab1266a38165e)
+*  3.0.51 [1b03955836](https://github.com/ccxt/ccxt/commits/1b03955836d5e9be376909e1ffe51923f05987ad)
+
+
+## 3.0.50 (2023-04-02)
+
+*  Add return types to a few fetch* methods. [493fdbe667](https://github.com/ccxt/ccxt/commits/493fdbe667116b4fe866802349e80fad846c4a1b)
+*  fix(gate): fix #17443 [d9786eb2a4](https://github.com/ccxt/ccxt/commits/d9786eb2a4c8ae7a8505e0bd63527258c8404467)
+*  3.0.50 [a449c04aa3](https://github.com/ccxt/ccxt/commits/a449c04aa3ec0ca0c3c9805ea59266287079e02e)
+
+
+## 3.0.49 (2023-04-02)
+
+*  coinex editOrder [7ae1bc2fc1](https://github.com/ccxt/ccxt/commits/7ae1bc2fc11ff71cf2671a97d308aaff57fb7159)
+*  coinex add NotSupported [54cfa6e041](https://github.com/ccxt/ccxt/commits/54cfa6e041a41fea8e6627d2e2b015e0ef1fd7ff)
+*  Update coinex.ts [f106f665ef](https://github.com/ccxt/ccxt/commits/f106f665efefa23b9c34fb7c71c97bf079baeec2)
+*  coinex linting [f98faccd72](https://github.com/ccxt/ccxt/commits/f98faccd72294590cda8ef3eecd09c3c1770dd1a)
+*  coinex linting [b0103117af](https://github.com/ccxt/ccxt/commits/b0103117af6af8a3a30c969b5b3a53772074f7b4)
+*  bybit: use updatedTime ccxt/ccxt#17427 [e0cebb2864](https://github.com/ccxt/ccxt/commits/e0cebb28643f425e118fd662574fa8cbf798a574)
+*  bybit: update timestamp of position [784bafe911](https://github.com/ccxt/ccxt/commits/784bafe9119de5892cddddf469caa63131c90cf0)
+*  add checkRequiredArgument [5e3607acc8](https://github.com/ccxt/ccxt/commits/5e3607acc851e59a73a15a81b3b5e160224b2c52)
+*  typo [ad92b809f4](https://github.com/ccxt/ccxt/commits/ad92b809f4ce75727358011e87aaa2d20c29d5b1)
+*  fix linting [41fd1a8ebb](https://github.com/ccxt/ccxt/commits/41fd1a8ebb5a96b94af5313e17f09da994800e04)
+*  fix(binance): setMarginMod exception [3e60408022](https://github.com/ccxt/ccxt/commits/3e60408022292fb7c7e64dba7f7651ba3232557a)
+*  add type [a1d313cba1](https://github.com/ccxt/ccxt/commits/a1d313cba14a9517453661a90faa2e3d21a0b464)
+*  change condition [fb992d3123](https://github.com/ccxt/ccxt/commits/fb992d3123f2956c692db68c00ce5e3cae4fdace)
+*  fix(phemex): usd markets handling [b8ec3cf26d](https://github.com/ccxt/ccxt/commits/b8ec3cf26d3182823858e38c42b2591b874d2557)
+*  fix(Phemex): sandbox v2 [7729365dc4](https://github.com/ccxt/ccxt/commits/7729365dc40adc1264b54c7d32dc80fd802ca94e)
+*  3.0.49 [18999c18f2](https://github.com/ccxt/ccxt/commits/18999c18f2c5e2c0ceb72310a2c5efa8db0a8668)
+
+
+## 3.0.48 (2023-04-01)
+
+*  krakenfutures: fix signing for private endpoints [52ae325f20](https://github.com/ccxt/ccxt/commits/52ae325f2006c8307a8a9ff346cfa9d70eb968a6)
+*  kucoin pro refactor out indexBy [edd77d6a90](https://github.com/ccxt/ccxt/commits/edd77d6a90cd6e323d1416521d9a90639e987da7)
+*  kucoin pro refactor out indexBy [137fb0bae2](https://github.com/ccxt/ccxt/commits/137fb0bae2ba797c85e1d93d42aa416f3f88ac7a)
+*  php camelCase implicit api [30669190b8](https://github.com/ccxt/ccxt/commits/30669190b87041f4bc7e77f2d769dfd80a694688)
+*  update generateImplicitApi [1f53cce461](https://github.com/ccxt/ccxt/commits/1f53cce461ecd6728c04262701524dbc1455652f)
+*  fix(gate): watchOrders and watchMyTrades [ed81fb6169](https://github.com/ccxt/ccxt/commits/ed81fb6169ac28d3877e6a79765963e85954dcc0)
+*  3.0.48 [e1c1365059](https://github.com/ccxt/ccxt/commits/e1c13650598b7a44f25c540860b790f828379518)
+
+
+## 3.0.47 (2023-03-31)
+
+*  ascendex parseTransaction fee [5025856320](https://github.com/ccxt/ccxt/commits/502585632099c470c3b282e74e3c509bd3cb182f)
+*  ascendex linting [a7a68eb676](https://github.com/ccxt/ccxt/commits/a7a68eb67640d49c78a4cc81abada7789503ee6c)
+*  fix some mexc bugs [d104871499](https://github.com/ccxt/ccxt/commits/d104871499b97c7b7c241d24bd4ecfc19643a920)
+*  fix some mexc bugs [15fd17e221](https://github.com/ccxt/ccxt/commits/15fd17e221c458894a546752a0c8c383d081ecb7)
+*  add more type hints [1de686fc81](https://github.com/ccxt/ccxt/commits/1de686fc8192aba7d1b6777dde2e8f39aa020381)
+*  fix build [4df7f1c3ae](https://github.com/ccxt/ccxt/commits/4df7f1c3aee5ce4245773465aa51c59016ac5643)
+*  fix build [1b300897e7](https://github.com/ccxt/ccxt/commits/1b300897e742e85f6c04fcadfe22d1c7b3735146)
+*  safecurrency & safecurrencycode fix [19cbda3271](https://github.com/ccxt/ccxt/commits/19cbda327188cb8010c1045f01bf3a6f890a3860)
+*  fix travis: remove server request [f92a724485](https://github.com/ccxt/ccxt/commits/f92a724485e6d9503c710de7d7d4589ed160d07e)
+*  bitmart: update fetchContractMarkets ccxt/ccxt#17416 [be20fe8934](https://github.com/ccxt/ccxt/commits/be20fe89345f7316b50a2b11acbac12be582fa1c)
+*  refactor out indexById pro/gate [a3e4a53240](https://github.com/ccxt/ccxt/commits/a3e4a5324061dae3b09e8b4c026ab370205a0d51)
+*  minor edit related to a3e4a53240 [7c8e26e78a](https://github.com/ccxt/ccxt/commits/7c8e26e78ac41356309a4c95ce165cda3e871b7b)
+*  remove unused import (pass build) [d56c7cf92f](https://github.com/ccxt/ccxt/commits/d56c7cf92f5bb2546fbce82209d44d251f62117e)
+*  remove unused import (pass build) [d9977f0ef8](https://github.com/ccxt/ccxt/commits/d9977f0ef8dc1f587e29982f49067d6876cb08f9)
+*  add client type hint [64503fba80](https://github.com/ccxt/ccxt/commits/64503fba801fc5bb56960f48fbc9397d3a5460d2)
+*  add client type hint [39d196f405](https://github.com/ccxt/ccxt/commits/39d196f4059fbe949e92e438eca74b00c7875979)
+*  pushback ccxt bundle [ff5cf2dd49](https://github.com/ccxt/ccxt/commits/ff5cf2dd49703e6bb1451e05618aa303bc938c31)
+*  3.0.47 [b93d173ad1](https://github.com/ccxt/ccxt/commits/b93d173ad108c7c310052598d0c0d9da6780f3e8)
+
+
+## 3.0.46 (2023-03-31)
+
+*  initial [1a3a810815](https://github.com/ccxt/ccxt/commits/1a3a8108152547dd8e6875824ce1ed2127e39e46)
+*  sample [fa0bd0d62a](https://github.com/ccxt/ccxt/commits/fa0bd0d62a54abbe53fb54630c525012ed4e402c)
+*  update [9aa7400088](https://github.com/ccxt/ccxt/commits/9aa7400088af85196c5c208985ecb59dddab7169)
+*  final [3a7e717b42](https://github.com/ccxt/ccxt/commits/3a7e717b4209fed64a0c734150a004a2f33619e3)
+*  path fix [e00c71522f](https://github.com/ccxt/ccxt/commits/e00c71522f395cab98423da0878e856f9468e54c)
+*  minor [c30d02ac46](https://github.com/ccxt/ccxt/commits/c30d02ac46947513fe752174a047cd48f1160b61)
+*  minor [0e4251d4db](https://github.com/ccxt/ccxt/commits/0e4251d4db18f6b7985ff8efde75549d5d731872)
+*  minor [cc6a952e4e](https://github.com/ccxt/ccxt/commits/cc6a952e4eca330ba7a6e16e2c428dec4c8fc33b)
+*  fix [980e80465b](https://github.com/ccxt/ccxt/commits/980e80465be9fd5848fe81cd3b9b17f20c12bf73)
+*  newline in end [61144d8fca](https://github.com/ccxt/ccxt/commits/61144d8fca172316ec9618d16fd4cbdc80af2953)
+*  py async [f22d5aa408](https://github.com/ccxt/ccxt/commits/f22d5aa408c7444c826db50f6359a5aecc75ba0b)
+*  php async comment [ddebf884f3](https://github.com/ccxt/ccxt/commits/ddebf884f3f80ebd2b62cbc6f0c0414498896aa7)
+*  php async [5db42f5361](https://github.com/ccxt/ccxt/commits/5db42f536142a5c8bcd39ae6658e821e9892f5a8)
+*  reorganize [f85755c9e3](https://github.com/ccxt/ccxt/commits/f85755c9e3eaf03413f3eafd3356c875500f04be)
+*  updates [11a104be88](https://github.com/ccxt/ccxt/commits/11a104be88f4585d353811da5fe1c8cfe456285f)
+*  safePosition & parsePosition updates [eb0391d8da](https://github.com/ccxt/ccxt/commits/eb0391d8dadef08152d0dcf36ca1228c0233a32e)
+*  Delete ftx.js [92a59ab792](https://github.com/ccxt/ccxt/commits/92a59ab79276cd7e2b5488432d65fb7d912a891e)
+*  remove aax [d2656f31e5](https://github.com/ccxt/ccxt/commits/d2656f31e5c319032a384ca036eae485dba0c964)
+*  bitget cancelOrders, fetchOpenOrders edits [eb2d3395b8](https://github.com/ccxt/ccxt/commits/eb2d3395b885925b5517585005b1f299b890115b)
+*  simple typo at huobi.ts [008c4c2903](https://github.com/ccxt/ccxt/commits/008c4c290333b15f1dbcdfec143855064b186404)
+*  fix(lbank): signature [925f395040](https://github.com/ccxt/ccxt/commits/925f3950400519a8766c2739dbc59a2ca08e76fe)
+*  fix(kucoin): watchOrders timestamp [a36bfb904c](https://github.com/ccxt/ccxt/commits/a36bfb904c724cff48305a760953f94351efb14c)
+*  minor [070a0ad5c9](https://github.com/ccxt/ccxt/commits/070a0ad5c9704ead5682f0297a20a3d8fad487b9)
+*  style edits [f13af8d44c](https://github.com/ccxt/ccxt/commits/f13af8d44cec2a42e65b0d2dcb51155b7725fdb9)
+*  phemex proper private api fix [f0001c22cc](https://github.com/ccxt/ccxt/commits/f0001c22cc42ed61241cc9fc2f6b6c007117b370)
+*  merge [12aa738bce](https://github.com/ccxt/ccxt/commits/12aa738bce247451937b91236857e43247ac755d)
+*  restore [7814a959b7](https://github.com/ccxt/ccxt/commits/7814a959b708d5225e83d1ba3f92cc6359e6197f)
+*  minor edit to signature [6c62f27b56](https://github.com/ccxt/ccxt/commits/6c62f27b5693955f829c619d1cf59b6c9397616e)
+*  inline [ad830a94c3](https://github.com/ccxt/ccxt/commits/ad830a94c3267dcc56679479252ad50acc2e10d0)
+*  add symbols to type hints [bfe9bfce19](https://github.com/ccxt/ccxt/commits/bfe9bfce19d710231a133cd1101c5365ac30bb46)
+*  add favicon to docs [3f51c774f5](https://github.com/ccxt/ccxt/commits/3f51c774f528009c9bec7c07be1b67785437e63b)
+*  add favicon to docs [11a23ae311](https://github.com/ccxt/ccxt/commits/11a23ae31103bd5c6d768b4ad222aba41b0974eb)
+*  add more type hints [82d2524051](https://github.com/ccxt/ccxt/commits/82d2524051b360b8a7f7c30f3f41fbde8108b042)
+*  add more type hints [bc50a25b82](https://github.com/ccxt/ccxt/commits/bc50a25b82020902a26d9d9f86a57b6925d95658)
+*  edit to ordertype / orderside type hints [0d4625443e](https://github.com/ccxt/ccxt/commits/0d4625443ec10b4c085be6d154717c53578f3110)
+*  remove unused imports [44f5107217](https://github.com/ccxt/ccxt/commits/44f5107217f810047207762c96c30c27dd158830)
+*  certify bitmex [ef460eac21](https://github.com/ccxt/ccxt/commits/ef460eac219a26c2a985e9344c6d7d3123ed0fb4)
+*  remove unused imports [acc0b94696](https://github.com/ccxt/ccxt/commits/acc0b9469672ef2dbb98e2ac3ce7a2209c6b0165)
+*  remove unused imports [4dc15fed61](https://github.com/ccxt/ccxt/commits/4dc15fed61893dd18f918de2d934a31da30df6a6)
+*  review fixes [62628d5faa](https://github.com/ccxt/ccxt/commits/62628d5faabf5826f5a4eb2dd072f8522b26aa48)
+*  fix(krakenfutures): fix markets clash [376f08f6b3](https://github.com/ccxt/ccxt/commits/376f08f6b30665797a80bdef0afd62f04a70e2c6)
+*  edit transpile and generateImplicitAPI to generate php api [b2cdbb2559](https://github.com/ccxt/ccxt/commits/b2cdbb255989668ea767aa198852f6c4e8e22f24)
+*  add php abstract definitions (initial) [0e9c11f1f0](https://github.com/ccxt/ccxt/commits/0e9c11f1f05993fc402beca6320863c0f29fc2db)
+*  add php abstract definitions (initial) [a6f52055e5](https://github.com/ccxt/ccxt/commits/a6f52055e51ef314af0c7628ad265276e74fa329)
+*  add support for async php [68fafa5c84](https://github.com/ccxt/ccxt/commits/68fafa5c84f5742ad145da3fe85f80949ffb6e8c)
+*  initial async abstract [8e91049f24](https://github.com/ccxt/ccxt/commits/8e91049f2470a207938d782364d21cf25edcf9d6)
+*  pushback transpiled examples [071fdeb27a](https://github.com/ccxt/ccxt/commits/071fdeb27a0ca17292e748189a0aeee857f1a2d0)
+*  pushback transpiled examples [f45f8527a1](https://github.com/ccxt/ccxt/commits/f45f8527a1fcf95806a60291329ecb4ce7c42119)
+*  pushback abstract php files [bb53ab2c6e](https://github.com/ccxt/ccxt/commits/bb53ab2c6e5fc5bfe9d7d0912f7a27b0e1cc9c3f)
+*  solve bug due to "undefined" subscriptionHash [bb59a5fcaf](https://github.com/ccxt/ccxt/commits/bb59a5fcaf739b07686f19561e40c88195953084)
+*  remove useless subscription [366a601566](https://github.com/ccxt/ccxt/commits/366a601566292ef8afc305dfd8c58eb1892f53f0)
+*  watch edits [0cbfd922e1](https://github.com/ccxt/ccxt/commits/0cbfd922e1c40ec251ecb555255f0ec7e7212a3b)
+*  fix implicit api generation for some classes [cde0d1908f](https://github.com/ccxt/ccxt/commits/cde0d1908f10ec525b8839bfdf7ad94cc6bea7ae)
+*  3.0.46 [6e3d4333b9](https://github.com/ccxt/ccxt/commits/6e3d4333b9528e72a69a2268c02c5c6724a928a9)
+
+
+## 3.0.45 (2023-03-30)
+
+*  type hints for symbol [f9d7e2ef22](https://github.com/ccxt/ccxt/commits/f9d7e2ef22cb4003b077d437cb811f1c3f7547d5)
+*  add more types to base class [484e80f653](https://github.com/ccxt/ccxt/commits/484e80f6537e84a748d343624ebd6512ea321166)
+*  remove duplicate declaration [cf5d49102c](https://github.com/ccxt/ccxt/commits/cf5d49102c8ae536c2f3f1a77434bf5e39066d1a)
+*  add integer type support [6a956df390](https://github.com/ccxt/ccxt/commits/6a956df390969b5ced749a63121b19853d9f6f2b)
+*  add derived files [54f3bad268](https://github.com/ccxt/ccxt/commits/54f3bad268005165150b9fb0655caf5c539a7ce3)
+*  add Int import [bbf28e2a3f](https://github.com/ccxt/ccxt/commits/bbf28e2a3fc29ed9d12ca4f5e07380f6d6c1a635)
+*  add derived files [d1476e0667](https://github.com/ccxt/ccxt/commits/d1476e06674dc16e0a5690223b2945a288e5ca75)
+*  fix remaining bugs in derived files [4c9cf625f1](https://github.com/ccxt/ccxt/commits/4c9cf625f1d225de4242f3a3b7849bd5beb44601)
+*  pass build [cc72474c82](https://github.com/ccxt/ccxt/commits/cc72474c82c4fe70764f06f6d8bcaf27b7922900)
+*  same signature [49555afd28](https://github.com/ccxt/ccxt/commits/49555afd2890d085f73c66d369cf00064717763f)
+*  same signature [6de33ef011](https://github.com/ccxt/ccxt/commits/6de33ef011e58a7388ba55ddb1104f8704cbb201)
+*  fix(types): python3.7 support [0487925f69](https://github.com/ccxt/ccxt/commits/0487925f69dd62e1adc63f527d4cf054d474176d)
+*  3.0.45 [887d1642ec](https://github.com/ccxt/ccxt/commits/887d1642ec9062e5b4b3e92a86f92fdfb6c8ef49)
+
+
+## 3.0.44 (2023-03-30)
+
+*  feat(mexc3): add mexc3 websockets [2b4d2c964b](https://github.com/ccxt/ccxt/commits/2b4d2c964bb92677bf35317e26815b966768f92e)
+*  typescript [27a8325cee](https://github.com/ccxt/ccxt/commits/27a8325cee3ade2425d0e620b6b3d9056087ff69)
+*  fix conflicts [e3f9c748c5](https://github.com/ccxt/ccxt/commits/e3f9c748c5f67c41d585d7d267917bfaa18f7171)
+*  fix build [14c5b9bc77](https://github.com/ccxt/ccxt/commits/14c5b9bc77c4c800e7db9dec6cb9e219ae148c0e)
+*  fix transpile error [8551686f70](https://github.com/ccxt/ccxt/commits/8551686f701696d9a87ee31296291c95110e921d)
+*  kraken new endpoints [5f8e60adf2](https://github.com/ccxt/ccxt/commits/5f8e60adf2da4c8674f4c3e5a2231ea9679dafb2)
+*  save [565051f217](https://github.com/ccxt/ccxt/commits/565051f217a3391a287c27be2a481ba99aba42f6)
+*  save [ca3c778de4](https://github.com/ccxt/ccxt/commits/ca3c778de4903bc755e859c83c6a9586da9a3f70)
+*  update usdt settled endpoints [d8bc8938f1](https://github.com/ccxt/ccxt/commits/d8bc8938f101ebe55b83c6e5ff928eb6fe3a458e)
+*  save [7e64e35376](https://github.com/ccxt/ccxt/commits/7e64e35376f55b7baa33ce9310f81b5f1e8a5e83)
+*  complete mexc3 pro implementation [77d8dd8750](https://github.com/ccxt/ccxt/commits/77d8dd875014808c2ab1bb3b1cd48289f5de0ce8)
+*  pass build [dc76e97310](https://github.com/ccxt/ccxt/commits/dc76e973102b9eae8569127f575823419894c0d0)
+*  fix bitmex authenticate [faf28e61d8](https://github.com/ccxt/ccxt/commits/faf28e61d83ed2b07519d31fb76bb3ed360a2da1)
+*  fix bitmex authenticate [631aee8d08](https://github.com/ccxt/ccxt/commits/631aee8d08661d2d0e34ba4e4d12e52cb1324620)
+*  deprecate mexc v2 api [88e6d40f15](https://github.com/ccxt/ccxt/commits/88e6d40f15621893f3b7d0c775a50539b5252ca1)
+*  move crypto functions out of base class [fa96950918](https://github.com/ccxt/ccxt/commits/fa9695091861606fc8bf7915ac54f6b266fe279c)
+*  remove a base method [d5ca3f3879](https://github.com/ccxt/ccxt/commits/d5ca3f3879b6f303fdab6ee947c758464c66edd8)
+*  comment out signHash tests [dc1aaa9741](https://github.com/ccxt/ccxt/commits/dc1aaa9741a23b1e494c3f3085c6bf8d0fd7ddd8)
+*  comment out signHash tests [ebff7c0f65](https://github.com/ccxt/ccxt/commits/ebff7c0f6570082c7b7ddd49cf5d08e9448a97cc)
+*  transpile type hints [d88a935df1](https://github.com/ccxt/ccxt/commits/d88a935df17c135e6ebfc6471dcda65b60e5e6f2)
+*  php type imports [fc1064fccd](https://github.com/ccxt/ccxt/commits/fc1064fccd9acf05fb33a1c70182a8e87f656030)
+*  add python import [9dc0cf0390](https://github.com/ccxt/ccxt/commits/9dc0cf03904eea34f49dadd705b52c4d1b244015)
+*  fix linting [d4e363336c](https://github.com/ccxt/ccxt/commits/d4e363336cdc0d983893dbdbda6eda9a5c4e91ff)
+*  fix throttle bug [3337d7e888](https://github.com/ccxt/ccxt/commits/3337d7e888dd6b3ce83967392734f1d87d742ed1)
+*  fix library imports [f5bed77414](https://github.com/ccxt/ccxt/commits/f5bed77414c99ad8a963845e07515ee5e10a8892)
+*  pass build [c5c91b3ea8](https://github.com/ccxt/ccxt/commits/c5c91b3ea8a79a50417d2bbe2efa178c540fc287)
+*  remove types from derived files [d23503bc17](https://github.com/ccxt/ccxt/commits/d23503bc17845e413e122e2a192ba84103fe107e)
+*  delete failed types [0fbc456b64](https://github.com/ccxt/ccxt/commits/0fbc456b645fbc6ca7af8f36a3a4486a879198f4)
+*  add type [48f61e6669](https://github.com/ccxt/ccxt/commits/48f61e6669fa9b54421efe9c7f21e9eb77736cfd)
+*  pass python build [f90437d154](https://github.com/ccxt/ccxt/commits/f90437d154f09e822731047dd8b21978cba227bc)
+*  another attempt at types [d70cdabbea](https://github.com/ccxt/ccxt/commits/d70cdabbeaf0fc16b2e6ae9b20ead5ad66d55cc5)
+*  edit eslintrc [1e30d5ee21](https://github.com/ccxt/ccxt/commits/1e30d5ee21adbf526d5919db5e3fe73267fe40e9)
+*  edit to nullable implementation [29928abc96](https://github.com/ccxt/ccxt/commits/29928abc96e04eed1eae9374b83f96342b975125)
+*  fix(ts): remove MessageEvent type due to incompatibility with ts5 [3662f3751f](https://github.com/ccxt/ccxt/commits/3662f3751fe8495252248689ef17133054b8f023)
+*  add base exchange [2c45705746](https://github.com/ccxt/ccxt/commits/2c457057461b72e7a08b9c9307fecc047fba88ad)
+*  support for nullable values [60ac8d7a1d](https://github.com/ccxt/ccxt/commits/60ac8d7a1d9e7bb3a489715782cf39c2ebae99e0)
+*  pass build [b39e40b0f5](https://github.com/ccxt/ccxt/commits/b39e40b0f5fb4b232ee43a95b0ab0da6033e0523)
+*  pass build [3c71c278bf](https://github.com/ccxt/ccxt/commits/3c71c278bf58499e202b78e8d2a5d38a440ded69)
+*  add another possible case [3e57d6ec45](https://github.com/ccxt/ccxt/commits/3e57d6ec45c1097ea65971c0e1972309fc9f66cd)
+*  pass build [5f645237a5](https://github.com/ccxt/ccxt/commits/5f645237a5b53c92dd6dab7f5f03585fb323cc6d)
+*  3.0.44 [1235cb9cc6](https://github.com/ccxt/ccxt/commits/1235cb9cc64d0fa84b2c36f1b25ddb80b5897067)
+
+
+## 3.0.43 (2023-03-29)
+
+*  phemex fetchSpotMarkets fix [e3345834f1](https://github.com/ccxt/ccxt/commits/e3345834f15168e1599046283cb8ae3480f4e83b)
+*  phemex parseSpotOrder fix [61e7f7d6c5](https://github.com/ccxt/ccxt/commits/61e7f7d6c5bfbcb3793eb2b23b7eaefb573297d3)
+*  phemex linting [487508a838](https://github.com/ccxt/ccxt/commits/487508a8383d231329e5885a382f773010018153)
+*  phemex safeInteger [bffe14a47a](https://github.com/ccxt/ccxt/commits/bffe14a47aee7063106d6926fb57daff9405ce2d)
+*  3.0.42 [723436cdd1](https://github.com/ccxt/ccxt/commits/723436cdd1de6685c34e97b20a2f597aa89ecb53)
+*  wazirx on travis [51c08a3ba4](https://github.com/ccxt/ccxt/commits/51c08a3ba4d0273c8c2785579df2b32ae193e102)
+*  wazirx on travis [423201fa43](https://github.com/ccxt/ccxt/commits/423201fa431338c20269a1146afcad336157ec16)
+*  .travis.yml [1607b2e8d1](https://github.com/ccxt/ccxt/commits/1607b2e8d1098e39d6261c0e677a1ad2c4169411)
+*  .travis.yml after_failure sleep 10 [5c4b1e9c10](https://github.com/ccxt/ccxt/commits/5c4b1e9c10105e25760266d7d8f01f1dc61b3b3e)
+*  phemex fetchMyTrades limit [766e2be021](https://github.com/ccxt/ccxt/commits/766e2be0217f3d57f97c725701fc2f53071411d2)
+*  fix(Phemex): create order [6268c50636](https://github.com/ccxt/ccxt/commits/6268c506364414b4f59676b41fe9a6b36f5dfc53)
+*  mexc3 parseTransaction fixes [37f13d3e74](https://github.com/ccxt/ccxt/commits/37f13d3e74931ffde2820af05a407e8482119624)
+*  throttle refactor [496a8b72ec](https://github.com/ccxt/ccxt/commits/496a8b72ecd9c2571b27e168629e0e8589c3a002)
+*  3.0.43 [1034cae07e](https://github.com/ccxt/ccxt/commits/1034cae07ef1d3b330780d7bc4dd5353c0ceab5f)
+
+
+## 3.0.41 (2023-03-28)
+
+*  fix build [55c1f3701b](https://github.com/ccxt/ccxt/commits/55c1f3701bca3c7912c3ccd3be1c24191430338c)
+*  mexc3 fetchDeposits/fetchWithdrawals fixes [05865bbe59](https://github.com/ccxt/ccxt/commits/05865bbe592353207f25661d64ddea583d335789)
+*  mexc3 linting [cf7cef10f3](https://github.com/ccxt/ccxt/commits/cf7cef10f372f8d6bd9cc63b973c3f373a67f057)
+*  fix(kucoin): privatePostAccounts endpoint version [31d91a08b2](https://github.com/ccxt/ccxt/commits/31d91a08b2ba55fbd152c6f1c842ab37abe889e7)
+*  update rate limits [6353003b86](https://github.com/ccxt/ccxt/commits/6353003b86e3650b41d53c4413d0222f20d7dddd)
+*  merge [833c8eea05](https://github.com/ccxt/ccxt/commits/833c8eea05a5ff70dae601e627427b8a50d193f5)
+*  cleanup probit [a5edd37279](https://github.com/ccxt/ccxt/commits/a5edd3727949ed41f2a8543bc2ddbc0db9e7b63a)
+*  edit probit [0af05b8848](https://github.com/ccxt/ccxt/commits/0af05b88488cf0911e15b883f28c2f0e13682a48)
+*  bybit: add 140001 ccxt/ccxt#17372 [81eedc3ef7](https://github.com/ccxt/ccxt/commits/81eedc3ef74b561ccacc2689d82df2ac5b70bae6)
+*  bybit: add rsa signature [32883e122f](https://github.com/ccxt/ccxt/commits/32883e122f94307324ba59f00dec63996b3249dc)
+*  3.0.41 [918af04fe8](https://github.com/ccxt/ccxt/commits/918af04fe8b56e20de431c064716f7d0f57b4d93)
+
+
+## 3.0.40 (2023-03-27)
+
+*  remove question mark [1092093ef9](https://github.com/ccxt/ccxt/commits/1092093ef92bce5153bcfea7fb6d55172e5118ed)
+*  remove question mark [eae1ac64f7](https://github.com/ccxt/ccxt/commits/eae1ac64f78097157334398907282944748d2f5a)
+*  [ci deploy] [d640e699a4](https://github.com/ccxt/ccxt/commits/d640e699a404de8dc89428fc06c4ba3605ac129a)
+*  3.0.40 [8e7fafa7e9](https://github.com/ccxt/ccxt/commits/8e7fafa7e9d1a86676e21e755fc681202643dae7)
+
+
+## 3.0.39 (2023-03-27)
+
+*  edit build/generateImplicitAPI [6c15c4bcfd](https://github.com/ccxt/ccxt/commits/6c15c4bcfd6a8d3f5ae485e0b903a25439cc5c9e)
+*  add abstract directory [a7834a2c45](https://github.com/ccxt/ccxt/commits/a7834a2c45c7607db4bd32cd869beaaad72f736c)
+*  add abstract directory [5230e3567d](https://github.com/ccxt/ccxt/commits/5230e3567d697c680c9030dc3d49346dc1f91e02)
+*  increase rule priority close #17367 [ci deploy] [e6cb3e0725](https://github.com/ccxt/ccxt/commits/e6cb3e0725936ecde7d1accdaf36f15198053ae7)
+*  3.0.39 [0ba1fa88c3](https://github.com/ccxt/ccxt/commits/0ba1fa88c3c62668f8c4059a2cbe8741038e01d3)
+
+
+## 3.0.38 (2023-03-27)
+
+*  `fetchDepositWithdrawFees` [e7f51e0efe](https://github.com/ccxt/ccxt/commits/e7f51e0efe9ad9097f8877bf2bc6ca37350fd6e0)
+*  updates `networks` & `networksById` [21b8c7b2ce](https://github.com/ccxt/ccxt/commits/21b8c7b2ced4ca19a6548156ebdb6b77c8bcf5c2)
+*  fix build [e7e2cd51d4](https://github.com/ccxt/ccxt/commits/e7e2cd51d4b49c5bb489262aaa3f70d3c7dc74eb)
+*  remove untyped optional parameters [5501afb00c](https://github.com/ccxt/ccxt/commits/5501afb00c2b9f5faef93f206c62ab95e6fd414e)
+*  remove typed optional parameter [2c56f3caa2](https://github.com/ccxt/ccxt/commits/2c56f3caa237c374dbe557e789f77e0f954eca38)
+*  remove trailing spaces [3b56ca7dc7](https://github.com/ccxt/ccxt/commits/3b56ca7dc709dbe78aa72de6b74f4c997780c697)
+*  okx editOrder [b0291f627b](https://github.com/ccxt/ccxt/commits/b0291f627ba8435aaf6cdc3c465e4e01c0497171)
+*  Exhange#setMarkets: Currency.numericId is a number and not a string. [60e6cd354d](https://github.com/ccxt/ccxt/commits/60e6cd354dc50a5c7097dbe83525d63c5d9fa26f)
+*  fix(bitmex): fix #17313 [8cc91b4380](https://github.com/ccxt/ccxt/commits/8cc91b438012444f2962cb7d8d244808a7fafa17)
+*  fix transpile [c7704bd051](https://github.com/ccxt/ccxt/commits/c7704bd0511c46f28c5ee92fbcd6ebebe2d993b6)
+*  fix(bitmex): fetchMarkets [7e48361c62](https://github.com/ccxt/ccxt/commits/7e48361c62e8c4e4df290aabc73ab39b57588e00)
+*  binance: patch ccxt/ccxt#17326 [a286cdd0bc](https://github.com/ccxt/ccxt/commits/a286cdd0bc7aadfebf175ed57363c8ac347a4e4b)
+*  binance: add apis [75f8f8f677](https://github.com/ccxt/ccxt/commits/75f8f8f677f8f7380d065b4e602cfacbf13735b9)
+*  bybit: add get announcement api [ea1359d889](https://github.com/ccxt/ccxt/commits/ea1359d889825b4ecb270c5e601d0cd41e27b482)
+*  okx: update saving apis [c643223cae](https://github.com/ccxt/ccxt/commits/c643223cae86796cbf4ba74d464d9e29d98383f6)
+*  pass build [8c64246e2f](https://github.com/ccxt/ccxt/commits/8c64246e2f55e61b65c82a0cafb10890c9f6e00b)
+*  fix sign [e584b1f245](https://github.com/ccxt/ccxt/commits/e584b1f2453db337102eebc24c00aae56935630c)
+*  fix(ts): abstract implicit API [c0eabe7ac5](https://github.com/ccxt/ccxt/commits/c0eabe7ac55f730d24f035f40612cb957bbb1521)
+*  replace quotes [556279977f](https://github.com/ccxt/ccxt/commits/556279977f189cdc9851e0d05e8d6b9601ee023a)
+*  update [d50e3e4a51](https://github.com/ccxt/ccxt/commits/d50e3e4a51f61c889d5f10765f0c56de2531231f)
+*  fix npm [d490943a1d](https://github.com/ccxt/ccxt/commits/d490943a1d9e9133226cd35f7600463cb31615f0)
+*  linting [8921bfb82a](https://github.com/ccxt/ccxt/commits/8921bfb82ad815647addfe75ebd5eadd68b39a68)
+*  3.0.38 [09d95bca1d](https://github.com/ccxt/ccxt/commits/09d95bca1dbbb0c2fbccf260519c4249fe7b281c)
+
+
+## 3.0.37 (2023-03-27)
+
+*  ignore binance in test [f2914dda64](https://github.com/ccxt/ccxt/commits/f2914dda64fdc9d55e6d23b27e8ac8568f6c0744)
+*  3.0.37 [5ed9e5f32f](https://github.com/ccxt/ccxt/commits/5ed9e5f32f302098c709ca9b6223699f061772d8)
+
+
+## 3.0.36 (2023-03-26)
+
+*  bybit: add institutional loan apis ccxt/ccxt#17285 [808da1f6b0](https://github.com/ccxt/ccxt/commits/808da1f6b0a44ebed5f47da2315715ea2e7d74f6)
+*  add information about the ccxt cdn server [7fa4244f96](https://github.com/ccxt/ccxt/commits/7fa4244f963208a62a7d83b43ea287d7d6b1812d)
+*  Added support for clientOrderId in Crypto.com [1274e8bb27](https://github.com/ccxt/ccxt/commits/1274e8bb27a34fdce0d2f207fe272e2c3a92a2c0)
+*  fix linting [a4969c723d](https://github.com/ccxt/ccxt/commits/a4969c723d01f4151c5077edc5956960a2a67db9)
+*  3.0.36 [765ffd23b0](https://github.com/ccxt/ccxt/commits/765ffd23b0e318063fba61940fda58de0b06e628)
+
+
+## 3.0.35 (2023-03-25)
+
+*  Add Exchang#fetchTime return type. [a981d0e2fd](https://github.com/ccxt/ccxt/commits/a981d0e2fd83007bf9ee1275335c7c7b28e054a3)
+*  Add OHLCVC type and typings for parseTimeframe() and buildOHLCVC(). [f07d88c42f](https://github.com/ccxt/ccxt/commits/f07d88c42f2048635d6aa285d7ee9ed7390de2e8)
+*  feat(bybit): increase positions limit [30f845e541](https://github.com/ccxt/ccxt/commits/30f845e541927c9c460ad37e04c193670491ba0c)
+*  fix(md5): hmac signing [8f4e057f2a](https://github.com/ccxt/ccxt/commits/8f4e057f2a6e8dc6c8ad224613bf58073d48c50a)
+*  fix(hitbtc): signing [48d5702e85](https://github.com/ccxt/ccxt/commits/48d5702e85386dbcb134b01269020422b75604be)
+*  add md5 hmac test [9410259473](https://github.com/ccxt/ccxt/commits/9410259473ace7687724deb362d399bfec01aac3)
+*  3.0.35 [4398b5122e](https://github.com/ccxt/ccxt/commits/4398b5122e6c06b5aba83c2a19664e9534e0ca16)
+
+
+## 3.0.34 (2023-03-25)
+
+*  safeMarket refix #17310 [b47a16d9fd](https://github.com/ccxt/ccxt/commits/b47a16d9fd585c910e7e3ca9991b018218224926)
+*  safeMarket refix #17310 [c14a859205](https://github.com/ccxt/ccxt/commits/c14a85920503737fba60517f16665306e174ea2c)
+*  [ci deploy] [f7f22aeac6](https://github.com/ccxt/ccxt/commits/f7f22aeac65a0e8b2481fe153d9f3188dee92c2c)
+*  3.0.34 [7153dcb23a](https://github.com/ccxt/ccxt/commits/7153dcb23a3cfbea07fdd5d30eaf2b2dbbe4a86f)
+
+
+## 3.0.33 (2023-03-24)
+
+*  fix coinex: signature [f61fc1c919](https://github.com/ccxt/ccxt/commits/f61fc1c9191bad610751391c1f5a15c6c73a0b69)
+*  3.0.33 [ca969cda51](https://github.com/ccxt/ccxt/commits/ca969cda51fe6a230650af12a794113dd31b73c9)
+
+
+## 3.0.32 (2023-03-24)
+
+*  binance: Market['strike'] is a number, not a string [8e8f88491e](https://github.com/ccxt/ccxt/commits/8e8f88491eb42f89252f2f400a364cd0ea6113ca)
+*  huobijp hostname update [43b7f16bb3](https://github.com/ccxt/ccxt/commits/43b7f16bb30a49e284e690936d3d1bfac9e08f9e)
+*  build: improve implicit api methods [3b86a34784](https://github.com/ccxt/ccxt/commits/3b86a347848c690a164564c37ca7a4eb6ba29f83)
+*  fix ts: add more types [bc392472f6](https://github.com/ccxt/ccxt/commits/bc392472f68adc328ebe680274d17d799d1dab73)
+*  pushback ccxt.browser.min.js [1fd8c13d1e](https://github.com/ccxt/ccxt/commits/1fd8c13d1e0b7d0607f093a338c4037e50679a99)
+*  pushback ccxt.browser.min.js [566a087dd0](https://github.com/ccxt/ccxt/commits/566a087dd04712ce4454dd506a5f7ab0841aebc4)
+*  add: ts types [d7c8a4ceb7](https://github.com/ccxt/ccxt/commits/d7c8a4ceb75b408beb5fc219a57edc6cfb7461b7)
+*  tcp window size increase for sockets [5d7b980d9f](https://github.com/ccxt/ccxt/commits/5d7b980d9fc5ea90986efb6ec60ec496949c4de7)
+*  make new agent with keepalive if missing node [0d2b6f2d8b](https://github.com/ccxt/ccxt/commits/0d2b6f2d8be03943d9d8221dc86eb11e6d8cd240)
+*  binance: Market['strike'] is a number, not a string [f8e8ca85a1](https://github.com/ccxt/ccxt/commits/f8e8ca85a1c2c5d637f90f5fcf2f43d8655f725f)
+*  make new agent with keepalive if missing node [16674bb55a](https://github.com/ccxt/ccxt/commits/16674bb55a331356d29cc5dd930b1a38da0507ea)
+*  restore [5680b2ee45](https://github.com/ccxt/ccxt/commits/5680b2ee4521fb146b42cba487e0fd0046c476d5)
+*  restore [a40034dc6a](https://github.com/ccxt/ccxt/commits/a40034dc6a32bfac589880ae8dc9295732961b14)
+*  3.0.32 [802a4f8dfd](https://github.com/ccxt/ccxt/commits/802a4f8dfd03efdd259fb6cae3d5c874cd9e607e)
+
+
+## 3.0.31 (2023-03-24)
+
+*  idex handleTicker string math [8cbeb179cb](https://github.com/ccxt/ccxt/commits/8cbeb179cb2bf4a090aa58969b51de18a8448d8c)
+*  initial commit [989a33c9b0](https://github.com/ccxt/ccxt/commits/989a33c9b004d27b8f2ae36cf720e14447cbb582)
+*  cleanup cryptojs [a026dd22f6](https://github.com/ccxt/ccxt/commits/a026dd22f6f8d1b350487b01351a78875643108f)
+*  reduce size of cryptojs [359a8f068b](https://github.com/ccxt/ccxt/commits/359a8f068b408f3d06c930daefb93d9ee2b2f9d5)
+*  add derived classes [3b3c5b4d2b](https://github.com/ccxt/ccxt/commits/3b3c5b4d2b617f6fa122bd20af85076f82728c31)
+*  pass build [0ebf0bde39](https://github.com/ccxt/ccxt/commits/0ebf0bde39c5d956ac7ee62fbb46f5547ee1b2e1)
+*  save edits [1b39867311](https://github.com/ccxt/ccxt/commits/1b3986731191b21161bc8f8f302825451eb144fa)
+*  port all deps to ts and esm [cec1e9b108](https://github.com/ccxt/ccxt/commits/cec1e9b108a0ede9148d725cb69efb80440f4b4d)
+*  update crypto and encode base classes [15ca1a4fcd](https://github.com/ccxt/ccxt/commits/15ca1a4fcd8397a55af779d1b405fab39d016c2e)
+*  add derived files [f27d33a019](https://github.com/ccxt/ccxt/commits/f27d33a01930d050b3ee816a958476a5e80c6ada)
+*  misc files [d897862dfc](https://github.com/ccxt/ccxt/commits/d897862dfcfd0fdc27c21131b6b990f676be80d1)
+*  save edits [0bb9fa985d](https://github.com/ccxt/ccxt/commits/0bb9fa985ded927fe3966028cdd4641ed3f20318)
+*  delete old sdeps [b52e8a1fa5](https://github.com/ccxt/ccxt/commits/b52e8a1fa569ff9958a2da0d057a8ba686fe0891)
+*  save webpack config [e9e9519762](https://github.com/ccxt/ccxt/commits/e9e9519762e165201df202f37e761a21005db350)
+*  update webpack config to typescript [ebbd64c474](https://github.com/ccxt/ccxt/commits/ebbd64c474e580b9bb75495344414d672a954a10)
+*  minor edit [a6ccc52f99](https://github.com/ccxt/ccxt/commits/a6ccc52f99ef111362f91f27606ec412240c9aba)
+*  successful tree shaking activated [bf0446e3d5](https://github.com/ccxt/ccxt/commits/bf0446e3d5ad1a70a2576d2d67fff0ad5e85f766)
+*  minor edits [9ca6a7299b](https://github.com/ccxt/ccxt/commits/9ca6a7299b6bd3aafa5dcb99df2930103625885a)
+*  restore and merge [0eaca7e8bc](https://github.com/ccxt/ccxt/commits/0eaca7e8bc0004798f4560fd3f5ccfce239c9683)
+*  work in progress move esm loading to derived files [b07e67e90f](https://github.com/ccxt/ccxt/commits/b07e67e90f2db9f4e83330c98c2165471446a543)
+*  add most fixes to derived files [7fd75c9c40](https://github.com/ccxt/ccxt/commits/7fd75c9c4022e9ea7bbd5e876c09650c94a44096)
+*  readd crypto functions [bbd0bb3f39](https://github.com/ccxt/ccxt/commits/bbd0bb3f39f52ae71e0f5ad69b642980248fdb4f)
+*  almost completed [04fe51ecce](https://github.com/ccxt/ccxt/commits/04fe51ecce5c7e3815dd7284af58218a868a1531)
+*  minor edit to md5 [8ee16d0d00](https://github.com/ccxt/ccxt/commits/8ee16d0d00975b4298b080e4ca3b4592e4255996)
+*  package.json edits [b6ba7a24d4](https://github.com/ccxt/ccxt/commits/b6ba7a24d4df656789f19a74892e23d576c61918)
+*  pass php crypto tests [1bcdb7e1a1](https://github.com/ccxt/ccxt/commits/1bcdb7e1a16d4a43d065539f2d34f0096a5ea827)
+*  minor comment edit [7e4f839c0e](https://github.com/ccxt/ccxt/commits/7e4f839c0e422c0c513aa7de4a58a4eef50a630b)
+*  implement waves eddsa [cb23c730bd](https://github.com/ccxt/ccxt/commits/cb23c730bd5feeccf0db157950c6b91b1effc063)
+*  complete [b8d36ff42d](https://github.com/ccxt/ccxt/commits/b8d36ff42dad3500c7f8c478fe162c55c818d40f)
+*  fix a bug [2c9f2cd559](https://github.com/ccxt/ccxt/commits/2c9f2cd5596dd1e9456b9e4b8dbe75930cbc4eec)
+*  add transpile [b2c668d955](https://github.com/ccxt/ccxt/commits/b2c668d95528eda09723356b74ab56401a2bfdb7)
+*  restore file [1bffe93e81](https://github.com/ccxt/ccxt/commits/1bffe93e819afad279a804a3453dece73fe80402)
+*  add file [9e2acf9607](https://github.com/ccxt/ccxt/commits/9e2acf960705ed57bcb34c0aacbce9c6085e83d5)
+*  update webpack config [95723bb9c3](https://github.com/ccxt/ccxt/commits/95723bb9c393c7801107c11bbf4000df9f0053ba)
+*  run transpile [fdd1c0f456](https://github.com/ccxt/ccxt/commits/fdd1c0f4568665a578d9567ab0df0e35e62e1b3f)
+*  restore inflate [10deb45d1e](https://github.com/ccxt/ccxt/commits/10deb45d1ee39ce6874bdc68d5e617cacd0ec6bd)
+*  better encoding support [6b1e98370f](https://github.com/ccxt/ccxt/commits/6b1e98370fc0a3cd2ba36f4a3412ac348a9568d6)
+*  fix more bugs with type hints [63b913dfee](https://github.com/ccxt/ccxt/commits/63b913dfee485d936a4a13d2d35d57be880ae792)
+*  fix windows path and zlib [34f5ccd365](https://github.com/ccxt/ccxt/commits/34f5ccd365bf848ce90918dff01b779d4b2bc443)
+*  minor edits [2297da9996](https://github.com/ccxt/ccxt/commits/2297da9996d900cc5b1fbeb9d6fd263129000f74)
+*  rebuild [b8fbf04590](https://github.com/ccxt/ccxt/commits/b8fbf04590ed01e04d5d47d0052f60e1b31dd504)
+*  add missing file [c9b542ce8e](https://github.com/ccxt/ccxt/commits/c9b542ce8e47ee493eaeb1a8b4331fd17f17a6bc)
+*  add webpack config [d81e1b76c2](https://github.com/ccxt/ccxt/commits/d81e1b76c23c6daf404ea096edc59e8451410725)
+*  refix [e2b5dbfa15](https://github.com/ccxt/ccxt/commits/e2b5dbfa156e5e628a67b0cc66c7216eb8f28edb)
+*  nodejs 16 [7e5e22ce6a](https://github.com/ccxt/ccxt/commits/7e5e22ce6a4d9cfa820b0f24e4a894175c9dc1fe)
+*  okx fetchCurrencies fix [3d80c25e3c](https://github.com/ccxt/ccxt/commits/3d80c25e3c6e4953ab15c33e90dd7d3b57b265dd)
+*  add generate implicit api [9a168b96b4](https://github.com/ccxt/ccxt/commits/9a168b96b49536e40114d71f9b47abefdb808d2c)
+*  small fix [e846023ee5](https://github.com/ccxt/ccxt/commits/e846023ee5a26c53da92e6050a884780bb723244)
+*  add command inside package.json [2a3916e480](https://github.com/ccxt/ccxt/commits/2a3916e480d442478e42cc014153a8e19b38e356)
+*  example [b5f97e2868](https://github.com/ccxt/ccxt/commits/b5f97e2868cbb997e135d61e923b6b349ee9a486)
+*  remove extra space [34427722cb](https://github.com/ccxt/ccxt/commits/34427722cbdfc44b0bbee2544379447b0f60dece)
+*  update [754633c282](https://github.com/ccxt/ccxt/commits/754633c28298b28d2723b519bdb7ba207da34ecd)
+*  new schema [91b09a47f2](https://github.com/ccxt/ccxt/commits/91b09a47f2adac839c62b45b7e4340cee28b71bc)
+*  change derived files [0b8e983630](https://github.com/ccxt/ccxt/commits/0b8e983630e0deb72bea8e24a68ca6bc693eacec)
+*  better type support [7adb35c166](https://github.com/ccxt/ccxt/commits/7adb35c1669bacc5159b5cfabe2c34beaf66c31e)
+*  fix some ts bugs [d1a49dea18](https://github.com/ccxt/ccxt/commits/d1a49dea18c69b7141a3803bc81e51176b1ad622)
+*  fix more derived files [1957eef364](https://github.com/ccxt/ccxt/commits/1957eef36451985567da14f4a887d2b388e75f68)
+*  restore imports [8cd48cd27f](https://github.com/ccxt/ccxt/commits/8cd48cd27f2e770765e411c326c5ac451e39568a)
+*  all compiling now [290f6ddc43](https://github.com/ccxt/ccxt/commits/290f6ddc4396775bee454fa7f9911a28b18fba0e)
+*  use js file [3a0693dfbb](https://github.com/ccxt/ccxt/commits/3a0693dfbbc62019ef40d03ad0063d1fc28533c2)
+*  add kucoinfutures [a2e4da032b](https://github.com/ccxt/ccxt/commits/a2e4da032bb97baae4022031b693478ee7313b23)
+*  minor edits [c541352a2c](https://github.com/ccxt/ccxt/commits/c541352a2c18777169cead9b6d45b8f37265007b)
+*  merge [aefae2a08e](https://github.com/ccxt/ccxt/commits/aefae2a08e0b05dcba3916d75e1e748484de5314)
+*  minor typescript edit [d576250458](https://github.com/ccxt/ccxt/commits/d57625045871ee7310a6e06e95cc6a814a80643f)
+*  fix huobijp bug [e1fad0670b](https://github.com/ccxt/ccxt/commits/e1fad0670b6e84415aa8b5bedb18d75b6c319b85)
+*  fix huobijp bug [fa5026bc70](https://github.com/ccxt/ccxt/commits/fa5026bc703845d4aeb1fb2901740d5d68e5e952)
+*  remove (this as any) [ffb046b3dd](https://github.com/ccxt/ccxt/commits/ffb046b3dd50090f0bdec1b1a6ef99dc1c561428)
+*  fix implicit api bugs [867e45274d](https://github.com/ccxt/ccxt/commits/867e45274d85547e998e136940b7c51b87a05376)
+*  fix more implicit api stuff using typescript hints [ci deploy] [e202ea0b76](https://github.com/ccxt/ccxt/commits/e202ea0b76fff182500aedd61a215b3372af152c)
+*  3.0.31 [21ac876c95](https://github.com/ccxt/ccxt/commits/21ac876c954828bd9059dc8dc0bd75f3eea4f487)
+
+
+## 3.0.30 (2023-03-23)
+
+*  fix Exchange: safeMarket [25cf5fd2e1](https://github.com/ccxt/ccxt/commits/25cf5fd2e1915dd40ecb5314b5b7120001f07c25)
+*  fix fetchTickers [c8b3068d84](https://github.com/ccxt/ccxt/commits/c8b3068d84d240253d33fbb887a45efeebba57d5)
+*  fix bybit: future type and parseTIcker [9aa950d175](https://github.com/ccxt/ccxt/commits/9aa950d1753b50bec77a34631a67e2fbb4fa519f)
+*  fix(bybit,gate): polluting markets loading [2ba367e186](https://github.com/ccxt/ccxt/commits/2ba367e1869b7c820a4f14c1ea6174b46a913626)
+*  3.0.30 [57c57cdc26](https://github.com/ccxt/ccxt/commits/57c57cdc26fe251e6f3e4584d277681d724bfe6d)
+
+
+## 3.0.29 (2023-03-23)
+
+*  fix(wazirx):watchBalance add info to balance structure [19e66800d4](https://github.com/ccxt/ccxt/commits/19e66800d4279c668587d3dca52c8bd99393772e)
+*  update npm command [6882ca1a43](https://github.com/ccxt/ccxt/commits/6882ca1a43e20ff353af85d246d5b6600839d1a8)
+*  fix windows compatbility issue [764e780aaa](https://github.com/ccxt/ccxt/commits/764e780aaa363270fd7a2632e71cdcf9ba27c4b5)
+*  remove replaceAll [0a73db4c29](https://github.com/ccxt/ccxt/commits/0a73db4c29461117ae9e22b2305e9bf04ea44d94)
+*  fix(binance): parse deposit status, fix #17218 [15d0a00ae2](https://github.com/ccxt/ccxt/commits/15d0a00ae2b9aa20971d57807a8a5de70ab65549)
+*  lint [1ab8c904cc](https://github.com/ccxt/ccxt/commits/1ab8c904cca1b4dea34a0de92097d94895677d9d)
+*  fixed bybit stop_loss triggerDirection for Shorts order [a817739f2a](https://github.com/ccxt/ccxt/commits/a817739f2a1b9f4f886d99016de838474a128b9b)
+*  fixed bybit stop_loss triggerDirection for Shorts order [3cdfb783e0](https://github.com/ccxt/ccxt/commits/3cdfb783e0d0a204a7c42f60825f3c9dc46f99bb)
+*  generating files [881f79901d](https://github.com/ccxt/ccxt/commits/881f79901d19f5e8a6c89f291b9109ad10479c5d)
+*  pr comments [4735e326ea](https://github.com/ccxt/ccxt/commits/4735e326ea38a4e02d8a05837f49492355373297)
+*  generating files [8181e0c415](https://github.com/ccxt/ccxt/commits/8181e0c415c83b0c170c5fe2a032b3635a1c8871)
+*  Revert "generating files" [2d23b66f5c](https://github.com/ccxt/ccxt/commits/2d23b66f5c8554fe632b0bcc344b6a1129844041)
+*  Revert "generating files" [39b32e7c96](https://github.com/ccxt/ccxt/commits/39b32e7c96f5034ee648fd796f63f17770a0592a)
+*  removing generated files [a2dbe7e296](https://github.com/ccxt/ccxt/commits/a2dbe7e29649e8df97a62a4444fff00b570fdac8)
+*  removing generated files [48f0bcf4dc](https://github.com/ccxt/ccxt/commits/48f0bcf4dca88f82cdefa4b9abd5dcedc85aa0aa)
+*  bitmart cancelAllOrders enhancement [1b33ebb86e](https://github.com/ccxt/ccxt/commits/1b33ebb86e68166d0dc73c35571e9d6823d05e67)
+*  bitmart linting [a2567f6af6](https://github.com/ccxt/ccxt/commits/a2567f6af6b1f40d1b7beba41aee4fc8af35d747)
+*  bitmart linting [074a7f373f](https://github.com/ccxt/ccxt/commits/074a7f373fb4a54f6a4d341865a46970a689d60a)
+*  fix gate [fae9b0e890](https://github.com/ccxt/ccxt/commits/fae9b0e89043473e906c3e531ef2b491e16b85f5)
+*  po tif omit [49d70550c0](https://github.com/ccxt/ccxt/commits/49d70550c03a306822497b94daed40edd18a589a)
+*  rename to PostOnly [4763a4542b](https://github.com/ccxt/ccxt/commits/4763a4542b0a5fbffaafd44652713e29643a9b3b)
+*  coinex parseTransaction fix [f0bc47ed45](https://github.com/ccxt/ccxt/commits/f0bc47ed45ff0a361a9da8353047acdfec454093)
+*  changes to takeProfit & createContractV3Order [008235561e](https://github.com/ccxt/ccxt/commits/008235561e1d8354d9b535b8259868c8e89fbb70)
+*  feat(binance): fetchOHLCV baseVolume for inverse markets [576e1ae090](https://github.com/ccxt/ccxt/commits/576e1ae0908d600a0836e62d0cb2eab42c5870de)
+*  feat(bybit): fetchOHLCV baseVolume for inverse markets [9bd67a3ec1](https://github.com/ccxt/ccxt/commits/9bd67a3ec174ec44233071c714e6150bf6be1974)
+*  change stopLossTrigger conditional to ternary [1cacfb60f3](https://github.com/ccxt/ccxt/commits/1cacfb60f30a89497364a7cf60c211bab775b16c)
+*  handle market type [7aeaea0aeb](https://github.com/ccxt/ccxt/commits/7aeaea0aebc79ce65f81d3bf28a0666454d5755d)
+*  rename variable [efb2e445c3](https://github.com/ccxt/ccxt/commits/efb2e445c3c20d46a12c841655beadc654007dd6)
+*  add time_in_force [c156774b52](https://github.com/ccxt/ccxt/commits/c156774b52e44c7b99876dd6afcc361fc114d2e9)
+*  replace [0a737c82e1](https://github.com/ccxt/ccxt/commits/0a737c82e171f676cca9e7fb45d19592a40fc7d1)
+*  gtc [63d9051a55](https://github.com/ccxt/ccxt/commits/63d9051a55aeb14112ba8355f84b497c57c82233)
+*  variable add [bc6a174596](https://github.com/ccxt/ccxt/commits/bc6a174596f72a30e7b3faed3054a7edee3270be)
+*  simplify options [99c54d4a00](https://github.com/ccxt/ccxt/commits/99c54d4a00d54180451662f9f9fbebf0a5dda528)
+*  lowercase [6b4a73d076](https://github.com/ccxt/ccxt/commits/6b4a73d076a4e667adc1bd3ad3e6bb2753cd61b1)
+*  revert [979c274064](https://github.com/ccxt/ccxt/commits/979c274064201f70cd9d46f4d561ba085d6dbf9c)
+*  fix(OKX): demo trading [11f8e84dcf](https://github.com/ccxt/ccxt/commits/11f8e84dcf978521c8f1a892b1ce88ff729182cb)
+*  bybit: patch order fee [2c7df679a2](https://github.com/ccxt/ccxt/commits/2c7df679a2c3dd1e1b354c806363ef93ba10a854)
+*  typo orderStatus [19ac5635c4](https://github.com/ccxt/ccxt/commits/19ac5635c4b0d5bd080ab1292736a9624cb62968)
+*  update createMarketOrder flag [859115b462](https://github.com/ccxt/ccxt/commits/859115b462fad5ec769952f45e099e6c0d4235cd)
+*  3.0.28 [402df2470e](https://github.com/ccxt/ccxt/commits/402df2470e732ac857ecdb46444784adabcd042d)
+*  3.0.29 [a8f4689942](https://github.com/ccxt/ccxt/commits/a8f46899426bceb5f07fd3d13577488ed43998c8)
+
+
+## 3.0.27 (2023-03-22)
+
+*  kraken handleTicker string math [14bee62015](https://github.com/ccxt/ccxt/commits/14bee62015359cecee0f3db5cbebecc7905289a3)
+*  ascendex parsePosition string math [bf6ad3e4e5](https://github.com/ccxt/ccxt/commits/bf6ad3e4e51f968c2879465f304241d12308d077)
+*  ascendex parsePosition remove safePosition [15efb649d2](https://github.com/ccxt/ccxt/commits/15efb649d25d6f77a4fcb283216d902afc10d648)
+*  fix ts: add some more prop types [5a66c750a1](https://github.com/ccxt/ccxt/commits/5a66c750a1d4e331a94861fc2a07467e691c6aa6)
+*  add defaults [73d0944c19](https://github.com/ccxt/ccxt/commits/73d0944c194b40279d2e43da1965d814d8b82129)
+*  fix: parsePrecision [d24d8daafa](https://github.com/ccxt/ccxt/commits/d24d8daaface1416038d729bcae8dada9139cf7d)
+*  zb parseOrder side fix [6393a7d7b0](https://github.com/ccxt/ccxt/commits/6393a7d7b0946ee198225e33005c92dc3ade1700)
+*  fix(bitpro,bitget): fix parseOHLCV and fetchOrderTrades [cd1eb9f596](https://github.com/ccxt/ccxt/commits/cd1eb9f5960fe39b48b7820e6ebc7f4fb302b8d1)
+*  remove unnecessary this as any [f8975c1ec8](https://github.com/ccxt/ccxt/commits/f8975c1ec8f47b72c35a735cd354fb7aa9946feb)
+*  ccxt.ts: also export Dictionary and MinMax. [ae529d2d42](https://github.com/ccxt/ccxt/commits/ae529d2d42d6d85d6c774ec456ba46a8db9cdd42)
+*  3.0.27 [b9a77e29bb](https://github.com/ccxt/ccxt/commits/b9a77e29bbc2a77c580804affdc70b9b7396b231)
+
+
+## 3.0.26 (2023-03-21)
+
+*  fix(kucoin): handlePong [756cb79fa2](https://github.com/ccxt/ccxt/commits/756cb79fa2cdc7a34934c8f5cffaac1e6d422958)
+*  3.0.26 [8ae4393fb3](https://github.com/ccxt/ccxt/commits/8ae4393fb322e4d14ec8e78d71d677a2fd044c3c)
+
+
+## 3.0.25 (2023-03-20)
+
+*  fix(ascendex): fix #17256 python handle ping await error [7d8a03ca11](https://github.com/ccxt/ccxt/commits/7d8a03ca1181421ef5332fb36410f29146ecd94e)
+*  fix: Remove setTimeout_safe [5096ea8ce6](https://github.com/ccxt/ccxt/commits/5096ea8ce62edc02192798f902cf1d069f55b149)
+*  bitstamp parseTrade fix [4a99dcb94b](https://github.com/ccxt/ccxt/commits/4a99dcb94b7da0526c5d8c04ace02e5d7474f3b2)
+*  bitstamp linting [0612824703](https://github.com/ccxt/ccxt/commits/06128247033301cb107c393bef5e5c2620de04dd)
+*  restore [143c4fe37b](https://github.com/ccxt/ccxt/commits/143c4fe37ba3e56062ef90eb1f673a6525926869)
+*  add any [2be8757796](https://github.com/ccxt/ccxt/commits/2be8757796428f3b3d6f470b710294d2e722d458)
+*  fix(bybit): add symbol to fetchPositions [00e7795fe3](https://github.com/ccxt/ccxt/commits/00e7795fe35de0976536f927ef58e06c74a7636a)
+*  3.0.25 [73afc7f86c](https://github.com/ccxt/ccxt/commits/73afc7f86ca90791743e15132de65624dd45d72f)
+
+
+## 3.0.24 (2023-03-20)
+
+*  gate: add apis [54dc8590b2](https://github.com/ccxt/ccxt/commits/54dc8590b2ab926750c7abfbc9b86f50e236584d)
+*  docs: upgdate required node version to 15 to support AbortController [f9a6e2e358](https://github.com/ccxt/ccxt/commits/f9a6e2e35828b3c74ad42bab1476a942519976cb)
+*  fix(mexc): GASNEO name as GAS [eb2e531f23](https://github.com/ccxt/ccxt/commits/eb2e531f23fcd5a246471ecb09e428a28d72f90b)
+*  fix(bybit): v5 does not require symbol for spot trades [384d80562c](https://github.com/ccxt/ccxt/commits/384d80562cc2b821531ff8775b6296077490f39b)
+*  3.0.24 [a84b56b9f7](https://github.com/ccxt/ccxt/commits/a84b56b9f7ee89ea105385845688c4a4330bba9d)
+
+
+## 3.0.23 (2023-03-19)
+
+*  bitget symbol on maintenance error handling [179740e005](https://github.com/ccxt/ccxt/commits/179740e0057064023d1c1ba30eec793220f3f276)
+*  bitget error handling [8383416586](https://github.com/ccxt/ccxt/commits/83834165861b791d14bd51377edad3f587487d02)
+*  bitget error handling [6666b07b63](https://github.com/ccxt/ccxt/commits/6666b07b63f8ab08a35c78e714f791a96a7b4433)
+*  fix(binance): postOnly Orders [d72ff8b4ea](https://github.com/ccxt/ccxt/commits/d72ff8b4eaf40e2a2795549fd1497c83a2cebd7f)
+*  remove timeInForce [e0082ab35b](https://github.com/ccxt/ccxt/commits/e0082ab35b21c0bec4702de60776aec02c0842d2)
+*  feat add cancelAllOrders to base Exchange [054f541914](https://github.com/ccxt/ccxt/commits/054f541914174ca345bec52e17680ca21bd65330)
+*  3.0.23 [06e252fbb1](https://github.com/ccxt/ccxt/commits/06e252fbb1ab75aede198c33effaf557b014cd36)
+
+
+## 3.0.22 (2023-03-18)
+
+*  add missing package.json [09a433073c](https://github.com/ccxt/ccxt/commits/09a433073ce4f63c864d2190e90c63fc27d819fb)
+*  3.0.22 [24a59c76a0](https://github.com/ccxt/ccxt/commits/24a59c76a038c3ca5a2e5b4474d1f46cb052eb0d)
+
+
+## 3.0.21 (2023-03-18)
+
+*  `fetchDepositWithdrawFees` [dd2266b848](https://github.com/ccxt/ccxt/commits/dd2266b8484b7b44545ab2c4f814ff9c4d299094)
+*  feat: add 1:1 CommonJS structure instead of bundle [4f31700c89](https://github.com/ccxt/ccxt/commits/4f31700c89180ec05cdb0744f60180fa8fbe3038)
+*  update ccxt.cjs [6e7217d0d6](https://github.com/ccxt/ccxt/commits/6e7217d0d6ac2766fa5f0ef79d875ad6611e8234)
+*  update rollup [61c664c596](https://github.com/ccxt/ccxt/commits/61c664c596272b1206c131d563b6efe21d22a892)
+*  update vss [2ba039a82d](https://github.com/ccxt/ccxt/commits/2ba039a82d6264692ec73e69966eec84a82b7de4)
+*  stub folder [8d82adfa95](https://github.com/ccxt/ccxt/commits/8d82adfa95df32f65406e6f03039e79d8a7e7222)
+*  review updates [a3594cc9c6](https://github.com/ccxt/ccxt/commits/a3594cc9c634ab60433d0aff0258d969585284a3)
+*  change untyped optional parameters [d79d9643d4](https://github.com/ccxt/ccxt/commits/d79d9643d45acfc012113382e1cf3e4fcc66595f)
+*  remove typed optional parameter [ae1afd5333](https://github.com/ccxt/ccxt/commits/ae1afd533364887c5cf1d02fa2e8a911e36ae9c4)
+*  okx.ts transfer fix [680f49036a](https://github.com/ccxt/ccxt/commits/680f49036a0a0c2bebfd4098cf5953e5b35ce06b)
+*  restore bundle [17ed16b72e](https://github.com/ccxt/ccxt/commits/17ed16b72eea3c1b6a573086041cdd820974328d)
+*  Add bundle version as well [75f0372974](https://github.com/ccxt/ccxt/commits/75f03729740490b159043f0ed8def0fe9538f470)
+*  update vss [64253cdca3](https://github.com/ccxt/ccxt/commits/64253cdca327895b79dc93273860ac03a5cf1668)
+*  feat(TS): add watchTicker and watchTickers type [f33cf0c747](https://github.com/ccxt/ccxt/commits/f33cf0c747fc081d720647d1508fc42cb086bff8)
+*  add doc [0b6675b2ce](https://github.com/ccxt/ccxt/commits/0b6675b2ce5861d0d554837f5b8e5bbd82587853)
+*  build: pushback cjs files [9e16cbf994](https://github.com/ccxt/ccxt/commits/9e16cbf994e8b3e7446ec4761715a6c9377c3255)
+*  feat: Add more ts types [49f5ecf8d5](https://github.com/ccxt/ccxt/commits/49f5ecf8d5660e528ae83719f29473dd622e5397)
+*  ts: transpile stubs [28346882f2](https://github.com/ccxt/ccxt/commits/28346882f2256b3530d23d0bbc7090a7aa4dbea1)
+*  remove old re definitions [889ac3cd38](https://github.com/ccxt/ccxt/commits/889ac3cd38e2756ad254216c1b03bd840e451309)
+*  add parseMarketLeverageTiers [b254b2e923](https://github.com/ccxt/ccxt/commits/b254b2e923401ee78a080680d84b2e1df5532549)
+*  3.0.21 [25c913dc6d](https://github.com/ccxt/ccxt/commits/25c913dc6df912322a74c563d7dd9b979bff31ae)
+
+
+## 3.0.20 (2023-03-18)
+
+*  fix(ts): add default types [bda267e539](https://github.com/ccxt/ccxt/commits/bda267e539d006fb83b9df2a30230ec0ef387807)
+*  close #17241 [cd8e8af9fb](https://github.com/ccxt/ccxt/commits/cd8e8af9fbaabdcca649ae22c9d6d33f05951b20)
+*  3.0.20 [b9d8366e49](https://github.com/ccxt/ccxt/commits/b9d8366e4951f92b97f5cb31e84724d68f306722)
+
+
+## 3.0.19 (2023-03-17)
+
+*  fix(Exchange): markets type [dd78b497e2](https://github.com/ccxt/ccxt/commits/dd78b497e26051cf9e47f3fcddacddd854bdd245)
+*  fix: Uniformize sign header [f8f4e819f1](https://github.com/ccxt/ccxt/commits/f8f4e819f1f03f9140871e079caef1559fed64b3)
+*  fix: restored named Exceptions exports [aca8410321](https://github.com/ccxt/ccxt/commits/aca8410321a41606144f71f6af4fa096928b9d5c)
+*  fix(abortError): store it as prop [3922a50d51](https://github.com/ccxt/ccxt/commits/3922a50d51d4e76693d99af819c884cd6e8e9774)
+*  move AbortError [35a77e59e4](https://github.com/ccxt/ccxt/commits/35a77e59e4a8d828f786975328512c3f268da3b8)
+*  3.0.19 [c6030235da](https://github.com/ccxt/ccxt/commits/c6030235dad3febf37b4073e612921a37dc75e79)
+
+
+## 3.0.18 (2023-03-17)
+
+*  exmo order status [c7ba593e57](https://github.com/ccxt/ccxt/commits/c7ba593e570669c3043578a96b248ba4fc425059)
+*  docs: update docs to new docsify links [80e9c46230](https://github.com/ccxt/ccxt/commits/80e9c46230e4d909ac8a47f5268978c4d3f973e0)
+*  update [2fe61eb952](https://github.com/ccxt/ccxt/commits/2fe61eb952bd3a6acb2e4e0f5da4a50a5a307fde)
+*  [krakenfutures] Add `params.clientOrderId` to createOrder [01a62a17a1](https://github.com/ccxt/ccxt/commits/01a62a17a14301db786bcf3412965ed15258a80a)
+*  3.0.18 [8889ac9658](https://github.com/ccxt/ccxt/commits/8889ac96588dce8b8253bc6c3b598e0f7ee969bf)
+
+
+## 3.0.17 (2023-03-16)
+
+*  coinsph.js added (work in progress) [1a142f6760](https://github.com/ccxt/ccxt/commits/1a142f67603e1f595251a3fa75426249fa7a4fe1)
+*  Update coinsph.js [edd87f9ddb](https://github.com/ccxt/ccxt/commits/edd87f9ddb30f9e20927640f0cb39c00fb057255)
+*  Update coinsph.js [1b5cc0a083](https://github.com/ccxt/ccxt/commits/1b5cc0a0835038d3b32daa68bd2eff5a2497437c)
+*  Update coinsph.js [a4fc7e85b5](https://github.com/ccxt/ccxt/commits/a4fc7e85b55bc94c7a7dc1f9182f8f042e07a159)
+*  Update coinsph.js [6538914edf](https://github.com/ccxt/ccxt/commits/6538914edf66dc7b78d65810eea4f91ace7f63df)
+*  Update coinsph.js [445554cbd0](https://github.com/ccxt/ccxt/commits/445554cbd048682fc5e7e211a181ebfa0b47cf37)
+*  Update coinsph.js [86734d791f](https://github.com/ccxt/ccxt/commits/86734d791fdbf94001305dd00231621f1a184137)
+*  Update coinsph.js [5d7be7b62e](https://github.com/ccxt/ccxt/commits/5d7be7b62ef47b252e94cdbe0af8a7f66171208c)
+*  Update coinsph.js [7123cd6c26](https://github.com/ccxt/ccxt/commits/7123cd6c260f2d594604ba47f1e4cac50b0313fd)
+*  Update coinsph.js [002a7a550c](https://github.com/ccxt/ccxt/commits/002a7a550c40679f8629cda02ff3495f1b37ccc4)
+*  Update coinsph.js [5b6cf28a65](https://github.com/ccxt/ccxt/commits/5b6cf28a65653e9d431d2414260b61cdfe53f0c4)
+*  Update coinsph.js [9a1b99569e](https://github.com/ccxt/ccxt/commits/9a1b99569e099bc82bf99a5aa73fefae9665120a)
+*  Update coinsph.js [43c60a6377](https://github.com/ccxt/ccxt/commits/43c60a63773e2f3cbf74b69b92b526df3af5a456)
+*  coinsph.ts added [1ab1821e2a](https://github.com/ccxt/ccxt/commits/1ab1821e2a0da9f73d94eb00dff2620ca51ecc22)
+*  ready for check [515a870135](https://github.com/ccxt/ccxt/commits/515a870135e4f6b8c6759a3401e8a4d989ea7778)
+*  TS errors fixed [0fd09f35d0](https://github.com/ccxt/ccxt/commits/0fd09f35d0ac51c35f38e8bc26c2ff731ae90b5f)
+*  Delete coinsph.js [5df5772785](https://github.com/ccxt/ccxt/commits/5df5772785c67adc3e4451a65c229ac8e72ac5b0)
+*  Update coinsph.ts [46a1fe840e](https://github.com/ccxt/ccxt/commits/46a1fe840e3f6bb547fbf1f045a01b5ec3a59e04)
+*  Update coinsph.ts [3781085258](https://github.com/ccxt/ccxt/commits/378108525811626979efb5c81b6cb62271f28795)
+*  coinsph [ci deploy] [85f7eae9bd](https://github.com/ccxt/ccxt/commits/85f7eae9bd09b7837310b94ed23f5e1ca6f98c19)
+*  coinsph naming edit fix #17217 [ci deploy] [b1ad8d2ecb](https://github.com/ccxt/ccxt/commits/b1ad8d2ecb88609fcaf4fb4c5f13a5f041fedbd5)
+*  3.0.17 [c580c8ccae](https://github.com/ccxt/ccxt/commits/c580c8ccae7d34f02da42f4575c9468a300e97df)
+
+
+## 3.0.16 (2023-03-16)
+
+*  feat(okx): fetchOHLCV retrieve base volume [eee4eb34c1](https://github.com/ccxt/ccxt/commits/eee4eb34c153f9c269fb1550ade26f9c5aac3a79)
+*  fix parseOHLCV [22832de1f1](https://github.com/ccxt/ccxt/commits/22832de1f18eff4698496b8275649f722903b857)
+*  parseDepositAddresses undefined result fix [d1901ede24](https://github.com/ccxt/ccxt/commits/d1901ede241eb034ee3148d89ed1fddf38d6aed1)
+*  restore [8e6639bef2](https://github.com/ccxt/ccxt/commits/8e6639bef24b1767cbbafc7b21d08cc06b29ab41)
+*  fix(Exchange): fetchDepositAddresses [3cf0612f67](https://github.com/ccxt/ccxt/commits/3cf0612f672c4bd3c5286b08d2bc1e5a735f4879)
+*  3.0.16 [e8b12c2b30](https://github.com/ccxt/ccxt/commits/e8b12c2b3092cca9aed5b561d635da0d84b680ba)
+
+
+## 3.0.15 (2023-03-16)
+
+*  kucoin parseTransactionStatus [95a7d7f35b](https://github.com/ccxt/ccxt/commits/95a7d7f35b9d5c21aaf9bc553dc00c256a0d5919)
+*  fix(kraken): watchOrderbook handleDeltas [ee7b0dcea4](https://github.com/ccxt/ccxt/commits/ee7b0dcea4eb63210a1e9c6b011cfa995ce55018)
+*  3.0.15 [287fc7d2e4](https://github.com/ccxt/ccxt/commits/287fc7d2e48a4d89f87d9ded5b3629b1a8176e04)
+
+
+## 3.0.14 (2023-03-16)
+
+*  feat(TS): type optional parameters [c851956563](https://github.com/ccxt/ccxt/commits/c8519565636a3c953b901bcc1ce223be13cf6a20)
+*  feat(build): don't duplicate generated preamble [3f68e03c3e](https://github.com/ccxt/ccxt/commits/3f68e03c3edb6aae48f22b40bbd3c0eef0634480)
+*  more types and stubs [37fc664c4b](https://github.com/ccxt/ccxt/commits/37fc664c4b1e74e86931055a4320e2ddd1ae692d)
+*  3.0.14 [72bb310318](https://github.com/ccxt/ccxt/commits/72bb3103182c6bfe88b90b92dce0ae63124229fb)
+
+
+## 3.0.13 (2023-03-16)
+
+*  poloniexfutures createOrder, fetchOrder, cancelOrder, parseOrder clean up [4e8aac543b](https://github.com/ccxt/ccxt/commits/4e8aac543bb9a96f97d539230f78c829a12ba336)
+*  poloniexfutures fetchOrder cost change value [6708f6f24f](https://github.com/ccxt/ccxt/commits/6708f6f24f7d2c3aaaaaefb036c8b6102eacf10c)
+*  poloniexfutures.fetchOpenOrders fix to fetch open orders [c6c9b71b4e](https://github.com/ccxt/ccxt/commits/c6c9b71b4edd0979e964377a19e5f7890b85a639)
+*  poloniexfutures.parseOrder minor change [eb5fd1bcdc](https://github.com/ccxt/ccxt/commits/eb5fd1bcdce331fc98e86d129ea564049b0caf2c)
+*  poloniexfutures fetchOrdersByStatus minor change [60a16a70a6](https://github.com/ccxt/ccxt/commits/60a16a70a6dbeb4633c3d7f89d89bb4d881a9dd4)
+*  feat(build): add cjs test [552f6e8f19](https://github.com/ccxt/ccxt/commits/552f6e8f19816c8f304c970cb4e7c44fe5e7100d)
+*  update testsmanager [b9da10de39](https://github.com/ccxt/ccxt/commits/b9da10de399b2adcc7c4b41f0e75be03f4fed8c2)
+*  3.0.12 [8353be6385](https://github.com/ccxt/ccxt/commits/8353be6385298294be0db67114856aa8d1e9d514)
+*  keys.json [ci deploy] [758deca751](https://github.com/ccxt/ccxt/commits/758deca751bfe0f0debac9c570104e52206ffa58)
+*  3.0.13 [d1af2acda2](https://github.com/ccxt/ccxt/commits/d1af2acda22156fa019636e19ab87cdbbfdc062c)
+
+
+## 3.0.11 (2023-03-16)
+
+*  fix: parsePrecision returns precision as a string number that is not scientific notation [a24eb267f6](https://github.com/ccxt/ccxt/commits/a24eb267f695559e84629b187eb5a8e055dea22b)
+*  fix(Binance): default settle value [370e8eafc0](https://github.com/ccxt/ccxt/commits/370e8eafc07728b6008b77ee04613307eb8d7ceb)
+*  update docs [2baae302b8](https://github.com/ccxt/ccxt/commits/2baae302b8c4864c874a83f772d7fa1f49112815)
+*  update docs again [9d0941e4f4](https://github.com/ccxt/ccxt/commits/9d0941e4f4b69bff4e537af272b663f287907fb4)
+*  update docs again [f6d695fad3](https://github.com/ccxt/ccxt/commits/f6d695fad3460d87818d890d7d4b5aaad95f45ec)
+*  fix parsePrecision [1b8a99cf86](https://github.com/ccxt/ccxt/commits/1b8a99cf865541fd39c1b7df9135e33b22af96d1)
+*  fix(PRO): restore exchange export [1fc3b0fd72](https://github.com/ccxt/ccxt/commits/1fc3b0fd724a68c65a67722a7ac9a87a728bf647)
+*  handle str precision inside decimal_to_precision [a244e1861c](https://github.com/ccxt/ccxt/commits/a244e1861c248c0b92b707c4f79b04a815bfe7ce)
+*  adatp decimal_to_precision and add tests [3eb4713caa](https://github.com/ccxt/ccxt/commits/3eb4713caae18b8fda2be67e786436fd84b9e029)
+*  3.0.11 [33a4b82d6c](https://github.com/ccxt/ccxt/commits/33a4b82d6cfea6e98e75f0c35f390bf73fcf59b1)
+
+
+## 3.0.10 (2023-03-15)
+
+*  bybit: update contract v3 signature ccxt/ccxt#17172 [c7989b7d0c](https://github.com/ccxt/ccxt/commits/c7989b7d0cdc15cc3706a6ea38c79c0b781e4716)
+*  fix(TS): init values for ws structures [dd3b5b403f](https://github.com/ccxt/ccxt/commits/dd3b5b403fe043d82d5a5abf04498c5ad5fa2321)
+*  fix cli [9d8448bb1e](https://github.com/ccxt/ccxt/commits/9d8448bb1e7104b49852d87e025594d2572dc085)
+*  update defaults [68ac1eceeb](https://github.com/ccxt/ccxt/commits/68ac1eceeb2a911b80d8e472c530925e7d98f8be)
+*  3.0.10 [d41fa65070](https://github.com/ccxt/ccxt/commits/d41fa65070309fdad54d0db9e3abdd7806f474bd)
+
+
+## 3.0.9 (2023-03-15)
+
+*  emitTypes & package json [10ca559cbb](https://github.com/ccxt/ccxt/commits/10ca559cbb60c5f255e6e274d6457acdf6891a22)
+*  try simple emitTypes fix [8d53bda522](https://github.com/ccxt/ccxt/commits/8d53bda522306f80b0913f8d687c9e809e7d4d70)
+*  improve comment [3c1fcbca64](https://github.com/ccxt/ccxt/commits/3c1fcbca645d6dc4d8236473777af87854cc818a)
+*  add print [80d49188a0](https://github.com/ccxt/ccxt/commits/80d49188a06e217ecf794efc207c98c6163c3889)
+*  try alias [cd5e333129](https://github.com/ccxt/ccxt/commits/cd5e333129d2579a23607a153112233ae78063f2)
+*  try alias [6e1728f3e2](https://github.com/ccxt/ccxt/commits/6e1728f3e2fc70ddc7de909c0713b4dc6cfafd7e)
+*  update emitTypes.js [92f625dcb4](https://github.com/ccxt/ccxt/commits/92f625dcb455d1e69335eddee578436a454cb3d3)
+*  missing package.json [0d163d647e](https://github.com/ccxt/ccxt/commits/0d163d647e5c0ceb0590709ecae8e4123e7a3bf9)
+*  update cleanup [15f03b8012](https://github.com/ccxt/ccxt/commits/15f03b8012451a3fd91341ddbae5fa15b8536125)
+*  restore [18601d3f76](https://github.com/ccxt/ccxt/commits/18601d3f76c275b62598b8d297fa8ad1d1cf7209)
+*  restore [825756ab05](https://github.com/ccxt/ccxt/commits/825756ab050bb79c182ed3c6122cafa63d741e0b)
+*  restore travis [42b2fd747d](https://github.com/ccxt/ccxt/commits/42b2fd747d2f7a782d16544d1c32bb7f23a4ee12)
+*  add new line [25bc1a1480](https://github.com/ccxt/ccxt/commits/25bc1a1480cc2f946b1ec33f8c7115a8d95bd039)
+*  remove sleeps [0b29abe14b](https://github.com/ccxt/ccxt/commits/0b29abe14ba69c5af8f2712c7f8eeae70195a3f4)
+*  [ci deploy] [8833e3587a](https://github.com/ccxt/ccxt/commits/8833e3587a89f2ffc797a4a6804b2165c507f96a)
+*  3.0.9 [6a2c7496ba](https://github.com/ccxt/ccxt/commits/6a2c7496baa5be36ec405cf13f30cd61c00d77c7)
+
+
+## 3.0.8 (2023-03-14)
+
+*  fix commonjs import errors [183799796b](https://github.com/ccxt/ccxt/commits/183799796b54d1e8cf78e8cfdb72d9c7cf2fcd57)
+*  readd js to pass travis [ci deploy] [f5b3b0a6a4](https://github.com/ccxt/ccxt/commits/f5b3b0a6a4dce5b36dfc5bdd4335bd92719ced2e)
+*  3.0.8 [67eaac7dc1](https://github.com/ccxt/ccxt/commits/67eaac7dc14b9c7b3394066100e1d5f59da4ac85)
+
+
+## 3.0.7 (2023-03-14)
+
+*  package.json: set node version to 15.0.0 in engines [d5f6c01c17](https://github.com/ccxt/ccxt/commits/d5f6c01c17676ee66410a2dcf81e4688cf4fe377)
+*  add ts example [b74bdd7de3](https://github.com/ccxt/ccxt/commits/b74bdd7de356bdb86eb4ac65ece7fd004a876c54)
+*  feat(TS): add more types and stub methods [0e0591c5fa](https://github.com/ccxt/ccxt/commits/0e0591c5fa90aa22cab5d4aa3e1b354f1d54f66b)
+*  update export exchanges [3a90163ffd](https://github.com/ccxt/ccxt/commits/3a90163ffd7e19296c1506b8f693b57c15dc608a)
+*  remove duplicated [089a48de67](https://github.com/ccxt/ccxt/commits/089a48de67f60b1ee83d6100609b921a7574c912)
+*  3.0.7 [9e278bfb1b](https://github.com/ccxt/ccxt/commits/9e278bfb1bb2701019064c6e8ef4ac2a7a42d67b)
+
+
+## 3.0.6 (2023-03-14)
+
+*  fix(bybit): v5 uta spot market buy [12788e279e](https://github.com/ccxt/ccxt/commits/12788e279eda32b827bb51f3923a9854f0e07fd8)
+*  blank line [829125e4df](https://github.com/ccxt/ccxt/commits/829125e4df51781557a12f05f44ac7d8f375ef1f)
+*  add throw [1242ab62e5](https://github.com/ccxt/ccxt/commits/1242ab62e55b3de36a52b6ac1ae4cf900482cb28)
+*  fix key [5ef77b06c6](https://github.com/ccxt/ccxt/commits/5ef77b06c6d9bdbc2891f5664ec5f09ca568c8ea)
+*  feat(TS): improve types [46082cad5e](https://github.com/ccxt/ccxt/commits/46082cad5e7c320d8eb8c821a30ac2c03df9e733)
+*  createOrder type [c394816426](https://github.com/ccxt/ccxt/commits/c3948164262882d7b0a5819e07af455cadf351e1)
+*  add Order and Trade types [af761aebf3](https://github.com/ccxt/ccxt/commits/af761aebf3077b0b3ac8865ad0512dbe1e9c147d)
+*  add ticker [b17bb1f276](https://github.com/ccxt/ccxt/commits/b17bb1f2766328e0827e8f6e4a5a4553f626a590)
+*  3.0.6 [6b36b63547](https://github.com/ccxt/ccxt/commits/6b36b63547c283b02572ad0eddc958fd0898aec4)
+
+
+## 3.0.5 (2023-03-14)
+
+*  docs: docstring links updated to new documentation links [64a10d7503](https://github.com/ccxt/ccxt/commits/64a10d7503e6c1ae4e6efb7c79b4f521fe10b249)
+*  markdown files docstring links updated to new documentation links [695c0cb31f](https://github.com/ccxt/ccxt/commits/695c0cb31f2edda5a1f9b0406cc46f9a1ebd72a8)
+*  CONTRIBUTING.md minor fixes [fc57cc4ff3](https://github.com/ccxt/ccxt/commits/fc57cc4ff32e42a29cfb0e852ac9f441ca82bb27)
+*  CONTRIBUTING.md minor fixes [7bca328781](https://github.com/ccxt/ccxt/commits/7bca328781c70510a8d123b49f899e76717cd2e8)
+*  CONTRIBUTING.md minor fixes [410d21d79b](https://github.com/ccxt/ccxt/commits/410d21d79bcb7d3d7e3c7819d7cba7e418e2dbf4)
+*  add contributing to wiki [2ae28a16a7](https://github.com/ccxt/ccxt/commits/2ae28a16a7a61ca941f763a7c98e995b45a978f4)
+*  add contributing to wiki [c099fb625d](https://github.com/ccxt/ccxt/commits/c099fb625d634309b71b4b7e5d10b2535e933148)
+*  fix(Phemex): add default posSide [4660544937](https://github.com/ccxt/ccxt/commits/4660544937c7d68bcd9c8c859a99d25e33e92d42)
+*  remove blank [2beb3f7ab6](https://github.com/ccxt/ccxt/commits/2beb3f7ab6bce8162ea951447b03a011f6df2f67)
+*  remove extra checks [b4dab5f0fb](https://github.com/ccxt/ccxt/commits/b4dab5f0fb95b1fa7815930c084bbe35afd61d95)
+*  improve param handling [a021299d25](https://github.com/ccxt/ccxt/commits/a021299d251d7b6526fd65d691fba1b5f5a6bffc)
+*  precision fix [858b4ef72c](https://github.com/ccxt/ccxt/commits/858b4ef72c34586612bf6c4e3118e2bbec09c774)
+*  add side to eslintrc [153fc79c00](https://github.com/ccxt/ccxt/commits/153fc79c00670f6d0c82ffb0fa71bc62ff7af5db)
+*  fetch: fix websocker usage [eea2669b93](https://github.com/ccxt/ccxt/commits/eea2669b93fc919199ef1df0a6ebae6b99d81886)
+*  3.0.5 [f3415c0f68](https://github.com/ccxt/ccxt/commits/f3415c0f6812fb80e41218f030e8280ebf9ab4a2)
+
+
+## 3.0.4 (2023-03-13)
+
+*  node fetch remove a dependency [ci deploy] [ae89b87a53](https://github.com/ccxt/ccxt/commits/ae89b87a5344560d840b79a2a67602c9f3116c53)
+*  3.0.4 [00c5c62972](https://github.com/ccxt/ccxt/commits/00c5c629723a0ad5a5a79782de609e6872fbfa34)
+
+
+## 3.0.3 (2023-03-13)
+
+*  fix npm package [ci deploy] [4d288d1eed](https://github.com/ccxt/ccxt/commits/4d288d1eed949a9b693c258e0f3c65f53f1d1b1d)
+*  3.0.3 [3ea34884f8](https://github.com/ccxt/ccxt/commits/3ea34884f81c00fd413ef956a508f7a8c1352c15)
+
+
+## 3.0.2 (2023-03-13)
+
+*  regenerate js files [ci deploy] [f323703153](https://github.com/ccxt/ccxt/commits/f3237031531821fb66cb77c89f63f5e353fbf62f)
+*  run tsc to regenerate files [ci deploy] [a7dfd2257c](https://github.com/ccxt/ccxt/commits/a7dfd2257cd36426df2ea0fe3b7a6d86b2884ad2)
+*  3.0.2 [1b8aded9b1](https://github.com/ccxt/ccxt/commits/1b8aded9b1d2d9bdf4f23d64467f316e40ff01c8)
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### 3.1.5 (2023-05-21)
-
-### 3.1.4 (2023-05-21)
-
-### 3.1.3 (2023-05-20)
-
-### 3.1.2 (2023-05-19)
-
-### 3.1.1 (2023-05-18)
-
-### 3.0.107 (2023-05-18)
-
-### 3.0.106 (2023-05-17)
-
-### 3.0.105 (2023-05-16)
-
-### 3.0.104 (2023-05-15)
-
-
-### Bug Fixes
-
-* **phemex:** ping pong handling ([ae0aea8](https://github.com/ccxt/ccxt/commit/ae0aea856985609ebacdd0a375758575fb9e7743))
-
-### 3.0.103 (2023-05-14)
-
-
-### Bug Fixes
-
-* **gate:** fix status for partial orders and canceled orders ([6218c59](https://github.com/ccxt/ccxt/commit/6218c59564e30ad738091c4d184870f3bc4eb482))
-
-### 3.0.102 (2023-05-13)
-
-### 3.0.101 (2023-05-12)
-
-
-### Bug Fixes
-
-* **coinbase:** fetchOrders, fetchOrdersByStatus, fix since ([fb444e5](https://github.com/ccxt/ccxt/commit/fb444e562784ec949a7b034909fd095ea9cc5b52))
-
-### 3.0.100 (2023-05-11)
-
-### 3.0.99 (2023-05-10)
-
-### 3.0.98 (2023-05-09)
-
-### 3.0.97 (2023-05-08)
-
-
-### Bug Fixes
-
-* **deribit:** fix [#17729](https://github.com/ccxt/ccxt/issues/17729) ([2a5d61a](https://github.com/ccxt/ccxt/commit/2a5d61af37235ca85f72bbbab2440685c68a4d39))
-
-### 3.0.96 (2023-05-06)
-
-### 3.0.95 (2023-05-06)
-
-### 3.0.94 (2023-05-05)
-
-
-### Bug Fixes
-
-* **whitebit:** signing ([08249c7](https://github.com/ccxt/ccxt/commit/08249c79b6a4680acf0da4f186aa2fc8ce10f6f1))
-
-### 3.0.93 (2023-05-05)
-
-### 3.0.92 (2023-05-04)
-
-### 3.0.91 (2023-05-04)
-
-### 3.0.90 (2023-05-03)
-
-### 3.0.89 (2023-05-02)
-
-### 3.0.88 (2023-05-02)
-
-### 3.0.87 (2023-05-02)
-
-### 3.0.86 (2023-05-01)
-
-### 3.0.85 (2023-05-01)
-
-### 3.0.84 (2023-04-30)
-
-### 3.0.83 (2023-04-29)
-
-### 3.0.82 (2023-04-28)
-
-
-### Bug Fixes
-
-* **phemex:** watchOrders auth flow ([5a53e1e](https://github.com/ccxt/ccxt/commit/5a53e1e91f4c33bf4c792ed8cbee90ab36f5cd1f))
-
-### 3.0.81 (2023-04-28)
-
-### 3.0.80 (2023-04-27)
-
-
-### Bug Fixes
-
-* **webpack:** webworkers usage ([bc63ad9](https://github.com/ccxt/ccxt/commit/bc63ad905c5db0c1b3ff1ad62e3eabeb48126c3a))
-
-### 3.0.79 (2023-04-27)
-
-### 3.0.78 (2023-04-26)
-
-### 3.0.77 (2023-04-25)
-
-### 3.0.76 (2023-04-24)
-
-
-### Features
-
-* **Deribit:** add spot markets ([d561ecf](https://github.com/ccxt/ccxt/commit/d561ecffb0e7f4ca894a6285f0aa1c3d2c097dcc))
-
-### 3.0.75 (2023-04-23)
-
-### 3.0.74 (2023-04-21)
-
-### 3.0.73 (2023-04-20)
-
-### 3.0.72 (2023-04-19)
-
-
-### Features
-
-* **bitget:** change fetchOpenInterest error type ([026e199](https://github.com/ccxt/ccxt/commit/026e199bf96cca54c3b367ab8031a81c83ad8cc9))
-
-### 3.0.71 (2023-04-18)
-
-### 3.0.70 (2023-04-18)
-
-### 3.0.69 (2023-04-17)
-
-### 3.0.68 (2023-04-17)
-
-### 3.0.67 (2023-04-16)
-
-### 3.0.66 (2023-04-15)
-
-
-### Bug Fixes
-
-* **bybit:** createOrder v3 stopPrice ([40defcc](https://github.com/ccxt/ccxt/commit/40defccc6fed6a7aeef43c7092cd67659cde842f))
-
-### 3.0.65 (2023-04-15)
-
-### 3.0.64 (2023-04-14)
-
-### 3.0.63 (2023-04-14)
-
-### 3.0.62 (2023-04-12)
-
-
-### Bug Fixes
-
-* **bybit:** createMarketBuyOrderRequiresPrice ([4948630](https://github.com/ccxt/ccxt/commit/494863020a07bb2fe707acebba41049b714ee77e))
-
-### 3.0.61 (2023-04-11)
-
-### 3.0.60 (2023-04-10)
-
-### 3.0.59 (2023-04-10)
-
-### 3.0.58 (2023-04-09)
-
-### 3.0.57 (2023-04-09)
-
-### 3.0.56 (2023-04-06)
-
-### 3.0.55 (2023-04-06)
-
-### 3.0.54 (2023-04-05)
-
-### 3.0.53 (2023-04-04)
-
-### 3.0.52 (2023-04-04)
-
-### 3.0.51 (2023-04-03)
-
-### 3.0.50 (2023-04-02)
-
-### 3.0.49 (2023-04-02)
-
-
-### Bug Fixes
-
-* **Phemex:** sandbox v2 ([7729365](https://github.com/ccxt/ccxt/commit/7729365dc40adc1264b54c7d32dc80fd802ca94e))
-
-### 3.0.48 (2023-04-01)
-
-
-### Bug Fixes
-
-* **gate:** watchOrders and watchMyTrades ([ed81fb6](https://github.com/ccxt/ccxt/commit/ed81fb6169ac28d3877e6a79765963e85954dcc0))
-
-### 3.0.47 (2023-03-31)
-
-### 3.0.46 (2023-03-31)
-
-### 3.0.45 (2023-03-30)
-
-
-### Bug Fixes
-
-* **types:** python3.7 support ([0487925](https://github.com/ccxt/ccxt/commit/0487925f69dd62e1adc63f527d4cf054d474176d))
-
-### 3.0.44 (2023-03-30)
-
-### 3.0.43 (2023-03-29)
-
-### 3.0.41 (2023-03-28)
-
-### 3.0.40 (2023-03-27)
-
-### 3.0.39 (2023-03-27)
-
-### 3.0.38 (2023-03-27)
-
-### 3.0.37 (2023-03-27)
-
-### 3.0.36 (2023-03-26)
-
-### 3.0.35 (2023-03-25)
-
-### 3.0.34 (2023-03-25)
-
-### 3.0.33 (2023-03-24)
-
-### 3.0.32 (2023-03-24)
-
-### 3.0.31 (2023-03-24)
-
-### 3.0.30 (2023-03-23)
-
-
-### Bug Fixes
-
-* **bybit,gate:** polluting markets loading ([2ba367e](https://github.com/ccxt/ccxt/commit/2ba367e1869b7c820a4f14c1ea6174b46a913626))
-
-### 3.0.29 (2023-03-23)
-
-### 3.0.27 (2023-03-22)
-
-### 3.0.26 (2023-03-21)
-
-
-### Bug Fixes
-
-* **kucoin:** handlePong ([756cb79](https://github.com/ccxt/ccxt/commit/756cb79fa2cdc7a34934c8f5cffaac1e6d422958))
-
-### 3.0.25 (2023-03-20)
-
-### 3.0.24 (2023-03-20)
-
-### 3.0.23 (2023-03-19)
-
-### 3.0.22 (2023-03-18)
-
-### 3.0.21 (2023-03-18)
-
-### 3.0.20 (2023-03-18)
-
-### 3.0.19 (2023-03-17)
-
-### 3.0.18 (2023-03-17)
-
-### 3.0.17 (2023-03-16)
-
-### 3.0.16 (2023-03-16)
-
-
-### Bug Fixes
-
-* **Exchange:** fetchDepositAddresses ([3cf0612](https://github.com/ccxt/ccxt/commit/3cf0612f672c4bd3c5286b08d2bc1e5a735f4879))
-
-### 3.0.15 (2023-03-16)
-
-
-### Bug Fixes
-
-* **kraken:** watchOrderbook handleDeltas ([ee7b0dc](https://github.com/ccxt/ccxt/commit/ee7b0dcea4eb63210a1e9c6b011cfa995ce55018))
-
-### 3.0.14 (2023-03-16)
-
-### 3.0.13 (2023-03-16)
-
-### 3.0.11 (2023-03-16)
-
-### 3.0.10 (2023-03-15)
-
-### 3.0.9 (2023-03-15)
-
-### 3.0.8 (2023-03-14)
-
-### 3.0.7 (2023-03-14)
-
-### 3.0.6 (2023-03-14)
-
-### 3.0.5 (2023-03-14)
-
-### 3.0.4 (2023-03-13)
-
-### 3.0.3 (2023-03-13)
-
-### 3.0.2 (2023-03-13)
-
-### 3.0.1 (2023-03-13)
-
-### 2.9.16 (2023-03-13)
-
-### 2.9.15 (2023-03-13)
-
-### 2.9.14 (2023-03-13)
-
-### 2.9.13 (2023-03-12)
-
-
-### Bug Fixes
-
-* **Phemex:** createOrder usd settled contracts [ci deploy] ([cdd673d](https://github.com/ccxt/ccxt/commit/cdd673da65b6d788f6955ea22a209028704bd0e5))
-
-### 2.9.12 (2023-03-11)
-
-### 2.9.11 (2023-03-10)
-
-### 2.9.10 (2023-03-09)
-
-### 2.9.9 (2023-03-09)
-
-### 2.9.8 (2023-03-08)
-
-### 2.9.7 (2023-03-07)
-
-### 2.9.6 (2023-03-06)
-
-### 2.9.5 (2023-03-06)
-
-### 2.9.4 (2023-03-06)
-
-### 2.9.3 (2023-03-06)
-
-### 2.9.2 (2023-03-06)
-
-### 2.9.1 (2023-03-06)
-
-### 2.8.99 (2023-03-06)
-
-### 2.8.98 (2023-03-05)
-
-### 2.8.97 (2023-03-05)
-
-### 2.8.96 (2023-03-05)
-
-### 2.8.95 (2023-03-05)
-
-### 2.8.94 (2023-03-04)
-
-
-### Bug Fixes
-
-* **bybit:** parseTicker default type ([8a929fa](https://github.com/ccxt/ccxt/commit/8a929fa60908ba4d8ff31bb2b95945c1bf9353e1))
-
-### 2.8.93 (2023-03-04)
-
-
-### Bug Fixes
-
-* **binance:** stream reconnect ([da96a59](https://github.com/ccxt/ccxt/commit/da96a597f6296524fc0151d2c1bd40974948b71c))
-
-### 2.8.92 (2023-03-04)
-
-### 2.8.91 (2023-03-04)
-
-### 2.8.90 (2023-03-04)
-
-### 2.8.89 (2023-03-04)
-
-### 2.8.88 (2023-03-04)
-
-
-### Features
-
-* **coinbasepro:** Added bidVolume and askVolume to watchTicker ([86ed8aa](https://github.com/ccxt/ccxt/commit/86ed8aaec409b9447019907024eaa6ad575c5a21))
-
-### 2.8.87 (2023-03-04)
-
-### 2.8.86 (2023-03-04)
-
-### 2.8.85 (2023-03-04)
-
-### 2.8.84 (2023-03-03)
-
-### 2.8.83 (2023-03-03)
-
-### 2.8.82 (2023-03-03)
-
-### 2.8.81 (2023-03-03)
-
-
-### Bug Fixes
-
-* **phemex:** fix handleSettle ([4754570](https://github.com/ccxt/ccxt/commit/4754570e25168fa8fe9a508edcd62e0270b3ccd5))
-
-### 2.8.80 (2023-03-03)
-
-### 2.8.79 (2023-03-02)
-
-### 2.8.78 (2023-03-02)
-
-
-### Bug Fixes
-
-* **whitebit:** handle authenticate error ([39cd58c](https://github.com/ccxt/ccxt/commit/39cd58c62843473cb2aa314d80f4916f93007de4))
-
-### 2.8.77 (2023-03-02)
-
-### 2.8.76 (2023-03-02)
-
-
-### Bug Fixes
-
-* **Gate:** sandbox markets loading ([b564e9d](https://github.com/ccxt/ccxt/commit/b564e9dd4607b0ec2d278fcf5502cfc1e8b5e4cf))
-
-### 2.8.75 (2023-03-02)
-
-### 2.8.74 (2023-03-02)
-
-
-### Bug Fixes
-
-* **Cex:** incorrect currency precision parsing ([ea6c278](https://github.com/ccxt/ccxt/commit/ea6c278e7d216686bbcbc322af10e3b04970d7bc))
-
-### 2.8.73 (2023-03-02)
-
-
-### Bug Fixes
-
-* **ascendex:** fix [#17010](https://github.com/ccxt/ccxt/issues/17010) ([fb03e92](https://github.com/ccxt/ccxt/commit/fb03e924662a147ab394698f0958eaee8f91cb7c))
-
-### 2.8.72 (2023-03-02)
-
-### 2.8.71 (2023-03-02)
-
-
-### Bug Fixes
-
-* **bybit:** setMarginMode rename and leverage ([4fc1fef](https://github.com/ccxt/ccxt/commit/4fc1fef9fe7ce34ff4b44e7a1dc297e5fd4a6875))
-
-### 2.8.70 (2023-03-02)
-
-### 2.8.69 (2023-03-01)
-
-
-### Bug Fixes
-
-* **Exchange:** restore options ([3fa16bb](https://github.com/ccxt/ccxt/commit/3fa16bba1fa3e533ced07850d1117a73f2fad68a))
-
-### 2.8.68 (2023-03-01)
-
-### 2.8.67 (2023-03-01)
-
-
-### Bug Fixes
-
-* **Bybit:** timeframe parsing ([9178d79](https://github.com/ccxt/ccxt/commit/9178d792144469882f54eccbacd04155483bb9a9))
-
-### 2.8.66 (2023-03-01)
-
-
-### Bug Fixes
-
-* **bybit:** remove isUnifiedMarginEnabled from ws ([83f895b](https://github.com/ccxt/ccxt/commit/83f895b025c96a00909cedb61dba3ff78aa0e0e4))
-
-### 2.8.65 (2023-03-01)
-
-
-### Bug Fixes
-
-* **bybit:** fix fetchOHLCV since ([6025fdc](https://github.com/ccxt/ccxt/commit/6025fdc00b19a280da078832502066fc2bc0f3e5))
-
-### 2.8.64 (2023-03-01)
-
-### 2.8.63 (2023-03-01)
-
-### 2.8.62 (2023-03-01)
-
-### 2.8.61 (2023-03-01)
-
-### 2.8.60 (2023-02-28)
-
-
-### Bug Fixes
-
-* **exmo:** watchBalance info ([ac097d0](https://github.com/ccxt/ccxt/commit/ac097d088409f5648e18d37735bba3b91688a82e))
-
-### 2.8.59 (2023-02-28)
-
-### 2.8.58 (2023-02-28)
-
-### 2.8.57 (2023-02-28)
-
-### 2.8.56 (2023-02-28)
-
-
-### Bug Fixes
-
-* **gate:** reset correctly orderbook after invalid nonce error ([309acb6](https://github.com/ccxt/ccxt/commit/309acb66457cc3c1074fcde01cffad224a62e032))
-
-### 2.8.55 (2023-02-28)
-
-### 2.8.54 (2023-02-27)
-
-### 2.8.53 (2023-02-27)
-
-### 2.8.52 (2023-02-27)
-
-### 2.8.51 (2023-02-27)
-
-### 2.8.50 (2023-02-27)
-
-### 2.8.49 (2023-02-27)
-
-### 2.8.48 (2023-02-27)
-
-### 2.8.47 (2023-02-26)
-
-### 2.8.46 (2023-02-26)
-
-### 2.8.45 (2023-02-26)
-
-### 2.8.44 (2023-02-26)
-
-### 2.8.43 (2023-02-26)
-
-### 2.8.42 (2023-02-26)
-
-### 2.8.41 (2023-02-25)
-
-### 2.8.40 (2023-02-25)
-
-
-### Bug Fixes
-
-* **kucoin:** watchBalance add info and time to balance structure ([27d7c28](https://github.com/ccxt/ccxt/commit/27d7c283a3b8f6186cfd4c1e6824c515b0538ef3))
-
-### 2.8.39 (2023-02-25)
-
-### 2.8.38 (2023-02-25)
-
-### 2.8.37 (2023-02-24)
-
-
-### Bug Fixes
-
-* **Kucoin:** fix transaction status ([ca5b3d6](https://github.com/ccxt/ccxt/commit/ca5b3d66846dde00e2aaffdd217e746a70fbe2b7))
-
-### 2.8.36 (2023-02-24)
-
-
-### Bug Fixes
-
-* **Binance:** fix parseTrades margin ([7d52071](https://github.com/ccxt/ccxt/commit/7d52071baa76ec97a3692c3cce7cd534915ce3bb))
-
-### 2.8.35 (2023-02-24)
-
-### 2.8.34 (2023-02-24)
-
-
-### Features
-
-* **ccxt.d.ts:** add transfer and setLeverage types ([6e2c7d9](https://github.com/ccxt/ccxt/commit/6e2c7d94acbefeee90a02721f1b67bb424629c37))
-
-### 2.8.33 (2023-02-24)
-
-### 2.8.32 (2023-02-23)
-
-### 2.8.31 (2023-02-22)
-
-### 2.8.30 (2023-02-22)
-
-### 2.8.29 (2023-02-22)
-
-### 2.8.28 (2023-02-22)
-
-### 2.8.27 (2023-02-22)
-
-### 2.8.26 (2023-02-22)
-
-### 2.8.25 (2023-02-22)
-
-### 2.8.24 (2023-02-21)
-
-
-### Bug Fixes
-
-* **Gate:** average price inside parseOrder ([e7e0b25](https://github.com/ccxt/ccxt/commit/e7e0b251bd6e55f4a81ad92e65e11581feb35234))
-
-### 2.8.23 (2023-02-21)
-
-### 2.8.22 (2023-02-21)
-
-### 2.8.21 (2023-02-21)
-
-### 2.8.17 (2023-02-20)
-
-### 2.8.16 (2023-02-18)
-
-### 2.8.15 (2023-02-18)
-
-
-### Features
-
-* **Binance:** support different ids in editOrder ([f0ee83b](https://github.com/ccxt/ccxt/commit/f0ee83bead5ac41e1231b528bab94afe0f0d32f8))
-
-### 2.8.14 (2023-02-18)
-
-
-### Bug Fixes
-
-* **Bitget:** fetchLeverage method ([8fff1e4](https://github.com/ccxt/ccxt/commit/8fff1e430a811259df98f46ec793977c73ab226e))
-
-### 2.8.13 (2023-02-18)

--- a/change.sh
+++ b/change.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+previous_tag=0
+for current_tag in $(git tag --sort=-creatordate)
+do
+    major_version=$(echo ${current_tag} | cut -d '.' -f 1)
+    major_version=$(echo "$major_version" | sed -e "s/v//")
+    if [ "$major_version" -ge 3 ] ;then
+        if [ "$previous_tag" != 0 ]; then
+            tag_date=$(git log -1 --pretty=format:'%ad' --date=short ${previous_tag})
+            printf "## ${previous_tag} (${tag_date})\n\n"
+            git log ${current_tag}...${previous_tag} --pretty=format:'*  %s [%h](https://github.com/ccxt/ccxt/commits/%H)' --reverse | grep -v Merge | grep -v skip | grep -v '-'
+            # print $commits
+            printf "\n\n"
+        fi
+        previous_tag=${current_tag}
+    fi
+
+done


### PR DESCRIPTION
- replaced the package used to create the changelog since it was not working with a simpler bash script