### PR TITLE
binance - support obsolete format

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -205,6 +205,7 @@ export default class Exchange {
     ohlcvs: any
     myTrades: any
     positions    = {}
+    futureTypes  = []
     urls: {
         logo?: string;
         api?: string | Dictionary<string>;
@@ -653,6 +654,7 @@ export default class Exchange {
         this.ohlcvs       = {}
         this.myTrades     = undefined
         this.positions    = {}
+        this.futureTypes  = [ 'W', 'BW', 'M', 'BM', 'Q', 'BQ' ]
         // web3 and cryptography flags
         this.requiresWeb3 = false
         this.requiresEddsa = false
@@ -3418,6 +3420,17 @@ export default class Exchange {
                     }
                 }
                 return markets[0];
+            } else {
+                // temporary support for old futures
+                if (symbol.indexOf ('-') >= 0) {
+                    for (let i = 0; i < this.futureTypes.length; i++) {
+                        const fType = this.futureTypes[i];
+                        const checkSymbol = symbol.replace ('-', '-' + fType);
+                        if (checkSymbol in this.markets) {
+                            return this.markets[checkSymbol];
+                        }
+                    }
+                }
             }
         }
         throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3425,8 +3425,9 @@ export default class Exchange {
                 if (symbol.indexOf ('-') >= 0) {
                     for (let i = 0; i < this.futureTypes.length; i++) {
                         const fType = this.futureTypes[i];
-                        const checkSymbol = symbol.replace ('-', '-' + fType);
-                        if (checkSymbol in this.markets) {
+                        const newPrefix = '-' + fType;
+                        const checkSymbol = symbol.replace ('-', newPrefix);
+                        if (symbol.indexOf (newPrefix) < 0 && checkSymbol in this.markets) {
                             return this.markets[checkSymbol];
                         }
                     }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2160,11 +2160,19 @@ export default class binance extends Exchange {
         let inverse = undefined;
         const strike = this.safeInteger (market, 'strikePrice');
         let symbol = base + '/' + quote;
+        let oldFuturesSymbol = undefined;
         if (contract) {
             if (swap) {
                 symbol = symbol + ':' + settle;
             } else if (future) {
-                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
+                let deliveryPrefix = '';
+                if (contractType === 'CURRENT_QUARTER' || contractType === 'NEXT_QUARTER') {
+                    deliveryPrefix = 'Q';
+                } else if (contractType === 'CURRENT_MONTH' || contractType === 'NEXT_MONTH') {
+                    deliveryPrefix = 'M';
+                }
+                symbol = symbol + ':' + settle + '-' + deliveryPrefix + this.yymmdd (expiry);
+                oldFuturesSymbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
             } else if (option) {
                 symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + this.numberToString (strike) + '-' + this.safeString (optionParts, 3);
             }
@@ -2281,6 +2289,9 @@ export default class binance extends Exchange {
             const filter = this.safeValue2 (filtersByType, 'MIN_NOTIONAL', 'NOTIONAL', {});
             entry['limits']['cost']['min'] = this.safeNumber2 (filter, 'minNotional', 'notional');
             entry['limits']['cost']['max'] = this.safeNumber (filter, 'maxNotional');
+        }
+        if (oldFuturesSymbol !== undefined) {
+            entry['oldFuturesSymbol'] = oldFuturesSymbol; // removed from base
         }
         return entry;
     }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2290,9 +2290,6 @@ export default class binance extends Exchange {
             entry['limits']['cost']['min'] = this.safeNumber2 (filter, 'minNotional', 'notional');
             entry['limits']['cost']['max'] = this.safeNumber (filter, 'maxNotional');
         }
-        if (oldFuturesSymbol !== undefined) {
-            entry['oldFuturesSymbol'] = oldFuturesSymbol; // removed from base
-        }
         return entry;
     }
 


### PR DESCRIPTION
This is first possible way, lets call this `(A)`. It might not an ideal, because it adds checks inside `market()` however it is:
- least instrusive change to codebase
- it is not increased performance cost of any user, other than who use **futures** symbol and especially uses inexistent market (which is already a failure & exception, so a tiniest added performance cost wouldn't make any change for them)

if you are sure that this is not accepted solution, I'll submit `(B)`, where we intervene and modify `fetchMarkets` to insert extra lines inside all exchange implementations (which will be more intrusive).