### PR TITLE
feat(bybit): add watchTickers

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2618,8 +2618,18 @@ export default class Exchange {
         return result;
     }
 
-    marketSymbols (symbols, type: string = undefined) {
+    marketSymbols (symbols, type: string = undefined, allowEmpty = true) {
         if (symbols === undefined) {
+            if (!allowEmpty) {
+                throw new ArgumentsRequired (this.id + ' empty list of symbols is not supported');
+            }
+            return symbols;
+        }
+        const symbolsLength = symbols.length;
+        if (symbolsLength === 0) {
+            if (!allowEmpty) {
+                throw new ArgumentsRequired (this.id + ' empty list of symbols is not supported');
+            }
             return symbols;
         }
         const result = [];


### PR DESCRIPTION
```
p bybit watchTickers '["BTC/USDT:USDT", "ETH/USDT:USDT"]' --sandbox          
Python v3.11.5
CCXT v4.0.105
bybit.watchTickers(['BTC/USDT:USDT', 'ETH/USDT:USDT'])
{'ask': 26112.7,
 'askVolume': 0.2,
 'average': 26356.35,
 'baseVolume': 67054.616,
 'bid': 26110.5,
 'bidVolume': 225.049,
 'change': -487.3,
 'close': 26112.7,
 'datetime': '2023-09-25T09:11:11.981Z',
 'high': 26731.1,
 'info': {'ask1Price': '26112.70',
          'ask1Size': '0.200',
          'bid1Price': '26110.50',
          'bid1Size': '225.049',
          'fundingRate': '0.000079',
          'highPrice24h': '26731.10',
          'indexPrice': '26125.12',
          'lastPrice': '26112.70',
          'lowPrice24h': '25980.00',
          'markPrice': '26112.70',
          'nextFundingTime': '1695657600000',
          'openInterest': '125915.029',
          'openInterestValue': '3287981377.77',
          'prevPrice1h': '26171.80',
          'prevPrice24h': '26600.00',
          'price24hPcnt': '-0.018319',
          'symbol': 'BTCUSDT',
          'tickDirection': 'MinusTick',
          'turnover24h': '1757520140.8905',
          'volume24h': '67054.6160'},
 'last': 26112.7,
 'low': 25980.0,
 'open': 26600.0,
 'percentage': -1.8319,
 'previousClose': None,
 'quoteVolume': 1757520140.8905,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1695633071981,
 'vwap': 26210.278213963673}
{'ask': 1577.81,
 'askVolume': 3934.69,
 'average': 1586.445,
 'baseVolume': 4436429.29,
 'bid': 1577.7,
 'bidVolume': 1737.15,
 'change': -17.49,
 'close': 1577.7,
 'datetime': '2023-09-25T09:11:10.480Z',
 'high': 1600.75,
 'info': {'ask1Price': '1577.81',
          'ask1Size': '3934.69',
          'bid1Price': '1577.70',
          'bid1Size': '1737.15',
          'fundingRate': '0.0001',
          'highPrice24h': '1600.75',
          'indexPrice': '1577.65',
          'lastPrice': '1577.70',
          'lowPrice24h': '1565.48',
          'markPrice': '1577.70',
          'nextFundingTime': '1695657600000',
          'openInterest': '132062.98',
          'openInterestValue': '208355763.55',
          'prevPrice1h': '1580.88',
          'prevPrice24h': '1595.19',
          'price24hPcnt': '-0.010964',
          'symbol': 'ETHUSDT',
          'tickDirection': 'MinusTick',
          'turnover24h': '7023953137.8977',
          'volume24h': '4436429.2900'},
 'last': 1577.7,
 'low': 1565.48,
 'open': 1595.19,
 'percentage': -1.0964,
 'previousClose': None,
 'quoteVolume': 7023953137.8977,
 'symbol': 'ETH/USDT:USDT',
 'timestamp': 1695633070480,
 'vwap': 1583.2446949464847}
```

```
 p bybit watchTickers '["BTC/USDT", "ETH/USDT"]' --sandbox 
Python v3.11.5
CCXT v4.0.105
bybit.watchTickers(['BTC/USDT', 'ETH/USDT'])
{'ask': None,
 'askVolume': None,
 'average': 20320.24,
 'baseVolume': 14091.333591,
 'bid': None,
 'bidVolume': None,
 'change': 86.64,
 'close': 20363.56,
 'datetime': '2023-09-25T09:12:26.661Z',
 'high': 22238.48,
 'info': {'highPrice24h': '22238.48',
          'lastPrice': '20363.56',
          'lowPrice24h': '20009.17',
          'prevPrice24h': '20276.92',
          'price24hPcnt': '0.0043',
          'symbol': 'BTCUSDT',
          'turnover24h': '300838405.99603411',
          'usdIndexPrice': '26120.60000001',
          'volume24h': '14091.333591'},
 'last': 20363.56,
 'low': 20009.17,
 'open': 20276.92,
 'percentage': 0.43,
 'previousClose': None,
 'quoteVolume': 300838405.9960341,
 'symbol': 'BTC/USDT',
 'timestamp': 1695633146661,
 'vwap': 21349.179199630667}
{'ask': None,
 'askVolume': None,
 'average': 1651.95,
 'baseVolume': 12382.21628,
 'bid': None,
 'bidVolume': None,
 'change': -148.56,
 'close': 1577.67,
 'datetime': '2023-09-25T09:12:27.666Z',
 'high': 1739.0,
 'info': {'highPrice24h': '1739',
          'lastPrice': '1577.67',
          'lowPrice24h': '1539.52',
          'prevPrice24h': '1726.23',
          'price24hPcnt': '-0.0861',
          'symbol': 'ETHUSDT',
          'turnover24h': '20943068.2465887',
          'usdIndexPrice': '1577.21424524',
          'volume24h': '12382.21628'},
 'last': 1577.67,
 'low': 1539.52,
 'open': 1726.23,
 'percentage': -8.61,
 'previousClose': None,
 'quoteVolume': 20943068.2465887,
 'symbol': 'ETH/USDT',
 'timestamp': 1695633147666,
 'vwap': 1691.3828488375184}
{'ask': None,
 'askVolume': None,
 'average': 20320.24,
 'baseVolume': 14091.333591,
 'bid': None,
 'bidVolume': None,
 'change': 86.64,
 'close': 20363.56,
 'datetime': '2023-09-25T09:12:28.146Z',
 'high': 22238.48,
 'info': {'highPrice24h': '22238.48',
          'lastPrice': '20363.56',
          'lowPrice24h': '20009.17',
          'prevPrice24h': '20276.92',
          'price24hPcnt': '0.0043',
          'symbol': 'BTCUSDT',
          'turnover24h': '300838405.99603411',
          'usdIndexPrice': '26120.53000001',
          'volume24h': '14091.333591'},
 'last': 20363.56,
 'low': 20009.17,
 'open': 20276.92,
 'percentage': 0.43,
 'previousClose': None,
 'quoteVolume': 300838405.9960341,
 'symbol': 'BTC/USDT',
 'timestamp': 1695633148146,
 'vwap': 21349.179199630667}
```

