### PR TITLE
private tests: fix runtime errors for Python and PHP.

### DIFF
--- a/ts/src/test/Exchange/base/test.balance.ts
+++ b/ts/src/test/Exchange/base/test.balance.ts
@@ -16,8 +16,8 @@ function testBalance (exchange, skippedProperties, method, entry) {
     const codesTotal = Object.keys (entry['total']);
     const codesFree = Object.keys (entry['free']);
     const codesUsed = Object.keys (entry['used']);
-    let allCodes = codesTotal.concat (codesFree);
-    allCodes = allCodes.concat (codesUsed);
+    let allCodes = exchange.arrayConcat (codesTotal, codesFree);
+    allCodes = exchange.arrayConcat (allCodes, codesUsed);
     const codesLength = codesTotal.length;
     const freeLength = codesFree.length;
     const usedLength = codesUsed.length;

--- a/ts/src/test/Exchange/test.fetchBalance.ts
+++ b/ts/src/test/Exchange/test.fetchBalance.ts
@@ -1,7 +1,7 @@
 
 import testBalance from './base/test.balance.js';
 
-async function testFetchBalance (exchange, skippedProperties, code, symbol) {
+async function testFetchBalance (exchange, skippedProperties) {
     const method = 'fetchBalance';
     const response = await exchange.fetchBalance ();
     testBalance (exchange, skippedProperties, method, response);

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -670,7 +670,8 @@ export default class testMainClass extends baseMainTestClass {
                 errors.push (testName);
             }
         }
-        if (errors.length > 0) {
+        const errorsCnt = errors.length; // PHP transpile count($errors)
+        if (errorsCnt > 0) {
             throw new Error ('Failed private tests [' + market['type'] + ']: ' + errors.join (', '));
         } else {
             if (this.info) {


### PR DESCRIPTION
`testfetchBalance()` had an error in Python due to missing positional arguments