### PR TITLE
fix(bitfinex2): watchOrders timestamp - fix #18001

### DIFF
--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -1058,7 +1058,7 @@ export default class bitfinex2 extends bitfinex2Rest {
         const trimmedStatus = this.safeString (stateParts, 0);
         const status = this.parseWsOrderStatus (trimmedStatus);
         const price = this.safeString (order, 16);
-        const timestamp = this.safeInteger (order, 4);
+        const timestamp = this.safeInteger2 (order, 5, 4);
         const average = this.safeString (order, 17);
         const stopPrice = this.omitZero (this.safeString (order, 18));
         return this.safeOrder ({


### PR DESCRIPTION
It takes by default the updated timestamp and if not defined the created timestamp