### PR TITLE
feat(bybit): add clientOrderId support to fetchOrderTrades

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5731,10 +5731,16 @@ export default class bybit extends Exchange {
          * @param {int|undefined} limit the maximum number of trades to retrieve
          * @param {object} params extra parameters specific to the bybit api endpoint
          * @returns {[object]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
+         *
          */
-        const request = {
-            'orderId': id,
-        };
+        const request = {};
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'orderLinkId');
+        if (clientOrderId !== undefined) {
+            request['orderLinkId'] = clientOrderId;
+        } else {
+            request['orderId'] = id;
+        }
+        params = this.omit (params, [ 'clientOrderId', 'orderLinkId' ]);
         return await this.fetchMyTrades (symbol, since, limit, this.extend (request, params));
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -647,6 +647,7 @@ export default class bybit extends Exchange {
                     '10028': PermissionDenied, // The API can only be accessed by unified account users.
                     '10029': PermissionDenied, // The requested symbol is invalid, please check symbol whitelist
                     '12201': BadRequest, // {"retCode":12201,"retMsg":"Invalid orderCategory parameter.","result":{},"retExtInfo":null,"time":1666699391220}
+                    '12141': BadRequest, // "retCode":12141,"retMsg":"Duplicate clientOrderId.","result":{},"retExtInfo":{},"time":1686134298989}
                     '100028': PermissionDenied, // The API cannot be accessed by unified account users.
                     '110001': InvalidOrder, // Order does not exist
                     '110003': InvalidOrder, // Order price is out of permissible range


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18147


DEMO
```
p bybit fetchOrderTrades None "BTC/USDT" None None '{"clientOrderId":"mycustomid2"}' --sandbox          
Python v3.10.9
CCXT v3.1.28
bybit.fetchOrderTrades(None,BTC/USDT,None,None,{'clientOrderId': 'mycustomid2'})
[{'amount': 0.000186,
  'cost': 4.98615594,
  'datetime': '2023-06-07T10:45:41.682Z',
  'fee': {'cost': 1.86e-07, 'currency': None},
  'fees': [{'cost': 1.86e-07, 'currency': None}],
  'id': '2100000000024829518',
  'info': {'blockTradeId': '',
           'closedSize': '',
           'execFee': '0.000000186',
           'execId': '2100000000024829518',
           'execPrice': '26807.29',
           'execQty': '0.000186',
           'execTime': '1686134741682',
           'execType': 'Trade',
           'execValue': '4.98615594',
           'feeRate': '0.001',
           'indexPrice': '',
           'isMaker': False,
           'leavesQty': '0',
           'markIv': '',
           'markPrice': '',
           'orderId': '1437796855623725056',
           'orderLinkId': 'mycustomid2',
           'orderPrice': '999999',
           'orderQty': '0',
           'orderType': 'Market',
           'side': 'Buy',
           'stopOrderType': 'UNKNOWN',
           'symbol': 'BTCUSDT',
           'tradeIv': '',
           'underlyingPrice': ''},
  'order': '1437796855623725056',
  'price': 26807.29,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1686134741682,
  'type': 'market'}]
```
