### PR TITLE
fix(bitget): fetchBalance, adjust swap free balance

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2574,6 +2574,8 @@ export default class bitget extends Exchange {
         /**
          * @method
          * @name bitget#fetchBalance
+         * @see https://bitgetlimited.github.io/apidoc/en/spot/#get-account-assets
+         * @see https://bitgetlimited.github.io/apidoc/en/mix/#get-account-list
          * @description query for balance and get the amount of funds available for trading or funds locked in orders
          * @param {object} [params] extra parameters specific to the bitget api endpoint
          * @returns {object} a [balance structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#balance-structure}
@@ -2639,13 +2641,32 @@ export default class bitget extends Exchange {
     parseBalance (balance) {
         const result = { 'info': balance };
         //
+        // spot
+        //
         //     {
-        //       coinId: '1',
-        //       coinName: 'BTC',
-        //       available: '0.00099900',
-        //       frozen: '0.00000000',
-        //       lock: '0.00000000',
-        //       uTime: '1661595535000'
+        //         coinId: '1',
+        //         coinName: 'BTC',
+        //         available: '0.00099900',
+        //         frozen: '0.00000000',
+        //         lock: '0.00000000',
+        //         uTime: '1661595535000'
+        //     }
+        //
+        // swap
+        //
+        //     {
+        //         marginCoin: 'BTC',
+        //         locked: '0.00001948',
+        //         available: '0.00006622',
+        //         crossMaxAvailable: '0.00004674',
+        //         fixedMaxAvailable: '0.00004674',
+        //         maxTransferOut: '0.00004674',
+        //         equity: '0.00006622',
+        //         usdtEquity: '1.734307497491',
+        //         btcEquity: '0.000066229058',
+        //         crossRiskRate: '0.066308887072',
+        //         unrealizedPL: '0',
+        //         bonus: '0'
         //     }
         //
         for (let i = 0; i < balance.length; i++) {
@@ -2653,10 +2674,12 @@ export default class bitget extends Exchange {
             const currencyId = this.safeString2 (entry, 'coinName', 'marginCoin');
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
+            const spotAccountFree = this.safeString (entry, 'available');
+            const contractAccountFree = this.safeString (entry, 'maxTransferOut');
+            account['free'] = (contractAccountFree !== undefined) ? contractAccountFree : spotAccountFree;
             const frozen = this.safeString (entry, 'frozen');
             const locked = this.safeString2 (entry, 'lock', 'locked');
             account['used'] = Precise.stringAdd (frozen, locked);
-            account['free'] = this.safeString (entry, 'available');
             result[code] = account;
         }
         return this.safeBalance (result);


### PR DESCRIPTION
This PR adjusts the swap balances for fetchBalance on Bitget by using a different `'free'` value, the previous version returned incorrect values for swap balances.

There's some unusual behavior if you have an open position compared to if you have an open order.
If you have an open position the interface shows your total amount including your unrealized PNL and it shows the frozen amount to be 0. My current implementation doesn't consider the unrealized PNL so the fetchBalance response will differ from the `Account assets` field in the interface when there's open positions.

closes: #19119

### Open Orders:
![Screenshot 2023-09-07](https://github.com/ccxt/ccxt/assets/83686770/a2c31c20-d236-4a8f-8015-0ceef09850e8)
```
bitget.fetchBalance ()
2023-09-07T23:43:37.117Z iteration 0 passed in 302 ms

{
  info: [
    {
      marginCoin: 'BTC',
      locked: '0.00001948',
      available: '0.00006622',
      crossMaxAvailable: '0.00004674',
      fixedMaxAvailable: '0.00004674',
      maxTransferOut: '0.00004674',
      equity: '0.00006622',
      usdtEquity: '1.73392018141',
      btcEquity: '0.000066229058',
      crossRiskRate: '0.066323698884',
      unrealizedPL: '0',
      bonus: '0'
    },
    ...
  ],
  BTC: { free: 0.00004674, used: 0.00001948, total: 0.00006622 },
  ...
  free: {
    BTC: 0.00004674,
    ...
  },
  used: {
    BTC: 0.00001948,
    ...
  },
  total: {
    BTC: 0.00006622,
    ...
  }
}
```

### Active Open Positions:
![Screenshot open position](https://github.com/ccxt/ccxt/assets/83686770/62c93b15-876d-4d66-a315-5b9a8ea267c5)
```
bitget.fetchBalance ()
2023-09-08T04:08:02.460Z iteration 0 passed in 316 ms

{
  info: [
    {
      marginCoin: 'BTC',
      locked: '0',
      available: '0.00034604',
      crossMaxAvailable: '0.00034604',
      fixedMaxAvailable: '0.00034604',
      maxTransferOut: '0.00034604',
      equity: '0.00036736',
      usdtEquity: '9.660211052811',
      btcEquity: '0.000367367661',
      crossRiskRate: '0',
      unrealizedPL: '0.0457',
      bonus: '0'
    },
    ...
  ],
  BTC: { free: 0.00034604, used: 0, total: 0.00034604 },
  ...
  free: {
    BTC: 0.00034604,
    ...
  },
  used: {
    BTC: 0,
    ...
  },
  total: {
    BTC: 0.00034604,
    ...
  }
}
```