### PR TITLE
feat(bitget): add history OHLCV candles

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2450,7 +2450,8 @@ export default class bitget extends Exchange {
         let response = undefined;
         if (market['spot']) {
             const spotOptions = this.safeValue (options, 'spot', {});
-            const method = this.safeString (spotOptions, 'method', 'publicSpotGetMarketCandles');
+            const defaultSpotMethod = this.safeString (params, 'method', 'publicSpotGetMarketCandles');
+            const method = this.safeString (spotOptions, 'method', defaultSpotMethod);
             if (method === 'publicSpotGetMarketCandles') {
                 response = await this.publicSpotGetMarketCandles (extended);
             } else if (method === 'publicSpotGetMarketHistoryCandles') {
@@ -2458,7 +2459,8 @@ export default class bitget extends Exchange {
             }
         } else {
             const swapOptions = this.safeValue (options, 'swap', {});
-            const swapMethod = this.safeString (swapOptions, 'method', 'publicMixGetMarketCandles');
+            const defaultSwapMethod = this.safeString (params, 'method', 'publicMixGetMarketCandles');
+            const swapMethod = this.safeString (swapOptions, 'method', defaultSwapMethod);
             if (swapMethod === 'publicMixGetMarketCandles') {
                 response = await this.publicMixGetMarketCandles (extended);
             } else if (swapMethod === 'publicMixGetMarketHistoryCandles') {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -988,6 +988,14 @@ export default class bitget extends Exchange {
                 'withdraw': {
                     'fillResponseFromRequest': true,
                 },
+                'fetchOHLCV': {
+                    'spot': {
+                        'method': 'publicSpotGetMarketCandles', // or publicSpotGetMarketHistoryCandles
+                    },
+                    'swap:': {
+                        'method': 'publicMixGetMarketCandles', // or publicMixGetMarketHistoryCandles or publicMixGetMarketHistoryIndexCandles or publicMixGetMarketHistoryMarkCandles
+                    },
+                },
                 'accountsByType': {
                     'main': 'EXCHANGE',
                     'spot': 'EXCHANGE',
@@ -2436,13 +2444,30 @@ export default class bitget extends Exchange {
                 }
             }
         }
+        const options = this.safeValue (this.options, 'fetchOHLCV', {});
         const ommitted = this.omit (params, [ 'until', 'till' ]);
         const extended = this.extend (request, ommitted);
         let response = undefined;
         if (market['spot']) {
-            response = await this.publicSpotGetMarketCandles (extended);
+            const spotOptions = this.safeValue (options, 'spot', {});
+            const method = this.safeString (spotOptions, 'method', 'publicSpotGetMarketCandles');
+            if (method === 'publicSpotGetMarketCandles') {
+                response = await this.publicSpotGetMarketCandles (extended);
+            } else if (method === 'publicSpotGetMarketHistoryCandles') {
+                response = await this.publicSpotGetMarketHistoryCandles (extended);
+            }
         } else {
-            response = await this.publicMixGetMarketCandles (extended);
+            const swapOptions = this.safeValue (options, 'swap', {});
+            const swapMethod = this.safeString (swapOptions, 'method', 'publicMixGetMarketCandles');
+            if (swapMethod === 'publicMixGetMarketCandles') {
+                response = await this.publicMixGetMarketCandles (extended);
+            } else if (swapMethod === 'publicMixGetMarketHistoryCandles') {
+                response = await this.publicMixGetMarketHistoryCandles (extended);
+            } else if (swapMethod === 'publicMixGetMarketHistoryIndexCandles') {
+                response = await this.publicMixGetMarketHistoryIndexCandles (extended);
+            } else if (swapMethod === 'publicMixGetMarketHistoryMarkCandles') {
+                response = await this.publicMixGetMarketHistoryMarkCandles (extended);
+            }
         }
         //  [ ["1645911960000","39406","39407","39374.5","39379","35.526","1399132.341"] ]
         const data = this.safeValue (response, 'data', response);


### PR DESCRIPTION
DEMO

```
 n bitget fetchOHLCV "BTC/USDT" "1h" undefined undefined '{"method":"publicSpotGetMarketHistoryCandles"}'          
Debugger attached.
2023-07-27T11:15:11.658Z
Node.js: v19.5.0
CCXT v4.0.40
bitget.fetchOHLCV (BTC/USDT, 1h, , , [object Object])
2023-07-27T11:15:13.563Z iteration 0 passed in 470 ms

1686859200000 | 25460.34 | 25592.31 | 25223.96 | 25567.42 |  422.2062
1686862800000 | 25567.42 | 25755.55 | 25509.53 | 25573.49 |  502.7266
1686866400000 | 25573.49 | 25654.05 | 25550.03 | 25630.02 |  528.9963
1686870000000 | 25630.02 | 25637.46 | 25556.95 | 25597.04 |  276.0621
1686873600000 | 25597.04 |  25597.3 | 25445.33 | 25497.05 |  450.9169
1686877200000 | 25497.05 | 25575.58 | 25454.18 | 25517.08 |  402.9569
1686880800000 | 25517.08 | 25554.76 | 25484.93 | 25553.77 |  243.5197
1686884400000 | 25553.77 | 25605.65 | 25530.04 | 25561.69 |  453.0449
```
```
✗ n bitget fetchOHLCV "BTC/USDT:USDT" "1h" undefined undefined '{"method":"publicMixGetMarketHistoryCandles"}'          
Debugger attached.
2023-07-27T11:15:49.006Z
Node.js: v19.5.0
CCXT v4.0.40
bitget.fetchOHLCV (BTC/USDT:USDT, 1h, , , [object Object])
2023-07-27T11:15:50.886Z iteration 0 passed in 402 ms

1689735600000 |   30005 |   30058 |   29983 | 30036.5 |  4177.102
1689739200000 | 30036.5 |   30177 | 30033.5 | 30081.5 |  6638.374
1689742800000 | 30081.5 | 30102.5 | 30045.5 |   30082 |  5123.389
1689746400000 |   30082 |   30093 |   29988 | 30025.5 |  4831.728
1689750000000 | 30025.5 |   30055 |   29949 | 29982.5 |  5055.879
1689753600000 | 29982.5 | 30006.5 | 29855.5 |   29908 |   5611.29
1689757200000 |   29908 | 30027.5 |   29851 | 29986.5 |  5777.053
1689760800000 | 29986.5 |   30015 | 29958.5 |   29968 |  4629.249
1689764400000 |   29968 | 30013.5 |   29941 | 29995.5 |  3050.842
1689768000000 | 29995.5 | 30003.5 | 29870.5 |   29930 |  3706.827
1689771600000 |   29930 |   30107 |   29810 | 29976.5 |  7459.688
1689775200000 | 29976.5 | 30039.5 |   29763 | 29809.5 |  7872.341
1689778800000 | 29809.5 |   29972 | 29742.5 |   29935 |   6742.08
1689782400000 |   29935 | 29956.5 | 29851.5 |   29882 |  4547.876
1689786000000 |   29882 | 30066.5 | 29861.5 | 29970.5 |  5057.065
1689789600000 | 29970.5 | 30073.5 |   29923 |   30057 |  3860.865
1689793200000 |   30057 | 30085.5 | 30008.5 | 30025.5 |  3652.713
1689796800000 | 30025.5 |   30035 |   29926 |   29946 |  4904.699
1689800400000 |   29946 | 29947.5 | 29833.5 |   29912 |  4844.732
1689804000000 |   29912 |   29938 | 29835.5 | 29860.5 |  4621.959
1689807600000 | 29860.5 | 29935.5 |   29816 |   29900 |  5458.479
1689811200000 |   29900 |   29990 |   29873 |   29979 |  5802.788
1689814800000 |   29979 |   30010 |   29950 | 29972.5 |  3921.356
1689818400000 | 29972.5 |   30029 | 29958.5 |   29967 |  3409.785
1689822000000 |   29967 |   29973 |   29898 | 29940.5 |  3486.119
1689825600000 | 29940.5 |   29970 |   29912 |   29946 |  3660.608
1689829200000 |   29946 |   30158 | 29938.5 | 30109.
```
```
 n bitget fetchOHLCV "BTC/USDT:USDT" "1h" undefined undefined '{"method":"publicMixGetMarketHistoryIndexCandles"}'
Debugger attached.
2023-07-27T11:16:09.990Z
Node.js: v19.5.0
CCXT v4.0.40
bitget.fetchOHLCV (BTC/USDT:USDT, 1h, , , [object Object])
2023-07-27T11:16:11.819Z iteration 0 passed in 396 ms

1689735600000 | 30025.267499 | 30076.651249 | 30007.357708 | 30059.172307 | 0
1689739200000 | 30059.172307 | 30188.819166 | 30057.705531 | 30099.528615 | 0
1689742800000 | 30099.528615 | 30119.889999 | 30064.701041 | 30102.476907 | 0
1689746400000 | 30102.476907 | 30112.694791 | 30004.840416 | 30044.062083 | 0
1689750000000 | 30044.062083 | 30073.570624 | 29968.475416 | 30000.472083 | 0
1689753600000 | 30000.472083 | 30014.947916 | 29882.620833 | 29924.310103 | 0
1689757200000 | 29924.310103 | 30045.647499 | 29867.643749 | 30005.611249 | 0
1689760800000 | 30005.611249 | 30034.257083 | 29976.269538 | 29987.772783 | 0
1689764400000 | 29987.772783 | 30031.656041 | 29962.110416 | 30015.757575 | 0
1689768000000 | 30015.757575 | 30024.026907 | 29887.909583 | 29950.299999 | 0
1689771600000 | 29950.299999 | 30123.926874 | 29839.731489 | 29995.0
```
