### PR TITLE
fix(gate): order status

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4181,7 +4181,6 @@ export default class gate extends Exchange {
         let remainingString = this.safeString (order, 'left');
         let cost = this.safeString (order, 'filled_total');
         const triggerPrice = this.safeNumber (trigger, 'price');
-        let rawStatus = undefined;
         let average = this.safeNumber2 (order, 'avg_deal_price', 'fill_price');
         if (triggerPrice) {
             remainingString = amount;
@@ -4191,10 +4190,8 @@ export default class gate extends Exchange {
             const isMarketOrder = Precise.stringEquals (price, '0') && (timeInForce === 'IOC');
             type = isMarketOrder ? 'market' : 'limit';
             side = Precise.stringGt (amount, '0') ? 'buy' : 'sell';
-            rawStatus = this.safeString (order, 'finish_as', 'open');
-        } else {
-            rawStatus = this.safeString (order, 'status');
         }
+        const rawStatus = this.safeStringN (order, [ 'status', 'finish_as', 'open' ]);
         let timestamp = this.safeInteger (order, 'create_time_ms');
         if (timestamp === undefined) {
             timestamp = this.safeTimestamp2 (order, 'create_time', 'ctime');

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -838,8 +838,11 @@ export default class gate extends gateRest {
             if (event === 'put' || event === 'update') {
                 parsed['status'] = 'open';
             } else if (event === 'finish') {
-                const left = this.safeNumber (info, 'left');
-                parsed['status'] = (left === 0) ? 'closed' : 'canceled';
+                const status = this.safeString (parsed, 'status');
+                if (status === undefined) {
+                    const left = this.safeNumber (info, 'left');
+                    parsed['status'] = (left === 0) ? 'closed' : 'canceled';
+                }
             }
             stored.append (parsed);
             const symbol = parsed['symbol'];


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19096
```
p gate createOrder "LTC/USDT" market buy 1 5
Python v3.10.9
CCXT v4.0.82
gate.createOrder(LTC/USDT,market,buy,1,5)
{'amount': 0.07808839606434484,
 'average': 64.03,
 'clientOrderId': 'apiv4',
 'cost': 5.0,
 'datetime': '2023-09-04T11:14:10.324Z',
 'fee': {'cost': 0.000156, 'currency': 'LTC'},
 'fees': [{'cost': 0.000156, 'currency': 'LTC'}],
 'filled': 0.078,
 'id': '394120049349',
 'info': {'account': 'spot',
          'amend_text': '-',
          'amount': '5',
          'avg_deal_price': '64.03',
          'biz_info': 'ch:ccxt',
          'create_time': '1693826050',
          'create_time_ms': '1693826050324',
          'currency_pair': 'LTC_USDT',
          'fee': '0.000156',
          'fee_currency': 'LTC',
          'fill_price': '4.99434',
          'filled_total': '4.99434',
          'finish_as': 'filled',
          'gt_discount': False,
          'gt_fee': '0',
          'gt_maker_fee': '0',
          'gt_taker_fee': '0',
          'iceberg': '0',
          'id': '394120049349',
          'left': '0.00566',
          'point_fee': '0',
          'price': '0',
          'rebated_fee': '0',
          'rebated_fee_currency': 'USDT',
          'side': 'buy',
          'status': 'closed',
          'text': 'apiv4',
          'time_in_force': 'ioc',
          'type': 'market',
          'update_time': '1693826050',
          'update_time_ms': '1693826050324'},
 'lastTradeTimestamp': 1693826050324,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 64.03,
 'reduceOnly': None,
 'remaining': 8.8396064344838e-05,
 'side': 'buy',
 'status': 'closed',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'IOC',
 'timestamp': 1693826050324,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
```
 p gate watchOrders "LTC/USDT"                
Python v3.10.9
CCXT v4.0.82
gate.watchOrders(LTC/USDT)
[{'amount': 0.07808839606434484,
  'average': 64.03,
  'clientOrderId': 'apiv4',
  'cost': 5.0,
  'datetime': '2023-09-04T11:14:10.324Z',
  'fee': {'cost': 0.000156, 'currency': 'LTC'},
  'fees': [{'cost': 0.000156, 'currency': 'LTC'}],
  'filled': 0.078,
  'id': '394120049349',
  'info': {'account': 'spot',
           'amend_text': '-',
           'amount': '5',
           'avg_deal_price': '64.03',
           'biz_info': 'ch:ccxt',
           'create_time': '1693826050',
           'create_time_ms': '1693826050324',
           'currency_pair': 'LTC_USDT',
           'event': 'finish',
           'fee': '0.000156',
           'fee_currency': 'LTC',
           'filled_total': '4.99434',
           'finish_as': 'filled',
           'gt_fee': '0',
           'id': '394120049349',
           'left': '0.00566',
           'point_fee': '0',
           'price': '0',
           'rebated_fee': '0',
           'rebated_fee_currency': 'LTC',
           'side': 'buy',
           'stp_act': '-',
           'stp_id': 0,
           'text': 'apiv4',
           'time_in_force': 'ioc',
           'type': 'market',
           'update_time': '1693826050',
           'update_time_ms': '1693826050324',
           'user': 10406147},
  'lastTradeTimestamp': 1693826050324,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 64.03,
  'reduceOnly': None,
  'remaining': 8.8396064344838e-05,
  'side': 'buy',
  'status': 'closed',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1693826050324,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```
```
p gate createOrder "LTC/USDT" limit buy 0.1 50
Python v3.10.9
CCXT v4.0.82
gate.createOrder(LTC/USDT,limit,buy,0.1,50)
{'amount': 0.1,
 'average': None,
 'clientOrderId': 'apiv4',
 'cost': 0.0,
 'datetime': '2023-09-04T11:14:38.214Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '394120203701',
 'info': {'account': 'spot',
          'amend_text': '-',
          'amount': '0.1',
          'biz_info': 'ch:ccxt',
          'create_time': '1693826078',
          'create_time_ms': '1693826078214',
          'currency_pair': 'LTC_USDT',
          'fee': '0',
          'fee_currency': 'LTC',
          'fill_price': '0',
          'filled_total': '0',
          'finish_as': 'open',
          'gt_discount': False,
          'gt_fee': '0',
          'gt_maker_fee': '0',
          'gt_taker_fee': '0',
          'iceberg': '0',
          'id': '394120203701',
          'left': '0.1',
          'point_fee': '0',
          'price': '50',
          'rebated_fee': '0',
          'rebated_fee_currency': 'USDT',
          'side': 'buy',
          'status': 'open',
          'text': 'apiv4',
          'time_in_force': 'gtc',
          'type': 'limit',
          'update_time': '1693826078',
          'update_time_ms': '1693826078214'},
 'lastTradeTimestamp': 1693826078214,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': 0.1,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1693826078214,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
```
 p gate cancelOrder "394120203701" "LTC/USDT"                 
Python v3.10.9
CCXT v4.0.82
gate.cancelOrder(394120203701,LTC/USDT)
{'amount': 0.1,
 'average': None,
 'clientOrderId': 'apiv4',
 'cost': 0.0,
 'datetime': '2023-09-04T11:14:38.214Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '394120203701',
 'info': {'account': 'spot',
          'amend_text': '-',
          'amount': '0.1',
          'biz_info': 'ch:ccxt',
          'create_time': '1693826078',
          'create_time_ms': '1693826078214',
          'currency_pair': 'LTC_USDT',
          'fee': '0',
          'fee_currency': 'LTC',
          'fill_price': '0',
          'filled_total': '0',
          'finish_as': 'cancelled',
          'gt_discount': False,
          'gt_fee': '0',
          'gt_maker_fee': '0',
          'gt_taker_fee': '0',
          'iceberg': '0',
          'id': '394120203701',
          'left': '0.1',
          'point_fee': '0',
          'price': '50',
          'rebated_fee': '0',
          'rebated_fee_currency': 'USDT',
          'side': 'buy',
          'status': 'cancelled',
          'text': 'apiv4',
          'time_in_force': 'gtc',
          'type': 'limit',
          'update_time': '1693826100',
          'update_time_ms': '1693826100792'},
 'lastTradeTimestamp': 1693826100792,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': None,
 'remaining': 0.1,
 'side': 'buy',
 'status': 'canceled',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1693826078214,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
```
[{'amount': 0.1,
  'average': None,
  'clientOrderId': 'apiv4',
  'cost': 0.0,
  'datetime': '2023-09-04T11:14:38.214Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '394120203701',
  'info': {'account': 'spot',
           'amend_text': '-',
           'amount': '0.1',
           'avg_deal_price': '0',
           'biz_info': 'ch:ccxt',
           'create_time': '1693826078',
           'create_time_ms': '1693826078214',
           'currency_pair': 'LTC_USDT',
           'event': 'finish',
           'fee': '0',
           'fee_currency': 'LTC',
           'filled_total': '0',
           'finish_as': 'cancelled',
           'gt_fee': '0',
           'id': '394120203701',
           'left': '0.1',
           'point_fee': '0',
           'price': '50',
           'rebated_fee': '0',
           'rebated_fee_currency': 'LTC',
           'side': 'buy',
           'stp_act': '-',
           'stp_id': 0,
           'text': 'apiv4',
           'time_in_force': 'gtc',
           'type': 'limit',
           'update_time': '1693826100',
           'update_time_ms': '1693826100792',
           'user': 10406147},
  'lastTradeTimestamp': 1693826100792,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 50.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'canceled',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'GTC',
  'timestamp': 1693826078214,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
