### PR TITLE
Bitmart: transfer, fetchTransfers, add swap support

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -84,7 +84,7 @@ export default class bitmart extends Exchange {
                 'fetchTransactionFee': true,
                 'fetchTransactionFees': false,
                 'fetchTransfer': false,
-                'fetchTransfers': false,
+                'fetchTransfers': true,
                 'fetchWithdrawAddressesByNetwork': false,
                 'fetchWithdrawal': true,
                 'fetchWithdrawals': true,
@@ -3139,10 +3139,9 @@ export default class bitmart extends Exchange {
         //         }
         //     }
         //
-        return this.extend (this.parseTransfer (response, currency), {
-            'amount': this.parseNumber (amountToPrecision),
-            'fromAccount': fromAccount,
-            'toAccount': toAccount,
+        const data = this.safeValue (response, 'data', {});
+        return this.extend (this.parseTransfer (data, currency), {
+            'status': this.parseTransferStatus (this.safeString2 (response, 'code', 'message')),
         });
     }
 
@@ -3150,8 +3149,25 @@ export default class bitmart extends Exchange {
         const statuses = {
             '1000': 'ok',
             'OK': 'ok',
+            'FINISHED': 'ok',
         };
         return this.safeString (statuses, status, status);
+    }
+
+    parseTransferToAccount (type) {
+        const types = {
+            'contract_to_spot': 'spot',
+            'spot_to_contract': 'swap',
+        };
+        return this.safeString (types, type, type);
+    }
+
+    parseTransferFromAccount (type) {
+        const types = {
+            'contract_to_spot': 'swap',
+            'spot_to_contract': 'spot',
+        };
+        return this.safeString (types, type, type);
     }
 
     parseTransfer (transfer, currency = undefined) {
@@ -3159,38 +3175,103 @@ export default class bitmart extends Exchange {
         // margin
         //
         //     {
-        //         "message": "OK",
-        //         "code": 1000,
-        //         "trace": "b26cecec-ef5a-47d9-9531-2bd3911d3d55",
-        //         "data": {
-        //             "transfer_id": "ca90d97a621e47d49774f19af6b029f5"
-        //         }
+        //         "transfer_id": "ca90d97a621e47d49774f19af6b029f5"
         //     }
         //
         // swap
         //
         //     {
+        //         "currency": "USDT",
+        //         "amount": "5"
+        //     }
+        //
+        // fetchTransfers
+        //
+        //     {
+        //         "transfer_id": "902463535961567232",
+        //         "currency": "USDT",
+        //         "amount": "5",
+        //         "type": "contract_to_spot",
+        //         "state": "FINISHED",
+        //         "timestamp": 1695330539565
+        //     }
+        //
+        const currencyId = this.safeString (transfer, 'currency');
+        const timestamp = this.safeInteger (transfer, 'timestamp');
+        return {
+            'id': this.safeString (transfer, 'transfer_id'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'amount': this.safeNumber (transfer, 'amount'),
+            'fromAccount': this.parseTransferFromAccount (this.safeString (transfer, 'type')),
+            'toAccount': this.parseTransferToAccount (this.safeString (transfer, 'type')),
+            'status': this.parseTransferStatus (this.safeString (transfer, 'state')),
+        };
+    }
+
+    async fetchTransfers (code: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitmart#fetchTransfers
+         * @description fetch a history of internal transfers made on an account, only transfers between spot and swap are supported
+         * @see https://developer-pro.bitmart.com/en/futures/#get-transfer-list-signed
+         * @param {string} code unified currency code of the currency transferred
+         * @param {int} [since] the earliest time in ms to fetch transfers for
+         * @param {int} [limit] the maximum number of transfer structures to retrieve
+         * @param {object} [params] extra parameters specific to the bitmart api endpoint
+         * @param {int} [params.page] the required number of pages, default is 1, max is 1000
+         * @param {int} [params.until] the latest time in ms to fetch transfers for
+         * @returns {object[]} a list of [transfer structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#transfer-structure}
+         */
+        await this.loadMarkets ();
+        if (limit === undefined) {
+            limit = 10;
+        }
+        const request = {
+            'page': this.safeInteger (params, 'page', 1), // default is 1, max is 1000
+            'limit': limit, // default is 10, max is 100
+        };
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+            request['currency'] = currency['id'];
+        }
+        if (since !== undefined) {
+            request['time_start'] = since;
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const until = this.safeInteger2 (params, 'until', 'till'); // unified in milliseconds
+        const endTime = this.safeInteger (params, 'time_end', until); // exchange-specific in milliseconds
+        params = this.omit (params, [ 'till', 'until' ]);
+        if (endTime !== undefined) {
+            request['time_end'] = endTime;
+        }
+        const response = await this.privatePostAccountV1TransferContractList (this.extend (request, params));
+        //
+        //     {
         //         "message": "OK",
         //         "code": 1000,
-        //         "trace": "4cad858074667097ac6ba5257c57305d.68.16953302431189455",
+        //         "trace": "7f9d93e10f9g4513bc08a7btc2a5559a.69.16953325693032193",
         //         "data": {
-        //             "currency": "USDT",
-        //             "amount": "5"
+        //             "records": [
+        //                 {
+        //                     "transfer_id": "902463535961567232",
+        //                     "currency": "USDT",
+        //                     "amount": "5",
+        //                     "type": "contract_to_spot",
+        //                     "state": "FINISHED",
+        //                     "timestamp": 1695330539565
+        //                 },
+        //             ]
         //         }
         //     }
         //
-        const data = this.safeValue (transfer, 'data', {});
-        const currencyId = this.safeString (transfer, 'currency');
-        return {
-            'id': this.safeString (data, 'transfer_id'),
-            'timestamp': undefined,
-            'datetime': undefined,
-            'currency': this.safeCurrencyCode (currencyId, currency),
-            'amount': this.safeNumber (transfer, 'amount'),
-            'fromAccount': undefined,
-            'toAccount': undefined,
-            'status': this.parseTransferStatus (this.safeString2 (transfer, 'code', 'message')),
-        };
+        const data = this.safeValue (response, 'data', {});
+        const records = this.safeValue (data, 'records', []);
+        return this.parseTransfers (records, currency, since, limit);
     }
 
     async fetchBorrowInterest (code: string = undefined, symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {


### PR DESCRIPTION
Added swap support to the transfer method, and added the fetchTransfers method:
### transfer:
```
bitmart.transfer (USDT, 5, swap, spot)
2023-09-21T21:08:59.740Z iteration 0 passed in 1003 ms

{
  id: undefined,
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: 5,
  fromAccount: undefined,
  toAccount: undefined,
  status: 'ok'
}
```

### fetchTransfers:
```
bitmart.fetchTransfers ()
2023-09-21T22:02:00.685Z iteration 0 passed in 423 ms

                id |     timestamp |                 datetime | currency | amount | fromAccount | toAccount | status
--------------------------------------------------------------------------------------------------------------------
775779810478354432 | 1665126785740 | 2022-10-07T07:13:05.740Z |     USDT |   64.4 |        spot |      swap |     ok
775786265549959168 | 1665128324749 | 2022-10-07T07:38:44.749Z |     USDT |  64.37 |        swap |      spot |     ok
900041329436487680 | 1694753040527 | 2023-09-15T04:44:00.527Z |     USDT |   9.88 |        spot |      swap |     ok
902462376760799232 | 1695330263190 | 2023-09-21T21:04:23.190Z |     USDT |      5 |        spot |      swap |     ok
902463535961567232 | 1695330539565 | 2023-09-21T21:08:59.565Z |     USDT |      5 |        swap |      spot |     ok
902476274582908928 | 1695333576689 | 2023-09-21T21:59:36.689Z |     USDT |      5 |        spot |      swap |     ok
902476534705254400 | 1695333638707 | 2023-09-21T22:00:38.707Z |     USDT |      5 |        swap |      spot |     ok
7 objects
```