### PR TITLE
Phemex set leverage hedged

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -3971,8 +3971,8 @@ export default class phemex extends Exchange {
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the phemex api endpoint
          * @param {bool} params.hedged set to true if hedged position mode is enabled (by default long and short leverage are set to the same value)
-         * @param {bool} params.longLeverageRr *hedged mode only* set the leverage for long positions
-         * @param {bool} params.shortLeverageRr *hedged mode only* set the leverage for short positions
+         * @param {float} params.longLeverageRr *hedged mode only* set the leverage for long positions
+         * @param {float} params.shortLeverageRr *hedged mode only* set the leverage for short positions
          * @returns {object} response from the exchange
          */
         // WARNING: THIS WILL INCREASE LIQUIDATION PRICE FOR OPEN ISOLATED LONG POSITIONS

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -3985,17 +3985,21 @@ export default class phemex extends Exchange {
         }
         await this.loadMarkets ();
         const isHedged = this.safeValue (params, 'hedged', false);
+        const longLeverageRr = this.safeInteger (params, 'longLeverageRr');
+        const shortLeverageRr = this.safeInteger (params, 'shortLeverageRr');
         const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
         };
         let response = undefined;
         if (market['settle'] === 'USDT') {
-            if (!isHedged) {
+            if (!isHedged && longLeverageRr === undefined && shortLeverageRr === undefined) {
                 request['leverageRr'] = leverage;
             } else {
-                request['longLeverageRr'] = this.safeInteger (params, 'longLeverageRr', leverage);
-                request['shortLeverageRr'] = this.safeInteger (params, 'shortLeverageRr', leverage);
+                const long = (longLeverageRr !== undefined) ? longLeverageRr : leverage;
+                const short = (shortLeverageRr !== undefined) ? shortLeverageRr : leverage;
+                request['longLeverageRr'] = long;
+                request['shortLeverageRr'] = short;
             }
             response = await this.privatePutPositionsLeverage (this.extend (request, params));
         } else {

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -4001,10 +4001,10 @@ export default class phemex extends Exchange {
                 request['longLeverageRr'] = long;
                 request['shortLeverageRr'] = short;
             }
-            response = await this.privatePutPositionsLeverage (this.extend (request, params));
+            response = await this.privatePutGPositionsLeverage (this.extend (request, params));
         } else {
             request['leverage'] = leverage;
-            response = await this.privatePutGPositionsLeverage (this.extend (request, params));
+            response = await this.privatePutPositionsLeverage (this.extend (request, params));
         }
         return response;
     }


### PR DESCRIPTION
- Allows setting the leverage when in `hedged` mode

Demo:

```
✗ n phemex setPositionMode true  "LTC/USDT:USDT"         
2023-05-23T15:51:40.418Z
Node.js: v18.14.0
CCXT v3.1.6
phemex.setPositionMode (true, LTC/USDT:USDT)
2023-05-23T15:51:42.979Z iteration 0 passed in 1002 ms

{ code: '0', msg: '', data: 'ok' }
2023-05-23T15:51:42.979Z iteration 1 passed in 1002 ms
```
```
p  phemex setLeverage 6 "LTC/USDT:USDT" '{"hedged":true}'
Python v3.10.9
CCXT v3.1.6
phemex.setLeverage(6,LTC/USDT:USDT,{'hedged': True})
{'code': '0', 'data': 'OK', 'msg': ''}
```
```
p  phemex setLeverage 6 "LTC/USD:USD"                    
Python v3.10.9
CCXT v3.1.6
phemex.setLeverage(6,LTC/USD:USD)
{'code': '0', 'data': 'OK', 'msg': ''}
```
