### PR TITLE
feat(krakenfutures): add lastUpdateTimestamp

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1250,6 +1250,7 @@ export default class krakenfutures extends Exchange {
         const marketId = this.safeString (details, 'symbol');
         market = this.safeMarket (marketId, market);
         const timestamp = this.parse8601 (this.safeString2 (details, 'timestamp', 'receivedTime'));
+        const lastUpdateTimestamp = this.parse8601 (this.safeString (details, 'lastUpdateTime'));
         if (price === undefined) {
             price = this.safeString (details, 'limitPrice');
         }
@@ -1319,6 +1320,7 @@ export default class krakenfutures extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': undefined,
+            'lastUpdateTimestamp': lastUpdateTimestamp,
             'symbol': this.safeString (market, 'symbol'),
             'type': this.parseOrderType (type),
             'timeInForce': timeInForce,


### PR DESCRIPTION
DEMO
```
p krakenfutures fetchOpenOrders --sandbox
Python v3.10.9
CCXT v3.1.51
krakenfutures.fetchOpenOrders()
[{'amount': 0.1,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-06-25T12:00:26.436Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': 'd89e9a47-df94-49b2-a89e-fe24e4fccb2b',
  'info': {'filledSize': '0',
           'lastUpdateTime': '2023-06-25T12:00:26.436Z',
           'limitPrice': '50',
           'orderType': 'lmt',
           'order_id': 'd89e9a47-df94-49b2-a89e-fe24e4fccb2b',
           'receivedTime': '2023-06-25T12:00:26.436Z',
           'reduceOnly': False,
           'side': 'buy',
           'status': 'untouched',
           'symbol': 'pf_ltcusd',
           'unfilledSize': '0.1'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': 1687694426436,
  'postOnly': False,
  'price': 50.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USD:USD',
  'takeProfitPrice': None,
  'timeInForce': 'gtc',
  'timestamp': 1687694426436,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
