### PR TITLE
phemex parseTicker fix

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1222,7 +1222,7 @@ export default class phemex extends Exchange {
         const symbol = market['symbol'];
         const timestamp = this.safeIntegerProduct (ticker, 'timestamp', 0.000001);
         const last = this.fromEp (this.safeString2 (ticker, 'lastEp', 'closeRp'), market);
-        const quoteVolume = this.fromEv (this.safeString2 (ticker, 'turnoverEv', 'turnoverRv'), market);
+        const quoteVolume = this.fromEr (this.safeString2 (ticker, 'turnoverEv', 'turnoverRv'), market);
         let baseVolume = this.safeString (ticker, 'volume');
         if (baseVolume === undefined) {
             baseVolume = this.fromEv (this.safeString2 (ticker, 'volumeEv', 'volumeRq'), market);


### PR DESCRIPTION
same as in `parseTrade`
https://phemex.com/spot/trade/TUSDT - for example T/USDT has 3.7M volume in base, it's about 80k USDT, now we get 800M `quoteVolume` so we need to use `ratioScale` not `valueScale`
```
{
  symbol: 'T/USDT',
  timestamp: 1688136644011,
  datetime: '2023-06-30T14:50:44.011Z',
  high: 0.022889,
  low: 0.020598,
  bid: 0.021447,
  bidVolume: undefined,
  ask: 0.021471,
  askVolume: undefined,
  vwap: 219.7623416575287,
  open: 0.021796,
  close: 0.021432,
  last: 0.021432,
  previousClose: undefined,
  change: -0.000364,
  percentage: -1.6700311983850247,
  average: 0.021614,
  baseVolume: 3658547.8,
  quoteVolume: 804011031.594,
  info: {
    askEp: '2147100',
    bidEp: '2144700',
    highEp: '2288900',
    indexEp: '2145294',
    lastEp: '2143200',
    lowEp: '2059800',
    openEp: '2179600',
    symbol: 'sTUSDT',
    timestamp: '1688136644011417036',
    turnoverEv: '8040110315940',
    volumeEv: '36585478000'
  }
}
```