### PR TITLE
fix(xt): swap orders amount precision

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2220,10 +2220,9 @@ export default class xt extends Exchange {
     async createContractOrder (symbol: string, type, side, amount, price = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const convertContractsToAmount = Precise.stringDiv (this.numberToString (amount), this.numberToString (market['contractSize']));
         const request = {
             'symbol': market['id'],
-            'origQty': this.amountToPrecision (symbol, this.parseNumber (convertContractsToAmount)),
+            'origQty': this.amountToPrecision (symbol, amount),
         };
         const timeInForce = this.safeStringUpper (params, 'timeInForce');
         if (timeInForce !== undefined) {


### PR DESCRIPTION
```
n xt createOrder "LTC/USDT:USDT" limit buy 1 50
Debugger attached.
2023-06-05T15:10:48.822Z
Node.js: v18.14.0
CCXT v3.1.24
xt.createOrder (LTC/USDT:USDT, limit, buy, 1, 50)
2023-06-05T15:10:51.514Z iteration 0 passed in 409 ms

{
  info: {
    returnCode: '0',
    msgInfo: 'success',
    error: null,
    result: '236038028768839361'
  },
  id: '236038028768839361',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'LTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  stopLoss: undefined,
  takeProfit: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  average: undefined,
  status: undefined,
  fee: { currency: undefined, cost: undefined },
  trades: [],
  fees: [ { currency: undefined, cost: undefined } ],
  reduceOnly: undefined,
  triggerPrice: undefined
}
2023-06-05T15:10:51.514Z iteration 1 passed in 409 ms
```
Expected error:
```
n xt createOrder "LTC/USDT:USDT" limit buy 0.1  50   
Debugger attached.
2023-06-05T15:11:28.259Z
Node.js: v18.14.0
CCXT v3.1.24
xt.createOrder (LTC/USDT:USDT, limit, buy, 0.1, 50)
ArgumentsRequired xt amount of LTC/USDT:USDT must be greater than minimum amount precision of 0
```
