### PR TITLE
fix(bingx): fetchTicker fix

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1139,7 +1139,8 @@ export default class bingx extends Exchange {
         //    }
         //
         const data = this.safeValue (response, 'data');
-        return this.parseTicker (data, market);
+        const ticker = this.safeValue (data, 0, data);
+        return this.parseTicker (ticker, market);
     }
 
     async fetchTickers (symbols: string[] = undefined, params = {}) {
@@ -1190,6 +1191,20 @@ export default class bingx extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         //
+        // spot
+        //    {
+        //        symbol: 'BTC-USDT',
+        //        openPrice: '26032.08',
+        //        highPrice: '26178.86',
+        //        lowPrice: '25968.18',
+        //        lastPrice: '26113.60',
+        //        volume: '1161.79',
+        //        quoteVolume: '30288466.44',
+        //        openTime: '1693081020762',
+        //        closeTime: '1693167420762'
+        //    }
+        // swap
+        //
         //    {
         //        "symbol": "BTC-USDT",
         //        "priceChange": "52.5",
@@ -1206,15 +1221,15 @@ export default class bingx extends Exchange {
         //    }
         //
         const marketId = this.safeString (ticker, 'symbol');
-        const defaultType = this.safeString (this.options, 'defaultType', 'swap');
-        const symbol = this.safeSymbol (marketId, market, '-', defaultType);
+        const change = this.safeString (ticker, 'priceChange');
+        const type = (change === undefined) ? 'spot' : 'swap';
+        const symbol = this.safeSymbol (marketId, market, undefined, type);
         const open = this.safeString (ticker, 'openPrice');
         const high = this.safeString (ticker, 'highPrice');
         const low = this.safeString (ticker, 'lowPrice');
         const close = this.safeString (ticker, 'lastPrice');
         const quoteVolume = this.safeString (ticker, 'quoteVolume');
         const baseVolume = this.safeString (ticker, 'volume');
-        const change = this.safeString (ticker, 'chapriceChangenge');
         const percentage = this.safeString (ticker, 'priceChangePercent');
         const ts = this.safeInteger (ticker, 'closeTime');
         const datetime = this.iso8601 (ts);

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1114,7 +1114,7 @@ export default class bingx extends Exchange {
         };
         let response = undefined;
         if (market['spot']) {
-            response = await this.spotV1PublicGetCommonSymbols (this.extend (request, params));
+            response = await this.spotV1PrivateGetTicker24hr (this.extend (request, params));
         } else {
             response = await this.swapV2PublicGetQuoteTicker (this.extend (request, params));
         }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1114,9 +1114,9 @@ export default class bingx extends Exchange {
         };
         let response = undefined;
         if (market['spot']) {
-            response = await this.swapV2PublicGetQuoteTicker (this.extend (request, params));
-        } else {
             response = await this.spotV1PublicGetCommonSymbols (this.extend (request, params));
+        } else {
+            response = await this.swapV2PublicGetQuoteTicker (this.extend (request, params));
         }
         //
         //    {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19015
```
 p bingx fetchTicker "BTC/USDT:USDT"
Python v3.10.9
CCXT v4.0.76
bingx.fetchTicker(BTC/USDT:USDT)
{'ask': None,
 'askVolume': None,
 'average': 26061.6,
 'baseVolume': 23206.0593,
 'bid': None,
 'bidVolume': None,
 'change': 56.1,
 'close': 26092.7,
 'datetime': '2023-08-27T20:22:26.044Z',
 'high': 26173.1,
 'info': {'closeTime': '1693167746044',
          'highPrice': '26173.1',
          'lastPrice': '26092.7',
          'lastQty': '0.2332',
          'lowPrice': '25957.4',
          'openPrice': '26030.5',
          'openTime': '1693167803975',
          'priceChange': '56.1',
          'priceChangePercent': '0.22',
          'quoteVolume': '605796942.05',
          'symbol': 'BTC-USDT',
          'volume': '23206.0593'},
 'last': 26092.7,
 'low': 25957.4,
 'open': 26030.5,
 'percentage': 0.22,
 'previousClose': None,
 'quoteVolume': 605796942.05,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1693167746044,
 'vwap': 26105.11910783577}
```
```
p bingx fetchTicker "BTC/USDT"     
Python v3.10.9
CCXT v4.0.76
bingx.fetchTicker(BTC/USDT)
{'ask': None,
 'askVolume': None,
 'average': 26072.195,
 'baseVolume': 1157.46,
 'bid': None,
 'bidVolume': None,
 'change': 52.05,
 'close': 26098.22,
 'datetime': '2023-08-27T20:23:50.275Z',
 'high': 26178.86,
 'info': {'closeTime': '1693167830275',
          'highPrice': '26178.86',
          'lastPrice': '26098.22',
          'lowPrice': '25968.18',
          'openPrice': '26046.17',
          'openTime': '1693081430275',
          'quoteVolume': '30176183.14',
          'symbol': 'BTC-USDT',
          'volume': '1157.46'},
 'last': 26098.22,
 'low': 25968.18,
 'open': 26046.17,
 'percentage': 0.1998374425107415,
 'previousClose': None,
 'quoteVolume': 30176183.14,
 'symbol': 'BTC/USDT',
 'timestamp': 1693167830275,
 'vwap': 26071.037565013045}
```
