### PR TITLE
Crypto.com: fetchTickers, migrate to the unified API

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2926,7 +2926,7 @@ export default class Exchange {
         throw new NotSupported (this.id + ' fetchPositionsRisk() is not supported yet');
     }
 
-    async fetchBidsAsks (symbols: string[] = undefined, params = {}) {
+    async fetchBidsAsks (symbols: string[] = undefined, params = {}): Promise<Dictionary<Ticker>> {
         throw new NotSupported (this.id + ' fetchBidsAsks() is not supported yet');
     }
 
@@ -3711,7 +3711,7 @@ export default class Exchange {
         return this.filterByArray (results, 'symbol', symbols);
     }
 
-    parseTickers (tickers, symbols: string[] = undefined, params = {}) {
+    parseTickers (tickers, symbols: string[] = undefined, params = {}): Dictionary<Ticker> {
         //
         // the value of tickers is either a dict or a list
         //

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -611,36 +611,16 @@ export default class cryptocom extends Exchange {
         /**
          * @method
          * @name cryptocom#fetchTicker
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#public-get-tickers
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} params extra parameters specific to the cryptocom api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        const request = {
-            'instrument_name': market['id'],
-        };
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTicker', market, params);
-        if (marketType !== 'spot') {
-            throw new NotSupported (this.id + ' fetchTicker() only supports spot markets');
-        }
-        const response = await this.v2PublicGetPublicGetTicker (this.extend (request, query));
-        //
-        //   {
-        //       "id":"-1",
-        //       "method":"public/get-tickers",
-        //       "code":"0",
-        //       "result":{
-        //          "data":[
-        //             { "i":"BTC_USDT", "h":"20567.16", "l":"20341.39", "a":"20394.23", "v":"2236.3762", "vv":"45739074.30", "c":"-0.0036", "b":"20394.01", "k":"20394.02", "t":"1667406085934" }
-        //          ]
-        //   }
-        //
-        const resultResponse = this.safeValue (response, 'result', {});
-        const data = this.safeValue (resultResponse, 'data', {});
-        const first = this.safeValue (data, 0, {});
-        return this.parseTicker (first, market);
+        symbol = this.symbol (symbol);
+        const tickers = await this.fetchTickers ([ symbol ], params);
+        return this.safeValue (tickers, symbol);
     }
 
     async fetchOrders (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {


### PR DESCRIPTION
Migrated fetchTickers to the unified API:
```
cryptocom.fetchTickers (BTC/USD)
2023-06-22T03:31:44.334Z iteration 0 passed in 295 ms

{
  'BTC/USD': {
    symbol: 'BTC/USD',
    timestamp: 1687404704955,
    datetime: '2023-06-22T03:31:44.955Z',
    high: 30821.45,
    low: 28686.16,
    bid: 30266.02,
    bidVolume: undefined,
    ask: 30271.56,
    askVolume: undefined,
    vwap: 29669.49590309386,
    open: 30265.9559,
    close: 30266.01,
    last: 30266.01,
    previousClose: undefined,
    change: 0.0541,
    percentage: undefined,
    average: undefined,
    baseVolume: 1770.3481,
    quoteVolume: 52525335.7,
    info: {
      i: 'BTC_USD',
      h: '30821.45',
      l: '28686.16',
      a: '30266.01',
      v: '1770.3481',
      vv: '52525335.70',
      c: '0.0541',
      b: '30266.02',
      k: '30271.56',
      t: 1687404704955
    }
  }
}
```