### PR TITLE
fix(lbank2): python error mapping

### DIFF
--- a/ts/src/lbank2.ts
+++ b/ts/src/lbank2.ts
@@ -2683,8 +2683,8 @@ export default class lbank2 extends Exchange {
         if (response === undefined) {
             return undefined;
         }
-        const success = this.safeString (response, 'result');
-        if (success === 'false') {
+        const success = this.safeValue (response, 'result');
+        if (success === 'false' || !success) {
             const errorCode = this.safeString (response, 'error_code');
             const message = this.safeString ({
                 '10000': 'Internal error',


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/18969
- 
```
 lbank2 createOrder "TYPE/USDT" limit buy 700 100           
Python v3.10.9
CCXT v4.0.74
lbank2.createOrder(TYPE/USDT,limit,buy,700,100)
Traceback (most recent call last):
  File "/Users/cjg/Git/ccxt10/ccxt/examples/py/cli.py", line 239, in <module>
    asyncio.run(main())
  File "/opt/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/cjg/Git/ccxt10/ccxt/examples/py/cli.py", line 216, in main
    result = await method(*args)
  File "/Users/cjg/Git/ccxt10/ccxt/python/ccxt/async_support/lbank2.py", line 1277, in create_order
    response = await getattr(self, method)(self.extend(request, params))
  File "/Users/cjg/Git/ccxt10/ccxt/python/ccxt/async_support/base/exchange.py", line 1839, in request
    return await self.fetch2(path, api, method, params, headers, body, config)
  File "/Users/cjg/Git/ccxt10/ccxt/python/ccxt/async_support/base/exchange.py", line 1836, in fetch2
    return await self.fetch(request['url'], request['method'], request['headers'], request['body'])
  File "/Users/cjg/Git/ccxt10/ccxt/python/ccxt/async_support/base/exchange.py", line 221, in fetch
    self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
  File "/Users/cjg/Git/ccxt10/ccxt/python/ccxt/async_support/lbank2.py", line 2616, in handle_errors
    raise ErrorClass(message)
ccxt.base.errors.InsufficientFunds: Insufficient account balance
```
```
n lbank2 createOrder "TYPE/USDT" limit buy 700 100          
2023-08-24T11:01:09.346Z
Node.js: v18.14.0
CCXT v4.0.74
lbank2.createOrder (TYPE/USDT, limit, buy, 700, 100)
InsufficientFunds Insufficient account balance
```
