### PR TITLE
okx - add method for fetchTrades

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1792,7 +1792,9 @@ export default class okx extends Exchange {
             if (limit !== undefined) {
                 request['limit'] = limit; // default 100
             }
-            response = await this.publicGetMarketTrades (this.extend (request, params));
+            let method = undefined;
+            [ method, params ] = this.handleOptionAndParams (params, 'fetchTrades', 'method', 'publicGetMarketTrades');
+            response = await this[method] (this.extend (request, params));
         }
         //
         //     {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1794,7 +1794,11 @@ export default class okx extends Exchange {
             }
             let method = undefined;
             [ method, params ] = this.handleOptionAndParams (params, 'fetchTrades', 'method', 'publicGetMarketTrades');
-            response = await this[method] (this.extend (request, params));
+            if (method === 'publicGetMarketTrades') {
+                response = await this.publicGetMarketTrades (this.extend (request, params));
+            } else if (method === 'publicGetMarketHistoryTrades') {
+                response = await this.publicGetMarketHistoryTrades (this.extend (request, params));
+            }
         }
         //
         //     {


### PR DESCRIPTION
Users can choose it to use another method (i.e. `publicGetMarketHistoryTrades`)