### PR TITLE
bingx: update

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1676,10 +1676,11 @@ export default class bingx extends Exchange {
             'currency': this.safeString (order, 'feeAsset'),
             'rate': this.safeString2 (order, 'fee', 'commission'),
         };
+        const clientOrderId = this.safeString (order, 'clientOrderId');
         return this.safeOrder ({
             'info': order,
             'id': orderId,
-            'clientOrderId': undefined,
+            'clientOrderId': clientOrderId,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -102,6 +102,7 @@ export default class bingx extends Exchange {
                             'post': {
                                 'trade/order': 3,
                                 'trade/cancel': 3,
+                                'trade/batchOrders': 3,
                             },
                         },
                     },


### PR DESCRIPTION
Changes:
* add new api
* add clientOrderId => test their api but the behavior seems not right, the clientOrderId wasn't set / return for spot order api

When I create order for spot, I found the handleErrors didn't work.
The error response from spot: `'{"code":100202,"msg":"Code: 100202, Msg: {\"Code\":100202,\"Msg\":\"order PendingManager.PlaceMultiOrdersNormalUser transfer in: dtm DTM.handleTaskEvent withdrawal fail: dtm DTM.withdrawal ret fail, code: 102202, msg: \",\"RemoteInfo\":null,\"TextData\":{\"Format\":\"用户资产不足\",\"Args\":[]}}","debugMsg":""}'` (not a correct json string).

For swap, they return `{"code":101204,"msg":"Insufficient margin","data":{}}`, so it works fine.