### PR TITLE
temporary enable of debug [ci skip]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,7 @@ diff=$(echo "$diff" | sed -e "s/python\/tox\.ini//")
 critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 if [[ "$diff" =~ $critical_pattern ]]; then
   echo "$msgPrefix Important changes detected - doing full build & test"
+  echo "$diff"
   build_and_test_all
 fi
 


### PR DESCRIPTION
@carlosmiei  once in a while we get unexpected behavior from build.sh, in a current PR I got "important changes detected" while on travis it didnt.  also, a few days ago similar happened to you (when you had only bybit modified and it "detected critical changes" and made full rebuild), so lets leave for several weeks to see "echo $diff" log whenever it will misbehave.

