### PR TITLE
fix(kucoinfutures): fetchFundingRateHistory error handling and others

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4155,7 +4155,7 @@ export default class kucoin extends Exchange {
         this.throwExactlyMatchedException (this.exceptions['exact'], message, feedback);
         this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
         this.throwBroadlyMatchedException (this.exceptions['broad'], body, feedback);
-        if (errorCode !== '200000') {
+        if (errorCode !== '200000' && errorCode !== '200') {
             throw new ExchangeError (feedback);
         }
         return undefined;


### PR DESCRIPTION

```
p  kucoinfutures fetchFundingRateHistory "BTC/USDT:USDT" None 2     
Python v3.10.9
CCXT v4.0.95
kucoinfutures.fetchFundingRateHistory(BTC/USDT:USDT,None,2)
[{'datetime': '2023-09-14T04:00:00.000Z',
  'fundingRate': 8.5e-05,
  'info': {'granularity': 28800000,
           'symbol': 'XBTUSDTM',
           'timePoint': 1694664000000,
           'value': 8.5e-05},
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1694664000000},
 {'datetime': '2023-09-14T12:00:00.000Z',
  'fundingRate': 5.4e-05,
  'info': {'granularity': 28800000,
           'symbol': 'XBTUSDTM',
           'timePoint': 1694692800000,
           'value': 5.4e-05},
  'symbol': 'BTC/USDT:USDT',
  'timestamp': 1694692800000}]
```
