### PR TITLE
probit.createOrder string math

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -1236,7 +1236,9 @@ export default class probit extends Exchange {
                 if (createMarketBuyOrderRequiresPrice) {
                     if (price !== undefined) {
                         if (cost === undefined) {
-                            cost = amount * price;
+                            const amountString = this.numberToString (amount);
+                            const priceString = this.numberToString (price);
+                            cost = this.parseNumber (Precise.stringMul (amountString, priceString));
                         }
                     } else if (cost === undefined) {
                         throw new InvalidOrder (this.id + " createOrder() requires the price argument for market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false and supply the total cost value in the 'amount' argument or in the 'cost' extra parameter (the exchange-specific behaviour)");


### PR DESCRIPTION
Probit currently experiences troubles when calling private methods via the cli, so I tested using this script instead

```
import probit from '/Users/samgermain/Documents/CCXT/ccxt/ts/src/pro/probit.js';
import keys from './keys.local.json' assert { type: "json" };

// console.log ('CCXT Version:', ccxt.version);

async function main () {

    const exchange = new probit ({
        'apiKey': keys.probit.apiKey,
        'secret': keys.probit.secret,
        'options': {
            'defaultType': 'swap',
        },
    });
    // exchange.setSandboxMode (true);

    await exchange.signIn ();
    const markets = await exchange.loadMarkets ();
    const order = await exchange.createOrder ('SOL/USDT', 'market', 'buy', 0.3, 23.312)
    console.log (order);

};

main ();
```

```
% node --loader ts-node/esm example.ts 
{
  id: '6213445438',
  info: {
    id: '6213445438',
    user_id: '60fc9f31-f4a0-4099-95c9-a3c93696d961',
    market_id: 'SOL-USDT',
    type: 'market',
    side: 'buy',
    limit_price: '0',
    time_in_force: 'ioc',
    filled_cost: '0',
    filled_quantity: '0',
    status: 'open',
    time: '2023-07-31T23:19:43.716Z',
    client_order_id: '',
    cost: '6.9936'
  },
  clientOrderId: undefined,
  timestamp: 1690845583716,
  datetime: '2023-07-31T23:19:43.716Z',
  lastTradeTimestamp: undefined,
  symbol: 'SOL/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  status: 'open',
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: undefined,
  filled: 0,
  remaining: undefined,
  average: undefined,
  cost: 6.9936,
  fee: undefined,
  trades: [],
  fees: [],
  lastUpdateTimestamp: undefined,
  postOnly: false,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```