### PR TITLE
feat(bybit): add pagination cursor 

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5411,6 +5411,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const data = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (data.length > 0)) {
+            const first = data[0];
+            first['nextPageCursor'] = paginationCursor;
+            data[0] = first;
+        }
         return this.parseOrders (data, market, since, limit);
     }
 
@@ -5540,6 +5546,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const orders = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (orders.length > 0)) {
+            const first = orders[0];
+            first['nextPageCursor'] = paginationCursor;
+            orders[0] = first;
+        }
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -5641,6 +5653,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const orders = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (orders.length > 0)) {
+            const first = orders[0];
+            first['nextPageCursor'] = paginationCursor;
+            orders[0] = first;
+        }
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -5835,6 +5853,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const trades = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (trades.length > 0)) {
+            const first = trades[0];
+            first['nextPageCursor'] = paginationCursor;
+            trades[0] = first;
+        }
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -5891,6 +5915,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const trades = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (trades.length > 0)) {
+            const first = trades[0];
+            first['nextPageCursor'] = paginationCursor;
+            trades[0] = first;
+        }
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -5960,6 +5990,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const trades = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (trades.length > 0)) {
+            const first = trades[0];
+            first['nextPageCursor'] = paginationCursor;
+            trades[0] = first;
+        }
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -6037,6 +6073,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const trades = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (trades.length > 0)) {
+            const first = trades[0];
+            first['nextPageCursor'] = paginationCursor;
+            trades[0] = first;
+        }
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -7074,6 +7116,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const positions = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (positions.length > 0)) {
+            const first = positions[0];
+            first['nextPageCursor'] = paginationCursor;
+            positions[0] = first;
+        }
         const results = [];
         for (let i = 0; i < positions.length; i++) {
             let rawPosition = positions[i];
@@ -7228,6 +7276,12 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const positions = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (positions.length > 0)) {
+            const first = positions[0];
+            first['nextPageCursor'] = paginationCursor;
+            positions[0] = first;
+        }
         return this.parsePositions (positions, symbols, params);
     }
 
@@ -7805,6 +7859,12 @@ export default class bybit extends Exchange {
         const id = this.safeString (result, 'symbol');
         market = this.safeMarket (id, market, undefined, 'contract');
         const data = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (data.length > 0)) {
+            const first = data[0];
+            first['nextPageCursor'] = paginationCursor;
+            data[0] = first;
+        }
         return this.parseOpenInterest (data[0], market);
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1150,7 +1150,7 @@ export default class bybit extends Exchange {
 
     addPaginationCursorToResult (response) {
         const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'list', []);
+        const data = this.safeValueN (result, [ 'list', 'rows', 'data' ], []);
         const paginationCursor = this.safeString (result, 'nextPageCursor');
         if ((paginationCursor !== undefined) && (data.length > 0)) {
             const first = data[0];
@@ -6294,8 +6294,7 @@ export default class bybit extends Exchange {
         //         "time": 1672191992512
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'rows', []);
+        const data = this.addPaginationCursorToResult (response);
         return this.parseTransactions (data, currency, since, limit);
     }
 
@@ -6370,8 +6369,7 @@ export default class bybit extends Exchange {
         //         "time": 1672194949928
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'rows', []);
+        const data = this.addPaginationCursorToResult (response);
         return this.parseTransactions (data, currency, since, limit);
     }
 
