### PR TITLE
fix(xt): error handling when response is undefined

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -4563,7 +4563,7 @@ export default class xt extends Exchange {
         //     }
         //
         const status = this.safeStringUpper2 (response, 'msgInfo', 'mc');
-        if (status !== 'SUCCESS') {
+        if (status !== undefined && status !== 'SUCCESS') {
             const feedback = this.id + ' ' + body;
             const error = this.safeValue (response, 'error', {});
             const spotErrorCode = this.safeString (response, 'mc');


### PR DESCRIPTION
```
ExchangeNotAvailable xt GET https://sapi.xt.com/v4/balances 502 Bad Gateway 
---------------------------------------------------
[ExchangeNotAvailable] xt GET https://sapi.xt.com/v4/balances 502 Bad Gateway

    at handleHttpStatusCode       Users/cjg/Git/ccxt12/ccxt/js/src/base/Exchange.js:833   
    at                            Users/cjg/Git/ccxt12/ccxt/js/src/base/Exchange.js:749   
    at processTicksAndRejections  node:internal/process/task_queues:95                    
    at fetch2                     Users/cjg/Git/ccxt12/ccxt/js/src/base/Exchange.js:2479  
    at request                    Users/cjg/Git/ccxt12/ccxt/js/src/base/Exchange.js:2482  
    at fetchBalance               Users/cjg/Git/ccxt12/ccxt/js/src/xt.js:2026             
    at async run                  Users/cjg/Git/ccxt12/ccxt/examples/js/cli.js:298        

xt GET https://sapi.xt.com/v4/balances 502 Bad Gateway 
Waiting for the debugger to disconnect...
```
