### PR TITLE
add - network prop

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -247,6 +247,7 @@ export default class bingx extends Exchange {
                     'PFUTURES': 'swap',
                     'SFUTURES': 'future',
                 },
+                'networks': {},
             },
         });
     }

--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -163,6 +163,7 @@ export default class bit2c extends Exchange {
             },
             'options': {
                 'fetchTradesMethod': 'public_get_exchanges_pair_trades',
+                'networks': {},
             },
             'precisionMode': TICK_SIZE,
             'exceptions': {

--- a/ts/src/bitbns.ts
+++ b/ts/src/bitbns.ts
@@ -151,6 +151,9 @@ export default class bitbns extends Exchange {
                 },
                 'broad': {},
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -392,6 +392,7 @@ export default class bitfinex extends Exchange {
                     'funding': 'deposit',
                     'swap': 'trading',
                 },
+                'networks': {},
             },
         });
     }

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -333,6 +333,7 @@ export default class bitfinex2 extends Exchange {
                 'withdraw': {
                     'includeFee': false,
                 },
+                'networks': {},
             },
             'exceptions': {
                 'exact': {

--- a/ts/src/bitflyer.ts
+++ b/ts/src/bitflyer.ts
@@ -114,6 +114,9 @@ export default class bitflyer extends Exchange {
                 },
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/bitforex.ts
+++ b/ts/src/bitforex.ts
@@ -151,6 +151,9 @@ export default class bitforex extends Exchange {
                 '4004': OrderNotFound,
                 '10204': DDoSProtection,
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -164,6 +164,7 @@ export default class bithumb extends Exchange {
                         },
                     },
                 },
+                'networks': {},
             },
             'commonCurrencies': {
                 'ALT': 'ArchLoot',

--- a/ts/src/bitpanda.ts
+++ b/ts/src/bitpanda.ts
@@ -291,6 +291,7 @@ export default class bitpanda extends Exchange {
                     'method': 'fetchPrivateTradingFees', // or 'fetchPublicTradingFees'
                 },
                 'fiat': [ 'EUR', 'CHF' ],
+                'networks': {},
             },
         });
     }

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -108,6 +108,7 @@ export default class bitso extends Exchange {
                     'TUSD': 0.01,
                 },
                 'defaultPrecision': 0.00000001,
