### PR TITLE
Delta: enable sandboxMode testnet

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -195,6 +195,7 @@ export default class delta extends Exchange {
                     'TRC20': 'TRC20(TRON)',
                     'BEP20': 'BEP20(BSC)',
                 },
+                'sandboxMode': false,
             },
             'precisionMode': TICK_SIZE,
             'requiredCredentials': {
@@ -222,6 +223,11 @@ export default class delta extends Exchange {
                 },
             },
         });
+    }
+
+    setSandboxMode (enable) {
+        super.setSandboxMode (enable);
+        this.options['sandboxMode'] = enable;
     }
 
     async fetchTime (params = {}) {
@@ -2434,6 +2440,8 @@ export default class delta extends Exchange {
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         const requestPath = '/' + this.version + '/' + this.implodeParams (path, params);
+        const sandboxMode = this.safeValue (this.options, 'sandboxMode', false);
+        this.setSandboxMode (sandboxMode);
         let url = this.urls['api'][api] + requestPath;
         const query = this.omit (params, this.extractParams (path));
         if (api === 'public') {


### PR DESCRIPTION
Added sandboxMode testnet functionality to delta:
```
delta GET https://testnet-api.delta.exchange/v2/wallet/balances 200 OK

{
  info: {
    meta: { net_equity: '42724.86925305', robo_trading_equity: '0' },
    result: [
      {
        asset_id: '1',
        asset_symbol: 'ETH',
        available_balance: '10',
        available_balance_for_robo: '10',
        balance: '10',
        commission: '0',
        cross_commission: '0',
        cross_locked_collateral: '0',
        cross_order_margin: '0',
        cross_position_margin: '0',
        id: '138411',
        interest_credit: '0',
        order_margin: '0',
        pending_referral_bonus: '0',
        pending_trading_fee_credit: '0',
        portfolio_margin: '0',
        position_margin: '0',
        trading_fee_credit: '0',
        unvested_amount: '0',
        user_id: '30084879'
      },
      ...
    ],
    success: true
  },
  ETH: { free: 10, used: 0, total: 10 },
  BTC: { free: 0.25, used: 0, total: 0.25 },
  USDT: { free: 15000, used: 0, total: 15000 },
  XRP: { free: 100, used: 0, total: 100 },
  USDC: { free: 1000, used: 0, total: 1000 },
  DETO: { free: 0, used: 0, total: 0 },
  free: { ETH: 10, BTC: 0.25, USDT: 15000, XRP: 100, USDC: 1000, DETO: 0 },
  used: { ETH: 0, BTC: 0, USDT: 0, XRP: 0, USDC: 0, DETO: 0 },
  total: { ETH: 10, BTC: 0.25, USDT: 15000, XRP: 100, USDC: 1000, DETO: 0 }
}
```