### PR TITLE
Crypto.com: fetchWithdrawals, migrate to the unified API

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -168,6 +168,7 @@ export default class cryptocom extends Exchange {
                             'private/get-currency-networks': 10 / 3,
                             'private/get-deposit-address': 10 / 3,
                             'private/get-accounts': 10 / 3,
+                            'private/get-withdrawal-history': 10 / 3,
                         },
                     },
                 },
@@ -1538,10 +1539,12 @@ export default class cryptocom extends Exchange {
          * @method
          * @name cryptocom#fetchWithdrawals
          * @description fetch all withdrawals made from an account
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#private-get-withdrawal-history
          * @param {string} code unified currency code
          * @param {int} [since] the earliest time in ms to fetch withdrawals for
          * @param {int} [limit] the maximum number of withdrawals structures to retrieve
          * @param {object} [params] extra parameters specific to the cryptocom api endpoint
+         * @param {int} [params.until] timestamp in ms for the ending date filter, default is the current time
          * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/#/?id=transaction-structure}
          */
         await this.loadMarkets ();
@@ -1558,28 +1561,34 @@ export default class cryptocom extends Exchange {
         if (limit !== undefined) {
             request['page_size'] = limit;
         }
-        const response = await this.v2PrivatePostPrivateGetWithdrawalHistory (this.extend (request, params));
+        const until = this.safeInteger2 (params, 'until', 'till');
+        params = this.omit (params, [ 'until', 'till' ]);
+        if (until !== undefined) {
+            request['end_ts'] = until;
+        }
+        const response = await this.v1PrivatePostPrivateGetWithdrawalHistory (this.extend (request, params));
         //
         //     {
-        //       id: 1640704829096,
-        //       method: 'private/get-withdrawal-history',
-        //       code: 0,
-        //       result: {
-        //         withdrawal_list: [
-        //           {
-        //             currency: 'DOGE',
-        //             client_wid: '',
-        //             fee: 50,
-        //             create_time: 1640425168000,
-        //             id: '3180557',
-        //             update_time: 1640425168000,
-        //             amount: 1102.64092,
-        //             address: 'DDrGGqmp5Ddo1QH9tUvDfoL4u4rqys5975',
-        //             status: '5',
-        //             txid: 'ce23e9e21b6c38eef953070a05110e6dca2fd2bcc76d3381000547b9ff5290b2/0'
-        //           }
-        //         ]
-        //       }
+        //         "id": 1688613879534,
+        //         "method": "private/get-withdrawal-history",
+        //         "code": 0,
+        //         "result": {
+        //             "withdrawal_list": [
+        //                 {
+        //                     "currency": "BTC",
+        //                     "client_wid": "",
+        //                     "fee": 0.0005,
+        //                     "create_time": 1688613850000,
+        //                     "id": "5275977",
+        //                     "update_time": 1688613850000,
+        //                     "amount": 0.0005,
+        //                     "address": "1234NMEWbiF8ZkwUMxmfzMxi2A1MQ44bMn",
+        //                     "status": "1",
+        //                     "txid": "",
+        //                     "network_id": "BTC"
+        //                 }
+        //             ]
+        //         }
         //     }
         //
         const data = this.safeValue (response, 'result', {});
@@ -2047,15 +2056,17 @@ export default class cryptocom extends Exchange {
         // fetchWithdrawals
         //
         //     {
-        //         "currency": "XRP",
-        //         "client_wid": "my_withdrawal_002",
-        //         "fee": 1.0,
-        //         "create_time": 1607063412000,
-        //         "id": "2220",
-        //         "update_time": 1607063460000,
-        //         "amount": 100,
-        //         "address": "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBf?1234567890",
-        //         "status": "1"
+        //         "currency": "BTC",
+        //         "client_wid": "",
+        //         "fee": 0.0005,
+        //         "create_time": 1688613850000,
+        //         "id": "5775977",
+        //         "update_time": 1688613850000,
+        //         "amount": 0.0005,
+        //         "address": "1234NMEWbiF8ZkwUMxmfzMxi2A1MQ44bMn",
+        //         "status": "1",
+        //         "txid": "",
+        //         "network_id": "BTC"
         //     }
         //
         // withdraw
@@ -2080,24 +2091,20 @@ export default class cryptocom extends Exchange {
             type = 'deposit';
             status = this.parseDepositStatus (rawStatus);
         }
-        const id = this.safeString (transaction, 'id');
         const addressString = this.safeString (transaction, 'address');
         const [ address, tag ] = this.parseAddress (addressString);
         const currencyId = this.safeString (transaction, 'currency');
         const code = this.safeCurrencyCode (currencyId, currency);
         const timestamp = this.safeInteger (transaction, 'create_time');
-        const amount = this.safeNumber (transaction, 'amount');
-        const txId = this.safeString (transaction, 'txid');
         const feeCost = this.safeNumber (transaction, 'fee');
         let fee = undefined;
         if (feeCost !== undefined) {
             fee = { 'currency': code, 'cost': feeCost };
         }
-        const updated = this.safeInteger (transaction, 'update_time');
         return {
             'info': transaction,
-            'id': id,
-            'txid': txId,
+            'id': this.safeString (transaction, 'id'),
+            'txid': this.safeString (transaction, 'txid'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'network': undefined,
@@ -2108,10 +2115,10 @@ export default class cryptocom extends Exchange {
             'tagTo': tag,
             'tagFrom': undefined,
             'type': type,
-            'amount': amount,
+            'amount': this.safeNumber (transaction, 'amount'),
             'currency': code,
             'status': status,
-            'updated': updated,
+            'updated': this.safeInteger (transaction, 'update_time'),
             'internal': undefined,
             'fee': fee,
         };


### PR DESCRIPTION
Migrated fetchWithdrawals to the v1 unified API:
```
cryptocom.fetchWithdrawals ()
2023-07-06T03:43:19.669Z iteration 0 passed in 308 ms

     id | txid |     timestamp |                 datetime | network |                            address |                          addressTo | addressFrom | tag | tagTo | tagFrom |       type | amount | currency |  status |        updated | internal |                              fee
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5775977 |      | 1688613850000 | 2023-07-06T03:24:10.000Z |         | 1234NMEWbiF8ZkwUMxmfzMxi2A1MQ44bMn | 1234NMEWbiF8ZkwUMxmfzMxi2A1MQ44bMn |             |     |       |         | withdrawal | 0.0005 |      BTC | pending |  1688613850000 |          | {"currency":"BTC","cost":0.0005}
1 objects
```