### PR TITLE
fix(exchange): await ws close

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1261,11 +1261,13 @@ export default class Exchange {
 
     async close () {
         const clients = Object.values (this.clients || {});
+        const closedClients = [];
         for (let i = 0; i < clients.length; i++) {
             const client = clients[i] as WsClient;
             delete this.clients[client.url];
-            await client.close ();
+            closedClients.push(client.close ());
         }
+        return Promise.all (closedClients);
     }
 
     async loadOrderBook (client, messageHash, symbol, limit = undefined, params = {}) {

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -1,6 +1,6 @@
 import { RequestTimeout, NetworkError ,NotSupported, BaseError } from '../../base/errors.js';
 import { inflateSync, gunzipSync } from '../../static_dependencies/fflake/browser.js';
-import { createFuture } from './Future.js';
+import { Future, createFuture } from './Future.js';
 
 import {
     isNode,
@@ -12,6 +12,7 @@ import { utf8 } from '../../static_dependencies/scure-base/index.js';
 
 export default class Client {
     connected: Promise<any>
+    disconnected: Future
     futures: {}
     rejections: {}
     keepAlive: number
@@ -244,6 +245,9 @@ export default class Client {
         if (!this.error) {
             // todo: exception types for server-side disconnects
             this.reset (new NetworkError ('connection closed by remote server, closing code ' + String (event.code)))
+        }
+        if (this.disconnected !== undefined) {
+            this.disconnected.resolve (true);
         }
         this.onCloseCallback (this, event)
     }

--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -6,6 +6,7 @@ import {
     milliseconds,
 } from '../../base/functions.js';
 import WebSocket from 'ws';
+import { createFuture } from './Future.js';
 
 const WebSocketPlatform = isNode ? WebSocket : self.WebSocket;
 
@@ -59,8 +60,12 @@ export default class WsClient extends Client {
 
     close () {
         if (this.connection instanceof WebSocketPlatform) {
-            return this.connection.close ()
+            if (this.disconnected === undefined) {
+                this.disconnected = createFuture ();
+            }
+            this.connection.close ();
         }
+        return this.disconnected;
     }
 
 };


### PR DESCRIPTION
- Make client.close() return a future that is resolved once ws is actually closed
- Exchange.close() now closes connections in parallel.