### PR TITLE
feat(kucoin) - triggerPriceType (QUICK)

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -1138,11 +1138,18 @@ export default class kucoinfutures extends kucoin {
             'leverage': 1,
         };
         const [ triggerPrice, stopLossPrice, takeProfitPrice ] = this.handleTriggerPrices (params);
+        const triggerPriceTypes = {
+            'mark': 'MP',
+            'last': 'TP',
+            'index': 'IP',
+        };
+        const triggerPriceType = this.safeString (params, 'triggerPriceType', 'mark');
+        const triggerPriceTypeValue = this.safeString (triggerPriceTypes, triggerPriceType, triggerPriceType);
         params = this.omit (params, [ 'stopLossPrice', 'takeProfitPrice', 'triggerPrice', 'stopPrice' ]);
         if (triggerPrice) {
             request['stop'] = (side === 'buy') ? 'up' : 'down';
             request['stopPrice'] = this.priceToPrecision (symbol, triggerPrice);
-            request['stopPriceType'] = 'MP';
+            request['stopPriceType'] = triggerPriceTypeValue;
         } else if (stopLossPrice || takeProfitPrice) {
             if (stopLossPrice) {
                 request['stop'] = (side === 'buy') ? 'up' : 'down';
@@ -1152,7 +1159,7 @@ export default class kucoinfutures extends kucoin {
                 request['stopPrice'] = this.priceToPrecision (symbol, takeProfitPrice);
             }
             request['reduceOnly'] = true;
-            request['stopPriceType'] = 'MP';
+            request['stopPriceType'] = triggerPriceTypeValue;
         }
         const uppercaseType = type.toUpperCase ();
         const timeInForce = this.safeStringUpper (params, 'timeInForce');


### PR DESCRIPTION
added `triggerPriceType` param ( https://docs.kucoin.com/futures/#place-an-order:~:text=above%20the%20stopPrice.-,stopPriceType%3A,-There%20are%20three )

```
.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1, 2000, {triggerPrice: 1980} );
```
![img](https://imgsh.net/i/PZwo88B.png)

```
.createOrder('ETH/USDT:USDT', 'limit', 'buy', 1, 2000, {triggerPrice: 1980, triggerPriceType: 'index'} );
```
![img](https://imgsh.net/i/C7AnKmK.png)