### PR TITLE
feat(phemex): add from/to endpoint to fetchOHLCV

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1120,9 +1120,10 @@ export default class phemex extends Exchange {
          * @see https://github.com/phemex/phemex-api-docs/blob/master/Public-Contract-API-en.md#query-kline
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
-         * @param {int} [since] *emulated not supported by the exchange* timestamp in ms of the earliest candle to fetch
+         * @param {int} [since] *only used for USDT settled contracts, otherwise is emulated and not supported by the exchange* timestamp in ms of the earliest candle to fetch
          * @param {int} [limit] the maximum amount of candles to fetch
          * @param {object} [params] extra parameters specific to the phemex api endpoint
+         * @param {int} [params.until] *USDT settled only* end time in ms
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         await this.loadMarkets ();
@@ -1132,32 +1133,44 @@ export default class phemex extends Exchange {
             'symbol': market['id'],
             'resolution': this.safeString (this.timeframes, timeframe, timeframe),
         };
-        const possibleLimitValues = [ 5, 10, 50, 100, 500, 1000 ];
-        const maxLimit = 1000;
-        if (limit === undefined && since === undefined) {
-            limit = possibleLimitValues[5];
+        const until = this.safeInteger2 (params, 'until', 'to');
+        params = this.omit (params, [ 'until' ]);
+        const usesSpecialFromToEndpoint = ((market['linear'] || market['settle'] === 'USDT')) && ((since !== undefined) || (until !== undefined));
+        let maxLimit = 1000;
+        if (usesSpecialFromToEndpoint) {
+            maxLimit = 2000;
         }
-        if (since !== undefined) {
-            // phemex also provides kline query with from/to, however, this interface is NOT recommended and does not work properly.
-            // we do not send since param to the exchange, instead we calculate appropriate limit param
-            const duration = this.parseTimeframe (timeframe) * 1000;
-            const timeDelta = this.milliseconds () - since;
-            limit = this.parseToInt (timeDelta / duration); // setting limit to the number of candles after since
-        }
-        if (limit > maxLimit) {
+        if (limit === undefined) {
             limit = maxLimit;
-        } else {
-            for (let i = 0; i < possibleLimitValues.length; i++) {
-                if (limit <= possibleLimitValues[i]) {
-                    limit = possibleLimitValues[i];
-                }
-            }
         }
-        request['limit'] = limit;
+        request['limit'] = Math.min (limit, maxLimit);
         let response = undefined;
         if (market['linear'] || market['settle'] === 'USDT') {
-            response = await this.publicGetMdV2KlineLast (this.extend (request, params));
+            if ((until !== undefined) || (since !== undefined)) {
+                if (since !== undefined) {
+                    since = since / 1000;
+                    request['from'] = since;
+                }
+                if (until !== undefined) {
+                    request['to'] = until;
+                } else {
+                    // when since is defined 'to' is mandatory
+                    const candleDuration = this.parseTimeframe (timeframe);
+                    const to = since + (maxLimit * candleDuration);
+                    request['to'] = to;
+                }
+                response = await this.publicGetMdV2KlineList (this.extend (request, params));
+            } else {
+                response = await this.publicGetMdV2KlineLast (this.extend (request, params));
+            }
         } else {
+            if (since !== undefined) {
+                // phemex also provides kline query with from/to, however, this interface is NOT recommended and does not work properly.
+                // we do not send since param to the exchange, instead we calculate appropriate limit param
+                const duration = this.parseTimeframe (timeframe) * 1000;
+                const timeDelta = this.milliseconds () - since;
+                limit = this.parseToInt (timeDelta / duration); // setting limit to the number of candles after since
+            }
             response = await this.publicGetMdV2Kline (this.extend (request, params));
         }
         //

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1149,17 +1149,21 @@ export default class phemex extends Exchange {
             if ((until !== undefined) || (since !== undefined)) {
                 const candleDuration = this.parseTimeframe (timeframe);
                 if (since !== undefined) {
-                    since = since / 1000;
+                    since = Math.round (since / 1000);
                     request['from'] = since;
                 } else {
                     // when 'to' is defined since is mandatory
-                    since = until - (maxLimit * candleDuration);
+                    since = (until / 100) - (maxLimit * candleDuration);
                 }
                 if (until !== undefined) {
-                    request['to'] = until;
+                    request['to'] = Math.round (until / 1000);
                 } else {
                     // when since is defined 'to' is mandatory
-                    const to = since + (maxLimit * candleDuration);
+                    let to = since + (maxLimit * candleDuration);
+                    const now = this.seconds ();
+                    if (to > now) {
+                        to = now;
+                    }
                     request['to'] = to;
                 }
                 response = await this.publicGetMdV2KlineList (this.extend (request, params));

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1123,7 +1123,7 @@ export default class phemex extends Exchange {
          * @param {int} [since] *only used for USDT settled contracts, otherwise is emulated and not supported by the exchange* timestamp in ms of the earliest candle to fetch
          * @param {int} [limit] the maximum amount of candles to fetch
          * @param {object} [params] extra parameters specific to the phemex api endpoint
-         * @param {int} [params.until] *USDT settled only* end time in ms
+         * @param {int} [params.until] *USDT settled/ linear swaps only* end time in ms
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         await this.loadMarkets ();

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1147,15 +1147,18 @@ export default class phemex extends Exchange {
         let response = undefined;
         if (market['linear'] || market['settle'] === 'USDT') {
             if ((until !== undefined) || (since !== undefined)) {
+                const candleDuration = this.parseTimeframe (timeframe);
                 if (since !== undefined) {
                     since = since / 1000;
                     request['from'] = since;
+                } else {
+                    // when 'since' is mandatory since is mandatory
+                    since = until - (maxLimit * candleDuration);
                 }
                 if (until !== undefined) {
                     request['to'] = until;
                 } else {
                     // when since is defined 'to' is mandatory
-                    const candleDuration = this.parseTimeframe (timeframe);
                     const to = since + (maxLimit * candleDuration);
                     request['to'] = to;
                 }

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1152,7 +1152,7 @@ export default class phemex extends Exchange {
                     since = since / 1000;
                     request['from'] = since;
                 } else {
-                    // when 'since' is mandatory since is mandatory
+                    // when 'to' is defined since is mandatory
                     since = until - (maxLimit * candleDuration);
                 }
                 if (until !== undefined) {


### PR DESCRIPTION
DEMO

```
n phemex fetchOHLCV "LTC/USD:USD" 1m           
Debugger attached.
2023-09-28T13:40:57.966Z
Node.js: v18.18.0
CCXT v4.0.108
phemex.fetchOHLCV (LTC/USD:USD, 1m)
2023-09-28T13:41:02.762Z iteration 0 passed in 1230 ms

1695848400000 | 63.47 | 63.47 | 63.43 | 63.45 |   5821
1695848460000 | 63.42 | 63.42 | 63.42 | 63.42 |   2730
1695848520000 |  63.4 | 63.43 |  63.4 | 63.43 |  38589
1695848580000 | 63.43 | 63.44 | 63.41 | 63.41 |  39786
1695848640000 | 63.41 | 63.41 | 63.39 | 63.39 | 155337
1695848700000 | 63.39 | 63.39 | 63.36 | 63.36 |  14478
```
```
 n phemex fetchOHLCV "LTC/USDT:USDT" 1m 1692960343000 500      
Debugger attached.
2023-09-28T13:42:03.629Z
Node.js: v18.18.0
CCXT v4.0.108
phemex.fetchOHLCV (LTC/USDT:USDT, 1m, 1692960343000, 500)
2023-09-28T13:42:08.344Z iteration 0 passed in 1477 ms

1693050360000 | 65.44 | 65.44 | 65.44 | 65.44 |   79.27
1693050420000 | 65.44 | 65.44 | 65.38 |  65.4 |   83.55
1693050480000 |  65.4 |  65.4 |  65.4 |  65.4 |   10.21
1693050540000 | 65.41 | 65.41 | 65.41 | 65.41 |    0.01
1693050600000 | 65.41 | 65.41 | 65.41 | 65.41 |    0.01
1693050660000 | 65.41 | 65.41 | 65.41 | 65.41 |  259.71
1693050720000 | 65.41 | 65.41 | 65.41 | 65.41 |   41.31
1693050780000 | 65.41 | 65.41 | 65.41 | 65.41 |     5.4
1693050840000 | 65.41 | 65.41 | 65.38 | 65.38 |  122.18
1693050900000 | 65.39 | 65.39 | 65.38 | 65.38 |   25.82
1693050960000 | 65.37 | 65.38 | 65.37 | 65.37 |  172.76
```
