### PR TITLE
fix(binanceWs): fetchOpenOrdersWs symbol requirement removal

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1833,7 +1833,6 @@ export default class binance extends binanceRest {
          * @param {object} [params] extra parameters specific to the binance api endpoint
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        this.checkRequiredSymbol ('fetchOpenOrdersWs', symbol);
         await this.loadMarkets ();
         this.checkIsSpot ('fetchOpenOrdersWs', symbol);
         const url = this.urls['api']['ws']['ws'];
@@ -1842,9 +1841,11 @@ export default class binance extends binanceRest {
         let returnRateLimits = false;
         [ returnRateLimits, params ] = this.handleOptionAndParams (params, 'fetchOrderWs', 'returnRateLimits', false);
         const payload = {
-            'symbol': this.marketId (symbol),
             'returnRateLimits': returnRateLimits,
         };
+        if (symbol !== undefined) {
+            payload['symbol'] = this.marketId (symbol);
+        }
         const message = {
             'id': messageHash,
             'method': 'openOrders.status',


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18705

DEMO

```
p binance fetchOpenOrdersWs --sandbox
Python v3.10.9
CCXT v4.0.43
binance.fetchOpenOrdersWs()
[{'amount': 0.002,
  'average': None,
  'clientOrderId': 'x-R4BD3S82d59a66489401748191cf4c',
  'cost': 0.0,
  'datetime': '2023-07-27T10:47:12.481Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'filled': 0.0,
  'id': '10011014',
  'info': {'clientOrderId': 'x-R4BD3S82d59a66489401748191cf4c',
           'cummulativeQuoteQty': '0.00000000',
           'executedQty': '0.00000000',
           'icebergQty': '0.00000000',
           'isWorking': True,
           'orderId': 10011014,
           'orderListId': -1,
           'origQty': '0.00200000',
           'origQuoteOrderQty': '0.00000000',
           'price': '25000.00000000',
           'selfTradePreventionMode': 'NONE',
           'side': 'BUY',
           'status': 'NEW',
           'stopPrice': '0.00000000',
           'symbol': 'BTCUSDT',
           'time': 1690454832481,
           'timeInForce': 'GTC',
           'type': 'LIMIT',
           'updateTime': 1690454832481,
           'workingTime': 1690454832481},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': 1690454832481,
  'postOnly': False,
  'price': 25000.0,
  'reduceOnly': None,
  'remaining': 0.002,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'GTC',
  'timestamp': 1690454832481,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
