### PR TITLE
fix(bitget): watchBalance fix

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1083,6 +1083,7 @@ export default class bitget extends bitgetRest {
             const account = (code in this.balance) ? this.balance[code] : this.account ();
             account['free'] = this.safeString (rawBalance, 'available');
             account['total'] = this.safeString (rawBalance, 'equity');
+            account['used'] = this.safeString (rawBalance, 'frozen');
             this.balance[code] = account;
         }
         this.balance = this.safeBalance (this.balance);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18041

DEMO

```
 p bitget watchBalance          
Python v3.10.9
CCXT v3.1.9
bitget.watchBalance()
{'ADA': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'BGB': {'free': 1.15, 'total': 1.15, 'used': 0.0},
 'LTC': {'free': 0.1140711, 'total': 0.1140711, 'used': 0.0},
 'USDT': {'free': 30.44569783459, 'total': 35.44569783459, 'used': 5.0},
 'free': {'ADA': 0.0, 'BGB': 1.15, 'LTC': 0.1140711, 'USDT': 30.44569783459},
 'total': {'ADA': 0.0, 'BGB': 1.15, 'LTC': 0.1140711, 'USDT': 35.44569783459},
 'used': {'ADA': 0.0, 'BGB': 0.0, 'LTC': 0.0, 'USDT': 5.0}}
```
