### PR TITLE
fix(bitfinex2): protect handleErrors

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -2508,7 +2508,7 @@ export default class bitfinex2 extends Exchange {
         }
         if (statusCode === 500) {
             // See https://docs.bitfinex.com/docs/abbreviations-glossary#section-errorinfo-codes
-            const errorCode = this.safeString (response[1], '');
+            const errorCode = this.safeString (response, 1, '');
             const errorText = this.safeString (response, 2, '');
             const feedback = this.id + ' ' + errorText;
             this.throwBroadlyMatchedException (this.exceptions['broad'], errorText, feedback);

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -2508,10 +2508,7 @@ export default class bitfinex2 extends Exchange {
         }
         if (statusCode === 500) {
             // See https://docs.bitfinex.com/docs/abbreviations-glossary#section-errorinfo-codes
-            let errorCode = this.numberToString (response[1]);
-            if (errorCode === undefined) {
-                errorCode = '';
-            }
+            const errorCode = this.safeString (response[1], '');
             const errorText = this.safeString (response, 2, '');
             const feedback = this.id + ' ' + errorText;
             this.throwBroadlyMatchedException (this.exceptions['broad'], errorText, feedback);

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -2508,8 +2508,11 @@ export default class bitfinex2 extends Exchange {
         }
         if (statusCode === 500) {
             // See https://docs.bitfinex.com/docs/abbreviations-glossary#section-errorinfo-codes
-            const errorCode = this.numberToString (response[1]);
-            const errorText = response[2];
+            let errorCode = this.numberToString (response[1]);
+            if (errorCode === undefined) {
+                errorCode = '';
+            }
+            const errorText = this.safeString (response, 2, '');
             const feedback = this.id + ' ' + errorText;
             this.throwBroadlyMatchedException (this.exceptions['broad'], errorText, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);


### PR DESCRIPTION
- Protecting agains this error message `['error', None, 'ERR_RATE_LIMIT']` 
- fixes https://github.com/ccxt/ccxt/issues/18600