### PR TITLE
Bitmart: cancelAllOrders, add swap support

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2214,6 +2214,7 @@ export default class bitmart extends Exchange {
          * @see https://developer-pro.bitmart.com/en/futures/#cancel-all-orders-signed
          * @param {string} symbol unified market symbol of the market to cancel orders in
          * @param {object} [params] extra parameters specific to the bitmart api endpoint
+         * @param {string} [params.side] *spot only* 'buy' or 'sell'
          * @returns {object[]} a list of [order structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();
@@ -2227,11 +2228,6 @@ export default class bitmart extends Exchange {
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         if (type === 'spot') {
-            const side = this.safeString (params, 'side');
-            if (side !== undefined) {
-                request['side'] = side;
-                params = this.omit (params, 'side');
-            }
             response = await this.privatePostSpotV1CancelOrders (this.extend (request, params));
         } else if (type === 'swap') {
             this.checkRequiredSymbol ('cancelAllOrders', symbol);

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2211,6 +2211,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#cancelAllOrders
          * @description cancel all open orders in a market
          * @see https://developer-pro.bitmart.com/en/spot/#cancel-all-orders
+         * @see https://developer-pro.bitmart.com/en/futures/#cancel-all-orders-signed
          * @param {string} symbol unified market symbol of the market to cancel orders in
          * @param {object} [params] extra parameters specific to the bitmart api endpoint
          * @returns {object[]} a list of [order structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
@@ -2222,23 +2223,36 @@ export default class bitmart extends Exchange {
             market = this.market (symbol);
             request['symbol'] = market['id'];
         }
+        let response = undefined;
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
-        if (type !== 'spot') {
-            throw new NotSupported (this.id + ' cancelAllOrders() does not support ' + type + ' orders, only spot orders are accepted');
+        if (type === 'spot') {
+            const side = this.safeString (params, 'side');
+            if (side !== undefined) {
+                request['side'] = side;
+                params = this.omit (params, 'side');
+            }
+            response = await this.privatePostSpotV1CancelOrders (this.extend (request, params));
+        } else if (type === 'swap') {
+            this.checkRequiredSymbol ('cancelAllOrders', symbol);
+            response = await this.privatePostContractPrivateCancelOrders (this.extend (request, params));
         }
-        const side = this.safeString (params, 'side');
-        if (side !== undefined) {
-            request['side'] = side;
-            params = this.omit (params, 'side');
-        }
-        const response = await this.privatePostSpotV1CancelOrders (this.extend (request, params));
+        //
+        // spot
         //
         //     {
         //         "code": 1000,
         //         "trace":"886fb6ae-456b-4654-b4e0-d681ac05cea1",
         //         "message": "OK",
         //         "data": {}
+        //     }
+        //
+        // swap
+        //
+        //     {
+        //         "code": 1000,
+        //         "message": "Ok",
+        //         "trace": "7f9c94e10f9d4513bc08a7bfc2a5559a.70.16954131323145323"
         //     }
         //
         return response;


### PR DESCRIPTION
Added swap support to cancelAllOrders:
```
bitmart.cancelAllOrders (BTC/USDT:USDT)
2023-09-22T20:16:40.663Z iteration 0 passed in 516 ms

{
  code: '1000',
  message: 'Ok',
  trace: '4caf855074664097ac6ba5257c47305d.71.16954138013050949'
}
```