### PR TITLE
bitforex fetchMyTrades since edit

### DIFF
--- a/ts/src/bitforex.ts
+++ b/ts/src/bitforex.ts
@@ -381,7 +381,7 @@ export default class bitforex extends Exchange {
             request['limit'] = limit;
         }
         if (since !== undefined) {
-            request['startTime'] = since;
+            request['startTime'] = Math.max (since - 1, 0);
         }
         const endTime = this.safeInteger2 (params, 'until', 'endTime');
         if (endTime !== undefined) {


### PR DESCRIPTION
It gives trades only with `timestamp > since`.
Strange, but it's works ok for `endTime`