### PR TITLE
feat(tests) - better output

### DIFF
--- a/php/test/test_async.php
+++ b/php/test/test_async.php
@@ -12,14 +12,17 @@ use React\Promise;
 
 assert_options (ASSERT_CALLBACK, function(){
     $args = func_get_args();
+    $message = '';
     try {
         $file = $args[0];
         $line = $args[1];
-        $message = $args[3];
-        var_dump("[ASSERT_ERROR] - $message [ $file : $line ]");
+        $assert_message = $args[3];
+        $message = "[ASSERT_ERROR] - [ $file : $line ] $message";
     } catch (\Exception $exc) {
-        var_dump("[ASSERT_ERROR] -" . json_encode($args));
+        $message = "[ASSERT_ERROR] -" . json_encode($args);
     }
+    $message = substr($message, 0, 1000);
+    var_dump($message);
     exit;
 });
 
@@ -100,7 +103,8 @@ function exception_message($exc) {
             $output .= "\n";
         }
     }
-    return '[' . get_class($exc) . '] ' . $output . "\n\n";
+    $message = '[' . get_class($exc) . '] ' . $output . "\n\n";
+    return substr($message, 0, 1000);
 }
 
 

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -69,7 +69,7 @@ Error = Exception
 
 
 def handle_all_unhandled_exceptions(type, value, traceback):
-    dump((type), (value), '\n\n' + ('\n'.join(format_tb(traceback))))
+    dump((type), (value), '\n<UNHANDLED EXCEPTION>\n' + ('\n'.join(format_tb(traceback))))
     exit(1)  # unrecoverable crash
 
 
@@ -129,7 +129,11 @@ async def call_method(testFiles, methodName, exchange, skippedProperties, args):
 
 
 def exception_message(exc):
-    return '[' + type(exc).__name__ + '] ' + "".join(format_exception(type(exc), exc, exc.__traceback__, limit=6))
+    message = '[' + type(exc).__name__ + '] ' + "".join(format_exception(type(exc), exc, exc.__traceback__, limit=6))
+    if len(message) > 1000:
+        # Accessing out of range element causes error
+        message = message[0:1000]
+    return message
 
 
 def exit_script():

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -9,10 +9,10 @@ import errorsHierarchy from '../base/errorHierarchy.js';
 // js specific codes //
 const __dirname = fileURLToPath (new URL ('.', import.meta.url));
 process.on ('uncaughtException', (e) => {
-    console.log (e, e.stack); process.exit (1);
+    console.log (e, '<UNHANDLED EXCEPTION>', e.stack); process.exit (1);
 });
 process.on ('unhandledRejection', (e: any) => {
-    console.log (e, e.stack); process.exit (1);
+    console.log (e, '<UNHANDLED REJECTION>', e.stack); process.exit (1);
 });
 const [ processPath, , exchangeId = null, exchangeSymbol = undefined ] = process.argv.filter ((x) => !x.startsWith ('--'));
 const AuthenticationError = ccxt.AuthenticationError;
@@ -67,7 +67,7 @@ async function callMethod (testFiles, methodName, exchange, skippedProperties, a
 }
 
 function exceptionMessage (exc) {
-    return '[' + exc.constructor.name + '] ' + exc.message.slice (0, 500);
+    return '[' + exc.constructor.name + '] ' + exc.stack.slice (0, 1000);
 }
 
 function exitScript () {


### PR DESCRIPTION
fixed imperfections of tests. during last 6 months or so, after we have unified tests & logs, I have concluded that we needed to raise the failed tests output from 500 chars to 1000 chars definitely.

also, corrected php/js/py minor output params