### PR TITLE
throttler issue - example [DO NOT MERGE]

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -7,7 +7,7 @@ const binance = new ccxt.binance({});
 async function t(){
     while (true) {
         const t1 = new Date().getTime();
-        await binance.sleep(50);
+        // await binance.sleep(50); // neither adding this "tricks" throttler
         const ts = await binance.fetchTrades('BNB/USDT:USDT');
         console.log("FETCH ELAPSED", new Date().getTime() - t1);
     }

--- a/examples/test.js
+++ b/examples/test.js
@@ -6,10 +6,10 @@ const binance = new ccxt.binance({});
 
 async function t(){
     while (true) {
-        const t1 = new Date().getTime();
+        const t1 = binance.milliseconds ();
         // await binance.sleep(50); // neither adding this "tricks" throttler
         const ts = await binance.fetchTrades('BNB/USDT:USDT');
-        console.log("FETCH ELAPSED", new Date().getTime() - t1);
+        console.log("FETCH ELAPSED", binance.milliseconds () - t1);
     }
 }
 

--- a/examples/test.js
+++ b/examples/test.js
@@ -1,0 +1,16 @@
+import ccxt from '../js/ccxt.js';
+
+
+
+const binance = new ccxt.binance({});
+
+async function t(){
+    while (true) {
+        const t1 = new Date().getTime();
+        await binance.sleep(50);
+        const ts = await binance.fetchTrades('BNB/USDT:USDT');
+        console.log("FETCH ELAPSED", new Date().getTime() - t1);
+    }
+}
+
+t();

--- a/js/src/base/Exchange.js
+++ b/js/src/base/Exchange.js
@@ -2632,8 +2632,10 @@ export default class Exchange {
     }
     async fetch2(path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}) {
         if (this.enableRateLimit) {
+            const t1 = this.milliseconds();
             const cost = this.calculateRateLimiterCost(api, method, path, params, config);
             await this.throttle(cost);
+            console.log ("Throttler duration: ", this.milliseconds() - t1);
         }
         this.lastRestRequestTimestamp = this.milliseconds();
         const request = this.sign(path, api, method, params, headers, body);


### PR DESCRIPTION
`node ./examples/test.js`
after initial requests, the further requests are being throttled for no reason, around 1 second per call.

```
...
Throttler duration:  1002
FETCH ELAPSED 1364
Throttler duration:  999
FETCH ELAPSED 1395
Throttler duration:  996
FETCH ELAPSED 1397
...
```

_from my location it takes appx 400 ms for roundtrip._
