### PR TITLE
Bitget: fetchTrades 'since' support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2225,7 +2225,7 @@ export default class bitget extends Exchange {
         }, market);
     }
 
-    async fetchTrades (symbol: string, limit: Int = undefined, since: Int = undefined, params = {}) {
+    async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}) {
         /**
          * @method
          * @name bitget#fetchTrades

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2502,7 +2502,7 @@ export default class bitget extends Exchange {
             }
         }
         const options = this.safeValue (this.options, 'fetchOHLCV', {});
-        const ommitted = this.omit (params, [ 'until', 'till' ]);
+        const ommitted = this.omit (params, [ 'until', 'till', 'method' ]);
         const extended = this.extend (request, ommitted);
         let response = undefined;
         if (market['spot']) {


### PR DESCRIPTION
Changed the fetchTrades endpoints to ones that support 'since' and a higher limit:
fixes: #18888

### spot:
```
bitget.fetchTrades (BTC/USDT, , 1692074345000)
2023-08-15T04:39:21.800Z iteration 0 passed in 371 ms

                 id | order |   symbol | side | type | takerOrMaker |    price | amount |       cost | fee |     timestamp |                 datetime | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------
1075203222110945282 |       | BTC/USDT |  buy |      |              | 29376.81 | 0.0074 | 217.388394 |     | 1692074345000 | 2023-08-15T04:39:05.000Z |   []
1075203230499553281 |       | BTC/USDT | sell |      |              | 29376.27 | 0.0098 | 287.887446 |     | 1692074347000 | 2023-08-15T04:39:07.000Z |   []
1075203238867189761 |       | BTC/USDT |  buy |      |              | 29375.81 | 0.0135 | 396.573435 |     | 1692074349000 | 2023-08-15T04:39:09.000Z |   []
3 objects
```

### swap:
```
bitget.fetchTrades (BTC/USDT:USDT, , 1692074410000)
2023-08-15T04:40:41.372Z iteration 0 passed in 369 ms

                 id | order |        symbol | side | type | takerOrMaker |   price | amount |       cost | fee |     timestamp |                 datetime | fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------
1075203497475158018 |       | BTC/USDT:USDT | sell |      |              |   29371 |  4.339 | 127440.769 |     | 1692074410000 | 2023-08-15T04:40:10.000Z |   []
1075203516718624769 |       | BTC/USDT:USDT |  buy |      |              | 29371.5 |  0.002 |     58.743 |     | 1692074415000 | 2023-08-15T04:40:15.000Z |   []
1075203517721063425 |       | BTC/USDT:USDT | sell |      |              |   29371 |  0.047 |   1380.437 |     | 1692074415000 | 2023-08-15T04:40:15.000Z |   []
3 objects
```