@@ -6635,8 +6633,7 @@ export default class bybit extends Exchange {
         //         "time": 1672132481405
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue2 (result, 'data', 'list', []);
+        const data = this.addPaginationCursorToResult (response);
         return this.parseLedger (data, currency, since, limit);
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1148,6 +1148,18 @@ export default class bybit extends Exchange {
         return this.milliseconds () - this.options['timeDifference'];
     }
 
+    addPaginationCursorToResult (response) {
+        const result = this.safeValue (response, 'result', {});
+        const data = this.safeValue (result, 'list', []);
+        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        if ((paginationCursor !== undefined) && (data.length > 0)) {
+            const first = data[0];
+            first['nextPageCursor'] = paginationCursor;
+            data[0] = first;
+        }
+        return data;
+    }
+
     async isUnifiedEnabled (params = {}) {
         // The API key of user id must own one of permissions will be allowed to call following API endpoints.
         // SUB UID: "Account Transfer"
@@ -4946,14 +4958,7 @@ export default class bybit extends Exchange {
         //         "time": 1672221263862
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
-            const first = data[0];
-            first['nextPageCursor'] = paginationCursor;
-            data[0] = first;
-        }
+        const data = this.addPaginationCursorToResult (response);
         return this.parseOrders (data, market, since, limit);
     }
 
@@ -5039,14 +5044,7 @@ export default class bybit extends Exchange {
         //         "time": 1657713451741
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
-            const first = data[0];
-            first['nextPageCursor'] = paginationCursor;
-            data[0] = first;
-        }
+        const data = this.addPaginationCursorToResult (response);
         return this.parseOrders (data, market, since, limit);
     }
 
@@ -5141,14 +5139,7 @@ export default class bybit extends Exchange {
         //         "time": 1672221263862
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
-            const first = data[0];
-            first['nextPageCursor'] = paginationCursor;
-            data[0] = first;
-        }
+        const data = this.addPaginationCursorToResult (response);
         return this.parseOrders (data, market, since, limit);
     }
 
@@ -5409,14 +5400,7 @@ export default class bybit extends Exchange {
         //         "time": 1672219526294
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
-            const first = data[0];
-            first['nextPageCursor'] = paginationCursor;
-            data[0] = first;
-        }
+        const data = this.addPaginationCursorToResult (response);
         return this.parseOrders (data, market, since, limit);
     }
 
@@ -5544,14 +5528,7 @@ export default class bybit extends Exchange {
         //         "time": 1665565614320
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const orders = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (orders.length > 0)) {
-            const first = orders[0];
-            first['nextPageCursor'] = paginationCursor;
-            orders[0] = first;
-        }
+        const orders = this.addPaginationCursorToResult (response);
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -5651,14 +5628,7 @@ export default class bybit extends Exchange {
         //         "time": 1672219526294
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const orders = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (orders.length > 0)) {
-            const first = orders[0];
-            first['nextPageCursor'] = paginationCursor;
-            orders[0] = first;
-        }
+        const orders = this.addPaginationCursorToResult (response);
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -5851,14 +5821,7 @@ export default class bybit extends Exchange {
         //         "time": 1672283754510
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const trades = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (trades.length > 0)) {
-            const first = trades[0];
-            first['nextPageCursor'] = paginationCursor;
-            trades[0] = first;
-        }
+        const trades = this.addPaginationCursorToResult (response);
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -5913,14 +5876,7 @@ export default class bybit extends Exchange {
         //         "time": "1666768215157"
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const trades = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (trades.length > 0)) {
-            const first = trades[0];
-            first['nextPageCursor'] = paginationCursor;
-            trades[0] = first;
-        }
+        const trades = this.addPaginationCursorToResult (response);
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -5988,14 +5944,7 @@ export default class bybit extends Exchange {
         //         "time": 1657714292783
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const trades = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (trades.length > 0)) {
-            const first = trades[0];
-            first['nextPageCursor'] = paginationCursor;
-            trades[0] = first;
-        }
+        const trades = this.addPaginationCursorToResult (response);
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -6071,14 +6020,7 @@ export default class bybit extends Exchange {
         //         "time": 1672283754510
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const trades = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (trades.length > 0)) {
-            const first = trades[0];
-            first['nextPageCursor'] = paginationCursor;
-            trades[0] = first;
-        }
+        const trades = this.addPaginationCursorToResult (response);
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -7114,14 +7056,7 @@ export default class bybit extends Exchange {
         //         "time": 1657713693182
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const positions = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (positions.length > 0)) {
-            const first = positions[0];
-            first['nextPageCursor'] = paginationCursor;
-            positions[0] = first;
-        }
+        const positions = this.addPaginationCursorToResult (response);
         const results = [];
         for (let i = 0; i < positions.length; i++) {
             let rawPosition = positions[i];
@@ -7274,14 +7209,7 @@ export default class bybit extends Exchange {
         //         "time": 1672280219169
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const positions = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (positions.length > 0)) {
-            const first = positions[0];
-            first['nextPageCursor'] = paginationCursor;
-            positions[0] = first;
-        }
+        const positions = this.addPaginationCursorToResult (response);
         return this.parsePositions (positions, symbols, params);
     }
 
