### PR TITLE
fix(bingx): signature fix

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2813,7 +2813,8 @@ export default class bingx extends Exchange {
             this.checkRequiredCredentials ();
             params['timestamp'] = this.nonce ();
             let query = this.urlencode (params);
-            const signature = this.hmac (this.encode (query), this.encode (this.secret), sha256);
+            const rawQuery = this.rawencode (params);
+            const signature = this.hmac (this.encode (rawQuery), this.encode (this.secret), sha256);
             if (Object.keys (params).length) {
                 query = '?' + query + '&';
             } else {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18846

DEMO

```
 p bingx fetchOpenOrders "OTHR#99961/USDT"
Python v3.10.9
CCXT v4.0.56
bingx.fetchOpenOrders(OTHR#99961/USDT)
[]
```


```
p bingx fetchBalance                                     
Python v3.10.9
CCXT v4.0.56
bingx.fetchBalance()
{'LTC': {'free': 0.1090908, 'total': 0.1090908, 'used': 0.0},
 'USDT': {'free': 7.0031438, 'total': 12.0031438, 'used': 5.0},
 'VST': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'free': {'LTC': 0.1090908, 'USDT': 7.0031438, 'VST': 0.0},
 'info': {'code': '0',
          'data': {'balances': [{'asset': 'USDT',
                                 'free': '7.0031438',
                                 'locked': '5'},
                                {'asset': 'LTC',
                                 'free': '0.1090908',
                                 'locked': '0'},
                                {'asset': 'VST', 'free': '0', 'locked': '0'}]},
          'debugMsg': '',
          'msg': ''},
 'total': {'LTC': 0.1090908, 'USDT': 12.0031438, 'VST': 0.0},
 'used': {'LTC': 0.0, 'USDT': 5.0, 'VST': 0.0}}
```
```
✗ p bingx fetchBalance --swap              
Python v3.10.9
CCXT v4.0.56
bingx.fetchBalance()
{'USDT': {'free': 39.8108, 'total': 39.8108, 'used': 0.0},
 'free': {'USDT': 39.8108},
 'info': {'code': '0',
          'data': {'balance': {'asset': 'USDT',
                               'availableMargin': '39.8108',
                               'balance': '39.8108',
                               'equity': '39.8108',
                               'freezedMargin': '0.0000',
                               'realisedProfit': '0.0000',
                               'unrealizedProfit': '0.0000',
                               'usedMargin': '0.0000',
                               'userId': '1177064765068660742'}},
          'msg': ''},
 'total': {'USDT': 39.8108},
 'used': {'USDT': 0.0}}
```
```
 p bingx fetchMyTrades "LTC/USDT:USDT" 1688998808000  
Python v3.10.9
CCXT v4.0.56
bingx.fetchMyTrades(LTC/USDT:USDT,1688998808000)
[{'amount': 99.3,
  'cost': 986.049,
  'datetime': '2023-07-13T23:13:24.000Z',
  'fee': {'cost': 0.0497, 'currency': 'USDT', 'rate': None},
  'fees': [{'cost': 0.0497, 'currency': 'USDT', 'rate': None}],
  'id': '1679509334255693824',
  'info': {'amount': '99.3000',
           'clientOrderID': '',
           'commission': '-0.0497',
           'currency': 'USDT',
           'filledTime': '2023-07-13T23:13:24.000+0800',
           'filledTm': '2023-07-13T23:13:24Z',
           'liquidatedMarginRatio': '0.00',
           'liquidatedPrice': '0.00',
           'orderId': '1679509334255693824',
           'price': '99.30',
           'volume': '10'},
  'order': None,
  'price': 99.3,
  'side': None,
  'symbol': 'LTC/USDT:USDT',
  'takerOrMaker': None,
  'timestamp': 1689290004000,
  'type': None},
```
```
✗ p bingx createOrder "LTC/USDT" limit buy 0.1 50          
Python v3.10.9
CCXT v4.0.56
bingx.createOrder(LTC/USDT,limit,buy,0.1,50)
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': 0.0,
 'datetime': '2023-08-10T10:36:01.769Z',
 'fee': {'cost': None, 'currency': None, 'rate': None},
 'fees': [{'cost': None, 'currency': None, 'rate': None}],
 'filled': 0.0,
 'id': '1689586393099010048',
 'info': {'cummulativeQuoteQty': '0',
          'executedQty': '0',
          'orderId': '1689586393099010048',
          'origQty': '0.1',
          'price': '50',
          'side': 'BUY',
          'status': 'PENDING',
          'symbol': 'LTC-USDT',
          'transactTime': '1691663761769',
          'type': 'LIMIT'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': 0.1,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': 1691663761769,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
