### PR TITLE
fix(exchange.php): is empty return true for countable objects with length 0

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -839,7 +839,7 @@ class Exchange {
     }
 
     public static function is_empty($object) {
-        return empty($object);
+        return empty($object) || count($object) === 0;
     }
 
     public static function keysort($array) {


### PR DESCRIPTION
Problem:
is_empty was returning false for countable objects with length 0, for example ArrayCache