### PR TITLE
fix(binance): handle ws order's updateTimestamp

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1413,6 +1413,7 @@ export default class binance extends binanceRest {
         } else if (executionType === 'TRADE') {
             lastTradeTimestamp = T;
         }
+        const lastUpdateTimestamp = T;
         let fee = undefined;
         const feeCost = this.safeString (order, 'n');
         if ((feeCost !== undefined) && (Precise.stringGt (feeCost, '0'))) {
@@ -1451,6 +1452,7 @@ export default class binance extends binanceRest {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,
+            'lastUpdateTimestamp': lastUpdateTimestamp,
             'type': type,
             'timeInForce': timeInForce,
             'postOnly': undefined,


### PR DESCRIPTION
Just added the lastUpdateTimestamp in the parseWsOrder function as it is present in the base parseOrder function.