### PR TITLE
Crypto.com: fetchLedger

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -47,6 +47,7 @@ export default class cryptocom extends Exchange {
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
                 'fetchFundingRates': false,
+                'fetchLedger': true,
                 'fetchMarginMode': false,
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
@@ -2330,6 +2331,151 @@ export default class cryptocom extends Exchange {
         const data = this.safeValue (response, 'result');
         const currencyMap = this.safeValue (data, 'currency_map');
         return this.parseDepositWithdrawFees (currencyMap, codes, 'full_name');
+    }
+
+    async fetchLedger (code: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name cryptocom#fetchLedger
+         * @description fetch the history of changes, actions done by the user or operations that altered the balance of the user
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#private-get-transactions
+         * @param {string|undefined} code unified currency code
+         * @param {int|undefined} since timestamp in ms of the earliest ledger entry
+         * @param {int|undefined} limit max number of ledger entries to return
+         * @param {object} params extra parameters specific to the cryptocom api endpoint
+         * @param {int|undefined} params.until timestamp in ms for the ending date filter, default is the current time
+         * @returns {object} a [ledger structure]{@link https://docs.ccxt.com/en/latest/manual.html#ledger-structure}
+         */
+        await this.loadMarkets ();
+        const request = {};
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
+        if (since !== undefined) {
+            request['start_time'] = since;
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
+        if (until !== undefined) {
+            request['end_time'] = until;
+        }
+        const response = await this.v1PrivatePostPrivateGetTransactions (this.extend (request, params));
+        //
+        //     {
+        //         "id": 1686813195698,
+        //         "method": "private/get-transactions",
+        //         "code": 0,
+        //         "result": {
+        //             "data": [
+        //                 {
+        //                     "account_id": "ce075cef-1234-4321-bd6e-gf9007351e64",
+        //                     "event_date": "2023-06-15",
+        //                     "journal_type": "TRADING",
+        //                     "journal_id": "6530219460124075091",
+        //                     "transaction_qty": "6.0091224",
+        //                     "transaction_cost": "6.0091224",
+        //                     "realized_pnl": "0",
+        //                     "order_id": "6530219477766741833",
+        //                     "trade_id": "6530219495775954765",
+        //                     "trade_match_id": "4611686018455865176",
+        //                     "event_timestamp_ms": 1686804665013,
+        //                     "event_timestamp_ns": "1686804665013642422",
+        //                     "client_oid": "CCXT_d6ea7c5db6c1495aa8b758",
+        //                     "taker_side": "",
+        //                     "side": "BUY",
+        //                     "instrument_name": "USD"
+        //                 },
+        //             ]
+        //         }
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        const ledger = this.safeValue (result, 'data', []);
+        return this.parseLedger (ledger, currency, since, limit);
+    }
+
+    parseLedgerEntry (item, currency = undefined) {
+        //
+        //     {
+        //         "account_id": "ce075cef-1234-4321-bd6e-gf9007351e64",
+        //         "event_date": "2023-06-15",
+        //         "journal_type": "TRADING",
+        //         "journal_id": "6530219460124075091",
+        //         "transaction_qty": "6.0091224",
+        //         "transaction_cost": "6.0091224",
+        //         "realized_pnl": "0",
+        //         "order_id": "6530219477766741833",
+        //         "trade_id": "6530219495775954765",
+        //         "trade_match_id": "4611686018455865176",
+        //         "event_timestamp_ms": 1686804665013,
+        //         "event_timestamp_ns": "1686804665013642422",
+        //         "client_oid": "CCXT_d6ea7c5db6c1495aa8b758",
+        //         "taker_side": "",
+        //         "side": "BUY",
+        //         "instrument_name": "USD"
+        //     }
+        //
+        const timestamp = this.safeInteger (item, 'event_timestamp_ms');
+        const currencyId = this.safeString (item, 'instrument_name');
+        let amount = this.safeString (item, 'transaction_qty');
+        let direction = undefined;
+        if (Precise.stringLt (amount, '0')) {
+            direction = 'out';
+            amount = Precise.stringAbs (amount);
+        } else {
+            direction = 'in';
+        }
+        return {
+            'id': this.safeString (item, 'order_id'),
+            'direction': direction,
+            'account': this.safeString (item, 'account_id'),
+            'referenceId': this.safeString (item, 'trade_id'),
+            'referenceAccount': this.safeString (item, 'trade_match_id'),
+            'type': this.parseLedgerEntryType (this.safeString (item, 'journal_type')),
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'amount': this.parseNumber (amount),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'before': undefined,
+            'after': undefined,
+            'status': undefined,
+            'fee': {
+                'currency': undefined,
+                'cost': undefined,
+            },
+            'info': item,
+        };
+    }
+
+    parseLedgerEntryType (type) {
+        const ledgerType = {
+            'TRADING': 'trade',
+            'TRADE_FEE': 'fee',
+            'WITHDRAW_FEE': 'fee',
+            'WITHDRAW': 'withdrawal',
+            'DEPOSIT': 'deposit',
+            'ROLLBACK_WITHDRAW': 'rollback',
+            'ROLLBACK_DEPOSIT': 'rollback',
+            'FUNDING': 'fee',
+            'REALIZED_PNL': 'trade',
+            'INSURANCE_FUND': 'insurance',
+            'SOCIALIZED_LOSS': 'trade',
+            'LIQUIDATION_FEE': 'fee',
+            'SESSION_RESET': 'reset',
+            'ADJUSTMENT': 'adjustment',
+            'SESSION_SETTLE': 'settlement',
+            'UNCOVERED_LOSS': 'trade',
+            'ADMIN_ADJUSTMENT': 'adjustment',
+            'DELIST': 'delist',
+            'SETTLEMENT_FEE': 'fee',
+            'AUTO_CONVERSION': 'conversion',
+            'MANUAL_CONVERSION': 'conversion',
+        };
+        return this.safeString (ledgerType, type, type);
     }
 
     nonce () {


### PR DESCRIPTION
Added fetchLedger to Crypto.com using the v1 unified API:
```
cryptocom.fetchLedger ()
2023-06-22T05:16:08.238Z iteration 0 passed in 328 ms

                 id | direction |                              account |         referenceId |    referenceAccount |  type | currency |      amount |     timestamp |                 datetime | before | after | status | fee
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6142909895109003988 |        in | e7929acf-3ce5-4a9b-b3e6-b8ef0f0c51ca | 6142909898393034321 | 4611686018456260581 | trade |      USD |     6.06494 | 1687410942003 | 2023-06-22T05:15:42.003Z |        |       |        |  {}
6142909895109003988 |       out | e7929acf-3ce5-4a9b-b3e6-b8ef0f0c51ca | 6142909898393034321 | 4611686018456260581 | trade |      BTC |      0.0002 | 1687410942003 | 2023-06-22T05:15:42.003Z |        |       |        |  {}
6142909895109003988 |       out | e7929acf-3ce5-4a9b-b3e6-b8ef0f0c51ca | 6142909898393034321 | 4611686018456260581 |   fee |      USD | 0.001516235 | 1687410942003 | 2023-06-22T05:15:42.003Z |        |       |        |  {}
6142909895109003988 |        in | e7929acf-3ce5-4a9b-b3e6-b8ef0f0c51ca | 6142909898393034319 | 4611686018456260580 | trade |      USD |     0.30326 | 1687410942003 | 2023-06-22T05:15:42.003Z |        |       |        |  {}
6142909895109003988 |       out | e7929acf-3ce5-4a9b-b3e6-b8ef0f0c51ca | 6142909898393034319 | 4611686018456260580 | trade |      BTC |     0.00001 | 1687410942003 | 2023-06-22T05:15:42.003Z |        |       |        |  {}
6142909895109003988 |       out | e7929acf-3ce5-4a9b-b3e6-b8ef0f0c51ca | 6142909898393034319 | 4611686018456260580 |   fee |      USD | 0.000075815 | 1687410942003 | 2023-06-22T05:15:42.003Z |        |       |        |  {}
6 objects
```