### PR TITLE
feat(huobi): fetchOpenInterestHistory default required value

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -7319,10 +7319,7 @@ export default class huobi extends Exchange {
             '1d': '1day',
         };
         const market = this.market (symbol);
-        const amountType = this.safeNumber2 (params, 'amount_type', 'amountType');
-        if (amountType === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOpenInterestHistory requires parameter params.amountType to be either 1 (cont), or 2 (cryptocurrency)');
-        }
+        const amountType = this.safeInteger2 (params, 'amount_type', 'amountType', 2);
         const request = {
             'period': timeframes[timeframe],
             'amount_type': amountType,


### PR DESCRIPTION
```
Python v3.10.9
CCXT v4.0.33
huobi.fetchOpenInterestHistory(BTC/USDT:USDT)
[{'baseVolume': 3480.067,
  'datetime': '2023-07-19T14:00:00.000Z',
  'info': {'amount_type': '2',
           'ts': '1689775200000',
           'value': '103696600.41910000000000000',
           'volume': '3480.0670000000000000'},
  'openInterestAmount': 3480.067,
  'openInterestValue': 103696600.4191,
  'quoteVolume': 103696600.4191,
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1689775200000},
 {'baseVolume': 3482.47,
```
