### PR TITLE
Gate: cancelOrder, cancelAllOrders, add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1210,7 +1210,9 @@ export default class gate extends Exchange {
         if (market !== undefined) {
             if (market['contract']) {
                 request['contract'] = market['id'];
-                request['settle'] = market['settleId'];
+                if (!market['option']) {
+                    request['settle'] = market['settleId'];
+                }
             } else {
                 request['currency_pair'] = market['id'];
             }
@@ -3691,7 +3693,7 @@ export default class gate extends Exchange {
         //        "status": "open"
         //    }
         //
-        // FUTURE AND SWAP
+        // FUTURE, SWAP AND OPTION
         // createOrder/cancelOrder/fetchOrder
         //
         //    {
@@ -4145,6 +4147,7 @@ export default class gate extends Exchange {
             'margin': 'privateSpotDelete' + pathMiddle + 'OrdersOrderId',
             'swap': 'privateFuturesDeleteSettle' + pathMiddle + 'OrdersOrderId',
             'future': 'privateDeliveryDeleteSettle' + pathMiddle + 'OrdersOrderId',
+            'option': 'privateOptionsDeleteOrdersOrderId',
         });
         const response = await this[method] (this.extend (request, requestParams));
         //
@@ -4202,7 +4205,7 @@ export default class gate extends Exchange {
         //         "status": "canceled"
         //     }
         //
-        // perpetual swaps
+        // swap, future and option
         //
         //     {
         //         id: "82241928192",

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4255,6 +4255,7 @@ export default class gate extends Exchange {
             'margin': 'privateSpotDelete' + methodTail,
             'swap': 'privateFuturesDeleteSettle' + methodTail,
             'future': 'privateDeliveryDeleteSettle' + methodTail,
+            'option': 'privateOptionsDeleteOrders',
         });
         const response = await this[method] (this.extend (request, requestParams));
         //


### PR DESCRIPTION
Added option support to cancelOrder and cancelAllOrders:

### cancelOrder:
```
gate.cancelOrder (2593450699, BTC/USDT:USDT-230601-27500-C)

{
  id: '2593450699',
  clientOrderId: 'api',
  timestamp: 1685503873000,
  datetime: '2023-05-31T03:31:13.000Z',
  lastTradeTimestamp: 1685504374000,
  status: 'canceled',
  symbol: 'BTC/USDT:USDT-230601-27500-C',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 200,
  stopPrice: undefined,
  triggerPrice: undefined,
  average: undefined,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  fee: undefined,
  fees: [],
  trades: [],
  info: {
    id: '2593450699',
    contract: 'BTC_USDT-20230601-27500-C',
    mkfr: '0.0003',
    tkfr: '0.0003',
    tif: 'gtc',
    is_reduce_only: false,
    create_time: '1685503873',
    finish_time: '1685504374',
    price: '200',
    size: '1',
    refr: '0',
    left: '1',
    text: 'api',
    fill_price: '0',
    user: '5691076',
    finish_as: 'cancelled',
    status: 'finished',
    is_liq: false,
    refu: '0',
    is_close: false,
    iceberg: '0'
  }
}
```

### cancelAllOrders:
```
gate.cancelAllOrders (BTC/USDT:USDT-230601-27500-C)

        id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   status |                       symbol |  type | timeInForce | postOnly | reduceOnly | side | price | stopPrice | triggerPrice | average | amount | cost | filled | remaining | fee | fees | trades
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2593893656 |           api | 1685506307000 | 2023-05-31T04:11:47.000Z |      1685506331000 | canceled | BTC/USDT:USDT-230601-27500-C | limit |         GTC |    false |      false |  buy |   200 |           |              |         |      1 |    0 |      0 |         1 |     |   [] |     []
1 objects
```