### PR TITLE
woo: remove apis GET /v1/client/info

### DIFF
--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -161,7 +161,6 @@ export default class woo extends Exchange {
                             'client/trade/{tid}': 1,
                             'order/{oid}/trades': 1,
                             'client/trades': 1,
-                            'client/info': 60,
                             'asset/deposit': 10,
                             'asset/history': 60,
                             'sub_account/all': 60,


### PR DESCRIPTION
The GET /v1/client/info is deprecated in woo: https://docs.woo.org/#get-account-information-new

I removed this api in PR.