### PR TITLE
bitvavo-fetchDepositWithdrawFees

### DIFF
--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -1786,7 +1786,7 @@ export default class bitvavo extends Exchange {
         return result;
     }
 
-    async fetchDepositWithdrawFees (codes = undefined, params = {}) {
+    async fetchDepositWithdrawFees (codes: string[] = undefined, params = {}) {
         /**
          * @method
          * @name bitvavo#fetchDepositWithdrawFees

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -45,6 +45,8 @@ export default class bitvavo extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
+                'fetchDepositWithdrawFee': 'emulated',
+                'fetchDepositWithdrawFees': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
                 'fetchFundingRateHistory': false,
@@ -259,6 +261,14 @@ export default class bitvavo extends Exchange {
                 'BITVAVO-ACCESS-WINDOW': 10000, // default 10 sec
                 'fetchCurrencies': {
                     'expires': 1000, // 1 second
+                },
+                'networks': {
+                    'ERC20': 'ETH',
+                    'TRC20': 'TRX',
+                },
+                'networksById': {
+                    'TRX': 'TRC20',
+                    'ETH': 'ERC20',
                 },
             },
             'precisionMode': SIGNIFICANT_DIGITS,
@@ -1730,6 +1740,84 @@ export default class bitvavo extends Exchange {
             'updated': undefined,
             'fee': fee,
         };
+    }
+
+    parseDepositWithdrawFee (fee, currency = undefined) {
+        //
+        //   {
+        //       "symbol": "1INCH",
+        //       "name": "1inch",
+        //       "decimals": 8,
+        //       "depositFee": "0",
+        //       "depositConfirmations": 64,
+        //       "depositStatus": "OK",
+        //       "withdrawalFee": "6.1",
+        //       "withdrawalMinAmount": "6.1",
+        //       "withdrawalStatus": "OK",
+        //       "networks": [
+        //         "ETH"
+        //       ],
+        //       "message": ""
+        //   }
+        //
+        const result = {
+            'info': fee,
+            'withdraw': {
+                'fee': this.safeNumber (fee, 'withdrawalFee'),
+                'percentage': false,
+            },
+            'deposit': {
+                'fee': this.safeNumber (fee, 'depositFee'),
+                'percentage': false,
+            },
+            'networks': {},
+        };
+        const networks = this.safeValue (fee, 'networks');
+        let networkId = this.safeValue (networks, 0); // Bitvavo currently only supports one network per currency
+        const currencyCode = this.safeString (currency, 'code');
+        if (networkId === 'Mainnet') {
+            networkId = currencyCode;
+        }
+        const networkCode = this.networkIdToCode (networkId, currencyCode);
+        result['networks'][networkCode] = {
+            'deposit': result['deposit'],
+            'withdraw': result['withdraw'],
+        };
+        return result;
+    }
+
+    async fetchDepositWithdrawFees (codes = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitvavo#fetchDepositWithdrawFees
+         * @description fetch deposit and withdraw fees
+         * @see https://docs.bitvavo.com/#tag/General/paths/~1assets/get
+         * @param {[string]|undefined} codes list of unified currency codes
+         * @param {object} params extra parameters specific to the bitrue api endpoint
+         * @returns {object} a list of [fee structures]{@link https://docs.ccxt.com/en/latest/manual.html#fee-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.publicGetAssets (params);
+        //
+        //   [
+        //       {
+        //           "symbol": "1INCH",
+        //           "name": "1inch",
+        //           "decimals": 8,
+        //           "depositFee": "0",
+        //           "depositConfirmations": 64,
+        //           "depositStatus": "OK",
+        //           "withdrawalFee": "6.1",
+        //           "withdrawalMinAmount": "6.1",
+        //           "withdrawalStatus": "OK",
+        //           "networks": [
+        //             "ETH"
+        //           ],
+        //           "message": ""
+        //       },
+        //   ]
+        //
+        return this.parseDepositWithdrawFees (response, codes, 'symbol');
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
```
CCXT v3.1.45
bitvavo.fetchDepositWithdrawFees(['USDT', 'ETH'])
{'ETH': {'deposit': {'fee': 0.0, 'percentage': False},
         'info': {'decimals': '8',
                  'depositConfirmations': '64',
                  'depositFee': '0',
                  'depositStatus': 'OK',
                  'message': '',
                  'name': 'Ethereum',
                  'networks': ['Mainnet'],
                  'symbol': 'ETH',
                  'withdrawalFee': '0.002',
                  'withdrawalMinAmount': '0.002',
                  'withdrawalStatus': 'OK'},
         'networks': {'ETH': {'deposit': {'fee': 0.0, 'percentage': False},
                              'withdraw': {'fee': 0.002, 'percentage': False}}},
         'withdraw': {'fee': 0.002, 'percentage': False}},
 'USDT': {'deposit': {'fee': 0.0, 'percentage': False},
          'info': {'decimals': '6',
                   'depositConfirmations': '64',
                   'depositFee': '0',
                   'depositStatus': 'OK',
                   'message': '',
                   'name': 'Tether',
                   'networks': ['ETH'],
                   'symbol': 'USDT',
                   'withdrawalFee': '3.7',
                   'withdrawalMinAmount': '3.7',
                   'withdrawalStatus': 'OK'},
          'networks': {'ERC20': {'deposit': {'fee': 0.0, 'percentage': False},
                                 'withdraw': {'fee': 3.7,
                                              'percentage': False}}},
          'withdraw': {'fee': 3.7, 'percentage': False}}}
```