### PR TITLE
Add status for bitso

### DIFF
--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -1057,7 +1057,8 @@ export default class bitso extends Exchange {
         const statuses = {
             'partial-fill': 'open', // this is a common substitution in ccxt
             'partially filled': 'open',
-            'completed': 'closed'
+            'queued': 'open',
+            'completed': 'closed',
         };
         return this.safeString (statuses, status, status);
     }

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -1056,7 +1056,8 @@ export default class bitso extends Exchange {
     parseOrderStatus (status) {
         const statuses = {
             'partial-fill': 'open', // this is a common substitution in ccxt
-            'completed': 'closed',
+            'partially filled': 'open',
+            'completed': 'closed'
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
https://docs.bitso.com/bitso-api/docs/look-up-orders#json-response-payload
status | The order's status. Possible values: queued, open, **partially filled**, and closed.

Below in the "Look Up Orders Response Object" there is an example: "status": "partially filled",