### PR TITLE
fix(tests) - remove percentage from trading fees

### DIFF
--- a/ts/src/test/Exchange/base/test.tradingFee.ts
+++ b/ts/src/test/Exchange/base/test.tradingFee.ts
@@ -7,8 +7,9 @@ function testTradingFee (exchange, skippedProperties, method, symbol, entry) {
         'symbol': 'ETH/BTC',
         'maker': exchange.parseNumber ('0.002'),
         'taker': exchange.parseNumber ('0.003'),
-        'percentage': false,
-        'tierBased': false,
+        // todo: most exchanges do not have the below props implemented, so comment out it temporarily
+        // 'percentage': false,
+        // 'tierBased': false,
     };
     const emptyAllowedFor = [ 'tierBased', 'percentage', 'symbol' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);


### PR DESCRIPTION
only kraken has percentage & tierBased fields, so for now, it's better we don't use them as mandatory fields in tests