### PR TITLE
fix(binance): orders trade fee for one order with multiple trades

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2264,7 +2264,8 @@ export default class binance extends binanceRest {
         if (executionType === 'TRADE') {
             const trade = this.parseTrade (message);
             const orderId = this.safeString (trade, 'order');
-            const tradeFee = this.safeValue (trade, 'fee');
+            let tradeFee = this.safeValue (trade, 'fee');
+            tradeFee = this.extend ({}, tradeFee);
             const symbol = this.safeString (trade, 'symbol');
             if (orderId !== undefined && tradeFee !== undefined && symbol !== undefined) {
                 const cachedOrders = this.orders;
@@ -2275,7 +2276,7 @@ export default class binance extends binanceRest {
                         // accumulate order fees
                         const fees = this.safeValue (order, 'fees');
                         const fee = this.safeValue (order, 'fee');
-                        if (fees !== undefined) {
+                        if (!this.isEmpty (fees)) {
                             let insertNewFeeCurrency = true;
                             for (let i = 0; i < fees.length; i++) {
                                 const orderFee = fees[i];


### PR DESCRIPTION
- Create copy of tradeFee to avoid future mutations
- Use this.isEmpty as fees can be empty array instead of undefined
- fix #18592 
- fix #17929 