### PR TITLE
fix(wazirx): createOrder - stopPrice orders reduce stopPrice to allowed precision

### DIFF
--- a/ts/src/wazirx.ts
+++ b/ts/src/wazirx.ts
@@ -826,6 +826,7 @@ export default class wazirx extends Exchange {
         const stopPrice = this.safeString (params, 'stopPrice');
         if (stopPrice !== undefined) {
             request['type'] = 'stop_limit';
+            request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
         }
         const response = await this.privatePostOrder (this.extend (request, params));
         // {


### PR DESCRIPTION


```
% ccxt wazirx createOrder ADA/USDT limit sell 8 0.26 '{"stopPrice": 0.26}'
2023-08-29T22:54:51.472Z
Node.js: v18.15.0
CCXT v4.0.78
wazirx.createOrder (ADA/USDT, limit, sell, 8, 0.26, [object Object])
2023-08-29T22:54:55.106Z iteration 0 passed in 1295 ms

{
  info: {
    id: '3757631466',
    symbol: 'adausdt',
    type: 'stop_limit',
    side: 'sell',
    status: 'idle',
    price: '0.26',
    stopPrice: '0.26',
    origQty: '8',
    executedQty: '0',
    avgPrice: '0',
    createdTime: '1693349695000',
    updatedTime: '1693349695000',
    clientOrderId: 'fc8e6d1c-76a1-41ba-a66c-d56b8bcc8314'
  },
  id: '3757631466',
  clientOrderId: undefined,
  timestamp: 1693349695000,
  datetime: '2023-08-29T22:54:55.000Z',
  lastTradeTimestamp: 1693349695000,
  status: 'idle',
  symbol: 'ADA/USDT',
  type: 'stop_limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'sell',
  price: 0.26,
  amount: undefined,
  filled: 0,
  remaining: undefined,
  cost: 0,
  fee: undefined,
  average: undefined,
  trades: [],
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
2023-08-29T22:54:55.106Z iteration 1 passed in 1295 ms
```