### PR TITLE
fix(ascendex) - WS structural unif

### DIFF
--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -52,14 +52,13 @@ export default class ascendex extends ascendexRest {
     async watchPublic (messageHash, symbol: string, method = undefined, params = {}) {
         const url = this.urls['api']['ws']['public'];
         const id = this.nonce ();
-        const idString = id.toString ();
         const request = {
-            'id': idString,
+            'id': id.toString (),
             'op': 'sub',
         };
         const message = this.extend (request, params);
         const subscription = {
-            'id': idString,
+            'id': id.toString (),
             'messageHash': messageHash,
             'symbol': symbol,
             'params': params,
@@ -922,7 +921,6 @@ export default class ascendex extends ascendexRest {
         //
         //     { m: 'sub', id: '1647515701', ch: 'depth:BTC/USDT', code: 0 }
         //
-        const channel = this.safeString (message, 'ch', '');
         const id = this.safeString (message, 'id');
         const subscriptionsById = this.indexBy (client.subscriptions, 'id');
         const subscription = this.safeValue (subscriptionsById, id);


### PR DESCRIPTION
this was the only exchange which had obsolete/anti-unifyish  signature (i.e. `handleOrderBookSubscription`,`watchOrderBookSnapshot` ..), and prevented me to make unification of some WS parts across all exchanges, because of only ascendex .
after this is merged, I can do some unification across all exchanges.