### PR TITLE
fix(bybit): market() override

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1384,6 +1384,16 @@ export default class bybit extends Exchange {
                 return this.markets[symbol];
             } else if (symbol in this.markets_by_id) {
                 const markets = this.markets_by_id[symbol];
+                let defaultType = this.safeString2 (this.options, 'defaultType', 'defaultSubType', 'spot');
+                if (defaultType === 'future') {
+                    defaultType = 'contract';
+                }
+                for (let i = 0; i < markets.length; i++) {
+                    const market = markets[i];
+                    if (market[defaultType]) {
+                        return market;
+                    }
+                }
                 return markets[0];
             } else if ((symbol.indexOf ('-C') > -1) || (symbol.indexOf ('-P') > -1)) {
                 return this.createExpiredOptionMarket (symbol);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18938


```
p bybit fetchTicker "BTCUSDT" --sandbox --spot 
Python v3.10.9
CCXT v4.0.67
bybit.fetchTicker(BTCUSDT)
{'ask': 26152.6,
 'askVolume': 0.026917,
 'average': 24896.9248,
 'baseVolume': 5602.334395,
 'bid': 26098.88,
 'bidVolume': 0.000602,
 'change': 2404.1504,
 'close': 26099.0,
 'datetime': None,
 'high': 29752.1178,
 'info': {'ask1Price': '26152.6',
          'ask1Size': '0.026917',
          'bid1Price': '26098.88',
          'bid1Size': '0.000602',
          'highPrice24h': '29752.1178',
          'lastPrice': '26099',
          'lowPrice24h': '18000',
          'prevPrice24h': '23694.8496',
          'price24hPcnt': '0.1015',
          'symbol': 'BTCUSDT',
          'turnover24h': '157947959.4437128322',
          'usdIndexPrice': '26137.63000001',
          'volume24h': '5602.334395'},
 'last': 26099.0,
 'low': 18000.0,
 'open': 23694.8496,
 'percentage': 10.15,
 'previousClose': None,
 'quoteVolume': 157947959.44371283,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': 28193.240229408482}
```
```
p bybit fetchTicker "BTCUSDT" --sandbox        
Python v3.10.9
CCXT v4.0.67
bybit.fetchTicker(BTCUSDT)
{'ask': 26128.5,
 'askVolume': 161.744,
 'average': 27270.9,
 'baseVolume': 179424.97,
 'bid': 26127.4,
 'bidVolume': 0.001,
 'change': -2286.2,
 'close': 26127.8,
 'datetime': None,
 'high': 28600.0,
 'info': {'ask1Price': '26128.50',
          'ask1Size': '161.744',
          'basis': '',
          'basisRate': '',
          'bid1Price': '26127.40',
          'bid1Size': '0.001',
          'deliveryFeeRate': '',
          'deliveryTime': '0',
          'fundingRate': '0.0001',
          'highPrice24h': '28600.00',
          'indexPrice': '26108.58',
          'lastPrice': '26127.80',
          'lowPrice24h': '25916.60',
          'markPrice': '26127.79',
          'nextFundingTime': '1692374400000',
          'openInterest': '191319.678',
          'openInterestValue': '4998760369.65',
          'predictedDeliveryPrice': '',
          'prevPrice1h': '26300.80',
          'prevPrice24h': '28414.00',
          'price24hPcnt': '-0.08046',
          'symbol': 'BTCUSDT',
          'turnover24h': '4809413462.0114',
          'volume24h': '179424.9700'},
 'last': 26127.8,
 'low': 25916.6,
 'open': 28414.0,
 'percentage': -8.046,
 'previousClose': None,
 'quoteVolume': 4809413462.0114,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': None,
 'vwap': 26804.59393144332}
```
```
 p bybit fetchTicker "BTC/USDT" --sandbox
Python v3.10.9
CCXT v4.0.67
bybit.fetchTicker(BTC/USDT)
{'ask': 26102.0,
 'askVolume': 0.032323,
 'average': 24897.4198,
 'baseVolume': 5602.857236,
 'bid': 26092.42,
 'bidVolume': 0.011344,
 'change': 2405.1404,
 'close': 26099.99,
 'datetime': None,
 'high': 29752.1178,
 'info': {'ask1Price': '26102',
          'ask1Size': '0.032323',
          'bid1Price': '26092.42',
          'bid1Size': '0.011344',
          'highPrice24h': '29752.1178',
          'lastPrice': '26099.99',
          'lowPrice24h': '18000',
          'prevPrice24h': '23694.8496',
          'price24hPcnt': '0.1015',
          'symbol': 'BTCUSDT',
          'turnover24h': '157961611.5199636922',
          'usdIndexPrice': '25975.59000001',
          'volume24h': '5602.857236'},
 'last': 26099.99,
 'low': 18000.0,
 'open': 23694.8496,
 'percentage': 10.15,
 'previousClose': None,
 'quoteVolume': 157961611.51996368,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': 28193.04595252116}
```
```
p bybit fetchTicker "BTC/USDT:USDT" --sandbox
Python v3.10.9
CCXT v4.0.67
bybit.fetchTicker(BTC/USDT:USDT)
{'ask': 26061.9,
 'askVolume': 67.814,
 'average': 27237.55,
 'baseVolume': 179424.938,
 'bid': 26047.0,
 'bidVolume': 104.917,
 'change': -2352.1,
 'close': 26061.5,
 'datetime': None,
 'high': 28600.0,
 'info': {'ask1Price': '26061.90',
          'ask1Size': '67.814',
          'basis': '',
          'basisRate': '',
          'bid1Price': '26047.00',
          'bid1Size': '104.917',
          'deliveryFeeRate': '',
          'deliveryTime': '0',
          'fundingRate': '0.0001',
          'highPrice24h': '28600.00',
          'indexPrice': '26047.11',
          'lastPrice': '26061.50',
          'lowPrice24h': '25916.60',
          'markPrice': '26054.43',
          'nextFundingTime': '1692374400000',
          'openInterest': '191320.601',
          'openInterestValue': '4984749206.31',
          'predictedDeliveryPrice': '',
          'prevPrice1h': '26233.90',
          'prevPrice24h': '28413.60',
          'price24hPcnt': '-0.08278',
          'symbol': 'BTCUSDT',
          'turnover24h': '4809403523.0096',
          'volume24h': '179424.9380'},
 'last': 26061.5,
 'low': 25916.6,
 'open': 28413.6,
 'percentage': -8.278,
 'previousClose': None,
 'quoteVolume': 4809403523.0096,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': None,
 'vwap': 26804.543318329586}
```
