### PR TITLE
fix(bitstamp): 3d timeframe

### DIFF
--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -107,7 +107,7 @@ export default class bitstamp extends Exchange {
                 '6h': '21600',
                 '12h': '43200',
                 '1d': '86400',
-                '1w': '259200',
+                '3d': '259200',
             },
             'requiredCredentials': {
                 'apiKey': true,


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18649

```
n bitget fetchOHLCV "BTC/USDT" "3d"                     
Debugger attached.
2023-07-25T14:13:46.956Z
Node.js: v18.14.0
CCXT v4.0.39
bitget.fetchOHLCV (BTC/USDT, 3d)
2023-07-25T14:13:48.910Z iteration 0 passed in 412 ms

1664582400000 | 19420.15 | 19701.14 | 18922.64 | 19628.31 | 25457.2515
1664841600000 | 19628.31 | 20451.22 | 19497.09 | 19964.22 |  29504.464
1665100800000 | 19964.22 | 20053.05 |  19260.4 | 19440.04 | 15230.5286
1665360000000 | 19440.04 | 19522.88 | 18847.76 | 19154.61 | 20333.5769
1665619200000 | 19154.61 | 19949.28 | 18190.07 | 19069.44 | 29459.8653
1665878400000 | 19069.44 | 19706.66 | 19064.89 | 19328.58 | 15746.0736
1666137600000 | 19328.58 | 19357.98 | 18665.05 | 19160.95 | 12811.3564
1666396800000 | 19160.95 | 19691.78 | 19076.85 |  19330.6 |  13581.221
1666656000000 |  19330.6 | 21015.07 |    19242 | 20292.05 | 25876.5681
1666915200000 | 20292.05 | 21070.57 |  20004.8 | 20628.11 | 16991.4875
1667174400000 | 20628.11 | 20841.08 | 20061.25 |  20151.9 | 19300.5608
1667433600000 |  20151.9 | 21473.18 | 20038.43 | 21300.15 | 25660.0837
1667692800000 | 21300.15 | 21363.67 | 17015.38 | 18545.88 | 45170.2844
1667952000000 | 18545.88 | 18585.01 |    15576 | 17054.21 | 109053.762
1668211200000 | 17054.21 | 17183.52 | 15823.35 | 16614.66 | 69807.8741
```
