### PR TITLE
feat(binance): add sor support for createOrder

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4232,6 +4232,7 @@ export default class binance extends Exchange {
          * @param {object} [params] extra parameters specific to the binance api endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
          * @param {boolean} [params.sor] *spot only* whether to use SOR (Smart Order Routing) or not, default is false
+         * @param {boolean} [params.test] *spot only* whether to use the test endpoint or not, default is false
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4222,6 +4222,8 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/futures/en/#new-order-trade
          * @see https://binance-docs.github.io/apidocs/delivery/en/#new-order-trade
          * @see https://binance-docs.github.io/apidocs/voptions/en/#new-order-trade
+         * @see https://binance-docs.github.io/apidocs/spot/en/#new-order-using-sor-trade
+         * @see https://binance-docs.github.io/apidocs/spot/en/#test-new-order-using-sor-trade
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit' or 'STOP_LOSS' or 'STOP_LOSS_LIMIT' or 'TAKE_PROFIT' or 'TAKE_PROFIT_LIMIT' or 'STOP'
          * @param {string} side 'buy' or 'sell'
@@ -4229,6 +4231,7 @@ export default class binance extends Exchange {
          * @param {float} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the binance api endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
+         * @param {boolean} [params.sor] *spot only* whether to use SOR (Smart Order Routing) or not, default is false
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -4236,8 +4239,11 @@ export default class binance extends Exchange {
         const marketType = this.safeString (params, 'type', market['type']);
         const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
         const request = this.createOrderRequest (symbol, type, side, amount, price, params);
+        const sor = this.safeValue2 (params, 'sor', 'SOR', false);
         let method = 'privatePostOrder';
-        if (market['linear']) {
+        if (sor) {
+            method = 'privatePostSorOrder';
+        } else if (market['linear']) {
             method = 'fapiPrivatePostOrder';
         } else if (market['inverse']) {
             method = 'dapiPrivatePostOrder';

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -7895,7 +7895,7 @@ export default class binance extends Exchange {
             }
         } else if ((api === 'private') || (api === 'eapiPrivate') || (api === 'sapi' && path !== 'system/status') || (api === 'sapiV2') || (api === 'sapiV3') || (api === 'sapiV4') || (api === 'wapi' && path !== 'systemStatus') || (api === 'dapiPrivate') || (api === 'dapiPrivateV2') || (api === 'fapiPrivate') || (api === 'fapiPrivateV2')) {
             this.checkRequiredCredentials ();
-            if (method === 'POST' && path === 'order') {
+            if (method === 'POST' && ((path === 'order') || (path === 'sor/order'))) {
                 // inject in implicit API calls
                 const newClientOrderId = this.safeString (params, 'newClientOrderId');
                 if (newClientOrderId === undefined) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4239,8 +4239,9 @@ export default class binance extends Exchange {
         const market = this.market (symbol);
         const marketType = this.safeString (params, 'type', market['type']);
         const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
-        const request = this.createOrderRequest (symbol, type, side, amount, price, params);
         const sor = this.safeValue2 (params, 'sor', 'SOR', false);
+        params = this.omit (params, 'sor', 'SOR');
+        const request = this.createOrderRequest (symbol, type, side, amount, price, params);
         let method = 'privatePostOrder';
         if (sor) {
             method = 'privatePostSorOrder';


### PR DESCRIPTION
- RIght now, regardless of the used symbol it responds with "InvalidOrder binance {"code":-1013,"msg":"This symbol has no SOR."}"