### PR TITLE
bithumb fetchTrades fix

### DIFF
--- a/python/ccxt/bithumb.py
+++ b/python/ccxt/bithumb.py
@@ -617,7 +617,7 @@ class bithumb(Exchange, ImplicitAPI):
         self.load_markets()
         market = self.market(symbol)
         request = {
-            'currency': market['base'],
+            'currency': f'{market["base"]}_{market["quote"]}',
         }
         if limit is not None:
             request['count'] = limit  # default 20, max 100


### PR DESCRIPTION
now we use only this https://api.bithumb.com/transaction_history/ticker/market['base'] which is equal to https://api.bithumb.com/public/transaction_history/market['base']_KRW

We also need to parse https://api.bithumb.com/public/transaction_history/market['base']_market['quote'] to get all pairs