### PR TITLE
kucoin-fetchDepositWithdrawFees

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -919,10 +919,10 @@ export default class kucoin extends Exchange {
         //    }
         //
         const data = this.safeValue (response, 'data');
-        return this.parseDepositWithdrawSingleFee (data, currency);
+        return this.parseDepositWithdrawFee (data, currency);
     }
 
-    parseDepositWithdrawSingleFee (fee, currency = undefined) {
+    parseDepositWithdrawFee (fee, currency = undefined) {
         //
         //    {
         //        "currency": "USDT",
@@ -937,42 +937,6 @@ export default class kucoin extends Exchange {
         //        "precision": 6,
         //        "chain": "ERC20"
         //    }
-        //
-        const result = this.depositWithdrawFee (fee);
-        const isWithdrawEnabled = this.safeValue (fee, 'isWithdrawEnabled');
-        if (isWithdrawEnabled) {
-            const networkId = this.safeString (fee, 'chain');
-            const networkCode = this.networkIdToCode (networkId, this.safeString (currency, 'code'));
-            result['networks'][networkCode] = {
-                'withdraw': {
-                    'fee': this.safeNumber (fee, 'withdrawMinFee'),
-                    'percentage': undefined,
-                },
-                'deposit': {
-                    'fee': undefined,
-                    'percentage': undefined,
-                },
-            };
-        }
-        return this.assignDefaultDepositWithdrawFees (result);
-    }
-
-    parseDepositWithdrawFee (fee, currency = undefined) {
-        //
-        //   {
-        //       currency: 'ETH',
-        //       name: 'ETH',
-        //       fullName: 'Ethereum',
-        //       precision: 8,
-        //       confirms: 64,
-        //       contractAddress: '',
-        //       withdrawalMinSize: '0.01',
-        //       withdrawalMinFee: '0.005',
-        //       isWithdrawEnabled: true,
-        //       isDepositEnabled: true,
-        //       isMarginEnabled: true,
-        //       isDebitEnabled: true
-        //   }
         //
         const result = {
             'info': fee,
@@ -990,6 +954,17 @@ export default class kucoin extends Exchange {
         if (isWithdrawEnabled) {
             result['withdraw']['fee'] = this.safeNumber (fee, 'withdrawalMinFee');
             result['withdraw']['percentage'] = false;
+            const networkId = this.safeString (fee, 'chain');
+            if (networkId) {
+                const networkCode = this.networkIdToCode (networkId, this.safeString (currency, 'code'));
+                result['networks'][networkCode] = {
+                    'withdraw': result['withdraw'],
+                    'deposit': {
+                        'fee': undefined,
+                        'percentage': undefined,
+                    },
+                };
+            }
         }
         return result;
     }


### PR DESCRIPTION
```
Python v3.8.10
CCXT v3.1.49
kucoin.fetchDepositWithdrawFees(['USDT', 'ETH'])
{'ETH': {'deposit': {'fee': None, 'percentage': None},
         'info': {'confirms': 64,
                  'contractAddress': '',
                  'currency': 'ETH',
                  'fullName': 'Ethereum',
                  'isDebitEnabled': True,
                  'isDepositEnabled': True,
                  'isMarginEnabled': True,
                  'isWithdrawEnabled': True,
                  'name': 'ETH',
                  'precision': 8,
                  'withdrawalMinFee': '0.005',
                  'withdrawalMinSize': '0.01'},
         'networks': {},
         'withdraw': {'fee': 0.005, 'percentage': False}},
 'USDT': {'deposit': {'fee': None, 'percentage': None},
          'info': {'confirms': 64,
                   'contractAddress': '0xdac17f958d2ee523a2206206994597c13d831ec7',
                   'currency': 'USDT',
                   'fullName': 'Tether',
                   'isDebitEnabled': True,
                   'isDepositEnabled': True,
                   'isMarginEnabled': True,
                   'isWithdrawEnabled': True,
                   'name': 'USDT',
                   'precision': 8,
                   'withdrawalMinFee': '25',
                   'withdrawalMinSize': '40'},
          'networks': {},
          'withdraw': {'fee': 25.0, 'percentage': False}}}
```