### PR TITLE
Bybit: editOrder, stopLoss takeProfit, enable values to be set to zero

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4039,16 +4039,16 @@ export default class bybit extends Exchange {
             triggerPrice = isStopLossTriggerOrder ? stopLossTriggerPrice : takeProfitTriggerPrice;
         }
         if (triggerPrice !== undefined) {
-            request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
+            request['triggerPrice'] = triggerPrice;
         }
         if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
                 const slTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice', stopLoss);
-                request['stopLoss'] = this.priceToPrecision (symbol, slTriggerPrice);
+                request['stopLoss'] = slTriggerPrice;
             }
             if (isTakeProfit) {
                 const tpTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice', takeProfit);
-                request['takeProfit'] = this.priceToPrecision (symbol, tpTriggerPrice);
+                request['takeProfit'] = tpTriggerPrice;
             }
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');


### PR DESCRIPTION
Removed priceToPrecision from setting the `triggerPrice`, `stopLoss` and `takeProfit` so that a value of zero can be used:
fixes: #19412
```
bybit editOrder "'e3c2ca9d-83d9-473f-a5c6-8ab839aa9290'" BTC/USDT:USDT limit buy undefined undefined '{"stopLoss":"0","takeProfit":"0"}'

bybit.editOrder (e3c2ca9d-83d9-473f-a5c6-8ab839aa9290, BTC/USDT:USDT, limit, buy, , , [object Object])
2023-09-30T03:56:48.323Z iteration 0 passed in 695 ms

{
  info: {
    retCode: '0',
    retMsg: 'OK',
    result: {
      orderId: 'e3c2ca9d-83d9-473f-a5c6-8ab839aa9290',
      orderLinkId: ''
    },
    retExtInfo: {},
    time: '1696046208327'
  },
  id: 'e3c2ca9d-83d9-473f-a5c6-8ab839aa9290',
  fees: [],
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  trades: [],
  reduceOnly: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  status: undefined,
  fee: undefined
}
```

Before these changes this error would occur:
```
InvalidOrder bybit price of BTC/USDT:USDT must be greater than minimum price precision of 0.1
---------------------------------------------------
[InvalidOrder] bybit price of BTC/USDT:USDT must be greater than minimum price precision of 0.1

    at priceToPrecision           …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:3385  
    at editOrder                  mnt/c/Users/Dan/Documents/GitHub/ccxt/js/src/bybit.js:4072    
    at processTicksAndRejections  node:internal/process/task_queues:96
    at async run                  mnt/c/Users/Dan/Documents/GitHub/ccxt/examples/js/cli.js:298  

bybit price of BTC/USDT:USDT must be greater than minimum price precision of 0.1
```