### PR TITLE
fetchUnderlyingAssets: new options method

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -108,6 +108,7 @@ export default class binance extends Exchange {
                 'fetchTransactionFees': true,
                 'fetchTransactions': false,
                 'fetchTransfers': true,
+                'fetchUnderlyingAssets': false,
                 'fetchVolatilityHistory': false,
                 'fetchWithdrawal': false,
                 'fetchWithdrawals': true,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -89,6 +89,7 @@ export default class bybit extends Exchange {
                 'fetchTradingFees': true,
                 'fetchTransactions': false,
                 'fetchTransfers': true,
+                'fetchUnderlyingAssets': false,
                 'fetchVolatilityHistory': true,
                 'fetchWithdrawals': true,
                 'setLeverage': true,

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -84,6 +84,7 @@ export default class cryptocom extends Exchange {
                 'fetchTransactionFees': false,
                 'fetchTransactions': false,
                 'fetchTransfers': true,
+                'fetchUnderlyingAssets': false,
                 'fetchVolatilityHistory': false,
                 'fetchWithdrawals': true,
                 'reduceMargin': false,

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -72,6 +72,7 @@ export default class delta extends Exchange {
                 'fetchTrades': true,
                 'fetchTransfer': undefined,
                 'fetchTransfers': undefined,
+                'fetchUnderlyingAssets': false,
                 'fetchVolatilityHistory': false,
                 'fetchWithdrawal': undefined,
                 'fetchWithdrawals': undefined,

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -85,6 +85,7 @@ export default class deribit extends Exchange {
                 'fetchTransactions': false,
                 'fetchTransfer': false,
                 'fetchTransfers': true,
+                'fetchUnderlyingAssets': false,
                 'fetchVolatilityHistory': true,
                 'fetchWithdrawal': false,
                 'fetchWithdrawals': true,

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -6264,19 +6264,22 @@ export default class gate extends Exchange {
         return await this.privateFuturesPostSettleDualMode (this.extend (request, query));
     }
 
-    async fetchUnderlyingAssets (params = {}) {
+    async fetchUnderlyingAssets (marketType: string = undefined, params = {}) {
         /**
          * @method
          * @name gate#fetchUnderlyingAssets
          * @description fetches the market ids of underlying assets for different derivative types
          * @see https://www.gate.io/docs/developers/apiv4/en/#list-all-underlyings
+         * @param {string|undefined} marketType the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @param {object} [params] exchange specific params
          * @returns {object[]} a list of [underlying assets]{@link https://github.com/ccxt/ccxt/wiki/Manual#underlying-assets-structure}
          */
         await this.loadMarkets ();
-        let type = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
-        if (type !== 'option') {
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
+        if ((marketType === undefined) || (marketType === 'spot')) {
+            marketType = 'option';
+        }
+        if (marketType !== 'option') {
             throw new NotSupported (this.id + ' fetchUnderlyingAssets() supports option markets only');
         }
         const response = await this.publicOptionsGetUnderlyings (params);

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -6264,17 +6264,17 @@ export default class gate extends Exchange {
         return await this.privateFuturesPostSettleDualMode (this.extend (request, query));
     }
 
-    async fetchUnderlyingAssets (marketType: string = undefined, params = {}) {
+    async fetchUnderlyingAssets (params = {}) {
         /**
          * @method
          * @name gate#fetchUnderlyingAssets
          * @description fetches the market ids of underlying assets for a specific contract market type
-         * @see https://www.gate.io/docs/developers/apiv4/en/#list-all-underlyings
-         * @param {string|undefined} marketType the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @param {object} [params] exchange specific params
+         * @param {string} [params.type] the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @returns {object[]} a list of [underlying assets]{@link https://github.com/ccxt/ccxt/wiki/Manual#underlying-assets-structure}
          */
         await this.loadMarkets ();
+        let marketType = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
         if ((marketType === undefined) || (marketType === 'spot')) {
             marketType = 'option';

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -6268,7 +6268,7 @@ export default class gate extends Exchange {
         /**
          * @method
          * @name gate#fetchUnderlyingAssets
-         * @description fetches the market ids of underlying assets for different derivative types
+         * @description fetches the market ids of underlying assets for a specific contract market type
          * @see https://www.gate.io/docs/developers/apiv4/en/#list-all-underlyings
          * @param {string|undefined} marketType the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @param {object} [params] exchange specific params

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -6271,7 +6271,7 @@ export default class gate extends Exchange {
          * @description fetches the market ids of underlying assets for different derivative types
          * @see https://www.gate.io/docs/developers/apiv4/en/#list-all-underlyings
          * @param {object} [params] exchange specific params
-         * @returns {object[]} a list of [underlying assets objects]
+         * @returns {object[]} a list of [underlying assets]{@link https://github.com/ccxt/ccxt/wiki/Manual#underlying-assets-structure}
          */
         await this.loadMarkets ();
         let type = undefined;

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -109,6 +109,7 @@ export default class okx extends Exchange {
                 'fetchTransactions': false,
                 'fetchTransfer': true,
                 'fetchTransfers': true,
+                'fetchUnderlyingAssets': true,
                 'fetchVolatilityHistory': false,
                 'fetchWithdrawal': true,
                 'fetchWithdrawals': true,
@@ -6734,6 +6735,38 @@ export default class okx extends Exchange {
             }
         }
         return result;
+    }
+
+    async fetchUnderlyingAssets (params = {}) {
+        /**
+         * @method
+         * @name okx#fetchUnderlyingAssets
+         * @description fetches the market ids of underlying assets for different derivative types
+         * @see https://www.okx.com/docs-v5/en/#public-data-rest-api-get-underlying
+         * @param {object} [params] exchange specific params
+         * @returns {object[]} a list of [underlying assets]
+         */
+        await this.loadMarkets ();
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
+        const request = {
+            'instType': this.convertToInstrumentType (type),
+        };
+        const response = await this.publicGetPublicUnderlying (this.extend (request, params));
+        //
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             [
+        //                 "BTC-USD",
+        //                 "ETH-USD"
+        //             ]
+        //         ],
+        //         "msg": ""
+        //     }
+        //
+        const underlyings = this.safeValue (response, 'data', []);
+        return underlyings[0];
     }
 
     handleErrors (httpCode, reason, url, method, headers, body, response, requestHeaders, requestBody) {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6744,7 +6744,7 @@ export default class okx extends Exchange {
          * @description fetches the market ids of underlying assets for different derivative types
          * @see https://www.okx.com/docs-v5/en/#public-data-rest-api-get-underlying
          * @param {object} [params] exchange specific params
-         * @returns {object[]} a list of [underlying assets]
+         * @returns {object[]} a list of [underlying assets]{@link https://github.com/ccxt/ccxt/wiki/Manual#underlying-assets-structure}
          */
         await this.loadMarkets ();
         let type = undefined;

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6741,7 +6741,7 @@ export default class okx extends Exchange {
         /**
          * @method
          * @name okx#fetchUnderlyingAssets
-         * @description fetches the market ids of underlying assets for different derivative types
+         * @description fetches the market ids of underlying assets for a specific contract market type
          * @see https://www.okx.com/docs-v5/en/#public-data-rest-api-get-underlying
          * @param {string|undefined} marketType the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @param {object} [params] exchange specific params

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6737,20 +6737,26 @@ export default class okx extends Exchange {
         return result;
     }
 
-    async fetchUnderlyingAssets (params = {}) {
+    async fetchUnderlyingAssets (marketType: string = undefined, params = {}) {
         /**
          * @method
          * @name okx#fetchUnderlyingAssets
          * @description fetches the market ids of underlying assets for different derivative types
          * @see https://www.okx.com/docs-v5/en/#public-data-rest-api-get-underlying
+         * @param {string|undefined} marketType the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @param {object} [params] exchange specific params
          * @returns {object[]} a list of [underlying assets]{@link https://github.com/ccxt/ccxt/wiki/Manual#underlying-assets-structure}
          */
         await this.loadMarkets ();
-        let type = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
+        if ((marketType === undefined) || (marketType === 'spot')) {
+            marketType = 'option';
+        }
+        if ((marketType !== 'option') && (marketType !== 'swap') && (marketType !== 'future')) {
+            throw new NotSupported (this.id + ' fetchUnderlyingAssets() supports contract markets only');
+        }
         const request = {
-            'instType': this.convertToInstrumentType (type),
+            'instType': this.convertToInstrumentType (marketType),
         };
         const response = await this.publicGetPublicUnderlying (this.extend (request, params));
         //

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6737,17 +6737,18 @@ export default class okx extends Exchange {
         return result;
     }
 
-    async fetchUnderlyingAssets (marketType: string = undefined, params = {}) {
+    async fetchUnderlyingAssets (params = {}) {
         /**
          * @method
          * @name okx#fetchUnderlyingAssets
          * @description fetches the market ids of underlying assets for a specific contract market type
          * @see https://www.okx.com/docs-v5/en/#public-data-rest-api-get-underlying
-         * @param {string|undefined} marketType the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @param {object} [params] exchange specific params
+         * @param {string} [params.type] the contract market type, 'option', 'swap' or 'future', the default is 'option'
          * @returns {object[]} a list of [underlying assets]{@link https://github.com/ccxt/ccxt/wiki/Manual#underlying-assets-structure}
          */
         await this.loadMarkets ();
+        let marketType = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchUnderlyingAssets', undefined, params);
         if ((marketType === undefined) || (marketType === 'spot')) {
             marketType = 'option';

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1592,6 +1592,7 @@ The unified ccxt API is a subset of methods common among the exchanges. It curre
 - `fetchMyTrades ([symbol[, since[, limit[, params]]]])`
 - `fetchOpenInterest ([symbol[, params]])`
 - `fetchVolatilityHistory ([code[, params]])`
+- `fetchUnderlyingAssets ()`
 - ...
 
 ```text
@@ -1899,6 +1900,7 @@ if ($exchange->has['fetchMyTrades']) {
 - [Funding Rate History](#funding-rate-history)
 - [Open Interest History](#open-interest-history)
 - [Volatility History](#volatility-history)
+- [Underlying Assets](#underlying-assets)
 
 ## Order Book
 
@@ -2934,6 +2936,30 @@ Returns
     datetime: '2023-07-28T00:50:00.000Z',
     volatility: 0.23854072,
 }
+```
+
+## Underlying Assets
+
+*contract only*
+
+Use the `fetchUnderlyingAssets` method to get the market id's of underlying assets for a derivative contract type from the exchange.
+
+```javascript
+fetchUnderlyingAssets (params = {})
+```
+
+Parameters
+
+- **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"instType": "OPTION"}`)
+
+Returns
+
+- An [underlying assets structure](#underlying-assets-structure)
+
+### Underlying Assets Structure
+
+```javascript
+[ 'BTC_USDT', 'ETH_USDT', 'DOGE_USDT' ]
 ```
 
 # Private API

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2945,13 +2945,13 @@ Returns
 Use the `fetchUnderlyingAssets` method to get the market id's of underlying assets for a contract market type from the exchange.
 
 ```javascript
-fetchUnderlyingAssets (marketType = undefined, params = {})
+fetchUnderlyingAssets (params = {})
 ```
 
 Parameters
 
-- **marketType** (String) Unified marketType, the default is 'option' (e.g. `"option"`)
 - **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"instType": "OPTION"}`)
+- **params.type** (String) Unified marketType, the default is 'option' (e.g. `"option"`)
 
 Returns
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2942,14 +2942,15 @@ Returns
 
 *contract only*
 
-Use the `fetchUnderlyingAssets` method to get the market id's of underlying assets for a derivative contract type from the exchange.
+Use the `fetchUnderlyingAssets` method to get the market id's of underlying assets for a contract market type from the exchange.
 
 ```javascript
-fetchUnderlyingAssets (params = {})
+fetchUnderlyingAssets (marketType = undefined, params = {})
 ```
 
 Parameters
 
+- **marketType** (String) Unified marketType, the default is 'option' (e.g. `"option"`)
 - **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"instType": "OPTION"}`)
 
 Returns


### PR DESCRIPTION
Added a new options related method `fetchUnderlyingAssets` to multiple exchanges:

### Gate:
```
gate.fetchUnderlyingAssets ()
2023-09-07T02:42:44.633Z iteration 0 passed in 222 ms

[ 'BTC_USDT', 'ETH_USDT', 'DOGE_USDT' ]
3 objects
```

### Okx:
```
okx.fetchUnderlyingAssets ()
2023-09-07T02:44:46.155Z iteration 0 passed in 378 ms

[ 'BTC-USD', 'ETH-USD' ]
2 objects
```