### PR TITLE
feat(bitfinex2): add funding rate methods

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1,4 +1,5 @@
 // ---------------------------------------------------------------------------
+import { time } from 'console';
 import { ExchangeError, InvalidAddress, ArgumentsRequired, InsufficientFunds, AuthenticationError, OrderNotFound, InvalidOrder, BadRequest, InvalidNonce, BadSymbol, OnMaintenance, NotSupported, PermissionDenied, ExchangeNotAvailable } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import Exchange from './abstract/bitfinex2.js';
@@ -45,6 +46,9 @@ export default class bitfinex2 extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDepositsWithdrawals': true,
+                'fetchFundingRate': true,
+                'fetchFundingRateHistory': true,
+                'fetchFundingRates': true,
                 'fetchIndexOHLCV': false,
                 'fetchLedger': true,
                 'fetchMarginMode': false,
@@ -153,6 +157,7 @@ export default class bitfinex2 extends Exchange {
                         'candles/trade:{timeframe}:{symbol}/hist': 2.66,
                         'status/{type}': 2.66,
                         'status/deriv': 2.66,
+                        'status/deriv/{symbol}/hist': 2.66,
                         'liquidations/hist': 80, // 3 requests a minute = 0.05 requests a second => ( 1000ms / rateLimit ) / 0.05 = 80
                         'rankings/{key}:{timeframe}:{symbol}/{section}': 2.66,
                         'rankings/{key}:{timeframe}:{symbol}/hist': 2.66,
@@ -2631,5 +2636,230 @@ export default class bitfinex2 extends Exchange {
         //     ]
         //
         return this.parseLedger (response, currency, since, limit);
+    }
+
+    async fetchFundingRate (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name bitfine#fetchFundingRate
+         * @description fetch the current funding rate
+         * @see https://docs.bitfinex.com/reference/rest-public-derivatives-status
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the bingx api endpoint
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        return this.fetchFundingRates ([ symbol ], params);
+    }
+
+    async fetchFundingRates (symbols: string[] = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitfine#fetchFundingRate
+         * @description fetch the current funding rate
+         * @see https://docs.bitfinex.com/reference/rest-public-derivatives-status
+         * @param {string[]} symbols list of unified market symbols
+         * @param {object} [params] extra parameters specific to the bingx api endpoint
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        if (symbols === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingRates() requires a symbols argument');
+        }
+        await this.loadMarkets ();
+        const marketIds = this.marketIds (symbols);
+        const request = {
+            'keys': marketIds.join (','),
+        };
+        const response = await this.publicGetStatusDeriv (this.extend (request, params));
+        //
+        //   [
+        //       [
+        //          "tBTCF0:USTF0",
+        //          1691165059000,
+        //          null,
+        //          29297.851276225,
+        //          29277.5,
+        //          null,
+        //          36950860.76010306,
+        //          null,
+        //          1691193600000,
+        //          0.00000527,
+        //          82,
+        //          null,
+        //          0.00014548,
+        //          null,
+        //          null,
+        //          29278.8925,
+        //          null,
+        //          null,
+        //          9636.07644994,
+        //          null,
+        //          null,
+        //          null,
+        //          0.0005,
+        //          0.0025
+        //       ]
+        //   ]
+        //
+        return this.parseFundingRates (response);
+    }
+
+    async fetchFundingRateHistory (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitfine#fetchFundingRateHistory
+         * @description fetches historical funding rate prices
+         * @see https://docs.bitfinex.com/reference/rest-public-derivatives-status-history
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the bingx api endpoint
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        await this.loadMarkets ();
+        this.checkRequiredSymbol ('fetchFundingRateHistory', symbol);
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.publicGetStatusDerivSymbolHist (this.extend (request, params));
+        //
+        //   [
+        //       [
+        //          "tBTCF0:USTF0",
+        //          1691165059000,
+        //          null,
+        //          29297.851276225,
+        //          29277.5,
+        //          null,
+        //          36950860.76010306,
+        //          null,
+        //          1691193600000,
+        //          0.00000527,
+        //          82,
+        //          null,
+        //          0.00014548,
+        //          null,
+        //          null,
+        //          29278.8925,
+        //          null,
+        //          null,
+        //          9636.07644994,
+        //          null,
+        //          null,
+        //          null,
+        //          0.0005,
+        //          0.0025
+        //       ]
+        //   ]
+        //
+        const rates = [];
+        for (let i = 0; i < response.length; i++) {
+            const fr = response[i];
+            const rate = this.parseFundingRateHistory (fr, market);
+            rates.push (rate);
+        }
+        return this.filterBySymbolSinceLimit (rates, symbol, since, limit);
+    }
+
+    parseFundingRate (contract, market = undefined) {
+        //
+        //       [
+        //          "tBTCF0:USTF0",
+        //          1691165059000,
+        //          null,
+        //          29297.851276225,
+        //          29277.5,
+        //          null,
+        //          36950860.76010306,
+        //          null,
+        //          1691193600000,
+        //          0.00000527,
+        //          82,
+        //          null,
+        //          0.00014548,
+        //          null,
+        //          null,
+        //          29278.8925,
+        //          null,
+        //          null,
+        //          9636.07644994,
+        //          null,
+        //          null,
+        //          null,
+        //          0.0005,
+        //          0.0025
+        //       ]
+        //
+        const marketId = this.safeString (contract, 0);
+        const timestamp = this.safeInteger (contract, 1);
+        const nextFundingTimestamp = this.safeInteger (contract, 8);
+        return {
+            'info': contract,
+            'symbol': this.safeSymbol (marketId, market),
+            'markPrice': this.safeNumber (contract, 15),
+            'indexPrice': this.safeNumber (contract, 3),
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'fundingRate': this.safeNumber (contract, 12),
+            'fundingTimestamp': undefined,
+            'fundingDatetime': undefined,
+            'nextFundingRate': this.safeNumber (contract, 9),
+            'nextFundingTimestamp': nextFundingTimestamp,
+            'nextFundingDatetime': this.iso8601 (nextFundingTimestamp),
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
+        };
+    }
+
+    parseFundingRateHistory (contract, market = undefined) {
+        //
+        // [
+        //     1691165494000,
+        //     null,
+        //     29278.95838065,
+        //     29260.5,
+        //     null,
+        //     36950860.76010305,
+        //     null,
+        //     1691193600000,
+        //     0.00001449,
+        //     222,
+        //     null,
+        //     0.00014548,
+        //     null,
+        //     null,
+        //     29260.005,
+        //     null,
+        //     null,
+        //     9635.86484562,
+        //     null,
+        //     null,
+        //     null,
+        //     0.0005,
+        //     0.0025
+        // ]
+        //
+        const timestamp = this.safeInteger (contract, 0);
+        const nextFundingTimestamp = this.safeInteger (contract, 7);
+        return {
+            'info': contract,
+            'symbol': this.safeSymbol (undefined, market),
+            'markPrice': this.safeNumber (contract, 14),
+            'indexPrice': this.safeNumber (contract, 2),
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'fundingRate': this.safeNumber (contract, 11),
+            'fundingTimestamp': undefined,
+            'fundingDatetime': undefined,
+            'nextFundingRate': this.safeNumber (contract, 8),
+            'nextFundingTimestamp': nextFundingTimestamp,
+            'nextFundingDatetime': this.iso8601 (nextFundingTimestamp),
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
+        };
     }
 }

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1,5 +1,4 @@
 // ---------------------------------------------------------------------------
