### PR TITLE
Bybit: update stopLoss, takeProfit implementation

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3927,11 +3927,11 @@ export default class bybit extends Exchange {
         } else if (timeInForce === 'ioc') {
             request['timeInForce'] = 'IOC';
         }
-        let triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
-        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice');
-        const takeProfitTriggerPrice = this.safeNumber (params, 'takeProfitPrice');
-        const stopLoss = this.safeNumber (params, 'stopLoss');
-        const takeProfit = this.safeNumber (params, 'takeProfit');
+        let triggerPrice = this.safeValue2 (params, 'triggerPrice', 'stopPrice');
+        const stopLossTriggerPrice = this.safeValue (params, 'stopLossPrice');
+        const takeProfitTriggerPrice = this.safeValue (params, 'takeProfitPrice');
+        const stopLoss = this.safeValue (params, 'stopLoss');
+        const takeProfit = this.safeValue (params, 'takeProfit');
         const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
         const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
         const isStopLoss = stopLoss !== undefined;
@@ -3948,15 +3948,19 @@ export default class bybit extends Exchange {
             request['reduceOnly'] = true;
         } else if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
-                request['stopLoss'] = this.priceToPrecision (symbol, stopLoss);
+                const stopLossTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice');
+                request['stopLoss'] = this.priceToPrecision (symbol, stopLossTriggerPrice);
             }
             if (isTakeProfit) {
-                request['takeProfit'] = this.priceToPrecision (symbol, takeProfit);
+                const takeProfitTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice');
+                request['takeProfit'] = this.priceToPrecision (symbol, takeProfitTriggerPrice);
             }
         }
         if (market['spot']) {
             // only works for spot market
-            if (triggerPrice !== undefined || stopLossTriggerPrice !== undefined || takeProfitTriggerPrice !== undefined || isStopLoss || isTakeProfit) {
+            if (triggerPrice !== undefined) {
+                request['orderFilter'] = 'StopOrder';
+            } else if (stopLossTriggerPrice !== undefined || takeProfitTriggerPrice !== undefined || isStopLoss || isTakeProfit) {
                 request['orderFilter'] = 'tpslOrder';
             }
         }
@@ -4229,11 +4233,11 @@ export default class bybit extends Exchange {
         } else if (timeInForce === 'ioc') {
             request['timeInForce'] = 'ImmediateOrCancel';
         }
-        let triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
-        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice', triggerPrice);
-        const takeProfitTriggerPrice = this.safeNumber (params, 'takeProfitPrice');
-        const stopLoss = this.safeNumber (params, 'stopLoss');
-        const takeProfit = this.safeNumber (params, 'takeProfit');
+        let triggerPrice = this.safeValue2 (params, 'triggerPrice', 'stopPrice');
+        const stopLossTriggerPrice = this.safeValue (params, 'stopLossPrice');
+        const takeProfitTriggerPrice = this.safeValue (params, 'takeProfitPrice');
+        const stopLoss = this.safeValue (params, 'stopLoss');
+        const takeProfit = this.safeValue (params, 'takeProfit');
         const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
         const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
         const isStopLoss = stopLoss !== undefined;
@@ -4250,10 +4254,12 @@ export default class bybit extends Exchange {
             request['reduceOnly'] = true;
         } else if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
-                request['stopLoss'] = this.priceToPrecision (symbol, stopLoss);
+                const stopLossTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice');
+                request['stopLoss'] = this.priceToPrecision (symbol, stopLossTriggerPrice);
             }
             if (isTakeProfit) {
-                request['takeProfit'] = this.priceToPrecision (symbol, takeProfit);
+                const takeProfitTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice');
+                request['takeProfit'] = this.priceToPrecision (symbol, takeProfitTriggerPrice);
             }
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');


### PR DESCRIPTION
Updated the stopLoss and takeProfit implementation on Bybit to use the unified approach:

### 1. trigger order:
```
bybit createOrder BTC/USDT:USDT limit buy 0.001 23000 '{"triggerPrice":"24000","positionIdx":1}'

bybit.createOrder (BTC/USDT:USDT, limit, buy, 0.001, 23000, [object Object])
2023-08-31T04:50:06.202Z iteration 0 passed in 1099 ms

{
  info: { orderId: '9bc63b51-0b45-4daf-86be-5cf835409b20', orderLinkId: '' },
  id: '9bc63b51-0b45-4daf-86be-5cf835409b20',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```

### 2. stopLoss and takeProfit attached after opening a position:
```
bybit createOrder BTC/USDT:USDT market sell 0.001 undefined '{"stopLossPrice":"24000","positionIdx":1}'

bybit.createOrder (BTC/USDT:USDT, market, sell, 0.001, , [object Object])
2023-08-31T04:55:19.159Z iteration 0 passed in 1532 ms

{
  info: { orderId: 'f6499401-4737-4110-b637-54c336e27d14', orderLinkId: '' },
  id: 'f6499401-4737-4110-b637-54c336e27d14',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```

### 3. stopLoss and takeProfit attached upon opening a position:
```
bybit createOrder BTC/USDT:USDT limit buy 0.001 23000 '{"stopLoss":{"stopPrice":"22000"},"positionIdx":1}'

bybit.createOrder (BTC/USDT:USDT, limit, buy, 0.001, 23000, [object Object])
2023-08-31T04:59:22.840Z iteration 0 passed in 1502 ms

{
  info: { orderId: 'cdd61c2b-7817-4035-9c39-8669e3c31fe8', orderLinkId: '' },
  id: 'cdd61c2b-7817-4035-9c39-8669e3c31fe8',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: undefined,
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```