### PR TITLE
fix(base): fix handleOptionAndParams

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -269,6 +269,7 @@ class Transpiler {
             [ /\.isSignificantPrecision\s/g, '.is_significant_precision'],
             [ /\.filterByLimit\s/g, '.filter_by_limit'],
             [ /\.fetchTime\s/g, '.fetch_time'],
+            [ /\.handleOptionAndParams\s/g, '.handle_option_and_params'],
             [ /\ssha(1|256|384|512)([,)])/g, ' \'sha$1\'$2'], // from js imports to this
             [ /\s(md5|secp256k1|ed25519|keccak)([,)])/g, ' \'$1\'$2'], // from js imports to this
 


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18438

DEMO

```
p bybit handle_option_and_params '{"type":"spot"}' 'createOrder' 'type' --sandbox
Python v3.10.9
CCXT v4.0.4
bybit.handle_option_and_params({'type': 'spot'},createOrder,type)
```
