### PR TITLE
fix(binance): fix editOrder timestamp update, fix #18028

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1407,7 +1407,7 @@ export default class binance extends binanceRest {
         let timestamp = this.safeInteger (order, 'O');
         const T = this.safeInteger (order, 'T');
         let lastTradeTimestamp = undefined;
-        if (executionType === 'NEW') {
+        if (executionType === 'NEW' || executionType === 'AMENDMENT') {
             if (timestamp === undefined) {
                 timestamp = T;
             }


### PR DESCRIPTION
When editting an order the timestamp wasn't being updated correctly, therefore it wasn't always filtered correctly and shown in new updates.