### PR TITLE
fix(kucoin): include trades in order and fix #19083

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -633,7 +633,7 @@ export default class kucoin extends kucoinRest {
             'cost': undefined,
             'average': undefined,
             'filled': filled,
-            'remaining': undefined,
+            'remaining': this.safeNumber (order, 'remainSize'),
             'status': status,
             'fee': undefined,
             'trades': trades,


### PR DESCRIPTION
- Store trades in order for every match
- SafeOrder should then use the trades to calculate the cost and fix #19083

Note: Did not have the keys to test it