### PR TITLE
feat: allow check for market type of symbols

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -125,7 +125,8 @@ const {
     , NetworkError
     , ExchangeNotAvailable
     , ArgumentsRequired
-    , RateLimitExceeded } from "./errors.js"
+    , RateLimitExceeded, 
+    BadRequest} from "./errors.js"
 
 import { Precise } from './Precise.js'
 
@@ -2345,13 +2346,18 @@ export default class Exchange {
         return result;
     }
 
-    marketSymbols (symbols) {
+    marketSymbols (symbols, type: string = undefined) {
         if (symbols === undefined) {
             return symbols;
         }
         const result = [];
         for (let i = 0; i < symbols.length; i++) {
-            result.push (this.symbol (symbols[i]));
+            const market = this.market (symbols[i]);
+            if (type !== undefined && market['type'] !== type) {
+                throw new BadRequest (this.id + ' symbols must be of same type ' + type + '. If the type is incorrect you can change it in options or the params of the request');
+            }
+            const symbol = this.safeString (market, 'symbol', symbols[i]);
+            result.push (symbol);
         }
         return result;
     }


### PR DESCRIPTION
- Add market type check to `marketSymbols` function.
- On many cases when `marketSymbols()` is called it only allows for symbols of one type to be used. This makes it easy to tell the user if they trying to fetch symbols of different types and sends them an error.