### PR TITLE
Gate: fetchPosition, fetchPositions, add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4596,11 +4596,9 @@ export default class gate extends Exchange {
         if (!market['contract']) {
             throw new BadRequest (this.id + ' fetchPosition() supports contract markets only');
         }
-        let type = undefined;
         let request = {};
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchPosition', market, params);
-        [ request, params ] = this.prepareRequest (market, type, params);
-        const method = this.getSupportedMapping (type, {
+        [ request, params ] = this.prepareRequest (market, market['type'], params);
+        const method = this.getSupportedMapping (market['type'], {
             'swap': 'privateFuturesGetSettlePositionsContract',
             'future': 'privateDeliveryGetSettlePositionsContract',
             'option': 'privateOptionsGetPositionsContract',

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4598,12 +4598,15 @@ export default class gate extends Exchange {
         }
         let request = {};
         [ request, params ] = this.prepareRequest (market, market['type'], params);
-        const method = this.getSupportedMapping (market['type'], {
-            'swap': 'privateFuturesGetSettlePositionsContract',
-            'future': 'privateDeliveryGetSettlePositionsContract',
-            'option': 'privateOptionsGetPositionsContract',
-        });
-        const response = await this[method] (this.extend (request, params));
+        const extendedRequest = this.extend (request, params);
+        let response = undefined;
+        if (market['type'] === 'swap') {
+            response = await this.privateFuturesGetSettlePositionsContract (extendedRequest);
+        } else if (market['type'] === 'future') {
+            response = await this.privateDeliveryGetSettlePositionsContract (extendedRequest);
+        } else if (market['type'] === 'option') {
+            response = await this.privateOptionsGetPositionsContract (extendedRequest);
+        }
         //
         // swap and future
         //


### PR DESCRIPTION
Added option support to fetchPosition and fetchPositions:

### fetchPosition:
```
gate.fetchPosition (BTC/USDT:USDT-230602-26500-C)

{
  info: {
    close_order: null,
    size: '1',
    vega: '5.29756',
    theta: '-98.98917',
    gamma: '0.00056',
    delta: '0.68691',
    contract: 'BTC_USDT-20230602-26500-C',
    entry_price: '529',
    unrealised_pnl: '-1.0131',
    user: '5691076',
    mark_price: '427.69',
    underlying_price: '26810.2',
    underlying: 'BTC_USDT',
    realised_pnl: '-0.08042877',
    mark_iv: '0.4224',
    pending_orders: '0'
  },
  id: undefined,
  symbol: 'BTC/USDT:USDT-230602-26500-C',
  timestamp: undefined,
  datetime: undefined,
  lastUpdateTimestamp: undefined,
  initialMargin: undefined,
  initialMarginPercentage: undefined,
  maintenanceMargin: undefined,
  maintenanceMarginPercentage: undefined,
  entryPrice: 529,
  notional: undefined,
  leverage: undefined,
  unrealizedPnl: -1.0131,
  contracts: 1,
  contractSize: 1,
  marginRatio: undefined,
  liquidationPrice: undefined,
  markPrice: 427.69,
  lastPrice: undefined,
  collateral: undefined,
  marginMode: 'isolated',
  side: 'long',
  percentage: undefined
}
```

### fetchPositions:
```
gate.fetchPositions (BTC/USDT:USDT-230602-26500-C)

id |                       symbol | timestamp | datetime | lastUpdateTimestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice | notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | liquidationPrice | markPrice | lastPrice | collateral | marginMode | side | percentage
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | BTC/USDT:USDT-230602-26500-C |           |          |                     |               |                         |                   |                             |        529 |          |          |       -1.0172 |         1 |            1 |             |                  |    427.28 |           |            |   isolated | long |
1 objects
```