### PR TITLE
Coinbase: fetchOrderBook

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -73,7 +73,7 @@ export default class coinbase extends Exchange {
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
-                'fetchOrderBook': false,
+                'fetchOrderBook': true,
                 'fetchOrders': true,
                 'fetchPosition': false,
                 'fetchPositionMode': false,
@@ -2730,6 +2730,52 @@ export default class coinbase extends Exchange {
         //
         const trades = this.safeValue (response, 'fills', []);
         return this.parseTrades (trades, market, since, limit);
+    }
+
+    async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name coinbase#fetchOrderBook
+         * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
+         * @see https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproductbook
+         * @param {string} symbol unified symbol of the market to fetch the order book for
+         * @param {int|undefined} limit the maximum amount of order book entries to return
+         * @param {object} params extra parameters specific to the coinbase api endpoint
+         * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'product_id': market['id'],
+        };
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const response = await this.v3PrivateGetBrokerageProductBook (this.extend (request, params));
+        //
+        //     {
+        //         "pricebook": {
+        //             "product_id": "BTC-USDT",
+        //             "bids": [
+        //                 {
+        //                     "price": "30757.85",
+        //                     "size": "0.115"
+        //                 },
+        //             ],
+        //             "asks": [
+        //                 {
+        //                     "price": "30759.07",
+        //                     "size": "0.04877659"
+        //                 },
+        //             ],
+        //             "time": "2023-06-30T04:02:40.533606Z"
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'pricebook', {});
+        const time = this.safeString (data, 'time');
+        const timestamp = this.parse8601 (time);
+        return this.parseOrderBook (data, symbol, timestamp, 'bids', 'asks', 'price', 'size');
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
Added fetchOrderBook to Coinbase:
```
coinbase.fetchOrderBook (BTC/USDT, 3)
2023-06-30T04:48:33.512Z iteration 0 passed in 534 ms

{
  symbol: 'BTC/USDT',
  bids: [ [ 31263.15, 0.115 ], [ 31262.93, 0.01269032 ], [ 31262.92, 0.04 ] ],
  asks: [ [ 31271.68, 0.04797968 ], [ 31272.92, 0.033 ], [ 31275.29, 0.01 ] ],
  timestamp: 1688100514158,
  datetime: '2023-06-30T04:48:34.158Z',
  nonce: undefined
}
```