### PR TITLE
Bitmart: createOrder, add swap support

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2141,10 +2141,8 @@ export default class bitmart extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         let marginMode = undefined;
-        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
-        this.checkRequiredArgument ('createOrder', marginMode, 'marginMode', [ 'isolated', 'cross' ]);
-        const leverage = this.safeString (params, 'leverage');
-        this.checkRequiredArgument ('createOrder', leverage, 'leverage');
+        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params, 'cross');
+        const leverage = this.safeString (params, 'leverage', '1');
         const request = {
             'symbol': market['id'],
             'type': type,


### PR DESCRIPTION
I'm getting an exchange error calling these endpoints:
https://developer-pro.bitmart.com/en/futures/#submit-order-signed
https://developer-pro.bitmart.com/en/futures/#submit-plan-order-signed
```
[ExchangeError] bitmart {"trace":"7f9c94e10f9d4513bc08a7bfc2a5559a.77.16951899100377605","code":30019,"data":{},"message":"You do not have the permissions to perform this operation. Please contact customer service or BD for assistance."}
```
```
bitmart createOrder BTC/USDT:USDT limit buy 1 22000 '{"marginMode":"isolated","leverage":"10"}'
```
```
bitmart createOrder BTC/USDT:USDT limit buy 1 25000 '{"marginMode":"isolated","leverage":"10","triggerPrice":"26000","price_way":1}'
```