### PR TITLE
fix(gate): php parseOrder - fix 

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4015,8 +4015,8 @@ export default class gate extends Exchange {
         //        "order_type": ""
         //    }
         //
-        const put = this.safeValue2 (order, 'put', 'initial');
-        const trigger = this.safeValue (order, 'trigger');
+        const put = this.safeValue2 (order, 'put', 'initial', {});
+        const trigger = this.safeValue (order, 'trigger', {});
         let contract = this.safeString (put, 'contract');
         let type = this.safeString (put, 'type');
         let timeInForce = this.safeStringUpper2 (put, 'time_in_force', 'tif');


### PR DESCRIPTION
fix error:

```php
PHP Fatal error:  Uncaught TypeError: ccxt\async\Exchange::safe_number(): Argument #1 ($obj) must be of type array, null given
```

fixes: #17664