### PR TITLE
fix(bitmex): fetchFundingRates filtering

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -2301,7 +2301,9 @@ export default class bitmex extends Exchange {
                 filteredResponse.push (item);
             }
         }
-        return this.parseFundingRates (filteredResponse, symbols);
+        symbols = this.marketSymbols (symbols);
+        const result = this.parseFundingRates (filteredResponse);
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     parseFundingRate (contract, market = undefined) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19069

```
p bitmex fetchFundingRates '["BTC/USDT:USDT", "LTC/USDT:USDT"]
quote> '                               
Python v3.10.9
CCXT v4.0.80
bitmex.fetchFundingRates(['BTC/USDT:USDT', 'LTC/USDT:USDT'])
{'BTC/USDT:USDT': {'datetime': '2023-09-01T14:19:55.747Z',
                   'estimatedSettlePrice': 25946.1,
                   'fundingDatetime': '2023-09-01T20:00:00.000Z',
                   'fundingRate': 7.9e-05,
                   'fundingTimestamp': None,
                   'indexPrice': None,
                   'info': {'askPrice': '25934.5',
                            'bidPrice': '25930.5',
                            'calcInterval': None,
                            'deleverage': True,
                            'expiry': None,
                            'fairBasis': '1.46',
                            'fairBasisRate': '0.086505',
                            'fairMethod': 'FundingRate',
                            'fairPrice': '25947.56',
                            'foreignNotional24h': '28536559.209499992',
                            'front': '2021-11-10T04:00:00.000Z',
                            'fundingBaseSymbol': '.XBTBON8H',
                            'fundingInterval': '2000-01-01T08:00:00.000Z',
                            'fundingPremiumSymbol': '.XBTUSDTPI8H',
                            'fundingQuoteSymbol': '.USDTBON8H',
                            'fundingRate': '0.000079',
                            'fundingTimestamp': '2023-09-01T20:00:00.000Z',
                            'hasLiquidity': True,
                            'highPrice': '27163.5',
                            'homeNotional24h': '1085.8279999999997',
                            'impactAskPrice': '25935.596',
                            'impactBidPrice': '25929.577',
                            'impactMidPrice': '25932.5',
                            'indicativeFundingRate': '-0.000016',
                            'indicativeSettlePrice': '25946.1',
                            'initMargin': '0.01',
                            'isInverse': False,
                            'isQuanto': False,
                            'lastChangePcnt': '-0.0429',
                            'lastPrice': '25925',
                            'lastPriceProtected': '25925',
                            'lastTickDirection': 'PlusTick',
                            'limit': None,
                            'limitDownPrice': None,
                            'limitUpPrice': None,
                            'listedSettle': None,
                            'listing': '2021-11-10T04:00:00.000Z',
                            'lotSize': '1000',
                            'lowPrice': '25640.5',
                            'maintMargin': '0.005',
                            'makerFee': '0.0002',
                            'markMethod': 'FairPrice',
                            'markPrice': '25947.56',
                            'maxOrderQty': '1000000000',
                            'maxPrice': '1000000',
                            'midPrice': '25932.5',
                            'multiplier': '1',
                            'openInterest': '242139000',
                            'openValue': '6282916230840',
                            'positionCurrency': 'XBT',
                            'prevClosePrice': '26046.96',
                            'prevPrice24h': '27055.5',
                            'prevTotalTurnover': '19152981899343500',
                            'publishInterval': None,
                            'publishTime': None,
                            'quoteCurrency': 'USDT',
                            'quoteToSettleMultiplier': '1000000',
                            'rebalanceInterval': None,
                            'rebalanceTimestamp': None,
                            'reference': 'BMEX',
                            'referenceSymbol': '.BXBTT',
                            'relistInterval': None,
                            'riskLimit': '1000000000000',
                            'riskStep': '1000000000000',
                            'rootSymbol': 'XBT',
                            'settlCurrency': 'USDt',
                            'settle': None,
                            'settledPrice': None,
                            'settledPriceAdjustmentRate': None,
                            'settlementFee': '0',
                            'state': 'Open',
                            'symbol': 'XBTUSDT',
                            'takerFee': '0.00075',
                            'taxed': True,
                            'tickSize': '0.5',
                            'timestamp': '2023-09-01T14:19:55.747Z',
                            'totalTurnover': '19153058394868500',
                            'totalVolume': '666703402000',
                            'turnover': '76495525000',
                            'turnover24h': '28536559209500',
                            'typ': 'FFWCSX',
                            'underlying': 'XBT',
                            'underlyingSymbol': 'XBTT=',
                            'underlyingToPositionMultiplier': '1000000',
                            'underlyingToSettleMultiplier': None,
                            'volume': '2951000',
                            'volume24h': '1085828000',
                            'vwap': '26280.921'},
                   'interestRate': None,
                   'markPrice': 25947.56,
                   'nextFundingDatetime': None,
                   'nextFundingRate': -1.6e-05,
                   'nextFundingTimestamp': None,
                   'previousFundingDatetime': None,
                   'previousFundingRate': None,
                   'previousFundingTimestamp': None,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1693577995747},
 'LTC/USDT:USDT': {'datetime': '2023-09-01T14:19:55.747Z',
                   'estimatedSettlePrice': 63.513,
                   'fundingDatetime': '2023-09-01T20:00:00.000Z',
                   'fundingRate': 0.0001,
                   'fundingTimestamp': None,
                   'indexPrice': None,
                   'info': {'askPrice': '63.48',
                            'bidPrice': '63.47',
                            'calcInterval': None,
                            'deleverage': True,
                            'expiry': None,
                            'fairBasis': '0.005',
                            'fairBasisRate': '0.1095',
                            'fairMethod': 'FundingRate',
                            'fairPrice': '63.518',
                            'foreignNotional24h': '1512070.4459999998',
                            'front': '2021-11-10T04:00:00.000Z',
                            'fundingBaseSymbol': '.LTCBON8H',
                            'fundingInterval': '2000-01-01T08:00:00.000Z',
                            'fundingPremiumSymbol': '.LTCUSDTPI8H',
                            'fundingQuoteSymbol': '.USDTBON8H',
                            'fundingRate': '0.0001',
                            'fundingTimestamp': '2023-09-01T20:00:00.000Z',
                            'hasLiquidity': True,
                            'highPrice': '67.46',
                            'homeNotional24h': '23536.199999999997',
                            'impactAskPrice': '63.48835',
                            'impactBidPrice': '63.44963',
                            'impactMidPrice': '63.47',
                            'indicativeFundingRate': '0.000069',
                            'indicativeSettlePrice': '63.513',
                            'initMargin': '0.03',
                            'isInverse': False,
                            'isQuanto': False,
                            'lastChangePcnt': '-0.055',
                            'lastPrice': '63.4',
                            'lastPriceProtected': '63.4',
                            'lastTickDirection': 'ZeroPlusTick',
                            'limit': None,
                            'limitDownPrice': None,
                            'limitUpPrice': None,
                            'listedSettle': None,
                            'listing': '2021-11-10T04:00:00.000Z',
                            'lotSize': '1000',
                            'lowPrice': '63.18',
                            'maintMargin': '0.015',
                            'makerFee': '0.0002',
                            'markMethod': 'FairPrice',
                            'markPrice': '63.518',
                            'maxOrderQty': '1000000000',
                            'maxPrice': '1000000',
                            'midPrice': '63.475',
                            'multiplier': '100',
                            'openInterest': '187803000',
                            'openValue': '1192887095400',
                            'positionCurrency': 'LTC',
                            'prevClosePrice': '63.939',
                            'prevPrice24h': '67.09',
                            'prevTotalTurnover': '1425115244769000',
                            'publishInterval': None,
                            'publishTime': None,
                            'quoteCurrency': 'USDT',
                            'quoteToSettleMultiplier': '1000000',
                            'rebalanceInterval': None,
                            'rebalanceTimestamp': None,
                            'reference': 'BMEX',
                            'referenceSymbol': '.BLTCT',
                            'relistInterval': None,
                            'riskLimit': '1000000000000',
                            'riskStep': '1000000000000',
                            'rootSymbol': 'LTC',
                            'settlCurrency': 'USDt',
                            'settle': None,
                            'settledPrice': None,
                            'settledPriceAdjustmentRate': None,
                            'settlementFee': '0',
                            'state': 'Open',
                            'symbol': 'LTCUSDT',
                            'takerFee': '0.00075',
                            'taxed': True,
                            'tickSize': '0.01',
                            'timestamp': '2023-09-01T14:19:55.747Z',
                            'totalTurnover': '1425122799181000',
                            'totalVolume': '169087213000',
                            'turnover': '7554412000',
                            'turnover24h': '1512070446000',
                            'typ': 'FFWCSX',
                            'underlying': 'LTC',
                            'underlyingSymbol': 'LTCT=',
                            'underlyingToPositionMultiplier': '10000',
                            'underlyingToSettleMultiplier': None,
                            'volume': '1191000',
                            'volume24h': '235362000',
                            'vwap': '64.24447'},
                   'interestRate': None,
                   'markPrice': 63.518,
                   'nextFundingDatetime': None,
                   'nextFundingRate': 6.9e-05,
                   'nextFundingTimestamp': None,
                   'previousFundingDatetime': None,
                   'previousFundingRate': None,
                   'previousFundingTimestamp': None,
                   'symbol': 'LTC/USDT:USDT',
                   'timestamp': 1693577995747}}
```
