### PR TITLE
Gate: fetchMyTrades, add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2784,6 +2784,10 @@ export default class gate extends Exchange {
          * @method
          * @name gate#fetchMyTrades
          * @description Fetch personal trading history
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-personal-trading-history
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-personal-trading-history-2
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-personal-trading-history-3
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-personal-trading-history-4
          * @param {string|undefined} symbol unified market symbol
          * @param {int|undefined} since the earliest time in ms to fetch trades for
          * @param {int|undefined} limit the maximum number of trades structures to retrieve


### PR DESCRIPTION
Added option support to fetchMyTrades:
```
gate.fetchMyTrades ()
2023-06-02T03:44:33.410Z iteration 0 passed in 226 ms

id |     timestamp |                 datetime |                       symbol |      order | type | side | takerOrMaker | price | amount | cost | fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------
15 | 1685594610000 | 2023-06-01T04:43:30.000Z | BTC/USDT:USDT-230602-26500-C | 2610995222 |      |  buy |        taker |   529 |      1 |  529 |     |   []
16 | 1685594770000 | 2023-06-01T04:46:10.000Z | BTC/USDT:USDT-230602-26500-C | 2611026125 |      | sell |        taker |   333 |      1 |  333 |     |   []
2 objects
```