### PR TITLE
feat(krakenfutures): add setLeverage and fetchLeverage

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -110,6 +110,7 @@ export default class krakenfutures extends Exchange {
                         'fills',
                         'transfers',
                         'leveragepreferences',
+                        'pnlpreferences',
                     ],
                     'post': [
                         'sendorder',
@@ -123,6 +124,7 @@ export default class krakenfutures extends Exchange {
                     ],
                     'put': [
                         'leveragepreferences',
+                        'pnlpreferences',
                     ],
                 },
                 'charts': {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -50,6 +50,7 @@ export default class krakenfutures extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchIsolatedPositions': false,
                 'fetchLeverageTiers': true,
+                'fetchLeverage': true,
                 'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': true,
@@ -108,6 +109,7 @@ export default class krakenfutures extends Exchange {
                         'recentorders',
                         'fills',
                         'transfers',
+                        'leveragepreferences',
                     ],
                     'post': [
                         'sendorder',
@@ -2072,6 +2074,31 @@ export default class krakenfutures extends Exchange {
         // { result: 'success', serverTime: '2023-08-01T09:40:32.345Z' }
         //
         return await this.privatePutLeveragepreferences (this.extend (request, params));
+    }
+
+    async fetchLeverage (symbol: string = undefined, params = {}) {
+        /**
+         * @method
+         * @name krakenfutures#fetchLeverage
+         * @description fetch the set leverage for a market
+         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-get-the-leverage-setting-for-a-market
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the krakenfutures api endpoint
+         * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        this.checkRequiredSymbol ('fetchLeverage', symbol);
+        await this.loadMarkets ();
+        const request = {
+            'symbol': this.marketId (symbol).toUpperCase (),
+        };
+        //
+        //   {
+        //       result: 'success',
+        //       serverTime: '2023-08-01T09:54:08.900Z',
+        //       leveragePreferences: [ { symbol: 'PF_LTCUSD', maxLeverage: '5.00' } ]
+        //   }
+        //
+        return await this.privateGetLeveragepreferences (this.extend (request, params));
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -63,7 +63,7 @@ export default class krakenfutures extends Exchange {
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTickers': true,
                 'fetchTrades': true,
-                'setLeverage': false,
+                'setLeverage': true,
                 'setMarginMode': false,
                 'transfer': true,
             },
@@ -118,6 +118,9 @@ export default class krakenfutures extends Exchange {
                         'cancelallorders',
                         'cancelallordersafter',
                         'withdrawal',                              // for futures wallet -> kraken spot wallet
+                    ],
+                    'put': [
+                        'leveragepreferences',
                     ],
                 },
                 'charts': {
@@ -2046,6 +2049,27 @@ export default class krakenfutures extends Exchange {
             'fromAccount': fromAccount,
             'toAccount': toAccount,
         });
+    }
+
+    async setLeverage (leverage, symbol: string = undefined, params = {}) {
+        /**
+         * @method
+         * @name krakenfutures#setLeverage
+         * @description set the level of leverage for a market
+         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-set-the-leverage-setting-for-a-market
+         * @param {float} leverage the rate of leverage
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the delta api endpoint
+         * @returns {object} response from the exchange
+         */
+        await this.loadMarkets ();
+        const request = {
+            'maxLeverage': leverage,
+        };
+        if (symbol !== undefined) {
+            request['symbol'] = this.marketId (symbol);
+        }
+        return await this.privatePutLeveragepreferences (this.extend (request, params));
     }
 
     handleErrors (code, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2062,13 +2062,15 @@ export default class krakenfutures extends Exchange {
          * @param {object} [params] extra parameters specific to the delta api endpoint
          * @returns {object} response from the exchange
          */
+        this.checkRequiredSymbol ('setLeverage', symbol);
         await this.loadMarkets ();
         const request = {
             'maxLeverage': leverage,
+            'symbol': this.marketId (symbol).toUpperCase (),
         };
-        if (symbol !== undefined) {
-            request['symbol'] = this.marketId (symbol);
-        }
+        //
+        // { result: 'success', serverTime: '2023-08-01T09:40:32.345Z' }
+        //
         return await this.privatePutLeveragepreferences (this.extend (request, params));
     }
 


### PR DESCRIPTION
Currently fails with the following error:
```
krakenfutures PUT https://futures.kraken.com/derivatives/api/v3/leveragepreferences?maxLeverage=5&symbol=pf_ltcusd 500 Internal Server Error {"status":"INTERNAL_SERVER_ERROR","result":"error","errors":[{"code":87,"message":"CONTRACT_DOES_NOT_EXIST"}],"serverTime":"2023-08-01T09:35:03.024Z"}
```
