### PR TITLE
Bybit: createOrder, remove stop order trigger direction

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3699,7 +3699,6 @@ export default class bybit extends Exchange {
         const isBuy = side === 'buy';
         const ascending = stopLossTriggerPrice ? !isBuy : isBuy;
         if (triggerPrice !== undefined) {
-            request['triggerDirection'] = ascending ? 2 : 1;
             request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
         } else if (isStopLossTriggerOrder || isTakeProfitTriggerOrder) {
             request['triggerDirection'] = ascending ? 2 : 1;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3601,6 +3601,7 @@ export default class bybit extends Exchange {
          * @param {boolean} [params.isLeverage] *unified spot only* false then spot trading true then margin trading
          * @param {string} [params.tpslMode] *contract only* 'full' or 'partial'
          * @param {string} [params.mmp] *option only* market maker protection
+         * @param {int} [params.triggerDirection] *contract only* conditional orders, 1: triggered when market price rises to triggerPrice, 2: triggered when market price falls to triggerPrice
          * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();


### PR DESCRIPTION
Removed `triggerDirection` from stop orders:
```
bybit.createOrder (BTC/USDT:USDT, limit, buy, 0.001, 23000, {"stopPrice":"24000"},"positionIdx":2})
2023-09-19T01:28:48.281Z iteration 0 passed in 2249 ms

{
  info: { orderId: 'bf980b06-bea9-4906-a4ac-020b9b2e38b4', orderLinkId: '' },
  id: 'bf980b06-bea9-4906-a4ac-020b9b2e38b4',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: []
}
```