### PR TITLE
phemex parseTrade fix

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1627,8 +1627,8 @@ export default class phemex extends Exchange {
                 priceString = this.fromEp (this.safeString (trade, 'execPriceEp'), market);
                 amountString = this.fromEv (this.safeString (trade, 'execBaseQtyEv'), market);
                 amountString = this.safeString (trade, 'execQty', amountString);
-                costString = this.fromEv (this.safeString2 (trade, 'execQuoteQtyEv', 'execValueEv'), market);
-                feeCostString = this.fromEv (this.safeString (trade, 'execFeeEv'), market);
+                costString = this.fromEr (this.safeString2 (trade, 'execQuoteQtyEv', 'execValueEv'), market);
+                feeCostString = this.fromEr (this.safeString (trade, 'execFeeEv'), market);
                 if (feeCostString !== undefined) {
                     feeRateString = this.fromEr (this.safeString (trade, 'feeRateEr'), market);
                     if (market['spot']) {

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1458,6 +1458,9 @@ export default class phemex extends Exchange {
         //         "leavesQuoteQtyEv": 0,
         //         "execFeeEv": 0,
         //         "feeRateEr": 0
+        //         "baseCurrency": 'BTC',
+        //         "quoteCurrency": 'USDT',
+        //         "feeCurrency": 'BTC'
         //     }
         //
         // swap
@@ -1632,7 +1635,7 @@ export default class phemex extends Exchange {
                 if (feeCostString !== undefined) {
                     feeRateString = this.fromEr (this.safeString (trade, 'feeRateEr'), market);
                     if (market['spot']) {
-                        feeCurrencyCode = (side === 'buy') ? market['base'] : market['quote'];
+                        feeCurrencyCode = this.safeCurrencyCode (this.safeString (trade, 'feeCurrency');
                     } else {
                         const info = this.safeValue (market, 'info');
                         if (info !== undefined) {

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1635,7 +1635,7 @@ export default class phemex extends Exchange {
                 if (feeCostString !== undefined) {
                     feeRateString = this.fromEr (this.safeString (trade, 'feeRateEr'), market);
                     if (market['spot']) {
-                        feeCurrencyCode = this.safeCurrencyCode (this.safeString (trade, 'feeCurrency');
+                        feeCurrencyCode = this.safeCurrencyCode (this.safeString (trade, 'feeCurrency'));
                     } else {
                         const info = this.safeValue (market, 'info');
                         if (info !== undefined) {


### PR DESCRIPTION
now: 
```
{
    info: {
      qtyType: 'ByBase',
      transactTimeNs: '1687982988215582385',
      clOrdID: 'ccxt2022c37ae63714d0b021',
      orderID: '03d96fd9-933f-4718-a657-670065bd097d',
      symbol: 'sTUSDT',
      side: 'Sell',
      priceEP: '2147200',
      baseQtyEv: '11158000',
      quoteQtyEv: '0',
      action: 'Replace',
      execStatus: 'MakerFill',
      ordStatus: 'Filled',
      ordType: 'Limit',
      execInst: 'None',
      timeInForce: 'GoodTillCancel',
      stopDirection: 'UNSPECIFIED',
      tradeType: 'Trade',
      stopPxEp: '0',
      execId: 'f1087b84-b414-51cd-9a04-69df81e6ddc4',
      execPriceEp: '2147200',
      execBaseQtyEv: '11158000',
      execQuoteQtyEv: '2395845760',
      leavesBaseQtyEv: '0',
      leavesQuoteQtyEv: '0',
      execFeeEv: '2395846',
      feeRateEr: '100000',
      baseCurrency: 'T',
      quoteCurrency: 'USDT',
      feeCurrency: 'USDT'
    },
    id: 'f1087b84-b414-51cd-9a04-69df81e6ddc4',
    symbol: 'T/USDT',
    timestamp: 1687982988215,
    datetime: '2023-06-28T20:09:48.215Z',
    order: '03d96fd9-933f-4718-a657-670065bd097d',
    type: 'limit',
    side: 'sell',
    takerOrMaker: 'maker',
    price: 0.021472,
    amount: 1115.8,
    cost: 239584.576,
    fee: { cost: 239.5846, rate: 0.001, currency: 'USDT' },
    fees: [ [Object] ]
 }
```

so `cost` and `fee cost` are abnormal. As I understood we should use `ratioScale`, not `valueScale` here. Maybe they made some changes because I found this problem not so long ago