### PR TITLE
Lbank: sign error for private methods

### DIFF
--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -817,7 +817,7 @@ export default class lbank extends Exchange {
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
-        const query = this.omit (params, this.extractParams (path));
+        let query = this.omit (params, this.extractParams (path));
         let url = this.urls['api']['rest'] + '/' + this.version + '/' + this.implodeParams (path, params);
         // Every endpoint ends with ".do"
         url += '.do';
@@ -827,10 +827,10 @@ export default class lbank extends Exchange {
             }
         } else {
             this.checkRequiredCredentials ();
-            const queryInner = this.keysort (this.extend ({
+            query = this.keysort (this.extend ({
                 'api_key': this.apiKey,
-            }, params));
-            const queryString = this.rawencode (queryInner);
+            }, query));
+            const queryString = this.rawencode (query);
             const message = this.hash (this.encode (queryString), md5).toUpperCase ();
             const cacheSecretAsPem = this.safeValue (this.options, 'cacheSecretAsPem', true);
             let pem = undefined;


### PR DESCRIPTION
Adjusted the sign method in Lbank to use the api_key as a parameter for private methods.
### Before:
the `api_key` parameter was missing from private methods:
```
lbank.fetchBalance ()
ExchangeError The required parameters can not be empty
```