### PR TITLE
Update bitvavo precision mode

### DIFF
--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -3,7 +3,7 @@
 
 import Exchange from './abstract/bitvavo.js';
 import { ExchangeError, BadSymbol, AuthenticationError, InsufficientFunds, InvalidOrder, ArgumentsRequired, OrderNotFound, InvalidAddress, BadRequest, RateLimitExceeded, PermissionDenied, ExchangeNotAvailable, AccountSuspended, OnMaintenance } from './base/errors.js';
-import { SIGNIFICANT_DIGITS, DECIMAL_PLACES, TRUNCATE, ROUND } from './base/functions/number.js';
+import { DECIMAL_PLACES, TRUNCATE, ROUND } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { Int } from './base/types.js';
@@ -261,7 +261,7 @@ export default class bitvavo extends Exchange {
                     'expires': 1000, // 1 second
                 },
             },
-            'precisionMode': SIGNIFICANT_DIGITS,
+            'precisionMode': DECIMAL_PLACES,
             'commonCurrencies': {
                 'MIOTA': 'IOTA', // https://github.com/ccxt/ccxt/issues/7487
             },


### PR DESCRIPTION
> Price precision determines how many significant digits are allowed. The rationale behind this is that for higher amounts, smaller price increments are less relevant. Examples of valid prices for precision 5 are: 100010, 11313, 7500.10, 7500.20, 500.12, 0.0012345. Examples of precision 6 are: 11313.1, 7500.11, 7500.25, 500.123, 0.00123456.

Based on the bitvavo [documentation (see excerpt above)](https://docs.bitvavo.com/#tag/General/paths/~1markets/get) - and based on the implementation of the different `amountToPrecision` methods - the actual correct precisionMode for bitvavo is DECIMAL_PLACES.

This should be aligned between what ccxt is using vs. what it's reporting to be using.