### PR TITLE
fix(coinex): watchTickers - new watchTickers implementation

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1358,6 +1358,18 @@ export default class Exchange {
     // ------------------------------------------------------------------------
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
 
+    findMessageHashes (client, element: string): string[] {
+        const result = [];
+        const messageHashes = Object.keys (client.futures);
+        for (let i = 0; i < messageHashes.length; i++) {
+            const messageHash = messageHashes[i];
+            if (messageHash.indexOf (element) >= 0) {
+                result.push (messageHash);
+            }
+        }
+        return result;
+    }
+
     filterByLimit (array: object[], limit: Int = undefined, key: IndexType = 'timestamp'): any {
         if (this.valueIsDefined (limit)) {
             const arrayLength = array.length;

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -144,10 +144,10 @@ export default class coinex extends coinexRest {
             this.tickers[symbol] = parsedTicker;
             newTickers.push (parsedTicker);
         }
-        const messageHashes = this.findMessageHashes (client, 'tickers:');
+        const messageHashes = this.findMessageHashes (client, 'tickers::');
         for (let i = 0; i < messageHashes.length; i++) {
             const messageHash = messageHashes[i];
-            const parts = messageHash.split (':');
+            const parts = messageHash.split ('::');
             const symbolsString = parts[1];
             const symbols = symbolsString.split (',');
             const tickers = this.filterByArray (newTickers, 'symbol', symbols);
@@ -416,7 +416,7 @@ export default class coinex extends coinexRest {
         const url = this.urls['api']['ws'][type];
         let messageHash = 'tickers';
         if (symbols !== undefined) {
-            messageHash = 'tickers:' + symbols.join (',');
+            messageHash = 'tickers::' + symbols.join (',');
         }
         const subscribe = {
             'method': 'state.subscribe',

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -157,7 +157,7 @@ export default class coinex extends coinexRest {
                 client.resolve (tickers, messageHash);
             }
         }
-        client.resolve (this.tickers, 'tickers');
+        client.resolve (newTickers, 'tickers');
     }
 
     parseWSTicker (ticker, market = undefined) {
@@ -424,10 +424,9 @@ export default class coinex extends coinexRest {
             'params': [],
         };
         const request = this.deepExtend (subscribe, params);
-        const tickers = await this.watch (url, messageHash, request, messageHash);
-        const result = this.filterByArray (tickers, 'symbol', symbols);
+        const newTickers = await this.watch (url, messageHash, request, messageHash);
         if (this.newUpdates) {
-            return result;
+            return newTickers;
         }
         return this.filterByArray (this.tickers, 'symbol', symbols);
     }

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -141,12 +141,23 @@ export default class coinex extends coinexRest {
             const symbol = this.safeSymbol (marketId, undefined, undefined, defaultType);
             const market = this.safeMarket (marketId, undefined, undefined, defaultType);
             const parsedTicker = this.parseWSTicker (rawTicker, market);
-            const messageHash = 'ticker:' + symbol;
             this.tickers[symbol] = parsedTicker;
             newTickers.push (parsedTicker);
-            client.resolve (parsedTicker, messageHash);
         }
-        client.resolve (newTickers, 'tickers');
+        const messageHashes = this.findMessageHashes (client, 'tickers:');
+        for (let i = 0; i < messageHashes.length; i++) {
+            const messageHash = messageHashes[i];
+            const parts = messageHash.split (':');
+            const symbolsString = parts[1];
+            const symbols = symbolsString.split (',');
+            const tickers = this.filterByArray (newTickers, 'symbol', symbols);
+            const tickersSymbols = Object.keys (tickers);
+            const numTickers = tickersSymbols.length;
+            if (numTickers > 0) {
+                client.resolve (tickers, messageHash);
+            }
+        }
+        client.resolve (this.tickers, 'tickers');
     }
 
     parseWSTicker (ticker, market = undefined) {
@@ -403,7 +414,10 @@ export default class coinex extends coinexRest {
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('watchTickers', undefined, params);
         const url = this.urls['api']['ws'][type];
-        const messageHash = 'tickers';
+        let messageHash = 'tickers';
+        if (symbols !== undefined) {
+            messageHash = 'tickers:' + symbols.join (',');
+        }
         const subscribe = {
             'method': 'state.subscribe',
             'id': this.requestId (),
@@ -412,15 +426,10 @@ export default class coinex extends coinexRest {
         const request = this.deepExtend (subscribe, params);
         const tickers = await this.watch (url, messageHash, request, messageHash);
         const result = this.filterByArray (tickers, 'symbol', symbols);
-        const keys = Object.keys (result);
-        const resultLength = keys.length;
-        if (resultLength > 0) {
-            if (this.newUpdates) {
-                return result;
-            }
-            return this.filterByArray (this.tickers, 'symbol', symbols);
+        if (this.newUpdates) {
+            return result;
         }
-        return await this.watchTickers (symbols, params);
+        return this.filterByArray (this.tickers, 'symbol', symbols);
     }
 
     async watchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}) {


### PR DESCRIPTION
There are two issues with the current watchTickers implementation

- it can hit amaximum recursion depth error (Fix #18015)
- if a user calls watchTickers (['BTC/USDT']) and watchTickers (['BTC/USDT', ETH/USDT']) and a new BTC/USDT ticker is received only the first ticker will resolve, when I believe on userland it would make sense for both to resolve. (It's been a while since I've tested this but I believe it is still an issue)

This PR proposes the following fix:
1. Add the symbols to the messageHash
2. When a message is received find all messageHashes that contain the symbol to resolve
3. Build array of tickers for that message hash to resolve.
4. Resolve each messageHash
5. In watchTickers check if to return only new updates or all tickers filtered by that symbol

Alternative solution. Use a new cache object to handle this like the one proposed for `watchPositions` in this PR #15622

If we decide this as a good solution it should then be applied to the rest of `watchTickers` implementations.

