### PR TITLE
Zonda fetch ticker v2

### DIFF
--- a/ts/src/zonda.ts
+++ b/ts/src/zonda.ts
@@ -244,8 +244,8 @@ export default class zonda extends Exchange {
                 },
             },
             'options': {
-                'fetchTickerMethod': 'fetchTickerV2', // fetchTickerV1, fetchTickerV2, fetchTickerV1AndV2
-                'fetchTickersMethod': 'fetchTickersV2', // fetchTickersV1, fetchTickersV2, fetchTickersV1AndV2
+                'fetchTickerMethod': 'fetchTickerV2', // fetchTickerV1, fetchTickerV2
+                'fetchTickersMethod': 'fetchTickersV2', // fetchTickersV1, fetchTickersV2
                 'fiatCurrencies': [ 'EUR', 'USD', 'GBP', 'PLN' ],
                 'transfer': {
                     'fillResponseFromRequest': true,
@@ -663,7 +663,7 @@ export default class zonda extends Exchange {
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
          * @param {str} symbol unified symbol of the market to fetch the ticker for
          * @param {dict} params extra parameters specific to the gemini api endpoint
-         * @param {dict} params.fetchTickerMethod 'fetchTickerV2', 'fetchTickerV1' or 'fetchTickerV1AndV2' - 'fetchTickerV1' for original ccxt.zonda.fetchTicker - 'fetchTickerV1AndV2' for 2 api calls to get the result of both fetchTicker methods - uses this.options['fetchTickerMethod'] if not set - default = 'fetchTickerV2'
+         * @param {dict} params.fetchTickerMethod 'fetchTickerV2' or 'fetchTickerV1' - 'fetchTickerV1' for original ccxt.zonda.fetchTicker - uses this.options['fetchTickerMethod'] if not set - default = 'fetchTickerV2'
          * @returns {dict} a [ticker structure]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         const defaultMethod = this.safeString (this.options, 'fetchTickerMethod', 'fetchTickerV2');
@@ -764,148 +764,16 @@ export default class zonda extends Exchange {
          * @description fetches price tickers for multiple markets, statistical calculations with the information calculated over the past 24 hours each market
          * @param {[str]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {dict} params extra parameters specific to the zonda api endpoint
-         * @param {dict} params.fetchTickerMethod 'fetchTickersV2', 'fetchTickersV1' or 'fetchTickersV1AndV2' - 'fetchTickersV1' for original ccxt.zonda.fetchTickers - 'fetchTickersV1AndV2' for 2 api calls to get the result of both fetchTickers methods - uses this.options['fetchTickersMethod'] if not set - default = 'fetchTickersV2'
+         * @param {dict} params.fetchTickerMethod 'fetchTickersV2' or 'fetchTickersV1','fetchTickersV1' for original ccxt.zonda.fetchTickers,  uses this.options['fetchTickersMethod'] if not set - default = 'fetchTickersV2'
          * @returns {dict} an array of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
          */
         const defaultMethod = this.safeString (this.options, 'fetchTickersMethod', 'fetchTickersV2');
         const fetchTickersMethod = this.safeString (params, 'fetchTickersMethod', defaultMethod);
-        if (fetchTickersMethod === 'fetchTickersV1AndV2') {
-            return await this.fetchTickersV1AndV2 (symbols, params);
-        } else if (fetchTickersMethod === 'fetchTickersV1') {
+        if (fetchTickersMethod === 'fetchTickersV1') {
             return await this.fetchTickersV1 (symbols, params);
         } else {
             return await this.fetchTickersV2 (symbols, params);
         }
-    }
-
-    async fetchTickerV1AndV2 (symbol, params = {}) {
-        /**
-         * @ignore
-         * @method
-         * @name zonda#fetchTickerV1AndV2
-         * @description retrieves the results of both fetchTickerV1 and fetchTickerV2
-         * @param {str} symbol unified symbol of the market to fetch the ticker for
-         * @param {dict} params extra parameters specific to the zonda api endpoint
-         * @returns {dict} a [ticker structure]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
-         */
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        const request = {
-            'symbol': market['id'],
-        };
-        const responseV1 = await this.v1_01PublicGetTradingStatsSymbol (this.extend (request, params));
-        const stats = this.safeValue (responseV1, 'stats');
-        //
-        //    {
-        //        status: 'Ok',
-        //        stats: {
-        //            m: 'ETH-PLN',
-        //            h: '13485.13',
-        //            l: '13100.01',
-        //            v: '126.10710939',
-        //            r24h: '13332.72'
-        //        }
-        //    }
-        //
-        const responseV2 = await this.v1_01PublicGetTradingTickerSymbol (this.extend (request, params));
-        const ticker = this.safeValue (responseV2, 'ticker');
-        //
-        //    {
-        //        "status": "Ok",
-        //        "ticker": {
-        //            "market": {
-        //                "code": "ADA-USDT",
-        //                "first": {
-        //                    "currency": "ADA",
-        //                    "minOffer": "0.21",
-        //                    "scale": 6
-        //                },
-        //                "second": {
-        //                    "currency": "USDT",
-        //                    "minOffer": "0.099",
-        //                    "scale": 6
-        //                },
-        //                "amountPrecision": 6,
-        //                "pricePrecision": 6,
-        //                "ratePrecision": 6
-        //            },
-        //            "time": "1655810976780",
-        //            "highestBid": "0.498543",
-        //            "lowestAsk": "0.50684",
-        //            "rate": "0.50588",
-        //            "previousRate": "0.504981"
-        //        }
-        //    }
-        //
-        const tickerV1 = this.parseTicker (stats);
-        const tickerV2 = this.parseTicker (ticker);
-        return this.deepExtend (tickerV2, tickerV1);
-    }
-
-    async fetchTickersV1AndV2 (symbols, params = {}) {
-        /**
-         * @ignore
-         * @method
-         * @name zonda#fetchTickersV1AndV2
-         * @description retrieves the results of both fetchTickersV1 and fetchTickersV2
-         * @param {str} symbols unified symbol of the market to fetch the ticker for
-         * @param {dict} params extra parameters specific to the zonda api endpoint
-         * @returns {dict} a [ticker structure]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
-         */
-        await this.loadMarkets ();
-        const responseV1 = await this.v1_01PublicGetTradingStats (params);
-        //
-        //     {
-        //         status: 'Ok',
-        //         items: {
-        //             'DAI-PLN': {
-        //                 m: 'DAI-PLN',
-        //                 h: '4.41',
-        //                 l: '4.37',
-        //                 v: '8.71068087',
-        //                 r24h: '4.36'
-        //             },
-        //             ...
-        //         }
-        //     }
-        //
-        const responseV2 = await this.v1_01PublicGetTradingTicker (params);
-        //
-        //    {
-        //        "status": "Ok",
-        //        "items": {
-        //            "DAI-PLN": {
-        //                "market": {
-        //                    "code": "DAI-PLN",
-        //                    "first": {
-        //                        "currency": "DAI",
-        //                        "minOffer": "0.99",
-        //                        "scale": 8
-        //                    },
-        //                    "second": {
-        //                        "currency": "PLN",
-        //                        "minOffer": "5",
-        //                        "scale": 2
-        //                    },
-        //                    "amountPrecision": 8,
-        //                    "pricePrecision": 2,
-        //                    "ratePrecision": 2
-        //                },
-        //                "time": "1655810825137",
-        //                "highestBid": "4.42",
-        //                "lowestAsk": "4.44",
-        //                "rate": "4.44",
-        //                "previousRate": "4.43"
-        //            },
-        //            ...
-        //        }
-        //    }
-        //
-        const itemsV1 = this.safeValue (responseV1, 'items');
-        const itemsV2 = this.safeValue (responseV2, 'items');
-        const tickersV1 = this.parseTickers (itemsV1, symbols);
-        const tickersV2 = this.parseTickers (itemsV2, symbols);
-        return this.deepExtend (tickersV2, tickersV1);
     }
 
     async fetchTickersV2 (symbols = undefined, params = {}) {

--- a/ts/src/zonda.ts
+++ b/ts/src/zonda.ts
@@ -668,7 +668,13 @@ export default class zonda extends Exchange {
          */
         const defaultMethod = this.safeString (this.options, 'fetchTickerMethod', 'fetchTickerV2');
         const fetchTickerMethod = this.safeString (params, 'fetchTickerMethod', defaultMethod);
-        return await this[fetchTickerMethod] (symbol, params);
+        if (fetchTickerMethod === 'fetchTickerV1') {
+            return await this.fetchTickerV1 (symbol, params);
+        } else if (fetchTickerMethod === 'fetchTickerV2') {
+            return await this.fetchTickerV2 (symbol, params);
+        } else {
+            return await this.fetchTickerV1AndV2 (symbol, params);
+        }
     }
 
     async fetchTickerV2 (symbol, params = {}) {
@@ -763,7 +769,13 @@ export default class zonda extends Exchange {
          */
         const defaultMethod = this.safeString (this.options, 'fetchTickersMethod', 'fetchTickersV2');
         const fetchTickersMethod = this.safeString (params, 'fetchTickersMethod', defaultMethod);
-        return await this[fetchTickersMethod] (symbols, params);
+        if (fetchTickersMethod === 'fetchTickersV1AndV2') {
+            return await this.fetchTickersV1AndV2 (symbols, params);
+        } else if (fetchTickersMethod === 'fetchTickersV1') {
+            return await this.fetchTickersV1 (symbols, params);
+        } else {
+            return await this.fetchTickersV2 (symbols, params);
+        }
     }
 
     async fetchTickerV1AndV2 (symbol, params = {}) {

--- a/ts/src/zonda.ts
+++ b/ts/src/zonda.ts
@@ -670,10 +670,8 @@ export default class zonda extends Exchange {
         const fetchTickerMethod = this.safeString (params, 'fetchTickerMethod', defaultMethod);
         if (fetchTickerMethod === 'fetchTickerV1') {
             return await this.fetchTickerV1 (symbol, params);
-        } else if (fetchTickerMethod === 'fetchTickerV2') {
-            return await this.fetchTickerV2 (symbol, params);
         } else {
-            return await this.fetchTickerV1AndV2 (symbol, params);
+            return await this.fetchTickerV2 (symbol, params);
         }
     }
 


### PR DESCRIPTION
fixes: #13921

### v1_01PublicGetTradingTicker (Default)

```
% zonda fetchTicker BTC/USDT              
(node:10895) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-06-21T03:31:39.311Z
Node.js: v18.15.0
CCXT v3.1.45
zonda.fetchTicker (BTC/USDT)
2023-06-21T03:31:41.150Z iteration 0 passed in 1175 ms

{
  symbol: 'BTC/USDT',
  timestamp: 1687318299476,
  datetime: '2023-06-21T03:31:39.476Z',
  high: undefined,
  low: undefined,
  bid: 28634.800006,
  bidVolume: undefined,
  ask: 28700,
  askVolume: undefined,
  vwap: undefined,
  open: undefined,
  close: 28634.800005,
  last: 28634.800005,
  previousClose: 28745,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: undefined,
  quoteVolume: undefined,
  info: {
    market: {
      code: 'BTC-USDT',
      first: { currency: 'BTC', minOffer: '0.0000038', scale: '8' },
      second: { currency: 'USDT', minOffer: '0.108', scale: '6' },
      amountPrecision: '8',
      pricePrecision: '6',
      ratePrecision: '6'
    },
    time: '1687318299476',
    highestBid: '28634.800006',
    lowestAsk: '28700',
    rate: '28634.800005',
    previousRate: '28745'
  }
}
2023-06-21T03:31:41.150Z iteration 1 passed in 1175 ms
```

```
2023-06-21T03:30:53.860Z
Node.js: v18.15.0
CCXT v3.1.45
zonda.fetchTickers (BTC/USDT,ETH/USDT)
2023-06-21T03:30:55.811Z iteration 0 passed in 1191 ms

{
  'ETH/USDT': {
    symbol: 'ETH/USDT',
    timestamp: 1687318215277,
    datetime: '2023-06-21T03:30:15.277Z',
    high: undefined,
    low: undefined,
    bid: 1802.82,
    bidVolume: undefined,
    ask: 1808.46,
    askVolume: undefined,
    vwap: undefined,
    open: undefined,
    close: 1803.840002,
    last: 1803.840002,
    previousClose: 1803.12,
    change: undefined,
    percentage: undefined,
    average: undefined,
    baseVolume: undefined,
    quoteVolume: undefined,
    info: {
      market: {
        code: 'ETH-USDT',
        first: { currency: 'ETH', minOffer: '0.00006', scale: '8' },
        second: { currency: 'USDT', minOffer: '0.108', scale: '6' },
        amountPrecision: '8',
        pricePrecision: '6',
        ratePrecision: '6'
      },
      time: '1687318215277',
      highestBid: '1802.82',
      lowestAsk: '1808.46',
      rate: '1803.840002',
      previousRate: '1803.12'
    }
  },
  'BTC/USDT': {
    symbol: 'BTC/USDT',
    timestamp: 1687318251087,
    datetime: '2023-06-21T03:30:51.087Z',
    high: undefined,
    low: undefined,
    bid: 28634.800003,
    bidVolume: undefined,
    ask: 28737.289998,
    askVolume: undefined,
    vwap: undefined,
    open: undefined,
    close: 28745,
    last: 28745,
    previousClose: 28746.7,
    change: undefined,
    percentage: undefined,
    average: undefined,
    baseVolume: undefined,
    quoteVolume: undefined,
    info: {
      market: {
        code: 'BTC-USDT',
        first: { currency: 'BTC', minOffer: '0.0000038', scale: '8' },
        second: { currency: 'USDT', minOffer: '0.108', scale: '6' },
        amountPrecision: '8',
        pricePrecision: '6',
        ratePrecision: '6'
      },
      time: '1687318251087',
      highestBid: '28634.800003',
      lowestAsk: '28737.289998',
      rate: '28745',
      previousRate: '28746.7'
    }
  }
}
2023-06-21T03:30:55.811Z iteration 1 passed in 1191 ms
```

```
2023-06-21T03:28:03.496Z
Node.js: v18.15.0
CCXT v3.1.45
zonda.fetchTickers ()
2023-06-21T03:28:05.404Z iteration 0 passed in 1213 ms

{
  'BTG/EUR': {
    symbol: 'BTG/EUR',
    timestamp: 1687228547727,
    datetime: '2023-06-20T02:35:47.727Z',
    high: undefined,
    low: undefined,
    bid: 9.6,
    bidVolume: undefined,
    ask: 12.93,
    askVolume: undefined,
    vwap: undefined,
    open: undefined,
    close: 10.01,
    last: 10.01,
    previousClose: 11.72,
    change: undefined,
    percentage: undefined,
    average: undefined,
    baseVolume: undefined,
    quoteVolume: undefined,
    info: {
      ...
    }
  },
  ...
  2023-06-21T03:28:05.404Z iteration 1 passed in 1213 ms
```

### v1_01PublicGetTradingStats

```
% zonda fetchTicker BTC/USDT '{"method": "v1_01PublicGetTradingStatsSymbol"}'          
2023-06-21T03:40:06.104Z
Node.js: v18.15.0
CCXT v3.1.45
zonda.fetchTicker (BTC/USDT, [object Object])
2023-06-21T03:40:07.943Z iteration 0 passed in 1186 ms

{
  symbol: 'BTC/USDT',
  timestamp: undefined,
  datetime: undefined,
  high: 28800,
  low: 26703.950101,
  bid: undefined,
  bidVolume: undefined,
  ask: undefined,
  askVolume: undefined,
  vwap: undefined,
  open: 27122.2,
  close: undefined,
  last: undefined,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: 6.72932396,
  quoteVolume: undefined,
  info: {
    m: 'BTC-USDT',
    h: '28800',
    l: '26703.950101',
    v: '6.72932396',
    r24h: '27122.2'
  }
}
2023-06-21T03:40:07.943Z iteration 1 passed in 1186 ms
```

```
2023-06-21T03:41:36.728Z
Node.js: v18.15.0
CCXT v3.1.45
zonda.fetchTickers (, [object Object])
2023-06-21T03:41:38.583Z iteration 0 passed in 1199 ms

{
  'BTG/EUR': {
    symbol: 'BTG/EUR',
    timestamp: undefined,
    datetime: undefined,
    high: undefined,
    low: undefined,
    bid: undefined,
    bidVolume: undefined,
    ask: undefined,
    askVolume: undefined,
    vwap: undefined,
    open: 10.01,
    close: undefined,
    last: undefined,
    previousClose: undefined,
    change: undefined,
    percentage: undefined,
    average: undefined,
    baseVolume: 0,
    quoteVolume: undefined,
    info: { m: 'BTG-EUR', h: null, l: null, v: '0', r24h: '10.01' }
  },
...
```