### PR TITLE
fix(bybit): watchTickers market selection

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2085,10 +2085,10 @@ export default class bybit extends Exchange {
         //         "change24h": "86"
         //     }
         //
+        const isSpot = this.safeString (ticker, 'openInterestValue') === undefined;
         const timestamp = this.safeInteger (ticker, 'time');
         const marketId = this.safeString (ticker, 'symbol');
-        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
-        const type = this.safeString (market, 'type', defaultType);
+        const type = isSpot ? 'spot' : 'contract';
         market = this.safeMarket (marketId, market, undefined, type);
         const symbol = this.safeSymbol (marketId, market, undefined, type);
         const last = this.safeString (ticker, 'lastPrice');

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -287,7 +287,8 @@ export default class bybit extends bybitRest {
         const topic = this.safeString (message, 'topic', '');
         const updateType = this.safeString (message, 'type', '');
         const data = this.safeValue (message, 'data', {});
-        const isSpot = this.safeString (data, 's') !== undefined;
+        const isSpot = this.safeString (data, 'openInterestValue') === undefined;
+        const type = isSpot ? 'spot' : 'contract';
         let symbol = undefined;
         let parsed = undefined;
         if ((updateType === 'snapshot') || isSpot) {
@@ -297,7 +298,7 @@ export default class bybit extends bybitRest {
             const topicParts = topic.split ('.');
             const topicLength = topicParts.length;
             const marketId = this.safeString (topicParts, topicLength - 1);
-            const market = this.market (marketId);
+            const market = this.safeMarket (marketId, undefined, undefined, type);
             symbol = market['symbol'];
             // update the info in place
             const ticker = this.safeValue (this.tickers, symbol, {});


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18931

```
p bybit watchTicker "BTC/USDT" --sandbox 
Python v3.10.9
CCXT v4.0.65
bybit.watchTicker(BTC/USDT)
{'ask': None,
 'askVolume': None,
 'average': 27213.8095,
 'baseVolume': 2474.90763,
 'bid': None,
 'bidVolume': None,
 'change': -2662.9806,
 'close': 25882.3192,
 'datetime': '2023-08-17T14:06:30.338Z',
 'high': 28908.7,
 'info': {'highPrice24h': '28908.7',
          'lastPrice': '25882.3192',
          'lowPrice24h': '24000',
          'prevPrice24h': '28545.2998',
          'price24hPcnt': '-0.0933',
          'symbol': 'BTCUSDT',
          'turnover24h': '68463797.4509006124',
          'usdIndexPrice': '28370.95000001',
          'volume24h': '2474.90763'},
 'last': 25882.3192,
 'low': 24000.0,
 'open': 28545.2998,
 'percentage': -9.33,
 'previousClose': None,
 'quoteVolume': 68463797.45090061,
 'symbol': 'BTC/USDT',
 'timestamp': 1692281190338,
 'vwap': 27663.172807342555}
{'ask': None,
 'askVolume': None,
 'average': 27213.8095,
 'baseVolume': 2474.90763,
 'bid': None,
 'bidVolume': None,
 'change': -2662.9806,
 'close': 25882.3192,
 'datetime': '2023-08-17T14:06:30.641Z',
 'high': 28908.7,
 'info': {'highPrice24h': '28908.7',
          'lastPrice': '25882.3192',
          'lowPrice24h': '24000',
          'prevPrice24h': '28545.2998',
          'price24hPcnt': '-0.0933',
          'symbol': 'BTCUSDT',
          'turnover24h': '68463797.4509006124',
          'usdIndexPrice': '28370.40000001',
          'volume24h': '2474.90763'},
 'last': 25882.3192,
 'low': 24000.0,
 'open': 28545.2998,
 'percentage': -9.33,
 'previousClose': None,
 'quoteVolume': 68463797.45090061,
 'symbol': 'BTC/USDT',
 'timestamp': 1692281190641,
 'vwap': 27663.172807342555}
```
```
p bybit watchTicker "BTC/USDT:USDT" --sandbox          
Python v3.10.9
CCXT v4.0.65
bybit.watchTicker(BTC/USDT:USDT)
{'ask': 28433.9,
 'askVolume': 154.224,
 'average': 28774.6,
 'baseVolume': 34717.921,
 'bid': 28421.3,
 'bidVolume': 246.451,
 'change': -681.4,
 'close': 28433.9,
 'datetime': '2023-08-17T14:06:58.646Z',
 'high': 30939.1,
 'info': {'ask1Price': '28433.90',
          'ask1Size': '154.224',
          'bid1Price': '28421.30',
          'bid1Size': '246.451',
          'fundingRate': '0.0001',
          'highPrice24h': '30939.10',
          'indexPrice': '28425.75',
          'lastPrice': '28433.90',
          'lowPrice24h': '28000.00',
          'markPrice': '28425.35',
          'nextFundingTime': '1692288000000',
          'openInterest': '154911.381',
          'openInterestValue': '4403410223.91',
          'prevPrice1h': '28460.40',
          'prevPrice24h': '29115.30',
          'price24hPcnt': '-0.023403',
          'symbol': 'BTCUSDT',
          'tickDirection': 'ZeroPlusTick',
          'turnover24h': '1000277863.8962',
          'volume24h': '34717.9210'},
 'last': 28433.9,
 'low': 28000.0,
 'open': 29115.3,
 'percentage': -2.3403,
 'previousClose': None,
 'quoteVolume': 1000277863.8962,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1692281218646,
 'vwap': 28811.571519394838}
{'ask': 28433.9,
 'askVolume': 154.224,
 'average': 28774.6,
 'baseVolume': 34717.921,
 'bid': 28421.3,
 'bidVolume': 246.451,
 'change': -681.4,
 'close': 28433.9,
 'datetime': '2023-08-17T14:06:59.046Z',
 'high': 30939.1,
 'info': {'ask1Price': '28433.90',
          'ask1Size': '154.224',
          'bid1Price': '28421.30',
          'bid1Size': '246.451',
          'fundingRate': '0.0001',
          'highPrice24h': '30939.10',
          'indexPrice': '28427.65',
          'lastPrice': '28433.90',
          'lowPrice24h': '28000.00',
          'markPrice': '28430.19',
          'nextFundingTime': '1692288000000',
          'openInterest': '154911.381',
          'openInterestValue': '4404159994.99',
          'prevPrice1h': '28460.40',
          'prevPrice24h': '29115.30',
          'price24hPcnt': '-0.023403',
          'symbol': 'BTCUSDT',
          'tickDirection': 'ZeroPlusTick',
          'turnover24h': '1000277863.8962',
          'volume24h': '34717.9210'},
 'last': 28433.9,
 'low': 28000.0,
 'open': 29115.3,
 'percentage': -2.3403,
 'previousClose': None,
 'quoteVolume': 1000277863.8962,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1692281219046,
 'vwap': 28811.571519394838}
```
