### PR TITLE
fix(bitmexWs): normalize orderbook amounts

### DIFF
--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -1180,7 +1180,7 @@ export default class bitmex extends bitmexRest {
             orderbook['symbol'] = symbol;
             for (let i = 0; i < data.length; i++) {
                 const price = this.safeFloat (data[i], 'price');
-                const size = this.safeFloat (data[i], 'size');
+                const size = this.convertFromRawQuantity (symbol, this.safeString (data[i], 'size'));
                 const id = this.safeString (data[i], 'id');
                 let side = this.safeString (data[i], 'side');
                 side = (side === 'Buy') ? 'bids' : 'asks';
@@ -1203,8 +1203,8 @@ export default class bitmex extends bitmexRest {
                 const market = this.safeMarket (marketId);
                 const symbol = market['symbol'];
                 const orderbook = this.orderbooks[symbol];
-                const price = this.safeFloat (data[i], 'price');
-                const size = (action === 'delete') ? 0 : this.safeFloat (data[i], 'size', 0);
+                const price = this.safeNumber (data[i], 'price');
+                const size = (action === 'delete') ? 0 : this.convertFromRawQuantity (symbol, this.safeString (data[i], 'size', '0'));
                 const id = this.safeString (data[i], 'id');
                 let side = this.safeString (data[i], 'side');
                 side = (side === 'Buy') ? 'bids' : 'asks';


### PR DESCRIPTION
```
p bitmex watchOrderBook "BTC/USDT"
Python v3.10.9
CCXT v4.0.47
bitmex.watchOrderBook(BTC/USDT)
{'asks': [[29540.5, 0.0067, '85400940919'], [29541.0, 0.0045, '85400940918'], [29542.0, 0.0035, '85400940916'], [29542.5, 0.1838, '85400940915'], [29543.0, 0.2737, '85400940914'], [29543.5, 0.0098, '85400940913'], [29549.5, 0.095, '85400940901'], [29550.0, 0.0051, '85400940900'], [29552.5, 0.0344, '85400940895'], [29555.5, 0.0328, '85400940889'], [29557.5, 0.0099, '85400940885'], [29558.5, 0.0337, '85400940883'], [29561.5, 0.0343, '85400940877'], [29564.5, 0.0356, '85400940871'], [29565.0, 0.0379, '85400940870'], [29566.0, 0.0318, '85400940868'], [29568.0, 0.0368, '85400940864'], [29570.5, 0.0378, '85400940859'], [29574.0, 0.038, '85400940852'], [29600.0, 0.0368, '85400940800'], [29650.0, 0.0051, '85400940700'], [29700.0, 0.0119, '85400940600'], [29728.0, 0.001, '85400940544'], [29749.0, 0.004, '85400940502'], [29800.0, 0.0067, '85400940400'], [29900.0, 0.0067, '85400940200'], [29906.0, 0.0248, '85400940188'], [29949.5, 0.095, '85400940101'], [30018.0, 0.001, '85400939964'], [30050.0, 0.0014, '85400939900'], [30061.0, 0.0033, '85400939878'], [30110.0, 0.002, '85400939780'], [30122.5, 0.0033, '85400939755'], [30183.5, 0.0033, '85400939633'], [30239.0, 0.0009, '85400939522'], [30245.0, 0.0033, '85400939510'], [30248.0, 0.0134, '85400939504'], [30306.0, 0.0033, '85400939388'], [30308.0, 0.001, '85400939384'], [30367.5, 0.0033, '85400939265'], [30397.0, 0.0245, '85400939206'], [30428.5, 0.0033, '85400939143'], [30430.0, 0.08, '85400939140'], [30490.0, 0.0033, '85400939020'], [30498.0, 0.041, '85400939004'], [30551.0, 0.0033, '85400938898'], [30597.5, 0.001, '85400938805'], [30612.0, 0.0033, '85400938776'], [30673.5, 0.0033, '85400938653'], [30734.5, 0.0033, '85400938531'], [30750.0, 0.0046, '85400938500'], [30796.0, 0.0033, '85400938408'], [30840.0, 0.002, '85400938320'], [30857.0, 0.0033, '85400938286'], [30887.5, 0.001, '85400938225'], [30918.5, 0.0033, '85400938163'], [30950.0, 0.003, '85400938100'], [30979.5, 0.0033, '85400938041'], [31041.0, 0.0033, '85400937918'], [31100.0, 0.02, '85400937800'], [31102.0, 0.0033, '85400937796'], [31163.5, 0.0033, '85400937673'], [31176.0, 0.001, '85400937648'], [31224.5, 0.003, '85400937551'], [31285.5, 0.0033, '85400937429'], [31347.0, 0.0033, '85400937306'], [31408.0, 0.0033, '85400937184'], [31466.0, 0.001, '85400937068'], [31469.5, 0.0033, '85400937061'], [31530.5, 0.0033, '85400936939'], [31588.0, 0.0013, '85400936824'], [31592.0, 0.0033, '85400936816'], [31653.0, 0.0033, '85400936694'], [31714.5, 0.0033, '85400936571'], [31756.0, 0.001, '85400936488'], [31775.5, 0.0033, '85400936449'], [31836.5, 0.0033, '85400936327'], [31898.0, 0.
```
```
 p bitmex watchOrderBook "BTC/USDT:USDT"
Python v3.10.9
CCXT v4.0.47
bitmex.watchOrderBook(BTC/USDT:USDT)
{'asks': [[29513.0, 7000.0, '73200940974'], [29513.5, 50000.0, '73200940973'], [29514.0, 350000.0, '73200940972'], [29515.0, 50000.0, '73200940970'], [29515.5, 6000.0, '73200940969'], [29516.0, 50000.0, '73200940968'], [29516.5, 356000.0, '73200940967'], [29517.0, 50000.0, '73200940966'], [29517.5, 458000.0, '73200940965'], [29518.0, 674000.0, '73200940964'], [29518.5, 6000.0, '73200940963'], [29519.0, 597000.0, '73200940962'], [29519.5, 350000.0, '73200940961'], [29520.5, 943000.0, '73200940959'], [29521.0, 1511000.0, '73200940958'], [29521.5, 217000.0, '73200940957'], [29522.0, 350000.0, '73200940956'], [29522.5, 30000.0, '73200940955'], [29523.0, 30000.0, '73200940954'], [29524.0, 643000.0, '73200940952'], [29524.5, 6000.0, '73200940951'], [29525.0, 1550000.0, '73200940950'], [29525.5, 820000.0, '73200940949'], [29526.0, 1219000.0, '73200940948'], [29528.0, 216000.0, '73200940944'], [29528.5, 350000.0, '73200940943'], [29530.5, 1372000.0, '73200940939'], [29531.0, 2272000.0, '73200940938'], [29532.5, 212000.0, '73200940935'], [29533.0, 350000.0, '73200940934'], [29533.5, 88000.0, '73200940933'], [29534.0, 33000.0, '73200940932'], [29535.5, 215000.0, '73200940929'], [29536.0, 350000.0, '73200940928'], [29539.0, 1384000.0, '73200940922'], [29539.5, 350000.0, '73200940921'], [29542.5, 1275000.0, '73200940915'], [29545.5, 641000.0, '73200940909'], [29546.0, 215000.0, '73200940908'], [29546.5, 355000.0, '73200940907'], [29549.0, 1000.0, '73200940902'], [29549.5, 212000.0, '73200940901'], [29550.0, 2384000.0, '73200940900']
```
