### PR TITLE
ci: patch link of troubleshooting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://docs.ccxt.com/en/latest/manual.html
     about: Read CCXT documentation for answers to common questions
   - name: Troubleshooting
-    url: https://docs.ccxt.com/en/latest/manual.html#troubleshooting
+    url: https://docs.ccxt.com/#/?id=troubleshooting
     about: Read our troubleshooting recommendations in our documentation
   - name: CCXT Discord
     url: https://discord.gg/dhzSKYU


### PR DESCRIPTION
The link of troubleshooting didn't work. In this PR, I update this.

It seems most redirection didn't work, probably need to fix that.
