### PR TITLE
Bybit: fetchVolatilityHistory

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -107,6 +107,7 @@ export default class binance extends Exchange {
                 'fetchTransactionFees': true,
                 'fetchTransactions': false,
                 'fetchTransfers': true,
+                'fetchVolatilityHistory': false,
                 'fetchWithdrawal': false,
                 'fetchWithdrawals': true,
                 'fetchWithdrawalWhitelist': false,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -88,6 +88,7 @@ export default class bybit extends Exchange {
                 'fetchTradingFees': true,
                 'fetchTransactions': false,
                 'fetchTransfers': true,
+                'fetchVolatilityHistory': true,
                 'fetchWithdrawals': true,
                 'setLeverage': true,
                 'setMarginMode': true,
@@ -8736,6 +8737,64 @@ export default class bybit extends Exchange {
         const result = [];
         for (let i = 0; i < settlements.length; i++) {
             result.push (this.parseSettlement (settlements[i], market));
+        }
+        return result;
+    }
+
+    async fetchVolatilityHistory (code: string, params = {}) {
+        /**
+         * @method
+         * @name bybit#fetchVolatilityHistory
+         * @description fetch the historical volatility of an option market based on an underlying asset
+         * @see https://bybit-exchange.github.io/docs/v5/market/iv
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the bybit api endpoint
+         * @param {int} [params.period] the period in days to fetch the volatility for: 7,14,21,30,60,90,180,270
+         * @returns {object[]} a list of [volatility history objects]{@link https://docs.ccxt.com/#/?id=volatility-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'category': 'option',
+            'baseCoin': currency['id'],
+        };
+        const response = await this.publicGetV5MarketHistoricalVolatility (this.extend (request, params));
+        //
+        //     {
+        //         "retCode": 0,
+        //         "retMsg": "SUCCESS",
+        //         "category": "option",
+        //         "result": [
+        //             {
+        //                 "period": 7,
+        //                 "value": "0.23854072",
+        //                 "time": "1690574400000"
+        //             }
+        //         ]
+        //     }
+        //
+        const volatility = this.safeValue (response, 'result', []);
+        return this.parseVolatilityHistory (volatility);
+    }
+
+    parseVolatilityHistory (volatility) {
+        //
+        //     {
+        //         "period": 7,
+        //         "value": "0.23854072",
+        //         "time": "1690574400000"
+        //     }
+        //
+        const result = [];
+        for (let i = 0; i < volatility.length; i++) {
+            const entry = volatility[i];
+            const timestamp = this.safeInteger (entry, 'time');
+            result.push ({
+                'info': volatility,
+                'timestamp': timestamp,
+                'datetime': this.iso8601 (timestamp),
+                'volatility': this.safeNumber (entry, 'value'),
+            });
         }
         return result;
     }

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -83,6 +83,7 @@ export default class cryptocom extends Exchange {
                 'fetchTransactionFees': false,
                 'fetchTransactions': false,
                 'fetchTransfers': true,
+                'fetchVolatilityHistory': false,
                 'fetchWithdrawals': true,
                 'reduceMargin': false,
                 'repayMargin': true,

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -71,6 +71,7 @@ export default class delta extends Exchange {
                 'fetchTrades': true,
                 'fetchTransfer': undefined,
                 'fetchTransfers': undefined,
+                'fetchVolatilityHistory': false,
                 'fetchWithdrawal': undefined,
                 'fetchWithdrawals': undefined,
                 'reduceMargin': true,

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -56,7 +56,6 @@ export default class deribit extends Exchange {
                 'fetchDepositAddress': true,
                 'fetchDeposits': true,
                 'fetchDepositWithdrawFees': true,
-                'fetchHistoricalVolatility': true,
                 'fetchIndexOHLCV': false,
                 'fetchLeverageTiers': false,
                 'fetchMarginMode': false,
@@ -83,6 +82,7 @@ export default class deribit extends Exchange {
                 'fetchTransactions': false,
                 'fetchTransfer': false,
                 'fetchTransfers': true,
+                'fetchVolatilityHistory': true,
                 'fetchWithdrawal': false,
                 'fetchWithdrawals': true,
                 'transfer': true,
@@ -2498,7 +2498,16 @@ export default class deribit extends Exchange {
         return this.parsePositions (result, symbols);
     }
 
-    async fetchHistoricalVolatility (code: string, params = {}) {
+    async fetchVolatilityHistory (code: string, params = {}) {
+        /**
+         * @method
+         * @name deribit#fetchVolatilityHistory
+         * @description fetch the historical volatility of an option market based on an underlying asset
+         * @see https://docs.deribit.com/#public-get_historical_volatility
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the deribit api endpoint
+         * @returns {object[]} a list of [volatility history objects]{@link https://docs.ccxt.com/#/?id=volatility-structure}
+         */
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {
@@ -2519,13 +2528,31 @@ export default class deribit extends Exchange {
         //         "testnet": false
         //     }
         //
-        const volatilityResult = this.safeValue (response, 'result', {});
+        return this.parseVolatilityHistory (response);
+    }
+
+    parseVolatilityHistory (volatility) {
+        //
+        //     {
+        //         "jsonrpc": "2.0",
+        //         "result": [
+        //             [1640142000000,63.828320460740585],
+        //             [1640142000000,63.828320460740585],
+        //             [1640145600000,64.03821964123213]
+        //         ],
+        //         "usIn": 1641515379467734,
+        //         "usOut": 1641515379468095,
+        //         "usDiff": 361,
+        //         "testnet": false
+        //     }
+        //
+        const volatilityResult = this.safeValue (volatility, 'result', []);
         const result = [];
         for (let i = 0; i < volatilityResult.length; i++) {
             const timestamp = this.safeInteger (volatilityResult[i], 0);
             const volatility = this.safeNumber (volatilityResult[i], 1);
             result.push ({
-                'info': response,
+                'info': volatility,
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'volatility': volatility,

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -129,6 +129,7 @@ export default class gate extends Exchange {
                 'fetchTradingFee': true,
                 'fetchTradingFees': true,
                 'fetchTransactionFees': true,
+                'fetchVolatilityHistory': false,
                 'fetchWithdrawals': true,
                 'reduceMargin': true,
                 'repayMargin': true,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -108,6 +108,7 @@ export default class okx extends Exchange {
                 'fetchTransactions': false,
                 'fetchTransfer': true,
                 'fetchTransfers': true,
+                'fetchVolatilityHistory': false,
                 'fetchWithdrawal': true,
                 'fetchWithdrawals': true,
                 'fetchWithdrawalWhitelist': false,

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1590,6 +1590,7 @@ The unified ccxt API is a subset of methods common among the exchanges. It curre
 - `fetchClosedOrders ([symbol[, since[, limit[, params]]]])`
 - `fetchMyTrades ([symbol[, since[, limit[, params]]]])`
 - `fetchOpenInterest ([symbol[, params]])`
+- `fetchVolatilityHistory ([code[, params]])`
 - ...
 
 ```text
@@ -1896,6 +1897,7 @@ if ($exchange->has['fetchMyTrades']) {
 - [Funding Rate](#funding-rate)
 - [Funding Rate History](#funding-rate-history)
 - [Open Interest History](#open-interest-history)
+- [Volatility History](#volatility-history)
 
 ## Order Book
 
@@ -2896,6 +2898,40 @@ Returns
         sumOpenInterestValue: '3508262107.38000000',
         timestamp: '1649379000000'
     }
+}
+```
+
+## Historical Volatility
+
+*option only*
+
+Use the `fetchVolatilityHistory` method to get the volatility history for the code of an options underlying asset from the exchange.
+
+```javascript
+fetchVolatilityHistory (code, params = {})
+```
+
+Parameters
+
+- **code** (String) *required* Unified CCXT currency code (e.g. `"BTC"`)
+- **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"endTime": 1645807945000}`)
+
+Returns
+
+- An array of [volatility history structures](#volatility-structure)
+
+### Volatility Structure
+
+```javascript
+{
+    info: {
+        "period": 7,
+        "value": "0.23854072",
+        "time": "1690574400000"
+    }
+    timestamp: 1649379000000,
+    datetime: '2023-07-28T00:50:00.000Z',
+    volatility: 0.23854072,
 }
 ```
 


### PR DESCRIPTION
Changed the name of fetchHistoricalVolatility to fetchVolatilityHistory and added it to bybit: Also updated documentation, set fetchVolatilityHistory to false on exchanges with options support that don't have a corresponding endpoint and updated the deribit implementation.
```
bybit.fetchVolatilityHistory (BTC)
2023-07-28T21:15:43.553Z iteration 0 passed in 254 ms

    timestamp |                 datetime | volatility
-----------------------------------------------------
1690578000000 | 2023-07-28T21:00:00.000Z | 0.23863844
1 objects
```