### PR TITLE
fix(bybit): restore options loading

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -34,6 +34,7 @@ let [processPath, , exchangeId, methodName, ... params] = process.argv.filter (x
     , isSpot = process.argv.includes ('--spot')
     , isSwap = process.argv.includes ('--swap')
     , isFuture = process.argv.includes ('--future')
+    , isOption = process.argv.includes ('--option')
 
 //-----------------------------------------------------------------------------
 
@@ -94,6 +95,8 @@ try {
         exchange.options['defaultType'] = 'swap';
     } else if (isFuture) {
         exchange.options['defaultType'] = 'future';
+    } else if (isOption) {
+        exchange.options['defaultType'] = 'option';
     }
 
     // check auth keys in env var

--- a/examples/php/cli.php
+++ b/examples/php/cli.php
@@ -37,6 +37,9 @@ $main = function() use ($argv) {
         $future = count(array_filter($args, function ($option) { return strstr($option, '--future') !== false; })) > 0;
         $args = array_values(array_filter($args, function ($option) { return strstr($option, '--future') === false; }));
 
+        $option = count(array_filter($args, function ($option) { return strstr($option, '--option') !== false; })) > 0;
+        $args = array_values(array_filter($args, function ($option) { return strstr($option, '--option') === false; }));
+
         $new_updates = count(array_filter($args, function ($option) { return strstr($option, '--newUpdates') !== false; })) > 0;
         $args = array_values(array_filter($args, function ($option) { return strstr($option, '--newUpdates') === false; }));
 
@@ -72,6 +75,8 @@ $main = function() use ($argv) {
                 $exchange->options['defaultType'] = 'swap';
             } else if ($future) {
                 $exchange->options['defaultType'] = 'future';
+            } else if ($option) {
+                $exchange->options['defaultType'] = 'option';
             }
 
             if ($new_updates) {

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -59,6 +59,7 @@ parser.add_argument('--test', action='store_true', help='enable sandbox/testnet'
 parser.add_argument('--spot', action='store_true', help='enable spot markets')
 parser.add_argument('--swap', action='store_true', help='enable swap markets')
 parser.add_argument('--future', action='store_true', help='enable future markets')
+parser.add_argument('--option', action='store_true', help='enable option markets')
 parser.add_argument('exchange_id', type=str, help='exchange id in lowercase', nargs='?')
 parser.add_argument('method', type=str, help='method or property', nargs='?')
 parser.add_argument('args', type=str, help='arguments', nargs='*')
@@ -147,6 +148,8 @@ async def main():
         exchange.options['defaultType'] = 'swap'
     elif argv.future:
         exchange.options['defaultType'] = 'future'
+    elif argv.option:
+        exchange.options['defaultType'] = 'option'
 
     # check auth keys in env var
     requiredCredentials = exchange.requiredCredentials

--- a/examples/ts/cli.ts
+++ b/examples/ts/cli.ts
@@ -34,6 +34,7 @@ let [processPath, , exchangeId, methodName, ... params] = process.argv.filter (x
     , isSpot = process.argv.includes ('--spot')
     , isSwap = process.argv.includes ('--swap')
     , isFuture = process.argv.includes ('--future')
+    , isOption = process.argv.includes ('--option')
 
 //-----------------------------------------------------------------------------
 
@@ -98,6 +99,8 @@ try {
         exchange.options['defaultType'] = 'swap';
     } else if (isFuture) {
         exchange.options['defaultType'] = 'future';
+    } else if (isOption) {
+        exchange.options['defaultType'] = 'option';
     }
 
     // check auth keys in env var

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1375,17 +1375,26 @@ export default class bybit extends Exchange {
         if (this.options['adjustForTimeDifference']) {
             await this.loadTimeDifference ();
         }
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchMarkets', undefined, params);
         const promisesUnresolved = [
             this.fetchSpotMarkets (params),
             this.fetchDerivativesMarkets ({ 'category': 'linear' }),
             this.fetchDerivativesMarkets ({ 'category': 'inverse' }),
         ];
+        if (type === 'option') {
+            promisesUnresolved.push (this.fetchDerivativesMarkets ({ 'category': 'option' }));
+        }
         const promises = await Promise.all (promisesUnresolved);
         const spotMarkets = promises[0];
         const linearMarkets = promises[1];
         const inverseMarkets = promises[2];
         let markets = spotMarkets;
         markets = this.arrayConcat (markets, linearMarkets);
+        if (type === 'option') {
+            const optionMarkets = promises[3];
+            markets = this.arrayConcat (markets, optionMarkets);
+        }
         return this.arrayConcat (markets, inverseMarkets);
     }
 


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18148
- loads options markets when `defaultType = 'option'` 


```
p bybit fetchTrades "BTC/USD:USDC-230609-18000-P" --sandbox --option
Python v3.10.9
CCXT v3.1.30
bybit.fetchTrades(BTC/USD:USDC-230609-18000-P)
[]
```
