### PR TITLE
Revert "multilang-edit"

### DIFF
--- a/multilang.sh
+++ b/multilang.sh
@@ -119,6 +119,7 @@ done
 
 shift $((OPTIND - 1))
 
+# if there are any unparsed options then print usage and exit
 if grep -q -Ee "^-[^0-9]" <<< "$@"; then
   usage
 fi

--- a/multilang.sh
+++ b/multilang.sh
@@ -119,10 +119,6 @@ done
 
 shift $((OPTIND - 1))
 
-if grep  -q -e "-[^0-9]" <<< "$@"; then
-  usage
-fi
-
 if ${verbose}; then
   args="--verbose $@"
 else

--- a/multilang.sh
+++ b/multilang.sh
@@ -119,6 +119,10 @@ done
 
 shift $((OPTIND - 1))
 
+if grep -q -Ee "^-[^0-9]" <<< "$@"; then
+  usage
+fi
+
 if ${verbose}; then
   args="--verbose $@"
 else


### PR DESCRIPTION
This reverts commit 7779b6931bb25c9b34ab5510e4008d2152ec7567.

I don't understand what the purpose of this commit was, but it creates some problems, when I run `./multilang.sh upbit fetchMarketById BTC-ETC`, it prints the usage and exits

This happens because -E is present within the arguments

```
% grep -o -e "-[^0-9]" <<< "upbit fetchMarketById BTC-ETC"
-E
```