### PR TITLE
fix(okx): open interest timestamp

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6461,7 +6461,7 @@ export default class okx extends Exchange {
         const id = this.safeString (interest, 'instId');
         market = this.safeMarket (id, market);
         const time = this.safeInteger (interest, 'ts');
-        const timestamp = this.safeNumber (interest, 0, time);
+        const timestamp = this.safeInteger (interest, 0, time);
         let baseVolume = undefined;
         let quoteVolume = undefined;
         let openInterestAmount = undefined;


### PR DESCRIPTION
DEMO

```
Python v3.10.9
CCXT v4.0.33
okx.fetchOpenInterestHistory(BTC/USDT:USDT)
[{'baseVolume': None,
  'datetime': '2023-01-22T16:00:00.000Z',
  'info': ['1674403200000', '1806967760.2192', '3017398324.7053'],
  'openInterestAmount': None,
  'openInterestValue': 1806967760.2192,
  'quoteVolume': 3017398324.7053,
  'symbol': None,
  'timestamp': 1674403200000},
 {'baseVolume': None,
  'datetime': '2023-01-23T16:00:00.000Z',
  'info': ['1674489600000', '1783316159.7797', '3321450927.246'],
  'openInterestAmount': None,
  'openInterestValue': 1783316159.7797,
  'quoteVolume': 3321450927.246,
  'symbol': None,
  'timestamp': 1674489600000},
```
