### PR TITLE
fix(binance): editOrder ws timestamp, fix #18051

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1688,7 +1688,8 @@ export default class binance extends binanceRest {
                     parsed['fees'] = fees;
                 }
                 parsed['trades'] = this.safeValue (order, 'trades');
-                if (parsed['timestamp'] === undefined) {
+                const timestamp = this.safeInteger (parsed, 'timestamp');
+                if (timestamp === undefined) {
                     parsed['timestamp'] = this.safeInteger (order, 'timestamp');
                     parsed['datetime'] = this.safeString (order, 'datetime');
                 }

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1688,8 +1688,10 @@ export default class binance extends binanceRest {
                     parsed['fees'] = fees;
                 }
                 parsed['trades'] = this.safeValue (order, 'trades');
-                parsed['timestamp'] = this.safeInteger (order, 'timestamp');
-                parsed['datetime'] = this.safeString (order, 'datetime');
+                if (parsed['timestamp'] === undefined) {
+                    parsed['timestamp'] = this.safeInteger (order, 'timestamp');
+                    parsed['datetime'] = this.safeString (order, 'datetime');
+                }
             }
             cachedOrders.append (parsed);
             client.resolve (this.orders, messageHash);


### PR DESCRIPTION
### Problem
When editting an order, the timestamp was getting overwritten by the old timestamp

### Solution
Only overwrite timestamp if undefined