### PR TITLE
Okx: set option support to true

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -26,7 +26,7 @@ export default class okx extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': true,
-                'option': undefined,
+                'option': true,
                 'addMargin': true,
                 'borrowMargin': true,
                 'cancelAllOrders': false,


### PR DESCRIPTION
Options are now fully supported on Okx but require 10,000 USD of assets in your account to trade:
```
ExchangeError okx
{
    "code": "1",
    "data": [
        {
            "clOrdId": "e747386590ce4dBC5b3edf8e54f08612",
            "ordId": "",
            "sCode": "51147",
            "sMsg": "To trade options, make sure you have more than 10,000 USD worth of assets in your trading account first, then activate options trading ",
            "tag": "e747386590ce4dGD"
        }
    ],
    "msg": "All operations failed"
}
```