### PR TITLE
feat(bingx): add spot support to fetchTickers

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1154,15 +1154,20 @@ export default class bingx extends Exchange {
          * @returns {object} a dictionary of [ticker structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#ticker-structure}
          */
         await this.loadMarkets ();
+        let market = undefined;
         if (symbols !== undefined) {
             symbols = this.marketSymbols (symbols);
             const firstSymbol = this.safeString (symbols, 0);
-            const market = this.market (firstSymbol);
-            if (!market['swap']) {
-                throw new BadRequest (this.id + ' fetchTicker is only supported for swap markets.');
-            }
+            market = this.market (firstSymbol);
         }
-        const response = await this.swapV2PublicGetQuoteTicker (params);
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        let response = undefined;
+        if (type === 'spot') {
+            response = await this.spotV1PrivateGetTicker24hr (params);
+        } else {
+            response = await this.swapV2PublicGetQuoteTicker (params);
+        }
         //
         //    {
         //        "code": 0,


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/19015

```
 p bingx fetchTickers '["BTC/USDT"]'
Python v3.10.9
CCXT v4.0.76
bingx.fetchTickers(['BTC/USDT'])
{'BTC/USDT': {'ask': None,
              'askVolume': None,
              'average': 25996.865,
              'baseVolume': 1252.41,
              'bid': None,
              'bidVolume': None,
              'change': -113.73,
              'close': 25940.0,
              'datetime': '2023-08-28T08:11:48.391Z',
              'high': 26178.86,
              'info': {'closeTime': '1693210308391',
                       'highPrice': '26178.86',
                       'lastPrice': '25940.00',
                       'lowPrice': '25888.79',
                       'openPrice': '26053.73',
                       'openTime': '1693123908391',
                       'quoteVolume': '32627402.52',
                       'symbol': 'BTC-USDT',
                       'volume': '1252.41'},
              'last': 25940.0,
              'low': 25888.79,
              'open': 26053.73,
              'percentage': -0.4365209895089877,
              'previousClose': None,
              'quoteVolume': 32627402.52,
              'symbol': 'BTC/USDT',
              'timestamp': 1693210308391,
              'vwap': 26051.69434929456}}
```
```
 p bingx fetchTickers '["BTC/USDT:USDT"]'
Python v3.10.9
CCXT v4.0.76
bingx.fetchTickers(['BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': None,
                   'askVolume': None,
                   'average': 25981.05,
                   'baseVolume': 32755.0563,
                   'bid': None,
                   'bidVolume': None,
                   'change': -117.4,
                   'close': 25923.6,
                   'datetime': '2023-08-28T08:11:29.977Z',
                   'high': 26173.1,
                   'info': {'closeTime': '1693210289977',
                            'highPrice': '26173.1',
                            'lastPrice': '25923.6',
                            'lastQty': '0.0025',
                            'lowPrice': '25859.3',
                            'openPrice': '26038.5',
                            'openTime': '1693210328200',
                            'priceChange': '-117.4',
                            'priceChangePercent': '-0.45',
                            'quoteVolume': '852407808.93',
                            'symbol': 'BTC-USDT',
                            'volume': '32755.0563'},
                   'last': 25923.6,
                   'low': 25859.3,
                   'open': 26038.5,
                   'percentage': -0.45,
                   'previousClose': None,
                   'quoteVolume': 852407808.93,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1693210289977,
                   'vwap': 26023.70153550919}}
```


