### PR TITLE
fix(huobi) - shadow vars rename (QUICK)

### DIFF
--- a/ts/src/pro/huobi.ts
+++ b/ts/src/pro/huobi.ts
@@ -414,8 +414,7 @@ export default class huobi extends huobiRest {
                 orderbook.reset (snapshot);
                 // unroll the accumulated deltas
                 for (let i = 0; i < messages.length; i++) {
-                    const message = messages[i];
-                    this.handleOrderBookMessage (client, message, orderbook);
+                    this.handleOrderBookMessage (client, messages[i], orderbook);
                 }
                 this.orderbooks[symbol] = orderbook;
                 client.resolve (orderbook, messageHash);
@@ -1669,14 +1668,14 @@ export default class huobi extends huobiRest {
             const action = this.safeString (message, 'action');
             if (action === 'ping') {
                 const data = this.safeValue (message, 'data');
-                const ping = this.safeInteger (data, 'ts');
-                await client.send ({ 'action': 'pong', 'data': { 'ts': ping }});
+                const pingTs = this.safeInteger (data, 'ts');
+                await client.send ({ 'action': 'pong', 'data': { 'ts': pingTs }});
                 return;
             }
             const op = this.safeString (message, 'op');
             if (op === 'ping') {
-                const ping = this.safeInteger (message, 'ts');
-                await client.send ({ 'op': 'pong', 'ts': ping });
+                const pingTs = this.safeInteger (message, 'ts');
+                await client.send ({ 'op': 'pong', 'ts': pingTs });
             }
         } catch (e) {
             const error = new NetworkError (this.id + ' pong failed ' + this.json (e));
@@ -2145,7 +2144,7 @@ export default class huobi extends huobiRest {
             const signature = this.hmac (this.encode (payload), this.encode (this.secret), sha256, 'base64');
             let request = undefined;
             if (type === 'spot') {
-                const params = {
+                const newParams = {
                     'authType': 'api',
                     'accessKey': this.apiKey,
                     'signatureMethod': 'HmacSHA256',
@@ -2154,7 +2153,7 @@ export default class huobi extends huobiRest {
                     'signature': signature,
                 };
                 request = {
-                    'params': params,
+                    'params': newParams,
                     'action': 'req',
                     'ch': 'auth',
                 };


### PR DESCRIPTION
especially, there was `params` overwritten in `authenticate()` method