### PR TITLE
wavesexchange - add precision mode

### DIFF
--- a/ts/src/wavesexchange.ts
+++ b/ts/src/wavesexchange.ts
@@ -7,6 +7,7 @@ import { Precise } from './base/Precise.js';
 import { ed25519 } from './static_dependencies/noble-curves/ed25519.js';
 import { eddsa } from './base/functions/crypto.js';
 import { Int, OrderSide, OrderType } from './base/types.js';
+import { DECIMAL_PLACES } from './base/functions/number.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -297,6 +298,7 @@ export default class wavesexchange extends Exchange {
             'currencies': {
                 'WX': this.safeCurrencyStructure ({ 'id': 'EMAMLxDnv3xiz8RXg8Btj33jcEw3wLczL3JKYYmuubpc', 'numericId': undefined, 'code': 'WX', 'precision': this.parseNumber ('8') }),
             },
+            'precisionMode': DECIMAL_PLACES,
             'options': {
                 'allowedCandles': 1440,
                 'accessToken': undefined,


### PR DESCRIPTION
this was the only exchange that was missing "precisionMode" key (even though it still defaulted to DECIMAL_PLACES, we need it to have explicitly, like all other exchanges have it).