@@ -7789,13 +7717,7 @@ export default class bybit extends Exchange {
         //     }
         //
         const result = this.safeValue (response, 'result', {});
-        const data = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
-            const first = data[0];
-            first['nextPageCursor'] = paginationCursor;
-            data[0] = first;
-        }
+        const data = this.addPaginationCursorToResult (response);
         const id = this.safeString (result, 'symbol');
         market = this.safeMarket (id, market, undefined, 'contract');
         return this.parseOpenInterests (data, market, since, limit);
@@ -7858,13 +7780,7 @@ export default class bybit extends Exchange {
         const result = this.safeValue (response, 'result', {});
         const id = this.safeString (result, 'symbol');
         market = this.safeMarket (id, market, undefined, 'contract');
-        const data = this.safeValue (result, 'list', []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
-            const first = data[0];
-            first['nextPageCursor'] = paginationCursor;
-            data[0] = first;
-        }
+        const data = this.addPaginationCursorToResult (response);
         return this.parseOpenInterest (data[0], market);
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1152,7 +1152,8 @@ export default class bybit extends Exchange {
         const result = this.safeValue (response, 'result', {});
         const data = this.safeValueN (result, [ 'list', 'rows', 'data', 'dataList' ], []);
         const paginationCursor = this.safeString2 (result, 'nextPageCursor', 'cursor');
-        if ((paginationCursor !== undefined) && (data.length > 0)) {
+        const dataLength = data.length;
+        if ((paginationCursor !== undefined) && (dataLength > 0)) {
             const first = data[0];
             first['nextPageCursor'] = paginationCursor;
             data[0] = first;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1150,8 +1150,8 @@ export default class bybit extends Exchange {
 
     addPaginationCursorToResult (response) {
         const result = this.safeValue (response, 'result', {});
-        const data = this.safeValueN (result, [ 'list', 'rows', 'data' ], []);
-        const paginationCursor = this.safeString (result, 'nextPageCursor');
+        const data = this.safeValueN (result, [ 'list', 'rows', 'data', 'dataList' ], []);
+        const paginationCursor = this.safeString2 (result, 'nextPageCursor', 'cursor');
         if ((paginationCursor !== undefined) && (data.length > 0)) {
             const first = data[0];
             first['nextPageCursor'] = paginationCursor;
@@ -5644,8 +5644,7 @@ export default class bybit extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchUSDCOpenOrders', market, params);
         request['category'] = (type === 'swap') ? 'perpetual' : 'option';
         const response = await this.privatePostOptionUsdcOpenapiPrivateV1QueryActiveOrders (this.extend (request, params));
-        const result = this.safeValue (response, 'result', {});
-        const orders = this.safeValue (result, 'dataList', []);
+        const orders = this.addPaginationCursorToResult (response);
         //
         //     {
         //         "retCode": 0,
@@ -6064,8 +6063,7 @@ export default class bybit extends Exchange {
         //       "retMsg": "Success."
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const dataList = this.safeValue (result, 'dataList', []);
+        const dataList = this.addPaginationCursorToResult (response);
         return this.parseTrades (dataList, market, since, limit);
     }
 
@@ -7128,8 +7126,7 @@ export default class bybit extends Exchange {
         //         "retMsg": "Success."
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const positions = this.safeValue (result, 'dataList', []);
+        const positions = this.addPaginationCursorToResult (response);
         const results = [];
         for (let i = 0; i < positions.length; i++) {
             let rawPosition = positions[i];


### PR DESCRIPTION
Currently, I cannot depaginate `fetchMyTrades` against ByBit (`/v5/execution/list`) because `nextPageCursor` is not copied over to the first result set member from the ByBit response.

In this PR, I copy the routine of adding this property, from other functions, to where I can, so that we can depaginate as many endpoints as possible.