### PR TITLE
fix(bybit) - remove skip for tests

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -489,7 +489,7 @@
         }
     },
     "bybit": {
-        "skip": "403 forbidden, RateLimitExceeded",
+        "httpsProxy": "http://51.83.140.52:11230",
         "skipMethods": {
             "fetchTickers": {
                 "symbol" :"returned symbol is not same as requested symbol. i.e. BTC/USDT:USDT vs BTC/USDT"

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -44,7 +44,7 @@ export default class bybit extends Exchange {
                 'createStopOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
-                'fetchBorrowInterest': false, // temporarily disabled, as it does not work
+                'fetchBorrowInterest': false, // temporarily disabled, as it doesn't work
                 'fetchBorrowRate': true,
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,


### PR DESCRIPTION
bybit endless RateLimit exceptions are gone (?) atm, so we can return it back to tests.