### PR TITLE
fix(bitget): orderbook checksum

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -430,7 +430,8 @@ export default class bitget extends bitgetRest {
             storedOrderBook['timestamp'] = timestamp;
             storedOrderBook['datetime'] = this.iso8601 (timestamp);
             const checksum = this.safeValue (this.options, 'checksum', true);
-            if (checksum) {
+            const isSnapshot = this.safeString (message, 'action') === 'snapshot'; // snapshot does not have a checksum
+            if (!isSnapshot && checksum) {
                 const storedAsks = storedOrderBook['asks'];
                 const storedBids = storedOrderBook['bids'];
                 const asksLength = storedAsks.length;


### PR DESCRIPTION
```
✗ p bitget watchOrderBook "BTC/USDT"
Python v3.10.9
CCXT v4.0.49
bitget.watchOrderBook(BTC/USDT)
{'asks': [[29159.58, 6.7536, ['29159.58', '6.7536']], [29159.59, 0.8239, ['29159.59', '0.8239']], [29159.6, 0.2843, ['29159.60', '0.2843']], [29159.66, 0.853, ['29159.66', '0.8530']], [29159.8, 0.1023, ['29159.80', '0.1023']], [29159.84, 0.48, ['29159.84', '0.4800']], [29159.87, 0.011, ['29159.87', '0.0110']], [29159.9, 0.2416, ['29159.90', '0.2416']], [29159.94, 0.0118, ['29159.94', '0.0118']], [29160.0, 0.3008, ['29160.00', '0.3008']], [29160.01, 0.272, ['29160.01', '0.2720']], [29160.02, 0.0256, ['29160.02', '0.0256']], [29160.03, 0.2303, ['29160.03', '0.2303']], [29160.1, 0.2893, ['29160.10', '0.2893']], [29160.11, 0.6784, ['29160.11', '0.6784']], [29160.16, 0.128, ['29160.16', '0.1280']], [29160.6, 0.5492, ['29160.60', '0.5492']], [29160.74, 0.0138, ['29160.74', '0.0138']], [29160.81, 0.0139, ['29160.81', '0.0139']], [29160.9, 0.46, ['29160.90', '0.4600']], [29161.03, 0.0456, ['29161.03', '0.0456']], [29161.04, 0.0105, ['29161.04', '0.0105']], [29161.09, 0.0135, ['29161.09', '0.0135']], [29161.33, 1.6476, ['29161.33', '1.6476']], [29161.37, 0.0326, ['29161.37', '0.0326']], [29161.43, 1.8685, ['29161.43', '1.8685']], [29161.44, 0.0416, ['29161.44', '0.0416']], [29161.46, 0.4, ['29161.46', '0.4000']], [29161.49, 0.0348, ['29161.49', '0.0348']], [29161.5, 0.66, ['29161.50', '0.6600']], [29161.53, 0.8449, ['29161.53', '0.8449']], [29161.54, 1.408, ['29161.54', '1.4080']], [29161.58, 0.0147, ['29161.58', '0.0147']], [29161.6, 0.5492, ['29161.60', '0.5492']], [29161.61, 0.014, ['29161.61', '0.0140']], [29161.64, 0.512, ['29161.64', '0.5120']], [29161.68, 0.0122, ['29161.68', '0.0122']], [29162.0, 0.4755, ['29162.00', '0.4755']], [29162.01, 0.0141, ['29162.01', '0.0141']], [29162.1, 0.0292, ['29162.10', '0.0292']], [29162.21, 0.0359, ['29162.21', '0.0359']], [29162.22, 0.64, ['29162.22', '0.6400']], [29162.32, 1.28, ['29162.32', '1.2800']], [29162.43, 0.0113, ['29162.43', '0.0113']], [29162.46, 0.0131, ['29162.46', '0.0131']], [29162.48, 0.0112, ['29162.48', '0.0112']], [29162.5, 0.1985, ['29162.50', '0.1985']], [29162.55, 0.1214, ['29162.55', '0.1214']], [29162.6, 0.5492, ['29162.60', '0.5492']], [29162.62, 0.0143, ['29162.62', '0.0143']], [29162.63, 0.3707, ['29162.63', '0.3707']], [29162.64, 0.0107, ['29162.64', '0.0107']], [29162.78, 0.4536, ['29162.78', '0.4536']], [29162.79, 0.5492, ['29162.79', '0.5492']], [29162.84, 1.04, ['29162.84', '1.0400']], [29162.88, 0.9233, ['29162.88', '0.9233']], [29163.0, 0.0109, ['29163.00', '0.0109']], [29163.07, 1.6475, ['29163.07', '1.6475']], [29163.1, 0.1215, ['29163.10', '0.1215']], [29163.2, 0.044, ['29163.20', '0.0440']], [29163.25, 0.0488, ['29163.25', '0.0488']], [29163.3, 0.064, ['29163.30', '0.0640']], [29163.35, 0.0136, ['29163.35', '0.0136']], [29163.36, 0.823, ['29163.36', '0.8230']], [29163.4, 0.1489, ['29163.40', '0.1489']], [29163.42, 0.0145, ['29163.42', '0.0145']], [29163.48, 0.0448, ['29163.48', '0.0448']], [29163.63, 0.2489, ['29163.63', '0.2489']], [2916
```
