### PR TITLE
base - remove emulated ohlcv

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -278,7 +278,7 @@ class Exchange {
         'fetchMarkets' => true,
         'fetchMarkOHLCV' => null,
         'fetchMyTrades' => null,
-        'fetchOHLCV' => 'emulated',
+        'fetchOHLCV' => null,
         'fetchOpenOrder' => null,
         'fetchOpenOrders' => null,
         'fetchOrder' => null,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -305,7 +305,7 @@ class Exchange(object):
         'fetchClosedOrders': None,
         'fetchCurrencies': 'emulated',
         'fetchDeposit': None,
-        'fetchDepositAddress': None,
+        'fetchDepositAddress': None,s
         'fetchDepositAddresses': None,
         'fetchDepositAddressesByNetwork': None,
         'fetchDeposits': None,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -324,7 +324,7 @@ class Exchange(object):
         'fetchMarkets': True,
         'fetchMarkOHLCV': None,
         'fetchMyTrades': None,
-        'fetchOHLCV': 'emulated',
+        'fetchOHLCV': None,
         'fetchOpenOrder': None,
         'fetchOpenOrders': None,
         'fetchOrder': None,

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -305,7 +305,7 @@ class Exchange(object):
         'fetchClosedOrders': None,
         'fetchCurrencies': 'emulated',
         'fetchDeposit': None,
-        'fetchDepositAddress': None,s
+        'fetchDepositAddress': None,
         'fetchDepositAddresses': None,
         'fetchDepositAddressesByNetwork': None,
         'fetchDeposits': None,


### PR DESCRIPTION
in TS we had removed them in the past, but leftovers were missed. breaks tests in php/py