### PR TITLE
lbank2 fetchMyTrades fix

### DIFF
--- a/ts/src/lbank2.ts
+++ b/ts/src/lbank2.ts
@@ -565,7 +565,7 @@ export default class lbank2 extends Exchange {
         if (feeCost !== undefined) {
             fee = {
                 'cost': feeCost,
-                'currency': undefined,
+                'currency': (side === 'buy') ? market['base'] : market['quote'],
                 'rate': this.safeString (trade, 'tradeFeeRate'),
             };
         }
@@ -1304,6 +1304,7 @@ export default class lbank2 extends Exchange {
         }
         if (since !== undefined) {
             request['start_date'] = this.ymd (since, '-'); // max query 2 days ago
+            request['end_date'] = this.ymd (since + 86400000, '-'); // will cover 2 days
         }
         const response = await this.privatePostTransactionHistory (this.extend (request, params));
         //


### PR DESCRIPTION
without `end_date` we will get this error if try to get some trades that were more than 2 days ago:
```
{"result":false,"error_code":10028,"ts":1688058138354} 
BadRequest: Wrong query time
```