### PR TITLE
fix(binance) - editOrder for spot

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3665,10 +3665,11 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/spot/en/#cancel-an-existing-order-and-send-a-new-order-trade
          * @param {string} id cancel order id
          * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit'
+         * @param {string} type 'market' or 'limit' or 'STOP_LOSS' or 'STOP_LOSS_LIMIT' or 'TAKE_PROFIT' or 'TAKE_PROFIT_LIMIT' or 'STOP'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
-         * @param {float} price the price at which the order is to be fullfilled, in units of the base currency, ignored in market orders
+         * @param {float} [price] the price at which the order is to be fullfilled, in units of the base currency, ignored in market orders
+         * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
          * @param {object} [params] extra parameters specific to the binance api endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
@@ -3677,31 +3678,8 @@ export default class binance extends Exchange {
         if (!market['spot']) {
             throw new NotSupported (this.id + ' editSpotOrder() does not support ' + market['type'] + ' orders');
         }
-        const clientOrderId = this.safeStringN (params, [ 'newClientOrderId', 'clientOrderId', 'origClientOrderId' ]);
-        let response = undefined;
-        if (market['spot']) {
-            const payload = this.editSpotOrderRequest (id, symbol, type, side, amount, price, params);
-            response = await this.privatePostOrderCancelReplace (payload);
-        } else {
-            const request = {
-                'symbol': market['id'],
-                'side': side.toUpperCase (),
-            };
-            request['orderId'] = id;
-            request['quantity'] = this.amountToPrecision (symbol, amount);
-            if (price !== undefined) {
-                request['price'] = this.priceToPrecision (symbol, price);
-            }
-            if (clientOrderId !== undefined) {
-                request['origClientOrderId'] = clientOrderId;
-            }
-            params = this.omit (params, [ 'clientOrderId', 'newClientOrderId' ]);
-            if (market['linear']) {
-                response = await this.fapiPrivatePutOrder (this.extend (request, params));
-            } else if (market['inverse']) {
-                response = await this.dapiPrivatePutOrder (this.extend (request, params));
-            }
-        }
+        const payload = this.editSpotOrderRequest (id, symbol, type, side, amount, price, params);
+        const response = await this.privatePostOrderCancelReplace (payload);
         //
         // spot
         //
@@ -3756,9 +3734,9 @@ export default class binance extends Exchange {
          * @param {string} type 'market' or 'limit' or 'STOP_LOSS' or 'STOP_LOSS_LIMIT' or 'TAKE_PROFIT' or 'TAKE_PROFIT_LIMIT' or 'STOP'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
-         * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} params extra parameters specific to the binance api endpoint
-         * @param {string|undefined} params.marginMode 'cross' or 'isolated', for spot margin trading
+         * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
          * @returns {object} request to be sent to the exchange
          */
         const market = this.market (symbol);

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3677,15 +3677,16 @@ export default class binance extends Exchange {
         if (!market['spot']) {
             throw new NotSupported (this.id + ' editSpotOrder() does not support ' + market['type'] + ' orders');
         }
-        const request = {
-            'symbol': market['id'],
-            'side': side.toUpperCase (),
-        };
         const clientOrderId = this.safeStringN (params, [ 'newClientOrderId', 'clientOrderId', 'origClientOrderId' ]);
         let response = undefined;
         if (market['spot']) {
-            response = await this.privatePostOrderCancelReplace (this.extend (request, params));
+            const payload = this.editSpotOrderRequest (id, symbol, type, side, amount, price, params);
+            response = await this.privatePostOrderCancelReplace (payload);
         } else {
+            const request = {
+                'symbol': market['id'],
+                'side': side.toUpperCase (),
+            };
             request['orderId'] = id;
             request['quantity'] = this.amountToPrecision (symbol, amount);
             if (price !== undefined) {


### PR DESCRIPTION
currently this does not work:
```
const o1 = await e.createOrder('ADA/USDT', 'limit', 'buy', 50, 0.2);
const o2 = await e.editOrder(o1.id, 'ADA/USDT', 'limit', 'buy', 50, 0.21);
```
PR seems to fix it, but @pcriadoperez I see that you were working on WS orders & related things in last month, so you could know this better - can you confirm whether this PR would fix it correctly?

(fixes #18667)