### PR TITLE
fix(binance): watchOrderBookForSymbols scope var [ci deploy]

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -249,8 +249,8 @@ export default class binance extends binanceRest {
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             const market = this.market (symbol);
-            const messageHash = market['lowercaseId'] + '@' + name + '@' + watchOrderBookRate + 'ms';
-            subParams.push (messageHash);
+            const symbolHash = market['lowercaseId'] + '@' + name + '@' + watchOrderBookRate + 'ms';
+            subParams.push (symbolHash);
         }
         const request = {
             'method': 'SUBSCRIBE',
@@ -462,7 +462,7 @@ export default class binance extends binanceRest {
                 delete this.orderbooks[symbol];
             }
             this.orderbooks[symbol] = this.orderBook ({}, limit);
-            subscription['symbol'] = symbol;
+            subscription = this.extend (subscription, { 'symbol': symbol });
             // fetch the snapshot in a separate async call
             this.spawn (this.fetchOrderBookSnapshot, client, message, subscription);
         }


### PR DESCRIPTION
```
 python examples/py/multiple-subscriptions-watchXForSymbols.py
CCXT Version: 4.0.93
orderbook bid: BTC/USDT[26153.16, 10.88388]
orderbook bid: BTC/USDT[26153.16, 10.88388]
orderbook bid: BTC/USDT[26153.16, 11.95491]
orderbook bid: BTC/USDT[26153.16, 11.52868]
orderbook bid: ETH/USDT[1596.11, 68.5005]
orderbook bid: BTC/USDT[26153.16, 11.79635]
orderbook bid: ETH/USDT[1596.11, 68.5005]
orderbook bid: DOGE/USDT[0.06107, 248157.0]
orderbook bid: BTC/USDT[26153.16, 12.23327]
orderbook bid: BTC/USDT[26153.16, 12.04184]
orderbook bid: ETH/USDT[1596.11, 69.4995]
orderbook bid: ETH/USDT[1596.11, 68.2675]
orderbook bid: BTC/USDT[26153.16, 9.79346]
orderbook bid: ETH/USDT[1596.11, 68.2675]
orderbook bid: BTC/USDT[26153.16, 9.79411]
orderbook bid: ETH/USDT[1596.11, 68.2675]
orderbook bid: DOGE/USDT[0.06107, 248157.0]
orderbook bid: BTC/USDT[26153.16, 9.79411]
orderbook bid: BTC/USDT[26153.16, 9.79411]
```
