### PR TITLE
feat(gate): fix fetchOpenInterestHistory

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -5578,7 +5578,7 @@ export default class gate extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadRequest (this.id + ' fetchOpenInterest() supports future markets only');
+            throw new BadRequest (this.id + ' fetchOpenInterest() supports swap markets only');
         }
         const request = {
             'contract': market['id'],

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -5577,7 +5577,7 @@ export default class gate extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (!market['future']) {
+        if (!market['swap']) {
             throw new BadRequest (this.id + ' fetchOpenInterest() supports future markets only');
         }
         const request = {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18427

DEMO
```
p gate fetchOpenInterestHistory "BTC/USDT:USDT" "5m" None 2
Python v3.10.9
CCXT v4.0.3
gate.fetchOpenInterestHistory(BTC/USDT:USDT,5m,None,2)
[{'datetime': '2023-07-01T13:50:00.000Z',
  'info': {'long_liq_amount': '0',
           'long_liq_size': '0',
           'long_liq_usd': '0',
           'lsr_account': '1.1503805175038',
           'lsr_taker': '0.42660506698284',
           'mark_price': '30551.93',
           'open_interest': '150508526',
           'open_interest_usd': '459832595.07552',
           'short_liq_amount': '0',
           'short_liq_size': '0',
           'short_liq_usd': '0',
           'time': '1688219400',
           'top_lsr_account': '1.1538461538462',
           'top_lsr_size': '0.98266500683631'},
  'openInterestAmount': 150508526.0,
  'openInterestValue': 459832595.07552,
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1688219400000},
 {'datetime': '2023-07-01T13:55:00.000Z',
  'info': {'long_liq_amount': '0',
           'long_liq_size': '0',
           'long_liq_usd': '0',
           'lsr_account': '1.1369156041287',
           'lsr_taker': '1.3917298866723',
           'mark_price': '30571.56',
           'open_interest': '150153332',
           'open_interest_usd': '459042159.84379',
           'short_liq_amount': '0',
           'short_liq_size': '0',
           'short_liq_usd': '0',
           'time': '1688219700',
           'top_lsr_account': '1.1538461538462',
           'top_lsr_size': '0.98311588029717'},
  'openInterestAmount': 150153332.0,
  'openInterestValue': 459042159.84379,
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1688219700000}]
```
```
p gate fetchOpenInterestHistory "BTC/USD:BTC" "5m" None 1 
Python v3.10.9
CCXT v4.0.3
gate.fetchOpenInterestHistory(BTC/USD:BTC,5m,None,1)
[{'datetime': '2023-07-01T13:55:00.000Z',
  'info': {'long_liq_amount': '0',
           'long_liq_size': '0',
           'long_liq_usd': '0',
           'lsr_account': '1.4117647058824',
           'lsr_taker': '0.48571428571429',
           'mark_price': '30510.17',
           'open_interest': '51699501',
           'open_interest_usd': '51699501',
           'short_liq_amount': '0',
           'short_liq_size': '0',
           'short_liq_usd': '0',
           'time': '1688219700',
           'top_lsr_account': '1.0181818181818',
           'top_lsr_size': '0.987322909593'},
  'openInterestAmount': 51699501.0,
  'openInterestValue': 51699501.0,
  'symbol': 'BTC/USD:BTC',
  'timestamp': 1688219700000}]
```
