### PR TITLE
Bitget: fetchTrades add 'endTime' support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2238,6 +2238,7 @@ export default class bitget extends Exchange {
          * @param {int} [since] timestamp in ms of the earliest trade to fetch
          * @param {int} [limit] the maximum amount of trades to fetch
          * @param {object} [params] extra parameters specific to the bitget api endpoint
+         * @param {int} [params.until] the latest time in ms to fetch deposits for
          * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html?#public-trades}
          */
         await this.loadMarkets ();
@@ -2251,6 +2252,12 @@ export default class bitget extends Exchange {
         if (since !== undefined) {
             request['startTime'] = since;
         }
+        const until = this.safeInteger2 (params, 'until', 'endTime');
+        if (until !== undefined) {
+            this.checkRequiredArgument ('fetchTrades', since, 'since');
+            request['endTime'] = until;
+        }
+        params = this.omit (params, 'until');
         const options = this.safeValue (this.options, 'fetchTrades', {});
         let response = undefined;
         if (market['spot']) {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2249,10 +2249,14 @@ export default class bitget extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
+        const until = this.safeInteger2 (params, 'until', 'endTime');
         if (since !== undefined) {
             request['startTime'] = since;
+            if (until === undefined) {
+                const now = this.milliseconds ();
+                request['endTime'] = now;
+            }
         }
-        const until = this.safeInteger2 (params, 'until', 'endTime');
         if (until !== undefined) {
             this.checkRequiredArgument ('fetchTrades', since, 'since');
             request['endTime'] = until;


### PR DESCRIPTION
Added endTime support to fetchTrades:
```
bitget fetchTrades BTC/USDT:USDT 1690416000000 undefined '{"endTime":1690416001000}'

bitget.fetchTrades (BTC/USDT:USDT, 1690416000000, , [object Object])
2023-08-17T23:31:49.992Z iteration 0 passed in 314 ms

                 id | order |        symbol | side | type | takerOrMaker | price | amount |     cost | fee |     timestamp |                 datetime | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------
1068247620557975553 |       | BTC/USDT:USDT |  buy |      |              | 29345 |  0.808 | 23710.76 |     | 1690416000000 | 2023-07-27T00:00:00.000Z |   []
1068247625431756801 |       | BTC/USDT:USDT |  buy |      |              | 29345 |  0.001 |   29.345 |     | 1690416001000 | 2023-07-27T00:00:01.000Z |   []
1068247625565974529 |       | BTC/USDT:USDT |  buy |      |              | 29345 |  0.163 | 4783.235 |     | 1690416001000 | 2023-07-27T00:00:01.000Z |   []
3 objects
```

Some behavior with the Bitget API that I noticed:
- if limit, since and endTime are all provided, limit will override since but not endTime
- if only since is provided it won't work unless the times are in the list of the most recent trades
- endTime doesn't work properly if since isn't provided