### PR TITLE
fix(base) - currencyToprecision force string

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3765,10 +3765,17 @@ export default class Exchange {
             precision = this.safeValue (networkItem, 'precision', precision);
         }
         if (precision === undefined) {
-            return fee;
+            return this.forceString (fee);
         } else {
             return this.decimalToPrecision (fee, ROUND, precision, this.precisionMode, this.paddingMode);
         }
+    }
+
+    forceString (value) {
+        if (typeof value !== 'string') {
+            return this.numberToString (value);
+        }
+        return value;
     }
 
     isTickPrecision () {


### PR DESCRIPTION
Currently in `currencyToPrecision` we have a code like:
```
if (precision === undefined) {
    return fee; // it is user input, so returned value can be either `string` or `numeric`, depending what user has provided
} else {
    return this.decimalToPrecision(); // is always `string`
}
``` 
so, currently we have a bug as we are dynamically `return`-ing different types from that method. I think we should always return same type (`string`). For that I have added `forceString` (which is [different from `numberToString`](https://github.com/ccxt/ccxt/pull/18942#discussion_r1301331310))


what I can say, is the following things (and please confirm if you agree):
- `currencyToPrecision` method is only used in `transfer, withdraw, borrowMargin & repayMargin`
- this change does not affect exchanges, where currencies have precisions.  even if exchange does not have `fetchCurrencies`, the currency precisions are emulated from `loadMarkets`. so, this change only affects exchanges, which have `fetchCurrencies`, but that endpoint lacks precision informations about currencies. such exchanges are only: `'bitopro','poloniex','whitebit','bitrue','bitmart', 'bitget'` (you can test this code: https://pastebin.com/TfJP2CZ4 )
