### PR TITLE
Revert "Bybit: createOrder, remove stop order trigger direction"

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3601,7 +3601,6 @@ export default class bybit extends Exchange {
          * @param {boolean} [params.isLeverage] *unified spot only* false then spot trading true then margin trading
          * @param {string} [params.tpslMode] *contract only* 'full' or 'partial'
          * @param {string} [params.mmp] *option only* market maker protection
-         * @param {int} [params.triggerDirection] *contract only* conditional orders, 1: triggered when market price rises to triggerPrice, 2: triggered when market price falls to triggerPrice
          * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();
@@ -3700,6 +3699,7 @@ export default class bybit extends Exchange {
         const isBuy = side === 'buy';
         const ascending = stopLossTriggerPrice ? !isBuy : isBuy;
         if (triggerPrice !== undefined) {
+            request['triggerDirection'] = ascending ? 2 : 1;
             request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
         } else if (isStopLossTriggerOrder || isTakeProfitTriggerOrder) {
             request['triggerDirection'] = ascending ? 2 : 1;


### PR DESCRIPTION
Reverts ccxt/ccxt#19323, which introduced a bug (#19362).

The PR also contains no explanation as to WHY such a change would be made, i therefore assume it's been a mistake (mistakes happen - though they should be cought in a review) - as well as reasonless change introducing a breaking change.


closes #19362