### PR TITLE
Gate: fetchOHLCV, add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2541,7 +2541,7 @@ export default class gate extends Exchange {
         if (market['option']) {
             limit = undefined;
         } else {
-            limit = (limit === undefined) ? maxLimit : Math.min(limit, maxLimit);
+            limit = (limit === undefined) ? maxLimit : Math.min (limit, maxLimit);
         }
         let until = this.safeInteger (params, 'until');
         if (until !== undefined) {


### PR DESCRIPTION
Added option support to fetchOHLCV, it looks like the the limit, from and to parameters aren't working on the exchange side, when they're defined it returns an empty list as the response.
```
gate.fetchOHLCV (BTC/USDT:USDT-230609-26500-C)
2023-06-06T03:25:39.704Z iteration 0 passed in 218 ms

1686004980000 | 100 | 100 | 90 | 90 | 20
1686005040000 |  90 |  90 | 90 | 90 |  0
1686005100000 |  90 |  90 | 90 | 90 |  0
...
1686021780000 |  90 |  90 | 90 | 90 |  0
1686021840000 |  90 |  90 | 90 | 90 |  0
1686021900000 |  90 |  90 | 90 | 90 |  0
283 objects
```