### PR TITLE
Bitmex string math

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -922,9 +922,9 @@ export default class bitmex extends Exchange {
         const type = this.parseLedgerEntryType (this.safeString (item, 'transactType'));
         const currencyId = this.safeString (item, 'currency');
         const code = this.safeCurrencyCode (currencyId, currency);
-        let amount = this.safeNumber (item, 'amount');
+        let amount = this.safeString (item, 'amount');
         if (amount !== undefined) {
-            amount = amount / 100000000;
+            amount = Precise.stringDiv (amount, '100000000');
         }
         let timestamp = this.parse8601 (this.safeString (item, 'transactTime'));
         if (timestamp === undefined) {
@@ -933,23 +933,23 @@ export default class bitmex extends Exchange {
             // for unrealized pnl and other transactions without a timestamp
             timestamp = 0; // see comments above
         }
-        let feeCost = this.safeNumber (item, 'fee', 0);
+        let feeCost = this.safeString (item, 'fee', 0);
         if (feeCost !== undefined) {
-            feeCost = feeCost / 100000000;
+            feeCost = Precise.stringDiv (feeCost, '100000000');
         }
         const fee = {
             'cost': feeCost,
             'currency': code,
         };
-        let after = this.safeNumber (item, 'walletBalance');
+        let after = this.safeString (item, 'walletBalance');
         if (after !== undefined) {
-            after = after / 100000000;
+            after = Precise.stringDiv (after, '100000000');
         }
-        const before = this.sum (after, -amount);
+        const before = Precise.stringAdd (after, '-' + amount);
         let direction = undefined;
-        if (amount < 0) {
+        if (Precise.stringLt (amount, 0)) {
             direction = 'out';
-            amount = Math.abs (amount);
+            amount = Precise.stringAbs (amount);
         } else {
             direction = 'in';
         }

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -985,7 +985,9 @@ export default class bitmex extends Exchange {
         };
         if (code !== undefined) {
             currency = this.currency (code);
-            request['currency'] = currency['id'];
+            const currencyBeginning = currency['id'].slice (0, -1);
+            const currencyEnd = currency['id'].slice (-1);
+            request['currency'] = currencyBeginning + currencyEnd.toLowerCase ();
         }
         //
         //     if (since !== undefined) {
@@ -1439,7 +1441,7 @@ export default class bitmex extends Exchange {
         //         "account": 0,
         //         "symbol": "string",
         //         "side": "string",
-        //         "lastQty": 0,
+        //         "lastQty": 0,,
         //         "lastPx": 0,
         //         "underlyingLastPx": 0,
         //         "lastMkt": "string",

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -918,7 +918,7 @@ export default class bitmex extends Exchange {
         const account = this.safeString (item, 'account');
         const referenceAccount = undefined;
         const currencyId = this.safeString (item, 'currency');
-        const code = this.safeCurrencyCode (currencyId, currency);
+        currency = this.safeCurrency (currencyId, currency);
         let amount = this.safeString (item, 'amount');
         if (amount !== undefined) {
             amount = Precise.stringDiv (amount, '100000000');
@@ -955,14 +955,14 @@ export default class bitmex extends Exchange {
             'referenceId': this.safeString (item, 'tx'),
             'referenceAccount': referenceAccount,
             'type': this.parseLedgerEntryType (this.safeString (item, 'transactType')),
-            'currency': code,
+            'currency': currency['code'],
             'amount': amount,
             'before': this.parseNumber (Precise.stringAdd (after, '-' + amount)),
             'after': after,
             'status': this.parseTransactionStatus (this.safeString (item, 'transactStatus')),
             'fee': {
                 'cost': feeCost,
-                'currency': code,
+                'currency': currency['code'],
             },
         };
     }

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -984,10 +984,16 @@ export default class bitmex extends Exchange {
             'currency': 'all',
         };
         if (code !== undefined) {
-            currency = this.currency (code);
-            const currencyBeginning = currency['id'].slice (0, -1);
-            const currencyEnd = currency['id'].slice (-1);
-            request['currency'] = currencyBeginning + currencyEnd.toLowerCase ();
+            let currencyId = undefined;
+            if (code === 'ETH' || code.toUpperCase () === 'GWEI') {
+                currencyId = 'Gwei';
+            } else {
+                currency = this.currency (code);
+                const currencyBeginning = currency['id'].slice (0, -1);
+                const currencyEnd = currency['id'].slice (-1);
+                currencyId = currencyBeginning + currencyEnd.toLowerCase ();
+            }
+            request['currency'] = currencyId;
         }
         //
         //     if (since !== undefined) {


### PR DESCRIPTION
```
 % bitmex fetchLedger
2023-06-19T17:55:05.705Z
Node.js: v18.15.0
CCXT v3.1.45
bitmex.fetchLedger ()
2023-06-19T17:55:07.653Z iteration 0 passed in 702 ms

                                  id |     timestamp |                 datetime | direction | account |                          referenceId | referenceAccount |        type | currency |     amount |      before |      after | status |                             fee
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2bbd7baf-f210-c599-95ab-ca443761982d | 1652748498003 | 2022-05-17T00:48:18.003Z |        in | 1833101 |                                      |                  | transaction |     USDT |          2 |           0 |          2 |     ok |  {"cost":"0","currency":"USDT"}
77f18fc7-edff-e2d0-610a-443d9b0ab9d6 | 1652788800000 | 2022-05-17T12:00:00.000Z |       out | 1833101 | 1b9dfbac-03b5-7b55-168e-07a1979c172c |                  |      margin |     USDT |  0.0999915 |  0.74544133 | 0.84543283 |     ok |  {"cost":"0","currency":"USDT"}
bb22e520-6e31-e77f-ea8f-4d78b302bbef | 1652788800000 | 2022-05-17T12:00:00.000Z |       out | 1833101 | 1b9dfbac-03b5-7b55-168e-07a1979c172c |                  |      margin |     USDT | 1.05457567 | -0.10915134 | 0.94542433 |     ok |  {"cost":"0","currency":"USDT"}
...
8a4c8bc3-44d0-96a2-45c2-d47dc3ccab37 | 1664884800000 | 2022-10-04T12:00:00.000Z |       out | 1833101 | a40a7c2c-2865-877f-6c8f-77578875bf17 |                  |      margin |     USDT | 0.00014982 |  0.12655869 | 0.12670851 |     ok |  {"cost":"0","currency":"USDT"}
41f5a52d-a974-9def-2cee-24b1ca95ee6e | 1664884800000 | 2022-10-04T12:00:00.000Z |       out | 1833101 | a40a7c2c-2865-877f-6c8f-77578875bf17 |                  |      margin |     USDT | 0.00007927 |  0.12677906 | 0.12685833 |     ok |  {"cost":"0","currency":"USDT"}
468bbc96-45d3-49e7-d009-f841072b3011 | 1670295803915 | 2022-12-06T03:03:23.915Z |        in | 1833101 |                                      |                  | transaction |     USDC |       0.12 |           0 |       0.12 |     ok |  {"cost":"0","currency":"USDC"}
29 objects
2023-06-19T17:55:07.653Z iteration 1 passed in 702 ms
```

```
 % bitmex fetchLedger USDT
2023-06-19T17:56:43.322Z
Node.js: v18.15.0
CCXT v3.1.45
bitmex.fetchLedger (USDT)
2023-06-19T17:56:44.969Z iteration 0 passed in 729 ms

                                  id |     timestamp |                 datetime | direction | account |                          referenceId | referenceAccount |        type | currency |     amount |      before |      after | status |                            fee
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2bbd7baf-f210-c599-95ab-ca443761982d | 1652748498003 | 2022-05-17T00:48:18.003Z |        in | 1833101 |                                      |                  | transaction |     USDT |          2 |           0 |          2 |     ok | {"cost":"0","currency":"USDT"}
77f18fc7-edff-e2d0-610a-443d9b0ab9d6 | 1652788800000 | 2022-05-17T12:00:00.000Z |       out | 1833101 | 1b9dfbac-03b5-7b55-168e-07a1979c172c |                  |      margin |     USDT |  0.0999915 |  0.74544133 | 0.84543283 |     ok | {"cost":"0","currency":"USDT"}
bb22e520-6e31-e77f-ea8f-4d78b302bbef | 1652788800000 | 2022-05-17T12:00:00.000Z |       out | 1833101 | 1b9dfbac-03b5-7b55-168e-07a1979c172c |                  |      margin |     USDT | 1.05457567 | -0.10915134 | 0.94542433 |     ok | {"cost":"0","currency":"USDT"}
...
7eb060c5-231f-4911-b708-18d7d52ffdaa | 1664838369738 | 2022-10-03T23:06:09.738Z |       out | 1833101 | 7eb060c5-231f-4911-b708-18d7d52ffdaa |                  |  Conversion |     USDT |       0.25 |  -0.1230624 |  0.1269376 |     ok | {"cost":"0","currency":"USDT"}
8a4c8bc3-44d0-96a2-45c2-d47dc3ccab37 | 1664884800000 | 2022-10-04T12:00:00.000Z |       out | 1833101 | a40a7c2c-2865-877f-6c8f-77578875bf17 |                  |      margin |     USDT | 0.00014982 |  0.12655869 | 0.12670851 |     ok | {"cost":"0","currency":"USDT"}
41f5a52d-a974-9def-2cee-24b1ca95ee6e | 1664884800000 | 2022-10-04T12:00:00.000Z |       out | 1833101 | a40a7c2c-2865-877f-6c8f-77578875bf17 |                  |      margin |     USDT | 0.00007927 |  0.12677906 | 0.12685833 |     ok | {"cost":"0","currency":"USDT"}
17 objects
2023-06-19T17:56:44.969Z iteration 1 passed in 729 ms
```

```
% bitmex fetchLedger ETH
2023-06-19T18:05:44.134Z
Node.js: v18.15.0
CCXT v3.1.45
bitmex.fetchLedger (ETH)
2023-06-19T18:05:45.718Z iteration 0 passed in 712 ms

                                  id |     timestamp |                 datetime | direction | account |                          referenceId | referenceAccount |       type | currency | amount | before | after | status |                           fee
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3a57f2ae-2a2b-053d-1511-bd396b20f120 | 1661468944620 | 2022-08-25T23:09:04.620Z |        in | 1833101 |                                      |                  |  SpotTrade |      ETH |   0.05 |      0 |  0.05 |     ok | {"cost":"0","currency":"ETH"}
37c36d32-7589-4d92-807d-e51de6c10b77 | 1664836331215 | 2022-10-03T22:32:11.215Z |       out | 1833101 | 37c36d32-7589-4d92-807d-e51de6c10b77 |                  | Conversion |      ETH |   0.05 |  -0.05 |     0 |     ok | {"cost":"0","currency":"ETH"}
2 objects
2023-06-19T18:05:45.718Z iteration 1 passed in 712 ms
```