### PR TITLE
fix(gate) - remove createDepositAddress

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -77,7 +77,6 @@ export default class gate extends Exchange {
                 'borrowMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
-                'createDepositAddress': true,
                 'createMarketOrder': true,
                 'createOrder': true,
                 'createPostOnlyOrder': true,
@@ -1758,19 +1757,6 @@ export default class gate extends Exchange {
             };
         }
         return result;
-    }
-
-    async createDepositAddress (code: string, params = {}) {
-        /**
-         * @method
-         * @name gate#createDepositAddress
-         * @description create a currency deposit address
-         * @see https://www.gate.io/docs/developers/apiv4/en/#generate-currency-deposit-address
-         * @param {string} code unified currency code of the currency for the deposit address
-         * @param {object} [params] extra parameters specific to the gate api endpoint
-         * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
-         */
-        return await this.fetchDepositAddress (code, params);
     }
 
     async fetchDepositAddress (code: string, params = {}) {


### PR DESCRIPTION
this was unnecessary to be there at all. it should default to base's implementation of `createDepositAddress` (if you think that `cDA` should always go through `fDA`, then we should change base's `cDA`'s stub method implementation instead, as it now throws exception if exchange does not have native `cDA`). 

so, in gate it's obviously odd, and in base - it depends how you @lead decide.