### PR TITLE
feat(coinbasepro): add sandbox mode

### DIFF
--- a/ts/src/pro/coinbasepro.ts
+++ b/ts/src/pro/coinbasepro.ts
@@ -29,6 +29,9 @@ export default class coinbasepro extends coinbaseproRest {
                 'api': {
                     'ws': 'wss://ws-feed.pro.coinbase.com',
                 },
+                'test': {
+                    'ws': 'wss://ws-feed-public.sandbox.exchange.coinbase.com',
+                },
             },
             'options': {
                 'tradesLimit': 1000,


### PR DESCRIPTION
DEMO
```
 n coinbasepro watchTicker "BTC/USD" --sandbox --verbose
Debugger attached.
2023-07-29T12:15:20.566Z
Node.js: v18.14.0
CCXT v4.0.43
coinbasepro.watchTicker (BTC/USD)
2023-07-29T12:15:21.122Z connecting to wss://ws-feed-public.sandbox.exchange.coinbase.com
2023-07-29T12:15:21.615Z onUpgrade
2023-07-29T12:15:21.617Z onOpen
2023-07-29T12:15:21.617Z sending {
  type: 'subscribe',
  product_ids: [ 'BTC-USD' ],
  channels: [ 'ticker' ]
}
2023-07-29T12:15:21.748Z onMessage {
  type: 'subscriptions',
  channels: [ { name: 'ticker', product_ids: [Array] } ]
}
2023-07-29T12:15:21.752Z onMessage {
  type: 'ticker',
  sequence: 1079063849,
  product_id: 'BTC-USD',
  price: '14938.18',
  open_24h: '5102.64',
  volume_24h: '146.27387460',
  low_24h: '4733.36',
  high_24h: '1000000',
  volume_30d: '874209.05576053',
  best_bid: '1000.28',
  best_bid_size: '0.50000000',
  best_ask: '15317.50',
  best_ask_size: '0.00010000',
  side: 'sell',
  time: '2023-07-29T10:16:02.514435Z',
  trade_id: 80260780,
  last_size: '0.0001'
}
{
  symbol: 'BTC/USD',
  timestamp: 1690625762514,
  datetime: '2023-07-29T10:16:02.514Z',
  high: 1000000,
  low: 4733.36,
  bid: 1000.28,
  bidVolume: 0.5,
  ask: 15317.5,
  askVolume: 0.0001,
  vwap: undefined,
  open: 5102.64,
  close: 14938.18,
  last: 14938.18,
  previousClose: undefined,
  change: undefined,
  percentage: undefined,
  average: undefined,
  baseVolume: 146.2738746,
  quoteVolume: undefined,
  info: {
    type: 'ticker',
    sequence: 1079063849,
    product_id: 'BTC-USD',
    price: '14938.18',
    open_24h: '5102.64',
    volume_24h: '146.27387460',
    low_24h: '4733.36',
    high_24h: '1000000',
    volume_30d: '874209.05576053',
    best_bid: '1000.28',
    best_bid_size: '0.50000000',
    best_ask: '15317.50',
    best_ask_size: '0.00010000',
    side: 'sell',
    time: '2023-07-29T10:16:02.514435Z',
    trade_id: 80260780,
    last_size: '0.0001'
  }
}
```
