### PR TITLE
Fix: mexc broker api url in js

### DIFF
--- a/js/src/mexc.js
+++ b/js/src/mexc.js
@@ -4987,7 +4987,11 @@ export default class mexc extends Exchange {
         [path, params] = this.resolvePath(path, params);
         let url = undefined;
         if (section === 'spot' || section === 'broker') {
-            url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
+            if(section === 'broker') {
+                url = this.urls['api'][section][access] + '/' + path;
+            } else {
+                url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
+            }
             let paramsEncoded = '';
             if (access === 'private') {
                 params['timestamp'] = this.milliseconds();

--- a/php/mexc.php
+++ b/php/mexc.php
@@ -4932,7 +4932,11 @@ class mexc extends Exchange {
         list($path, $params) = $this->resolve_path($path, $params);
         $url = null;
         if ($section === 'spot' || $section === 'broker') {
-            $url = $this->urls['api'][$section][$access] . '/api/' . $this->version . '/' . $path;
+            if($section === 'broker') {
+                $url = $this->urls['api'][$section][$access] . '/' . $path;
+            } else {
+                $url = $this->urls['api'][$section][$access] . '/api/' . $this->version . '/' . $path;
+            }
             $paramsEncoded = '';
             if ($access === 'private') {
                 $params['timestamp'] = $this->milliseconds();

--- a/python/ccxt/mexc.py
+++ b/python/ccxt/mexc.py
@@ -4684,7 +4684,10 @@ class mexc(Exchange, ImplicitAPI):
         path, params = self.resolve_path(path, params)
         url = None
         if section == 'spot' or section == 'broker':
-            url = self.urls['api'][section][access] + '/api/' + self.version + '/' + path
+            if section == 'broker':
+                url = self.urls['api'][section][access] + '/' + path
+            else:
+                url = self.urls['api'][section][access] + '/api/' + self.version + '/' + path
             paramsEncoded = ''
             if access == 'private':
                 params['timestamp'] = self.milliseconds()

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -5024,7 +5024,7 @@ export default class mexc extends Exchange {
         [ path, params ] = this.resolvePath (path, params);
         let url = undefined;
         if (section === 'spot' || section === 'broker') {
-            if(section === 'broker') {
+            if (section === 'broker') {
                 url = this.urls['api'][section][access] + '/' + path;
             } else {
                 url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -5024,7 +5024,11 @@ export default class mexc extends Exchange {
         [ path, params ] = this.resolvePath (path, params);
         let url = undefined;
         if (section === 'spot' || section === 'broker') {
-            url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
+            if(section === 'broker') {
+                url = this.urls['api'][section][access] + '/' + path;
+            } else {
+                url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
+            }
             let paramsEncoded = '';
             if (access === 'private') {
                 params['timestamp'] = this.milliseconds ();


### PR DESCRIPTION
mexc broker api url is adding /api/v3 twice.

Actual url: "https://api.mexc.com/api/v3/broker/api/v3/sub-account/virtualSubAccount"


Expected url: "https://api.mexc.com/api/v3/broker/sub-account/virtualSubAccount"