### PR TITLE
fix(phemex): fetchPosition - marginMode is parsed from response

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -3543,6 +3543,7 @@ export default class phemex extends Exchange {
         }
         const unrealizedPnl = Precise.stringMul (Precise.stringMul (priceDiff, contracts), contractSizeString);
         const marginRatio = Precise.stringDiv (maintenanceMarginString, collateral);
+        const isCross = this.safeValue (position, 'crossMargin');
         return this.safePosition ({
             'info': position,
             'id': undefined,
@@ -3565,7 +3566,7 @@ export default class phemex extends Exchange {
             'maintenanceMarginPercentage': this.parseNumber (maintenanceMarginPercentageString),
             'marginRatio': this.parseNumber (marginRatio),
             'datetime': undefined,
-            'marginMode': undefined,
+            'marginMode': isCross ? 'cross' : 'isolated',
             'side': side,
             'hedged': false,
             'percentage': undefined,


### PR DESCRIPTION
fixes: #18905

-----------------

This is a very small change, but I can't test it due to this error. Feel free to test it if you want though

```
phemex.fetchBalance ()
PermissionDenied phemex {"code": "401","msg": "401 Request IP mismatch."}
---------------------------------------------------
[PermissionDenied] phemex {"code": "401","msg": "401 Request IP mismatch."}

    at throwBroadlyMatchedException  ….../ccxt/ts/src/base/Exchange.ts:3450  
    at handleErrors                  Users/.../ccxt/ts/src/phemex.ts:4387    
    at                               ….../ccxt/ts/src/base/Exchange.ts:1003  
    at processTicksAndRejections     node:internal/process/task_queues:95                          
    at fetch2                        ….../ccxt/ts/src/base/Exchange.ts:2992  
    at request                       ….../ccxt/ts/src/base/Exchange.ts:2996  
    at fetchBalance                  Users/.../ccxt/ts/src/phemex.ts:1828    
    at async run                     Users/.../ccxt/examples/ts/cli.ts:301   

phemex {"code": "401","msg": "401 Request IP mismatch."}
```