### PR TITLE
huobi: add filled in spot order

### DIFF
--- a/ts/src/pro/huobi.ts
+++ b/ts/src/pro/huobi.ts
@@ -914,6 +914,7 @@ export default class huobi extends huobiRest {
                     'trades': trades,
                     'status': 'closed',
                     'symbol': market['symbol'],
+                    'filled': parsedTrade['amount'],
                 };
                 parsedOrder = order;
             } else {


### PR DESCRIPTION
fix ccxt/ccxt#18013

Because we didn't set filled when event is spot trades, the filled won't be updated.

BTW, I think it's possible that have multiple spot trades in single order. Should I retrieve order and update current trades / filled (it seems the key/data was "set" in cache)?