### PR TITLE
Delta: fetchLeverage

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -45,6 +45,7 @@ export default class delta extends Exchange {
                 'fetchFundingRateHistory': false,
                 'fetchFundingRates': true,
                 'fetchLedger': true,
+                'fetchLeverage': true,
                 'fetchLeverageTiers': false, // An infinite number of tiers, see examples/js/delta-maintenance-margin-rate-max-leverage.js
                 'fetchMarginMode': false,
                 'fetchMarketLeverageTiers': false,
@@ -2673,6 +2674,37 @@ export default class delta extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'info': interest,
         };
+    }
+
+    async fetchLeverage (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name delta#fetchLeverage
+         * @description fetch the set leverage for a market
+         * @see https://docs.delta.exchange/#get-order-leverage
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the delta api endpoint
+         * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'product_id': market['numericId'],
+        };
+        //
+        //     {
+        //         "result": {
+        //             "index_symbol": null,
+        //             "leverage": "10",
+        //             "margin_mode": "isolated",
+        //             "order_margin": "0",
+        //             "product_id": 84,
+        //             "user_id": 30084879
+        //         },
+        //         "success": true
+        //     }
+        //
+        return await this.privateGetProductsProductIdOrdersLeverage (this.extend (request, params));
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
Added fetchLeverage to Delta:
```
delta.fetchLeverage (BTC/USDT:USDT)
2023-07-26T05:55:11.574Z iteration 0 passed in 537 ms

{
  result: {
    index_symbol: null,
    leverage: '15',
    margin_mode: 'isolated',
    order_margin: '0',
    product_id: '84',
    user_id: '30084879'
  },
  success: true
}
```