### PR TITLE
Crypto.com: fetchFundingRateHistory

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -47,6 +47,7 @@ export default class cryptocom extends Exchange {
                 'fetchDepositWithdrawFees': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
+                'fetchFundingRateHistory': true,
                 'fetchFundingRates': false,
                 'fetchLedger': true,
                 'fetchMarginMode': false,
@@ -2735,6 +2736,76 @@ export default class cryptocom extends Exchange {
             result.push (this.parseSettlement (settlements[i], market));
         }
         return result;
+    }
+
+    async fetchFundingRateHistory (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name cryptocom#fetchFundingRateHistory
+         * @description fetches historical funding rates
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#public-get-valuations
+         * @param {string|undefined} symbol unified symbol of the market to fetch the funding rate history for
+         * @param {int|undefined} since timestamp in ms of the earliest funding rate to fetch
+         * @param {int|undefined} limit the maximum amount of [funding rate structures] to fetch
+         * @param {object} params extra parameters specific to the cryptocom api endpoint
+         * @param {int|undefined} params.until timestamp in ms for the ending date filter, default is the current time
+         * @returns {[object]} a list of [funding rate structures]{@link https://docs.ccxt.com/en/latest/manual.html?#funding-rate-history-structure}
+         */
+        this.checkRequiredSymbol ('fetchFundingRateHistory', symbol);
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new BadSymbol (this.id + ' fetchFundingRateHistory() supports swap contracts only');
+        }
+        const request = {
+            'instrument_name': market['id'],
+            'valuation_type': 'funding_hist',
+        };
+        if (since !== undefined) {
+            request['start_ts'] = since;
+        }
+        if (limit !== undefined) {
+            request['count'] = limit;
+        }
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
+        if (until !== undefined) {
+            request['end_ts'] = until;
+        }
+        const response = await this.v1PublicGetPublicGetValuations (this.extend (request, params));
+        //
+        //     {
+        //         "id": -1,
+        //         "method": "public/get-valuations",
+        //         "code": 0,
+        //         "result": {
+        //             "data": [
+        //                 {
+        //                     "v": "-0.000001884",
+        //                     "t": 1687892400000
+        //                 },
+        //             ],
+        //             "instrument_name": "BTCUSD-PERP"
+        //         }
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        const data = this.safeValue (result, 'data', []);
+        const marketId = this.safeString (result, 'instrument_name');
+        const rates = [];
+        for (let i = 0; i < data.length; i++) {
+            const entry = data[i];
+            const timestamp = this.safeInteger (entry, 't');
+            rates.push ({
+                'info': entry,
+                'symbol': this.safeSymbol (marketId, market),
+                'fundingRate': this.safeNumber (entry, 'v'),
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+            });
+        }
+        const sorted = this.sortBy (rates, 'timestamp');
+        return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit);
     }
 
     nonce () {


### PR DESCRIPTION
Added fetchFundingRateHistory to Crypto.com using the v1 unified API:
```
cryptocom.fetchFundingRateHistory (BTC/USD:USD, , 3)
2023-06-27T19:49:40.957Z iteration 0 passed in 357 ms

     symbol |  fundingRate |     timestamp |                 datetime
---------------------------------------------------------------------
BTC/USD:USD | -0.000001311 | 1687885200000 | 2023-06-27T17:00:00.000Z
BTC/USD:USD | -0.000001775 | 1687888800000 | 2023-06-27T18:00:00.000Z
BTC/USD:USD | -0.000001884 | 1687892400000 | 2023-06-27T19:00:00.000Z
3 objects
```