### PR TITLE
Crypto.com: withdraw, migrate to the unified API

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -1328,6 +1328,7 @@ export default class cryptocom extends Exchange {
          * @method
          * @name cryptocom#withdraw
          * @description make a withdrawal
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#private-create-withdrawal
          * @param {string} code unified currency code
          * @param {float} amount the amount to withdraw
          * @param {string} address the address to withdraw to
@@ -1346,7 +1347,7 @@ export default class cryptocom extends Exchange {
         if (tag !== undefined) {
             request['address_tag'] = tag;
         }
-        const response = await this.v2PrivatePostPrivateCreateWithdrawal (this.extend (request, params));
+        const response = await this.v1PrivatePostPrivateCreateWithdrawal (this.extend (request, params));
         //
         //    {
         //        "id":-1,

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -1347,6 +1347,12 @@ export default class cryptocom extends Exchange {
         if (tag !== undefined) {
             request['address_tag'] = tag;
         }
+        let networkCode = undefined;
+        [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
+        const networkId = this.networkCodeToId (networkCode);
+        if (networkId !== undefined) {
+            request['network_id'] = networkId;
+        }
         const response = await this.v1PrivatePostPrivateCreateWithdrawal (this.extend (request, params));
         //
         //    {


### PR DESCRIPTION
Migrated the withdraw method to the v1 unified API, I keep getting an unauthorized error for the new endpoint as well as the old endpoint:
```
cryptocom.withdraw (BTC, 0.002, 123cNMEWbiF8ZkwUMxmfzMxi2A1MQ44bMn)
PermissionDenied cryptocom {"id":1688187211596,"method":"private/create-withdrawal","code":10002,"message":"UNAUTHORIZED"}
---------------------------------------------------
[PermissionDenied] cryptocom {"id":1688187211596,"method":"private/create-withdrawal","code":10002,"message":"UNAUTHORIZED"}

    at throwExactlyMatchedException  …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:3044
    at handleErrors                  …/c/Users/Dan/Documents/GitHub/ccxt/js/src/cryptocom.js:2991
    at                               …Users/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:750
    at processTicksAndRejections     node:internal/process/task_queues:96
    at fetch2                        …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2637
    at request                       …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2640
    at withdraw                      …/c/Users/Dan/Documents/GitHub/ccxt/js/src/cryptocom.js:1356
    at async run                     mnt/c/Users/Dan/Documents/GitHub/ccxt/examples/js/cli.js:298

cryptocom {"id":1688187211596,"method":"private/create-withdrawal","code":10002,"message":"UNAUTHORIZED"}
```