### PR TITLE
fix!(exmo): createOrder can place market orders, response is parsed using parseOrder 

### DIFF
--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -1266,6 +1266,7 @@ export default class exmo extends Exchange {
         const market = this.market (symbol);
         const prefix = (type === 'market') ? (type + '_') : '';
         const orderType = prefix + side;
+        const isMarket = (type === 'market') && (price === undefined);
         const request = {
             'pair': market['id'],
             // 'leverage': 2,
@@ -1273,7 +1274,7 @@ export default class exmo extends Exchange {
             // spot - buy, sell, market_buy, market_sell, market_buy_total, market_sell_total
             // margin - limit_buy, limit_sell, market_buy, market_sell, stop_buy, stop_sell, stop_limit_buy, stop_limit_sell, trailing_stop_buy, trailing_stop_sell
             'type': orderType,
-            'price': ((type === 'market') && (price === undefined)) ? 0 : this.priceToPrecision (market['symbol'], price),
+            'price': isMarket ? 0 : this.priceToPrecision (market['symbol'], price),
             // 'stop_price': this.priceToPrecision (symbol, stopPrice),
             // 'distance': 0, // distance for trailing stop orders
             // 'expire': 0, // expiration timestamp in UTC timezone for the order, unless expire is 0

--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -1253,6 +1253,7 @@ export default class exmo extends Exchange {
          * @method
          * @name exmo#createOrder
          * @description create a trade order
+         * @see https://documenter.getpostman.com/view/10287440/SzYXWKPi#80daa469-ec59-4d0a-b229-6a311d8dd1cd
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -1265,10 +1266,6 @@ export default class exmo extends Exchange {
         const market = this.market (symbol);
         const prefix = (type === 'market') ? (type + '_') : '';
         const orderType = prefix + side;
-        let orderPrice = price;
-        if ((type === 'market') && (price === undefined)) {
-            orderPrice = 0;
-        }
         const request = {
             'pair': market['id'],
             // 'leverage': 2,
@@ -1276,7 +1273,7 @@ export default class exmo extends Exchange {
             // spot - buy, sell, market_buy, market_sell, market_buy_total, market_sell_total
             // margin - limit_buy, limit_sell, market_buy, market_sell, stop_buy, stop_sell, stop_limit_buy, stop_limit_sell, trailing_stop_buy, trailing_stop_sell
             'type': orderType,
-            'price': this.priceToPrecision (market['symbol'], orderPrice),
+            'price': ((type === 'market') && (price === undefined)) ? 0 : this.priceToPrecision (market['symbol'], price),
             // 'stop_price': this.priceToPrecision (symbol, stopPrice),
             // 'distance': 0, // distance for trailing stop orders
             // 'expire': 0, // expiration timestamp in UTC timezone for the order, unless expire is 0
@@ -1305,29 +1302,7 @@ export default class exmo extends Exchange {
             }
         }
         const response = await this[method] (this.extend (request, params));
-        const id = this.safeString (response, 'order_id');
-        const timestamp = this.milliseconds ();
-        const status = 'open';
-        return {
-            'id': id,
-            'info': response,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
-            'lastTradeTimestamp': undefined,
-            'status': status,
-            'symbol': market['symbol'],
-            'type': type,
-            'side': side,
-            'price': price,
-            'cost': undefined,
-            'amount': amount,
-            'remaining': amount,
-            'filled': 0.0,
-            'fee': undefined,
-            'trades': undefined,
-            'clientOrderId': clientOrderId,
-            'average': undefined,
-        };
+        return this.parseOrder (response, market);
     }
 
     async cancelOrder (id: string, symbol: string = undefined, params = {}) {
@@ -1534,7 +1509,7 @@ export default class exmo extends Exchange {
             'lastTradeTimestamp': undefined,
             'status': undefined,
             'symbol': symbol,
-            'type': 'limit',
+            'type': undefined,
             'timeInForce': undefined,
             'postOnly': undefined,
             'side': side,


### PR DESCRIPTION
- createOrder can place market orders
- response is parsed using parseOrder

Previously createOrder would through an error for market orders because we would be passing `0` as the second argument to `priceToPrecision`

```
% exmo createOrder XRP/USDT market sell 14.5                            
2023-08-14T14:44:38.563Z
Node.js: v18.15.0
CCXT v4.0.59
exmo.createOrder (XRP/USDT, market, sell, 14.5)
2023-08-14T14:44:40.495Z iteration 0 passed in 503 ms

{
  id: '36462323303',
  clientOrderId: undefined,
  datetime: undefined,
  timestamp: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'XRP/USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  average: undefined,
  trades: [],
  fee: undefined,
  info: { result: true, error: '', order_id: '36462323303' },
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-14T14:44:40.495Z iteration 1 passed in 503 ms
```