### PR TITLE
Bittrex fetchDepositWithdrawFees

### DIFF
--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -2052,6 +2052,78 @@ export default class bittrex extends Exchange {
         };
     }
 
+    parseDepositWithdrawFee (fee, currency = undefined) {
+        //
+        //     {
+        //         "symbol": "APXP",
+        //         "name": "APEX Protocol",
+        //         "coinType": "ETH_CONTRACT",
+        //         "status": "ONLINE",
+        //         "minConfirmations": 36,
+        //         "notice": "",
+        //         "txFee": "4702.00000000",
+        //         "logoUrl": "https://bittrex.com/content/dynamic/currencies/logos/6cbff899-0ba6-4284-931b-5306a0a2333a.png",
+        //         "prohibitedIn": [
+        //           "US"
+        //         ],
+        //         "baseAddress": "0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98",
+        //         "associatedTermsOfService": [
+        //         ],
+        //         "tags": [
+        //         ]
+        //     }
+        //
+        return {
+            'info': fee,
+            'withdraw': {
+                'fee': this.safeNumber (fee, 'txFee'),
+                'percentage': false,
+            },
+            'deposit': {
+                'fee': undefined,
+                'percentage': undefined,
+            },
+            'networks': {},
+        };
+    }
+
+    async fetchDepositWithdrawFees (codes = undefined, params = {}) {
+        /**
+         * @method
+         * @name bittrex#fetchDepositWithdrawFees
+         * @description fetch deposit and withdraw fees
+         * @see https://github.com/Bitrue-exchange/Spot-official-api-docs#exchangeInfo_endpoint
+         * @param {[string]|undefined} codes list of unified currency codes
+         * @param {object} params extra parameters specific to the bitrue api endpoint
+         * @returns {object} a list of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.publicGetCurrencies (params);
+        //
+        //   [
+        //       {
+        //           "symbol": "APXP",
+        //           "name": "APEX Protocol",
+        //           "coinType": "ETH_CONTRACT",
+        //           "status": "ONLINE",
+        //           "minConfirmations": 36,
+        //           "notice": "",
+        //           "txFee": "4702.00000000",
+        //           "logoUrl": "https://bittrex.com/content/dynamic/currencies/logos/6cbff899-0ba6-4284-931b-5306a0a2333a.png",
+        //           "prohibitedIn": [
+        //             "US"
+        //           ],
+        //           "baseAddress": "0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98",
+        //           "associatedTermsOfService": [
+        //           ],
+        //           "tags": [
+        //           ]
+        //       },
+        //   ]
+        //
+        return this.parseDepositWithdrawFees (response, codes, 'symbol');
+    }
+
     async withdraw (code: string, amount, address, tag = undefined, params = {}) {
         /**
          * @method

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -2089,7 +2089,7 @@ export default class bittrex extends Exchange {
         };
     }
 
-    async fetchDepositWithdrawFees (codes = undefined, params = {}) {
+    async fetchDepositWithdrawFees (codes: string[] = undefined, params = {}) {
         /**
          * @method
          * @name bittrex#fetchDepositWithdrawFees

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -48,6 +48,8 @@ export default class bittrex extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDeposit': true,
                 'fetchDepositAddress': true,
+                'fetchDepositWithdrawFee': 'emulated',
+                'fetchDepositWithdrawFees': true,
                 'fetchDeposits': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -2092,7 +2092,6 @@ export default class bittrex extends Exchange {
          * @method
          * @name bittrex#fetchDepositWithdrawFees
          * @description fetch deposit and withdraw fees
-         * @see https://github.com/Bitrue-exchange/Spot-official-api-docs#exchangeInfo_endpoint
          * @param {[string]|undefined} codes list of unified currency codes
          * @param {object} params extra parameters specific to the bitrue api endpoint
          * @returns {object} a list of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}


### PR DESCRIPTION
```
Python v3.8.10
CCXT v3.1.45
bitopro.fetchDepositWithdrawFees(['USDT'])
{'USDT': {'deposit': {'fee': None, 'percentage': None},
          'info': {'associatedTermsOfService': [],
                   'baseAddress': '0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98',
                   'coinType': 'ETH_CONTRACT',
                   'logoUrl': 'https://bittrex.com/content/dynamic/currencies/logos/e581f6ac-4e91-4f97-b720-ba80a7edc16c.png',
                   'minConfirmations': '36',
                   'name': 'Tether',
                   'notice': '',
                   'prohibitedIn': [],
                   'status': 'ONLINE',
                   'symbol': 'USDT',
                   'tags': [],
                   'txFee': '4.50000000'},
          'networks': {},
          'withdraw': {'fee': 4.5, 'percentage': False}}}
```