### PR TITLE
Assign number type via json

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1178,6 +1178,13 @@ class Exchange {
             }
         }
 
+        $type_names = array(
+            'string' => 'string',
+            'number' => 'floatval',
+        );
+        $assigned_type = $this->safe_string_lower($this->options, 'number', 'number');
+        $this->number = $type_names[$assigned_type];
+
         if ($this->markets) {
             $this->set_markets($this->markets);
         }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -466,6 +466,13 @@ class Exchange(object):
             self.session.trust_env = self.requests_trust_env
         self.logger = self.logger if self.logger else logging.getLogger(__name__)
 
+        type_names = {
+            'string': str,
+            'number': float,
+        }
+        assigned_type = self.safe_string_lower(self.options, 'number', 'number')
+        self.number = type_names[assigned_type]
+
     def __del__(self):
         if self.session:
             try:

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -192,7 +192,7 @@ export default class Exchange {
     minFundingAddressLength = 1 // used in checkAddress
     substituteCommonCurrencyCodes = true  // reserved
     quoteJsonNumbers = true // treat numbers in json as quoted precise strings
-    number = Number // or String (a pointer to a function)
+    number: NumberConstructor | StringConstructor // or String (a pointer to a function)
     handleContentTypeApplicationZip = false
 
     // whether fees should be summed by currency code
@@ -647,7 +647,6 @@ export default class Exchange {
         this.minFundingAddressLength = 1 // used in checkAddress
         this.substituteCommonCurrencyCodes = true  // reserved
         this.quoteJsonNumbers = true // treat numbers in json as quoted precise strings
-        this.number = Number // or String (a pointer to a function)
         this.handleContentTypeApplicationZip = false
         // whether fees should be summed by currency code
         this.reduceFees = true
@@ -735,6 +734,8 @@ export default class Exchange {
         if (this.markets) {
             this.setMarkets (this.markets)
         }
+        const assignedType = this.safeStringLower (this.options, 'number', 'number');
+        this.number = (assignedType === 'string' ? String : Number);
         this.newUpdates = ((this.options as any).newUpdates !== undefined) ? (this.options as any).newUpdates : true;
 
         this.afterConstruct ();
@@ -1065,7 +1066,7 @@ export default class Exchange {
         return
     }
 
-    parseNumber (value, d: number = undefined): number {
+    parseNumber (value, d: number = undefined): number | string {
         if (value === undefined) {
             return d
         } else {
@@ -3767,12 +3768,12 @@ export default class Exchange {
         return this.precisionMode === SIGNIFICANT_DIGITS;
     }
 
-    safeNumber (obj: object, key: IndexType, defaultNumber: number = undefined): number {
+    safeNumber (obj: object, key: IndexType, defaultNumber: number = undefined): number | string {
         const value = this.safeString (obj, key);
         return this.parseNumber (value, defaultNumber);
     }
 
-    safeNumberN (obj: object, arr: IndexType[], defaultNumber: number = undefined): number {
+    safeNumberN (obj: object, arr: IndexType[], defaultNumber: number = undefined): number | string {
         const value = this.safeStringN (obj, arr);
         return this.parseNumber (value, defaultNumber);
     }


### PR DESCRIPTION
# Changes

- can assign number via arguments passed to the constructor
    - e.g.
```js
const exchange = new okx ({
    'options': {
        'number': 'number',  // or 'string'
    },
});
```
- type for property `number` on `Exchange` changed to `NumberConstructor | StringConstructor`