### PR TITLE
Gate: createOrder, add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3274,8 +3274,10 @@ export default class gate extends Exchange {
                     // 'tif': 'gtc', // gtc, ioc, poc PendingOrCancelled == postOnly order
                     // 'text': clientOrderId, // 't-abcdef1234567890',
                     // 'auto_size': '', // close_long, close_short, note size also needs to be set to 0
-                    'settle': market['settleId'], // filled in prepareRequest above
                 };
+                if (!market['option']) {
+                    request['settle'] = market['settleId']; // filled in prepareRequest above
+                }
                 if (isMarketOrder) {
                     request['price'] = price; // set to 0 for market orders
                 } else {
@@ -3344,6 +3346,9 @@ export default class gate extends Exchange {
                 request['text'] = clientOrderId;
             }
         } else {
+            if (market['option']) {
+                throw new NotSupported (this.id + ' createOrder() conditional option orders are not supported');
+            }
             if (contract) {
                 // contract conditional order
                 request = {
@@ -3436,6 +3441,7 @@ export default class gate extends Exchange {
             'margin': 'privateSpotPost' + methodTail,
             'swap': 'privateFuturesPostSettle' + methodTail,
             'future': 'privateDeliveryPostSettle' + methodTail,
+            'option': 'privateOptionsPostOrders',
         });
         const response = await this[method] (this.deepExtend (request, params));
         //
@@ -3473,7 +3479,7 @@ export default class gate extends Exchange {
         //
         //     {"id": 5891843}
         //
-        // future and perpetual swaps
+        // futures, perpetual swaps and options
         //
         //     {
         //         "id": 95938572327,
@@ -3658,7 +3664,7 @@ export default class gate extends Exchange {
         //        "status": "open"
         //    }
         //
-        // FUTURE AND SWAP
+        // FUTURE, SWAP AND OPTION
         // createOrder/cancelOrder/fetchOrder
         //
         //    {


### PR DESCRIPTION
Added option support to createOrder:
```
gate.createOrder (BTC/USDT:USDT-230601-27500-C, limit, buy, 1, 200)

{
  id: '2593450699',
  clientOrderId: 'api',
  timestamp: 1685503873000,
  datetime: '2023-05-31T03:31:13.000Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'BTC/USDT:USDT-230601-27500-C',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 200,
  stopPrice: undefined,
  triggerPrice: undefined,
  average: undefined,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  fee: undefined,
  fees: [],
  trades: [],
  info: {
    id: '2593450699',
    contract: 'BTC_USDT-20230601-27500-C',
    mkfr: '0.0003',
    tkfr: '0.0003',
    tif: 'gtc',
    is_reduce_only: false,
    create_time: '1685503873',
    price: '200',
    size: '1',
    refr: '0',
    left: '1',
    text: 'api',
    fill_price: '0',
    user: '5691076',
    status: 'open',
    is_liq: false,
    refu: '0',
    is_close: false,
    iceberg: '0'
  }
}
```