### PR TITLE
Poloniex trigger orders

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1095,7 +1095,7 @@ export default class poloniex extends Exchange {
             };
         }
         const clientOrderId = this.safeString (order, 'clientOrderId');
-        const triggerPrice = this.safeString (order, 'triggerPrice', 'stopPrice');
+        const triggerPrice = this.safeString2 (order, 'triggerPrice', 'stopPrice');
         return this.safeOrder ({
             'info': order,
             'id': id,

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1170,6 +1170,7 @@ export default class poloniex extends Exchange {
             request['limit'] = limit;
         }
         const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        params = this.omit (params, [ 'trigger', 'stop' ]);
         let response = undefined;
         if (isTrigger) {
             response = await this.privateGetSmartorders (this.extend (request, params));
@@ -1344,8 +1345,8 @@ export default class poloniex extends Exchange {
             id = clientOrderId;
         }
         request['id'] = id;
-        params = this.omit (params, 'clientOrderId');
         const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        params = this.omit (params, [ 'clientOrderId', 'trigger', 'stop' ]);
         let response = undefined;
         if (isTrigger) {
             response = await this.privateDeleteSmartordersId (this.extend (request, params));
@@ -1387,6 +1388,7 @@ export default class poloniex extends Exchange {
             ];
         }
         const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        params = this.omit (params, [ 'trigger', 'stop' ]);
         let response = undefined;
         if (isTrigger) {
             response = await this.privateDeleteSmartorders (this.extend (request, params));
@@ -1431,9 +1433,11 @@ export default class poloniex extends Exchange {
             'id': id,
         };
         const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        params = this.omit (params, [ 'trigger', 'stop' ]);
         let response = undefined;
         if (isTrigger) {
             response = await this.privateGetSmartordersId (this.extend (request, params));
+            response = this.safeValue (response, 0);
         } else {
             response = await this.privateGetOrdersId (this.extend (request, params));
         }

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1345,7 +1345,13 @@ export default class poloniex extends Exchange {
         }
         request['id'] = id;
         params = this.omit (params, 'clientOrderId');
-        const response = await this.privateDeleteOrdersId (this.extend (request, params));
+        const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        let response = undefined;
+        if (isTrigger) {
+            response = await this.privateDeleteSmartordersId (this.extend (request, params));
+        } else {
+            response = await this.privateDeleteOrdersId (this.extend (request, params));
+        }
         //
         //   {
         //       "orderId":"210832697138888704",
@@ -1380,7 +1386,13 @@ export default class poloniex extends Exchange {
                 market['id'],
             ];
         }
-        const response = await this.privateDeleteOrders (this.extend (request, params));
+        const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        let response = undefined;
+        if (isTrigger) {
+            response = await this.privateDeleteSmartorders (this.extend (request, params));
+        } else {
+            response = await this.privateDeleteOrders (this.extend (request, params));
+        }
         //
         //     [
         //         {
@@ -1421,7 +1433,7 @@ export default class poloniex extends Exchange {
         const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
         let response = undefined;
         if (isTrigger) {
-            response = await this.privateGetSmartorders (this.extend (request, params));
+            response = await this.privateGetSmartordersId (this.extend (request, params));
         } else {
             response = await this.privateGetOrdersId (this.extend (request, params));
         }

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1308,12 +1308,18 @@ export default class poloniex extends Exchange {
         if (!market['spot']) {
             throw new NotSupported (this.id + ' editOrder() does not support ' + market['type'] + ' orders, only spot orders are accepted');
         }
-        const request = {
+        let request = {
             'id': id,
             // 'timeInForce': timeInForce,
         };
-        const orderRequest = this.orderRequest (symbol, type, side, amount, request, price, params);
-        let response = await this.privatePutOrdersId (this.extend (orderRequest[0], orderRequest[1]));
+        const triggerPrice = this.safeNumber2 (params, 'stopPrice', 'triggerPrice');
+        [ request, params ] = this.orderRequest (symbol, type, side, amount, request, price, params);
+        let response = undefined;
+        if (triggerPrice !== undefined) {
+            response = await this.privatePutSmartordersId (this.extend (request, params));
+        } else {
+            response = await this.privatePutOrdersId (this.extend (request, params));
+        }
         //
         //     {
         //         "id" : "78923648051920896",

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1151,6 +1151,7 @@ export default class poloniex extends Exchange {
          * @name poloniex#fetchOpenOrders
          * @description fetch all unfilled currently open orders
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-open-orders
+         * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-open-orders  // trigger orders
          * @param {string} symbol unified market symbol
          * @param {int} [since] the earliest time in ms to fetch open orders for
          * @param {int} [limit] the maximum number of  open orders structures to retrieve
@@ -1200,6 +1201,7 @@ export default class poloniex extends Exchange {
          * @name poloniex#createOrder
          * @description create a trade order
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-create-order
+         * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-create-order  // trigger orders
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -1272,6 +1274,7 @@ export default class poloniex extends Exchange {
          * @name poloniex#editOrder
          * @description edit a trade order
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-cancel-replace-order
+         * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-cancel-replace-order
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
@@ -1310,6 +1313,7 @@ export default class poloniex extends Exchange {
          * @name poloniex#cancelOrder
          * @description cancels an open order
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-cancel-order-by-id
+         * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-cancel-order-by-id  // trigger orders
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the poloniex api endpoint
@@ -1342,6 +1346,7 @@ export default class poloniex extends Exchange {
          * @name poloniex#cancelAllOrders
          * @description cancel all open orders
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-cancel-all-orders
+         * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-cancel-all-orders  // trigger orders
          * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the poloniex api endpoint
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -1384,6 +1389,7 @@ export default class poloniex extends Exchange {
          * @name poloniex#fetchOrder
          * @description fetch an order by it's id
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-order-details
+         * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-open-orders  // trigger orders
          * @param {string} id order id
          * @param {string} symbol unified market symbol, default is undefined
          * @param {object} [params] extra parameters specific to the poloniex api endpoint

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1095,6 +1095,7 @@ export default class poloniex extends Exchange {
             };
         }
         const clientOrderId = this.safeString (order, 'clientOrderId');
+        const triggerPrice = this.safeString (order, 'triggerPrice', 'stopPrice');
         return this.safeOrder ({
             'info': order,
             'id': id,
@@ -1109,8 +1110,8 @@ export default class poloniex extends Exchange {
             'postOnly': undefined,
             'side': side,
             'price': price,
-            'stopPrice': undefined,
-            'triggerPrice': undefined,
+            'stopPrice': triggerPrice,
+            'triggerPrice': triggerPrice,
             'cost': undefined,
             'average': this.safeString (order, 'avgPrice'),
             'amount': amount,
@@ -1168,7 +1169,13 @@ export default class poloniex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.privateGetOrders (this.extend (request, params));
+        const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        let response = undefined;
+        if (isTrigger) {
+            response = await this.privateGetSmartorders (this.extend (request, params));
+        } else {
+            response = await this.privateGetOrders (this.extend (request, params));
+        }
         //
         //     [
         //         {
@@ -1186,6 +1193,7 @@ export default class poloniex extends Exchange {
         //             "amount" : "0",
         //             "filledQuantity" : "0",
         //             "filledAmount" : "0",
+        //             "stopPrice": "3750.00",              // for trigger orders
         //             "createTime" : 16xxxxxxxxx26,
         //             "updateTime" : 16xxxxxxxxx36
         //         }
@@ -1410,7 +1418,13 @@ export default class poloniex extends Exchange {
         const request = {
             'id': id,
         };
-        const response = await this.privateGetOrdersId (this.extend (request, params));
+        const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+        let response = undefined;
+        if (isTrigger) {
+            response = await this.privateGetSmartorders (this.extend (request, params));
+        } else {
+            response = await this.privateGetOrdersId (this.extend (request, params));
+        }
         //
         //     {
         //         "id": "21934611974062080",
@@ -1427,6 +1441,7 @@ export default class poloniex extends Exchange {
         //         "amount": "0.00",
         //         "filledQuantity": "0.00",
         //         "filledAmount": "0.00",
+        //         "stopPrice": "3750.00",              // for trigger orders
         //         "createTime": 1646196019020,
         //         "updateTime": 1646196019020
         //     }

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1378,7 +1378,7 @@ export default class poloniex extends Exchange {
          * @description cancel all open orders
          * @see https://docs.poloniex.com/#authenticated-endpoints-orders-cancel-all-orders
          * @see https://docs.poloniex.com/#authenticated-endpoints-smart-orders-cancel-all-orders  // trigger orders
-         * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
+         * @param {string} symbol *required for stop orders* unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the poloniex api endpoint
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */


### PR DESCRIPTION
```
% poloniex createOrder ADA/USDT limit sell 3.5 0.25 '{"stopPrice": 0.25}'
2023-08-17T02:04:12.487Z
Node.js: v18.15.0
CCXT v4.0.61
poloniex.createOrder (ADA/USDT, limit, sell, 3.5, 0.25, [object Object])
2023-08-17T02:04:13.809Z iteration 0 passed in 321 ms

{
  info: { id: '215048064241500160', clientOrderId: '', type: 'sell' },
  id: '215048064241500160',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'ADA/USDT',
  type: 'sell',
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  average: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  trades: [],
  fee: undefined,
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-17T02:04:13.809Z iteration 1 passed in 321 ms
```
```
% poloniex fetchOrder '"215048064241500160"' undefined '{"stop": true}'
2023-08-17T02:08:00.809Z
Node.js: v18.15.0
CCXT v4.0.61
poloniex.fetchOrder (215048064241500160, , [object Object])
2023-08-17T02:08:02.411Z iteration 0 passed in 586 ms

{
  info: {
    id: '215048064241500160',
    clientOrderId: '',
    symbol: 'ADA_USDT',
    state: 'PENDING_NEW',
    accountType: 'SPOT',
    side: 'SELL',
    type: 'STOP_LIMIT',
    timeInForce: 'GTC',
    quantity: '3.5',
    price: '0.25',
    amount: '0',
    stopPrice: '0.25',
    createTime: 1692237853915,
    updateTime: 1692237853915
  },
  id: '215048064241500160',
  clientOrderId: undefined,
  timestamp: 1692237853915,
  datetime: '2023-08-17T02:04:13.915Z',
  lastTradeTimestamp: 1692237853915,
  status: 'PENDING_NEW',
  symbol: 'ADA/USDT',
  type: 'STOP_LIMIT',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  price: 0.25,
  stopPrice: 0.25,
  triggerPrice: 0.25,
  cost: undefined,
  average: undefined,
  amount: 3.5,
  filled: undefined,
  remaining: undefined,
  trades: [],
  fee: undefined,
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-17T02:08:02.411Z iteration 1 passed in 586 ms
```
```
% poloniex editOrder '"215048064241500160"' ADA/USDT limit sell 3.5 0.25 '{"stopPrice": 0.24}'
2023-08-17T02:12:52.320Z
Node.js: v18.15.0
CCXT v4.0.61
poloniex.editOrder (215048064241500160, ADA/USDT, limit, sell, 3.5, 0.25, [object Object])
2023-08-17T02:12:53.544Z iteration 0 passed in 335 ms

{
  info: { id: '215050244251975680', clientOrderId: '', type: 'sell' },
  id: '215050244251975680',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'ADA/USDT',
  type: 'sell',
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  average: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  trades: [],
  fee: undefined,
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-17T02:12:53.544Z iteration 1 passed in 335 ms
```
```
% poloniex fetchOpenOrders undefined undefined undefined '{"stop": true}'
2023-08-17T02:13:50.803Z
Node.js: v18.15.0
CCXT v4.0.61
poloniex.fetchOpenOrders (, , , [object Object])
2023-08-17T02:13:52.098Z iteration 0 passed in 279 ms

                id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | status |   symbol |       type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | cost | average | amount | filled | remaining | trades | fee | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
215050244251975680 |               | 1692238373667 | 2023-08-17T02:12:53.667Z |      1692238373667 |   open | ADA/USDT | STOP_LIMIT |         GTC |    false | sell |  0.25 |      0.24 |         0.24 |      |         |    3.5 |        |           |     [] |     |   [] |                     |            |                 |              
1 objects
2023-08-17T02:13:52.098Z iteration 1 passed in 279 ms
```
```
samgermain@Sams-MacBook-Pro ccxt % poloniex cancelOrder '"215050244251975680"' undefined '{"stop": true}'
2023-08-17T02:14:30.514Z
Node.js: v18.15.0
CCXT v4.0.61
poloniex.cancelOrder (215050244251975680, , [object Object])
2023-08-17T02:14:31.756Z iteration 0 passed in 359 ms

{
  info: {
    orderId: '215050244251975680',
    clientOrderId: '',
    state: 'CANCELED',
    code: 200,
    message: ''
  },
  id: '215050244251975680',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: 'canceled',
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  average: undefined,
  amount: undefined,
  filled: undefined,
  remaining: undefined,
  trades: [],
  fee: undefined,
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-17T02:14:31.756Z iteration 1 passed in 359 ms
```

```
% poloniex cancelAllOrders ADA/USDT '{"trigger": true}' 
2023-08-17T02:29:30.010Z
Node.js: v18.15.0
CCXT v4.0.61
poloniex.cancelAllOrders (ADA/USDT, [object Object])

           orderId | clientOrderId |    state | code | message
--------------------------------------------------------------
215052045621657600 |               | CANCELED |  200 |        
215052575408390144 |               | CANCELED |  200 |        
2 objects
2023-08-17T02:29:31.697Z iteration 1 passed in 529 ms
```