+                'networks': {},
             },
             'timeframes': {
                 '1m': '60',

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -423,6 +423,9 @@ export default class bitstamp extends Exchange {
                     'Ensure that there are no more than': InvalidOrder, // {"status": "error", "reason": {"amount": ["Ensure that there are no more than 0 decimal places."], "__all__": [""]}}
                 },
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/bitstamp1.ts
+++ b/ts/src/bitstamp1.ts
@@ -123,6 +123,9 @@ export default class bitstamp1 extends Exchange {
                 'ETH/EUR': { 'id': 'etheur', 'symbol': 'ETH/EUR', 'base': 'ETH', 'quote': 'EUR', 'baseId': 'eth', 'quoteId': 'eur', 'maker': 0.005, 'taker': 0.005, 'type': 'spot', 'spot': true },
                 'ETH/BTC': { 'id': 'ethbtc', 'symbol': 'ETH/BTC', 'base': 'ETH', 'quote': 'BTC', 'baseId': 'eth', 'quoteId': 'btc', 'maker': 0.005, 'taker': 0.005, 'type': 'spot', 'spot': true },
             },
+            'optioins': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -266,6 +266,7 @@ export default class bittrex extends Exchange {
                 // 'fetchClosedOrdersMethod': 'fetch_closed_orders_v3',
                 'fetchClosedOrdersFilterBySince': true,
                 // 'createOrderMethod': 'create_order_v1',
+                'networks': {},
             },
             'commonCurrencies': {
                 'BIFI': 'Bifrost Finance',

--- a/ts/src/bl3p.ts
+++ b/ts/src/bl3p.ts
@@ -107,6 +107,9 @@ export default class bl3p extends Exchange {
                 'BTC/EUR': { 'id': 'BTCEUR', 'symbol': 'BTC/EUR', 'base': 'BTC', 'quote': 'EUR', 'baseId': 'BTC', 'quoteId': 'EUR', 'maker': 0.0025, 'taker': 0.0025, 'type': 'spot', 'spot': true },
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/btcbox.ts
+++ b/ts/src/btcbox.ts
@@ -118,6 +118,9 @@ export default class btcbox extends Exchange {
                 '401': OrderNotFound, // cancel canceled, closed or non-existent order
                 '402': DDoSProtection,
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/btcturk.ts
+++ b/ts/src/btcturk.ts
@@ -131,6 +131,9 @@ export default class btcturk extends Exchange {
                 },
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/coinbasepro.ts
+++ b/ts/src/coinbasepro.ts
@@ -225,6 +225,9 @@ export default class coinbasepro extends Exchange {
                     'Cancel only mode': OnMaintenance, // https://github.com/ccxt/ccxt/issues/7690
                 },
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/coincheck.ts
+++ b/ts/src/coincheck.ts
@@ -163,6 +163,9 @@ export default class coincheck extends Exchange {
                 },
                 'broad': {},
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -294,6 +294,7 @@ export default class coinex extends Exchange {
                 'accountsById': {
                     'spot': '0',
                 },
+                'networks': {},
             },
             'commonCurrencies': {
                 'ACM': 'Actinium',

--- a/ts/src/coinfalcon.ts
+++ b/ts/src/coinfalcon.ts
@@ -131,6 +131,9 @@ export default class coinfalcon extends Exchange {
                 },
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/coinmate.ts
+++ b/ts/src/coinmate.ts
@@ -189,6 +189,7 @@ export default class coinmate extends Exchange {
                         'DAI': 'privatePostDaiWithdrawal',
                     },
                 },
+                'networks': {},
             },
             'exceptions': {
                 'exact': {

--- a/ts/src/coinone.ts
+++ b/ts/src/coinone.ts
@@ -135,6 +135,9 @@ export default class coinone extends Exchange {
             'commonCurrencies': {
                 'SOC': 'Soda Coin',
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/coinspot.ts
+++ b/ts/src/coinspot.ts
@@ -132,6 +132,7 @@ export default class coinspot extends Exchange {
             },
             'options': {
                 'fetchBalance': 'private_post_my_balances',
+                'networks': {},
             },
             'precisionMode': TICK_SIZE,
         });

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -392,6 +392,7 @@ export default class deribit extends Exchange {
                 'transfer': {
                     'method': 'privateGetSubmitTransferToSubaccount', // or 'privateGetSubmitTransferToUser'
                 },
+                'networks': {},
             },
         });
     }

--- a/ts/src/idex.ts
+++ b/ts/src/idex.ts
@@ -154,6 +154,7 @@ export default class idex extends Exchange {
                 'defaultTimeInForce': 'gtc',
                 'defaultSelfTradePrevention': 'cn',
                 'network': 'MATIC',
+                'networks': {},
             },
             'exceptions': {
                 'INVALID_ORDER_QUANTITY': InvalidOrder,

--- a/ts/src/independentreserve.ts
+++ b/ts/src/independentreserve.ts
@@ -135,6 +135,9 @@ export default class independentreserve extends Exchange {
                 'PLA': 'PlayChip',
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -157,6 +157,7 @@ export default class indodax extends Exchange {
                 'recvWindow': 5 * 1000, // default 5 sec
                 'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
+                'networks': {},
             },
             'commonCurrencies': {
                 'STR': 'XLM',

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -208,6 +208,7 @@ export default class krakenfutures extends Exchange {
                         },
                     },
                 },
+                'networks': {},
             },
             'timeframes': {
                 '1m': '1m',

--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -212,6 +212,7 @@ export default class latoken extends Exchange {
                 'fetchTradingFee': {
                     'method': 'fetchPrivateTradingFee', // or 'fetchPublicTradingFee'
                 },
+                'networks': {},
             },
         });
     }

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -142,6 +142,7 @@ export default class lbank extends Exchange {
             },
             'options': {
                 'cacheSecretAsPem': true,
+                'networks': {},
             },
             'precisionMode': TICK_SIZE,
         });

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -156,6 +156,9 @@ export default class luno extends Exchange {
                 },
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/lykke.ts
+++ b/ts/src/lykke.ts
@@ -178,6 +178,9 @@ export default class lykke extends Exchange {
             },
             'commonCurrencies': {
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/mercado.ts
+++ b/ts/src/mercado.ts
@@ -149,6 +149,7 @@ export default class mercado extends Exchange {
                     'LTC': 0.01,
                     'XRP': 0.1,
                 },
+                'networks': {},
             },
             'precisionMode': TICK_SIZE,
         });

--- a/ts/src/novadax.ts
+++ b/ts/src/novadax.ts
@@ -195,6 +195,7 @@ export default class novadax extends Exchange {
                 'transfer': {
                     'fillResponseFromRequest': true,
                 },
+                'networks': {},
             },
         });
     }

--- a/ts/src/oceanex.ts
+++ b/ts/src/oceanex.ts
@@ -145,6 +145,9 @@ export default class oceanex extends Exchange {
                     'The account does not exist': AuthenticationError,
                 },
             },
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/paymium.ts
+++ b/ts/src/paymium.ts
@@ -111,6 +111,9 @@ export default class paymium extends Exchange {
                 },
             },
             'precisionMode': TICK_SIZE,
+            'options': {
+                'networks': {},
+            },
         });
     }
 

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -257,6 +257,7 @@ export default class timex extends Exchange {
                 },
                 'defaultSort': 'timestamp,asc',
                 'defaultSortOrders': 'createdAt,asc',
+                'networks': {},
             },
         });
     }

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -182,6 +182,7 @@ export default class upbit extends Exchange {
                 'tradingFeesByQuoteCurrency': {
                     'KRW': 0.0005,
                 },
+                'networks': {},
             },
             'commonCurrencies': {
                 'TON': 'Tokamak Network',

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -229,6 +229,7 @@ export default class whitebit extends Exchange {
                     'margin': 'collateral',
                     'trade': 'spot',
                 },
+                'networks': {},
                 'networksById': {
                     'BEP20': 'BSC',
                 },

--- a/ts/src/zonda.ts
+++ b/ts/src/zonda.ts
@@ -254,6 +254,7 @@ export default class zonda extends Exchange {
                 'transfer': {
                     'fillResponseFromRequest': true,
                 },
+                'networks': {},
             },
             'precisionMode': TICK_SIZE,
             'exceptions': {


### PR DESCRIPTION
from now onwards, I'll be adding tests and to comply with it, exchanges should have `networks` prop under options.
I could have "defaulted" that from base too, but it's better that each exchange has already prepared `networks` prop so users/we could easily see and add networks there. networks are essential part of exchanges so "describe" signature should contain it (in future we might move it out from options one level up in hierarchy)