### PR TITLE
fix(okx): add new bussiness url to pro

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1017,7 +1017,7 @@ export default class okx extends okxRest {
          */
         await this.loadMarkets ();
         await this.authenticate ();
-        const url = this.urls['api']['ws']['private'];
+        const url = this.getUrl ('private', 'private');
         const messageHash = this.nonce ().toString ();
         let op = undefined;
         [ op, params ] = this.handleOptionAndParams (params, 'createOrderWs', 'op', 'batch-orders');
@@ -1088,7 +1088,7 @@ export default class okx extends okxRest {
          */
         await this.loadMarkets ();
         await this.authenticate ();
-        const url = this.urls['api']['ws']['private'];
+        const url = this.getUrl ('private', 'private');
         const messageHash = this.nonce ().toString ();
         let op = undefined;
         [ op, params ] = this.handleOptionAndParams (params, 'editOrderWs', 'op', 'amend-order');
@@ -1118,7 +1118,7 @@ export default class okx extends okxRest {
         }
         await this.loadMarkets ();
         await this.authenticate ();
-        const url = this.urls['api']['ws']['private'];
+        const url = this.getUrl ('private', 'private');
         const messageHash = this.nonce ().toString ();
         const clientOrderId = this.safeString2 (params, 'clOrdId', 'clientOrderId');
         params = this.omit (params, [ 'clientOrderId', 'clOrdId' ]);
@@ -1158,7 +1158,7 @@ export default class okx extends okxRest {
         }
         await this.loadMarkets ();
         await this.authenticate ();
-        const url = this.urls['api']['ws']['private'];
+        const url = this.getUrl ('private', 'private');
         const messageHash = this.nonce ().toString ();
         const args = [];
         for (let i = 0; i < idsLength; i++) {
@@ -1195,7 +1195,7 @@ export default class okx extends okxRest {
         if (market['type'] !== 'option') {
             throw new BadRequest (this.id + 'cancelAllOrdersWs is only applicable to Option in Portfolio Margin mode, and MMP privilege is required.');
         }
-        const url = this.urls['api']['ws']['private'];
+        const url = this.getUrl ('private', 'private');
         const messageHash = this.nonce ().toString ();
         const request = {
             'id': messageHash,

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -98,6 +98,7 @@ export default class okx extends okxRest {
     }
 
     getUrl (channel: string, access = 'public') {
+        // for context: https://www.okx.com/help-center/changes-to-v5-api-websocket-subscription-parameter-and-url
         const isPublic = (access === 'public');
         const url = this.urls['api']['ws'];
         if ((channel.indexOf ('candle') > -1) || (channel === 'orders-algo')) {

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -31,16 +31,10 @@ export default class okx extends okxRest {
             },
             'urls': {
                 'api': {
-                    'ws': {
-                        'public': 'wss://ws.okx.com:8443/ws/v5/public', // wss://wsaws.okx.com:8443/ws/v5/public
-                        'private': 'wss://ws.okx.com:8443/ws/v5/private', // wss://wsaws.okx.com:8443/ws/v5/private
-                    },
+                    'ws': 'wss://ws.okx.com:8443/ws/v5',
                 },
                 'test': {
-                    'ws': {
-                        'public': 'wss://wspap.okx.com:8443/ws/v5/public?brokerId=9999',
-                        'private': 'wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999',
-                    },
+                    'ws': 'wss://wspap.okx.com:8443/ws/v5',
                 },
             },
             'options': {
@@ -103,13 +97,24 @@ export default class okx extends okxRest {
         });
     }
 
+    getUrl (channel: string, access = 'public') {
+        const isPublic = (access === 'public');
+        const url = this.urls['api']['ws'];
+        if ((channel.indexOf ('candle') > -1) || (channel === 'orders-algo')) {
+            return url + '/business';
+        } else if (isPublic) {
+            return url + '/public';
+        }
+        return url + '/private';
+    }
+
     async subscribeMultiple (access, channel, symbols: string[] = undefined, params = {}) {
         await this.loadMarkets ();
         if (symbols === undefined) {
             symbols = this.symbols;
         }
         symbols = this.marketSymbols (symbols);
-        const url = this.urls['api']['ws'][access];
+        const url = this.getUrl (channel, access);
         let messageHash = channel;
         const args = [];
         messageHash += '::' + symbols.join (',');
@@ -130,7 +135,7 @@ export default class okx extends okxRest {
 
     async subscribe (access, messageHash, channel, symbol, params = {}) {
         await this.loadMarkets ();
-        const url = this.urls['api']['ws'][access];
+        const url = this.getUrl (channel, access);
         const firstArgument = {
             'channel': channel,
         };

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -618,7 +618,7 @@ export default class okx extends okxRest {
         this.checkRequiredCredentials ();
         const access = this.safeString (params, 'access', 'private');
         params = this.omit (params, [ 'access' ]);
-        const url = this.urls['api']['ws'][access];
+        const url = this.getUrl ('users', access);
         const messageHash = 'authenticated';
         const client = this.client (url);
         let future = this.safeValue (client.subscriptions, messageHash);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18955

```
p okx watchOHLCV "BTC/USDT:USDT" 1m          
Python v3.10.9
CCXT v4.0.68
okx.watchOHLCV(BTC/USDT:USDT,1m)
[[1692539640000, 26136.1, 26136.9, 26132.7, 26136.9, 88.47]]
[[1692539640000, 26136.1, 26136.9, 26132.7, 26134.4, 89.64]]
[[1692539640000, 26136.1, 26136.9, 26132.7, 26134.4, 89.73]]
```
```
 p okx watchTrades "BTC/USDT"                      
Python v3.10.9
CCXT v4.0.68
okx.watchTrades(BTC/USDT)
[{'amount': 0.00766958,
  'cost': 200.43296893,
  'datetime': '2023-08-20T13:55:02.418Z',
  'fee': None,
  'fees': [],
  'id': '433599224',
  'info': {'instId': 'BTC-USDT',
           'px': '26133.5',
           'side': 'buy',
           'sz': '0.00766958',
           'tradeId': '433599224',
           'ts': '1692539702418'},
  'order': None,
  'price': 26133.5,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1692539702418,
  'type': None}]
```
```
p okx watchTicker "BTC/USDT"                      
Python v3.10.9
CCXT v4.0.68
okx.watchTicker(BTC/USDT)
{'ask': 26138.0,
 'askVolume': 0.23976,
 'average': 26034.8,
 'baseVolume': 3516.59803379,
 'bid': 26137.9,
 'bidVolume': 0.99423358,
 'change': 203.0,
 'close': 26136.3,
 'datetime': '2023-08-20T13:55:21.811Z',
 'high': 26274.7,
 'info': {'askPx': '26138',
          'askSz': '0.23976',
          'bidPx': '26137.9',
          'bidSz': '0.99423358',
          'high24h': '26274.7',
          'instId': 'BTC-USDT',
          'instType': 'SPOT',
          'last': '26136.3',
          'lastSz': '0.00002095',
          'low24h': '25922',
          'open24h': '25933.3',
          'sodUtc0': '26101.8',
          'sodUtc8': '26215.2',
          'ts': '1692539721811',
          'vol24h': '3516.59803379',
          'volCcy24h': '91837753.112219603'},
 'last': 26136.3,
 'low': 25922.0,
 'open': 25933.3,
 'percentage': 0.7827773557549559,
 'previousClose': None,
 'quoteVolume': 91837753.1122196,
 'symbol': 'BTC/USDT',
 'timestamp': 1692539721811,
 'vwap': 26115.510567251786}
```
