### PR TITLE
Gate: fetchTicker, fetchTickers, add option support

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2147,19 +2147,25 @@ export default class gate extends Exchange {
             'future': 'publicDeliveryGetSettleTickers',
             'option': 'publicOptionsGetTickers',
         });
-        if (market['type'] === 'option') {
+        if (market['option']) {
             const marketId = market['id'];
             const optionParts = marketId.split ('-');
             request['underlying'] = this.safeString (optionParts, 0);
         }
         const response = await this[method] (this.extend (request, query));
-        const result = [];
-        for (let i = 0; i < response.length; i++) {
-            const entry = response[i];
-            const ticker = this.parseTicker (entry);
-            result.push (ticker);
+        let ticker = undefined;
+        if (market['option']) {
+            for (let i = 0; i < response.length; i++) {
+                const entry = response[i];
+                if (entry['name'] === market['id']) {
+                    ticker = entry;
+                    break;
+                }
+            }
+        } else {
+            ticker = this.safeValue (response, 0);
         }
-        return this.filterBySymbolSinceLimit (result, symbol);
+        return this.parseTicker (ticker, market);
     }
 
     parseTicker (ticker, market = undefined) {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2129,6 +2129,10 @@ export default class gate extends Exchange {
          * @method
          * @name gate#fetchTicker
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
+         * @see https://www.gate.io/docs/developers/apiv4/en/#get-details-of-a-specifc-order
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-futures-tickers
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-futures-tickers-2
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-tickers-of-options-contracts
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} params extra parameters specific to the gate api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -2141,10 +2145,21 @@ export default class gate extends Exchange {
             'margin': 'publicSpotGetTickers',
             'swap': 'publicFuturesGetSettleTickers',
             'future': 'publicDeliveryGetSettleTickers',
+            'option': 'publicOptionsGetTickers',
         });
+        if (market['type'] === 'option') {
+            const marketId = market['id'];
+            const optionParts = marketId.split ('-');
+            request['underlying'] = this.safeString (optionParts, 0);
+        }
         const response = await this[method] (this.extend (request, query));
-        const ticker = this.safeValue (response, 0);
-        return this.parseTicker (ticker, market);
+        const result = [];
+        for (let i = 0; i < response.length; i++) {
+            const entry = response[i];
+            const ticker = this.parseTicker (entry);
+            result.push (ticker);
+        }
+        return this.filterBySymbolSinceLimit (result, symbol);
     }
 
     parseTicker (ticker, market = undefined) {
@@ -2195,16 +2210,37 @@ export default class gate extends Exchange {
         //        A: '0.0353' // best ask size
         //     }
         //
-        const marketId = this.safeString2 (ticker, 'currency_pair', 'contract');
-        const marketType = ('contract' in ticker) ? 'contract' : 'spot';
+        // option
+        //
+        //     {
+        //         "vega": "0.00002",
+        //         "leverage": "12.277188268663",
+        //         "ask_iv": "0",
+        //         "delta": "-0.99999",
+        //         "last_price": "0",
+        //         "theta": "-0.00661",
+        //         "bid1_price": "1096",
+        //         "mark_iv": "0.7799",
+        //         "name": "BTC_USDT-20230608-28500-P",
+        //         "bid_iv": "0",
+        //         "ask1_price": "2935",
+        //         "mark_price": "2147.3",
+        //         "position_size": 0,
+        //         "bid1_size": 12,
+        //         "ask1_size": -14,
+        //         "gamma": "0"
+        //     }
+        //
+        const marketId = this.safeStringN (ticker, [ 'currency_pair', 'contract', 'name' ]);
+        const marketType = ('mark_price' in ticker) ? 'contract' : 'spot';
         const symbol = this.safeSymbol (marketId, market, '_', marketType);
-        const last = this.safeString (ticker, 'last');
-        const ask = this.safeString2 (ticker, 'lowest_ask', 'a');
-        const bid = this.safeString2 (ticker, 'highest_bid', 'b');
+        const last = this.safeString2 (ticker, 'last', 'last_price');
+        const ask = this.safeStringN (ticker, [ 'lowest_ask', 'a', 'ask1_price' ]);
+        const bid = this.safeStringN (ticker, [ 'highest_bid', 'b', 'bid1_price' ]);
         const high = this.safeString (ticker, 'high_24h');
         const low = this.safeString (ticker, 'low_24h');
-        const bidVolume = this.safeString (ticker, 'B');
-        const askVolume = this.safeString (ticker, 'A');
+        const bidVolume = this.safeString2 (ticker, 'B', 'bid1_size');
+        const askVolume = this.safeString2 (ticker, 'A', 'ask1_size');
         const timestamp = this.safeInteger (ticker, 't');
         let baseVolume = this.safeString2 (ticker, 'base_volume', 'volume_24h_base');
         if (baseVolume === 'nan') {
@@ -2247,6 +2283,7 @@ export default class gate extends Exchange {
          * @see https://www.gate.io/docs/developers/apiv4/en/#get-details-of-a-specifc-order
          * @see https://www.gate.io/docs/developers/apiv4/en/#list-futures-tickers
          * @see https://www.gate.io/docs/developers/apiv4/en/#list-futures-tickers-2
+         * @see https://www.gate.io/docs/developers/apiv4/en/#list-tickers-of-options-contracts
          * @param {[string]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} params extra parameters specific to the gate api endpoint
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -2265,7 +2302,14 @@ export default class gate extends Exchange {
             'margin': 'publicSpotGetTickers',
             'swap': 'publicFuturesGetSettleTickers',
             'future': 'publicDeliveryGetSettleTickers',
+            'option': 'publicOptionsGetTickers',
         });
+        if (type === 'option') {
+            this.checkRequiredArgument ('fetchTickers', symbols, 'symbols');
+            const marketId = market['id'];
+            const optionParts = marketId.split ('-');
+            request['underlying'] = this.safeString (optionParts, 0);
+        }
         const response = await this[method] (this.extend (request, requestParams));
         return this.parseTickers (response, symbols);
     }


### PR DESCRIPTION
Added option support to fetchTicker and fetchTickers:

### fetchTicker:
```
gate.fetchTicker (BTC/USDT:USDT-230609-26500-C)
2023-06-08T05:53:32.248Z iteration 0 passed in 232 ms

                      symbol | timestamp | datetime | high | low | bid | bidVolume | ask | askVolume | vwap | open | close | last | previousClose | change | percentage | average | baseVolume | quoteVolume
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT-230609-26500-C |           |          |      |     | 128 |         1 | 186 |       -52 |      |      |   111 |  111 |               |        |            |         |            |
1 objects
```

### fetchTickers:
```
gate.fetchTickers (BTC/USDT:USDT-230609-26500-C)
2023-06-08T06:00:24.755Z iteration 0 passed in 412 ms

{
  'BTC/USDT:USDT-230609-26500-C': {
    symbol: 'BTC/USDT:USDT-230609-26500-C',
    timestamp: undefined,
    datetime: undefined,
    high: undefined,
    low: undefined,
    bid: 124,
    bidVolume: 67,
    ask: 183,
    askVolume: -61,
    vwap: undefined,
    open: undefined,
    close: 111,
    last: 111,
    previousClose: undefined,
    change: undefined,
    percentage: undefined,
    average: undefined,
    baseVolume: undefined,
    quoteVolume: undefined,
    info: {
      vega: '5.56112',
      leverage: '68.002877307275',
      ask_iv: '0.4214',
      delta: '0.40375',
      last_price: '111',
      theta: '-98.36021',
      bid1_price: '124',
      mark_iv: '0.3819',
      name: 'BTC_USDT-20230609-26500-C',
      bid_iv: '0.3156',
      ask1_price: '183',
      mark_price: '156.57',
      position_size: '26',
      bid1_size: '67',
      ask1_size: '-61',
      gamma: '0.0007'
    }
  }
}
```