### PR TITLE
fix(test) - python exception

### DIFF
--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -129,7 +129,7 @@ async def call_method(testFiles, methodName, exchange, skippedProperties, args):
 
 
 def exception_message(exc):
-    return '[' + type(exc).__name__ + '] ' + "".join(format_exception(exc, limit=6))
+    return '[' + type(exc).__name__ + '] ' + "".join(format_exception(type(exc), exc, exc.__traceback__, limit=6))
 
 
 def exit_script():


### PR DESCRIPTION
even though we had as documented here: https://docs.python.org/3/library/traceback.html#traceback.print_exception:~:text=instead%20of%20passing%20value%20and%20tb%2C%20an%20exception%20object%20can%20be%20passed%20as%20the%20first%20argument
it still misbehaved: https://app.travis-ci.com/github/ccxt/ccxt/builds/265509178#L2177

so, i've amended it to be as traditional way.  (you can see here : https://www.mycompiler.io/view/ICubmNzrBrZ )