### PR TITLE
Mexc: update rateLimit weights

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -163,7 +163,7 @@ export default class mexc extends Exchange {
                             'order': 1,
                             'openOrders': 1,
                             'allOrders': 1,
-                            'account': 1,
+                            'account': 10,
                             'myTrades': 1,
                             'sub-account/list': 1,
                             'sub-account/apiKey': 1,
@@ -204,7 +204,7 @@ export default class mexc extends Exchange {
                             'sub-account/apiKey': 1,
                             'sub-account/futures': 1,
                             'sub-account/margin': 1,
-                            'batchOrders': 1,
+                            'batchOrders': 10,
                             'capital/withdraw/apply': 1,
                             'capital/transfer': 1,
                             'capital/deposit/address': 1,
@@ -234,8 +234,8 @@ export default class mexc extends Exchange {
                     'public': {
                         'get': {
                             'ping': 2,
-                            'detail': 2,
-                            'support_currencies': 2, // TODO: should we implement 'fetchCurrencies' solely for swap? because spot doesnt have it atm
+                            'detail': 100,
+                            'support_currencies': 2,
                             'depth/{symbol}': 2,
                             'depth_commits/{symbol}/{limit}': 2,
                             'index_price/{symbol}': 2,
@@ -300,7 +300,7 @@ export default class mexc extends Exchange {
                             'market/symbols': 1,
                             'market/coin/list': 2,
                             'common/timestamp': 1,
-                            'common/ping': 1,
+                            'common/ping': 2,
                             'market/ticker': 1,
                             'market/depth': 1,
                             'market/deals': 1,


### PR DESCRIPTION
Adjusted the ratelimit weights using the formula:
`requests-per-second` = 1000ms / ( rateLimit * weight)

### common weights:
rateLimit = 50
100 = 0.2 rps
40 = 0.5 rps
20 = 1 rps
10 = 2 rps
8 = 2.5 rps
5 = 4 rps
2.5 = 8 rps
2 = 10 rps
1 = 20 rps

### resources:
https://mxcdevelop.github.io/apidocs/spot_v3_en/#limits
https://mxcdevelop.github.io/apidocs/spot_v2_en/#rate-limit