### PR TITLE
feat(coinbasepro): improve watchTicker parsing

### DIFF
--- a/ts/src/pro/coinbasepro.ts
+++ b/ts/src/pro/coinbasepro.ts
@@ -682,29 +682,29 @@ export default class coinbasepro extends coinbaseproRest {
         const marketId = this.safeString (ticker, 'product_id');
         const symbol = this.safeSymbol (marketId, market, '-');
         const timestamp = this.parse8601 (this.safeString (ticker, 'time'));
-        const last = this.safeNumber (ticker, 'price');
-        return {
+        const last = this.safeString (ticker, 'price');
+        return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeNumber (ticker, 'high_24h'),
-            'low': this.safeNumber (ticker, 'low_24h'),
-            'bid': this.safeNumber (ticker, 'best_bid'),
-            'bidVolume': this.safeNumber (ticker, 'best_bid_size'),
-            'ask': this.safeNumber (ticker, 'best_ask'),
-            'askVolume': this.safeNumber (ticker, 'best_ask_size'),
+            'high': this.safeString (ticker, 'high_24h'),
+            'low': this.safeString (ticker, 'low_24h'),
+            'bid': this.safeString (ticker, 'best_bid'),
+            'bidVolume': this.safeString (ticker, 'best_bid_size'),
+            'ask': this.safeString (ticker, 'best_ask'),
+            'askVolume': this.safeString (ticker, 'best_ask_size'),
             'vwap': undefined,
-            'open': this.safeNumber (ticker, 'open_24h'),
+            'open': this.safeString (ticker, 'open_24h'),
             'close': last,
             'last': last,
             'previousClose': undefined,
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeNumber (ticker, 'volume_24h'),
+            'baseVolume': this.safeString (ticker, 'volume_24h'),
             'quoteVolume': undefined,
             'info': ticker,
-        };
+        });
     }
 
     handleDelta (bookside, delta) {


### PR DESCRIPTION
DEMO

```
p coinbasepro watchTickers '["BTC/USDT", "ETH/USDT"]'
Python v3.10.9
CCXT v4.0.70
coinbasepro.watchTickers(['BTC/USDT', 'ETH/USDT'])
{'ask': 1659.53,
 'askVolume': 7.17528684,
 'average': 1665.28,
 'baseVolume': 13296.22177783,
 'bid': 1659.2,
 'bidVolume': 0.5062,
 'change': -11.82,
 'close': 1659.37,
 'datetime': '2023-08-21T15:25:54.658Z',
 'high': 1694.69,
 'info': {'best_ask': '1659.53',
          'best_ask_size': '7.17528684',
          'best_bid': '1659.20',
          'best_bid_size': '0.50620000',
          'high_24h': '1694.69',
          'last_size': '2.34731',
          'low_24h': '1654.75',
          'open_24h': '1671.19',
          'price': '1659.37',
          'product_id': 'ETH-USDT',
          'sequence': 8538206761,
          'side': 'buy',
          'time': '2023-08-21T15:25:54.658590Z',
          'trade_id': 15837094,
          'type': 'ticker',
          'volume_24h': '13296.22177783',
          'volume_30d': '366152.97828411'},
 'last': 1659.37,
 'low': 1654.75,
 'open': 1671.19,
 'percentage': -0.7072804408834423,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'ETH/USDT',
 'timestamp': 1692631554658,
 'vwap': None}
{'ask': 25941.41,
 'askVolume': 0.38550925,
 'average': 26019.885,
 'baseVolume': 674.20280604,
 'bid': 25932.71,
 'bidVolume': 0.07557163,
 'change': -162.13,
 'close': 25938.82,
 'datetime': '2023-08-21T15:25:40.679Z',
 'high': 26302.72,
 'info': {'best_ask': '25941.41',
          'best_ask_size': '0.38550925',
          'best_bid': '25932.71',
          'best_bid_size': '0.07557163',
          'high_24h': '26302.72',
          'last_size': '0.05783258',
          'low_24h': '25885.92',
          'open_24h': '26100.95',
          'price': '25938.82',
          'product_id': 'BTC-USDT',
          'sequence': 9042166820,
          'side': 'buy',
          'time': '2023-08-21T15:25:40.679484Z',
          'trade_id': 14770104,
          'type': 'ticker',
          'volume_24h': '674.20280604',
          'volume_30d': '36419.43937455'},
 'last': 25938.82,
 'low': 25885.92,
 'open': 26100.95,
 'percentage': -0.6211651300048465,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1692631540679,
 'vwap': None}
```
