### PR TITLE
feat(hitbtc): params["triggerPrice"] unified

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -2059,10 +2059,12 @@ export default class hitbtc extends Exchange {
          * @param {object} [params] extra parameters specific to the hitbtc api endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated' only 'isolated' is supported, defaults to spot-margin endpoint if this is set
          * @param {bool} [params.margin] true for creating a margin order
+         * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const isLimit = (type === 'limit');
         const request = {
             'type': type,
             'side': side,
@@ -2090,25 +2092,28 @@ export default class hitbtc extends Exchange {
             request['reduce_only'] = reduceOnly;
         }
         const timeInForce = this.safeString2 (params, 'timeInForce', 'time_in_force');
-        const expireTime = this.safeString (params, 'expire_time');
-        const stopPrice = this.safeNumber2 (params, 'stopPrice', 'stop_price');
-        if ((type === 'limit') || (type === 'stopLimit') || (type === 'takeProfitLimit')) {
+        const triggerPrice = this.safeNumberN (params, [ 'triggerPrice', 'stopPrice', 'stop_price' ]);
+        if (isLimit || (type === 'stopLimit') || (type === 'takeProfitLimit')) {
             if (price === undefined) {
                 throw new ExchangeError (this.id + ' createOrder() requires a price argument for limit orders');
             }
             request['price'] = this.priceToPrecision (symbol, price);
         }
         if ((timeInForce === 'GTD')) {
+            const expireTime = this.safeString (params, 'expire_time');
             if (expireTime === undefined) {
                 throw new ExchangeError (this.id + ' createOrder() requires an expire_time parameter for a GTD order');
             }
-            request['expire_time'] = expireTime;
         }
-        if ((type === 'stopLimit') || (type === 'stopMarket') || (type === 'takeProfitLimit') || (type === 'takeProfitMarket')) {
-            if (stopPrice === undefined) {
-                throw new ExchangeError (this.id + ' createOrder() requires a stopPrice parameter for stop-loss and take-profit orders');
+        if (triggerPrice !== undefined) {
+            request['stop_price'] = this.priceToPrecision (symbol, triggerPrice);
+            if (isLimit) {
+                request['type'] = 'stopLimit';
+            } else if (type === 'market') {
+                request['type'] = 'stopMarket';
             }
-            request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
+        } else if ((type === 'stopLimit') || (type === 'stopMarket') || (type === 'takeProfitLimit') || (type === 'takeProfitMarket')) {
+            throw new ExchangeError (this.id + ' createOrder() requires a stopPrice parameter for stop-loss and take-profit orders');
         }
         let marketType = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('createOrder', market, params);
@@ -2121,6 +2126,7 @@ export default class hitbtc extends Exchange {
         if (marginMode !== undefined) {
             method = 'privatePostMarginOrder';
         }
+        params = this.omit (params, [ 'triggerPrice', 'timeInForce', 'time_in_force', 'stopPrice', 'stop_price', 'reduceOnly' ]);
         const response = await this[method] (this.extend (request, query));
         return this.parseOrder (response, market);
     }
@@ -2227,6 +2233,7 @@ export default class hitbtc extends Exchange {
         const postOnly = this.safeValue (order, 'post_only');
         const timeInForce = this.safeString (order, 'time_in_force');
         const rawTrades = this.safeValue (order, 'trades');
+        const stopPrice = this.safeString (order, 'stop_price');
         return this.safeOrder ({
             'info': order,
             'id': id,
@@ -2234,6 +2241,7 @@ export default class hitbtc extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,
+            'lastUpdateTimestamp': lastTradeTimestamp,
             'symbol': symbol,
             'price': price,
             'amount': amount,
@@ -2249,6 +2257,10 @@ export default class hitbtc extends Exchange {
             'average': average,
             'trades': rawTrades,
             'fee': undefined,
+            'stopPrice': stopPrice,
+            'triggerPrice': stopPrice,
+            'takeProfitPrice': undefined,
+            'stopLossPrice': undefined,
         }, market);
     }
 

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -2051,6 +2051,9 @@ export default class hitbtc extends Exchange {
          * @method
          * @name hitbtc#createOrder
          * @description create a trade order
+         * @see https://api.hitbtc.com/#create-new-spot-order
+         * @see https://api.hitbtc.com/#create-margin-order
+         * @see https://api.hitbtc.com/#create-futures-order
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'


### PR DESCRIPTION
- add `params["triggerPrice"]` to createOrder
- omit extra params so they are not sent to exchange

----------------

# Testing

## TS

```
% hitbtc createOrder ADA/USDT limit sell 4 0.26 '{"triggerPrice": 0.26}'
2023-08-14T15:19:33.364Z
Node.js: v18.15.0
CCXT v4.0.59
hitbtc.createOrder (ADA/USDT, limit, sell, 4, 0.26, [object Object])
2023-08-14T15:19:34.407Z iteration 0 passed in 161 ms

{
  info: {
    id: '1102796421289',
    client_order_id: 'bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk',
    symbol: 'ADAUSDT',
    side: 'sell',
    status: 'suspended',
    type: 'stopLimit',
    time_in_force: 'GTC',
    quantity: '4',
    quantity_cumulative: '0',
    price: '0.2600000',
    stop_price: '0.2600000',
    post_only: false,
    created_at: '2023-08-14T15:19:34.404Z',
    updated_at: '2023-08-14T15:19:34.404Z'
  },
  id: 'bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk',
  clientOrderId: 'bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk',
  timestamp: 1692026374404,
  datetime: '2023-08-14T15:19:34.404Z',
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: 'ADA/USDT',
  price: 0.26,
  amount: 4,
  type: 'stopLimit',
  side: 'sell',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: undefined,
  filled: 0,
  remaining: 4,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  stopPrice: 0.26,
  triggerPrice: 0.26,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  fees: []
}
2023-08-14T15:19:34.407Z iteration 1 passed in 161 ms
```
```
% hitbtc fetchOpenOrders
2023-08-14T15:22:20.265Z
Node.js: v18.15.0
CCXT v4.0.59
hitbtc.fetchOpenOrders ()
2023-08-14T15:22:21.273Z iteration 0 passed in 158 ms

                              id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol | price | amount |      type | side | timeInForce | postOnly | reduceOnly | filled | remaining | cost | status | average | trades | fee | stopPrice | triggerPrice | takeProfitPrice | stopLossPrice | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Tcmamtt3AEzTx1LGvEMmKKEbbuGoPuyf | Tcmamtt3AEzTx1LGvEMmKKEbbuGoPuyf | 1692026010513 | 2023-08-14T15:13:30.513Z |                    |                     | ADA/USDT |  0.26 |      4 | stopLimit | sell |         GTC |    false |            |      0 |         4 |    0 |   open |         |     [] |     |      0.26 |         0.26 |                 |               |   []
bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk | bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk | 1692026374404 | 2023-08-14T15:19:34.404Z |                    |                     | ADA/USDT |  0.26 |      4 | stopLimit | sell |         GTC |    false |            |      0 |         4 |    0 |   open |         |     [] |     |      0.26 |         0.26 |                 |               |   []
2 objects
2023-08-14T15:22:21.273Z iteration 1 passed in 158 ms
```
```
% hitbtc cancelOrder bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk
2023-08-14T15:23:00.195Z
Node.js: v18.15.0
CCXT v4.0.59
hitbtc.cancelOrder (bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk)
2023-08-14T15:23:01.216Z iteration 0 passed in 167 ms

{
  info: {
    id: '1102796421289',
    client_order_id: 'bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk',
    symbol: 'ADAUSDT',
    side: 'sell',
    status: 'canceled',
    type: 'stopLimit',
    time_in_force: 'GTC',
    quantity: '4',
    quantity_cumulative: '0',
    price: '0.2600000',
    stop_price: '0.2600000',
    post_only: false,
    created_at: '2023-08-14T15:19:34.404Z',
    updated_at: '2023-08-14T15:23:01.209Z'
  },
  id: 'bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk',
  clientOrderId: 'bEAsMYiqdxIYCbdO7Eovucwic8Kod2Pk',
  timestamp: 1692026374404,
  datetime: '2023-08-14T15:19:34.404Z',
  lastTradeTimestamp: 1692026581209,
  lastUpdateTimestamp: 1692026581209,
  symbol: 'ADA/USDT',
  price: 0.26,
  amount: 4,
  type: 'stopLimit',
  side: 'sell',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: undefined,
  filled: 0,
  remaining: 4,
  cost: 0,
  status: 'canceled',
  average: undefined,
  trades: [],
  fee: undefined,
  stopPrice: 0.26,
  triggerPrice: 0.26,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  fees: []
}
2023-08-14T15:23:01.216Z iteration 1 passed in 167 ms
```

## Python

```
% py hitbtc createOrder ADA/USDT limit sell 4 0.26 '{"triggerPrice": 0.26}'
Python v3.11.3
CCXT v4.0.59
hitbtc.createOrder(ADA/USDT,limit,sell,4,0.26,{'triggerPrice': 0.26})
{'amount': 4.0,
 'average': None,
 'clientOrderId': 'hj0j4jbrf3jkBCt8CbxO5aYQBATw3m_2',
 'cost': 0.0,
 'datetime': '2023-08-14T15:25:52.670Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': 'hj0j4jbrf3jkBCt8CbxO5aYQBATw3m_2',
 'info': {'client_order_id': 'hj0j4jbrf3jkBCt8CbxO5aYQBATw3m_2',
          'created_at': '2023-08-14T15:25:52.67Z',
          'id': '1102797350334',
          'post_only': False,
          'price': '0.2600000',
          'quantity': '4',
          'quantity_cumulative': '0',
          'side': 'sell',
          'status': 'suspended',
          'stop_price': '0.2600000',
          'symbol': 'ADAUSDT',
          'time_in_force': 'GTC',
          'type': 'stopLimit',
          'updated_at': '2023-08-14T15:25:52.67Z'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 0.26,
 'reduceOnly': None,
 'remaining': 4.0,
 'side': 'sell',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': 0.26,
 'symbol': 'ADA/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1692026752670,
 'trades': [],
 'triggerPrice': 0.26,
 'type': 'stopLimit'}
```