### PR TITLE
bitmart fee update

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -213,8 +213,8 @@ export default class bitmart extends Exchange {
                 'trading': {
                     'tierBased': true,
                     'percentage': true,
-                    'taker': this.parseNumber ('0.0025'),
-                    'maker': this.parseNumber ('0.0025'),
+                    'taker': this.parseNumber ('0.004'),
+                    'maker': this.parseNumber ('0.004'),
                     'tiers': {
                         'taker': [
                             [ this.parseNumber ('0'), this.parseNumber ('0.0020') ],


### PR DESCRIPTION
https://www.bitmart.com/fee/en-US
for Class-C pairs fee is 0.4%