### PR TITLE
feat(kraken): add transfer and transferOut

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -81,6 +81,7 @@ export default class kraken extends Exchange {
                 'setLeverage': false,
                 'setMarginMode': false, // Kraken only supports cross margin
                 'withdraw': true,
+                'transfer': true,
             },
             'timeframes': {
                 '1m': 1,

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -190,6 +190,7 @@ export default class kraken extends Exchange {
                         'WithdrawCancel': 3,
                         'WithdrawInfo': 3,
                         'WithdrawStatus': 3,
+                        'WalletTransfer': 3,
                         // staking
                         'Stake': 3,
                         'Unstake': 3,
@@ -2479,6 +2480,97 @@ export default class kraken extends Exchange {
         const result = this.safeValue (response, 'result');
         // todo unify parsePosition/parsePositions
         return result;
+    }
+
+    parseAccount (account) {
+        const accountByType = {
+            'spot': 'Spot Wallet',
+            'swap': 'Futures Wallet',
+            'future': 'Futures Wallet',
+        };
+        return this.safeString (accountByType, account, account);
+    }
+
+    async transferOut (code: string, amount, params = {}) {
+        /**
+         * @description transfer from spot wallet to futures wallet
+         * @param {str} code Unified currency code
+         * @param {float} amount Size of the transfer
+         * @param {dict} [params] Exchange specific parameters
+         * @returns a [transfer structure]{@link https://docs.ccxt.com/#/?id=transfer-structure}
+         */
+        return await this.transfer (code, amount, 'spot', 'swap', params);
+    }
+
+    async transfer (code: string, amount, fromAccount, toAccount, params = {}) {
+        /**
+         * @method
+         * @name kraken#transfer
+         * @see https://docs.kraken.com/rest/#tag/User-Funding/operation/walletTransfer
+         * @description transfers currencies between sub-accounts (only spot->swap direction is supported)
+         * @param {string} code Unified currency code
+         * @param {float} amount Size of the transfer
+         * @param {string} fromAccount 'spot' or 'Spot Wallet'
+         * @param {string} toAccount 'swap' or 'Futures Wallet'
+         * @param {object} [params] Exchange specific parameters
+         * @returns a [transfer structure]{@link https://docs.ccxt.com/#/?id=transfer-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        fromAccount = this.parseAccount (fromAccount);
+        toAccount = this.parseAccount (toAccount);
+        const request = {
+            'amount': this.currencyToPrecision (code, amount),
+            'from': fromAccount,
+            'to': toAccount,
+            'asset': currency['id'],
+        };
+        if (fromAccount !== 'Spot Wallet') {
+            throw new BadRequest (this.id + ' transfer cannot transfer from ' + fromAccount + ' to ' + toAccount + '. Use krakenfutures instead to transfer from the futures account.');
+        }
+        const response = await this.privatePostWalletTransfer (this.extend (request, params));
+        //
+        //   {
+        //       "error":[
+        //       ],
+        //       "result":{
+        //          "refid":"BOIUSIF-M7DLMN-UXZ3P5"
+        //       }
+        //   }
+        //
+        const transfer = this.parseTransfer (response, currency);
+        return this.extend (transfer, {
+            'amount': amount,
+            'fromAccount': fromAccount,
+            'toAccount': toAccount,
+        });
+    }
+
+    parseTransfer (transfer, currency = undefined) {
+        //
+        // transfer
+        //
+        //    {
+        //        "error":[
+        //        ],
+        //        "result":{
+        //           "refid":"BOIUSIF-M7DLMN-UXZ3P5"
+        //        }
+        //    }
+        //
+        const result = this.safeValue (transfer, 'result', {});
+        const refid = this.safeString (result, 'refid');
+        return {
+            'info': transfer,
+            'id': refid,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'currency': this.safeString (currency, 'code'),
+            'amount': undefined,
+            'fromAccount': undefined,
+            'toAccount': undefined,
+            'status': 'sucess',
+        };
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
DEMO

```
p kraken transfer "USDT" 1 spot swap
Python v3.10.9
CCXT v4.0.17
kraken.transfer(USDT,1,spot,swap)
{'amount': 1,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': 'Spot Wallet',
 'id': 'BOINU2Q-4PPWXH-55AFCC',
 'info': {'error': [], 'result': {'refid': 'BOINU2Q-4PPWXH-55AFCC'}},
 'status': 'sucess',
 'timestamp': None,
 'toAccount': 'Futures Wallet'}
```
