### PR TITLE
Bitget: fetchMarkOHLCV, fetchIndexOHLCV

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1000,7 +1000,7 @@ export default class bitget extends Exchange {
                     'spot': {
                         'method': 'publicSpotGetMarketCandles', // or publicSpotGetMarketHistoryCandles
                     },
-                    'swap:': {
+                    'swap': {
                         'method': 'publicMixGetMarketCandles', // or publicMixGetMarketHistoryCandles or publicMixGetMarketHistoryIndexCandles or publicMixGetMarketHistoryMarkCandles
                     },
                 },
@@ -2456,30 +2456,31 @@ export default class bitget extends Exchange {
             }
         }
         const options = this.safeValue (this.options, 'fetchOHLCV', {});
-        const ommitted = this.omit (params, [ 'until', 'till' ]);
-        const extended = this.extend (request, ommitted);
+        params = this.omit (params, [ 'until', 'till' ]);
         let response = undefined;
         if (market['spot']) {
             const spotOptions = this.safeValue (options, 'spot', {});
-            const defaultSpotMethod = this.safeString (params, 'method', 'publicSpotGetMarketCandles');
-            const method = this.safeString (spotOptions, 'method', defaultSpotMethod);
+            const defaultSpotMethod = this.safeString (spotOptions, 'method', 'publicSpotGetMarketCandles');
+            const method = this.safeString (params, 'method', defaultSpotMethod);
+            params = this.omit (params, 'method');
             if (method === 'publicSpotGetMarketCandles') {
-                response = await this.publicSpotGetMarketCandles (extended);
+                response = await this.publicSpotGetMarketCandles (this.extend (request, params));
             } else if (method === 'publicSpotGetMarketHistoryCandles') {
-                response = await this.publicSpotGetMarketHistoryCandles (extended);
+                response = await this.publicSpotGetMarketHistoryCandles (this.extend (request, params));
             }
         } else {
             const swapOptions = this.safeValue (options, 'swap', {});
-            const defaultSwapMethod = this.safeString (params, 'method', 'publicMixGetMarketCandles');
-            const swapMethod = this.safeString (swapOptions, 'method', defaultSwapMethod);
+            const defaultSwapMethod = this.safeString (swapOptions, 'method', 'publicMixGetMarketCandles');
+            const swapMethod = this.safeString (params, 'method', defaultSwapMethod);
+            params = this.omit (params, 'method');
             if (swapMethod === 'publicMixGetMarketCandles') {
-                response = await this.publicMixGetMarketCandles (extended);
+                response = await this.publicMixGetMarketCandles (this.extend (request, params));
             } else if (swapMethod === 'publicMixGetMarketHistoryCandles') {
-                response = await this.publicMixGetMarketHistoryCandles (extended);
+                response = await this.publicMixGetMarketHistoryCandles (this.extend (request, params));
             } else if (swapMethod === 'publicMixGetMarketHistoryIndexCandles') {
-                response = await this.publicMixGetMarketHistoryIndexCandles (extended);
+                response = await this.publicMixGetMarketHistoryIndexCandles (this.extend (request, params));
             } else if (swapMethod === 'publicMixGetMarketHistoryMarkCandles') {
-                response = await this.publicMixGetMarketHistoryMarkCandles (extended);
+                response = await this.publicMixGetMarketHistoryMarkCandles (this.extend (request, params));
             }
         }
         //  [ ["1645911960000","39406","39407","39374.5","39379","35.526","1399132.341"] ]

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -57,14 +57,14 @@ export default class bitget extends Exchange {
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
                 'fetchFundingRates': false,
-                'fetchIndexOHLCV': false,
+                'fetchIndexOHLCV': true,
                 'fetchLedger': true,
                 'fetchLeverage': true,
                 'fetchLeverageTiers': false,
                 'fetchMarginMode': undefined,
                 'fetchMarketLeverageTiers': true,
                 'fetchMarkets': true,
-                'fetchMarkOHLCV': false,
+                'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
                 'fetchOpenInterest': true,
@@ -2404,8 +2404,12 @@ export default class bitget extends Exchange {
          * @method
          * @name bitget#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://bitgetlimited.github.io/apidoc/en/spot/#get-candle-data
+         * @see https://bitgetlimited.github.io/apidoc/en/spot/#get-history-candle-data
          * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-candle-data
-         * @see https://bitgetlimited.github.io/apidoc/en/spot/#candlestick-line-timeframe
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-history-candle-data
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-history-index-candle-data
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-history-mark-candle-data
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -2472,15 +2476,16 @@ export default class bitget extends Exchange {
             const swapOptions = this.safeValue (options, 'swap', {});
             const defaultSwapMethod = this.safeString (swapOptions, 'method', 'publicMixGetMarketCandles');
             const swapMethod = this.safeString (params, 'method', defaultSwapMethod);
-            params = this.omit (params, 'method');
-            if (swapMethod === 'publicMixGetMarketCandles') {
+            const priceType = this.safeString (params, 'price');
+            params = this.omit (params, [ 'method', 'price' ]);
+            if ((priceType === 'mark') || (swapMethod === 'publicMixGetMarketHistoryMarkCandles')) {
+                response = await this.publicMixGetMarketHistoryMarkCandles (this.extend (request, params));
+            } else if ((priceType === 'index') || (swapMethod === 'publicMixGetMarketHistoryIndexCandles')) {
+                response = await this.publicMixGetMarketHistoryIndexCandles (this.extend (request, params));
+            } else if (swapMethod === 'publicMixGetMarketCandles') {
                 response = await this.publicMixGetMarketCandles (this.extend (request, params));
             } else if (swapMethod === 'publicMixGetMarketHistoryCandles') {
                 response = await this.publicMixGetMarketHistoryCandles (this.extend (request, params));
-            } else if (swapMethod === 'publicMixGetMarketHistoryIndexCandles') {
-                response = await this.publicMixGetMarketHistoryIndexCandles (this.extend (request, params));
-            } else if (swapMethod === 'publicMixGetMarketHistoryMarkCandles') {
-                response = await this.publicMixGetMarketHistoryMarkCandles (this.extend (request, params));
             }
         }
         //  [ ["1645911960000","39406","39407","39374.5","39379","35.526","1399132.341"] ]


### PR DESCRIPTION
Added fetchMarkOHLCV and fetchIndexOHLCV:

### fetchMarkOHLCV:
```
bitget.fetchMarkOHLCV (BTC/USDT:USDT, 1m, , 3)
2023-08-17T02:59:10.486Z iteration 0 passed in 289 ms

1692240960000 | 28575.3 | 28575.3 | 28569.5 | 28572.5 | 0
1692241020000 | 28572.5 | 28578.9 | 28572.5 | 28576.3 | 0
1692241080000 | 28576.3 | 28576.5 | 28574.5 | 28574.7 | 0
3 objects
```

### fetchIndexOHLCV:
```
bitget.fetchIndexOHLCV (BTC/USDT:USDT, 1m, , 3)
2023-08-17T02:59:52.056Z iteration 0 passed in 286 ms

1692240960000 | 28583.058144 | 28583.058144 | 28578.462916 | 28578.776249 | 0
1692241020000 | 28578.776249 | 28585.811076 | 28578.772916 | 28584.691752 | 0
1692241080000 | 28584.691752 | 28584.693814 | 28581.844432 | 28582.360447 | 0
3 objects
```