### PR TITLE
Delta: adjust option naming

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -645,7 +645,7 @@ export default class delta extends Exchange {
                             letter = 'M';
                             optionType = 'move';
                         }
-                        symbol = symbol + ':' + strike + ':' + letter;
+                        symbol = symbol + '-' + strike + '-' + letter;
                     } else {
                         type = 'future';
                     }

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -652,8 +652,6 @@ export default class delta extends Exchange {
                 } else {
                     type = 'swap';
                 }
-            } else {
-                symbol = id;
             }
             const state = this.safeString (market, 'state');
             result.push ({


### PR DESCRIPTION
Adjusted the option naming on delta to use hyphens instead of colons, changed from `BTC/USDT:USDT-230728:30000:C` to `BTC/USDT:USDT-230728-30000-C`