### PR TITLE
Okx: fetchSettlementHistory, handle expired market id

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6581,7 +6581,7 @@ export default class okx extends Exchange {
         const data = this.safeValue (response, 'data', []);
         const settlements = this.parseSettlements (data, market);
         const sorted = this.sortBy (settlements, 'timestamp');
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+        return this.filterBySymbolSinceLimit (sorted, market['symbol'], since, limit);
     }
 
     parseSettlement (settlement, market) {


### PR DESCRIPTION
Adjusted fetchSettlementHistory to handle expired market id's:
```
okx.fetchSettlementHistory (BTC-USD-230523-25750-C)
2023-07-18T02:19:33.833Z iteration 0 passed in 420 ms

                    symbol |              price |     timestamp |                 datetime
------------------------------------------------------------------------------------------
BTC/USD:BTC-230523-25750-C | 27290.148686700057 | 1684828800000 | 2023-05-23T08:00:00.000Z
1 objects
```