### PR TITLE
fix(Exchange): remove conflicting error message

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1434,9 +1434,6 @@ export default class Exchange {
         if (val > 1) {
             throw new ExchangeError (this.id + ' you have multiple conflicting proxy settings, please use only one from : proxyUrl, httpProxy, httpsProxy, socksProxy, userAgent');
         }
-        if ((val === 1) && (this.proxy !== undefined)) {
-            throw new ExchangeError (this.id + ' you have multiple conflicting proxy settings, instead of deprecated .proxy please use from: proxyUrl, httpProxy, httpsProxy, socksProxy');
-        }
         return [ proxyUrl, httpProxy, httpsProxy, socksProxy ];
     }
 


### PR DESCRIPTION
- With the current setup, defining only `this.proxy` would cause a  "multiple conflicting proxy settings" error