### PR TITLE
bitget-fetchDepositWithdrawFees

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4671,7 +4671,7 @@ export default class bitget extends Exchange {
         return result;
     }
 
-    async fetchDepositWithdrawFees (codes = undefined, params = {}) {
+    async fetchDepositWithdrawFees (codes: string[] = undefined, params = {}) {
         /**
          * @method
          * @name bitget#fetchDepositWithdrawFees


### PR DESCRIPTION
```
Python v3.8.10
CCXT v3.1.45
bitget.fetchDepositWithdrawFees(['USDT', 'ETH'])
{'ETH': {'deposit': {'fee': None, 'percentage': None},
         'info': {'chains': [{'browserUrl': 'https://nova-explorer.arbitrum.io/tx/',
                              'chain': 'ArbitrumNova',
                              'depositConfirm': '30',
                              'extraWithDrawFee': '0',
                              'minDepositAmount': '1',
                              'minWithdrawAmount': '10',
                              'needTag': 'false',
                              'rechargeable': 'false',
                              'withdrawConfirm': '30',
                              'withdrawFee': '0.1',
                              'withdrawable': 'false'},
                             {'browserUrl': 'https://arbiscan.io/tx/',
                              'chain': 'ArbitrumOne',
                              'depositConfirm': '24',
                              'extraWithDrawFee': '0',
                              'minDepositAmount': '0.001',
                              'minWithdrawAmount': '0.0008',
                              'needTag': 'false',
                              'rechargeable': 'true',
                              'withdrawConfirm': '24',
                              'withdrawFee': '0.0001',
                              'withdrawable': 'true'},
                             {'browserUrl': 'https://explorer.zksync.io/tx/',
                              'chain': 'zkSyncEra',
                              'depositConfirm': '64',
                              'extraWithDrawFee': '0',
                              'minDepositAmount': '0.001',
                              'minWithdrawAmount': '0.001',
                              'needTag': 'false',
                              'rechargeable': 'false',
                              'withdrawConfirm': '64',
                              'withdrawFee': '0.0003',
                              'withdrawable': 'true'},
                             {'browserUrl': 'https://etherscan.io/tx/',
                              'chain': 'ETH',
                              'depositConfirm': '64',
                              'extraWithDrawFee': '0',
                              'minDepositAmount': '0.001',
                              'minWithdrawAmount': '0.0098',
                              'needTag': 'false',
                              'rechargeable': 'true',
                              'withdrawConfirm': '1',
                              'withdrawFee': '0.00087',
                              'withdrawable': 'true'},
                             {'browserUrl': 'https://optimistic.etherscan.io/tx/',
                              'chain': 'Optimism',
                              'depositConfirm': '50',
                              'extraWithDrawFee': '0',
                              'minDepositAmount': '0.0001',
                              'minWithdrawAmount': '0.001',
                              'needTag': 'false',
                              'rechargeable': 'true',
                              'withdrawConfirm': '50',
                              'withdrawFee': '0.00035',
                              'withdrawable': 'true'},
                             {'browserUrl': 'https://bscscan.com/tx/',
                              'chain': 'BEP20',
                              'depositConfirm': '15',
                              'extraWithDrawFee': '0',
                              'minDepositAmount': '0.0001',
                              'minWithdrawAmount': '0.00011',
                              'needTag': 'false',
                              'rechargeable': 'true',
                              'withdrawConfirm': '15',
                              'withdrawFee': '0.00009',
                              'withdrawable': 'true'}],
                  'coinId': '3',
                  'coinName': 'ETH',
                  'transfer': 'true'},
         'networks': {'ArbitrumNova': {'deposit': {'fee': None,
                                                   'percentage': None},
                                       'withdraw': {'fee': 0.1,
                                                    'percentage': False}},
                      'ArbitrumOne': {'deposit': {'fee': None,
                                                  'percentage': None},
                                      'withdraw': {'fee': 0.0001,
                                                   'percentage': False}},
                      'BEP20': {'deposit': {'fee': None, 'percentage': None},
                                'withdraw': {'fee': 9e-05,
                                             'percentage': False}},
                      'ETH': {'deposit': {'fee': None, 'percentage': None},
                              'withdraw': {'fee': 0.00087,
                                           'percentage': False}},
                      'Optimism': {'deposit': {'fee': None, 'percentage': None},
                                   'withdraw': {'fee': 0.00035,
                                                'percentage': False}},
                      'zkSyncEra': {'deposit': {'fee': None,
                                                'percentage': None},
                                    'withdraw': {'fee': 0.0003,
                                                 'percentage': False}}},
         'withdraw': {'fee': None, 'percentage': None}},
 'USDT': {'deposit': {'fee': None, 'percentage': None},
          'info': {'chains': [{'browserUrl': 'https://www.omniexplorer.info/tx/',
                               'chain': 'OMNI',
                               'depositConfirm': '1',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '50',
                               'minWithdrawAmount': '100',
                               'needTag': 'false',
                               'rechargeable': 'false',
                               'withdrawConfirm': '1',
                               'withdrawFee': '15',
                               'withdrawable': 'false'},
                              {'browserUrl': 'https://etherscan.io/tx/',
                               'chain': 'ERC20',
                               'depositConfirm': '64',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.00000001',
                               'minWithdrawAmount': '1',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '1',
                               'withdrawFee': '3.0638816',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://polygonscan.com/tx/',
                               'chain': 'Polygon',
                               'depositConfirm': '60',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.00000001',
                               'minWithdrawAmount': '0.34',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '60',
                               'withdrawFee': '1',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://arbiscan.io/tx/',
                               'chain': 'ArbitrumOne',
                               'depositConfirm': '24',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.1',
                               'minWithdrawAmount': '4',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '24',
                               'withdrawFee': '0.1',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://bscscan.com/tx/',
                               'chain': 'BEP20',
                               'depositConfirm': '15',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.01',
                               'minWithdrawAmount': '10',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '15',
                               'withdrawFee': '0.29',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://hecoinfo.com/tx/',
                               'chain': 'HECO',
                               'depositConfirm': '20',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '1',
                               'minWithdrawAmount': '5',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '20',
                               'withdrawFee': '0.1',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://optimistic.etherscan.io/tx/',
                               'chain': 'Optimism',
                               'depositConfirm': '50',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '1',
                               'minWithdrawAmount': '10',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '50',
                               'withdrawFee': '1',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://avascan.info/blockchain/c/tx/',
                               'chain': 'C-Chain',
                               'depositConfirm': '60',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.00000001',
                               'minWithdrawAmount': '50',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '60',
                               'withdrawFee': '1',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://tronscan.org/#/transaction/|https://tronscan.org/#/address/',
                               'chain': 'TRC20',
                               'depositConfirm': '1',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.01',
                               'minWithdrawAmount': '10',
                               'needTag': 'false',
                               'rechargeable': 'true',
                               'withdrawConfirm': '1',
                               'withdrawFee': '1',
                               'withdrawable': 'true'},
                              {'browserUrl': 'https://solscan.io/tx/',
                               'chain': 'SOL',
                               'depositConfirm': '5',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.00000001',
                               'minWithdrawAmount': '2',
                               'needTag': 'false',
                               'rechargeable': 'false',
                               'withdrawConfirm': '5',
                               'withdrawFee': '1',
                               'withdrawable': 'false'},
                              {'browserUrl': 'https://bttcscan.com/tx/',
                               'chain': 'BTTC',
                               'depositConfirm': '64',
                               'extraWithDrawFee': '0',
                               'minDepositAmount': '0.01',
                               'minWithdrawAmount': '1',
                               'needTag': 'false',
                               'rechargeable': 'false',
                               'withdrawConfirm': '64',
                               'withdrawFee': '1',
                               'withdrawable': 'false'}],
                   'coinId': '2',
                   'coinName': 'USDT',
                   'transfer': 'true'},
          'networks': {'ArbitrumOne': {'deposit': {'fee': None,
                                                   'percentage': None},
                                       'withdraw': {'fee': 0.1,
                                                    'percentage': False}},
                       'BEP20': {'deposit': {'fee': None, 'percentage': None},
                                 'withdraw': {'fee': 0.29,
                                              'percentage': False}},
                       'BTTC': {'deposit': {'fee': None, 'percentage': None},
                                'withdraw': {'fee': 1.0, 'percentage': False}},
                       'C-Chain': {'deposit': {'fee': None, 'percentage': None},
                                   'withdraw': {'fee': 1.0,
                                                'percentage': False}},
                       'ERC20': {'deposit': {'fee': None, 'percentage': None},
                                 'withdraw': {'fee': 3.0638816,
                                              'percentage': False}},
                       'HECO': {'deposit': {'fee': None, 'percentage': None},
                                'withdraw': {'fee': 0.1, 'percentage': False}},
                       'OMNI': {'deposit': {'fee': None, 'percentage': None},
                                'withdraw': {'fee': 15.0, 'percentage': False}},
                       'Optimism': {'deposit': {'fee': None,
                                                'percentage': None},
                                    'withdraw': {'fee': 1.0,
                                                 'percentage': False}},
                       'Polygon': {'deposit': {'fee': None, 'percentage': None},
                                   'withdraw': {'fee': 1.0,
                                                'percentage': False}},
                       'SOL': {'deposit': {'fee': None, 'percentage': None},
                               'withdraw': {'fee': 1.0, 'percentage': False}},
                       'TRX': {'deposit': {'fee': None, 'percentage': None},
                               'withdraw': {'fee': 1.0, 'percentage': False}}},
          'withdraw': {'fee': None, 'percentage': None}}}
```