### PR TITLE
feat(lbank2) - withdraw true

### DIFF
--- a/ts/src/lbank2.ts
+++ b/ts/src/lbank2.ts
@@ -81,7 +81,7 @@ export default class lbank2 extends Exchange {
                 'setLeverage': false,
                 'setMarginMode': false,
                 'setPositionMode': false,
-                'withdraw': false,
+                'withdraw': true,
             },
             'timeframes': {
                 '1m': 'minute1',


### PR DESCRIPTION
Carlos, 
actually there does not seem any missing functionality from v2, there were only 2 flags for these:
- `fetchClosedOrders` didn't exist in v2, but even though in v1 existed, it was just emulated from `fetchOrders`, and doesn't make sense to be `true`: https://github.com/ccxt/ccxt/blob/master/ts/src/lbank.ts#L712  so, we dont need it in lbank-2
- `withdraw` was set to `false`, and just needed to be `true`.