### PR TITLE
unification - currency `type`

### DIFF
--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -426,7 +426,6 @@ export default class bigone extends Exchange {
                 networks[networkCode] = {
                     'id': networkId,
                     'network': networkCode,
-                    'type': type,
                     'margin': undefined,
                     'deposit': deposit,
                     'withdraw': withdraw,
@@ -455,6 +454,7 @@ export default class bigone extends Exchange {
                 'code': code,
                 'info': currency,
                 'name': name,
+                'type': type,
                 'active': undefined,
                 'deposit': currencyDepositEnabled,
                 'withdraw': currencyWithdrawEnabled,

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -706,7 +706,8 @@ export default class bitfinex2 extends Exchange {
             const label = this.safeValue (indexed['label'], id, []);
             const name = this.safeString (label, 1);
             const pool = this.safeValue (indexed['pool'], id, []);
-            const type = this.safeString (pool, 1);
+            const rawType = this.safeString (pool, 1);
+            const type = (rawType === undefined) ? 'other' : 'crypto';
             const feeValues = this.safeValue (indexed['fees'], id, []);
             const fees = this.safeValue (feeValues, 1, []);
             const fee = this.safeNumber (fees, 1);

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -474,6 +474,7 @@ export default class bittrex extends Exchange {
         //     ]
         //
         const result = {};
+        const ccc = [];
         for (let i = 0; i < response.length; i++) {
             const currency = response[i];
             const id = this.safeString (currency, 'symbol');
@@ -481,11 +482,22 @@ export default class bittrex extends Exchange {
             const precision = this.parseNumber ('1e-8'); // default precision, seems exchange has same amount-precision across all pairs in UI too. todo: fix "magic constants"
             const fee = this.safeNumber (currency, 'txFee'); // todo: redesign
             const isActive = this.safeString (currency, 'status');
+            const coinType = this.safeString (currency, 'coinType');
+            let type = undefined;
+            if (coinType === 'FIAT') {
+                type = 'fiat';
+            } else if (coinType === 'Award') {
+                // these are exchange credits
+                type = 'other';
+            } else {
+                // all others are cryptos
+                type = 'crypto';
+            }
             result[code] = {
                 'id': id,
                 'code': code,
                 'info': currency,
-                'type': this.safeString (currency, 'coinType'),
+                'type': type,
                 'name': this.safeString (currency, 'name'),
                 'active': (isActive === 'ONLINE'),
                 'deposit': undefined,

--- a/ts/src/bittrex.ts
+++ b/ts/src/bittrex.ts
@@ -474,7 +474,6 @@ export default class bittrex extends Exchange {
         //     ]
         //
         const result = {};
-        const ccc = [];
         for (let i = 0; i < response.length; i++) {
             const currency = response[i];
             const id = this.safeString (currency, 'symbol');

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -1129,7 +1129,7 @@ export default class kucoin extends Exchange {
                 };
             }
             // kucoin has determined 'fiat' currencies with below logic
-            const isFiat = rawPrecision === '2' && chainsLength === 0;
+            const isFiat = (rawPrecision === '2') && (chainsLength === 0);
             result[code] = {
                 'id': id,
                 'name': name,

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -1086,8 +1086,10 @@ export default class kucoin extends Exchange {
             const networks = {};
             const chains = this.safeValue (entry, 'chains', []);
             const extraChainsData = this.indexBy (this.safeValue (additionalDataGrouped, id, []), 'chain');
-            const precision = this.parseNumber (this.parsePrecision (this.safeString (entry, 'precision')));
-            for (let j = 0; j < chains.length; j++) {
+            const rawPrecision = this.safeString (entry, 'precision');
+            const precision = this.parseNumber (this.parsePrecision (rawPrecision));
+            const chainsLength = chains.length;
+            for (let j = 0; j < chainsLength; j++) {
                 const chain = chains[j];
                 const chainId = this.safeString (chain, 'chain');
                 const networkCode = this.networkIdToCode (chainId);
@@ -1126,10 +1128,13 @@ export default class kucoin extends Exchange {
                     },
                 };
             }
+            // kucoin has determined 'fiat' currencies with below logic
+            const isFiat = rawPrecision === '2' && chainsLength === 0;
             result[code] = {
                 'id': id,
                 'name': name,
                 'code': code,
+                'type': isFiat ? 'fiat' : 'crypto',
                 'precision': precision,
                 'info': entry,
                 'active': (isDepositEnabled || isWithdrawEnabled),

--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -437,10 +437,13 @@ export default class latoken extends Exchange {
             const code = this.safeCurrencyCode (tag);
             const fee = this.safeNumber (currency, 'fee');
             const currencyType = this.safeString (currency, 'type');
-            const parts = currencyType.split ('_');
-            const numParts = parts.length;
-            const lastPart = this.safeValue (parts, numParts - 1);
-            const type = lastPart.toLowerCase ();
+            let type = undefined;
+            if (currencyType === 'CURRENCY_TYPE_ALTERNATIVE') {
+                type = 'other';
+            } else {
+                // CURRENCY_TYPE_CRYPTO and CURRENCY_TYPE_IEO are all cryptos
+                type = 'crypto';
+            }
             const status = this.safeString (currency, 'status');
             const active = (status === 'CURRENCY_STATUS_ACTIVE');
             const name = this.safeString (currency, 'name');

--- a/ts/src/lykke.ts
+++ b/ts/src/lykke.ts
@@ -227,7 +227,8 @@ export default class lykke extends Exchange {
             const id = this.safeString (currency, 'assetId');
             const code = this.safeString (currency, 'symbol');
             const name = this.safeString (currency, 'name');
-            const type = this.safeString (currency, 'type');
+            const rawType = this.safeString (currency, 'type');
+            const type = (rawType === 'erc20Token') ? 'crypto' : 'other';
             const deposit = this.safeValue (currency, 'blockchainDepositEnabled');
             const withdraw = this.safeValue (currency, 'blockchainWithdrawal');
             const isDisabled = this.safeValue (currency, 'isDisabled');

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -366,7 +366,7 @@ export default class ndax extends Exchange {
             let type = ProductType === 'NationalCurrency' ? 'fiat' : 'crypto';
             if (ProductType === 'Unknown') {
                 // such currency is just a blanket entry
-                type = 'unknown';
+                type = 'other';
             }
             const code = this.safeCurrencyCode (this.safeString (currency, 'Product'));
             const isDisabled = this.safeValue (currency, 'IsDisabled');

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -362,12 +362,12 @@ export default class ndax extends Exchange {
             const currency = response[i];
             const id = this.safeString (currency, 'ProductId');
             const name = this.safeString (currency, 'ProductFullName');
-            if (name === 'Donottouch') {
-                // such "DO NOT USE" product is just an empty template, not actual currency
-                continue;
-            }
             const ProductType = this.safeString (currency, 'ProductType');
-            const type = ProductType === 'NationalCurrency' ? 'fiat' : 'crypto';
+            let type = ProductType === 'NationalCurrency' ? 'fiat' : 'crypto';
+            if (ProductType === 'Unknown') {
+                // such currency is just a blanket entry
+                type = 'unknown';
+            }
             const code = this.safeCurrencyCode (this.safeString (currency, 'Product'));
             const isDisabled = this.safeValue (currency, 'IsDisabled');
             const active = !isDisabled;

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -362,7 +362,12 @@ export default class ndax extends Exchange {
             const currency = response[i];
             const id = this.safeString (currency, 'ProductId');
             const name = this.safeString (currency, 'ProductFullName');
-            const type = this.safeString (currency, 'ProductType');
+            if (name === 'Donottouch') {
+                // such "DO NOT USE" product is just an empty template, not actual currency
+                continue;
+            }
+            const ProductType = this.safeString (currency, 'ProductType');
+            const type = ProductType === 'NationalCurrency' ? 'fiat' : 'crypto';
             const code = this.safeCurrencyCode (this.safeString (currency, 'Product'));
             const isDisabled = this.safeValue (currency, 'IsDisabled');
             const active = !isDisabled;

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -363,7 +363,7 @@ export default class ndax extends Exchange {
             const id = this.safeString (currency, 'ProductId');
             const name = this.safeString (currency, 'ProductFullName');
             const ProductType = this.safeString (currency, 'ProductType');
-            let type = ProductType === 'NationalCurrency' ? 'fiat' : 'crypto';
+            let type = (ProductType === 'NationalCurrency') ? 'fiat' : 'crypto';
             if (ProductType === 'Unknown') {
                 // such currency is just a blanket entry
                 type = 'other';


### PR DESCRIPTION
top exchanges had mostly `crypto` and `fiat` currencies as unified. so, (beside `info` exchange specific props) we have to unify those types (some exchanges return  i.e. `'CryptoCurrency'` or alike strings) however, we shouldn't return those raw strings to user, but unified type (like we have it for markets: `spot/swap/etc`).  at this moment, while testing all exchanges against `type` field, I have seen 3 common types:
```
- crypto
- fiat
- other
```
so, I've updated all exchanges to be consistent with those returned values. (note, `other` is not same as `undefined`, but it means that currency is somewhat other type, some exchanges call it strings like `'unknown', 'other', 'alternative', etc... , so it is not "undefined" type, but "other" is the common name. if someone on the earth is looking for exchange-specific value, they can use `info` for non-unified raw data)