-import { time } from 'console';
 import { ExchangeError, InvalidAddress, ArgumentsRequired, InsufficientFunds, AuthenticationError, OrderNotFound, InvalidOrder, BadRequest, InvalidNonce, BadSymbol, OnMaintenance, NotSupported, PermissionDenied, ExchangeNotAvailable } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import Exchange from './abstract/bitfinex2.js';


### PR DESCRIPTION
DEMO

```
p bitfinex2 fetchFundingRates '["LTC/USDT:USDT", "BTC/USDT:USDT"]'
Python v3.10.9
CCXT v4.0.49
bitfinex2.fetchFundingRates(['LTC/USDT:USDT', 'BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'datetime': '2023-08-04T16:29:45.000Z',
                   'estimatedSettlePrice': None,
                   'fundingDatetime': None,
                   'fundingRate': 0.00014548,
                   'fundingTimestamp': None,
                   'indexPrice': 29288.681009995,
                   'info': ['tBTCF0:USTF0',
                            '1691166585000',
                            None,
                            '29288.681009995',
                            '29270.5',
                            None,
                            '36950860.76010305',
                            None,
                            '1691193600000',
                            '0.00003959',
                            '573',
                            None,
                            '0.00014548',
                            None,
                            None,
                            '29269.19',
                            None,
                            None,
                            '9636.01345523',
                            None,
                            None,
                            None,
                            '0.0005',
                            '0.0025'],
                   'interestRate': None,
                   'markPrice': 29269.19,
                   'nextFundingDatetime': '2023-08-05T00:00:00.000Z',
                   'nextFundingRate': 3.959e-05,
                   'nextFundingTimestamp': 1691193600000,
                   'previousFundingDatetime': None,
                   'previousFundingRate': None,
                   'previousFundingTimestamp': None,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1691166585000},
 'LTC/USDT:USDT': {'datetime': '2023-08-04T16:29:45.000Z',
                   'estimatedSettlePrice': None,
                   'fundingDatetime': None,
                   'fundingRate': 0.0,
                   'fundingTimestamp': None,
                   'indexPrice': 83.469698005,
                   'info': ['tLTCF0:USTF0',
                            '1691166585000',
                            None,
                            '83.469698005',
                            '83.4685',
                            None,
                            '36950860.76010305',
                            None,
                            '1691193600000',
                            '0.00000418',
                            '573',
                            None,
                            '0',
                            None,
                            None,
                            '83.41475',
                            None,
                            None,
                            '16391.20503219',
                            None,
                            None,
                            None,
                            '0.0005',
                            '0.0025'],
                   'interestRate': None,
                   'markPrice': 83.41475,
                   'nextFundingDatetime': '2023-08-05T00:00:00.000Z',
                   'nextFundingRate': 4.18e-06,
                   'nextFundingTimestamp': 1691193600000,
                   'previousFundingDatetime': None,
                   'previousFundingRate': None,
                   'previousFundingTimestamp': None,
                   'symbol': 'LTC/USDT:USDT',
                   'timestamp': 1691166585000}}
```
```
p bitfinex2 fetchFundingRateHistory "BTC/USDT:USDT" None 2
Python v3.10.9
CCXT v4.0.49
bitfinex2.fetchFundingRateHistory(BTC/USDT:USDT,None,2)
[{'datetime': '2023-08-04T16:30:19.000Z',
  'estimatedSettlePrice': None,
  'fundingDatetime': None,
  'fundingRate': 0.00014548,
  'fundingTimestamp': None,
  'indexPrice': 29288.35711795,
  'info': ['1691166619000',
           None,
           '29288.35711795',
           '29270.5',
           None,
           '36950860.76010305',
           None,
           '1691193600000',
           '0.00004036',
           '584',
           None,
           '0.00014548',
           None,
           None,
           '29269.4425',
           None,
           None,
           '9636.01345523',
           None,
           None,
           None,
           '0.0005',
           '0.0025'],
  'interestRate': None,
  'markPrice': 29269.4425,
  'nextFundingDatetime': '2023-08-05T00:00:00.000Z',
  'nextFundingRate': 4.036e-05,
  'nextFundingTimestamp': 1691193600000,
  'previousFundingDatetime': None,
  'previousFundingRate': None,
  'previousFundingTimestamp': None,
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1691166619000},
 {'datetime': '2023-08-04T16:29:57.000Z',
  'estimatedSettlePrice': None,
  'fundingDatetime': None,
  'fundingRate': 0.00014548,
  'fundingTimestamp': None,
  'indexPrice': 29288.54435717,
  'info': ['1691166597000',
           None,
           '29288.54435717',
           '29270.5',
           None,
           '36950860.76010305',
           None,
           '1691193600000',
           '0.00003987',
           '577',
           None,
           '0.00014548',
           None,
           None,
           '29269.19',
           None,
           None,
           '9636.01345523',
           None,
           None,
           None,
           '0.0005',
           '0.0025'],
  'interestRate': None,
  'markPrice': 29269.19,
  'nextFundingDatetime': '2023-08-05T00:00:00.000Z',
  'nextFundingRate': 3.987e-05,
  'nextFundingTimestamp': 1691193600000,
  'previousFundingDatetime': None,
  'previousFundingRate': None,
  'previousFundingTimestamp': None,
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1691166597000}]
```
