### PR TITLE
fix(coinex): setLeverage limits and refactor

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3263,7 +3263,7 @@ export default class coinex extends Exchange {
         this.checkRequiredSymbol ('setLeverage', symbol);
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (!market['type']) {
+        if (!market['swap']) {
             throw new BadSymbol (this.id + ' setLeverage() supports swap contracts only');
         }
         let marginMode = undefined;

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3252,34 +3252,32 @@ export default class coinex extends Exchange {
         /**
          * @method
          * @name coinex#setLeverage
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http014_adjust_leverage
          * @description set the level of leverage for a market
          * @param {float} leverage the rate of leverage
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the coinex api endpoint
+         * @param {string} [params.marginMode] 'cross' or 'isolated' (default is 'cross')
          * @returns {object} response from the exchange
          */
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
-        }
+        this.checkRequiredSymbol ('setLeverage', symbol);
         await this.loadMarkets ();
-        const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode');
-        let defaultPositionType = undefined;
-        if (defaultMarginMode === 'isolated') {
-            defaultPositionType = 1;
-        } else if (defaultMarginMode === 'cross') {
-            defaultPositionType = 2;
-        }
-        const positionType = this.safeInteger (params, 'position_type', defaultPositionType);
-        if (positionType === undefined) {
-            throw new ArgumentsRequired (this.id + ' setLeverage() requires a position_type parameter that will transfer margin to the specified trading pair');
-        }
         const market = this.market (symbol);
-        const maxLeverage = this.safeInteger (market['limits']['leverage'], 'max', 100);
-        if (market['type'] !== 'swap') {
+        if (!market['type']) {
             throw new BadSymbol (this.id + ' setLeverage() supports swap contracts only');
         }
-        if ((leverage < 3) || (leverage > maxLeverage)) {
-            throw new BadRequest (this.id + ' setLeverage() leverage should be between 3 and ' + maxLeverage.toString () + ' for ' + symbol);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('setLeverage', params, 'cross');
+        let positionType = undefined;
+        if (marginMode === 'isolated') {
+            positionType = 1;
+        } else if (marginMode === 'cross') {
+            positionType = 2;
+        }
+        const minLeverage = this.safeInteger (market['limits']['leverage'], 'min', 1);
+        const maxLeverage = this.safeInteger (market['limits']['leverage'], 'max', 100);
+        if ((leverage < minLeverage) || (leverage > maxLeverage)) {
+            throw new BadRequest (this.id + ' setLeverage() leverage should be between ' + minLeverage.toString () + ' and ' + maxLeverage.toString () + ' for ' + symbol);
         }
         const request = {
             'market': market['id'],


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18630

DEMO

```
✗ n coinex setLeverage 2 "LTC/USDT:USDT" 
Debugger attached.
2023-07-24T09:03:07.998Z
Node.js: v18.14.0
CCXT v4.0.35
coinex.setLeverage (2, LTC/USDT:USDT)
2023-07-24T09:03:12.845Z iteration 0 passed in 3556 ms

{
  code: '0',
  data: { leverage: '2', position_type: '2', settle_switch: '2' },
  message: 'OK'
}
2023-07-24T09:03:12.845Z iteration 1 passed in 3556 ms
```
