### PR TITLE
Delta: fetchOpenInterest

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -50,6 +50,7 @@ export default class delta extends Exchange {
                 'fetchMarkets': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterest': true,
                 'fetchOpenOrders': true,
                 'fetchOrderBook': true,
                 'fetchPosition': true,
@@ -2429,6 +2430,145 @@ export default class delta extends Exchange {
             'previousFundingRate': undefined,
             'previousFundingTimestamp': undefined,
             'previousFundingDatetime': undefined,
+        };
+    }
+
+    async fetchOpenInterest (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name delta#fetchOpenInterest
+         * @description retrieves the open interest of a derivative market
+         * @see https://docs.delta.exchange/#get-ticker-for-a-product-by-symbol
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] exchange specific parameters
+         * @returns {object} an open interest structure{@link https://docs.ccxt.com/#/?id=interest-history-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['contract']) {
+            throw new BadRequest (this.id + ' fetchOpenInterest() supports contract markets only');
+        }
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.publicGetTickersSymbol (this.extend (request, params));
+        //
+        //     {
+        //         "result": {
+        //             "close": 894.0,
+        //             "contract_type": "call_options",
+        //             "greeks": {
+        //                 "delta": "0.67324861",
+        //                 "gamma": "0.00022178",
+        //                 "rho": "4.34638266",
+        //                 "spot": "30178.53195697",
+        //                 "theta": "-35.64972577",
+        //                 "vega": "16.34381277"
+        //             },
+        //             "high": 946.0,
+        //             "low": 893.0,
+        //             "mark_price": "1037.07582681",
+        //             "mark_vol": "0.35899491",
+        //             "oi": "0.0910",
+        //             "oi_change_usd_6h": "-90.5500",
+        //             "oi_contracts": "91",
+        //             "oi_value": "0.0910",
+        //             "oi_value_symbol": "BTC",
+        //             "oi_value_usd": "2746.3549",
+        //             "open": 946.0,
+        //             "price_band": {
+        //                 "lower_limit": "133.37794509",
+        //                 "upper_limit": "5663.66930164"
+        //             },
+        //             "product_id": 116171,
+        //             "quotes": {
+        //                 "ask_iv": "0.36932389",
+        //                 "ask_size": "1321",
+        //                 "best_ask": "1054",
+        //                 "best_bid": "1020",
+        //                 "bid_iv": "0.34851914",
+        //                 "bid_size": "2202",
+        //                 "impact_mid_price": null,
+        //                 "mark_iv": "0.35896335"
+        //             },
+        //             "size": 152,
+        //             "spot_price": "30178.53195697",
+        //             "strike_price": "29500",
+        //             "symbol": "C-BTC-29500-280723",
+        //             "timestamp": 1689834695286094,
+        //             "turnover": 4546.601744940001,
+        //             "turnover_symbol": "USDT",
+        //             "turnover_usd": 4546.601744940001,
+        //             "volume": 0.15200000000000002
+        //         },
+        //         "success": true
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        return this.parseOpenInterest (result, market);
+    }
+
+    parseOpenInterest (interest, market = undefined) {
+        //
+        //     {
+        //         "close": 894.0,
+        //         "contract_type": "call_options",
+        //         "greeks": {
+        //             "delta": "0.67324861",
+        //             "gamma": "0.00022178",
+        //             "rho": "4.34638266",
+        //             "spot": "30178.53195697",
+        //             "theta": "-35.64972577",
+        //             "vega": "16.34381277"
+        //         },
+        //         "high": 946.0,
+        //         "low": 893.0,
+        //         "mark_price": "1037.07582681",
+        //         "mark_vol": "0.35899491",
+        //         "oi": "0.0910",
+        //         "oi_change_usd_6h": "-90.5500",
+        //         "oi_contracts": "91",
+        //         "oi_value": "0.0910",
+        //         "oi_value_symbol": "BTC",
+        //         "oi_value_usd": "2746.3549",
+        //         "open": 946.0,
+        //         "price_band": {
+        //             "lower_limit": "133.37794509",
+        //             "upper_limit": "5663.66930164"
+        //         },
+        //         "product_id": 116171,
+        //         "quotes": {
+        //             "ask_iv": "0.36932389",
+        //             "ask_size": "1321",
+        //             "best_ask": "1054",
+        //             "best_bid": "1020",
+        //             "bid_iv": "0.34851914",
+        //             "bid_size": "2202",
+        //             "impact_mid_price": null,
+        //             "mark_iv": "0.35896335"
+        //         },
+        //         "size": 152,
+        //         "spot_price": "30178.53195697",
+        //         "strike_price": "29500",
+        //         "symbol": "C-BTC-29500-280723",
+        //         "timestamp": 1689834695286094,
+        //         "turnover": 4546.601744940001,
+        //         "turnover_symbol": "USDT",
+        //         "turnover_usd": 4546.601744940001,
+        //         "volume": 0.15200000000000002
+        //     }
+        //
+        const timestamp = this.safeIntegerProduct (interest, 'timestamp', 0.001);
+        const marketId = this.safeString (interest, 'symbol');
+        return {
+            'symbol': this.safeSymbol (marketId, market),
+            'baseVolume': this.safeNumber (interest, 'oi_value'),
+            'quoteVolume': this.safeNumber (interest, 'oi_value_usd'),
+            'openInterestAmount': this.safeNumber (interest, 'oi_contracts'),
+            'openInterestValue': this.safeNumber (interest, 'oi'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
         };
     }
 


### PR DESCRIPTION
Added fetchOpenInterest to Delta:
```
delta.fetchOpenInterest (BTC/USDT:USDT-230728-29500-C)
2023-07-20T06:41:17.222Z iteration 0 passed in 529 ms

{
  symbol: 'BTC/USDT:USDT-230728-29500-C',
  baseVolume: 0.091,
  quoteVolume: 2741.9589,
  openInterestAmount: 91,
  openInterestValue: 0.091,
  timestamp: 1689835277112,
  datetime: '2023-07-20T06:41:17.112Z',
  info: {
    close: '894.0',
    contract_type: 'call_options',
    greeks: {
      delta: '0.66242859',
      gamma: '0.00022518',
      rho: '4.26942945',
      spot: '30129.70748447',
      theta: '-36.06087577',
      vega: '16.52302934'
    },
    high: '946.0',
    low: '893.0',
    mark_price: '1003.77834472',
    mark_vol: '0.35875498',
    oi: '0.0910',
    oi_change_usd_6h: '-90.4000',
    oi_contracts: '91',
    oi_value: '0.0910',
    oi_value_symbol: 'BTC',
    oi_value_usd: '2741.9589',
    open: '946.0',
    price_band: { lower_limit: '98.74351172', upper_limit: '5630.13895143' },
    product_id: '116171',
    quotes: {
      ask_iv: '0.36912311',
      ask_size: '1323',
      best_ask: '1021',
      best_bid: '987',
      bid_iv: '0.34854427',
      bid_size: '2206',
      impact_mid_price: null,
      mark_iv: '0.35875422'
    },
    size: '152',
    spot_price: '30129.62619471',
    strike_price: '29500',
    symbol: 'C-BTC-29500-280723',
    timestamp: '1689835277112446',
    turnover: '4546.601744940001',
    turnover_symbol: 'USDT',
    turnover_usd: '4546.601744940001',
    volume: '0.15200000000000002'
  }
}
```