### PR TITLE
fix(bitget): fetchTickers parsing

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1825,6 +1825,45 @@ export default class bitget extends Exchange {
         //         quoteVolume: '5552388715.9215',
         //         usdtVolume: '5552388715.9215'
         //     }
+        // spot tickers
+        //    {
+        //        "symbol":"LINKUSDT",
+        //        "high24h":"5.2816",
+        //        "low24h":"5.0828",
+        //        "close":"5.24",
+        //        "quoteVol":"1427864.6815",
+        //        "baseVol":"276089.9017",
+        //        "usdtVol":"1427864.68148328",
+        //        "ts":"1686653354407",
+        //        "buyOne":"5.239",
+        //        "sellOne":"5.2404",
+        //        "+":"95.187",
+        //        "askSz":"947.6127",
+        //        "openUtc0":"5.1599",
+        //        "changeUtc":"0.01552",
+        //        "change":"0.02594"
+        //    }
+        // swap tickers
+        //    {
+        //        "symbol":"BTCUSDT_UMCBL",
+        //        "last":"26139",
+        //        "bestAsk":"26139",
+        //        "bestBid":"26138.5",
+        //        "bidSz":"4.62",
+        //        "askSz":"11.142",
+        //        "high24h":"26260",
+        //        "low24h":"25637",
+        //        "timestamp":"1686653988192",
+        //        "priceChangePercent":"0.01283",
+        //        "baseVolume":"130207.098",
+        //        "quoteVolume":"3378775678.441",
+        //        "usdtVolume":"3378775678.441",
+        //        "openUtc":"25889",
+        //        "chgUtc":"0.00966",
+        //        "indexPrice":"26159.375846",
+        //        "fundingRate":"0.000062",
+        //        "holdingAmount":"74551.735"
+        //    }
         //
         let marketId = this.safeString (ticker, 'symbol');
         if ((market === undefined) && (marketId !== undefined) && (marketId.indexOf ('_') === -1)) {
@@ -1841,10 +1880,13 @@ export default class bitget extends Exchange {
         const quoteVolume = this.safeString2 (ticker, 'quoteVol', 'quoteVolume');
         const baseVolume = this.safeString2 (ticker, 'baseVol', 'baseVolume');
         const timestamp = this.safeInteger2 (ticker, 'ts', 'timestamp');
+        const bidVolume = this.safeString (ticker, 'bidSz');
+        const askVolume = this.safeString (ticker, 'askSz');
         const datetime = this.iso8601 (timestamp);
         const bid = this.safeString2 (ticker, 'buyOne', 'bestBid');
         const ask = this.safeString2 (ticker, 'sellOne', 'bestAsk');
-        const percentage = Precise.stringMul (this.safeString (ticker, 'priceChangePercent'), '100');
+        const percentage = Precise.stringMul (this.safeStringN (ticker, [ 'priceChangePercent', 'changeUtc', 'change', 'chgUtc' ]), '100');
+        const open = this.safeString2 (ticker, 'openUtc0', 'openUtc');
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
@@ -1852,11 +1894,11 @@ export default class bitget extends Exchange {
             'high': high,
             'low': low,
             'bid': bid,
-            'bidVolume': undefined,
+            'bidVolume': bidVolume,
             'ask': ask,
-            'askVolume': undefined,
+            'askVolume': askVolume,
             'vwap': undefined,
-            'open': undefined,
+            'open': open,
             'close': close,
             'last': undefined,
             'previousClose': undefined,


### PR DESCRIPTION
DEMO
```
p bitget fetchTickers '["BTC/USDT:USDT"]'
Python v3.10.9
CCXT v3.1.36
bitget.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 26158.0,
                   'askVolume': 3.04,
                   'average': 26023.25,
                   'baseVolume': 130133.519,
                   'bid': 26157.5,
                   'bidVolume': 6.315,
                   'change': 268.5,
                   'close': 26157.5,
                   'datetime': '2023-06-13T11:04:52.248Z',
                   'high': 26260.0,
                   'info': {'askSz': '3.04',
                            'baseVolume': '130133.519',
                            'bestAsk': '26158',
                            'bestBid': '26157.5',
                            'bidSz': '6.315',
                            'chgUtc': '0.01039',
                            'fundingRate': '0.000071',
                            'high24h': '26260',
                            'holdingAmount': '74386.126',
                            'indexPrice': '26175.622083',
                            'last': '26157.5',
                            'low24h': '25637',
                            'openUtc': '25889',
                            'priceChangePercent': '0.01356',
                            'quoteVolume': '3376925363.279',
                            'symbol': 'BTCUSDT_UMCBL',
                            'timestamp': '1686654292248',
                            'usdtVolume': '3376925363.279'},
                   'last': 26157.5,
                   'low': 25637.0,
                   'open': 25889.0,
                   'percentage': 1.356,
                   'previousClose': None,
                   'quoteVolume': 3376925363.279,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1686654292248,
                   'vwap': 25949.696813155417}}
```
```
p bitget fetchTickers '["BTC/USDT"]'     
Python v3.10.9
CCXT v3.1.36
bitget.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 26180.26,
              'askVolume': 2.1316,
              'average': 26042.295,
              'baseVolume': 9921.1494,
              'bid': 26179.17,
              'bidVolume': 0.0507,
              'change': 274.69,
              'close': 26179.64,
              'datetime': '2023-06-13T11:05:07.829Z',
              'high': 26269.84,
              'info': {'askSz': '2.1316',
                       'baseVol': '9921.1494',
                       'bidSz': '0.0507',
                       'buyOne': '26179.17',
                       'change': '0.01374',
                       'changeUtc': '0.0106',
                       'close': '26179.64',
                       'high24h': '26269.84',
                       'low24h': '25659.82',
                       'openUtc0': '25904.95',
                       'quoteVol': '257334259.9734',
                       'sellOne': '26180.26',
                       'symbol': 'BTCUSDT',
                       'ts': '1686654307829',
                       'usdtVol': '257334259.973339'},
              'last': 26179.64,
              'low': 25659.82,
              'open': 25904.95,
              'percentage': 1.06,
              'previousClose': None,
              'quoteVolume': 257334259.9734,
              'symbol': 'BTC/USDT',
              'timestamp': 1686654307829,
              'vwap': 25937.948275771352}}
```
