### PR TITLE
feat(okx): set default value for tpTriggerPxType and slTriggerPxType

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2618,7 +2618,7 @@ export default class okx extends Exchange {
                 } else {
                     request['tpOrdPx'] = '-1'; // market tp order
                 }
-                const takeProfitTriggerPriceType = this.safeString2 (stopLoss, 'triggerPriceType', 'tpTriggerPxType', 'last');
+                const takeProfitTriggerPriceType = this.safeString2 (takeProfit, 'triggerPriceType', 'tpTriggerPxType', 'last');
                 if (takeProfitTriggerPriceType !== undefined) {
                     if ((takeProfitTriggerPriceType !== 'last') && (takeProfitTriggerPriceType !== 'index') && (takeProfitTriggerPriceType !== 'mark')) {
                         throw new InvalidOrder (this.id + ' createOrder() take profit trigger price type must be one of "last", "index" or "mark"');

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2583,7 +2583,7 @@ export default class okx extends Exchange {
                 } else {
                     request['slOrdPx'] = '-1'; // market sl order
                 }
-                const stopLossTriggerPriceType = this.safeString2 (stopLoss, 'triggerPriceType', 'slTriggerPxType');
+                const stopLossTriggerPriceType = this.safeString2 (stopLoss, 'triggerPriceType', 'slTriggerPxType', 'last');
                 if (stopLossTriggerPriceType !== undefined) {
                     if ((stopLossTriggerPriceType !== 'last') && (stopLossTriggerPriceType !== 'index') && (stopLossTriggerPriceType !== 'mark')) {
                         throw new InvalidOrder (this.id + ' createOrder() stop loss trigger price type must be one of "last", "index" or "mark"');
@@ -2618,7 +2618,7 @@ export default class okx extends Exchange {
                 } else {
                     request['tpOrdPx'] = '-1'; // market tp order
                 }
-                const takeProfitTriggerPriceType = this.safeString2 (stopLoss, 'triggerPriceType', 'tpTriggerPxType');
+                const takeProfitTriggerPriceType = this.safeString2 (stopLoss, 'triggerPriceType', 'tpTriggerPxType', 'last');
                 if (takeProfitTriggerPriceType !== undefined) {
                     if ((takeProfitTriggerPriceType !== 'last') && (takeProfitTriggerPriceType !== 'index') && (takeProfitTriggerPriceType !== 'mark')) {
                         throw new InvalidOrder (this.id + ' createOrder() take profit trigger price type must be one of "last", "index" or "mark"');


### PR DESCRIPTION
Set a default value of 'last' for the `tpTriggerPxType` and `slTriggerPxType` params on takeProfit and stopLoss orders
Fixed a typo where the takeProfitTriggerPriceType was using the stopLoss object instead of takeProfit
fixes: #19226