### PR TITLE
bybit: add get affiliate user info api

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -395,6 +395,7 @@ export default class bybit extends Exchange {
                         // user
                         'v5/user/query-sub-members': 10,
                         'v5/user/query-api': 10,
+                        'v5/user/aff-customer-info': 10,
                         'v5/customer/info': 10,
                         'v5/spot-cross-margin-trade/loan-info': 1, // 50/s => cost = 50 / 50 = 1
                         'v5/spot-cross-margin-trade/account': 1, // 50/s => cost = 50 / 50 = 1


### PR DESCRIPTION
I added an missed api in bybit: https://bybit-exchange.github.io/docs/v5/user/affiliate-info.