### PR TITLE
do not overwrite timeInForce attribute, if it explicit given in params by order creation

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4500,7 +4500,7 @@ export default class binance extends Exchange {
         }
         const timeInForce = this.safeString (params, 'timeInForce');
         if (timeInForceIsRequired) {
-            if (!params['timeInForce']) {
+            if (!timeInForce) {
                 request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
             } else {
                 request['timeInForce'] = timeInForce;

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1,4 +1,3 @@
-
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/binance.js';
@@ -4499,8 +4498,13 @@ export default class binance extends Exchange {
             }
             request['price'] = this.priceToPrecision (symbol, price);
         }
+        const timeInForce = this.safeString (params, 'timeInForce');
         if (timeInForceIsRequired) {
-            request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
+            if (!params['timeInForce']) {
+                request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
+            } else {
+                request['timeInForce'] = timeInForce;
+            }
         }
         if (market['contract'] && postOnly) {
             request['timeInForce'] = 'GTX';
@@ -4521,7 +4525,7 @@ export default class binance extends Exchange {
             }
         }
         // remove timeInForce from params because PO is only used by this.isPostOnly and it's not a valid value for Binance
-        if (this.safeString (params, 'timeInForce') === 'PO') {
+        if (timeInForce === 'PO') {
             params = this.omit (params, [ 'timeInForce' ]);
         }
         const requestParams = this.omit (params, [ 'quoteOrderQty', 'cost', 'stopPrice', 'test', 'type', 'newClientOrderId', 'clientOrderId', 'postOnly' ]);


### PR DESCRIPTION
binanceusdm (futures) allows order creation with orderType: 'LIMIT' and timeInForce: 'GTX'. Current state doesn't allow to do this without changing global exchange options, which is ugly.