### PR TITLE
fix(gate): watchOHLCV return

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -500,15 +500,17 @@ export default class gate extends gateRest {
             const subscription = this.safeString (ohlcv, 'n', '');
             const parts = subscription.split ('_');
             const timeframe = this.safeString (parts, 0);
+            const timeframeId = this.findTimeframe (timeframe);
             const prefix = timeframe + '_';
             const marketId = subscription.replace (prefix, '');
             const symbol = this.safeSymbol (marketId, undefined, '_', marketType);
             const parsed = this.parseOHLCV (ohlcv);
-            let stored = this.safeValue (this.ohlcvs, symbol);
+            this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
+            let stored = this.safeValue (this.ohlcvs[symbol], timeframe);
             if (stored === undefined) {
                 const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
                 stored = new ArrayCacheByTimestamp (limit);
-                this.ohlcvs[symbol] = stored;
+                this.ohlcvs[symbol][timeframeId] = stored;
             }
             stored.append (parsed);
             marketIds[symbol] = timeframe;
@@ -519,7 +521,7 @@ export default class gate extends gateRest {
             const timeframe = marketIds[symbol];
             const interval = this.findTimeframe (timeframe);
             const hash = 'candles' + ':' + interval + ':' + symbol;
-            const stored = this.safeValue (this.ohlcvs, symbol);
+            const stored = this.safeValue (this.ohlcvs[symbol], interval);
             client.resolve (stored, hash);
         }
     }


### PR DESCRIPTION
DEMO

```
p gate watchOHLCV "BTC/USDT"
Python v3.10.9
CCXT v4.0.79
gate.watchOHLCV(BTC/USDT)
[[1693409820000, 27219.3, 27274.4, 27218.3, 27274.4, 375304.452502]]
[[1693409820000, 27219.3, 27276.1, 27218.3, 27265.8, 444248.000586]]
[[1693409820000, 27219.3, 27276.1, 27218.3, 27263.0, 461354.481791]]
```
