### PR TITLE
Update types.py

### DIFF
--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -11,6 +11,7 @@ else:
 
 OrderSide = Literal['buy', 'sell']
 OrderType = Literal['limit', 'market']
+PositionSide = Literal['LONG', 'SHORT']
 
 
 class Entry:


### PR DESCRIPTION
added a literal for possible `positionSide` values. Not being used for now since this parameter is fed as a dictionary called `params` in create_order, but still helps for static coding.