### PR TITLE
fix(gate): order status

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4193,7 +4193,7 @@ export default class gate extends Exchange {
             type = isMarketOrder ? 'market' : 'limit';
             side = Precise.stringGt (amount, '0') ? 'buy' : 'sell';
         }
-        const rawStatus = this.safeStringN (order, [ 'status', 'finish_as', 'open' ]);
+        const rawStatus = this.safeStringN (order, [ 'finish_as', 'status', 'open' ]);
         let timestamp = this.safeInteger (order, 'create_time_ms');
         if (timestamp === undefined) {
             timestamp = this.safeTimestamp2 (order, 'create_time', 'ctime');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/pull/19098

```
✗ p gate watchOrders            
Python v3.10.9
CCXT v4.0.97
gate.watchOrders()
[{'amount': 0.15,
  'average': None,
  'clientOrderId': 'apiv4',
  'cost': 0.0,
  'datetime': '2023-08-03T08:59:20.150Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '377061954804',
  'info': {'account': 'spot',
           'amend_text': '-',
           'amount': '0.15',
           'avg_deal_price': '0',
           'biz_info': 'ch:ccxt',
           'create_time': '1691053160',
           'create_time_ms': '1691053160150',
           'currency_pair': 'LTC_USDT',
           'event': 'finish',
           'fee': '0',
           'fee_currency': 'LTC',
           'filled_total': '0',
           'finish_as': 'cancelled',
           'gt_fee': '0',
           'id': '377061954804',
           'left': '0.15',
           'point_fee': '0',
           'price': '50',
           'rebated_fee': '0',
           'rebated_fee_currency': 'LTC',
           'side': 'buy',
           'stp_act': '-',
           'stp_id': 0,
           'text': 'apiv4',
           'time_in_force': 'gtc',
           'type': 'limit',
           'update_time': '1694777478',
           'update_time_ms': '1694777478158',
           'user': 10406147},
  'lastTradeTimestamp': 1694777478158,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 50.0,
  'reduceOnly': None,
  'remaining': 0.15,
  'side': 'buy',
  'status': 'canceled',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'GTC',
  'timestamp': 1691053160150,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
```
n gate watchOrders --swap --no-table
2023-09-15T11:34:58.701Z
Node.js: v18.14.0
CCXT v4.0.97
gate.watchOrders ()
[
  {
    id: '338445458923',
    clientOrderId: 'api',
    timestamp: 1694777710118,
    datetime: '2023-09-15T11:35:10.118Z',
    lastTradeTimestamp: 1694777710000,
    status: 'open',
    symbol: 'LTC/USDT:USDT',
    type: 'limit',
    timeInForce: 'GTC',
    postOnly: false,
    reduceOnly: false,
    side: 'buy',
    price: 50,
    stopPrice: undefined,
    triggerPrice: undefined,
    average: undefined,
    amount: 1,
    cost: 0,
    filled: 0,
    remaining: 1,
    fee: undefined,
    fees: [],
    trades: [],
    info: {
      amend_text: '-',
      biz_info: 'ch:ccxt',
      contract: 'LTC_USDT',
      create_time: 1694777710,
      create_time_ms: 1694777710118,
      fill_price: 0,
      finish_as: '_new',
      finish_time: 1694777710,
      finish_time_ms: 1694777710118,
      iceberg: 0,
      id: 338445458923,
      is_close: false,
      is_liq: false,
      is_reduce_only: false,
      left: 1,
      mkfr: 0.00015,
      price: 50,
      refr: 0,
      refu: 0,
      size: 1,
      status: 'open',
      stop_loss_price: '',
      stop_profit_price: '',
      stp_act: '-',
      stp_id: '0',
      text: 'api',
      tif: 'gtc',
      tkfr: 0.0005,
      user: '10406147'
    },
    lastUpdateTimestamp: undefined,
    takeProfitPrice: undefined,
    stopLossPrice: undefined
  }
]
```
```
 n gate watchOrders --swap --no-table
2023-09-15T11:35:39.923Z
Node.js: v18.14.0
CCXT v4.0.97
gate.watchOrders ()
[
  {
    id: '338445458923',
    clientOrderId: 'api',
    timestamp: 1694777710118,
    datetime: '2023-09-15T11:35:10.118Z',
    lastTradeTimestamp: 1694777759000,
    status: 'canceled',
    symbol: 'LTC/USDT:USDT',
    type: 'limit',
    timeInForce: 'GTC',
    postOnly: false,
    reduceOnly: false,
    side: 'buy',
    price: 50,
    stopPrice: undefined,
    triggerPrice: undefined,
    average: undefined,
    amount: 1,
    cost: 0,
    filled: 0,
    remaining: 1,
    fee: undefined,
    fees: [],
    trades: [],
    info: {
      amend_text: '-',
      biz_info: 'ch:ccxt',
      contract: 'LTC_USDT',
      create_time: 1694777710,
      create_time_ms: 1694777710118,
      fill_price: 0,
      finish_as: 'cancelled',
      finish_time: 1694777759,
      finish_time_ms: 1694777759955,
      iceberg: 0,
      id: 338445458923,
      is_close: false,
      is_liq: false,
      is_reduce_only: false,
      left: 1,
      mkfr: 0.00015,
      price: 50,
      refr: 0,
      refu: 0,
      size: 1,
      status: 'finished',
      stop_loss_price: '',
      stop_profit_price: '',
      stp_act: '-',
      stp_id: '0',
      text: 'api',
      tif: 'gtc',
      tkfr: 0.0005,
      user: '10406147'
    },
    lastUpdateTimestamp: undefined,
    takeProfitPrice: undefined,
    stopLossPrice: undefined
  }
]
```
