### PR TITLE
Gate: parseTradingFee, add discount support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1686,6 +1686,7 @@ export default class gate extends Exchange {
          * @method
          * @name gate#fetchTradingFee
          * @description fetch the trading fees for a market
+         * @see https://www.gate.io/docs/developers/apiv4/en/#retrieve-personal-trading-fee
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the gate api endpoint
          * @returns {object} a [fee structure]{@link https://docs.ccxt.com/#/?id=fee-structure}
@@ -1718,6 +1719,7 @@ export default class gate extends Exchange {
          * @method
          * @name gate#fetchTradingFees
          * @description fetch the trading fees for multiple markets
+         * @see https://www.gate.io/docs/developers/apiv4/en/#retrieve-personal-trading-fee
          * @param {object} params extra parameters specific to the gate api endpoint
          * @returns {object} a dictionary of [fee structures]{@link https://docs.ccxt.com/#/?id=fee-structure} indexed by market symbols
          */
@@ -1765,9 +1767,12 @@ export default class gate extends Exchange {
         //        "futures_maker_fee": "0"
         //    }
         //
+        const gtDiscount = this.safeValue (info, 'gt_discount');
+        const taker = gtDiscount ? 'gt_taker_fee' : 'taker_fee';
+        const maker = gtDiscount ? 'gt_maker_fee' : 'maker_fee';
         const contract = this.safeValue (market, 'contract');
-        const takerKey = contract ? 'futures_taker_fee' : 'taker_fee';
-        const makerKey = contract ? 'futures_maker_fee' : 'maker_fee';
+        const takerKey = contract ? 'futures_taker_fee' : taker;
+        const makerKey = contract ? 'futures_maker_fee' : maker;
         return {
             'info': info,
             'symbol': this.safeString (market, 'symbol'),


### PR DESCRIPTION
Added gt discount support to parseTradingFee:
https://www.gate.io/fee
fixes: #18032
```
gate.fetchTradingFee (BTC/USDT)
2023-05-26T20:39:48.842Z iteration 0 passed in 245 ms

{
  info: {
    user_id: '5691076',
    taker_fee: '0.002',
    maker_fee: '0',
    gt_discount: false,
    gt_taker_fee: '0',
    gt_maker_fee: '0',
    loan_fee: '0.18',
    point_type: '1',
    futures_taker_fee: '0.0005',
    futures_maker_fee: '0.00015'
  },
  symbol: 'BTC/USDT',
  maker: 0,
  taker: 0.002
}
```