### PR TITLE
fix(kucoin): orders using params["triggerPrice"] can be properly placed

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -1787,13 +1787,17 @@ export default class kucoin extends Exchange {
          * @param {float} amount the amount of currency to trade
          * @param {float} price *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
          * @param {object} [params]  Extra parameters specific to the exchange API endpoint
+         * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
+         * @param {string} [params.marginMode] 'cross', // cross (cross mode) and isolated (isolated mode), set to cross by default, the isolated mode will be released soon, stay tuned
+         * @param {string} [params.timeInForce] GTC, GTT, IOC, or FOK, default is GTC, limit orders only
+         * @param {string} [params.postOnly] Post only flag, invalid when timeInForce is IOC or FOK
+         *
+         * EXCHANGE SPECIFIC PARAMETERS
          * @param {string} [params.clientOid] client order id, defaults to uuid if not passed
          * @param {string} [params.remark] remark for the order, length cannot exceed 100 utf8 characters
          * @param {string} [params.tradeType] 'TRADE', // TRADE, MARGIN_TRADE // not used with margin orders
          * limit orders ---------------------------------------------------
-         * @param {string} [params.timeInForce] GTC, GTT, IOC, or FOK, default is GTC, limit orders only
          * @param {float} [params.cancelAfter] long, // cancel after n seconds, requires timeInForce to be GTT
-         * @param {string} [params.postOnly] Post only flag, invalid when timeInForce is IOC or FOK
          * @param {bool} [params.hidden] false, // Order will not be displayed in the order book
          * @param {bool} [params.iceberg] false, // Only a portion of the order is displayed in the order book
          * @param {string} [params.visibleSize] this.amountToPrecision (symbol, visibleSize), // The maximum visible size of an iceberg order
@@ -1801,11 +1805,9 @@ export default class kucoin extends Exchange {
          * @param {string} [params.funds] // Amount of quote currency to use
          * stop orders ----------------------------------------------------
          * @param {string} [params.stop]  Either loss or entry, the default is loss. Requires stopPrice to be defined
-         * @param {float} [params.stopPrice] The price at which a trigger order is triggered at
          * margin orders --------------------------------------------------
          * @param {float} [params.leverage] Leverage size of the order
          * @param {string} [params.stp] '', // self trade prevention, CN, CO, CB or DC
-         * @param {string} [params.marginMode] 'cross', // cross (cross mode) and isolated (isolated mode), set to cross by default, the isolated mode will be released soon, stay tuned
          * @param {bool} [params.autoBorrow] false, // The system will first borrow you funds at the optimal interest rate and then place an order for you
          * @param {bool} [params.hf] false, // true for hf order
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -1850,7 +1852,6 @@ export default class kucoin extends Exchange {
             method = 'privatePostHfOrders';
         } else if (triggerPrice || stopLossPrice || takeProfitPrice) {
             if (triggerPrice) {
-                request['stop'] = (side === 'buy') ? 'up' : 'down';
                 request['stopPrice'] = this.priceToPrecision (symbol, triggerPrice);
             } else if (stopLossPrice || takeProfitPrice) {
                 if (stopLossPrice) {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2411,9 +2411,6 @@ export default class kucoin extends Exchange {
         if (cancelExist) {
             status = 'canceled';
         }
-        if (status === undefined) {
-            status = 'closed';
-        }
         const stopPrice = this.safeNumber (order, 'stopPrice');
         return this.safeOrder ({
             'info': order,


### PR DESCRIPTION
- docstring parameters rearrange
- trigger orders fix
- status for orders is no longer `"closed"` by default (explanation: https://github.com/ccxt/ccxt/pull/16674#discussion_r1092393759)

----

With the changes made on #18694 I wasn't able to place a trigger order

The values for `params["stop"]` can only be `"entry"` or `"loss"`, but they were being set to `"up"` and `"down"`

![](https://i.imgur.com/kFb193p.png)

---------------------

# Testing

This is before the trigger price fix

```
% kucoin createOrder USDC/USDT limit sell 1.99 0.99 '{"triggerPrice": 0.99}'
2023-08-01T21:53:26.395Z
Node.js: v18.15.0
CCXT v4.0.47
kucoin.createOrder (USDC/USDT, limit, sell, 1.99, 0.99, [object Object])

[BadRequest] kucoin Stop order type invalid.

    at throwExactlyMatchedException  …samgermain/Documents/CCXT/ccxt/ts/src/base/Exchange.ts:3427  
    at handleErrors                  Users/samgermain/Documents/CCXT/ccxt/ts/src/kucoin.ts:4118    
    at                               …samgermain/Documents/CCXT/ccxt/ts/src/base/Exchange.ts:1001  
    at processTicksAndRejections     node:internal/process/task_queues:95                          
    at fetch2                        …samgermain/Documents/CCXT/ccxt/ts/src/base/Exchange.ts:2976  
    at request                       …samgermain/Documents/CCXT/ccxt/ts/src/base/Exchange.ts:2980  
    at createOrder                   Users/samgermain/Documents/CCXT/ccxt/ts/src/kucoin.ts:1881    
    at async run                     Users/samgermain/Documents/CCXT/ccxt/examples/ts/cli.ts:301   

kucoin Stop order type invalid.
```

This is after

```
% kucoin createOrder USDC/USDT limit sell 1.99 0.99 '{"triggerPrice": 0.99}'
2023-08-01T22:19:10.432Z
Node.js: v18.15.0
CCXT v4.0.47
kucoin.createOrder (USDC/USDT, limit, sell, 1.99, 0.99, [object Object])
2023-08-01T22:19:12.307Z iteration 0 passed in 312 ms

{
  info: { orderId: 'vs9f6p69gjg7fkfo000puajf' },
  id: 'vs9f6p69gjg7fkfo000puajf',
  clientOrderId: undefined,
  symbol: 'USDC/USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  amount: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  timestamp: undefined,
  datetime: undefined,
  fee: { currency: undefined, cost: undefined },
  status: undefined,
  lastTradeTimestamp: undefined,
  average: undefined,
  trades: [],
  fees: [ { currency: undefined, cost: undefined } ],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-01T22:19:12.307Z iteration 1 passed in 312 ms
```