### PR TITLE
feat(exmo): fetchOrderTrades - margin

### DIFF
--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -1188,6 +1188,19 @@ export default class exmo extends Exchange {
         //         "commission_percent": "0.2"
         //     }
         //
+        // margin
+        //
+        //    {
+        //        "is_maker": false,
+        //        "order_id": "123",
+        //        "pair": "BTC_USD",
+        //        "price": "54122.25",
+        //        "quantity": "0.00069994",
+        //        "trade_dt": "1619069561718824428",
+        //        "trade_id": "692842802860135010",
+        //        "type": "sell"
+        //    }
+        //
         const timestamp = this.safeTimestamp (trade, 'date');
         const id = this.safeString (trade, 'trade_id');
         const orderId = this.safeString (trade, 'order_id');
@@ -1199,7 +1212,12 @@ export default class exmo extends Exchange {
         const marketId = this.safeString (trade, 'pair');
         market = this.safeMarket (marketId, market, '_');
         const symbol = market['symbol'];
-        const takerOrMaker = this.safeString (trade, 'exec_type');
+        const isMaker = this.safeValue (trade, 'is_maker');
+        let takerOrMakerDefault = undefined;
+        if (isMaker !== undefined) {
+            takerOrMakerDefault = isMaker ? 'maker' : 'taker';
+        }
+        const takerOrMaker = this.safeString (trade, 'exec_type', takerOrMakerDefault);
         let fee = undefined;
         const feeCostString = this.safeString (trade, 'commission_amount');
         if (feeCostString !== undefined) {
@@ -1442,13 +1460,21 @@ export default class exmo extends Exchange {
          * @method
          * @name exmo#fetchOrderTrades
          * @description fetch all the trades made from a single order
+         * @see https://documenter.getpostman.com/view/10287440/SzYXWKPi#cf27781e-28e5-4b39-a52d-3110f5d22459  // spot
+         * @see https://documenter.getpostman.com/view/10287440/SzYXWKPi#00810661-9119-46c5-aec5-55abe9cb42c7  // margin
          * @param {string} id order id
          * @param {string} symbol unified market symbol
          * @param {int} [since] the earliest time in ms to fetch trades for
          * @param {int} [limit] the maximum number of trades to retrieve
          * @param {object} [params] extra parameters specific to the exmo api endpoint
+         * @param {string} [params.marginMode] set to "isolated" to fetch trades for a margin order
          * @returns {object[]} a list of [trade structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#trade-structure}
          */
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchOrderTrades', params);
+        if (marginMode === 'cross') {
+            throw new BadRequest (this.id + ' only supports isolated margin');
+        }
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -1456,32 +1482,53 @@ export default class exmo extends Exchange {
         const request = {
             'order_id': id.toString (),
         };
-        const response = await this.privatePostOrderTrades (this.extend (request, params));
-        //
-        //     {
-        //         "type": "buy",
-        //         "in_currency": "BTC",
-        //         "in_amount": "1",
-        //         "out_currency": "USD",
-        //         "out_amount": "100",
-        //         "trades": [
-        //             {
-        //                 "trade_id": 3,
-        //                 "date": 1435488248,
-        //                 "type": "buy",
-        //                 "pair": "BTC_USD",
-        //                 "order_id": 12345,
-        //                 "quantity": 1,
-        //                 "price": 100,
-        //                 "amount": 100,
-        //                 "exec_type": "taker",
-        //                 "commission_amount": "0.02",
-        //                 "commission_currency": "BTC",
-        //                 "commission_percent": "0.2"
-        //             }
-        //         ]
-        //     }
-        //
+        let response = undefined;
+        if (marginMode === 'isolated') {
+            response = await this.privatePostMarginUserOrderTrades (this.extend (request, params));
+            //
+            //    {
+            //        "trades": [
+            //            {
+            //                "is_maker": false,
+            //                "order_id": "123",
+            //                "pair": "BTC_USD",
+            //                "price": "54122.25",
+            //                "quantity": "0.00069994",
+            //                "trade_dt": "1619069561718824428",
+            //                "trade_id": "692842802860135010",
+            //                "type": "sell"
+            //            }
+            //        ]
+            //    }
+            //
+        } else {
+            response = await this.privatePostOrderTrades (this.extend (request, params));
+            //
+            //     {
+            //         "type": "buy",
+            //         "in_currency": "BTC",
+            //         "in_amount": "1",
+            //         "out_currency": "USD",
+            //         "out_amount": "100",
+            //         "trades": [
+            //             {
+            //                 "trade_id": 3,
+            //                 "date": 1435488248,
+            //                 "type": "buy",
+            //                 "pair": "BTC_USD",
+            //                 "order_id": 12345,
+            //                 "quantity": 1,
+            //                 "price": 100,
+            //                 "amount": 100,
+            //                 "exec_type": "taker",
+            //                 "commission_amount": "0.02",
+            //                 "commission_currency": "BTC",
+            //                 "commission_percent": "0.2"
+            //             }
+            //         ]
+            //     }
+            //
+        }
         const trades = this.safeValue (response, 'trades');
         return this.parseTrades (trades, market, since, limit);
     }


### PR DESCRIPTION
```
2023-09-07T18:59:41.793Z
Node.js: v18.15.0
CCXT v4.0.85
exmo.fetchOrderTrades (36689686299)
2023-09-07T18:59:45.648Z iteration 0 passed in 533 ms

       id |     timestamp |                 datetime |   symbol |       order | type | side | takerOrMaker |      price |     amount |       cost |                                                fee |                                                 fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
511920751 | 1694112946000 | 2023-09-07T18:55:46.000Z | ADA/USDT | 36689686299 |      |  buy |        taker | 0.25630994 | 8.07509891 | 2.06972811 | {"cost":0.01615019,"currency":"ADA","rate":0.0002} | [{"cost":0.01615019,"currency":"ADA","rate":0.0002}]
511920752 | 1694112946000 | 2023-09-07T18:55:46.000Z | ADA/USDT | 36689686299 |      |  buy |        taker | 0.25630995 | 1.92490109 |  0.4933713 |  {"cost":0.0038498,"currency":"ADA","rate":0.0002} |  [{"cost":0.0038498,"currency":"ADA","rate":0.0002}]
2 objects
2023-09-07T18:59:45.648Z iteration 1 passed in 533 ms
```

```
% exmo fetchOrderTrades '"692862104567883146"' undefined undefined undefined '{"marginMode": "isolated"}'
(node:7810) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-09-07T19:06:03.295Z
Node.js: v18.15.0
CCXT v4.0.85
exmo.fetchOrderTrades (692862104567883146, , , , [object Object])
2023-09-07T19:06:07.097Z iteration 0 passed in 516 ms

                id | timestamp | datetime |   symbol |              order | type | side | takerOrMaker |      price | amount |      cost | fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------
692862104567883420 |           |          | ADA/USDT | 692862104567883146 |      |  buy |        taker | 0.25634001 |     10 | 2.5634001 |     |   []
1 objects
2023-09-07T19:06:07.097Z iteration 1 passed in 516 ms
```

```
% py exmo fetchOrderTrades '692862104567883146' None None None '{"marginMode": "isolated"}'          
Python v3.11.3
CCXT v4.0.85
exmo.fetchOrderTrades(692862104567883146,None,None,None,{'marginMode': 'isolated'})
[{'amount': 10.0,
  'cost': 2.5634001,
  'datetime': None,
  'fee': None,
  'fees': [],
  'id': '692862104567883420',
  'info': {'amount': '2.5634001',
           'is_maker': False,
           'order_id': '692862104567883146',
           'pair': 'ADA_USDT',
           'price': '0.25634001',
           'quantity': '10',
           'trade_dt': '1694113427012648401',
           'trade_id': '692862104567883420',
           'type': 'buy'},
  'order': '692862104567883146',
  'price': 0.25634001,
  'side': 'buy',
  'symbol': 'ADA/USDT',
  'takerOrMaker': 'taker',
  'timestamp': None,
  'type': None}]
  ```