### PR TITLE
fix(huobi): ohlcv spot 1M and 1y period fix

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -2613,7 +2613,7 @@ export default class huobi extends Exchange {
         params = this.omit (params, 'price');
         let method = 'spotPublicGetMarketHistoryCandles';
         if (market['spot']) {
-            if (timeframe === '1M' || timeframe === '1Y') {
+            if (timeframe === '1M' || timeframe === '1y') {
                 // for some reason 1M and 1Y does not work with the regular endpoint
                 // https://github.com/ccxt/ccxt/issues/18006
                 method = 'spotPublicGetMarketHistoryKline';

--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -2613,6 +2613,11 @@ export default class huobi extends Exchange {
         params = this.omit (params, 'price');
         let method = 'spotPublicGetMarketHistoryCandles';
         if (market['spot']) {
+            if (timeframe === '1M' || timeframe === '1Y') {
+                // for some reason 1M and 1Y does not work with the regular endpoint
+                // https://github.com/ccxt/ccxt/issues/18006
+                method = 'spotPublicGetMarketHistoryKline';
+            }
             if (since !== undefined) {
                 request['from'] = this.parseToInt (since / 1000);
             }


### PR DESCRIPTION
- For some reason the regular candles endpoint does not work with 1M and 1y
- fixes https://github.com/ccxt/ccxt/issues/18006

DEMO:

```
 p huobi fetchOHLCV "BTC/USDT" 1y None 5          
Python v3.10.9
CCXT v3.1.8
huobi.fetchOHLCV(BTC/USDT,1y,None,5)
[[1546272000000, 3754.37, 13968.76, 3353.03, 7195.0, 11962383.938478826],
 [1577808000000, 7194.7, 29306.8, 3800.0, 28779.14, 15485551.365780719],
 [1609430400000, 28779.15, 69000.0, 27777.0, 48010.95, 9485680.84443445],
 [1640966400000, 47997.69, 48200.77, 15500.0, 16592.22, 3907666.574571144],
 [1672502400000, 16591.44, 31000.0, 16475.0, 26262.33, 550931.4062533524]]
```
```
p huobi fetchOHLCV "BTC/USDT" 1M None 5
Python v3.10.9
CCXT v3.1.8
huobi.fetchOHLCV(BTC/USDT,1M,None,5)
[[1672502400000, 16591.44, 23954.17, 16475.0, 23123.36, 87759.70945356198],
 [1675180800000, 23125.69, 25266.94, 21355.0, 23522.46, 84919.94286393009],
 [1677600000000, 23517.63, 29179.99, 19558.4, 28499.01, 150717.45798628224],
 [1680278400000, 28499.01, 31000.0, 26919.4, 29656.83, 123363.68257337988],
 [1682870400000, 29658.2, 29860.0, 25800.14, 26262.33, 104170.64596481444]]
```
