### PR TITLE
fix(Exchange.py): handle empty/none response properly

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -224,6 +224,8 @@ class Exchange(BaseExchange):
             return json_response
         if self.is_text_response(headers):
             return http_response
+        if http_response == '' or http_response is None:
+            return http_response
         return response.content
 
     async def load_markets_helper(self, reload=False, params={}):

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2577,6 +2577,9 @@ export default class bitget extends Exchange {
                 response = await this.publicMixGetMarketHistoryCandles (this.extend (request, params));
             }
         }
+        if (response === '') {
+            return []; // happens when a new token is listed
+        }
         //  [ ["1645911960000","39406","39407","39374.5","39379","35.526","1399132.341"] ]
         const data = this.safeValue (response, 'data', response);
         return this.parseOHLCVs (data, market, timeframe, since, limit);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19340
DEMO


```
 p bitget fetchOHLCV "PYUSDUSDT_SPBL" 30m --verbose
Python v3.11.5
CCXT v4.0.102
bitget.fetchOHLCV(PYUSDUSDT_SPBL,30m)

fetch Request: bitget GET https://api.bitget.com/api/spot/v1/market/candles?symbol=PYUSDUSDT_SPBL&limit=1000&period=30min RequestHeaders: {'User-Agent': 'python-requests/2.28.2', 'Accept-Encoding': 'gzip, deflate'} RequestBody: None

fetch Response: bitget GET https://api.bitget.com/api/spot/v1/market/candles?symbol=PYUSDUSDT_SPBL&limit=1000&period=30min 200 ResponseHeaders: {'Date': 'Thu, 21 Sep 2023 16:09:53 GMT', 'Content-Length': '0', 'Connection': 'keep-alive', 'X-Request-ID': '6b678962a0af460cae1fb948b88d3019', 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate', 'Pragma': 'no-cache', 'Expires': '0', 'X-XSS-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS', 'CF-Cache-Status': 'DYNAMIC', 'X-Frame-Options': 'SAMEORIGIN', 'Server': 'cloudflare', 'CF-RAY': '80a3933e48f6698f-FRA'} ResponseBody: 
[]
```
