### PR TITLE
fix(bybit): crash when fetchPosition array is empty

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7265,8 +7265,10 @@ export default class bybit extends Exchange {
             if (symbolsLength > 1) {
                 throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
             }
-            const market = this.market (symbols[0]);
-            settle = market['settle'];
+            if (symbolsLength === 1) {
+                const market = this.market (symbols[0]);
+                settle = market['settle'];
+            }
         } else if (symbols !== undefined) {
             symbols = [ symbols ];
         }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7257,8 +7257,8 @@ export default class bybit extends Exchange {
     async fetchUnifiedPositions (symbols: string[] = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {};
-        let type = undefined;
         let settle = undefined;
+        let market = undefined;
         const enableUnified = await this.isUnifiedEnabled ();
         if (Array.isArray (symbols)) {
             const symbolsLength = symbols.length;
@@ -7266,19 +7266,16 @@ export default class bybit extends Exchange {
                 throw new ArgumentsRequired (this.id + ' fetchPositions() does not accept an array with more than one symbol');
             }
             if (symbolsLength === 1) {
-                const market = this.market (symbols[0]);
-                settle = market['settle'];
+                market = this.market (symbols[0]);
             }
         } else if (symbols !== undefined) {
             symbols = [ symbols ];
+            market = this.market (symbols);
         }
         symbols = this.marketSymbols (symbols);
-        const symbolsLength = symbols.length;
-        if ((symbols === undefined) || (symbolsLength === 0)) {
+        if (market === undefined) {
             [ settle, params ] = this.handleOptionAndParams (params, 'fetchPositions', 'settle', 'USDT');
         } else {
-            const first = this.safeValue (symbols, 0);
-            const market = this.market (first);
             settle = market['settle'];
             request['symbol'] = market['id'];
         }
@@ -7286,16 +7283,20 @@ export default class bybit extends Exchange {
             request['settleCoin'] = settle;
             request['limit'] = 200;
         }
-        // market undefined
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchPositions', undefined, params);
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchPositions', market, params);
         let subType = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('fetchPositions', undefined, params, 'linear');
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchPositions', market, params, 'linear');
         request['category'] = subType;
         if (type === 'option') {
             request['category'] = 'option';
         }
-        const method = (enableUnified[1]) ? 'privateGetV5PositionList' : 'privateGetUnifiedV3PrivatePositionList';
-        const response = await this[method] (this.extend (request, params));
+        let response = undefined;
+        if (enableUnified[1]) {
+            response = await this.privateGetV5PositionList (this.extend (request, params));
+        } else {
+            response = await this.privateGetUnifiedV3PrivatePositionList (this.extend (request, params));
+        }
         //
         //     {
         //         "retCode": 0,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7271,7 +7271,8 @@ export default class bybit extends Exchange {
             symbols = [ symbols ];
         }
         symbols = this.marketSymbols (symbols);
-        if (symbols === undefined) {
+        const symbolsLength = symbols.length;
+        if ((symbols === undefined) || (symbolsLength === 0)) {
             [ settle, params ] = this.handleOptionAndParams (params, 'fetchPositions', 'settle', 'USDT');
         } else {
             const first = this.safeValue (symbols, 0);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18869

DEMO

```
 p bybit fetchPositions '[]' --sandbox --verbose
Python v3.10.9
CCXT v4.0.58
bybit.fetchPositions([])

fetch Request: bybit GET https://api-testnet.bybit.com/user/v3/private/query-api?api_key=Nofj9bojKEgCFUHzdX&recv_window=5000&timestamp=1691941166493&sign=794bbac307900d402e1ae8ae2c3d1d8e7b69dfe61640291b802ee4e4e9436769 RequestHeaders: {'Accept-Encoding': 'gzip, deflate'} RequestBody: None

fetch Response: bybit GET https://api-testnet.bybit.com/user/v3/private/query-api?api_key=Nofj9bojKEgCFUHzdX&recv_window=5000&timestamp=1691941166493&sign=794bbac307900d402e1ae8ae2c3d1d8e7b69dfe61640291b802ee4e4e9436769 200 ResponseHeaders: {'Content-Type': 'application/json; charset=utf-8', 'Content-Length': '694', 'Connection': 'keep-alive', 'Date': 'Sun, 13 Aug 2023 15:39:26 GMT', 'X-Bapi-Limit': '10', 'X-Bapi-Limit-Status': '9', 'X-Bapi-Limit-Reset-Timestamp': '1691941166649', 'Ret_code': '0', 'Traceid': '4a0a1264284ab5370766879c79b63f07', 'Timenow': '1691941166661', 'Server': 'Openresty', 'X-Cache': 'Miss from cloudfront', 'Via': '1.1 e4094f3d427f11ea8b257166e26f7db2.cloudfront.net (CloudFront)', 'X-Amz-Cf-Pop': 'LHR61-P4', 'X-Amz-Cf-Id': '2mURJDdZVFIajnp3dxPhOftXPeeba2xVK1AMnJ3t2l4vUYIweE5GSg=='} ResponseBody: {"retCode":0,"retMsg":"","result":{"id":"522300","note":"ccxt new","apiKey":"Nofj9bojKEgCFUHzdX","readOnly":0,"secret":"","permissions":{"ContractTrade":["Order","Position"],"Spot":["SpotTrade"],"Wallet":["AccountTransfer","SubMemberTransfer"],"Options":["OptionsTrade"],"Derivatives":["DerivativesTrade"],"CopyTrading":["CopyTrading"],"BlockTrade":[],"Exchange":["ExchangeHistory"],"NFT":[],"Affiliate":[]},"ips":["*"],"type":1,"deadlineDay":57,"expiredAt":"2023-10-10T14:13:06Z","createdAt":"2023-07-06T10:15:06Z","unified":0,"uta":1,"userID":452265,"inviterID":0,"vipLevel":"No VIP","mktMakerLevel":"0","affiliateID":0,"rsaPublicKey":"","isMaster":true},"retExtInfo":{},"time":1691941166661}

fetch Request: bybit GET https://api-testnet.bybit.com/v5/position/list?settleCoin=USDT&limit=200&category=linear RequestHeaders: {'Content-Type': 'application/json', 'X-BAPI-API-KEY': 'Nofj9bojKEgCFUHzdX', 'X-BAPI-TIMESTAMP': '1691941166822', 'X-BAPI-RECV-WINDOW': '5000', 'X-BAPI-SIGN': 'bccac99f4c41f356548473d8731a23b5782aee6a82a8e93bf6ba4e3c2da79c0e', 'Accept-Encoding': 'gzip, deflate'} RequestBody: None

fetch Response: bybit GET https://api-testnet.bybit.com/v5/position/list?settleCoin=USDT&limit=200&category=linear 200 ResponseHeaders: {'Content-Type': 'application/json; charset=utf-8', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Vary': 'Accept-Encoding', 'Date': 'Sun, 13 Aug 2023 15:39:26 GMT', 'X-Bapi-Limit': '50', 'X-Bapi-Limit-Status': '49', 'X-Bapi-Limit-Reset-Timestamp': '1691941166976', 'Ret_code': '0', 'Traceid': '57daa5289f7e93521036a1c137642920', 'Timenow': '1691941166979', 'Server': 'Openresty', 'Content-Encoding': 'gzip', 'X-Cache': 'Miss from cloudfront', 'Via': '1.1 e4094f3d427f11ea8b257166e26f7db2.cloudfront.net (CloudFront)', 'X-Amz-Cf-Pop': 'LHR61-P4', 'X-Amz-Cf-Id': '5ALDyiF2sS0YR45ah0obWsUqImy9-SztLYc7ZOrIlOuic26RXeboFA=='} ResponseBody: {"retCode":0,"retMsg":"OK","result":{"nextPageCursor":"BTCUSDT%2C1691913600105%2C2","category":"linear","list":[{"symbol":"ADAUSDT","leverage":"4","autoAddMargin":0,"avgPrice":"0.2993043","liqPrice":"","riskLimitValue":"200000","takeProfit":"0.35","positionValue":"4.78886875","tpslMode":"Full","riskId":116,"trailingStop":"0","unrealisedPnl":"-0.13126875","markPrice":"0.2911","adlRankIndicator":2,"cumRealisedPnl":"-0.08621332","positionMM":"0.03789193","createdTime":"1677510584589","positionIdx":0,"positionIM":"1.1991926","updatedTime":"1691913600327","side":"Buy","bustPrice":"","positionBalance":"0.20478267","size":"16","positionStatus":"Normal","stopLoss":"0.25","tradeMode":0},{"symbol":"LTCUSDT","leverage":"10","autoAddMargin":0,"avgPrice":"90.96636364","liqPrice":"","riskLimitValue":"200000","takeProfit":"","positionValue":"100.063","tpslMode":"Full","riskId":71,"trailingStop":"0","unrealisedPnl":"-8.873","markPrice":"82.9","adlRankIndicator":2,"cumRealisedPnl":"-8.63693121","positionMM":"1.05016119","createdTime":"1677168085779","positionIdx":0,"positionIM":"10.05583119","updatedTime":"1691913600131","side":"Buy","bustPrice":"","positionBalance":"1.04369235","size":"1.1","positionStatus":"Normal","stopLoss":"","tradeMode":0},{"symbol":"BTCUSDT","leverage":"10","autoAddMargin":0,"avgPrice":"27353","liqPrice":"","riskLimitValue":"2000000","takeProfit":"","positionValue":"27353","tpslMode":"Full","riskId":1,"trailingStop":"0","unrealisedPnl":"1687.9","markPrice":"29040.9","adlRankIndicator":2,"cumRealisedPnl":"0.78700101","positionMM":"150.18150975","createdTime":"1684663352623","positionIdx":1,"positionIM":"2748.85327475","updatedTime":"1691913600105","side":"Buy","bustPrice":"","positionBalance":"28892.04580833","size":"1","positionStatus":"Normal","stopLoss":"","tradeMode":0},{"symbol":"BTCUSDT","leverage":"10","autoAddMargin":0,"avgPrice":"31173","liqPrice":"","riskLimitValue":"2000000","takeProfit":"","positionValue":"31.173","tpslMode":"Full","riskId":1,"trailingStop":"0","unrealisedPnl":"2.1321","markPrice":"29040.9","adlRankIndicator":2,"cumRealisedPnl":"0.17058634","positionMM":"0.03771934","createdTime":"1684663352623","positionIdx":2,"positionIM":"0.03771934","updatedTime":"1691913600105","side":"Sell","bustPrice":"","positionBalance":"-27.63122548","size":"0.001","positionStatus":"Normal","stopLoss":"","tradeMode":0}]},"retExtInfo":{},"time":1691941166979}
[{'collateral': 0.20478267,
  'contractSize': 1.0,
  'contracts': 16.0,
  'datetime': '2023-08-13T08:00:00.327Z',
  'entryPrice': 0.2993043,
  'id': None,
  'info': {'adlRankIndicator': '2',
           'autoAddMargin': '0',
           'avgPrice': '0.2993043',
           'bustPrice': '',
           'createdTime': '1677510584589',
           'cumRealisedPnl': '-0.08621332',
           'leverage': '4',
           'liqPrice': '',
           'markPrice': '0.2911',
           'nextPageCursor': 'BTCUSDT%2C1691913600105%2C2',
           'positionBalance': '0.20478267',
           'positionIM': '1.1991926',
           'positionIdx': '0',
           'positionMM': '0.03789193',
           'positionStatus': 'Normal',
           'positionValue': '4.78886875',
           'riskId': '116',
           'riskLimitValue': '200000',
           'side': 'Buy',
           'size': '16',
           'stopLoss': '0.25',
           'symbol': 'ADAUSDT',
           'takeProfit': '0.35',
           'tpslMode': 'Full',
           'tradeMode': '0',
           'trailingStop': '0',
```
