### PR TITLE
probit fetchMyTrades fix

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -723,7 +723,7 @@ export default class probit extends Exchange {
         const now = this.milliseconds ();
         const request = {
             'limit': 100,
-            'start_time': this.iso8601 (now - 31536000000), // +365 days
+            'start_time': this.iso8601 (now - 31536000000), // -365 days
             'end_time': this.iso8601 (now),
         };
         if (symbol !== undefined) {

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -732,7 +732,7 @@ export default class probit extends Exchange {
         }
         if (since !== undefined) {
             request['start_time'] = this.iso8601 (since);
-            request['end_time'] =  this.iso8601 (Math.min (now, since + 31536000000));
+            request['end_time'] = this.iso8601 (Math.min (now, since + 31536000000));
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -720,10 +720,11 @@ export default class probit extends Exchange {
          */
         await this.loadMarkets ();
         let market = undefined;
+        const now = this.milliseconds ();
         const request = {
             'limit': 100,
-            'start_time': this.iso8601 (0),
-            'end_time': this.iso8601 (this.milliseconds ()),
+            'start_time': this.iso8601 (now - 31536000000), // +365 days
+            'end_time': this.iso8601 (now),
         };
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -731,6 +732,7 @@ export default class probit extends Exchange {
         }
         if (since !== undefined) {
             request['start_time'] = this.iso8601 (since);
+            request['end_time'] =  this.iso8601 (Math.min (now, since + 31536000000));
         }
         if (limit !== undefined) {
             request['limit'] = limit;


### PR DESCRIPTION
I've found that Probit now gives only maximum 365 days of trading history, in other cases we will get:
`BadRequest: probit {"errorCode":"INVALID_ARGUMENT","message":"","details":{"end_time":"invalid_max"}}`