### PR TITLE
feat(kraken): add postOnly support

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1,7 +1,6 @@
 
 //  ---------------------------------------------------------------------------
 
-import { red } from 'ololog';
 import Exchange from './abstract/kraken.js';
 import { AccountSuspended, BadSymbol, BadRequest, ExchangeNotAvailable, ArgumentsRequired, PermissionDenied, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress, RateLimitExceeded, OnMaintenance, NotSupported } from './base/errors.js';
 import { Precise } from './base/Precise.js';

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1,6 +1,7 @@
 
 //  ---------------------------------------------------------------------------
 
+import { red } from 'ololog';
 import Exchange from './abstract/kraken.js';
 import { AccountSuspended, BadSymbol, BadRequest, ExchangeNotAvailable, ArgumentsRequired, PermissionDenied, AuthenticationError, ExchangeError, OrderNotFound, DDoSProtection, InvalidNonce, InsufficientFunds, CancelPending, InvalidOrder, InvalidAddress, RateLimitExceeded, OnMaintenance, NotSupported } from './base/errors.js';
 import { Precise } from './base/Precise.js';
@@ -1253,6 +1254,8 @@ export default class kraken extends Exchange {
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} params extra parameters specific to the kraken api endpoint
+         * @param {bool} params.postOnly
+         * @param {bool} params.reduceOnly
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1438,11 +1441,12 @@ export default class kraken extends Exchange {
         if ((price === undefined) || Precise.stringEquals (price, '0')) {
             price = this.safeString (order, 'price', price);
         }
+        const flags = this.safeString (order, 'oflags', '');
+        const isPostOnly = flags.indexOf ('post') > -1;
         const average = this.safeNumber (order, 'price');
         if (market !== undefined) {
             symbol = market['symbol'];
             if ('fee' in order) {
-                const flags = order['oflags'];
                 const feeCost = this.safeString (order, 'fee');
                 fee = {
                     'cost': feeCost,
@@ -1475,7 +1479,7 @@ export default class kraken extends Exchange {
             'symbol': symbol,
             'type': type,
             'timeInForce': undefined,
-            'postOnly': undefined,
+            'postOnly': isPostOnly,
             'side': side,
             'price': price,
             'stopPrice': stopPrice,
@@ -1551,7 +1555,17 @@ export default class kraken extends Exchange {
         if (timeInForce !== undefined) {
             request['timeinforce'] = timeInForce;
         }
-        params = this.omit (params, [ 'price', 'stopPrice', 'price2', 'close', 'timeInForce' ]);
+        const isMarket = (type === 'market');
+        let postOnly = undefined;
+        [ postOnly, params ] = this.handlePostOnly (isMarket, false, params);
+        if (postOnly) {
+            request['oflags'] = 'post';
+        }
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        if (reduceOnly) {
+            request['reduce_only'] = true;
+        }
+        params = this.omit (params, [ 'price', 'stopPrice', 'price2', 'close', 'timeInForce', 'reduceOnly' ]);
         return [ request, params ];
     }
 


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18387

DEMO

```
 p kraken createOrder "LTC/USDT" limit buy 0.1 50 '{"postOnly":true}'
Python v3.10.9
CCXT v3.1.54
kraken.createOrder(LTC/USDT,limit,buy,0.1,50,{'postOnly': True})
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': 'O4FPTY-LSZPW-25TCDP',
 'info': {'descr': {'order': 'buy 0.10000000 LTCUSDT @ limit 50.00000'},
          'txid': ['O4FPTY-LSZPW-25TCDP']},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```

```
p kraken createOrderWs "LTC/USDT" limit buy 0.1 50 '{"postOnly":true}'
Python v3.10.9
CCXT v3.1.54
kraken.createOrderWs(LTC/USDT,limit,buy,0.1,50,{'postOnly': True})
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': 'ONLHFG-JYGYR-7FPRBM',
 'info': {'descr': 'buy 0.10000000 LTCUSDT @ limit 50.00000',
          'event': 'addOrderStatus',
          'reqid': 1,
          'status': 'ok',
          'txid': 'ONLHFG-JYGYR-7FPRBM'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': 'ok',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```

```
 p kraken fetchOrder "ONLHFG-JYGYR-7FPRBM"                             
Python v3.10.9
CCXT v3.1.54
kraken.fetchOrder(ONLHFG-JYGYR-7FPRBM)
{'amount': 0.1,
 'average': None,
 'clientOrderId': '0',
 'cost': 0.0,
 'datetime': '2023-06-28T09:56:35.014Z',
 'fee': {'cost': 0.0, 'currency': 'USDT', 'rate': None},
 'fees': [{'cost': 0.0, 'currency': 'USDT', 'rate': None}],
 'filled': 0.0,
 'id': 'ONLHFG-JYGYR-7FPRBM',
 'info': {'cost': '0.000000',
          'descr': {'close': '',
                    'leverage': 'none',
                    'order': 'buy 0.10000000 LTCUSDT @ limit 50.00000',
                    'ordertype': 'limit',
                    'pair': 'LTCUSDT',
                    'price': '50.00000',
                    'price2': '0',
                    'type': 'buy'},
          'expiretm': '0',
          'fee': '0.000000',
          'id': 'ONLHFG-JYGYR-7FPRBM',
          'limitprice': '0.000000',
          'misc': '',
          'oflags': 'post,fciq',
          'opentm': '1687946195.0143442',
          'price': '0.000000',
          'reason': None,
          'refid': None,
          'starttm': '0',
          'status': 'open',
          'stopprice': '0.000000',
          'userref': '0',
          'vol': '0.10000000',
          'vol_exec': '0.00000000'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': True,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': 0.1,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': 0.0,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'PO',
 'timestamp': 1687946195014,
 'trades': [],
 'triggerPrice': 0.0,
 'type': 'limit'}
```