### PR TITLE
lbank fetchMarkets fix

### DIFF
--- a/ts/src/lbank2.ts
+++ b/ts/src/lbank2.ts
@@ -279,6 +279,7 @@ export default class lbank2 extends Exchange {
          * @method
          * @name lbank2#fetchMarkets
          * @description retrieves data on all markets for lbank2
+         * @see https://www.lbank.com/en-US/docs/index.html#trading-pairs
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[object]} an array of objects representing market data
          */
@@ -303,23 +304,7 @@ export default class lbank2 extends Exchange {
             const base = baseId.toUpperCase ();
             const quote = quoteId.toUpperCase ();
             let symbol = base + '/' + quote;
-            const productTypes = {
-                '3l': true,
-                '5l': true,
-                '3s': true,
-                '5s': true,
-            };
             const amountPrecision = this.parseNumber (this.parsePrecision (this.safeString (market, 'quantityAccuracy')));
-            const contractSize = amountPrecision;
-            const ending = baseId.slice (-2);
-            const isLeveragedProduct = this.safeValue (productTypes, ending, false);
-            if (isLeveragedProduct) {
-                symbol += ':' + quote;
-            }
-            let linear = undefined;
-            if (isLeveragedProduct === true) {
-                linear = true;
-            }
             result.push ({
                 'id': marketId,
                 'symbol': symbol,
@@ -332,14 +317,14 @@ export default class lbank2 extends Exchange {
                 'type': 'spot',
                 'spot': true,
                 'margin': false,
-                'swap': isLeveragedProduct,
+                'swap': false,
                 'future': false,
                 'option': false,
                 'active': true,
-                'contract': isLeveragedProduct,
-                'linear': linear, // all leveraged ETF products are in USDT
+                'contract': undefined,
+                'linear': undefined,
                 'inverse': undefined,
-                'contractSize': isLeveragedProduct ? contractSize : undefined,
+                'contractSize': undefined,
                 'expiry': undefined,
                 'expiryDatetime': undefined,
                 'strike': undefined,


### PR DESCRIPTION
On all exchanges we determine leveraged ETF tokens (BTC3S/USDT) as spot market.
All ETF markets are here with other spot markets. So there is not `linear` product.
https://www.lbank.com/en-US/trade/btc3s_usdt/ 