### PR TITLE
fix(binance) - max trade limit (~QUICK~)

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3647,7 +3647,7 @@ export default class binance extends Exchange {
             }
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // default = 500, maximum = 1000
+            request['limit'] = market['inverse'] ? Math.min (limit, 1000) : limit; // default = 500, maximum = 1000
         }
         params = this.omit (params, [ 'until', 'fetchTradesMethod' ]);
         //

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3647,7 +3647,8 @@ export default class binance extends Exchange {
             }
         }
         if (limit !== undefined) {
-            request['limit'] = market['inverse'] ? Math.min (limit, 1000) : limit; // default = 500, maximum = 1000
+            const isFutureOrSwap = (market['swap'] || market['future']);
+            request['limit'] = isFutureOrSwap ? Math.min (limit, 1000) : limit; // default = 500, maximum = 1000
         }
         params = this.omit (params, [ 'until', 'fetchTradesMethod' ]);
         //


### PR DESCRIPTION
must be <= 1000 , otherwise:

https://dapi.binance.com/dapi/v1/aggTrades?symbol=BTCUSD_PERP&limit=1001
https://fapi.binance.com/fapi/v1/aggTrades?symbol=BTCUSDT&limit=1001

for spot, you can "request" any amount (but ofc response is limited to max): 
https://api.binance.com/api/v1/aggTrades?symbol=BTCUSDT&limit=99999999