### PR TITLE
fix(multiple-exchanges) - rename of maxRetries into snapshotMaxRetries

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1271,7 +1271,7 @@ export default class Exchange {
             client.reject (new ExchangeError (this.id + ' loadOrderBook() orderbook is not initiated'), messageHash);
             return;
         }
-        const maxRetries = this.handleOption ('watchOrderBook', 'maxRetries', 3);
+        const maxRetries = this.handleOption ('watchOrderBook', 'snapshotMaxRetries', 3);
         let tries = 0;
         try {
             const stored = this.orderbooks[symbol];

--- a/ts/src/pro/bitstamp.ts
+++ b/ts/src/pro/bitstamp.ts
@@ -32,7 +32,7 @@ export default class bitstamp extends bitstampRest {
                 'wsSessionToken': '',
                 'watchOrderBook': {
                     'snapshotDelay': 6,
-                    'maxRetries': 3,
+                    'snapshotMaxRetries': 3,
                 },
                 'tradesLimit': 1000,
                 'OHLCVLimit': 1000,

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -68,7 +68,7 @@ export default class gate extends gateRest {
                 'watchOrderBook': {
                     'interval': '100ms',
                     'snapshotDelay': 10, // how many deltas to cache before fetching a snapshot
-                    'maxRetries': 3,
+                    'snapshotMaxRetries': 3,
                 },
                 'watchBalance': {
                     'settle': 'usdt', // or btc

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -30,7 +30,7 @@ export default class kucoin extends kucoinRest {
                 },
                 'watchOrderBook': {
                     'snapshotDelay': 5,
-                    'maxRetries': 3,
+                    'snapshotMaxRetries': 3,
                 },
             },
             'streaming': {

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -36,7 +36,7 @@ export default class kucoinfutures extends kucoinfuturesRest {
                 'tradesLimit': 1000,
                 'watchOrderBook': {
                     'snapshotDelay': 20,
-                    'maxRetries': 3,
+                    'snapshotMaxRetries': 3,
                 },
                 'watchTicker': {
                     'name': 'contractMarket/tickerV2', // market/ticker

--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -49,7 +49,7 @@ export default class mexc extends mexcRest {
                 },
                 'watchOrderBook': {
                     'snapshotDelay': 25,
-                    'maxRetries': 3,
+                    'snapshotMaxRetries': 3,
                 },
                 'listenKey': undefined,
             },

--- a/ts/src/pro/poloniexfutures.ts
+++ b/ts/src/pro/poloniexfutures.ts
@@ -43,7 +43,7 @@ export default class poloniexfutures extends poloniexfuturesRest {
                 'watchOrderBook': {
                     'method': '/contractMarket/level2', // can also be '/contractMarket/level3v2'
                     'snapshotDelay': 5,
-                    'maxRetries': 3,
+                    'snapshotMaxRetries': 3,
                 },
                 'streamLimit': 5, // called tunnels by poloniexfutures docs
                 'streamBySubscriptionsHash': {},


### PR DESCRIPTION
next thing related to these OB snapshot fetching was the second part of exchanges, which don't use directly `fetchRestOrderBookSafe`, but use a bit more complex wrapper -[`loadOrderBook` base method](https://github.com/ccxt/ccxt/blob/master/ts/src/base/Exchange.ts#L1269) (which itself inside it uses `fetchRestOrderBookSafe`).

so, that wrapper itself also has 3* retries, but the option name `maxRetries` was not good and we can rename them also. I understand that it's different method that is being re-tried in this case, but it is still related to snapshot-fetching and it shouldn't matter from users' perspective