### PR TITLE
fix(base): duplicated markets with different ids

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -614,7 +614,6 @@ export default class Exchange {
             'commonCurrencies': { // gets extended/overwritten in subclasses
                 'XBT': 'BTC',
                 'BCC': 'BCH',
-                'BCHABC': 'BCH',
                 'BCHSV': 'BSV',
             },
             'precisionMode': DECIMAL_PLACES,

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -713,6 +713,9 @@ export default class delta extends Exchange {
         for (let i = 0; i < markets.length; i++) {
             const market = markets[i];
             let type = this.safeString (market, 'contract_type');
+            if (type === 'options_combos') {
+                continue;
+            }
             // const settlingAsset = this.safeValue (market, 'settling_asset', {});
             const quotingAsset = this.safeValue (market, 'quoting_asset', {});
             const underlyingAsset = this.safeValue (market, 'underlying_asset', {});

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -641,6 +641,9 @@ export default class hitbtc extends Exchange {
         const ids = Object.keys (response);
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i];
+            if (id.endsWith ('_BQX')) {
+                continue; // seems like an invalid symbol and if we try to access it individually we get: {"timestamp":"2023-09-02T14:38:20.351Z","error":{"description":"Try get /public/symbol, to get list of all available symbols.","code":2001,"message":"No such symbol: EOSUSD_BQX"},"path":"/api/3/public/symbol/EOSUSD_BQX","requestId":"e1e9fce6-16374591"}
+            }
             const market = this.safeValue (response, id);
             const marketType = this.safeString (market, 'type');
             const expiry = this.safeInteger (market, 'expiry');

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -208,7 +208,6 @@ export default class yobit extends Exchange {
                 'PAC': '$PAC',
                 'PLAY': 'PlayCoin',
                 'PIVX': 'Darknet',
-                'PRS': 'PRE',
                 'PURE': 'PurePOS',
                 'PUTIN': 'PutinCoin',
                 'SPACE': 'Spacecoin',


### PR DESCRIPTION
- https://github.com/ccxt/ccxt/issues/19080
- Some markets had the same symbol, whereas the market id was different, meaning that the user could be selecting the wrong market accidentally. 

Script that can be used to detect this issue:

```Javascript
    const exchange = new ccxt.bequant({})
    const markets = await exchange.fetchMarkets();
    for (let i = 0; i < markets.length; i++) {
        for (let j = i + 1; j < markets.length; j++) {
            const market1 = markets[i]
            const market2 = markets[j]
            if (market1.symbol === market2.symbol && (market1.id !== market2.id)) {
                log.bright.green ('Duplicate symbol different id', market1.symbol, market1.id, market2.id)
            }
        }
    }
```
