### PR TITLE
Composer - remove extra (QUICK)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -243,14 +243,7 @@
         "react/promise": "^2.9.0",
         "react/promise-timer": "^1.10"
     },
-    "suggest": {
-        "recoil/recoil": "Required for asynchronous API calls to exchanges with PHP",
-        "recoil/react": "Required for asynchronous API calls to exchanges with PHP",
-        "react/http": "Required for asynchronous API calls to exchanges with PHP",
-        "clue/buzz-react": "Required for asynchronous API calls to exchanges with PHP",
-        "react/event-loop": "Required for asynchronous API calls to exchanges with PHP",
-        "clue/http-proxy-react": "Required for using a proxy when doing asynchronous API calls to exchanges with PHP"
-    },
+    "suggest": { },
     "archive": {
         "exclude": [
             "/build",

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -102,10 +102,11 @@ class Exchange extends \ccxt\Exchange {
                 $request_browser_options = array( 'tcp' => $proxy, 'dns' => false );
                 $this->set_request_browser($request_browser_options);
             } else if ($socksProxy !== null) {
-                if (!class_exists('\Clue\React\Socks\Client')) {
+                $className = '\\Clue\\React\\Socks\\Client';
+                if (!class_exists($className)) {
                     throw new NotSupported($this->id . ' - to use SOCKS proxy with ccxt, at first you need install module "composer require clue/socks-react"');
                 }
-                $proxy = new \Clue\React\Socks\Client($socksProxy);
+                $proxy = new $className($socksProxy);
                 $request_browser_options = array( 'tcp' => $proxy, 'dns' => false );
                 $this->set_request_browser($request_browser_options);
             }

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1481,10 +1481,7 @@ asyncio.run(print_poloniex_ethbtc_ticker())
 
 ### PHP
 
-In the PHP 5-compatible version all API methods are synchronous, but with PHP 7.1+ the CCXT library optionally supports asynchronous concurrency mode using the 'yield' syntax (very similar to async/await in Python). The asynchronous PHP version uses the [RecoilPHP](https://github.com/recoilphp/recoil), [ReactPHP](https://reactphp.org/) and [clue/reactphp-buzz](https://github.com/clue/reactphp-buzz) libraries. In async mode you have all the same properties and methods, but any networking API method should be decorated with the `yield` keyword, your script should be in a ReactPHP/RecoilPHP wrapper, and all exchange constructors need to be passed the loop and kernel instances from the wrapper.
-
-To use the async version of the library, use the `ccxt_async` namespace, as in the following example:
-
+CCXT support PHP 8+ versions. The library has both synchronous and asynchronous versions. To use synchronous version, use `\ccxt` namespace (i.e. `new ccxt\binance()`) and to use asynchronous version, use `\ccxt\async` namespace (i.e. `new ccxt\async\binance()`). Asynchronous version uses [ReactPHP](https://reactphp.org/) library in the background. In async mode you have all the same properties and methods, but any networking API method should be decorated with the `\React\Async\await` keyword and your script should be in a ReactPHP wrapper:
 ```php
 // PHP
 <?php


### PR DESCRIPTION

- removed extra packages:
- - `recoil` packages are not needed anymore;
- - `react/http` is already inlcudede in `dependencies`;
- - `clue/buzz-react` - idk, but now it doesn't seem to be used anywhere. if any dependency uses it, it will be installed as sub/dependency by that package. ccxt no longer uses it directly
- - `react/event-loop` is already requirement for `react/async` dependency, so no need to be suggested at all.
- - `clue/http-proxy-react` is not needed to be installed, because we have it in static_dependencies.

- edited manual (was too much obsolete)
- edited dynamic class instantiation (because, without it, linter warned: https://imgsh.net/a/dPAsmoE.png )