### PR TITLE
TRACE commonCurrencies conflict

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -463,6 +463,7 @@ export default class gate extends Exchange {
                 'SBTC': 'Super Bitcoin',
                 'TNC': 'Trinity Network Credit',
                 'VAI': 'VAIOT',
+                'TRAC': 'TRACO', // conflict with OriginTrail (TRAC)
             },
             'requiredCredentials': {
                 'apiKey': true,


### PR DESCRIPTION
fix #18296 

OriginTrail Market Cap: $99,205,907
TRAC (Ordinals) Market Cap: $2,030,795