### PR TITLE
fix(idex) - max trade limit

### DIFF
--- a/ts/src/idex.ts
+++ b/ts/src/idex.ts
@@ -517,7 +517,7 @@ export default class idex extends Exchange {
             request['start'] = since;
         }
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         // [
         //   {


### PR DESCRIPTION
otherwise errors - https://api-matic.idex.io/v1/trades?market=ETH-USDC&limit=1001