### PR TITLE
fix(bitget): handle ws error

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1187,6 +1187,7 @@ export default class bitget extends bitgetRest {
                     delete client.subscriptions[messageHash];
                 }
             } else {
+                // Note: if error happens on a subscribe event, user will have to close exchange to resubscribe. Issue #19041
                 client.reject (e);
             }
             return true;

--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import bitgetRest from '../bitget.js';
-import { AuthenticationError, BadRequest, ArgumentsRequired, NotSupported, InvalidNonce } from '../base/errors.js';
+import { AuthenticationError, BadRequest, ArgumentsRequired, NotSupported, InvalidNonce, ExchangeError, RateLimitExceeded } from '../base/errors.js';
 import { Precise } from '../base/Precise.js';
 import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
@@ -53,9 +53,18 @@ export default class bitget extends bitgetRest {
                 'ws': {
                     'exact': {
                         '30001': BadRequest, // {"event":"error","code":30001,"msg":"instType:sp,channel:candleundefined,instId:BTCUSDT doesn't exist"}
+                        '30002': AuthenticationError, // illegal request
+                        '30003': BadRequest, // invalid op
+                        '30004': AuthenticationError, // requires login
+                        '30005': AuthenticationError, // login failed
+                        '30006': RateLimitExceeded, // too many requests
+                        '30007': RateLimitExceeded, // request over limit,connection close
+                        '30011': AuthenticationError, // invalid ACCESS_KEY
+                        '30012': AuthenticationError, // invalid ACCESS_PASSPHRASE
+                        '30013': AuthenticationError, // invalid ACCESS_TIMESTAMP
+                        '30014': BadRequest, // Request timestamp expired
                         '30015': AuthenticationError, // { event: 'error', code: 30015, msg: 'Invalid sign' }
                         '30016': BadRequest, // { event: 'error', code: 30016, msg: 'Param error' }
-                        '30011': AuthenticationError, // { event: 'error', code: 30011, msg: 'Invalid ACCESS_KEY' }
                     },
                 },
             },
@@ -1165,6 +1174,9 @@ export default class bitget extends bitgetRest {
                 const code = this.safeString (message, 'code');
                 const feedback = this.id + ' ' + this.json (message);
                 this.throwExactlyMatchedException (this.exceptions['ws']['exact'], code, feedback);
+                const msg = this.safeString (message, 'msg', '');
+                this.throwBroadlyMatchedException (this.exceptions['ws']['broad'], msg, feedback);
+                throw new ExchangeError (feedback);
             }
             return false;
         } catch (e) {
@@ -1174,6 +1186,8 @@ export default class bitget extends bitgetRest {
                 if (messageHash in client.subscriptions) {
                     delete client.subscriptions[messageHash];
                 }
+            } else {
+                client.reject (e);
             }
             return true;
         }


### PR DESCRIPTION
- Add missing error messages for ws (https://bitgetlimited.github.io/apidoc/en/spot/#websocket-error-code)
- Fix handleErrorMessage to throw error

Note: If error is thrown during a subscribe event for example exchange throws "too many requests". There is no data on the message to know which subscription produced the error, therefore the subscription can't be deleted, and even if the user uses the while, try catch pattern, it won't try to re subscribe on the following loop. The user will need to close the exchange and reopen.
I could not find a solution to this, unless we want to delete all subscriptions.