### PR TITLE
feat(bitget): add watchTickers

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -23,7 +23,7 @@ export default class bitget extends bitgetRest {
                 'watchOrderBookForSymbols': true,
                 'watchOrders': true,
                 'watchTicker': true,
-                'watchTickers': false,
+                'watchTickers': true,
                 'watchTrades': true,
                 'watchTradesForSymbols': true,
             },
@@ -130,6 +130,39 @@ export default class bitget extends bitgetRest {
         return await this.watchPublic (messageHash, args, params);
     }
 
+    async watchTickers (symbols: string[] = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitget#watchTickers
+         * @description watches a price ticker, a statistical calculation with the information calculated over the past 24 hours for all markets of a specific list
+         * @param {string[]} symbols unified symbol of the market to fetch the ticker for
+         * @param {object} [params] extra parameters specific to the bitget api endpoint
+         * @returns {object} a [ticker structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#ticker-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols, undefined, false);
+        const market = this.market (symbols[0]);
+        const instType = market['spot'] ? 'sp' : 'mc';
+        const messageHash = 'tickers::' + symbols.join (',');
+        const marketIds = this.marketIds (symbols);
+        const topics = [ ];
+        for (let i = 0; i < marketIds.length; i++) {
+            const marketId = marketIds[i];
+            const market = this.market (marketId);
+            const args = {
+                'instType': instType,
+                'channel': 'ticker',
+                'instId': this.getWsMarketId (market),
+            };
+            topics.push (args);
+        }
+        const tickers = await this.watchPublicMultiple (messageHash, topics, params);
+        if (this.newUpdates) {
+            return tickers;
+        }
+        return this.filterByArray (this.tickers, 'symbol', symbols);
+    }
+
     handleTicker (client: Client, message) {
         //
         //   {
@@ -157,6 +190,17 @@ export default class bitget extends bitgetRest {
         this.tickers[symbol] = ticker;
         const messageHash = 'ticker:' + symbol;
         client.resolve (ticker, messageHash);
+        // watchTickers part
+        const messageHashes = this.findMessageHashes (client, 'tickers::');
+        for (let i = 0; i < messageHashes.length; i++) {
+            const messageHash = messageHashes[i];
+            const parts = messageHash.split ('::');
+            const symbolsString = parts[1];
+            const symbols = symbolsString.split (',');
+            if (this.inArray (symbol, symbols)) {
+                client.resolve (ticker, messageHash);
+            }
+        }
         return message;
     }
 


### PR DESCRIPTION
DEMO

```
p bitget watchTickers '["BTC/USDT:USDT", "LTC/USDT:USDT"]'          
Python v3.11.5
CCXT v4.0.106
bitget.watchTickers(['BTC/USDT:USDT', 'LTC/USDT:USDT'])
{'ask': 26160.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 80505.268,
 'bid': 26159.9,
 'bidVolume': None,
 'change': None,
 'close': 26159.9,
 'datetime': '2023-09-25T15:04:45.051Z',
 'high': 26735.0,
 'info': {'askSz': '176.989',
          'baseVolume': '80505.268',
          'bestAsk': '26160',
          'bestBid': '26159.9',
          'bidSz': '3.022',
          'capitalRate': '0.000071',
          'chgUTC': '-0.00248',
          'deliveryPrice': '0',
          'high24h': '26735.0',
          'holding': '60478.169',
          'indexPrice': '26177.2',
          'instId': 'BTCUSDT',
          'last': '26159.9',
          'low24h': '25971.0',
          'markPrice': '26159.9',
          'nextSettleTime': 1695657600000,
          'openUtc': '26225.0',
          'priceChangePercent': '-0.01557',
          'quoteVolume': '2113643794.468',
          'symbolId': 'BTCUSDT_UMCBL',
          'symbolType': 1,
          'systemTime': 1695654285051},
 'last': 26159.9,
 'low': 25971.0,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 2113643794.468,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1695654285051,
 'vwap': 26254.726516381514}
{'ask': 64.28,
 'askVolume': None,
 'average': None,
 'baseVolume': 80783.4,
 'bid': 64.27,
 'bidVolume': None,
 'change': None,
 'close': 64.28,
 'datetime': '2023-09-25T15:04:45.051Z',
 'high': 64.97,
 'info': {'askSz': '1179.9',
          'baseVolume': '80783.4',
          'bestAsk': '64.28',
          'bestBid': '64.27',
          'bidSz': '136.9',
          'capitalRate': '0.000106',
          'chgUTC': '0.01165',
          'deliveryPrice': '0',
          'high24h': '64.97',
          'holding': '127052.5',
          'indexPrice': '64.32',
          'instId': 'LTCUSDT',
          'last': '64.28',
          'low24h': '62.53',
          'markPrice': '64.27',
          'nextSettleTime': 1695657600000,
          'openUtc': '63.54',
          'priceChangePercent': '-0.00588',
          'quoteVolume': '5176735.5',
          'symbolId': 'LTCUSDT_UMCBL',
          'symbolType': 1,
          'systemTime': 1695654285051},
 'last': 64.28,
 'low': 62.53,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 5176735.5,
 'symbol': 'LTC/USDT:USDT',
 'timestamp': 1695654285051,
 'vwap': 64.08167395776856}
{'ask': 64.28,
 'askVolume': None,
 'average': None,
 'baseVolume': 80783.4,
 'bid': 64.27,
 'bidVolume': None,
 'change': None,
 'close': 64.28,
 'datetime': '2023-09-25T15:04:45.307Z',
 'high': 64.97,
 'info': {'askSz': '1179.9',
          'baseVolume': '80783.4',
          'bestAsk': '64.28',
          'bestBid': '64.27',
          'bidSz': '136.9',
          'capitalRate': '0.000106',
          'chgUTC': '0.01165',
          'deliveryPrice': '0',
          'high24h': '64.97',
          'holding': '127052.5',
          'indexPrice': '64.32',
          'instId': 'LTCUSDT',
          'last': '64.28',
          'low24h': '62.53',
          'markPrice': '64.27',
          'nextSettleTime': 1695657600000,
          'openUtc': '63.54',
          'priceChangePercent': '-0.00588',
          'quoteVolume': '5176735.5',
          'symbolId': 'LTCUSDT_UMCBL',
          'symbolType': 1,
          'systemTime': 1695654285307},
 'last': 64.28,
 'low': 62.53,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 5176735.5,
 'symbol': 'LTC/USDT:USDT',
 'timestamp': 1695654285307,
 'vwap': 64.08167395776856}
```
```
p bitget watchTickers '["BTC/USDT", "LTC/USDT"]'
Python v3.11.5
CCXT v4.0.106
bitget.watchTickers(['BTC/USDT', 'LTC/USDT'])
{'ask': 26172.33,
 'askVolume': None,
 'average': 26375.025,
 'baseVolume': 4630.6367,
 'bid': 26172.3,
 'bidVolume': None,
 'change': -405.39,
 'close': 26172.33,
 'datetime': '2023-09-25T15:05:37.853Z',
 'high': 26736.43,
 'info': {'askSz': '0.3057',
          'baseVolume': '4630.6367',
          'bestAsk': '26172.33',
          'bestBid': '26172.3',
          'bidSz': '0.0755',
          'chgUTC': '-0.00293',
          'high24h': '26736.43',
          'instId': 'BTCUSDT',
          'labeId': 0,
          'last': '26172.33',
          'low24h': '26002.75',
          'open24h': '26577.72',
          'openUtc': '26249.22',
          'quoteVolume': '121783275.3371',
          'ts': 1695654337853},
 'last': 26172.33,
 'low': 26002.75,
 'open': 26577.72,
 'percentage': -1.5253001386123415,
 'previousClose': None,
 'quoteVolume': 121783275.3371,
 'symbol': 'BTC/USDT',
 'timestamp': 1695654337853,
 'vwap': 26299.466623477503}
{'ask': 64.32,
 'askVolume': None,
 'average': 64.507,
 'baseVolume': 25373.4129,
 'bid': 64.264,
 'bidVolume': None,
 'change': -0.484,
 'close': 64.265,
 'datetime': '2023-09-25T15:05:37.854Z',
 'high': 65.0,
 'info': {'askSz': '0.1144',
          'baseVolume': '25373.4129',
          'bestAsk': '64.32',
          'bestBid': '64.264',
          'bidSz': '1.8165',
          'chgUTC': '0.01154',
          'high24h': '65.000',
          'instId': 'LTCUSDT',
          'labeId': 0,
          'last': '64.265',
          'low24h': '62.615',
          'open24h': '64.749',
          'openUtc': '63.532',
          'quoteVolume': '1629981.0150',
          'ts': 1695654337854},
 'last': 64.265,
 'low': 62.615,
 'open': 64.749,
 'percentage': -0.7475018919211107,
 'previousClose': None,
 'quoteVolume': 1629981.015,
 'symbol': 'LTC/USDT',
 'timestamp': 1695654337854,
 'vwap': 64.23972295031702}
{'ask': 26172.33,
 'askVolume': None,
 'average': 26375.025,
 'baseVolume': 4630.6367,
 'bid': 26172.3,
 'bidVolume': None,
 'change': -405.39,
 'close': 26172.33,
 'datetime': '2023-09-25T15:05:38.172Z',
 'high': 26736.43,
 'info': {'askSz': '0.3057',
          'baseVolume': '4630.6367',
          'bestAsk': '26172.33',
          'bestBid': '26172.3',
          'bidSz': '0.0755',
          'chgUTC': '-0.00293',
          'high24h': '26736.43',
          'instId': 'BTCUSDT',
          'labeId': 0,
          'last': '26172.33',
          'low24h': '26002.75',
          'open24h': '26577.72',
          'openUtc': '26249.22',
          'quoteVolume': '121783275.3371',
          'ts': 1695654338172},
 'last': 26172.33,
 'low': 26002.75,
 'open': 26577.72,
 'percentage': -1.5253001386123415,
 'previousClose': None,
 'quoteVolume': 121783275.3371,
 'symbol': 'BTC/USDT',
 'timestamp': 1695654338172,
 'vwap': 26299.466623477503}
{'ask': 64.32,
 'askVolume': None,
 'average': 64.507,
 'baseVolume': 25373.4129,
 'bid': 64.264,
 'bidVolume': None,
 'change': -0.484,
 'close': 64.265,
 'datetime': '2023-09-25T15:05:38.172Z',
 'high': 65.0,
 'info': {'askSz': '0.1144',
          'baseVolume': '25373.4129',
          'bestAsk': '64.32',
          'bestBid': '64.264',
          'bidSz': '1.8165',
          'chgUTC': '0.01154',
          'high24h': '65.000',
          'instId': 'LTCUSDT',
          'labeId': 0,
          'last': '64.265',
          'low24h': '62.615',
          'open24h': '64.749',
          'openUtc': '63.532',
          'quoteVolume': '1629981.0150',
          'ts': 1695654338172},
 'last': 64.265,
 'low': 62.615,
 'open': 64.749,
 'percentage': -0.7475018919211107,
 'previousClose': None,
 'quoteVolume': 1629981.015,
 'symbol': 'LTC/USDT',
 'timestamp': 1695654338172,
 'vwap': 64.23972295031702}
{'ask': 26172.33,
 'askVolume': None,
 'average': 26375.02,
 'baseVolume': 4630.7037,
 'bid': 26172.01,
 'bidVolume': None,
 'change': -405.4,
 'close': 26172.32,
 'datetime': '2023-09-25T15:05:38.475Z',
 'high': 26736.43,
 'info': {'askSz': '0.3057',
          'baseVolume': '4630.7037',
          'bestAsk': '26172.33',
          'bestBid': '26172.01',
          'bidSz': '0.4407',
          'chgUTC': '-0.00293',
          'high24h': '26736.43',
          'instId': 'BTCUSDT',
          'labeId': 0,
          'last': '26172.32',
          'low24h': '26002.75',
          'open24h': '26577.72',
          'openUtc': '26249.22',
          'quoteVolume': '121785028.8825',
          'ts': 1695654338475},
 'last': 26172.32,
 'low': 26002.75,
 'open': 26577.72,
 'percentage': -1.5253377641121961,
 'previousClose': None,
 'quoteVolume': 121785028.8825,
 'symbol': 'BTC/USDT',
 'timestamp': 1695654338475,
 'vwap': 26299.464783829724}
{'ask': 64.32,
 'askVolume': None,
 'average': 64.507,
 'baseVolume': 25373.4129,
 'bid': 64.264,
 'bidVolume': None,
 'change': -0.484,
 'close': 64.265,
 'datetime': '2023-09-25T15:05:38.474Z',
 'high': 65.0,
 'info': {'askSz': '0.1144',
          'baseVolume': '25373.4129',
          'bestAsk': '64.32',
          'bestBid': '64.264',
          'bidSz': '1.8165',
          'chgUTC': '0.01154',
          'high24h': '65.000',
          'instId': 'LTCUSDT',
          'labeId': 0,
          'last': '64.265',
          'low24h': '62.615',
          'open24h': '64.749',
          'openUtc': '63.532',
          'quoteVolume': '1629981.0150',
          'ts': 1695654338474},
 'last': 64.265,
 'low': 62.615,
 'open': 64.749,
 'percentage': -0.7475018919211107,
 'previousClose': None,
 'quoteVolume': 1629981.015,
 'symbol': 'LTC/USDT',
 'timestamp': 1695654338474,
 'vwap': 64.23972295031702}
```
