### PR TITLE
fix(currencycom) - max trade limit (QUICK)

### DIFF
--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -1098,7 +1098,7 @@ export default class currencycom extends Exchange {
             // 'limit': 500, // default 500, max 1000
         };
         if (limit !== undefined) {
-            request['limit'] = limit; // default 500, max 1000
+            request['limit'] = Math.min (limit, 1000); // default 500, max 1000
         }
         if (since !== undefined) {
             request['startTime'] = since;


### PR DESCRIPTION
otherwise errors - https://api-adapter.backend.currency.com/api/v2/aggTrades?symbol=BTC%2FEUR&limit=1001