### PR TITLE
safeOrder check for parsedTrades

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1956,7 +1956,7 @@ export default class Exchange {
             (this as any).number = String;
             const firstTrade = this.safeValue (rawTrades, 0);
             // parse trades if they haven't already been parsed
-            const tradesAreParsed = (firstTrade !== undefined && 'info' in firstTrade && 'id' in firstTrade)
+            const tradesAreParsed = ((firstTrade !== undefined) && ('info' in firstTrade) && ('id' in firstTrade));
             if (!tradesAreParsed) {
                 trades = this.parseTrades (rawTrades, market);
             }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1954,7 +1954,12 @@ export default class Exchange {
             const oldNumber = this.number;
             // we parse trades as strings here!
             (this as any).number = String;
-            trades = this.parseTrades (rawTrades, market);
+            const firstTrade = this.safeValue (rawTrades, 0);
+            // parse trades if they haven't already been parsed
+            const tradesAreParsed = (firstTrade !== undefined && 'info' in firstTrade && 'id' in firstTrade)
+            if (!tradesAreParsed) {
+                trades = this.parseTrades (rawTrades, market);
+            }
             this.number = oldNumber;
             let tradesLength = 0;
             const isArray = Array.isArray (trades);


### PR DESCRIPTION
Check if trades have been parsed before calling parseTrades.
Alternative to: #19305 