### PR TITLE
fix(bybit): fetchTickers parsing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,6 @@ diff=$(echo "$diff" | sed -e "s/python\/tox\.ini//")
 critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 if [[ "$diff" =~ $critical_pattern ]]; then
   echo "$msgPrefix Important changes detected - doing full build & test"
-  echo $diff
   build_and_test_all
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,7 @@ diff=$(echo "$diff" | sed -e "s/python\/tox\.ini//")
 critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 if [[ "$diff" =~ $critical_pattern ]]; then
   echo "$msgPrefix Important changes detected - doing full build & test"
+  echo $diff
   build_and_test_all
 fi
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1831,8 +1831,9 @@ export default class bybit extends Exchange {
         const timestamp = this.safeInteger (ticker, 'time');
         const marketId = this.safeString (ticker, 'symbol');
         const defaultType = this.safeString (this.options, 'defaultType', 'spot');
-        market = this.safeMarket (marketId, market, undefined, defaultType);
-        const symbol = this.safeSymbol (marketId, market, undefined, defaultType);
+        const type = this.safeString (market, 'type', defaultType);
+        market = this.safeMarket (marketId, market, undefined, type);
+        const symbol = this.safeSymbol (marketId, market, undefined, type);
         const last = this.safeString (ticker, 'lastPrice');
         const open = this.safeString (ticker, 'prevPrice24h');
         let percentage = this.safeString (ticker, 'price24hPcnt');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18211
DEMO
```
 p bybit fetchTickers '["BTC/USDT"]' --sandbox                           
Python v3.10.9
CCXT v3.1.37
bybit.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': 23220.0,
              'askVolume': 0.342376,
              'average': 24678.57,
              'baseVolume': 196.333454,
              'bid': 23219.99,
              'bidVolume': 0.069375,
              'change': -2917.14,
              'close': 23220.0,
              'datetime': None,
              'high': 27046.92,
              'info': {'ask1Price': '23220',
                       'ask1Size': '0.342376',
                       'bid1Price': '23219.99',
                       'bid1Size': '0.069375',
                       'highPrice24h': '27046.92',
                       'lastPrice': '23220',
                       'lowPrice24h': '21500',
                       'prevPrice24h': '26137.14',
                       'price24hPcnt': '-0.1116',
                       'symbol': 'BTCUSDT',
                       'turnover24h': '4644487.19064979',
                       'usdIndexPrice': '25971.42020927',
                       'volume24h': '196.333454'},
              'last': 23220.0,
              'low': 21500.0,
              'open': 26137.14,
              'percentage': -11.16,
              'previousClose': None,
              'quoteVolume': 4644487.19064979,
              'symbol': 'BTC/USDT',
              'timestamp': None,
              'vwap': 23656.11716202879}}
```
```
p bybit fetchTickers '["BTC/USDT:USDT"]' --sandbox
Python v3.10.9
CCXT v3.1.37
bybit.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': 25968.0,
                   'askVolume': 0.012,
                   'average': 26054.25,
                   'baseVolume': 486074.743,
                   'bid': 25961.2,
                   'bidVolume': 100.0,
                   'change': -172.5,
                   'close': 25968.0,
                   'datetime': None,
                   'high': 26740.9,
                   'info': {'ask1Price': '25968.00',
                            'ask1Size': '0.012',
                            'basis': '',
                            'basisRate': '',
                            'bid1Price': '25961.20',
                            'bid1Size': '100.000',
                            'deliveryFeeRate': '',
                            'deliveryTime': '0',
                            'fundingRate': '0.0001',
                            'highPrice24h': '26740.90',
                            'indexPrice': '25973.44',
                            'lastPrice': '25968.00',
                            'lowPrice24h': '25500.00',
                            'markPrice': '25968.00',
                            'nextFundingTime': '1686758400000',
                            'openInterest': '111794.122',
                            'openInterestValue': '2903069760.10',
                            'predictedDeliveryPrice': '',
                            'prevPrice1h': '25924.20',
                            'prevPrice24h': '26140.50',
                            'price24hPcnt': '-0.006598',
                            'symbol': 'BTCUSDT',
                            'turnover24h': '12618955894.6871',
                            'volume24h': '486074.7430'},
                   'last': 25968.0,
                   'low': 25500.0,
                   'open': 26140.5,
                   'percentage': -0.6598,
                   'previousClose': None,
                   'quoteVolume': 12618955894.6871,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': None,
                   'vwap': 25960.937235299018}}
```
