### PR TITLE
hitbtc options['networks'] bug fix

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -207,8 +207,8 @@ export default class hitbtc extends Exchange {
                 'networks': {
                     'ETH': 'T20',
                     'ERC20': 'T20',
-                    'TRX': 'TTRX',
-                    'TRC20': 'TTRX',
+                    'TRX': 'TRX',
+                    'TRC20': 'TRX',
                     'OMNI': '',
                 },
                 'defaultTimeInForce': 'FOK',


### PR DESCRIPTION
Misstype in `options['networks']` for TRC20, TRX networks.
For USDT in ERC20 network currency `id` will be "USDT20", but for USDT in TRC20 network currency `id` will "USDTRX", not "USDTTRX".