### PR TITLE
[base] Exchange.fetchFundingRate normalize symbol

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3863,6 +3863,7 @@ export default class Exchange {
         if (this.has['fetchFundingRates']) {
             await this.loadMarkets ();
             const market = this.market (symbol);
+            symbol = market['symbol'];
             if (!market['contract']) {
                 throw new BadSymbol (this.id + ' fetchFundingRate() supports contract markets only');
             }


### PR DESCRIPTION
This changes allows both id and symbol call working - which is common convention of ccxt API
```
krakenfutures.fetchFundingRate('BTC/USD:USD')  # allowed
krakenfutures.fetchFundingRate('pf_xbtusd')  # originally disallowed
```

see also #18191 