### PR TITLE
krakenfutures & poloniex: handleOrder remove previousOrder logic

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -3,7 +3,6 @@
 import krakenfuturesRest from '../krakenfutures.js';
 import { ArgumentsRequired, AuthenticationError } from '../base/errors.js';
 import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
-import { Precise } from '../base/Precise.js';
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
 import { sha512 } from '../static_dependencies/noble-hashes/sha512.js';
 import { Int } from '../base/types.js';

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -502,59 +502,12 @@ export default class krakenfutures extends krakenfuturesRest {
         }
         const order = this.safeValue (message, 'order');
         if (order !== undefined) {
-            const marketId = this.safeStringLower (order, 'instrument');
             const messageHash = 'orders';
-            const symbol = this.safeSymbol (marketId);
-            const orderId = this.safeString (order, 'order_id');
-            const previousOrders = this.safeValue (orders.hashmap, symbol, {});
-            const previousOrder = this.safeValue (previousOrders, orderId);
-            if (previousOrder === undefined) {
-                const parsed = this.parseWsOrder (order);
-                orders.append (parsed);
-                client.resolve (orders, messageHash);
-                client.resolve (orders, messageHash + ':' + symbol);
-            } else {
-                const trade = this.parseWsTrade (order);
-                if (previousOrder['trades'] === undefined) {
-                    previousOrder['trades'] = [];
-                }
-                previousOrder['trades'].push (trade);
-                previousOrder['lastTradeTimestamp'] = trade['timestamp'];
-                let totalCost = '0';
-                let totalAmount = '0';
-                const trades = previousOrder['trades'];
-                for (let i = 0; i < trades.length; i++) {
-                    const trade = trades[i];
-                    totalCost = Precise.stringAdd (totalCost, this.numberToString (trade['cost']));
-                    totalAmount = Precise.stringAdd (totalAmount, this.numberToString (trade['amount']));
-                }
-                if (Precise.stringGt (totalAmount, '0')) {
-                    previousOrder['average'] = Precise.stringDiv (totalCost, totalAmount);
-                }
-                previousOrder['cost'] = totalCost;
-                if (previousOrder['filled'] !== undefined) {
-                    previousOrder['filled'] = Precise.stringAdd (previousOrder['filled'], this.numberToString (trade['amount']));
-                    if (previousOrder['amount'] !== undefined) {
-                        previousOrder['remaining'] = Precise.stringSub (previousOrder['amount'], previousOrder['filled']);
-                    }
-                }
-                if (previousOrder['fee'] === undefined) {
-                    previousOrder['fee'] = {
-                        'rate': undefined,
-                        'cost': '0',
-                        'currency': this.numberToString (trade['fee']['currency']),
-                    };
-                }
-                if ((previousOrder['fee']['cost'] !== undefined) && (trade['fee']['cost'] !== undefined)) {
-                    const stringOrderCost = this.numberToString (previousOrder['fee']['cost']);
-                    const stringTradeCost = this.numberToString (trade['fee']['cost']);
-                    previousOrder['fee']['cost'] = Precise.stringAdd (stringOrderCost, stringTradeCost);
-                }
-                // update the newUpdates count
-                orders.append (this.safeOrder (previousOrder));
-                client.resolve (orders, messageHash + ':' + symbol);
-                client.resolve (orders, messageHash);
-            }
+            const parsed = this.parseWsOrder (order);
+            const symbol = parsed['symbol'];
+            orders.append (parsed);
+            client.resolve (orders, messageHash);
+            client.resolve (orders, messageHash + ':' + symbol);
         } else {
             const isCancel = this.safeValue (message, 'is_cancel');
             if (isCancel) {

--- a/ts/src/pro/poloniex.ts
+++ b/ts/src/pro/poloniex.ts
@@ -622,67 +622,10 @@ export default class poloniex extends poloniexRest {
         for (let i = 0; i < data.length; i++) {
             const order = this.safeValue (data, i);
             const marketId = this.safeString (order, 'symbol');
-            const eventType = this.safeString (order, 'eventType');
             if (marketId !== undefined) {
-                const symbol = this.safeSymbol (marketId);
-                const orderId = this.safeString (order, 'orderId');
-                const clientOrderId = this.safeString (order, 'clientOrderId');
-                if (eventType === 'place' || eventType === 'canceled') {
-                    const parsed = this.parseWsOrder (order);
-                    orders.append (parsed);
-                } else {
-                    const previousOrders = this.safeValue (orders.hashmap, symbol, {});
-                    const previousOrder = this.safeValue2 (previousOrders, orderId, clientOrderId);
-                    const trade = this.parseWsTrade (order);
-                    this.handleMyTrades (client, trade);
-                    if (previousOrder['trades'] === undefined) {
-                        previousOrder['trades'] = [];
-                    }
-                    previousOrder['trades'].push (trade);
-                    previousOrder['lastTradeTimestamp'] = trade['timestamp'];
-                    let totalCost = '0';
-                    let totalAmount = '0';
-                    const previousOrderTrades = previousOrder['trades'];
-                    for (let i = 0; i < previousOrderTrades.length; i++) {
-                        const previousOrderTrade = previousOrderTrades[i];
-                        const cost = this.numberToString (previousOrderTrade['cost']);
-                        const amount = this.numberToString (previousOrderTrade['amount']);
-                        totalCost = Precise.stringAdd (totalCost, cost);
-                        totalAmount = Precise.stringAdd (totalAmount, amount);
-                    }
-                    if (Precise.stringGt (totalAmount, '0')) {
-                        previousOrder['average'] = this.parseNumber (Precise.stringDiv (totalCost, totalAmount));
-                    }
-                    previousOrder['cost'] = this.parseNumber (totalCost);
-                    if (previousOrder['filled'] !== undefined) {
-                        const tradeAmount = this.numberToString (trade['amount']);
-                        let previousOrderFilled = this.numberToString (previousOrder['filled']);
-                        previousOrderFilled = Precise.stringAdd (previousOrderFilled, tradeAmount);
-                        previousOrder['filled'] = previousOrderFilled;
-                        if (previousOrder['amount'] !== undefined) {
-                            const previousOrderAmount = this.numberToString (previousOrder['amount']);
-                            previousOrder['remaining'] = this.parseNumber (Precise.stringSub (previousOrderAmount, previousOrderFilled));
-                        }
-                    }
-                    if (previousOrder['fee'] === undefined) {
-                        previousOrder['fee'] = {
-                            'rate': undefined,
-                            'cost': 0,
-                            'currency': trade['fee']['currency'],
-                        };
-                    }
-                    if ((previousOrder['fee']['cost'] !== undefined) && (trade['fee']['cost'] !== undefined)) {
-                        const stringOrderCost = this.numberToString (previousOrder['fee']['cost']);
-                        const stringTradeCost = this.numberToString (trade['fee']['cost']);
-                        previousOrder['fee']['cost'] = Precise.stringAdd (stringOrderCost, stringTradeCost);
-                    }
-                    const rawState = this.safeString (order, 'state');
-                    const state = this.parseStatus (rawState);
-                    previousOrder['status'] = state;
-                    // update the newUpdates count
-                    orders.append (previousOrder);
-                    marketIds.push (marketId);
-                }
+                const parsed = this.parseWsOrder (order);
+                orders.append (parsed);
+                marketIds.push (marketId);
             }
         }
         for (let i = 0; i < marketIds.length; i++) {


### PR DESCRIPTION
The logic wasn't good for `poloniex` or `krakenfutures`, but I can't test `krakenfutures` at the moment. I'm also working on a new similar method in https://github.com/ccxt/ccxt/pull/18082 , but the logic should be removed for now because it's wrong, and I image that other PR might take a bit of time

```
% poloniex watchOrders
2023-06-02T03:05:05.380Z
Node.js: v18.15.0
CCXT v3.1.16
poloniex.watchOrders ()
   symbol |                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status |        fee | trades |         fees | reduceOnly
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
USDT/USDC | 187522524471513088 |               | 1685675253862 | 2023-06-02T03:07:33.862Z |                    | MARKET |             |          |  BUY |       |           |              |        |      |         |      0 |           |   open | {"cost":0} |     [] | [{"cost":0}] |           
1 objects
   symbol |                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice |       amount |         cost | average |       filled | remaining | status |                                  fee |          trades |                                   fees | reduceOnly
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
USDT/USDC | 187522524471513088 |               | 1685675253944 | 2023-06-02T03:07:33.944Z |                    | MARKET |             |          |  BUY |       |           |              | 12.999979116 | 12.999979116 |       1 | 12.999979116 |         0 | closed | {"cost":0.0259932,"currency":"USDT"} | [object Object] | [{"cost":0.0259932,"currency":"USDT"}] |           
1 objects
  symbol |                 id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status |        fee | trades |         fees | reduceOnly
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ADA/USDT | 187522604574326784 |               | 1685675272958 | 2023-06-02T03:07:52.958Z |                    | LIMIT |             |          |  BUY |  0.33 |           |              |      4 |    0 |         |      0 |         4 |   open | {"cost":0} |     [] | [{"cost":0}] |           
1 objects
```