### PR TITLE
fix(bybit): error mapping (InvalidOrder -> BadRequest)

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -728,7 +728,7 @@ export default class bybit extends Exchange {
                     '110023': InvalidOrder, // This contract only supports position reduction operation, please contact customer service for details
                     '110024': InvalidOrder, // You have an existing position, so position mode cannot be switched
                     '110025': InvalidOrder, // Position mode is not modified
-                    '110026': InvalidOrder, // Cross/isolated margin mode is not modified
+                    '110026': BadRequest, // Cross/isolated margin mode is not modified
                     '110027': InvalidOrder, // Margin is not modified
                     '110028': InvalidOrder, // Open orders exist, so you cannot change position mode
                     '110029': InvalidOrder, // Hedge mode is not available for this symbol


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/19311

DEMO
```
 n bybit setMarginMode "isolated" "BTC/USDT:USDT" '{"leverage": 3}'  --sandbox
2023-09-19T10:54:30.792Z
Node.js: v18.14.0
CCXT v4.0.100
bybit.setMarginMode (isolated, BTC/USDT:USDT, [object Object])
BadRequest bybit {"retCode":110026,"retMsg":"Cross/isolated margin mode is not modified","result":{},"retExtInfo":{},"time":1695120874155}
---------------------------------------------------
[BadRequest] bybit {"retCode":110026,"retMsg":"Cross/isolated margin mode is not modified","result":{},"retExtInfo":{},"time":1695120874155}

    at throwExactlyMatchedException  Users/cjg/Git/ccxt10/ccxt/js/src/base/Exchange.js:3114  
    at handleErrors                  Users/cjg/Git/ccxt10/ccxt/js/src/bybit.js:7387          
    at                               Users/cjg/Git/ccxt10/ccxt/js/src/base/Exchange.js:764   
    at processTicksAndRejections     node:internal/process/task_queues:95                    
    at fetch2                        Users/cjg/Git/ccxt10/ccxt/js/src/base/Exchange.js:2693  
    at request                       Users/cjg/Git/ccxt10/ccxt/js/src/base/Exchange.js:2696  
    at setMarginMode                 Users/cjg/Git/ccxt10/ccxt/js/src/bybit.js:6056          
    at async run                     Users/cjg/Git/ccxt10/ccxt/examples/js/cli.js:298        

bybit {"retCode":110026,"retMsg":"Cross/isolated margin mode is not modified","result":{},"retExtInfo":{},"time":1695120874155}
```
