### PR TITLE
fix(bitmex): base/quote volume inside ticker

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1372,8 +1372,8 @@ export default class bitmex extends Exchange {
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.convertFromRawQuantity (symbol, this.safeString (ticker, 'homeNotional24h')),
-            'quoteVolume': this.convertFromRawQuantity (symbol, this.safeString (ticker, 'foreignNotional24h')),
+            'baseVolume': this.safeString (ticker, 'homeNotional24h'),
+            'quoteVolume': this.safeString (ticker, 'foreignNotional24h'),
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19038

```
 p bitmex fetchTicker "BTC/USDT"
Python v3.10.9
CCXT v4.0.79
bitmex.fetchTicker(BTC/USDT)
{'ask': 27421.5,
 'askVolume': None,
 'average': 26693.0,
 'baseVolume': 25.7869,
 'bid': 27404.5,
 'bidVolume': None,
 'change': 1414.0,
 'close': 27400.0,
 'datetime': '2023-08-30T10:11:19.114Z',
 'high': 28071.5,
 'info': {'askPrice': '27421.5',
          'bidPrice': '27404.5',
          'calcInterval': None,
          'deleverage': False,
          'expiry': None,
          'fairBasis': None,
          'fairBasisRate': None,
          'fairMethod': '',
          'fairPrice': None,
          'foreignNotional24h': '706120.9412',
          'front': None,
          'fundingBaseSymbol': '',
          'fundingInterval': None,
          'fundingPremiumSymbol': '',
          'fundingQuoteSymbol': '',
          'fundingRate': None,
          'fundingTimestamp': None,
          'hasLiquidity': True,
          'highPrice': '28071.5',
          'homeNotional24h': '25.7869',
          'impactAskPrice': '27421.5',
          'impactBidPrice': '27404.5',
          'impactMidPrice': '27413',
          'indicativeFundingRate': None,
          'indicativeSettlePrice': None,
          'initMargin': '1',
          'isInverse': False,
          'isQuanto': False,
          'lastChangePcnt': '0.0544',
          'lastPrice': '27400',
          'lastPriceProtected': '27400',
          'lastTickDirection': 'PlusTick',
          'limit': None,
          'limitDownPrice': None,
          'limitUpPrice': None,
          'listedSettle': None,
          'listing': '2022-05-17T04:00:00.000Z',
          'lotSize': '10000',
          'lowPrice': '25950',
          'maintMargin': '1',
          'makerFee': '-0.00025',
          'markMethod': 'LastPrice',
          'markPrice': '27400',
          'maxOrderQty': '100000000000',
          'maxPrice': '1000000',
          'midPrice': '27413',
          'multiplier': '1',
          'openInterest': '0',
          'openValue': '0',
          'positionCurrency': '',
          'prevClosePrice': '26007.5',
          'prevPrice24h': '25986',
          'prevTotalTurnover': '540337866500850',
          'publishInterval': None,
          'publishTime': None,
          'quoteCurrency': 'USDT',
          'quoteToSettleMultiplier': '1000000',
          'rebalanceInterval': None,
          'rebalanceTimestamp': None,
          'reference': 'BMEX',
          'referenceSymbol': '',
          'relistInterval': None,
          'riskLimit': None,
          'riskStep': None,
          'rootSymbol': 'XBT',
          'settlCurrency': '',
          'settle': None,
          'settledPrice': None,
          'settledPriceAdjustmentRate': None,
          'settlementFee': '0',
          'state': 'Open',
          'symbol': 'XBT_USDT',
          'takerFee': '0.00075',
          'taxed': True,
          'tickSize': '0.5',
          'timestamp': '2023-08-30T10:11:19.114Z',
          'totalTurnover': '540337866500850',
          'totalVolume': '2391396690000',
          'turnover': '0',
          'turnover24h': '706120941200',
          'typ': 'IFXXXP',
          'underlying': 'XBT',
          'underlyingSymbol': '',
          'underlyingToPositionMultiplier': '100000000',
          'underlyingToSettleMultiplier': None,
          'volume': '0',
          'volume24h': '2578690000',
          'vwap': '27382.932465709335'},
 'last': 27400.0,
 'low': 25950.0,
 'open': 25986.0,
 'percentage': 5.441391518509967,
 'previousClose': None,
 'quoteVolume': 706120.9412,
 'symbol': 'BTC/USDT',
 'timestamp': 1693390279114,
 'vwap': 27382.932465709335}
```
