### PR TITLE
fix(bitmex): add reverse to fetchFundingRateHistory

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -2378,6 +2378,7 @@ export default class bitmex extends Exchange {
         if (until !== undefined) {
             request['endTime'] = this.iso8601 (until);
         }
+        request['reverse'] = true;
         const response = await this.publicGetFunding (this.extend (request, params));
         //
         //    [


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19129

```
p bitmex fetchFundingRateHistory "BTC/USDT:USDT" None 2
Python v3.10.9
CCXT v4.0.89
bitmex.fetchFundingRateHistory(BTC/USDT:USDT,None,2)
[{'datetime': '2023-09-10T20:00:00.000Z',
  'fundingRate': 1.6e-05,
  'info': {'fundingInterval': '2000-01-01T08:00:00.000Z',
           'fundingRate': '0.000016',
           'fundingRateDaily': '0.000048',
           'symbol': 'XBTUSDT',
           'timestamp': '2023-09-10T20:00:00.000Z'},
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1694376000000},
 {'datetime': '2023-09-11T04:00:00.000Z',
  'fundingRate': 5e-05,
  'info': {'fundingInterval': '2000-01-01T08:00:00.000Z',
           'fundingRate': '0.00005',
           'fundingRateDaily': '0.00015000000000000001',
           'symbol': 'XBTUSDT',
           'timestamp': '2023-09-11T04:00:00.000Z'},
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1694404800000}]
```
