### PR TITLE
Crypto.com: fetchTrades, fetchMyTrades, migrate to the unified API

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -746,11 +746,13 @@ export default class cryptocom extends Exchange {
         /**
          * @method
          * @name cryptocom#fetchTrades
-         * @description get the list of most recent trades for a particular symbol
+         * @description get a list of the most recent trades for a particular symbol
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#public-get-trades
          * @param {string} symbol unified symbol of the market to fetch trades for
-         * @param {int|undefined} since timestamp in ms of the earliest trade to fetch
-         * @param {int|undefined} limit the maximum amount of trades to fetch
+         * @param {int|undefined} since timestamp in ms of the earliest trade to fetch, maximum date range is one day
+         * @param {int|undefined} limit the maximum number of trades to fetch
          * @param {object} params extra parameters specific to the cryptocom api endpoint
+         * @param {int|undefined} params.until timestamp in ms for the ending date filter, default is the current time
          * @returns {[object]} a list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html?#public-trades}
          */
         await this.loadMarkets ();
@@ -759,40 +761,39 @@ export default class cryptocom extends Exchange {
             'instrument_name': market['id'],
         };
         if (since !== undefined) {
-            // maximum date range is one day
             request['start_ts'] = since;
         }
         if (limit !== undefined) {
-            request['page_size'] = limit;
+            request['count'] = limit;
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTrades', market, params);
-        const method = this.getSupportedMapping (marketType, {
-            'spot': 'v2PublicGetPublicGetTrades',
-            'future': 'derivativesPublicGetPublicGetTrades',
-            'swap': 'derivativesPublicGetPublicGetTrades',
-        });
-        const response = await this[method] (this.extend (request, query));
-        // {
-        //     "code":0,
-        //     "method":"public/get-trades",
-        //     "result": {
-        //          "instrument_name": "BTC_USDT",
-        //          "data:": [
-        //              {"dataTime":1591710781947,"d":465533583799589409,"s":"BUY","p":2.96,"q":16.0,"t":1591710781946,"i":"ICX_CRO"},
-        //              {"dataTime":1591707701899,"d":465430234542863152,"s":"BUY","p":0.007749,"q":115.0,"t":1591707701898,"i":"VET_USDT"},
-        //              {"dataTime":1591710786155,"d":465533724976458209,"s":"SELL","p":25.676,"q":0.55,"t":1591710786154,"i":"XTZ_CRO"},
-        //              {"dataTime":1591710783300,"d":465533629172286576,"s":"SELL","p":2.9016,"q":0.6,"t":1591710783298,"i":"XTZ_USDT"},
-        //              {"dataTime":1591710784499,"d":465533669425626384,"s":"SELL","p":2.7662,"q":0.58,"t":1591710784498,"i":"EOS_USDT"},
-        //              {"dataTime":1591710784700,"d":465533676120104336,"s":"SELL","p":243.21,"q":0.01647,"t":1591710784698,"i":"ETH_USDT"},
-        //              {"dataTime":1591710786600,"d":465533739878620208,"s":"SELL","p":253.06,"q":0.00516,"t":1591710786598,"i":"BCH_USDT"},
-        //              {"dataTime":1591710786900,"d":465533749959572464,"s":"BUY","p":0.9999,"q":0.2,"t":1591710786898,"i":"USDC_USDT"},
-        //              {"dataTime":1591710787500,"d":465533770081010000,"s":"BUY","p":3.159,"q":1.65,"t":1591710787498,"i":"ATOM_USDT"},
-        //            ]
-        //      }
-        // }
-        const resultResponse = this.safeValue (response, 'result', {});
-        const data = this.safeValue (resultResponse, 'data', []);
-        return this.parseTrades (data, market, since, limit);
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
+        if (until !== undefined) {
+            request['end_ts'] = until;
+        }
+        const response = await this.v1PublicGetPublicGetTrades (this.extend (request, params));
+        //
+        //     {
+        //         "id": -1,
+        //         "method": "public/get-trades",
+        //         "code": 0,
+        //         "result": {
+        //             "data": [
+        //                 {
+        //                     "s": "sell",
+        //                     "p": "26386.00",
+        //                     "q": "0.00453",
+        //                     "t": 1686944282062,
+        //                     "d": "4611686018455979970",
+        //                     "i": "BTC_USD"
+        //                 },
+        //             ]
+        //         }
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        const trades = this.safeValue (result, 'data', []);
+        return this.parseTrades (trades, market, since, limit);
     }
 
     async fetchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -1893,9 +1894,16 @@ export default class cryptocom extends Exchange {
 
     parseTrade (trade, market = undefined) {
         //
-        // public/get-trades
+        // fetchTrades
         //
-        // {"dataTime":1591710781947,"d":465533583799589409,"s":"BUY","p":2.96,"q":16.0,"t":1591710781946,"i":"ICX_CRO"},
+        //     {
+        //         "s": "sell",
+        //         "p": "26386.00",
+        //         "q": "0.00453",
+        //         "t": 1686944282062,
+        //         "d": "4611686018455979970",
+        //         "i": "BTC_USD"
+        //     }
         //
         // fetchMyTrades
         //


### PR DESCRIPTION
Migrated fetchTrades and fetchMyTrades to the unified API:

### fetchTrades:
```
cryptocom.fetchTrades (BTC/USD, , 3)
2023-06-16T19:44:44.826Z iteration 0 passed in 397 ms

                 id |     timestamp |                 datetime |  symbol | order | side | takerOrMaker |    price |  amount |       cost | type | fee | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------
4611686018455980102 | 1686944594908 | 2023-06-16T19:43:14.908Z | BTC/USD |       |  buy |              |    26362 | 0.00004 |    1.05448 |      |  {} | [{}]
4611686018455980103 | 1686944594908 | 2023-06-16T19:43:14.908Z | BTC/USD |       |  buy |              | 26364.84 | 0.00276 | 72.7669584 |      |  {} | [{}]
4611686018455980104 | 1686944597749 | 2023-06-16T19:43:17.749Z | BTC/USD |       | sell |              | 26360.74 |  0.0091 | 239.882734 |      |  {} | [{}]
3 objects
```

### fetchMyTrades:
```
cryptocom.fetchMyTrades ()
2023-06-16T19:32:27.001Z iteration 0 passed in 323 ms

                 id |     timestamp |                 datetime |  symbol |               order | side | takerOrMaker |    price |  amount |      cost | type |                                fee |
   fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6142909898247428343 | 1686941992887 | 2023-06-16T18:59:52.887Z | BTC/USD | 6142909895036331486 |  buy |        taker | 26347.16 | 0.00021 | 5.5329036 |      | {"currency":"BTC","cost":-5.25e-8} | [{"currency":"BTC","cost":-5.25e-8}]
1 objects
```