### PR TITLE
probit fetchDepositsWithdrawals true

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -47,6 +47,7 @@ export default class probit extends Exchange {
                 'fetchDepositAddress': true,
                 'fetchDepositAddresses': true,
                 'fetchDeposits': true,
+                'fetchDepositsWithdrawals': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
                 'fetchFundingRateHistory': false,
@@ -1499,7 +1500,9 @@ export default class probit extends Exchange {
         /**
          * @method
          * @name probit#fetchTransactions
-         * @description fetch all transactions made to an account
+         * @deprecated
+         * @description use fetchDepositsWithdrawals instead
+         * @see https://docs-en.probit.com/reference/transferpayment
          * @param {string} code unified currency code
          * @param {int} [since] the earliest time in ms to fetch transactions for
          * @param {int} [limit] the maximum number of transaction structures to retrieve


### PR DESCRIPTION
because we have `fetchTransactions` here.
BTW can you explain why `fetchTransactions` is deprecated?