### PR TITLE
Crypto.com: fetchSettlementHistory

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -2662,20 +2662,23 @@ export default class cryptocom extends Exchange {
          * @param {int|undefined} since timestamp in ms
          * @param {int|undefined} limit number of records
          * @param {object} params exchange specific params
-         * @param {int|undefined} params.type 'FUTURE', 'WARRANT'
+         * @param {int|undefined} params.type 'future', 'option'
          * @returns {[object]} a list of [settlement history objects]
          */
-        const type = this.safeStringUpper2 (params, 'type', 'instrument_type');
-        this.checkRequiredArgument ('fetchSettlementHistory', type, 'type', [ 'FUTURE', 'WARRANT' ]);
         await this.loadMarkets ();
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchSettlementHistory', market, params);
+        this.checkRequiredArgument ('fetchSettlementHistory', type, 'type', [ 'future', 'option' ]);
+        if (type === 'option') {
+            type = 'WARRANT';
+        }
         const request = {
-            'instrument_type': type,
+            'instrument_type': type.toUpperCase (),
         };
-        params = this.omit (params, 'type');
         const response = await this.v1PublicGetPublicGetExpiredSettlementPrice (this.extend (request, params));
         //
         //     {

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -2672,7 +2672,7 @@ export default class cryptocom extends Exchange {
         }
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchSettlementHistory', market, params);
-        this.checkRequiredArgument ('fetchSettlementHistory', type, 'type', [ 'future', 'option' ]);
+        this.checkRequiredArgument ('fetchSettlementHistory', type, 'type', [ 'future', 'option', 'WARRANT', 'FUTURE' ]);
         if (type === 'option') {
             type = 'WARRANT';
         }

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -59,6 +59,7 @@ export default class cryptocom extends Exchange {
                 'fetchOrders': true,
                 'fetchPositionMode': false,
                 'fetchPositions': false,
+                'fetchSettlementHistory': true,
                 'fetchStatus': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
@@ -2649,6 +2650,93 @@ export default class cryptocom extends Exchange {
             'code': undefined,
             'info': account,
         };
+    }
+
+    async fetchSettlementHistory (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name cryptocom#fetchSettlementHistory
+         * @description fetches historical settlement records
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#public-get-expired-settlement-price
+         * @param {string} symbol unified market symbol of the settlement history
+         * @param {int|undefined} since timestamp in ms
+         * @param {int|undefined} limit number of records
+         * @param {object} params exchange specific params
+         * @param {int|undefined} params.type 'FUTURE', 'WARRANT'
+         * @returns {[object]} a list of [settlement history objects]
+         */
+        const type = this.safeStringUpper2 (params, 'type', 'instrument_type');
+        this.checkRequiredArgument ('fetchSettlementHistory', type, 'type', [ 'FUTURE', 'WARRANT' ]);
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request = {
+            'instrument_type': type,
+        };
+        params = this.omit (params, 'type');
+        const response = await this.v1PublicGetPublicGetExpiredSettlementPrice (this.extend (request, params));
+        //
+        //     {
+        //         "id": -1,
+        //         "method": "public/get-expired-settlement-price",
+        //         "code": 0,
+        //         "result": {
+        //             "data": [
+        //                 {
+        //                     "i": "BTCUSD-230526",
+        //                     "x": 1685088000000,
+        //                     "v": "26464.1",
+        //                     "t": 1685087999500
+        //                 }
+        //             ]
+        //         }
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        const data = this.safeValue (result, 'data', []);
+        const settlements = this.parseSettlements (data, market);
+        const sorted = this.sortBy (settlements, 'timestamp');
+        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+    }
+
+    parseSettlement (settlement, market) {
+        //
+        //     {
+        //         "i": "BTCUSD-230526",
+        //         "x": 1685088000000,
+        //         "v": "26464.1",
+        //         "t": 1685087999500
+        //     }
+        //
+        const timestamp = this.safeInteger (settlement, 'x');
+        const marketId = this.safeString (settlement, 'i');
+        return {
+            'info': settlement,
+            'symbol': this.safeSymbol (marketId, market),
+            'price': this.safeNumber (settlement, 'v'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+        };
+    }
+
+    parseSettlements (settlements, market) {
+        //
+        //     [
+        //         {
+        //             "i": "BTCUSD-230526",
+        //             "x": 1685088000000,
+        //             "v": "26464.1",
+        //             "t": 1685087999500
+        //         }
+        //     ]
+        //
+        const result = [];
+        for (let i = 0; i < settlements.length; i++) {
+            result.push (this.parseSettlement (settlements[i], market));
+        }
+        return result;
     }
 
     nonce () {


### PR DESCRIPTION
Added fetchSettlementHistory to Crypto.com using the v1 unified API:
```
cryptocom fetchSettlementHistory undefined undefined 3 '{"type":"FUTURE"}'

cryptocom.fetchSettlementHistory (, , 3, [object Object])
2023-06-24T02:51:05.016Z iteration 0 passed in 310 ms

       symbol |   price |     timestamp |                 datetime
------------------------------------------------------------------
BTCUSD-230428 | 29491.2 | 1682668800000 | 2023-04-28T08:00:00.000Z
BTCUSD-230526 | 26464.1 | 1685088000000 | 2023-05-26T08:00:00.000Z
ETHUSD-230526 | 1812.51 | 1685088000000 | 2023-05-26T08:00:00.000Z
3 objects
```