### PR TITLE
fix(binance): bookTicker swap subscription

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -987,7 +987,17 @@ export default class binance extends binanceRest {
         client.resolve (result, messageHash);
         if (event === 'bookTicker') {
             // watch bookTickers
-            client.resolve ([ result ], '!' + 'bookTicker@arr');
+            client.resolve (result, '!' + 'bookTicker@arr');
+            const messageHashes = this.findMessageHashes (client, 'tickers::');
+            for (let i = 0; i < messageHashes.length; i++) {
+                const messageHash = messageHashes[i];
+                const parts = messageHash.split ('::');
+                const symbolsString = parts[1];
+                const symbols = symbolsString.split (',');
+                if (this.inArray (symbol, symbols)) {
+                    client.resolve (result, messageHash);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19073

```
p  binance watchTickers '["BTC/USDT:USDT","LTC/USDT:USDT"]' '{"name":"bookTicker"}'          
Python v3.10.9
CCXT v4.0.84
binance.watchTickers(['BTC/USDT:USDT', 'LTC/USDT:USDT'],{'name': 'bookTicker'})
{'ask': 62.9,
 'askVolume': 45.249,
 'average': None,
 'baseVolume': None,
 'bid': 62.89,
 'bidVolume': 244.097,
 'change': None,
 'close': None,
 'datetime': '2023-09-06T14:37:07.627Z',
 'high': None,
 'info': {'A': '45.249',
          'B': '244.097',
          'E': 1694011027627,
          'T': 1694011027624,
          'a': '62.90',
          'b': '62.89',
          'e': 'bookTicker',
          's': 'LTCUSDT',
          'u': 3238960940930},
 'last': None,
 'low': None,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'LTC/USDT:USDT',
 'timestamp': 1694011027627,
 'vwap': None}
{'ask': 62.9,
 'askVolume': 45.247,
 'average': None,
 'baseVolume': None,
 'bid': 62.89,
 'bidVolume': 244.097,
 'change': None,
 'close': None,
 'datetime': '2023-09-06T14:37:07.654Z',
 'high': None,
 'info': {'A': '45.247',
          'B': '244.097',
          'E': 1694011027654,
          'T': 1694011027648,
          'a': '62.90',
          'b': '62.89',
          'e': 'bookTicker',
          's': 'LTCUSDT',
          'u': 3238960941689},
 'last': None,
 'low': None,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'LTC/USDT:USDT',
 'timestamp': 1694011027654,
 'vwap': None}
```
```
p binance watchTickers '["BTC/USDT","LTC/USDT"]' '{"name":"bookTicker"}'                    
Python v3.10.9
CCXT v4.0.84
binance.watchTickers(['BTC/USDT', 'LTC/USDT'],{'name': 'bookTicker'})
{'ask': 25614.25,
 'askVolume': 8.78884,
 'average': None,
 'baseVolume': None,
 'bid': 25614.24,
 'bidVolume': 1.3771,
 'change': None,
 'close': None,
 'datetime': '2023-09-06T14:37:48.752Z',
 'high': None,
 'info': {'A': '8.78884000',
          'B': '1.37710000',
          'a': '25614.25000000',
          'b': '25614.24000000',
          's': 'BTCUSDT',
          'u': 38671859398},
 'last': None,
 'low': None,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1694011068752,
 'vwap': None}
{'ask': 25614.25,
 'askVolume': 8.78884,
 'average': None,
 'baseVolume': None,
 'bid': 25614.24,
 'bidVolume': 1.37759,
 'change': None,
 'close': None,
 'datetime': '2023-09-06T14:37:48.766Z',
 'high': None,
 'info': {'A': '8.78884000',
          'B': '1.37759000',
          'a': '25614.25000000',
          'b': '25614.24000000',
          's': 'BTCUSDT',
          'u': 38671859401},
 'last': None,
 'low': None,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1694011068766,
 'vwap': None}
```
