### PR TITLE
Bitopro fetchDepositWithdrawFees

### DIFF
--- a/ts/src/bitopro.ts
+++ b/ts/src/bitopro.ts
@@ -1604,6 +1604,63 @@ export default class bitopro extends Exchange {
         return this.parseTransaction (result, currency);
     }
 
+    parseDepositWithdrawFee (fee, currency = undefined) {
+        //    {
+        //        "currency":"eth",
+        //        "withdrawFee":"0.007",
+        //        "minWithdraw":"0.001",
+        //        "maxWithdraw":"1000",
+        //        "maxDailyWithdraw":"2000",
+        //        "withdraw":true,
+        //        "deposit":true,
+        //        "depositConfirmation":"12"
+        //    }
+        return {
+            'info': fee,
+            'withdraw': {
+                'fee': this.safeNumber (fee, 'withdrawFee'),
+                'percentage': false,
+            },
+            'deposit': {
+                'fee': undefined,
+                'percentage': undefined,
+            },
+            'networks': {},
+        };
+    }
+
+    async fetchDepositWithdrawFees (codes: string[] = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitopro#fetchDepositWithdrawFees
+         * @description fetch deposit and withdraw fees
+         * @see https://github.com/Bitrue-exchange/Spot-official-api-docs#exchangeInfo_endpoint
+         * @param {[string]|undefined} codes list of unified currency codes
+         * @param {object} params extra parameters specific to the bitrue api endpoint
+         * @returns {object} a list of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.publicGetProvisioningCurrencies (params);
+        //
+        //     {
+        //         "data":[
+        //             {
+        //                 "currency":"eth",
+        //                 "withdrawFee":"0.007",
+        //                 "minWithdraw":"0.001",
+        //                 "maxWithdraw":"1000",
+        //                 "maxDailyWithdraw":"2000",
+        //                 "withdraw":true,
+        //                 "deposit":true,
+        //                 "depositConfirmation":"12"
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        return this.parseDepositWithdrawFees (data, codes, 'currency');
+    }
+
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let url = '/' + this.implodeParams (path, params);
         const query = this.omit (params, this.extractParams (path));

--- a/ts/src/bitopro.ts
+++ b/ts/src/bitopro.ts
@@ -1634,7 +1634,7 @@ export default class bitopro extends Exchange {
          * @method
          * @name bitopro#fetchDepositWithdrawFees
          * @description fetch deposit and withdraw fees
-         * @see https://github.com/Bitrue-exchange/Spot-official-api-docs#exchangeInfo_endpoint
+         * @see https://github.com/bitoex/bitopro-offical-api-docs/blob/master/v3-1/rest-1/open/currencies.md
          * @param {[string]|undefined} codes list of unified currency codes
          * @param {object} params extra parameters specific to the bitrue api endpoint
          * @returns {object} a list of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}


### PR DESCRIPTION
```
Python v3.8.10
CCXT v3.1.45
bitopro.fetchDepositWithdrawFees(['USDT', 'ETH'])
{'ETH': {'deposit': {'fee': None, 'percentage': None},
         'info': {'currency': 'eth',
                  'deposit': True,
                  'depositConfirmation': '64',
                  'maxDailyWithdraw': '1000',
                  'maxWithdraw': '500',
                  'minWithdraw': '0.001',
                  'withdraw': True,
                  'withdrawFee': '0.0025'},
         'networks': {},
         'withdraw': {'fee': 0.0025, 'percentage': False}},
 'USDT': {'deposit': {'fee': None, 'percentage': None},
          'info': {'currency': 'usdt',
                   'deposit': True,
                   'depositConfirmation': '15',
                   'maxDailyWithdraw': '500000',
                   'maxWithdraw': '300000',
                   'minWithdraw': '10',
                   'withdraw': True,
                   'withdrawFee': '0.3'},
          'networks': {},
          'withdraw': {'fee': 0.3, 'percentage': False}}}
```