### PR TITLE
gate setPositionMode implementation

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -802,6 +802,7 @@ export default class gate extends Exchange {
                     'RISK_LIMIT_TOO_LOW': BadRequest, // {"label":"RISK_LIMIT_TOO_LOW","detail":"limit 1000000"}
                     'AUTO_TRIGGER_PRICE_LESS_LAST': InvalidOrder,  // {"label":"AUTO_TRIGGER_PRICE_LESS_LAST","message":"invalid argument: Trigger.Price must < last_price"}
                     'AUTO_TRIGGER_PRICE_GREATE_LAST': InvalidOrder, // {"label":"AUTO_TRIGGER_PRICE_GREATE_LAST","message":"invalid argument: Trigger.Price must > last_price"}
+                    'POSITION_HOLDING': BadRequest,
                 },
                 'broad': {},
             },

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -134,6 +134,7 @@ export default class gate extends Exchange {
                 'repayMargin': true,
                 'setLeverage': true,
                 'setMarginMode': false,
+                'setPositionMode': true,
                 'signIn': false,
                 'transfer': true,
                 'withdraw': true,
@@ -6010,6 +6011,24 @@ export default class gate extends Exchange {
             'dnw': 'deposit/withdraw',
         };
         return this.safeString (ledgerType, type, type);
+    }
+
+    async setPositionMode (hedged, symbol = undefined, params = {}) {
+        /**
+         * @method
+         * @name gate#setPositionMode
+         * @description set dual/hedged mode to true or false for a swap market, make sure all positions are closed and no orders are open before setting dual mode
+         * @see https://www.gate.io/docs/developers/apiv4/en/#enable-or-disable-dual-mode
+         * @param {bool} hedged set to true to enable dual mode
+         * @param {string|undefined} symbol if passed, dual mode is set for all markets with the same settle currency
+         * @param {object} params extra parameters specific to the gate api endpoint
+         * @param {string} params.settle settle currency
+         * @returns {object} response from the exchange
+         */
+        const market = (symbol !== undefined) ? this.market (symbol) : undefined;
+        const [ request, query ] = this.prepareRequest (market, 'swap', params);
+        request['dual_mode'] = hedged;
+        return await this.privateFuturesPostSettleDualMode (this.extend (request, query));
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {


### PR DESCRIPTION
```
% gate setPositionMode true BTC/USDT:USDT
2023-07-26T03:23:04.590Z
Node.js: v18.15.0
CCXT v4.0.37
gate.setPositionMode (true, BTC/USDT:USDT)
2023-07-26T03:23:09.985Z iteration 0 passed in 434 ms

{
  order_margin: '0',
  update_time: '1682564970',
  point: '0',
  update_id: '0',
  bonus: '0',
  history: {
    dnw: '7.8041',
    pnl: '-6.1014',
    refr: '0',
    point_fee: '0',
    point_dnw: '0',
    bonus_dnw: '0',
    point_refr: '0',
    bonus_offset: '0',
    cross_settle: '0',
    fee: '-0.7576647',
    fund: '0'
  },
  unrealised_pnl: '0',
  total: '0.9450353',
  available: '0.9450353',
  enable_credit: false,
  in_dual_mode: true,
  currency: 'USDT',
  position_margin: '0',
  user: '6676360'
}
2023-07-26T03:23:09.985Z iteration 1 passed in 434 ms
```

```
% gate setPositionMode false BTC/USDT:USDT
(node:10481) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-07-26T03:23:47.853Z
Node.js: v18.15.0
CCXT v4.0.37
gate.setPositionMode (false, BTC/USDT:USDT)
2023-07-26T03:23:54.029Z iteration 0 passed in 473 ms

{
  order_margin: '0',
  update_time: '1682564970',
  point: '0',
  update_id: '0',
  bonus: '0',
  history: {
    dnw: '7.8041',
    pnl: '-6.1014',
    refr: '0',
    point_fee: '0',
    point_dnw: '0',
    bonus_dnw: '0',
    point_refr: '0',
    bonus_offset: '0',
    cross_settle: '0',
    fee: '-0.7576647',
    fund: '0'
  },
  unrealised_pnl: '0',
  total: '0.9450353',
  available: '0.9450353',
  enable_credit: false,
  in_dual_mode: false,
  currency: 'USDT',
  position_margin: '0',
  user: '6676360'
}
2023-07-26T03:23:54.029Z iteration 1 passed in 473 ms
```

```
% gate setPositionMode true undefined '{"settle": "USDT"}'  
(node:10513) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-07-26T03:24:53.898Z
Node.js: v18.15.0
CCXT v4.0.37
gate.setPositionMode (true, , [object Object])
2023-07-26T03:25:01.219Z iteration 0 passed in 544 ms

{
  order_margin: '0',
  update_time: '1682564970',
  point: '0',
  update_id: '0',
  bonus: '0',
  history: {
    dnw: '7.8041',
    pnl: '-6.1014',
    refr: '0',
    point_fee: '0',
    point_dnw: '0',
    bonus_dnw: '0',
    point_refr: '0',
    bonus_offset: '0',
    cross_settle: '0',
    fee: '-0.7576647',
    fund: '0'
  },
  unrealised_pnl: '0',
  total: '0.9450353',
  available: '0.9450353',
  enable_credit: false,
  in_dual_mode: true,
  currency: 'USDT',
  position_margin: '0',
  user: '6676360'
}
2023-07-26T03:25:01.219Z iteration 1 passed in 544 ms
```

```
 % py gate setPositionMode false BTC/USDT:USDT
Python v3.11.3
CCXT v4.0.37
gate.setPositionMode(false,BTC/USDT:USDT)
{'available': '0.9450353',
 'bonus': '0',
 'currency': 'USDT',
 'enable_credit': False,
 'history': {'bonus_dnw': '0',
             'bonus_offset': '0',
             'cross_settle': '0',
             'dnw': '7.8041',
             'fee': '-0.7576647',
             'fund': '0',
             'pnl': '-6.1014',
             'point_dnw': '0',
             'point_fee': '0',
             'point_refr': '0',
             'refr': '0'},
 'in_dual_mode': False,
 'order_margin': '0',
 'point': '0',
 'position_margin': '0',
 'total': '0.9450353',
 'unrealised_pnl': '0',
 'update_id': '0',
 'update_time': '1682564970',
 'user': '6676360'}
```