### PR TITLE
fix(base): emulated fetchMarketLeverageTiers

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3789,7 +3789,7 @@ export default class Exchange {
 
     async fetchMarketLeverageTiers (symbol: string, params = {}) {
         if (this.has['fetchLeverageTiers']) {
-            const market = await this.market (symbol);
+            const market = this.market (symbol);
             if (!market['contract']) {
                 throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() supports contract markets only');
             }

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -3877,6 +3877,13 @@ export default class phemex extends Exchange {
          * @returns {object} a dictionary of [leverage tiers structures]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}, indexed by market symbols
          */
         await this.loadMarkets ();
+        if (symbols !== undefined) {
+            const first = this.safeValue (symbols, 0);
+            const market = this.market (first);
+            if (market['settle'] !== 'USD') {
+                throw new BadSymbol (this.id + ' fetchLeverageTiers() supports USD settled markets only');
+            }
+        }
         const response = await this.publicGetCfgV2Products (params);
         //
         //     {


### PR DESCRIPTION
DEMO

```
p phemex fetchMarketLeverageTiers "LTC/USD:USD"  
Python v3.10.9
CCXT v4.0.33
phemex.fetchMarketLeverageTiers(LTC/USD:USD)
[{'currency': 'USD',
  'info': {'initialMargin': '2.0%',
           'initialMarginEr': '2000000',
           'limit': '200000',
           'maintenanceMargin': '1.0%',
           'maintenanceMarginEr': '1000000'},
  'maintenanceMarginRate': '1.0%',
  'maxLeverage': None,
  'maxNotional': 200000,
  'minNotional': 0,
  'tier': 1},
 {'currency': 'USD',
  'info': {'initialMargin': '3.0%',
           'initialMarginEr': '3000000',
           'limit': '800000',
           'maintenanceMargin': '1.5%',
           'maintenanceMarginEr': '1500000'},
  'maintenanceMarginRate': '1.5%',
  'maxLeverage': None,
  'maxNotional': 800000,
  'minNotional': 200000,
  'tier': 2},
 {'currency': 'USD',
  'info': {'initialMargin': '4.0%',
           'initialMarginEr': '4000000',
           'limit': '1400000',
           'maintenanceMargin': '2.0%',
           'maintenanceMarginEr': '2000000'},
  'maintenanceMarginRate': '2.0%',
  'maxLeverage': None,
  'maxNotional': 1400000,
  'minNotional': 800000,
  'tier': 3},
 {'currency': 'USD',
  'info': {'initialMargin': '5.0%',
           'initialMarginEr': '5000000',
           'limit': '2000000',
           'maintenanceMargin': '2.5%',
           'maintenanceMarginEr': '2500000'},
  'maintenanceMarginRate': '2.5%',
  'maxLeverage': None,
  'maxNotional': 2000000,
  'minNotional': 1400000,
  'tier': 4},
 {'currency': 'USD',
  'info': {'initialMargin': '6.0%',
           'initialMarginEr': '6000000',
           'limit': '2600000',
           'maintenanceMargin': '3.0%',
           'maintenanceMarginEr': '3000000'},
  'maintenanceMarginRate': '3.0%',
  'maxLeverage': None,
  'maxNotional': 2600000,
  'minNotional': 2000000,
  'tier': 5},
 {'currency': 'USD',
  'info': {'initialMargin': '7.0%',
           'initialMarginEr': '7000000',
           'limit': '3200000',
           'maintenanceMargin': '3.5%',
           'maintenanceMarginEr': '3500000'},
  'maintenanceMarginRate': '3.5%',
  'maxLeverage': None,
  'maxNotional': 3200000,
  'minNotional': 2600000,
  'tier': 6},
 {'currency': 'USD',
  'info': {'initialMargin': '8.0%',
           'initialMarginEr': '8000000',
           'limit': '3800000',
           'maintenanceMargin': '4.0%',
           'maintenanceMarginEr': '4000000'},
  'maintenanceMarginRate': '4.0%',
  'maxLeverage': None,
  'maxNotional': 3800000,
  'minNotional': 3200000,
  'tier': 7},
 {'currency': 'USD',
  'info': {'initialMargin': '9.0%',
           'initialMarginEr': '9000000',
           'limit': '4400000',
           'maintenanceMargin': '4.5%',
           'maintenanceMarginEr': '4500000'},
  'maintenanceMarginRate': '4.5%',
  'maxLeverage': None,
  'maxNotional': 4400000,
  'minNotional': 3800000,
  'tier': 8},
 {'currency': 'USD',
  'info': {'initialMargin': '10.0%',
           'initialMarginEr': '10000000',
           'limit': '5000000',
           'maintenanceMargin': '5.0%',
           'maintenanceMarginEr': '5000000'},
  'maintenanceMarginRate': '5.0%',
  'maxLeverage': None,
  'maxNotional': 5000000,
  'minNotional': 4400000,
  'tier': 9},
 {'currency': 'USD',
  'info': {'initialMargin': '11.0%',
           'initialMarginEr': '11000000',
           'limit': '5600000',
           'maintenanceMargin': '5.5%',
           'maintenanceMarginEr': '5500000'},
  'maintenanceMarginRate': '5.5%',
  'maxLeverage': None,
  'maxNotional': 5600000,
  'minNotional': 5000000,
  'tier': 10}]
```
