### PR TITLE
fix(bitfinex): handleOrderBook - string math

### DIFF
--- a/ts/src/pro/bitfinex.ts
+++ b/ts/src/pro/bitfinex.ts
@@ -352,13 +352,13 @@ export default class bitfinex extends bitfinexRest {
             const orderbook = this.orderbooks[symbol];
             if (isRaw) {
                 const id = this.safeString (message, 1);
-                const price = this.safeFloat (message, 2);
+                const price = this.safeString (message, 2);
                 const size = (message[3] < 0) ? -message[3] : message[3];
                 const side = (message[3] < 0) ? 'asks' : 'bids';
                 const bookside = orderbook[side];
                 // price = 0 means that you have to remove the order from your book
-                const amount = (price > 0) ? size : 0;
-                bookside.store (price, amount, id);
+                const amount = Precise.stringGt (price, '0') ? size : '0';
+                bookside.store (this.parseNumber (price), this.parseNumber (amount), id);
             } else {
                 const size = (message[3] < 0) ? -message[3] : message[3];
                 const side = (message[3] < 0) ? 'asks' : 'bids';


### PR DESCRIPTION
# Testing

```
% bitfinex watchOrderBook BTC/USDT
2023-08-02T21:56:15.695Z
Node.js: v18.15.0
CCXT v4.0.43
bitfinex.watchOrderBook (BTC/USDT)
CountedOrderBook {
  bids: CountedBids(25) [
    [ 29188, 0.00051384, 1 ],
    [ 29181, 0.1815, 1 ],
    [ 29180, 0.1057, 1 ],
    ...
    [ 29147, 0.26593931, 1 ],
    [ 29146, 0.26593931, 1 ]
  ],
  asks: CountedAsks(25) [
    [ 29189, 3.14821955, 9 ],
    [ 29190, 0.685579, 1 ],
    [ 29192, 0.69590834, 2 ],
    ...
    [ 29219, 0.26593931, 1 ],
    [ 29220, 0.001, 1 ]
  ],
  timestamp: undefined,
  datetime: undefined,
  nonce: undefined,
  symbol: undefined
}
```

```
% py bitfinex watchOrderBook BTC/USDT
Python v3.11.3
CCXT v4.0.43
bitfinex.watchOrderBook(BTC/USDT)
{'asks': [[29189, 3.14821955, 9], [29190, 2.271158, 3], [29191, 0.000513, 1], [29192, 0.69577383, 2], [29193, 0.21678586, 3], [29196, 0.1057, 1], [29197, 0.01713103, 1], [29198, 0.06940458, 2], [29200, 1, 1], [29201, 2.25326, 2], [29202, 1, 1], [29203, 0.87, 1], [29204, 0.01015674, 1], [29205, 0.35286553, 3], [29206, 0.4877464, 3], [29207, 0.001, 1], [29208, 0.001, 1], [29209, 0.7139281, 3], [29210, 0.001, 1], [29212, 0.64699262, 1], [29214, 0.5295, 3], [29216, 0.94149779, 2], [29217, 0.1780737, 2], [29218, 0.47253905, 2], [29219, 1.06439554, 3]],
 'bids': [[29188, 8.4e-07, 1], [29181, 0.1934, 1], [29180, 0.11911, 2], [29178, 1.371664, 2], [29177, 0.685849, 1], [29175, 0.685907, 1], [29172, 0.0506431, 1], [29171, 0.75017825, 3], [29169, 0.1057, 1], [29168, 2.086064, 4], [29166, 0.6862, 2], [29165, 0.68983393, 3], [29164, 1.715374, 1], [29163, 0.0189942, 2], [29161, 0.54, 1], [29160, 0.35286464, 3], [29158, 0.0011, 1], [29156, 0.87, 1], [29154, 0.23311807, 1], [29151, 0.5285, 2], [29150, 0.35164358, 1], [29146, 0.26593931, 1], [29145, 0.26703931, 2], [29144, 0.21385144, 2], [29142, 2.361, 4]],
 'datetime': None,
 'nonce': None,
 'symbol': None,
 'timestamp': None}
```

```
% ph bitfinex watchOrderBook BTC/USDT
PHP v8.2.5
CCXT version :4.0.43
bitfinex->watchOrderBook(BTC/USDT)
PHP Deprecated:  Creation of dynamic property ccxt\pro\Client::$throttle is deprecated in /Users/samgermain/Documents/CCXT/ccxt/php/pro/Client.php on line 128

Deprecated: Creation of dynamic property ccxt\pro\Client::$throttle is deprecated in /Users/samgermain/Documents/CCXT/ccxt/php/pro/Client.php on line 128
ccxt\pro\CountedOrderBook Object
(
    [cache] => Array
        (
        )

    [storage:ArrayObject:private] => Array
        (
            [bids] => ccxt\pro\CountedBids Object
                (
                    [index] => Array
                        (
                            [0] => -29188
                            [1] => -29181
                            [2] => -29180
                            [3] => -29177
                            [4] => -29176
                            [5] => -29174
                            [6] => -29172
                            [7] => -29171
                            [8] => -29169
                            [9] => -29168
                            [10] => -29166
                            [11] => -29165
                            [12] => -29164
                            [13] => -29163
                            [14] => -29161
                            [15] => -29160
                            [16] => -29158
                            [17] => -29154
                            [18] => -29151
                            [19] => -29150
                            [20] => -29145
                            [21] => -29144
                            [22] => -29142
                            [23] => -29141
                            [24] => -29139
                        )

                    [depth] => 25
                    [n] => 9223372036854775807
                    [storage:ArrayObject:private] => Array
                        (
                            [0] => Array
                                (
                                    [0] => 29188
                                    [1] => 8.4E-7
                                    [2] => 1
                                )

                            [1] => Array
                                (
                                    [0] => 29181
                                    [1] => 0.1934
                                    [2] => 1
                                )

                            [2] => Array
                                (
                                    [0] => 29180
                                    [1] => 0.11911
                                    [2] => 2
                                )

                            [3] => Array
                                (
                                    [0] => 29177
                                    [1] => 1.371706
                                    [2] => 2
                                )

                            [4] => Array
                                (
                                    [0] => 29176
                                    [1] => 0.68587
                                    [2] => 1
                                )
                              ...
                        )

                )
```
            
            