### PR TITLE
fix(bitget): executePrice not required when type is market [ci deploy]

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2713,7 +2713,9 @@ export default class bitget extends Exchange {
                 const triggerType = this.safeString (params, 'triggerType', 'market_price');
                 request['triggerType'] = triggerType;
                 request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
-                request['executePrice'] = this.priceToPrecision (symbol, price);
+                if (price !== undefined) {
+                    request['executePrice'] = this.priceToPrecision (symbol, price);
+                }
                 method = 'privateSpotPostPlanPlacePlan';
             }
             if (quantity !== undefined) {


### PR DESCRIPTION
DEMO
```
p bitget createOrder "LTC/USDT" market sell 0.2 None '{"stopPrice": 40}'
Python v3.10.9
CCXT v3.1.36
bitget.createOrder(LTC/USDT,market,sell,0.2,None,{'stopPrice': 40})
{'amount': None,
 'average': None,
 'clientOrderId': '1052568164670967808',
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '1052568164679356416',
 'info': {'clientOrderId': '1052568164670967808',
          'orderId': '1052568164679356416'},
 'lastTradeTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```
