### PR TITLE
fix(throttler) - unified names in php

### DIFF
--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -32,7 +32,7 @@ use React\EventLoop\Loop;
 
 use Exception;
 
-include 'Throttler.php';
+include 'Throttle.php';
 
 $version = '4.0.3';
 

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -32,7 +32,7 @@ use React\EventLoop\Loop;
 
 use Exception;
 
-include 'Throttle.php';
+include 'Throttler.php';
 
 $version = '4.0.3';
 
@@ -44,7 +44,7 @@ class Exchange extends \ccxt\Exchange {
     public $marketsLoading = null;
     public $reloadingMarkets = null;
     public $tokenBucket;
-    public $throttle;
+    public $throttler;
 
     public $streaming = array(
         'keepAlive' => 30000,
@@ -60,7 +60,7 @@ class Exchange extends \ccxt\Exchange {
     public function __construct($options = array()) {
         parent::__construct($options);
         $this->set_request_browser();
-        $this->throttle = new Throttle($this->tokenBucket);
+        $this->throttler = new Throttler($this->tokenBucket);
     }
 
     public function set_request_browser($connector_options = array()) {
@@ -233,7 +233,7 @@ class Exchange extends \ccxt\Exchange {
 
     public function throttle($cost = null) {
         // stub so the async throttler gets called instead of the sync throttler
-        return call_user_func($this->throttle, $cost);
+        return call_user_func($this->throttler, $cost);
     }
 
     // the ellipsis packing/unpacking requires PHP 5.6+ :(

--- a/php/async/Throttle.php
+++ b/php/async/Throttle.php
@@ -7,7 +7,7 @@ use React\Promise\Promise;
 use React\EventLoop\Loop;
 use React\Async;
 
-class Throttle {
+class Throttler {
     public $config;
     public $queue;
     public $running;

--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -49,7 +49,7 @@ class Client {
     public $verbose = false; // verbose output
     public $gunzip = false;
     public $inflate = false;
-    public $throttle = null;
+    public $throttler = null;
     public $connection = null;
     public $connected; // connection-related Future
     public $isConnected = false;

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -2,7 +2,7 @@
 
 namespace ccxt\pro;
 
-use ccxt\async\Throttle;
+use ccxt\async\Throttler;
 use ccxt\BaseError;
 use ccxt\ExchangeError;
 use React\Async;
@@ -56,7 +56,7 @@ trait ClientTrait {
             $options = array_replace_recursive(array(
                 'log' => array($this, 'log'),
                 'verbose' => $this->verbose,
-                'throttle' => new Throttle($this->tokenBucket),
+                'throttle' => new Throttler($this->tokenBucket),
             ), $this->streaming, $ws_options);
             $this->clients[$url] = new Client($url, $on_message, $on_error, $on_close, $on_connected, $options);
         }

--- a/php/test/base/test_throttle.php
+++ b/php/test/base/test_throttle.php
@@ -1,6 +1,6 @@
 <?php
 
-use ccxt\async\Throttle;
+use ccxt\async\Throttler;
 
 include '../../vendor/autoload.php';
 
@@ -88,13 +88,13 @@ for ($i = 0; $i < count($test_cases); $i++) {
 $kernel = ReactKernel::create(Loop::get());
 
 $scheduler = function ($case) use ($kernel, $delta) {
-    $throttle = new Throttle(array(
+    $throttler = new Throttler(array(
         'refillRate' => $case['refillRate'],
         'tokens' => $case['tokens'],
     ), $kernel);
     $start = microtime(true);
     for ($i = 0; $i < $case['runs']; $i++) {
-        yield $throttle($case['cost']);
+        yield $throttler($case['cost']);
     }
     $end = microtime(true);
     $elapsed_ms = ($end - $start) * 1000;


### PR DESCRIPTION
make it exactly like its in JS, so users can access `ex.throttler` object in any language in unified manner.