### PR TITLE
Delta: fetchMarkOHLCV, fetchIndexOHLCV

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -44,6 +44,7 @@ export default class delta extends Exchange {
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': false,
                 'fetchFundingRates': true,
+                'fetchIndexOHLCV': true,
                 'fetchLedger': true,
                 'fetchLeverageTiers': false, // An infinite number of tiers, see examples/js/delta-maintenance-margin-rate-max-leverage.js
                 'fetchMarginMode': false,
@@ -1382,6 +1383,8 @@ export default class delta extends Exchange {
         const price = this.safeString (params, 'price');
         if (price === 'mark') {
             request['symbol'] = 'MARK:' + market['id'];
+        } else if (price === 'index') {
+            request['symbol'] = market['info']['spot_index']['symbol'];
         } else {
             request['symbol'] = market['id'];
         }

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -49,6 +49,7 @@ export default class delta extends Exchange {
                 'fetchMarginMode': false,
                 'fetchMarketLeverageTiers': false,
                 'fetchMarkets': true,
+                'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenInterest': true,
@@ -1354,6 +1355,7 @@ export default class delta extends Exchange {
          * @method
          * @name delta#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://docs.delta.exchange/#get-ohlc-candles
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -1364,7 +1366,6 @@ export default class delta extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'symbol': market['id'],
             'resolution': this.safeString (this.timeframes, timeframe, timeframe),
         };
         const duration = this.parseTimeframe (timeframe);
@@ -1378,6 +1379,13 @@ export default class delta extends Exchange {
             request['start'] = start;
             request['end'] = this.sum (start, limit * duration);
         }
+        const price = this.safeString (params, 'price');
+        if (price === 'mark') {
+            request['symbol'] = 'MARK:' + market['id'];
+        } else {
+            request['symbol'] = market['id'];
+        }
+        params = this.omit (params, 'price');
         const response = await this.publicGetHistoryCandles (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
Added fetchMarkOHLCV and fetchIndexOHLCV support to Delta:

### fetchMarkOHLCV:
```
delta.fetchMarkOHLCV (BTC/USDT:USDT, 1m, , 5)
2023-07-25T03:04:31.446Z iteration 0 passed in 543 ms

1690254000000 | 29117.92793651 | 29137.88676085 | 29117.92793651 | 29132.85874979 |
1690254060000 | 29132.85874979 | 29133.01653798 | 29118.62376893 |  29121.0335659 |
1690254120000 |  29121.0335659 | 29121.29715022 | 29101.70423143 | 29113.63442159 |
1690254180000 | 29113.63442159 | 29120.41186722 | 29113.35592364 | 29120.38800805 |
4 objects
```

### fetchIndexOHLCV:
```
delta.fetchIndexOHLCV (BTC/USDT:USDT, 1m, , 5)
2023-07-25T03:09:13.817Z iteration 0 passed in 1005 ms

1690254300000 | 29136.404082900364 | 29149.71429318133 | 29135.398395043634 |  29148.91678336597 |
1690254360000 | 29148.913005219183 | 29148.91678336597 |  29143.22607756652 |  29144.12275740156 |
1690254420000 |  29144.11807019931 | 29144.20129547925 | 29133.960885709213 | 29141.547233714526 |
3 objects
```