### PR TITLE
fix(krakenfutures): charts sandbox api

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -67,6 +67,7 @@ export default class krakenfutures extends Exchange {
                 'test': {
                     'public': 'https://demo-futures.kraken.com/derivatives/api/',
                     'private': 'https://demo-futures.kraken.com/derivatives/api/',
+                    'charts': 'https://demo-futures.kraken.com/api/charts/',
                     'www': 'https://demo-futures.kraken.com',
                 },
                 'logo': 'https://user-images.githubusercontent.com/24300605/81436764-b22fd580-9172-11ea-9703-742783e6376d.jpg',


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18311
```
p krakenfutures fetchOHLCV "BTC/USD:USD" 1m None 10 --sandbox 
Python v3.10.9
CCXT v3.1.50
krakenfutures.fetchOHLCV(BTC/USD:USD,1m,None,10)
[[1687623720000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687623780000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687623840000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687623900000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687623960000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687624020000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687624080000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687624140000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687624200000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0],
 [1687624260000, 30493.0, 30493.0, 30493.0, 30493.0, 0.0]]
```
