### PR TITLE
fix(cli.py): support sync calls [ci skip]

### DIFF
--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -211,7 +211,11 @@ async def main():
                 is_ws_method = True # handle ws methods
             print(f"{argv.exchange_id}.{argv.method}({','.join(map(str, args))})")
             while True:
-                result = await method(*args)
+                result = None
+                if asyncio.iscoroutinefunction(method):
+                    result = await method(*args)
+                else:
+                    result = method(*args)
                 if argv.table:
                     result = list(result.values()) if isinstance(result, dict) else result
                     print(table([exchange.omit(v, 'info') for v in result]))


### PR DESCRIPTION
```
p bybit market "BTC/USDT" --sandbox
Python v3.10.9
CCXT v3.1.38
bybit.market(BTC/USDT)
{'active': True,
 'base': 'BTC',
 'baseId': 'BTC',
 'contract': False,
 'contractSize': None,
 'expiry': None,
 'expiryDatetime': None,
 'feeSide': 'get',
 'future': False,
 'id': 'BTCUSDT',
 'info': {'baseCoin': 'BTC',
          'innovation': '0',
          'lotSizeFilter': {'basePrecision': '0.000001',
                            'maxOrderAmt': '1200000',
                            'maxOrderQty': '500',
                            'minOrderAmt': '1',
                            'minOrderQty': '0.00004',
                            'quotePrecision': '0.00000001'},
          'marginTrading': 'both',
          'priceFilter': {'tickSize': '0.01'},
          'quoteCoin': 'USDT',
          'status': 'Trading',
          'symbol': 'BTCUSDT'},
 'inverse': None,
 'limits': {'amount': {'max': 500.0, 'min': 4e-05},
            'cost': {'max': 1200000.0, 'min': 1.0},
            'leverage': {'max': None, 'min': 1.0},
            'price': {'max': None, 'min': None}},
 'linear': None,
 'maker': 0.001,
 'margin': None,
 'option': False,
 'optionType': None,
 'percentage': True,
 'precision': {'amount': 1e-06, 'price': 0.01},
 'quote': 'USDT',
 'quoteId': 'USDT',
 'settle': None,
 'settleId': None,
 'spot': True,
 'strike': None,
 'swap': False,
 'symbol': 'BTC/USDT',
 'taker': 0.001,
 'tierBased': True,
 'type': 'spot'}
```
```
 p bybit fetchTicker "BTC/USDT" --sandbox
Python v3.10.9
CCXT v3.1.38
bybit.fetchTicker(BTC/USDT)
{'ask': 23999.91,
 'askVolume': 0.116919,
 'average': 24982.235,
 'baseVolume': 192.495865,
 'bid': 23999.9,
 'bidVolume': 0.062298,
 'change': -1964.65,
 'close': 23999.91,
 'datetime': None,
 'high': 27046.92,
 'info': {'ask1Price': '23999.91',
          'ask1Size': '0.116919',
          'bid1Price': '23999.9',
          'bid1Size': '0.062298',
          'highPrice24h': '27046.92',
          'lastPrice': '23999.91',
          'lowPrice24h': '21500',
          'prevPrice24h': '25964.56',
          'price24hPcnt': '-0.0757',
          'symbol': 'BTCUSDT',
          'turnover24h': '4496844.72586623',
          'usdIndexPrice': '26002.66012504',
          'volume24h': '192.495865'},
 'last': 23999.91,
 'low': 21500.0,
 'open': 25964.56,
 'percentage': -7.57,
 'previousClose': None,
 'quoteVolume': 4496844.72586623,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': 23360.73414286707}
```
