### PR TITLE
Kucoinfutures doesn't have a setLeverage method

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -77,6 +77,7 @@ export default class kucoinfutures extends kucoin {
                 'fetchTrades': true,
                 'fetchTransactionFee': false,
                 'fetchWithdrawals': true,
+                'setLeverage': false,
                 'setMarginMode': false,
                 'transfer': true,
                 'withdraw': undefined,


### PR DESCRIPTION
kucoinfutures doesn't have a set_leverage method, but it doesn't either have a setLeverage key in the "has" list.