### PR TITLE
fix(okx): watchTickers require list of symbols

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import okxRest from '../okx.js';
-import { AuthenticationError, BadRequest, InvalidNonce } from '../base/errors.js';
+import { ArgumentsRequired, AuthenticationError, BadRequest, InvalidNonce } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
 import { Int, OrderSide, OrderType } from '../base/types.js';
@@ -239,6 +239,9 @@ export default class okx extends okxRest {
          * @param {string} [params.channel] the channel to subscribe to, tickers by default. Can be tickers, sprd-tickers, index-tickers, block-tickers
          * @returns {object} a [ticker structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#ticker-structure}
          */
+        if (this.isEmpty (symbols)) {
+            throw new ArgumentsRequired (this.id + ' watchTickers requires a list of symbols');
+        }
         let channel = undefined;
         [ channel, params ] = this.handleOptionAndParams (params, 'watchTickers', 'channel', 'tickers');
         const newTickers = await this.subscribeMultiple ('public', channel, symbols, params);


### PR DESCRIPTION
Calling watchTickers was giving an error. We were defaulting watchTickers to call tickers with all symbols and websocket was giving an error from too large of a request.