### PR TITLE
fix(whitebit): add loadMarkets to fetchTradingFees

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -659,6 +659,7 @@ export default class whitebit extends Exchange {
          * @param {object} [params] extra parameters specific to the whitebit api endpoint
          * @returns {object} a dictionary of [fee structures]{@link https://docs.ccxt.com/#/?id=fee-structure} indexed by market symbols
          */
+        await this.loadMarkets ();
         const response = await this.v4PublicGetAssets (params);
         //
         //      {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18861

DEMO

```
Python v3.10.9
CCXT v4.0.57
whitebit.fetchTradingFees()
{'1INCH/BTC': {'info': {'can_deposit': True,
                        'can_withdraw': True,
                        'confirmations': {'ERC20': '32'},
                        'currency_precision': '18',
                        'is_memo': False,
                        'limits': {'deposit': {'ERC20': {'min': '15'}},
                                   'withdraw': {'ERC20': {'min': '45.46'}}},
                        'maker_fee': '0.1',
                        'max_deposit': '0',
                        'max_withdraw': '0',
                        'min_deposit': '15',
                        'min_withdraw': '45.46',
                        'name': '1inch',
                        'networks': {'default': 'ERC20',
                                     'deposits': ['ERC20'],
                                     'withdraws': ['ERC20']},
                        'taker_fee': '0.1',
                        'unified_cryptoasset_id': '8104'},
               'maker': 0.001,
               'percentage': True,
               'symbol': '1INCH/BTC',
               'taker': 0.001,
               'tierBased': False},
 '1INCH/UAH': {'info': {'can_deposit': True,
                        'can_withdraw': True,
                        'confirmations': {'ERC20': '32'},
                        'currency_precision': '18',
                        'is_memo': False,
                        'limits': {'deposit': {'ERC20': {'min': '15'}},
                                   'withdraw': {'ERC20': {'min': '45.46'}}},
```
