### PR TITLE
feat(woo): add watchBalance

### DIFF
--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -15,7 +15,7 @@ export default class woo extends wooRest {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,
-                'watchBalance': false,
+                'watchBalance': true,
                 'watchMyTrades': false,
                 'watchOHLCV': true,
                 'watchOrderBook': true,
@@ -627,6 +627,75 @@ export default class woo extends wooRest {
         }
     }
 
+    async watchBalance (params = {}) {
+        /**
+         * @method
+         * @see https://docs.woo.org/#balance
+         * @name woo#watchBalance
+         * @description watch balance and get the amount of funds available for trading or funds locked in orders
+         * @param {object} [params] extra parameters specific to the woo api endpoint
+         * @returns {object} a [balance structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#balance-structure}
+         */
+        await this.loadMarkets ();
+        const topic = 'balance';
+        const messageHash = topic;
+        const request = {
+            'event': 'subscribe',
+            'topic': topic,
+        };
+        const message = this.extend (request, params);
+        return await this.watchPrivate (messageHash, message);
+    }
+
+    handleBalance (client, message) {
+        //
+        //   {
+        //       "topic": "balance",
+        //       "ts": 1695716888789,
+        //       "data": {
+        //          "balances": {
+        //             "USDT": {
+        //                "holding": 266.56059176,
+        //                "frozen": 0,
+        //                "interest": 0,
+        //                "pendingShortQty": 0,
+        //                "pendingExposure": 0,
+        //                "pendingLongQty": 0,
+        //                "pendingLongExposure": 0,
+        //                "version": 37,
+        //                "staked": 0,
+        //                "unbonding": 0,
+        //                "vault": 0,
+        //                "averageOpenPrice": 0,
+        //                "pnl24H": 0,
+        //                "fee24H": 0,
+        //                "markPrice": 1,
+        //                "pnl24HPercentage": 0
+        //             }
+        //          }
+        //
+        //    }
+        //
+        const data = this.safeValue (message, 'data');
+        const balances = this.safeValue (data, 'balances');
+        const keys = Object.keys (balances);
+        const ts = this.safeInteger (message, 'ts');
+        this.balance['info'] = data;
+        this.balance['timestamp'] = ts;
+        this.balance['datetime'] = this.iso8601 (ts);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            const value = balances[key];
+            const code = this.safeCurrencyCode (key);
+            const account = (code in this.balance) ? this.balance[code] : this.account ();
+            account['total'] = this.safeString (value, 'holding');
+            account['used'] = this.safeString (value, 'frozen');
+            this.balance[code] = account;
+        }
+        this.balance = this.safeBalance (this.balance);
+        client.resolve (this.balance, 'balance');
+    }
+
     handleMessage (client: Client, message) {
         const methods = {
             'ping': this.handlePing,
@@ -639,6 +708,7 @@ export default class woo extends wooRest {
             'auth': this.handleAuth,
             'executionreport': this.handleOrderUpdate,
             'trade': this.handleTrade,
+            'balance': this.handleBalance,
         };
         const event = this.safeString (message, 'event');
         let method = this.safeValue (methods, event);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19381

```
p woo watchBalance                          
Python v3.11.5
CCXT v4.0.106
woo.watchBalance()
{'LTC': {'free': 5.4e-07, 'total': 5.4e-07, 'used': 0.0},
 'USDT': {'free': 266.56059176, 'total': 266.56059176, 'used': 0.0},
 'datetime': '2023-09-26T08:45:58.370Z',
 'free': {'LTC': 5.4e-07, 'USDT': 266.56059176},
 'info': {'balances': {'LTC': {'averageOpenPrice': 88.77777778,
                               'fee24H': 0.0,
                               'frozen': 0.0,
                               'holding': 5.4e-07,
                               'interest': 0.0,
                               'markPrice': 64.52,
                               'pendingExposure': 0.0,
                               'pendingLongExposure': 0.0,
                               'pendingLongQty': 0.0,
                               'pendingShortQty': 0.0,
                               'pnl24H': 0.0,
                               'pnl24HPercentage': 0.0,
                               'staked': 0.0,
                               'unbonding': 0.0,
                               'vault': 0.0,
                               'version': 31},
                       'USDT': {'averageOpenPrice': 0.0,
                                'fee24H': 0.0,
                                'frozen': 0.0,
                                'holding': 266.56059176,
                                'interest': 0.0,
                                'markPrice': 1.0,
                                'pendingExposure': 0.0,
                                'pendingLongExposure': 0.0,
                                'pendingLongQty': 0.0,
                                'pendingShortQty': 0.0,
                                'pnl24H': 0.0,
                                'pnl24HPercentage': 0.0,
                                'staked': 0.0,
                                'unbonding': 0.0,
                                'vault': 0.0,
                                'version': 41}}},
 'timestamp': 1695717958370,
 'total': {'LTC': 5.4e-07, 'USDT': 266.56059176},
 'used': {'LTC': 0.0, 'USDT': 0.0}}
```
