### PR TITLE
fix(bitfinex2) - max trade limit (QUICK)

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1289,7 +1289,7 @@ export default class bitfinex2 extends Exchange {
             sort = '1';
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // default 120, max 5000
+            request['limit'] = Math.min (limit, 10000); // default 120, max 10000
         }
         request['sort'] = sort;
         const response = await this.publicGetTradesSymbolHist (this.extend (request, params));


### PR DESCRIPTION
https://api-pub.bitfinex.com/v2/trades/tBTCF0:USTF0/hist?limit=10001&sort=-1

https://docs.bitfinex.com/reference/rest-public-trades#:~:text=Number%20of%20records%20in%20response%20(max.%2010000).