### PR TITLE
feat(errors): added error type NoChange

### DIFF
--- a/ts/src/base/errors.ts
+++ b/ts/src/base/errors.ts
@@ -101,7 +101,13 @@ class BadSymbol extends BadRequest {
         this.name = 'BadSymbol';
     }
 }
-class MarginModeAlreadySet extends BadRequest {
+class NoChange extends BadRequest {
+    constructor (message) {
+        super (message);
+        this.name = 'NoChange';
+    }
+}
+class MarginModeAlreadySet extends NoChange {
     constructor (message) {
         super (message);
         this.name = 'MarginModeAlreadySet';


### PR DESCRIPTION
- NoChange extends BadRequest
- MarginModeAlreadySet now extends NoChange

Some exchanges return an error when a request is sent to update a value, but the value is already set to what is desired, e.g.

```
% py gate setPositionMode true BTC/USDT:USDT              
Python v3.11.3
CCXT v4.0.37
gate.setPositionMode(true,BTC/USDT:USDT)
Traceback (most recent call last):
  File "/Users/samgermain/Documents/CCXT/ccxt/examples/py/cli.py", line 239, in <module>
    asyncio.run(main())
  ...
  File "/Users/samgermain/Documents/CCXT/ccxt/python/ccxt/async_support/base/exchange.py", line 2170, in throw_exactly_matched_exception
    raise exact[string](message)
ccxt.base.errors.ExchangeError: gate {"label":"NO_CHANGE"}
...
```

We already have `MarginModeAlreadySet` for when binance returns an error in response to setting the MarginMode to a value that it is already set to (check https://github.com/samgermain/ccxt/commit/96fac634130c5a3304cf010eaf805045ad8cd544 for usage). The name `MarginModeAlreadySet` feels too specific for the type of error that this is, so I created the error type NoChange as a more inclusive error type. The error type of NoChange would include errors like MarginModeAlreadySet and the error listed above for setting the position mode