### PR TITLE
binance.addMargin amountToPrecision changed to costToPrecision

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -7977,7 +7977,7 @@ export default class binance extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        amount = this.amountToPrecision (symbol, amount);
+        amount = this.costToPrecision (symbol, amount);
         const request = {
             'type': addOrReduce,
             'symbol': market['id'],

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -8026,6 +8026,8 @@ export default class binance extends Exchange {
         /**
          * @method
          * @name binance#reduceMargin
+         * @see https://binance-docs.github.io/apidocs/delivery/en/#modify-isolated-position-margin-trade
+         * @see https://binance-docs.github.io/apidocs/futures/en/#modify-isolated-position-margin-trade
          * @description remove margin from a position
          * @param {string} symbol unified market symbol
          * @param {float} amount the amount of margin to remove
@@ -8039,6 +8041,8 @@ export default class binance extends Exchange {
         /**
          * @method
          * @name binance#addMargin
+         * @see https://binance-docs.github.io/apidocs/delivery/en/#modify-isolated-position-margin-trade
+         * @see https://binance-docs.github.io/apidocs/futures/en/#modify-isolated-position-margin-trade
          * @description add margin
          * @param {string} symbol unified market symbol
          * @param {float} amount amount of margin to add


### PR DESCRIPTION
fixes: #18160

```
2023-06-08T19:56:00.371Z
Node.js: v18.15.0
CCXT v3.1.31
binanceusdm.addMargin (BTC/USDT:USDT, 0.5, [object Object])
2023-06-08T19:56:04.018Z iteration 0 passed in 415 ms

{
  info: {
    code: 200,
    msg: 'Successfully modify position margin.',
    amount: 0.5,
    type: 1
  },
  type: 'add',
  amount: 0.5,
  code: 'USDT',
  symbol: 'BTC/USDT:USDT',
  status: 'ok'
}
2023-06-08T19:56:04.018Z iteration 1 passed in 415 ms
```