### PR TITLE
fix(deribit): removed spot duplicated markets

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -556,6 +556,7 @@ export default class deribit extends Exchange {
         //         testnet: false
         //     }
         //
+        const parsedMarkets = {};
         const currenciesResult = this.safeValue (currenciesResponse, 'result', []);
         const result = [];
         for (let i = 0; i < currenciesResult.length; i++) {
@@ -680,6 +681,11 @@ export default class deribit extends Exchange {
                         }
                     }
                 }
+                const parsedMarketValue = this.safeValue (parsedMarkets, symbol);
+                if (parsedMarketValue) {
+                    continue;
+                }
+                parsedMarkets[symbol] = true;
                 const minTradeAmount = this.safeNumber (market, 'min_trade_amount');
                 const tickSize = this.safeNumber (market, 'tick_size');
                 result.push ({

--- a/ts/src/pro/deribit.ts
+++ b/ts/src/pro/deribit.ts
@@ -472,7 +472,7 @@ export default class deribit extends deribitRest {
         const channel = this.safeString (params, 'channel');
         const marketId = this.safeString (data, 'instrument_name');
         const symbol = this.safeSymbol (marketId);
-        const timestamp = this.safeNumber (data, 'timestamp');
+        const timestamp = this.safeInteger (data, 'timestamp');
         let storedOrderBook = this.safeValue (this.orderbooks, symbol);
         if (storedOrderBook === undefined) {
             storedOrderBook = this.countedOrderBook ();


### PR DESCRIPTION
```
p deribit watchOrderBook "BTC_USDC"
Python v3.10.9
CCXT v3.1.52
deribit.watchOrderBook(BTC_USDC)
{'asks': [[30189.46, 1.0935, 1], [30189.48, 0.0009, 1], [30189.92, 0.0066, 1], [30191.0, 0.012, 1], [30196.98, 0.0066, 1], [30206.04, 0.0437, 1], [30209.31, 0.0021, 1], [30215.1, 0.0803, 1], [30224.16, 0.0434, 1], [30231.58, 0.0017, 1], [30233.21, 0.0508, 1], [30242.88, 0.9874, 1], [30254.67, 0.2, 1], [30288.59, 1.2, 1], [30344.48, 1.5798, 1], [30392.27, 0.0141, 1], [30452.0, 0.1, 1], [30455.96, 4.0, 1], [31500.0, 1.0, 1], [31565.59, 0.0018, 1], [31790.0, 1.0, 1], [32188.0, 0.0018, 1], [32988.0, 0.0018, 1], [34008.0, 0.0018, 1], [38000.0, 0.0001, 1]],
 'bids': [[30177.78, 0.0066, 1], [30169.8, 0.0065, 1], [30166.23, 0.0009, 1], [30160.74, 0.0435, 1], [30159.44, 0.75, 1], [30152.11, 1.0935, 1], [30151.68, 0.0438, 1], [30142.62, 0.0435, 1], [30140.28, 0.0017, 1], [30135.84, 0.0027, 1], [30124.43, 0.002, 1], [30083.28, 0.9874, 1], [30039.76, 0.2, 1], [30010.29, 0.5, 1], [30000.0, 0.433, 1], [29986.86, 1.5798, 1], [29985.23, 0.014, 1], [29967.0, 0.1669, 1], [29500.0, 0.1, 1], [29388.0, 0.0018, 1], [29059.0, 0.1721, 1], [29000.0, 0.1, 1], [28488.0, 0.0018, 1], [28468.0, 0.0035, 1], [28385.0, 0.1761, 1], [27636.0, 0.1809, 1], [27388.0, 0.0018, 1], [26743.0, 0.0025, 1], [26108.0, 0.0018, 1], [25750.0, 0.25, 1], [24828.0, 0.0018, 1], [24688.0, 0.0018, 1], [24654.0, 0.001, 1], [24588.0, 0.0018, 1], [24488.0, 0.0018, 1], [24388.0, 0.0018, 1], [24308.0, 0.0018, 1], [24188.0, 0.0018, 1], [24088.0, 0.0018, 1], [23958.0, 0.0018, 1], [23888.0, 0.0018, 1], [23825.0, 0.001, 1], [23788.0, 0.0018, 1], [23688.0, 0.0018, 1], [23588.0, 0.0018, 1], [23488.0, 0.0018, 1], [23408.0, 0.0018, 1], [23288.0, 0.0018, 1], [23188.0, 0.0018, 1], [23088.0, 0.0018, 1], [22988.0, 0.0018, 1], [22808.0, 0.0018, 1], [22708.0, 0.0018, 1], [22588.0, 0.0018, 1], [22528.0, 0.004, 1], [22498.0, 0.0018, 1], [22408.0, 0.0018, 1], [22288.0, 0.0018, 1], [22188.0, 0.0018, 1], [22088.0, 0.0018, 1], [21988.0, 0.0018, 1], [21888.0, 0.0018, 1], [21808.0, 0.0018, 1], [21708.0, 0.0018, 1], [21608.0, 0.0018, 1], [21508.0, 0.0018, 1], [21408.0, 0.0018, 1], [21268.0, 0.0018, 1], [21168.0, 0.0018, 1], [21068.0, 0.0018, 1], [20908.0, 0.0018, 1], [20788.0, 0.0018, 1], [20628.0, 0.0018, 1], [20528.0, 0.0018, 1], [162.02, 0.035, 1]],
 'datetime': '2023-06-26T10:09:12.403Z',
 'nonce': 1687774152403,
 'symbol': 'BTC/USDC',
 'timestamp': 1687774152403}
```
