### PR TITLE
base - missing python error

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -22,6 +22,7 @@ from ccxt.base.errors import BadSymbol
 from ccxt.base.errors import NullResponse
 from ccxt.base.errors import RateLimitExceeded
 from ccxt.base.errors import BadRequest
+from ccxt.base.errors import BadResponse
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
again, our IDE sees them, but we can't catch them during builds...
https://imgsh.net/a/z0GWnz4.png
we should do smth about this.