### PR TITLE
mexc: add broker api

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -5023,7 +5023,7 @@ export default class mexc extends Exchange {
         const access = this.safeString (api, 1);
         [ path, params ] = this.resolvePath (path, params);
         let url = undefined;
-        if (section === 'spot') {
+        if (section === 'spot' || section === 'broker') {
             url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
             let paramsEncoded = '';
             if (access === 'private') {
@@ -5046,7 +5046,7 @@ export default class mexc extends Exchange {
             if (method === 'POST') {
                 headers['Content-Type'] = 'application/json';
             }
-        } else if (section === 'contract' || section === 'spot2' || section === 'broker') {
+        } else if (section === 'contract' || section === 'spot2') {
             url = this.urls['api'][section][access] + '/' + this.implodeParams (path, params);
             params = this.omit (params, this.extractParams (path));
             if (access === 'public') {

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -121,6 +121,9 @@ export default class mexc extends Exchange {
                         'public': 'https://contract.mexc.com/api/v1/contract',
                         'private': 'https://contract.mexc.com/api/v1/private',
                     },
+                    'broker': {
+                        'private': 'https://api.mexc.com/api/v3/broker',
+                    },
                 },
                 'www': 'https://www.mexc.com/',
                 'doc': [
@@ -329,6 +332,29 @@ export default class mexc extends Exchange {
                             'order/cancel': 1,
                             'order/cancel_by_symbol': 1,
                             'asset/withdraw': 2,
+                        },
+                    },
+                },
+                'broker': {
+                    'private': {
+                        'get': {
+                            'sub-account/universalTransfer': 1,
+                            'sub-account/list': 1,
+                            'sub-account/apiKey': 1,
+                            'capital/deposit/subAddress': 1,
+                            'capital/deposit/subHisrec': 1,
+                            'capital/deposit/subHisrec/getall': 1,
+                        },
+                        'post': {
+                            'sub-account/virtualSubAccount': 1,
+                            'sub-account/apiKey': 1,
+                            'capital/deposit/subAddress': 1,
+                            'capital/withdraw/apply': 1,
+                            'sub-account/universalTransfer': 1,
+                            'sub-account/futures': 1,
+                        },
+                        'delete': {
+                            'sub-account/apiKey': 1,
                         },
                     },
                 },
@@ -5020,7 +5046,7 @@ export default class mexc extends Exchange {
             if (method === 'POST') {
                 headers['Content-Type'] = 'application/json';
             }
-        } else if (section === 'contract' || section === 'spot2') {
+        } else if (section === 'contract' || section === 'spot2' || section === 'broker') {
             url = this.urls['api'][section][access] + '/' + this.implodeParams (path, params);
             params = this.omit (params, this.extractParams (path));
             if (access === 'public') {


### PR DESCRIPTION
I added broker apis in mexc in this PR.

> Note: for now, call the broker function would get `Mandatory parameter 'signature' was not sent, was empty/null, or malformed.` error. And I didn't find how to make that signature in their documentation.