### PR TITLE
bybit: patch setMarginMode

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5979,12 +5979,10 @@ export default class bybit extends Exchange {
         await this.loadMarkets ();
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         const isUnifiedAccount = (enableUnifiedMargin || enableUnifiedAccount);
+        let market = undefined;
         let response = undefined;
-        if (symbol === undefined) {
+        if (isUnifiedAccount) {
             if (marginMode === 'isolated') {
-                if (!isUnifiedAccount) {
-                    throw new NotSupported (this.id + ' setMarginMode() Normal Account not support ISOLATED_MARGIN');
-                }
                 marginMode = 'ISOLATED_MARGIN';
             } else if (marginMode === 'cross') {
                 marginMode = 'REGULAR_MARGIN';
@@ -5998,41 +5996,61 @@ export default class bybit extends Exchange {
             };
             response = await this.privatePostV5AccountSetMarginMode (this.extend (request, params));
         } else {
-            const market = this.market (symbol);
-            let type = undefined;
-            [ type, params ] = this.getBybitType ('setMarginMode', market, params);
-            if (type === 'linear') {
-                if (isUnifiedAccount) {
-                    throw new NotSupported (this.id + ' setMarginMode() with symbol Unified Account only support inverse contract');
+            market = this.market (symbol);
+            const isUsdcSettled = market['settle'] === 'USDC';
+            if (isUsdcSettled) {
+                if (marginMode === 'cross') {
+                    marginMode = 'REGULAR_MARGIN';
+                } else if (marginMode === 'portfolio') {
+                    marginMode = 'PORTFOLIO_MARGIN';
+                } else {
+                    throw new NotSupported (this.id + ' setMarginMode() for usdc market marginMode must be either [cross, portfolio]');
                 }
-                const isUsdtSettled = market['settle'] === 'USDT';
-                if (!isUsdtSettled) {
-                    throw new NotSupported (this.id + ' setMarginMode() with symbol only support USDT perpetual / inverse contract');
-                }
-            } else if (type !== 'inverse') {
-                throw new NotSupported (this.id + ' setMarginMode() does not support this market type');
-            }
-            let tradeMode = undefined;
-            if (marginMode === 'cross') {
-                tradeMode = 0;
-            } else if (marginMode === 'isolated') {
-                tradeMode = 1;
+                const request = {
+                    'setMarginMode': marginMode,
+                };
+                response = await this.privatePostV5AccountSetMarginMode (this.extend (request, params));
             } else {
-                throw new NotSupported (this.id + ' setMarginMode() with symbol marginMode must be either [isolated, cross]');
+                let type = undefined;
+                [ type, params ] = this.getBybitType ('setPositionMode', market, params);
+                let tradeMode = undefined;
+                if (marginMode === 'cross') {
+                    tradeMode = 0;
+                } else if (marginMode === 'isolated') {
+                    tradeMode = 1;
+                } else {
+                    throw new NotSupported (this.id + ' setMarginMode() with symbol marginMode must be either [isolated, cross]');
+                }
+                let sellLeverage = undefined;
+                let buyLeverage = undefined;
+                const leverage = this.safeString (params, 'leverage');
+                if (leverage === undefined) {
+                    sellLeverage = this.safeString2 (params, 'sell_leverage', 'sellLeverage');
+                    buyLeverage = this.safeString2 (params, 'buy_leverage', 'buyLeverage');
+                    if (sellLeverage === undefined && buyLeverage === undefined) {
+                        throw new ArgumentsRequired (this.id + ' setMarginMode() requires a leverage parameter or sell_leverage and buy_leverage parameters');
+                    }
+                    if (buyLeverage === undefined) {
+                        buyLeverage = sellLeverage;
+                    }
+                    if (sellLeverage === undefined) {
+                        sellLeverage = buyLeverage;
+                    }
+                    params = this.omit (params, [ 'buy_leverage', 'sell_leverage', 'sellLeverage', 'buyLeverage' ]);
+                } else {
+                    sellLeverage = leverage;
+                    buyLeverage = leverage;
+                    params = this.omit (params, 'leverage');
+                }
+                const request = {
+                    'category': type,
+                    'symbol': market['id'],
+                    'tradeMode': tradeMode,
+                    'buyLeverage': buyLeverage,
+                    'sellLeverage': sellLeverage,
+                };
+                response = await this.privatePostV5PositionSwitchIsolated (this.extend (request, params));
             }
-            const leverage = this.safeString (params, 'leverage');
-            params = this.omit (params, [ 'leverage' ]);
-            if (leverage === undefined) {
-                throw new ArgumentsRequired (this.id + ' setMarginMode() with symbol requires leverage');
-            }
-            const request = {
-                'category': type,
-                'symbol': market['id'],
-                'tradeMode': tradeMode,
-                'buyLeverage': leverage,
-                'sellLeverage': leverage,
-            };
-            response = await this.privatePostV5PositionSwitchIsolated (this.extend (request, params));
         }
         return response;
     }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5996,6 +5996,9 @@ export default class bybit extends Exchange {
             };
             response = await this.privatePostV5AccountSetMarginMode (this.extend (request, params));
         } else {
+            if (symbol === undefined) {
+                throw new ArgumentsRequired (this.id + ' setMarginMode() requires a symbol parameter for non unified account');
+            }
             market = this.market (symbol);
             const isUsdcSettled = market['settle'] === 'USDC';
             if (isUsdcSettled) {


### PR DESCRIPTION
```
$ node examples/js/cli bybit setMarginMode isolated BTC/USDT:USDT '{"leverage":1}' --test

Node.js: v18.14.0
CCXT v4.0.100
bybit.setMarginMode (isolated, BTC/USDT:USDT, [object Object])

{
  retCode: '0',
  retMsg: 'OK',
  result: {},
  retExtInfo: {},
  time: 'xxxx'
}
```