### PR TITLE
fix(latoken): parseTicker response values corrected

### DIFF
--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -581,41 +581,47 @@ export default class latoken extends Exchange {
 
     parseTicker (ticker, market = undefined) {
         //
-        //     {
-        //         "symbol":"620f2019-33c0-423b-8a9d-cde4d7f8ef7f/0c3a106d-bde3-4c13-a26e-3fd2394529e5",
-        //         "baseCurrency":"620f2019-33c0-423b-8a9d-cde4d7f8ef7f",
-        //         "quoteCurrency":"0c3a106d-bde3-4c13-a26e-3fd2394529e5",
-        //         "volume24h":"76411867.852585600000000000",
-        //         "volume7d":"637809926.759451100000000000",
-        //         "change24h":"2.5300",
-        //         "change7d":"5.1300",
-        //         "lastPrice":"4426.9"
-        //     }
+        //    {
+        //        symbol: '92151d82-df98-4d88-9a4d-284fa9eca49f/0c3a106d-bde3-4c13-a26e-3fd2394529e5',
+        //        baseCurrency: '92151d82-df98-4d88-9a4d-284fa9eca49f',
+        //        quoteCurrency: '0c3a106d-bde3-4c13-a26e-3fd2394529e5',
+        //        volume24h: '165723597.189022176000000000',
+        //        volume7d: '934505768.625109571000000000',
+        //        change24h: '0.0200',
+        //        change7d: '-6.4200',
+        //        amount24h: '6438.457663100000000000',
+        //        amount7d: '35657.785013800000000000',
+        //        lastPrice: '25779.16',
+        //        lastQuantity: '0.248403300000000000',
+        //        bestBid: '25778.74',
+        //        bestBidQuantity: '0.6520232',
+        //        bestAsk: '25779.17',
+        //        bestAskQuantity: '0.4956043',
+        //        updateTimestamp: '1693965231406'
+        //    }
         //
         const marketId = this.safeString (ticker, 'symbol');
-        const symbol = this.safeSymbol (marketId, market);
         const last = this.safeString (ticker, 'lastPrice');
-        const change = this.safeString (ticker, 'change24h');
-        const timestamp = this.nonce ();
+        const timestamp = this.safeInteger (ticker, 'updateTimestamp');
         return this.safeTicker ({
-            'symbol': symbol,
+            'symbol': this.safeSymbol (marketId, market),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'low': this.safeString (ticker, 'low'),
-            'high': this.safeString (ticker, 'high'),
-            'bid': undefined,
-            'bidVolume': undefined,
-            'ask': undefined,
-            'askVolume': undefined,
+            'low': undefined,
+            'high': undefined,
+            'bid': this.safeString (ticker, 'bestBid'),
+            'bidVolume': this.safeString (ticker, 'bestBidQuantity'),
+            'ask': this.safeString (ticker, 'bestAsk'),
+            'askVolume': this.safeString (ticker, 'bestAskQuantity'),
             'vwap': undefined,
             'open': undefined,
             'close': last,
             'last': last,
             'previousClose': undefined,
-            'change': change,
-            'percentage': undefined,
+            'change': undefined,
+            'percentage': this.safeString (ticker, 'change24h'),
             'average': undefined,
-            'baseVolume': undefined,
+            'baseVolume': this.safeString (ticker, 'amount24h'),
             'quoteVolume': this.safeString (ticker, 'volume24h'),
             'info': ticker,
         }, market);
@@ -638,16 +644,24 @@ export default class latoken extends Exchange {
         };
         const response = await this.publicGetTickerBaseQuote (this.extend (request, params));
         //
-        //     {
-        //         "symbol":"620f2019-33c0-423b-8a9d-cde4d7f8ef7f/0c3a106d-bde3-4c13-a26e-3fd2394529e5",
-        //         "baseCurrency":"620f2019-33c0-423b-8a9d-cde4d7f8ef7f",
-        //         "quoteCurrency":"0c3a106d-bde3-4c13-a26e-3fd2394529e5",
-        //         "volume24h":"76411867.852585600000000000",
-        //         "volume7d":"637809926.759451100000000000",
-        //         "change24h":"2.5300",
-        //         "change7d":"5.1300",
-        //         "lastPrice":"4426.9"
-        //     }
+        //    {
+        //        symbol: '92151d82-df98-4d88-9a4d-284fa9eca49f/0c3a106d-bde3-4c13-a26e-3fd2394529e5',
+        //        baseCurrency: '92151d82-df98-4d88-9a4d-284fa9eca49f',
+        //        quoteCurrency: '0c3a106d-bde3-4c13-a26e-3fd2394529e5',
+        //        volume24h: '165723597.189022176000000000',
+        //        volume7d: '934505768.625109571000000000',
+        //        change24h: '0.0200',
+        //        change7d: '-6.4200',
+        //        amount24h: '6438.457663100000000000',
+        //        amount7d: '35657.785013800000000000',
+        //        lastPrice: '25779.16',
+        //        lastQuantity: '0.248403300000000000',
+        //        bestBid: '25778.74',
+        //        bestBidQuantity: '0.6520232',
+        //        bestAsk: '25779.17',
+        //        bestAskQuantity: '0.4956043',
+        //        updateTimestamp: '1693965231406'
+        //    }
         //
         return this.parseTicker (response, market);
     }
@@ -664,18 +678,26 @@ export default class latoken extends Exchange {
         await this.loadMarkets ();
         const response = await this.publicGetTicker (params);
         //
-        //     [
-        //         {
-        //             "symbol":"DASH/BTC",
-        //             "baseCurrency":"ed75c263-4ab9-494b-8426-031dab1c7cc1",
-        //             "quoteCurrency":"92151d82-df98-4d88-9a4d-284fa9eca49f",
-        //             "volume24h":"1.977753278000000000",
-        //             "volume7d":"18.964342670000000000",
-        //             "change24h":"-1.4800",
-        //             "change7d":"-5.5200",
-        //             "lastPrice":"0.003066"
-        //         },
-        //     ]
+        //    [
+        //        {
+        //            symbol: '92151d82-df98-4d88-9a4d-284fa9eca49f/0c3a106d-bde3-4c13-a26e-3fd2394529e5',
+        //            baseCurrency: '92151d82-df98-4d88-9a4d-284fa9eca49f',
+        //            quoteCurrency: '0c3a106d-bde3-4c13-a26e-3fd2394529e5',
+        //            volume24h: '165723597.189022176000000000',
+        //            volume7d: '934505768.625109571000000000',
+        //            change24h: '0.0200',
+        //            change7d: '-6.4200',
+        //            amount24h: '6438.457663100000000000',
+        //            amount7d: '35657.785013800000000000',
+        //            lastPrice: '25779.16',
+        //            lastQuantity: '0.248403300000000000',
+        //            bestBid: '25778.74',
+        //            bestBidQuantity: '0.6520232',
+        //            bestAsk: '25779.17',
+        //            bestAskQuantity: '0.4956043',
+        //            updateTimestamp: '1693965231406'
+        //        }
+        //    ]
         //
         return this.parseTickers (response, symbols);
     }


### PR DESCRIPTION
fixes: #19105

# Testing

### TS

```
% latoken fetchTicker BTC/USDT
2023-09-06T02:03:52.227Z
Node.js: v18.15.0
CCXT v4.0.83
latoken.fetchTicker (BTC/USDT)
2023-09-06T02:03:58.133Z iteration 0 passed in 1169 ms

{
  symbol: 'BTC/USDT',
  timestamp: 1693965835023,
  datetime: '2023-09-06T02:03:55.023Z',
  low: undefined,
  high: undefined,
  bid: 25779.55,
  bidVolume: 0.786907,
  ask: 25780.01,
  askVolume: 0.6165856,
  vwap: 25739.630095468037,
  open: undefined,
  close: 25780,
  last: 25780,
  previousClose: undefined,
  change: undefined,
  percentage: 0.12,
  average: undefined,
  baseVolume: 6418.0638996,
  quoteVolume: 165198590.70478112,
  info: {
    symbol: '92151d82-df98-4d88-9a4d-284fa9eca49f/0c3a106d-bde3-4c13-a26e-3fd2394529e5',
    baseCurrency: '92151d82-df98-4d88-9a4d-284fa9eca49f',
    quoteCurrency: '0c3a106d-bde3-4c13-a26e-3fd2394529e5',
    volume24h: '165198590.704781110000000000',
    volume7d: '934168809.946038388000000000',
    change24h: '0.1200',
    change7d: '-6.3700',
    amount24h: '6418.063899600000000000',
    amount7d: '35646.290115900000000000',
    lastPrice: '25780.00',
    lastQuantity: '0.031778200000000000',
    bestBid: '25779.55',
    bestBidQuantity: '0.7869070',
    bestAsk: '25780.01',
    bestAskQuantity: '0.6165856',
    updateTimestamp: '1693965835023'
  }
}
2023-09-06T02:03:58.133Z iteration 1 passed in 1169 ms
```

```
2023-09-06T02:06:20.777Z
Node.js: v18.15.0
CCXT v4.0.83
latoken.fetchTickers ()
2023-09-06T02:06:26.694Z iteration 0 passed in 1273 ms

{
  'CTI/USDT': {
    symbol: 'CTI/USDT',
    timestamp: 1693965986276,
    datetime: '2023-09-06T02:06:26.276Z',
    low: undefined,
    high: undefined,
    bid: 0.01181439,
    bidVolume: 564.35,
    ask: 0.01201196,
    askVolume: 1518.22,
    vwap: 0.012179971314932269,
    open: undefined,
    close: 0.01197498,
    last: 0.01197498,
    previousClose: undefined,
    change: undefined,
    percentage: -1.76,
    average: undefined,
    baseVolume: 4623212.65,
    quoteVolume: 56310.597459832,
    info: {
      symbol: 'CTI/USDT',
      baseCurrency: '2e5764ef-14e3-4891-b97a-d5d2478a531f',
      quoteCurrency: '0c3a106d-bde3-4c13-a26e-3fd2394529e5',
      volume24h: '56310.597459832000000000',
      volume7d: '499225.684474877700000000',
      change24h: '-1.7600',
      change7d: '-17.0800',
      amount24h: '4623212.650000000000000000',
      amount7d: '37749947.090000000000000000',
      lastPrice: '0.011974980000000000',
      lastQuantity: '1017.460000000000000000',
      bestBid: '0.01181439',
      bestBidQuantity: '564.35',
      bestAsk: '0.01201196',
      bestAskQuantity: '1518.22',
      updateTimestamp: '1693965986276'
    }
  },
  ...
```

### Python

```
 % py latoken fetchTicker BTC/USDT
Python v3.11.3
CCXT v4.0.83
latoken.fetchTicker(BTC/USDT)
{'ask': 25774.19,
 'askVolume': 0.5953996,
 'average': None,
 'baseVolume': 6419.7072518,
 'bid': 25773.76,
 'bidVolume': 0.6508018,
 'change': None,
 'close': 25774.18,
 'datetime': '2023-09-06T02:05:35.700Z',
 'high': None,
 'info': {'amount24h': '6419.707251800000000000',
          'amount7d': '35650.398454500000000000',
          'baseCurrency': '92151d82-df98-4d88-9a4d-284fa9eca49f',
          'bestAsk': '25774.19',
          'bestAskQuantity': '0.5953996',
          'bestBid': '25773.76',
          'bestBidQuantity': '0.6508018',
          'change24h': '0.0800',
          'change7d': '-6.3500',
          'lastPrice': '25774.18',
          'lastQuantity': '0.302891700000000000',
          'quoteCurrency': '0c3a106d-bde3-4c13-a26e-3fd2394529e5',
          'symbol': '92151d82-df98-4d88-9a4d-284fa9eca49f/0c3a106d-bde3-4c13-a26e-3fd2394529e5',
          'updateTimestamp': '1693965935700',
          'volume24h': '165241085.659281250000000000',
          'volume7d': '934269612.784439762000000000'},
 'last': 25774.18,
 'low': None,
 'open': None,
 'percentage': 0.08,
 'previousClose': None,
 'quoteVolume': 165241085.65928125,
 'symbol': 'BTC/USDT',
 'timestamp': 1693965935700,
 'vwap': 25739.66057610335}
 ```