### PR TITLE
fix #17686

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2783,6 +2783,7 @@ export default class okx extends Exchange {
             type = 'limit';
         }
         const marketId = this.safeString (order, 'instId');
+        market = this.safeMarket (marketId, market);
         const symbol = this.safeSymbol (marketId, market, '-');
         const filled = this.safeString (order, 'accFillSz');
         const price = this.safeString2 (order, 'px', 'ordPx');


### PR DESCRIPTION
- `parseOrder` now has `market` even if `market` argument is `undefined`
- fix: https://github.com/ccxt/ccxt/issues/17686