### PR TITLE
binance - fetchLastPrices remove bv & qv

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3087,8 +3087,6 @@ export default class binance extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'price': price,
             'side': undefined,
-            'baseVolume': undefined,
-            'quoteVolume': undefined,
             'info': info,
         };
     }


### PR DESCRIPTION

at this moment, we only have that method implemented on binance and it wont be breaking change, as `baseVolume & quoteVolume` is not ideally applicable/useful for "last price"