### PR TITLE
fix(bybit): watchOrders swap parsing

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -1065,16 +1065,17 @@ export default class bybit extends bybitRest {
         const first = this.safeValue (rawOrders, 0, {});
         const category = this.safeString (first, 'category');
         const isSpot = category === 'spot';
-        let parser = undefined;
-        if (isSpot) {
-            parser = 'parseWsSpotOrder';
-        } else {
-            parser = 'parseContractOrder';
+        if (!isSpot) {
             rawOrders = this.safeValue (rawOrders, 'result', rawOrders);
         }
         const symbols = {};
         for (let i = 0; i < rawOrders.length; i++) {
-            const parsed = this[parser] (rawOrders[i]);
+            let parsed = undefined;
+            if (isSpot) {
+                parsed = this.parseWsSpotOrder (rawOrders[i]);
+            } else {
+                parsed = this.parseOrder (rawOrders[i]);
+            }
             const symbol = parsed['symbol'];
             symbols[symbol] = true;
             orders.append (parsed);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19339
```
 p bybit watchOrders --swap --sandbox                                      
Python v3.10.9
CCXT v4.0.101
bybit.watchOrders()
[{'amount': 0.1,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-09-20T10:13:28.584Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'fees': [{'cost': 0.0, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': 'e92aeb81-59d5-46f8-86eb-5f495b8519a7',
  'info': {'avgPrice': '',
           'blockTradeId': '',
           'cancelType': 'UNKNOWN',
           'category': 'linear',
           'closeOnTrigger': False,
           'createdTime': '1695204808584',
           'cumExecFee': '0',
           'cumExecQty': '0',
           'cumExecValue': '0',
           'isLeverage': '',
           'lastPriceOnCreated': '65.55',
           'leavesQty': '0.1',
           'leavesValue': '5.6',
           'orderId': 'e92aeb81-59d5-46f8-86eb-5f495b8519a7',
           'orderIv': '',
           'orderLinkId': '',
           'orderStatus': 'New',
           'orderType': 'Limit',
           'placeType': '',
           'positionIdx': 0,
           'price': '56.00',
           'qty': '0.1',
           'reduceOnly': False,
           'rejectReason': 'EC_NoError',
           'side': 'Buy',
           'slLimitPrice': '',
           'slTriggerBy': 'UNKNOWN',
           'smpGroup': 0,
           'smpOrderId': '',
           'smpType': 'None',
           'stopLoss': '0.00',
           'stopOrderType': 'UNKNOWN',
           'symbol': 'LTCUSDT',
           'takeProfit': '0.00',
           'timeInForce': 'GTC',
           'tpLimitPrice': '',
           'tpTriggerBy': 'UNKNOWN',
           'tpslMode': 'UNKNOWN',
           'triggerBy': 'UNKNOWN',
           'triggerDirection': 0,
           'triggerPrice': '0.00',
           'updatedTime': '1695204808587'},
  'lastTradeTimestamp': 1695204808587,
  'lastUpdateTimestamp': 1695204808587,
  'postOnly': False,
  'price': 56.0,
  'reduceOnly': False,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': 'GTC',
  'timestamp': 1695204808584,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
```
p bybit watchOrders --spot --sandbox
Python v3.10.9
CCXT v4.0.101
bybit.watchOrders()
[{'amount': 0.3,
  'average': None,
  'clientOrderId': '1695204874827845',
  'cost': 0.0,
  'datetime': '2023-09-20T10:14:34.835Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '1513882647194031616',
  'info': {'avgPrice': '',
           'blockTradeId': '',
           'cancelType': 'UNKNOWN',
           'category': 'spot',
           'closeOnTrigger': False,
           'createdTime': '1695204874835',
           'cumExecFee': '0',
           'cumExecQty': '0.00000',
           'cumExecValue': '0.0000000',
           'feeCurrency': '',
           'isLeverage': '0',
           'lastPriceOnCreated': '',
           'leavesQty': '',
           'leavesValue': '',
           'orderId': '1513882647194031616',
           'orderIv': '',
           'orderLinkId': '1695204874827845',
           'orderStatus': 'New',
           'orderType': 'Limit',
           'positionIdx': 0,
           'price': '40.000',
           'qty': '0.30000',
           'reduceOnly': False,
           'rejectReason': '',
           'side': 'Buy',
           'slTriggerBy': '',
           'smpGroup': 0,
           'smpOrderId': '',
           'smpType': 'None',
           'stopLoss': '',
           'stopOrderType': '',
           'symbol': 'LTCUSDT',
           'takeProfit': '',
           'timeInForce': 'GTC',
           'tpTriggerBy': '',
           'triggerBy': '',
           'triggerDirection': 0,
           'triggerPrice': '',
           'updatedTime': '1695204874849'},
  'lastTradeTimestamp': 1695204874849,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 40.0,
  'reduceOnly': False,
  'remaining': 0.3,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'GTC',
  'timestamp': 1695204874835,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
