### PR TITLE
Delta: fetchFundingRate, fetchFundingRates

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -2309,6 +2309,7 @@ export default class delta extends Exchange {
          * @method
          * @name delta#fetchFundingRates
          * @description fetch the funding rate for multiple markets
+         * @see https://docs.delta.exchange/#get-tickers-for-products
          * @param {string[]|undefined} symbols list of unified market symbols
          * @param {object} [params] extra parameters specific to the delta api endpoint
          * @returns {object} a dictionary of [funding rates structures]{@link https://docs.ccxt.com/#/?id=funding-rates-structure}, indexe by market symbols

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -40,6 +40,7 @@ export default class delta extends Exchange {
                 'fetchDeposit': undefined,
                 'fetchDepositAddress': true,
                 'fetchDeposits': undefined,
+                'fetchFundingRate': true,
                 'fetchLedger': true,
                 'fetchLeverageTiers': false, // An infinite number of tiers, see examples/js/delta-maintenance-margin-rate-max-leverage.js
                 'fetchMarginMode': false,
@@ -2230,6 +2231,140 @@ export default class delta extends Exchange {
             'tag': this.safeString (depositAddress, 'memo'),
             'network': this.networkIdToCode (networkId),
             'info': depositAddress,
+        };
+    }
+
+    async fetchFundingRate (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name delta#fetchFundingRate
+         * @description fetch the current funding rate
+         * @see https://docs.delta.exchange/#get-ticker-for-a-product-by-symbol
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the delta api endpoint
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new BadSymbol (this.id + ' fetchFundingRate() supports swap contracts only');
+        }
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.publicGetTickersSymbol (this.extend (request, params));
+        //
+        //     {
+        //         "result": {
+        //             "close": 30600.5,
+        //             "contract_type": "perpetual_futures",
+        //             "funding_rate": "0.00602961",
+        //             "greeks": null,
+        //             "high": 30803.0,
+        //             "low": 30265.5,
+        //             "mark_basis": "-0.45601594",
+        //             "mark_price": "30600.10481568",
+        //             "oi": "469.9190",
+        //             "oi_change_usd_6h": "2226314.9900",
+        //             "oi_contracts": "469919",
+        //             "oi_value": "469.9190",
+        //             "oi_value_symbol": "BTC",
+        //             "oi_value_usd": "14385640.6802",
+        //             "open": 30458.5,
+        //             "price_band": {
+        //                 "lower_limit": "29067.08312627",
+        //                 "upper_limit": "32126.77608693"
+        //             },
+        //             "product_id": 139,
+        //             "quotes": {
+        //                 "ask_iv": null,
+        //                 "ask_size": "965",
+        //                 "best_ask": "30600.5",
+        //                 "best_bid": "30599.5",
+        //                 "bid_iv": null,
+        //                 "bid_size": "196",
+        //                 "impact_mid_price": null,
+        //                 "mark_iv": "-0.44931641"
+        //             },
+        //             "size": 1226303,
+        //             "spot_price": "30612.85362773",
+        //             "symbol": "BTCUSDT",
+        //             "timestamp": 1689136597460456,
+        //             "turnover": 37392218.45999999,
+        //             "turnover_symbol": "USDT",
+        //             "turnover_usd": 37392218.45999999,
+        //             "volume": 1226.3029999999485
+        //         },
+        //         "success": true
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        return this.parseFundingRate (result, market);
+    }
+
+    parseFundingRate (contract, market = undefined) {
+        //
+        //     {
+        //         "close": 30600.5,
+        //         "contract_type": "perpetual_futures",
+        //         "funding_rate": "0.00602961",
+        //         "greeks": null,
+        //         "high": 30803.0,
+        //         "low": 30265.5,
+        //         "mark_basis": "-0.45601594",
+        //         "mark_price": "30600.10481568",
+        //         "oi": "469.9190",
+        //         "oi_change_usd_6h": "2226314.9900",
+        //         "oi_contracts": "469919",
+        //         "oi_value": "469.9190",
+        //         "oi_value_symbol": "BTC",
+        //         "oi_value_usd": "14385640.6802",
+        //         "open": 30458.5,
+        //         "price_band": {
+        //             "lower_limit": "29067.08312627",
+        //             "upper_limit": "32126.77608693"
+        //         },
+        //         "product_id": 139,
+        //         "quotes": {
+        //             "ask_iv": null,
+        //             "ask_size": "965",
+        //             "best_ask": "30600.5",
+        //             "best_bid": "30599.5",
+        //             "bid_iv": null,
+        //             "bid_size": "196",
+        //             "impact_mid_price": null,
+        //             "mark_iv": "-0.44931641"
+        //         },
+        //         "size": 1226303,
+        //         "spot_price": "30612.85362773",
+        //         "symbol": "BTCUSDT",
+        //         "timestamp": 1689136597460456,
+        //         "turnover": 37392218.45999999,
+        //         "turnover_symbol": "USDT",
+        //         "turnover_usd": 37392218.45999999,
+        //         "volume": 1226.3029999999485
+        //     }
+        //
+        const timestamp = this.safeIntegerProduct (contract, 'timestamp', 0.001);
+        const marketId = this.safeString (contract, 'symbol');
+        return {
+            'info': contract,
+            'symbol': this.safeSymbol (marketId, market),
+            'markPrice': this.safeNumber (contract, 'mark_price'),
+            'indexPrice': this.safeNumber (contract, 'spot_price'),
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'fundingRate': this.safeNumber (contract, 'funding_rate'),
+            'fundingTimestamp': undefined,
+            'fundingDatetime': undefined,
+            'nextFundingRate': undefined,
+            'nextFundingTimestamp': undefined,
+            'nextFundingDatetime': undefined,
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
         };
     }
 


### PR DESCRIPTION
Added fetchFundingRate and fetchFundingRates to Delta:

### fetchFundingRate
```
delta.fetchFundingRate (BTC/USDT:USDT)
2023-07-13T06:11:29.925Z iteration 0 passed in 526 ms

{
  info: {
    close: '30318.5',
    contract_type: 'perpetual_futures',
    funding_rate: '0.00068232',
    greeks: null,
    high: '30976.0',
    low: '30193.0',
    mark_basis: '-0.38944781',
    mark_price: '30318.62724358',
    oi: '355.1860',
    oi_change_usd_6h: '323127.3300',
    oi_contracts: '355186',
    oi_value: '355.1860',
    oi_value_symbol: 'BTC',
    oi_value_usd: '10772385.3748',
    open: '30657.5',
    price_band: { lower_limit: '28799.68441457', upper_limit: '31831.23014241' },
    product_id: '139',
    quotes: {
      ask_iv: null,
      ask_size: '184',
      best_ask: '30318.5',
      best_bid: '30317.5',
      bid_iv: null,
      bid_size: '898',
      impact_mid_price: null,
      mark_iv: '-0.39899135'
    },
    size: '1331843',
    spot_price: '30329.18886961',
    symbol: 'BTCUSDT',
    timestamp: '1689228688516378',
    turnover: '40729092.42349991',
    turnover_symbol: 'USDT',
    turnover_usd: '40729092.42349991',
    volume: '1331.8429999999448'
  },
  symbol: 'BTC/USDT:USDT',
  markPrice: 30318.62724358,
  indexPrice: 30329.18886961,
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: 1689228688516,
  datetime: '2023-07-13T06:11:28.516Z',
  fundingRate: 0.00068232,
  fundingTimestamp: undefined,
  fundingDatetime: undefined,
  nextFundingRate: undefined,
  nextFundingTimestamp: undefined,
  nextFundingDatetime: undefined,
  previousFundingRate: undefined,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined
}
```

### fetchFundingRates
```
delta.fetchFundingRates (BTC/USDT:USDT,ETH/USDT:USDT)
2023-07-13T06:45:19.546Z iteration 0 passed in 677 ms

{
  'BTC/USDT:USDT': {
    info: {
      close: '30335.0',
      contract_type: 'perpetual_futures',
      funding_rate: '0.00068232',
      greeks: null,
      high: '30976.0',
      low: '30193.0',
      mark_basis: '-0.45017365',
      mark_price: '30336.07883351',
      oi: '353.2130',
      oi_change_usd_6h: '222312.1900',
      oi_contracts: '353213',
      oi_value: '353.2130',
      oi_value_symbol: 'BTC',
      oi_value_usd: '10719493.4450',
      open: '30726.5',
      price_band: { lower_limit: '28821.83274982', upper_limit: '31855.70988138' },
      product_id: '139',
      quotes: {
        ask_iv: null,
        ask_size: '1175',
        best_ask: '30335',
        best_bid: '30334',
        bid_iv: null,
        bid_size: '278',
        impact_mid_price: null,
        mark_iv: '-0.44161409'
      },
      size: '1290601',
      spot_price: '30348.63254556',
      symbol: 'BTCUSDT',
      timestamp: '1689230719454061',
      turnover: '39454635.82849997',
      turnover_symbol: 'USDT',
      turnover_usd: '39454635.82849997',
      volume: '1290.600999999945'
    },
    symbol: 'BTC/USDT:USDT',
    markPrice: 30336.07883351,
    indexPrice: 30348.63254556,
    interestRate: undefined,
    estimatedSettlePrice: undefined,
    timestamp: 1689230719454,
    datetime: '2023-07-13T06:45:19.454Z',
    fundingRate: 0.00068232,
    fundingTimestamp: undefined,
    fundingDatetime: undefined,
    nextFundingRate: undefined,
    nextFundingTimestamp: undefined,
    nextFundingDatetime: undefined,
    previousFundingRate: undefined,
    previousFundingTimestamp: undefined,
    previousFundingDatetime: undefined
  },
  'ETH/USDT:USDT': {
    info: {
      close: '1869.05',
      contract_type: 'perpetual_futures',
      funding_rate: '-0.00187927',
      greeks: null,
      high: '1901.0',
      low: '1861.9',
      mark_basis: '-0.49741478',
      mark_price: '1868.6392361',
      oi: '2345.3600',
      oi_change_usd_6h: '134564.5900',
      oi_contracts: '234536',
      oi_value: '2345.3600',
      oi_value_symbol: 'ETH',
      oi_value_usd: '4385836.9758',
      open: '1891.7',
      price_band: { lower_limit: '1775.68100246', upper_limit: '1962.5947922' },
      product_id: '176',
      quotes: {
        ask_iv: null,
        ask_size: '26',
        best_ask: '1868.6',
        best_bid: '1868.55',
        bid_iv: null,
        bid_size: '2167',
        impact_mid_price: null,
        mark_iv: '-0.50317789'
      },
      size: '722065',
      spot_price: '1869.49194038',
      symbol: 'ETHUSDT',
      timestamp: '1689230719454061',
      turnover: '13600956.389500033',
      turnover_symbol: 'USDT',
      turnover_usd: '13600956.389500033',
      volume: '7220.650000000044'
    },
    symbol: 'ETH/USDT:USDT',
    markPrice: 1868.6392361,
    indexPrice: 1869.49194038,
    interestRate: undefined,
    estimatedSettlePrice: undefined,
    timestamp: 1689230719454,
    datetime: '2023-07-13T06:45:19.454Z',
    fundingRate: -0.00187927,
    fundingTimestamp: undefined,
    fundingDatetime: undefined,
    nextFundingRate: undefined,
    nextFundingTimestamp: undefined,
    nextFundingDatetime: undefined,
    previousFundingRate: undefined,
    previousFundingTimestamp: undefined,
    previousFundingDatetime: undefined
  }
}
```