### PR TITLE
fix(base): protect filterByValueSinceLimit and protect filterBySinceLimit [ci deploy]

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1505,7 +1505,7 @@ export default class Exchange {
                 const entry = parsedArray[i];
                 const entryFiledEqualValue = entry[field] === value;
                 const firstCondition = valueIsDefined ? entryFiledEqualValue : true;
-                const entryKeyGESince = entry[key] && since && (entry[key] >= since);
+                const entryKeyGESince = (key in entry) && since && (entry[key] >= since);
                 const secondCondition = sinceIsDefined ? entryKeyGESince : true;
                 if (firstCondition && secondCondition) {
                     result.push (entry);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1482,7 +1482,7 @@ export default class Exchange {
             result = [ ];
             for (let i = 0; i < parsedArray.length; i++) {
                 const entry = parsedArray[i];
-                if (entry[key] >= since) {
+                if ((key in entry) && (entry[key] >= since)) {
                     result.push (entry);
                 }
             }


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18478


DEMO

```
 p okx watchOrders "BTC/USDT:USDT" 1688549830000  --sandbox
Python v3.10.9
CCXT v4.0.10
okx.watchOrders(BTC/USDT:USDT,1688549830000)
[{'amount': 1.0,
  'average': None,
  'clientOrderId': 'e847386590ce4dBC266ed7b32d66953a',
  'cost': None,
  'datetime': '2023-07-06T10:43:24.596Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'fees': [{'cost': 0.0, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '597135530010165248',
  'info': {'accFillSz': '0',
           'algoClOrdId': '',
           'algoId': '',
           'amendResult': '',
           'amendSource': '',
           'attachAlgoClOrdId': '',
           'avgPx': '0',
           'cTime': '1688640204596',
           'cancelSource': '',
           'category': 'normal',
           'ccy': '',
           'clOrdId': 'e847386590ce4dBC266ed7b32d66953a',
           'code': '0',
           'execType': '',
           'fee': '0',
           'feeCcy': 'USDT',
           'fillFee': '0',
           'fillFeeCcy': '',
           'fillNotionalUsd': '',
           'fillPnl': '0',
           'fillPx': '',
           'fillSz': '0',
           'fillTime': '',
           'instId': 'BTC-USDT-SWAP',
           'instType': 'SWAP',
           'lever': '3',
           'msg': '',
           'notionalUsd': '31.815307683000004',
           'ordId': '597135530010165248',
           'ordType': 'market',
           'pnl': '0',
           'posSide': 'long',
           'px': '',
           'quickMgnType': '',
           'rebate': '0',
           'rebateCcy': 'USDT',
           'reduceOnly': 'false',
           'reqId': '',
           'side': 'buy',
           'slOrdPx': '',
           'slTriggerPx': '',
           'slTriggerPxType': '',
           'source': '',
           'state': 'live',
           'stpId': '',
           'stpMode': '',
           'sz': '1',
           'tag': 'e847386590ce4dBC',
           'tdMode': 'cross',
           'tgtCcy': '',
           'tpOrdPx': '',
           'tpTriggerPx': '',
           'tpTriggerPxType': '',
           'tradeId': '',
           'uTime': '1688640204596'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': 1688640204596,
  'postOnly': None,
  'price': None,
  'reduceOnly': False,
  'remaining': 1.0,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1688640204596,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
[{'amount': 1.0,
  'average': 31186.9,
  'clientOrderId': 'e847386590ce4dBC266ed7b32d66953a',
  'cost': 31.1869,
  'datetime': '2023-07-06T10:43:24.596Z',
  'fee': {'cost': 0.01559345, 'currency': 'USDT'},
  'fees': [{'cost': 0.01559345, 'currency': 'USDT'}],
  'filled': 1.0,
  'id': '597135530010165248',
  'info': {'accFillSz': '1',
           'algoClOrdId': '',
           'algoId': '',
           'amendResult': '',
           'amendSource': '',
           'attachAlgoClOrdId': '',
           'avgPx': '31186.9',
           'cTime': '1688640204596',
           'cancelSource': '',
           'category': 'normal',
           'ccy': '',
           'clOrdId': 'e847386590ce4dBC266ed7b32d66953a',
           'code': '0',
           'execType': 'T',
           'fee': '-0.01559345',
           'feeCcy': 'USDT',
           'fillFee': '-0.01559345',
           'fillFeeCcy': 'USDT',
           'fillNotionalUsd': '31.192201773',
           'fillPnl': '0',
           'fillPx': '31186.9',
           'fillSz': '1',
           'fillTime': '1688640204597',
           'instId': 'BTC-USDT-SWAP',
           'instType': 'SWAP',
           'lever': '3',
           'msg': '',
           'notionalUsd': '31.815307683000004',
           'ordId': '597135530010165248',
           'ordType': 'market',
           'pnl': '0',
           'posSide': 'long',
           'px': '',
           'quickMgnType': '',
           'rebate': '0',
           'rebateCcy': 'USDT',
           'reduceOnly': 'false',
           'reqId': '',
           'side': 'buy',
           'slOrdPx': '',
           'slTriggerPx': '',
           'slTriggerPxType': '',
           'source': '',
           'state': 'filled',
           'stpId': '',
           'stpMode': '',
           'sz': '1',
           'tag': 'e847386590ce4dBC',
           'tdMode': 'cross',
           'tgtCcy': '',
           'tpOrdPx': '',
           'tpTriggerPx': '',
           'tpTriggerPxType': '',
           'tradeId': '684025383',
           'uTime': '1688640204597'},
  'lastTradeTimestamp': 1688640204597,
  'lastUpdateTimestamp': 1688640204597,
  'postOnly': None,
  'price': 31186.9,
  'reduceOnly': False,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1688640204596,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```
