### PR TITLE
currencycom - fetch order

### DIFF
--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -631,17 +631,6 @@ export default class currencycom extends Exchange {
         return result;
     }
 
-    async getAccountIdBySettleCurrency (currencyCode) {
-        await this.loadAccounts ();
-        for (let i = 0; i < this.accounts.length; i++) {
-            const account = this.accounts[i];
-            if (account['currency'] === currencyCode) {
-                return account['id'];
-            }
-        }
-        throw new ArgumentsRequired (this.id + ' does not have an account for ' + currencyCode);
-    }
-
     async fetchTradingFees (params = {}) {
         /**
          * @method

--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -631,15 +631,15 @@ export default class currencycom extends Exchange {
         return result;
     }
 
-    async getAccountIdByCurrency (currency) {
+    async getAccountIdBySettleCurrency (currencyCode) {
         await this.loadAccounts ();
         for (let i = 0; i < this.accounts.length; i++) {
             const account = this.accounts[i];
-            if (account['currency'] === currency) {
+            if (account['currency'] === currencyCode) {
                 return account['id'];
             }
         }
-        throw new ArgumentsRequired (this.id + ' does not have an account for ' + currency);
+        throw new ArgumentsRequired (this.id + ' does not have an account for ' + currencyCode);
     }
 
     async fetchTradingFees (params = {}) {

--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -1377,7 +1377,6 @@ export default class currencycom extends Exchange {
             'orderId': id,
             'symbol': market['id'],
         };
-        // @ts-ignore
         const response = await this.privateGetV2FetchOrder (this.extend (request, params));
         //
         //    {


### PR DESCRIPTION
currency.com was missing one of the most important method


JS

```
ccxt@3.1.23 cli.ts
node --loader ts-node/esm examples/ts/cli.ts currencycom fetchOrder 00a02503-0079-54c4-0000-0000123456d7 BTC/USD:USD   

(node:35396) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-06-05T11:13:40.643Z
Node.js: v18.14.0
CCXT v3.1.23
currencycom.fetchOrder (00a02503-0079-54c4-0000-0000123456d7, BTC/USD:USD)
2023-06-05T11:13:43.069Z iteration 0 passed in 254 ms

{
  info: {
    symbol: 'BTC/USD_LEVERAGE',
    accountId: '109698017413123456',
    orderId: '00a02503-0079-54c4-0000-0000123456d7',
    quantity: '0.00040',
    price: '25500.0',
    timestamp: '1685963501227',
    status: 'CREATED',
    type: 'LIMIT',
    timeInForceType: 'GTC',
    side: 'BUY',
    guaranteedStopLoss: false,
    trailingStopLoss: false,
    margin: '0.05',
    takeProfit: '25750.0',
    stopLoss: '25000.0'
  },
  id: '00a02503-0079-54c4-0000-0000123456d7',
  timestamp: 1685963501227,
  datetime: '2023-06-05T11:11:41.387Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USD:USD',
  type: 'limit',
  timeInForce: 'GTC',
  side: 'buy',
  price: 25500,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: 0.0004,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: [],
  clientOrderId: undefined,
  postOnly: false,
  reduceOnly: undefined
}
2023-06-05T11:13:43.069Z iteration 1 passed in 254 ms
```

PY
```

> ccxt@3.1.23 cli.py
> python3 ./examples/py/cli.py currencycom fetch_order 00a02503-0079-54c4-0000-0000123456d7 BTC/USD:USD

Python v3.10.11
CCXT v3.1.23
currencycom.fetch_order(00a02503-0079-54c4-0000-0000123456d7,BTC/USD:USD)
{'amount': 0.0004,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': '2023-06-05T11:11:41.387Z',
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '00a02503-0079-54c4-0000-0000123456d7',
 'info': {'accountId': '109698017413123456',
          'guaranteedStopLoss': False,
          'margin': '0.05',
          'orderId': '00a02503-0079-54c4-0000-0000123456d7',
          'price': '25500.0',
          'quantity': '0.00040',
          'side': 'BUY',
          'status': 'CANCELLED',
          'stopLoss': '25000.0',
          'symbol': 'BTC/USD_LEVERAGE',
          'takeProfit': '25750.0',
          'timeInForceType': 'GTC',
          'timestamp': '1685963501227',
          'trailingStopLoss': False,
          'type': 'LIMIT'},
 'lastTradeTimestamp': None,
 'postOnly': False,
 'price': 25500.0,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': 'CANCELLED',
 'stopPrice': None,
 'symbol': 'BTC/USD:USD',
 'timeInForce': 'GTC',
 'timestamp': 1685963501227,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```

