### PR TITLE
Fix buda exchange misscalculated fee by 1 decimal point

### DIFF
--- a/dist/cjs/src/buda.js
+++ b/dist/cjs/src/buda.js
@@ -290,8 +290,8 @@ class buda extends buda$1 {
                 'expiryDatetime': undefined,
                 'strike': undefined,
                 'optionType': undefined,
-                'taker': this.parseNumber(Precise["default"].stringDiv(taker_fee, '1000')),
-                'maker': this.parseNumber(Precise["default"].stringDiv(maker_fee, '1000')),
+                'taker': this.parseNumber(Precise["default"].stringDiv(taker_fee, '100')),
+                'maker': this.parseNumber(Precise["default"].stringDiv(maker_fee, '100')),
                 'precision': {
                     'amount': this.parseNumber(this.parsePrecision(this.safeString(baseInfo, 'input_decimals'))),
                     'price': this.parseNumber(this.parsePrecision(this.safeString(quoteInfo, 'input_decimals'))),


### PR DESCRIPTION
Fix issue where values of fee where wrong by 1 decimal.
When exchange returns fee for example "0.8" it refers to 0.8%, but when the fee is calculated in decimal points it is divided it by 1000 instead of 100, so there was an issue where "0.8" was referred as 0.0008 instead of 0.008, wich makes all the fees calculations wrong specific for buda exchange