### PR TITLE
Fix bithumb handle errors

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -1085,7 +1085,7 @@ export default class bithumb extends Exchange {
                     // https://github.com/ccxt/ccxt/issues/9017
                     return undefined; // no error
                 }
-                const feedback = this.id + ' ' + body;
+                const feedback = this.id + ' ' + message;
                 this.throwExactlyMatchedException (this.exceptions, status, feedback);
                 this.throwExactlyMatchedException (this.exceptions, message, feedback);
                 throw new ExchangeError (feedback);

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -1081,7 +1081,7 @@ export default class bithumb extends Exchange {
             if (status !== undefined) {
                 if (status === '0000') {
                     return undefined; // no error
-                } else if (message === '거래 진행중인 내역이 존재하지 않습니다') {
+                } else if (message === '거래 진행중인 내역이 존재하지 않습니다.') {
                     // https://github.com/ccxt/ccxt/issues/9017
                     return undefined; // no error
                 }


### PR DESCRIPTION
Fixed a problem with the method of the handle errors on the bithumb exchange

1. Exchange message displayed in Unicode
    - "\uc8fc\ubb38\ub7c9\uc774 \uc0ac\uc6a9\uac00\ub2a5 KRW\uc744 \ucd08\uacfc\ud558\uc600\uc2b5\ub2c8\ub2e4." 
2.  If there is no transaction in progress, the error should not be processed, but the error is being processed because the '.' does not exist
    -  '거래 진행중인 내역이 존재하지 않습니다'
