### PR TITLE
Gate: transfer, accountsByType, support options

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -495,6 +495,8 @@ export default class gate extends Exchange {
                     'future': 'delivery',
                     'futures': 'futures',
                     'delivery': 'delivery',
+                    'option': 'options',
+                    'options': 'options',
                 },
                 'defaultType': 'spot',
                 'swap': {
@@ -4250,6 +4252,7 @@ export default class gate extends Exchange {
          * @method
          * @name gate#transfer
          * @description transfer currency internally between wallets on the same account
+         * @see https://www.gate.io/docs/developers/apiv4/en/#transfer-between-trading-accounts
          * @param {string} code unified currency code for currency being transferred
          * @param {float} amount the amount of currency to transfer
          * @param {string} fromAccount the account to transfer currency from
@@ -4309,7 +4312,7 @@ export default class gate extends Exchange {
     parseTransfer (transfer, currency = undefined) {
         const timestamp = this.milliseconds ();
         return {
-            'id': undefined,
+            'id': this.safeString (transfer, 'tx_id'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'currency': this.safeCurrencyCode (undefined, currency),


### PR DESCRIPTION
Added options support to accountsByType so that transferring to the options account is supported:
```
gate.transfer (USDT, 32, spot, option)
2023-05-25T22:36:22.604Z iteration 0 passed in 254 ms

{
  id: '1685054182',
  timestamp: 1685054182604,
  datetime: '2023-05-25T22:36:22.604Z',
  currency: 'USDT',
  amount: undefined,
  fromAccount: undefined,
  toAccount: undefined,
  status: undefined,
  info: { tx_id: '1685054182' }
}
```