### PR TITLE
tests - with multiple retries

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -223,13 +223,11 @@ const testExchange = async (exchange) => {
     }
 
     if (skipSettings[exchange] && skipSettings[exchange].skip) {
-        const until = exchange.safeString (skipSettings[exchange], 'until');
-        if (until === undefined) {
+        if (!('until' in skipSettings[exchange])) {
             log.bright (('[' + percentsDoneCalc() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
             return [];
         }
-        const untilDate = new Date(until);
-        if (untilDate > new Date()) {
+        if (new Date(skipSettings[exchange].until) > new Date()) {
             // if untilDate has not been yet reached, skip test for exchange
             log.bright (('[' + percentsDoneCalc() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
             return [];

--- a/run-tests.js
+++ b/run-tests.js
@@ -210,26 +210,25 @@ const sequentialMap = async (input, fn) => {
 }
 
 /*  ------------------------------------------------------------------------ */
-const percentsDoneCalc = () => { 
-    return ((numExchangesTested / exchanges.length) * 100).toFixed (0) + '%'; 
-};
 
 const testExchange = async (exchange) => {
 
+    const percentsDone = () => ((numExchangesTested / exchanges.length) * 100).toFixed (0) + '%';
+
     // no need to test alias classes
     if (exchange.alias) {
-        log.bright (('[' + percentsDoneCalc() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
+        log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
         return [];
     }
 
     if (skipSettings[exchange] && skipSettings[exchange].skip) {
         if (!('until' in skipSettings[exchange])) {
-            log.bright (('[' + percentsDoneCalc() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
+            log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
             return [];
         }
         if (new Date(skipSettings[exchange].until) > new Date()) {
             // if untilDate has not been yet reached, skip test for exchange
-            log.bright (('[' + percentsDoneCalc() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
+            log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
             return [];
         }
     }
@@ -281,7 +280,7 @@ const testExchange = async (exchange) => {
     let logMessage = '';
 
     if (failed) {
-        logMessage += 'FAIL'.red;
+        logMessage+= 'FAIL'.red;
     } else if (hasWarnings) {
         logMessage = ('WARN: ' + (warnings.length ? warnings.join (' ') : '')).yellow;
     } else {
@@ -296,7 +295,8 @@ const testExchange = async (exchange) => {
             logMessage += infoMessages.blue;
         }
     }
-    log.bright (('[' + percentsDoneCalc() + ']').dim, 'Tested', exchange.cyan, logMessage)
+    numExchangesTested++;
+    log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, logMessage)
 
 /*  Return collected data to main loop     */
 
@@ -309,8 +309,8 @@ const testExchange = async (exchange) => {
         explain () {
             for (let { language, failed, output, hasWarnings, hasInfo, outputInfo } of completeTests) {
                 if (failed || hasWarnings) {
-                    const skippedExchange = output.indexOf('[SKIPPED]') >= 0;
-                    if (!failed && skippedExchange)
+                    const fullSkip = output.indexOf('[SKIPPED]') >= 0;
+                    if (!failed && fullSkip)
                         continue;
 
                     if (failed) { log.bright ('\nFAILED'.bgBrightRed.white, exchange.red,    '(' + language + '):\n') }
@@ -370,10 +370,7 @@ async function testAllExchanges () {
     const results = []
 
     for (const exchange of exchanges) {
-        taskPool.run (() => testExchange (exchange).then (x => {
-            numExchangesTested++
-            results.push (x);
-        }))
+        taskPool.run (() => testExchange (exchange).then (x => results.push (x)))
     }
 
     await Promise.all (taskPool.pending)

--- a/run-tests.js
+++ b/run-tests.js
@@ -217,16 +217,20 @@ const testExchange = async (exchange) => {
 
     // no need to test alias classes
     if (exchange.alias) {
+        numExchangesTested++;
         log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
         return [];
     }
 
     if (skipSettings[exchange] && skipSettings[exchange].skip) {
         if (!('until' in skipSettings[exchange])) {
+            // if until not specified, skip forever
+            numExchangesTested++;
             log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
             return [];
         }
         if (new Date(skipSettings[exchange].until) > new Date()) {
+            numExchangesTested++;
             // if untilDate has not been yet reached, skip test for exchange
             log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, '[Skipped]'.yellow)
             return [];

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -490,7 +490,6 @@
         }
     },
     "bybit": {
-        "skip": "2023-07-13 exchange not available with 403 forbidden error code",
         "httpsProxy": "http://51.83.140.52:11230",
         "skipPhpAsync": "missing php async proxy",
         "skipMethods": {

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -279,7 +279,7 @@ export default class testMainClass extends baseMainTestClass {
         // then regex-parsed by run-tests.js, so the exceptions are still printed out to
         // console from there. So, even if some public tests fail, the script will continue
         // doing other things (testing other spot/swap or private tests ...)
-        const maxRetries = 5;
+        const maxRetries = 3;
         const argsStringified = '(' + args.join (',') + ')';
         for (let i = 0; i < maxRetries; i++) {
             try {

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -304,7 +304,7 @@ export default class testMainClass extends baseMainTestClass {
             }
         }
         // if maxretries was gone with same `tempFailure` error, then let's eventually return false
-        dump ('[TEST_WARNING]', 'Method could not be tested, because of temporary access issues', exchange.id, methodName, argsStringified);
+        dump ('[TEST_WARNING]', 'Method not tested due to a Network/Availability issue', exchange.id, methodName, argsStringified);
         return false;
     }
 

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -267,16 +267,14 @@ export default class testMainClass extends baseMainTestClass {
             }
         } catch (e) {
             const isAuthError = (e instanceof AuthenticationError);
-            const isPermissionDenied = (e instanceof PermissionDenied);
             // If public test faces authentication error, we don't break (see comments under `testSafe` method)
-            // todo: changes are needed after .Features implementation
-            if (isPublic) {
-                if (isAuthError || isPermissionDenied) {
+            if (isPublic && isAuthError) {
+                if (this.info) {
                     dump ('[TEST_WARNING]', 'Authentication problem for public method', exceptionMessage (e), exchange.id, methodNameInTest, argsStringified);
-                    return;
                 }
+            } else {
+                throw e;
             }
-            throw e;
         }
     }
 

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -300,7 +300,7 @@ export default class testMainClass extends baseMainTestClass {
                     await exchange.sleep (i); // increase wait seconds on every retry
                     continue;
                 } else {
-                    // if not temp failure, then throw the exception without retrying
+                    // if not temp failure, then dump exception without retrying
                     dump ('[TEST_WARNING]', 'Public method could not be tested', exceptionMessage (e), exchange.id, methodName, argsStringified);
                     return false;
                 }

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -347,7 +347,8 @@ export default class testMainClass extends baseMainTestClass {
             const testArgs = tests[testName];
             promises.push (this.testSafe (testName, exchange, testArgs, true));
         }
-        // promises.push (testThrottle ()); // todo - not yet ready in other langs too
+        // todo - not yet ready in other langs too
+        // promises.push (testThrottle ());
         const results = await Promise.all (promises);
         const errors = [];
         for (let i = 0; i < testNames.length; i++) {

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -370,7 +370,7 @@ export default class testMainClass extends baseMainTestClass {
             if (errors.length) {
                 failedMsg = ' | Failed methods: ' + errors.join (', ');
             }
-            dump (this.addPadding ('[INFO:PUBLIC_TESTS_DONE]' +  market['type'] + failedMsg, 25), exchange.id);
+            dump (this.addPadding ('[INFO:PUBLIC_TESTS_DONE]' + market['type'] + failedMsg, 25), exchange.id);
         }
     }
 

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -298,7 +298,7 @@ export default class testMainClass extends baseMainTestClass {
                 const tempFailure = (isRateLimitExceeded || isExchangeNotAvailable || isNetworkError || isDDoSProtection || isRequestTimeout);
                 if (tempFailure) {
                     // wait and retry again
-                    await exchange.sleep (i); // increase wait seconds on every retry
+                    await exchange.sleep (i * 1000); // increase wait seconds on every retry
                     continue;
                 } else {
                     // if not temp failure, then dump exception without retrying

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -350,6 +350,7 @@ export default class testMainClass extends baseMainTestClass {
         // todo - not yet ready in other langs too
         // promises.push (testThrottle ());
         const results = await Promise.all (promises);
+        // now count which test-methods retuned `false` from "testSafe" and dump that info below
         const errors = [];
         for (let i = 0; i < testNames.length; i++) {
             if (!results[i]) {

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -302,7 +302,7 @@ export default class testMainClass extends baseMainTestClass {
                     continue;
                 } else {
                     // if not temp failure, then dump exception without retrying
-                    dump ('[TEST_WARNING]', 'Public method could not be tested', exceptionMessage (e), exchange.id, methodName, argsStringified);
+                    dump ('[TEST_WARNING]', 'Method could not be tested', exceptionMessage (e), exchange.id, methodName, argsStringified);
                     return false;
                 }
             }

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -366,7 +366,10 @@ export default class testMainClass extends baseMainTestClass {
         }
         if (this.info) {
             // we don't throw exception for public-tests, see comments under 'testSafe' method
-            const failedMsg = errors.length ? ' | Failed methods: ' + errors.join (', ') : '';
+            let failedMsg = '';
+            if (errors.length) {
+                failedMsg = ' | Failed methods: ' + errors.join (', ');
+            }
             dump (this.addPadding ('[INFO:PUBLIC_TESTS_DONE]' +  market['type'] + failedMsg, 25), exchange.id);
         }
     }

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -286,10 +286,6 @@ export default class testMainClass extends baseMainTestClass {
                 await this.testMethod (methodName, exchange, args, isPublic);
                 return true;
             } catch (e) {
-                if (e instanceof OnMaintenance) {
-                    dump ('[SKIPPED] Exchange is on maintenance', exchangeId);
-                    exitScript ();
-                }
                 const isRateLimitExceeded = (e instanceof RateLimitExceeded);
                 const isExchangeNotAvailable = (e instanceof ExchangeNotAvailable);
                 const isNetworkError = (e instanceof NetworkError);
@@ -368,7 +364,15 @@ export default class testMainClass extends baseMainTestClass {
     }
 
     async loadExchange (exchange) {
-        await exchange.loadMarkets ();
+        try {
+            await exchange.loadMarkets ();
+        } catch (e) {
+            if (e instanceof OnMaintenance) {
+                dump ('[SKIPPED] Exchange is on maintenance', exchangeId);
+                exitScript ();
+            }
+            throw e;
+        }
         assert (typeof exchange.markets === 'object', '.markets is not an object');
         assert (Array.isArray (exchange.symbols), '.symbols is not an array');
         const symbolsLength = exchange.symbols.length;


### PR DESCRIPTION
**Retries**
- this should be desired solution, so tests would no longer break on first exception (if that exception is one of the temporary connection exception: rate limit, timeout, etc..) and would retry up to 5 times, with an increasing wait time (0-5 seconds)

**Maintenance**
- we probably have to skip when OnMaintenance is thrown, as we neither approve neither disapprove the test in such case.

**Until**
- added "until" functiionality in skip-tests (but it's used whenever 'skip' is set also)