### PR TITLE
fix(base): python exchange ws close [ci deploy]

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -116,6 +116,7 @@ class Exchange(BaseExchange):
             self.session = aiohttp.ClientSession(loop=self.asyncio_loop, connector=connector, trust_env=self.aiohttp_trust_env)
 
     async def close(self):
+        await self.ws_close ()
         if self.session is not None:
             if self.own_session:
                 await self.session.close()
@@ -437,7 +438,6 @@ class Exchange(BaseExchange):
             await asyncio.wait([asyncio.create_task(client.close()) for client in self.clients.values()], return_when=asyncio.ALL_COMPLETED)
             for url in self.clients.copy():
                 del self.clients[url]
-        await super(Exchange, self).close()
 
     async def load_order_book(self, client, messageHash, symbol, limit=None, params={}):
         if symbol not in self.orderbooks:

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -116,7 +116,7 @@ class Exchange(BaseExchange):
             self.session = aiohttp.ClientSession(loop=self.asyncio_loop, connector=connector, trust_env=self.aiohttp_trust_env)
 
     async def close(self):
-        await self.ws_close ()
+        await self.ws_close()
         if self.session is not None:
             if self.own_session:
                 await self.session.close()


### PR DESCRIPTION
This PR changes the python `exchange.close()` to also close the websocket clients when calling `exchange.close()`.

Note: I used an existing function `ws_close` . Even though the function isin't in typescript or php, I decided to maintain it to be as backward compatible as possible and just in case any users call it.

To reproduce the error run the following:
```python
    ob = await exchange.watch_order_book('BTC/USDT')
    await exchange.close()
    print('------------ Will reconnect ------------')
    ob = await exchange.watch_order_book('BTC/USDT') ## throws an error 1006
```
    
    