### PR TITLE
fix(exchanges): authenticate

### DIFF
--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -221,6 +221,7 @@ export default class bittrex extends Exchange {
                     // 'Call to GetBalances was throttled. Try again in 60 seconds.': DDoSProtection,
                     'APISIGN_NOT_PROVIDED': AuthenticationError,
                     'APIKEY_INVALID': AuthenticationError,
+                    'INVALID_APIKEY': AuthenticationError,
                     'INVALID_SIGNATURE': AuthenticationError,
                     'INVALID_CURRENCY': ExchangeError,
                     'INVALID_PERMISSION': AuthenticationError,
@@ -2227,9 +2228,9 @@ export default class bittrex extends Exchange {
         //
         if (body[0] === '{') {
             const feedback = this.id + ' ' + body;
-            let success = this.safeValue (response, 'success');
+            let success = this.safeValue2 (response, 'success', 'Success');
             if (success === undefined) {
-                const codeInner = this.safeString (response, 'code');
+                const codeInner = this.safeString2 (response, 'code', 'ErrorCode');
                 if ((codeInner === 'NOT_FOUND') && (url.indexOf ('addresses') >= 0)) {
                     throw new InvalidAddress (feedback);
                 }
@@ -2245,7 +2246,7 @@ export default class bittrex extends Exchange {
                 success = (success === 'true');
             }
             if (!success) {
-                const message = this.safeString (response, 'message');
+                const message = this.safeString2 (response, 'message', 'ErrorCode');
                 if (message === 'APIKEY_INVALID') {
                     if (this.options['hasAlreadyAuthenticatedSuccessfully']) {
                         throw new DDoSProtection (feedback);

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -946,12 +946,13 @@ export default class ascendex extends ascendexRest {
         this.spawn (this.pong, client, message);
     }
 
-    authenticate (url, params = {}) {
+    async authenticate (url, params = {}) {
         this.checkRequiredCredentials ();
         const messageHash = 'authenticated';
         const client = this.client (url);
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
+        const future = client.future (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const timestamp = this.milliseconds ().toString ();
             const urlParts = url.split ('/');
             const partsLength = urlParts.length;
@@ -967,8 +968,7 @@ export default class ascendex extends ascendexRest {
                 'key': this.apiKey,
                 'sig': signature,
             };
-            future = this.watch (url, messageHash, this.extend (request, params));
-            client.subscriptions[messageHash] = future;
+            this.watch (url, messageHash, this.extend (request, params), messageHash);
         }
         return future;
     }

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -851,8 +851,9 @@ export default class bitfinex2 extends bitfinex2Rest {
         const url = this.urls['api']['ws']['private'];
         const client = this.client (url);
         const messageHash = 'authenticated';
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
+        const future = this.client (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const nonce = this.milliseconds ();
             const payload = 'AUTH' + nonce.toString ();
             const signature = this.hmac (this.encode (payload), this.encode (this.secret), sha384, 'hex');
@@ -865,8 +866,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                 'event': event,
             };
             const message = this.extend (request, params);
-            future = this.watch (url, messageHash, message);
-            client.subscriptions[messageHash] = future;
+            this.watch (url, messageHash, message, messageHash);
         }
         return future;
     }

--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1104,13 +1104,14 @@ export default class bitget extends bitgetRest {
         return await this.watch (url, messageHash, message, messageHash);
     }
 
-    authenticate (params = {}) {
+    async authenticate (params = {}) {
         this.checkRequiredCredentials ();
         const url = this.urls['api']['ws'];
         const client = this.client (url);
         const messageHash = 'authenticated';
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
+        const future = client.future (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const timestamp = this.seconds ().toString ();
             const auth = timestamp + 'GET' + '/user/verify';
             const signature = this.hmac (this.encode (auth), this.encode (this.secret), sha256, 'base64');
@@ -1127,8 +1128,7 @@ export default class bitget extends bitgetRest {
                 ],
             };
             const message = this.extend (request, params);
-            future = this.watch (url, messageHash, message);
-            client.subscriptions[messageHash] = future;
+            this.watch (url, messageHash, message, messageHash);
         }
         return future;
     }

--- a/ts/src/pro/bittrex.ts
+++ b/ts/src/pro/bittrex.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import bittrexRest from '../bittrex.js';
-import { InvalidNonce, BadRequest, AuthenticationError } from '../base/errors.js';
+import { InvalidNonce, BadRequest } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import { sha512 } from '../static_dependencies/noble-hashes/sha512.js';
 import { inflateSync as inflate } from '../static_dependencies/fflake/browser.js';

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -72,15 +72,15 @@ export default class krakenfutures extends krakenfuturesRest {
         const url = this.urls['api']['ws'];
         const messageHash = 'challenge';
         const client = this.client (url);
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
+        const future = client.future (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const request = {
                 'event': 'challenge',
                 'api_key': this.apiKey,
             };
             const message = this.extend (request, params);
-            future = await this.watch (url, messageHash, message);
-            client.subscriptions[messageHash] = future;
+            this.watch (url, messageHash, message, messageHash);
         }
         return future;
     }

--- a/ts/src/pro/okcoin.ts
+++ b/ts/src/pro/okcoin.ts
@@ -471,18 +471,18 @@ export default class okcoin extends okcoinRest {
     async authenticate (params = {}) {
         this.checkRequiredCredentials ();
         const url = this.urls['api']['ws'];
-        const messageHash = 'login';
+        const messageHash = 'authenticated';
         const client = this.client (url);
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
-            future = client.future ('authenticated');
+        const future = client.future (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const timestamp = this.seconds ().toString ();
             const method = 'GET';
             const path = '/users/self/verify';
             const auth = timestamp + method + path;
             const signature = this.hmac (this.encode (auth), this.encode (this.secret), sha256, 'base64');
             const request = {
-                'op': messageHash,
+                'op': 'login',
                 'args': [
                     this.apiKey,
                     this.password,
@@ -490,9 +490,9 @@ export default class okcoin extends okcoinRest {
                     signature,
                 ],
             };
-            this.spawn (this.watch, url, messageHash, request, messageHash, future);
+            this.watch (url, messageHash, request, messageHash);
         }
-        return await future;
+        return future;
     }
 
     async watchBalance (params = {}) {

--- a/ts/src/pro/phemex.ts
+++ b/ts/src/pro/phemex.ts
@@ -1507,8 +1507,9 @@ export default class phemex extends phemexRest {
         const client = this.client (url);
         const requestId = this.requestId ();
         const messageHash = 'authenticated';
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
+        const future = client.future (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const expiryDelta = this.safeInteger (this.options, 'expires', 120);
             const expiration = this.seconds () + expiryDelta;
             const payload = this.apiKey + expiration.toString ();
@@ -1524,8 +1525,7 @@ export default class phemex extends phemexRest {
             if (!(messageHash in client.subscriptions)) {
                 client.subscriptions[subscriptionHash] = this.handleAuthenticate;
             }
-            future = this.watch (url, messageHash, message);
-            client.subscriptions[messageHash] = future;
+            this.watch (url, messageHash, message, messageHash);
         }
         return await future;
     }

--- a/ts/src/pro/poloniex.ts
+++ b/ts/src/pro/poloniex.ts
@@ -79,8 +79,9 @@ export default class poloniex extends poloniexRest {
         const url = this.urls['api']['ws']['private'];
         const messageHash = 'authenticated';
         const client = this.client (url);
-        let future = this.safeValue (client.subscriptions, messageHash);
-        if (future === undefined) {
+        const future = client.future (messageHash);
+        const authenticated = this.safeValue (client.subscriptions, messageHash);
+        if (authenticated === undefined) {
             const accessPath = '/ws';
             const requestString = 'GET\n' + accessPath + '\nsignTimestamp=' + timestamp;
             const signature = this.hmac (this.encode (requestString), this.encode (this.secret), sha256, 'base64');
@@ -96,7 +97,7 @@ export default class poloniex extends poloniexRest {
                 },
             };
             const message = this.extend (request, params);
-            future = await this.watch (url, messageHash, message);
+            this.watch (url, messageHash, message, messageHash);
             //
             //    {
             //        "data": {
@@ -117,7 +118,6 @@ export default class poloniex extends poloniexRest {
             //        "channel": "auth"
             //    }
             //
-            client.subscriptions[messageHash] = future;
         }
         return future;
     }

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -824,14 +824,9 @@ export default class whitebit extends whitebitRest {
                 'id': id,
                 'method': this.handleAuthenticate,
             };
-            try {
-                await this.watch (url, messageHash, request, messageHash, subscription);
-            } catch (e) {
-                delete client.subscriptions[messageHash];
-                future.reject (e);
-            }
+            this.watch (url, messageHash, request, messageHash, subscription);
         }
-        return await future;
+        return future;
     }
 
     handleAuthenticate (client: Client, message) {


### PR DESCRIPTION
- Follow fix of: https://github.com/ccxt/ccxt/pull/18812
- Bittrex: add error handling
- Note: I made the functions consistent to return a future and not await as it's already awaited when called

Tested:
- [x] Alpaca
- [ ] Ascendex
- [ ] Bittrex (Didn't have API key)
- [ ] Krakenfutures
- [ ] Poloniex
- [ ] Phemex
- [ ] Probit
- [ ] whitebit

Reference
From @carlosmiei :
we have a problem in the authentication flow of authenticated streams in PHP, right now in a lot of exchanges we're storing the future in the client.subscriptions structure, but that is problem when we need to iterate over the subscriptions to get the method/id etc because in PHP future is not iterable,  so it crashes. My suggestion is to stop storing the future there and store onlly the messageHash, that is enough to understand if we're authenticated or not yet and it works everywhere (we can simply do client.future(messageHash) to retrieve it again ).
I applied the fix for huobi here: https://github.com/ccxt/ccxt/pull/18812

