### PR TITLE
fix(okx) - uppercase symbols

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -841,14 +841,14 @@ export default class okx extends Exchange {
             'commonCurrencies': {
                 // the exchange refers to ERC20 version of Aeternity (AEToken)
                 'AE': 'AET', // https://github.com/ccxt/ccxt/issues/4981
-                'BOX': 'DefiBox',
-                'HOT': 'Hydro Protocol',
+                'BOX': 'DEFIBOX',
+                'HOT': 'HYDROPROTOCOL',
                 'HSR': 'HC',
-                'MAG': 'Maggie',
-                'SBTC': 'Super Bitcoin',
-                'TRADE': 'Unitrade',
+                'MAG': 'MAGGIE',
+                'SBTC': 'SUPERBITCOIN',
+                'TRADE': 'UNITRADE',
                 'YOYO': 'YOYOW',
-                'WIN': 'WinToken', // https://github.com/ccxt/ccxt/issues/5701
+                'WIN': 'WINTOKEN', // https://github.com/ccxt/ccxt/issues/5701
             },
         });
     }


### PR DESCRIPTION
I think our standard is to have uppercase currency & symbols, so we shouldn't change that when just doing currency mappings