### PR TITLE
feat(bitget): add privateMixGetPositionHistoryPosition

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3912,7 +3912,7 @@ export default class bitget extends Exchange {
             // endTime and startTime mandatory
             let since = this.safeInteger2 (params, 'startTime', 'since');
             if (since === undefined) {
-                since = this.milliseconds () - 7889400000; // 3 months ago
+                since = this.milliseconds () - 7689600000; // 3 months ago
             }
             request['startTime'] = since;
             let until = this.safeInteger2 (params, 'endTime', 'until');

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4044,7 +4044,7 @@ export default class bitget extends Exchange {
         const marketId = this.safeString (position, 'symbol');
         market = this.safeMarket (marketId, market);
         const symbol = market['symbol'];
-        const timestamp = this.safeInteger (position, 'cTime');
+        const timestamp = this.safeInteger2 (position, 'cTime', 'ctime');
         let marginMode = this.safeString (position, 'marginMode');
         let collateral = undefined;
         let initialMargin = undefined;
@@ -4069,13 +4069,16 @@ export default class bitget extends Exchange {
         const contractSizeNumber = this.safeValue (market, 'contractSize');
         const contractSize = this.numberToString (contractSizeNumber);
         const baseAmount = this.safeString (position, 'total');
-        const entryPrice = this.safeString (position, 'averageOpenPrice');
+        const entryPrice = this.safeString2 (position, 'averageOpenPrice', 'openAvgPrice');
         const maintenanceMarginPercentage = this.safeString (position, 'keepMarginRate');
         const openNotional = Precise.stringMul (entryPrice, baseAmount);
         if (initialMargin === undefined) {
             initialMargin = Precise.stringDiv (openNotional, leverage);
         }
-        const contracts = this.parseNumber (Precise.stringDiv (baseAmount, contractSize));
+        let contracts = this.parseNumber (Precise.stringDiv (baseAmount, contractSize));
+        if (contracts === undefined) {
+            contracts = this.safeNumber (position, 'closeTotalPos');
+        }
         const markPrice = this.safeString (position, 'marketPrice');
         const notional = Precise.stringMul (baseAmount, markPrice);
         const initialMarginPercentage = Precise.stringDiv (initialMargin, notional);
@@ -4120,7 +4123,7 @@ export default class bitget extends Exchange {
             'hedged': hedged,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'lastUpdateTimestamp': undefined,
+            'lastUpdateTimestamp': this.safeInteger (position, 'utime'),
             'maintenanceMargin': this.parseNumber (maintenanceMargin),
             'maintenanceMarginPercentage': this.parseNumber (maintenanceMarginPercentage),
             'collateral': this.parseNumber (collateral),


### PR DESCRIPTION
DEMO

```
 p bitget fetchPositions           
Python v3.10.9
CCXT v4.0.39
bitget.fetchPositions()
[{'collateral': None,
  'contractSize': 1,
  'contracts': 19.0,
  'datetime': '2023-07-25T13:18:26.201Z',
  'entryPrice': 0.30326,
  'hedged': None,
  'id': None,
  'info': {'closeAvgPrice': '0.30419',
           'closeFee': '-0.00346',
           'closeTotalPos': '19',
           'ctime': '1690291106201',
           'holdSide': 'long',
           'marginCoin': 'USDT',
           'marginMode': 'crossed',
           'netProfit': '0.01074507',
           'openAvgPrice': '0.30326',
           'openFee': '-0.00345',
           'openTotalPos': '19',
           'pnl': '0.01767',
           'symbol': 'ADAUSDT_UMCBL',
           'totalFunding': '0',
           'utime': '1690292791333'},
  'initialMargin': None,
  'initialMarginPercentage': None,
  'lastPrice': 0.30419,
  'lastUpdateTimestamp': 1690292791333,
  'leverage': None,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'side': 'long',
  'symbol': 'ADA/USDT:USDT',
  'timestamp': 1690291106201,
  'unrealizedPnl': None}]
```
