### PR TITLE
add: [upbit] Add network as required parameter for withdrawals of digital assets

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -1749,18 +1749,18 @@ export default class upbit extends Exchange {
         };
         let method = 'privatePostWithdraws';
         if (code !== 'KRW') {
-            // 2023-05-23 Change to required parameters for digital assets 
+            // 2023-05-23 Change to required parameters for digital assets
             if (params['network'] === undefined) {
                 throw new ArgumentsRequired (this.id + ' withdraw() requires a network argument');
             }
             method += 'Coin';
-            request['net_type'] = params['network'].toUpperCase();
+            request['net_type'] = this.safeStringUpper (params, 'network');
             request['currency'] = currency['id'];
             request['address'] = address;
             if (tag !== undefined) {
                 request['secondary_address'] = tag;
             }
-            params = this.omit(params, 'network');
+            params = this.omit (params, 'network');
         } else {
             method += 'Krw';
         }

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/upbit.js';
-import { ExchangeError, BadRequest, AuthenticationError, InvalidOrder, InsufficientFunds, OrderNotFound, PermissionDenied, AddressPending } from './base/errors.js';
+import { ExchangeError, BadRequest, AuthenticationError, InvalidOrder, InsufficientFunds, OrderNotFound, PermissionDenied, AddressPending, ArgumentsRequired } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
@@ -1749,12 +1749,18 @@ export default class upbit extends Exchange {
         };
         let method = 'privatePostWithdraws';
         if (code !== 'KRW') {
+            // 2023-05-23 Change to required parameters for digital assets 
+            if (params['network'] === undefined) {
+                throw new ArgumentsRequired (this.id + ' withdraw() requires a network argument');
+            }
             method += 'Coin';
+            request['net_type'] = params['network'].toUpperCase();
             request['currency'] = currency['id'];
             request['address'] = address;
             if (tag !== undefined) {
                 request['secondary_address'] = tag;
             }
+            params = this.omit(params, 'network');
         } else {
             method += 'Krw';
         }

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -1750,11 +1750,13 @@ export default class upbit extends Exchange {
         let method = 'privatePostWithdraws';
         if (code !== 'KRW') {
             // 2023-05-23 Change to required parameters for digital assets
-            if (params['network'] === undefined) {
+            const network = this.safeStringUpper2 (params, 'network', 'net_type');
+            if (network === undefined) {
                 throw new ArgumentsRequired (this.id + ' withdraw() requires a network argument');
             }
+            params = this.omit (params, [ 'network' ]);
+            request['net_type'] = network;
             method += 'Coin';
-            request['net_type'] = this.safeStringUpper (params, 'network');
             request['currency'] = currency['id'];
             request['address'] = address;
             if (tag !== undefined) {


### PR DESCRIPTION
The Upbit Exchange has changed its "net_type" to mandatory for digital asset withdrawals from 2023-05-23.

- Upbit Exchange withdrawal API document
https://docs.upbit.com/reference/%EB%94%94%EC%A7%80%ED%84%B8%EC%9E%90%EC%82%B0-%EC%B6%9C%EA%B8%88%ED%95%98%EA%B8%B0