### PR TITLE
feat(deribit): add fetchFundingRate and fetchFundingRateHistory

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -2806,6 +2806,132 @@ export default class deribit extends Exchange {
         return this.parseDepositWithdrawFees (data, codes, 'currency');
     }
 
+    async fetchFundingRate (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name deribit#fetchFundingRate
+         * @description fetch the current funding rate
+         * @see https://docs.deribit.com/#public-get_funding_rate_value
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the deribit api endpoint
+         * @param {int} [params.start_timestamp] fetch funding rate starting from this timestamp
+         * @param {int} [params.end_timestamp] fetch funding rate ending at this timestamp
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const time = this.milliseconds ();
+        const request = {
+            'instrument_name': market['id'],
+            'start_timestamp': time - (8 * 60 * 60 * 1000), // 8h ago,
+            'end_timestamp': time,
+        };
+        const response = await this.publicGetGetFundingRateValue (this.extend (request, params));
+        //
+        //   {
+        //       "jsonrpc":"2.0",
+        //       "result":"0",
+        //       "usIn":"1691161645596519",
+        //       "usOut":"1691161645597149",
+        //       "usDiff":"630",
+        //       "testnet":false
+        //   }
+        //
+        return this.parseFundingRate (response, market);
+    }
+
+    async fetchFundingRateHistory (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name deribit#fetchFundingRateHistory
+         * @description fetch the current funding rate
+         * @see https://docs.deribit.com/#public-get_funding_rate_history
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the deribit api endpoint
+         * @param {int} [params.end_timestamp] fetch funding rate ending at this timestamp
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const time = this.milliseconds ();
+        const month = 30 * 24 * 60 * 60 * 1000;
+        if (since === undefined) {
+            since = time - month;
+        }
+        const request = {
+            'instrument_name': market['id'],
+            'start_timestamp': since,
+            'end_timestamp': time,
+        };
+        const response = await this.publicGetGetFundingRateHistory (this.extend (request, params));
+        //
+        //    {
+        //        "jsonrpc": "2.0",
+        //        "id": 7617,
+        //        "result": [
+        //          {
+        //            "timestamp": 1569891600000,
+        //            "index_price": 8222.87,
+        //            "prev_index_price": 8305.72,
+        //            "interest_8h": -0.00009234260068476106,
+        //            "interest_1h": -4.739622041017375e-7
+        //          }
+        //        ]
+        //    }
+        //
+        const rates = [];
+        const result = this.safeValue (response, 'result', []);
+        for (let i = 0; i < result.length; i++) {
+            const fr = result[i];
+            const rate = this.parseFundingRate (fr, market);
+            rates.push (rate);
+        }
+        return this.filterBySymbolSinceLimit (rates, symbol, since, limit);
+    }
+
+    parseFundingRate (contract, market = undefined) {
+        //
+        //   {
+        //       "jsonrpc":"2.0",
+        //       "result":"0",
+        //       "usIn":"1691161645596519",
+        //       "usOut":"1691161645597149",
+        //       "usDiff":"630",
+        //       "testnet":false
+        //   }
+        // history
+        //   {
+        //     "timestamp": 1569891600000,
+        //     "index_price": 8222.87,
+        //     "prev_index_price": 8305.72,
+        //     "interest_8h": -0.00009234260068476106,
+        //     "interest_1h": -4.739622041017375e-7
+        //   }
+        //
+        const timestamp = this.safeInteger (contract, 'timestamp');
+        const datetime = this.iso8601 (timestamp);
+        const result = this.safeNumber2 (contract, 'result', 'interest_8h');
+        return {
+            'info': contract,
+            'symbol': this.safeSymbol (undefined, market),
+            'markPrice': undefined,
+            'indexPrice': this.safeNumber (contract, 'index_price'),
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': timestamp,
+            'datetime': datetime,
+            'fundingRate': result,
+            'fundingTimestamp': undefined,
+            'fundingDatetime': undefined,
+            'nextFundingRate': undefined,
+            'nextFundingTimestamp': undefined,
+            'nextFundingDatetime': undefined,
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
+        };
+    }
+
     nonce () {
         return this.milliseconds ();
     }

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -58,6 +58,8 @@ export default class deribit extends Exchange {
                 'fetchDepositWithdrawFees': true,
                 'fetchIndexOHLCV': false,
                 'fetchLeverageTiers': false,
+                'fetchFundingRate': true,
+                'fetchFundingRateHistory': true,
                 'fetchMarginMode': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,


### PR DESCRIPTION
DEMO

```
p deribit fetchFundingRateHistory "ETH/USD:ETH" None 2   
Python v3.10.9
CCXT v4.0.49
deribit.fetchFundingRateHistory(ETH/USD:ETH,None,2)
[{'datetime': '2023-08-04T14:00:00.000Z',
  'estimatedSettlePrice': None,
  'fundingDatetime': None,
  'fundingRate': 0.0003108118735316121,
  'fundingTimestamp': None,
  'indexPrice': 1841.62,
  'info': {'index_price': '1841.62',
           'interest_1h': '0.000040037341082362756',
           'interest_8h': '0.0003108118735316121',
           'prev_index_price': '1837.77',
           'timestamp': '1691157600000'},
  'interestRate': None,
  'markPrice': None,
  'nextFundingDatetime': None,
  'nextFundingRate': None,
  'nextFundingTimestamp': None,
  'previousFundingDatetime': None,
  'previousFundingRate': None,
  'previousFundingTimestamp': None,
  'symbol': 'ETH/USD:ETH',
  'timestamp': 1691157600000},
 {'datetime': '2023-08-04T15:00:00.000Z',
  'estimatedSettlePrice': None,
  'fundingDatetime': None,
  'fundingRate': 0.0003472644414748492,
  'fundingTimestamp': None,
  'indexPrice': 1845.52,
  'info': {'index_price': '1845.52',
           'interest_1h': '0.000042599284093567054',
           'interest_8h': '0.0003472644414748492',
           'prev_index_price': '1841.62',
           'timestamp': '1691161200000'},
  'interestRate': None,
  'markPrice': None,
  'nextFundingDatetime': None,
  'nextFundingRate': None,
  'nextFundingTimestamp': None,
  'previousFundingDatetime': None,
  'previousFundingRate': None,
  'previousFundingTimestamp': None,
  'symbol': 'ETH/USD:ETH',
  'timestamp': 1691161200000}]
```
```
 p deribit fetchFundingRate "ETH/USD:ETH"                
Python v3.10.9
CCXT v4.0.49
deribit.fetchFundingRate(ETH/USD:ETH)
{'datetime': None,
 'estimatedSettlePrice': None,
 'fundingDatetime': None,
 'fundingRate': 0.00035470956525977115,
 'fundingTimestamp': None,
 'indexPrice': None,
 'info': {'jsonrpc': '2.0',
          'result': '0.00035470956525977115',
          'testnet': False,
          'usDiff': '303',
          'usIn': '1691162584698442',
          'usOut': '1691162584698745'},
 'interestRate': None,
 'markPrice': None,
 'nextFundingDatetime': None,
 'nextFundingRate': None,
 'nextFundingTimestamp': None,
 'previousFundingDatetime': None,
 'previousFundingRate': None,
 'previousFundingTimestamp': None,
 'symbol': 'ETH/USD:ETH',
 'timestamp': None}
```

