### PR TITLE
Bybit: editOrder, triggerPrice, stopLoss and takeProfit strings

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4038,9 +4038,9 @@ export default class bybit extends Exchange {
         if (amount !== undefined) {
             request['qty'] = this.amountToPrecision (symbol, amount);
         }
-        let triggerPrice = this.safeValue2 (params, 'triggerPrice', 'stopPrice');
-        const stopLossTriggerPrice = this.safeValue (params, 'stopLossPrice');
-        const takeProfitTriggerPrice = this.safeValue (params, 'takeProfitPrice');
+        let triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
+        const stopLossTriggerPrice = this.safeString (params, 'stopLossPrice');
+        const takeProfitTriggerPrice = this.safeString (params, 'takeProfitPrice');
         const stopLoss = this.safeValue (params, 'stopLoss');
         const takeProfit = this.safeValue (params, 'takeProfit');
         const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
@@ -4051,7 +4051,6 @@ export default class bybit extends Exchange {
             triggerPrice = isStopLossTriggerOrder ? stopLossTriggerPrice : takeProfitTriggerPrice;
         }
         if (triggerPrice !== undefined) {
-            triggerPrice = triggerPrice.toString ();
             const triggerPriceRequest = (triggerPrice === '0') ? triggerPrice : this.priceToPrecision (symbol, triggerPrice);
             request['triggerPrice'] = triggerPriceRequest;
             const triggerBy = this.safeString (params, 'triggerBy', 'LastPrice');
@@ -4059,16 +4058,14 @@ export default class bybit extends Exchange {
         }
         if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
-                let slTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice', stopLoss);
-                slTriggerPrice = slTriggerPrice.toString ();
+                const slTriggerPrice = this.safeString2 (stopLoss, 'triggerPrice', 'stopPrice', stopLoss);
                 const stopLossRequest = (slTriggerPrice === '0') ? slTriggerPrice : this.priceToPrecision (symbol, slTriggerPrice);
                 request['stopLoss'] = stopLossRequest;
                 const slTriggerBy = this.safeString (params, 'slTriggerBy', 'LastPrice');
                 request['slTriggerBy'] = slTriggerBy;
             }
             if (isTakeProfit) {
-                let tpTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice', takeProfit);
-                tpTriggerPrice = tpTriggerPrice.toString ();
+                const tpTriggerPrice = this.safeString2 (takeProfit, 'triggerPrice', 'stopPrice', takeProfit);
                 const takeProfitRequest = (tpTriggerPrice === '0') ? tpTriggerPrice : this.priceToPrecision (symbol, tpTriggerPrice);
                 request['takeProfit'] = takeProfitRequest;
                 const tpTriggerBy = this.safeString (params, 'tpTriggerBy', 'LastPrice');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3988,6 +3988,16 @@ export default class bybit extends Exchange {
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} price the price at which the order is to be fullfilled, in units of the base currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the bybit api endpoint
+         * @param {float} [params.triggerPrice] The price that a trigger order is triggered at
+         * @param {float} [params.stopLossPrice] The price that a stop loss order is triggered at
+         * @param {float} [params.takeProfitPrice] The price that a take profit order is triggered at
+         * @param {object} [params.takeProfit] *takeProfit object in params* containing the triggerPrice that the attached take profit order will be triggered
+         * @param {float} [params.takeProfit.triggerPrice] take profit trigger price
+         * @param {object} [params.stopLoss] *stopLoss object in params* containing the triggerPrice that the attached stop loss order will be triggered
+         * @param {float} [params.stopLoss.triggerPrice] stop loss trigger price
+         * @param {string} [params.triggerBy] 'IndexPrice', 'MarkPrice' or 'LastPrice', default is 'LastPrice', required if no initial value for triggerPrice
+         * @param {string} [params.slTriggerBy] 'IndexPrice', 'MarkPrice' or 'LastPrice', default is 'LastPrice', required if no initial value for stopLoss
+         * @param {string} [params.tpTriggerby] 'IndexPrice', 'MarkPrice' or 'LastPrice', default is 'LastPrice', required if no initial value for takeProfit
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         this.checkRequiredSymbol ('editOrder', symbol);
@@ -4041,16 +4051,28 @@ export default class bybit extends Exchange {
             triggerPrice = isStopLossTriggerOrder ? stopLossTriggerPrice : takeProfitTriggerPrice;
         }
         if (triggerPrice !== undefined) {
-            request['triggerPrice'] = triggerPrice;
+            triggerPrice = triggerPrice.toString ();
+            const triggerPriceRequest = (triggerPrice === '0') ? triggerPrice : this.priceToPrecision (symbol, triggerPrice);
+            request['triggerPrice'] = triggerPriceRequest;
+            const triggerBy = this.safeString (params, 'triggerBy', 'LastPrice');
+            request['triggerBy'] = triggerBy;
         }
         if (isStopLoss || isTakeProfit) {
             if (isStopLoss) {
-                const slTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice', stopLoss);
-                request['stopLoss'] = slTriggerPrice;
+                let slTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice', stopLoss);
+                slTriggerPrice = slTriggerPrice.toString ();
+                const stopLossRequest = (slTriggerPrice === '0') ? slTriggerPrice : this.priceToPrecision (symbol, slTriggerPrice);
+                request['stopLoss'] = stopLossRequest;
+                const slTriggerBy = this.safeString (params, 'slTriggerBy', 'LastPrice');
+                request['slTriggerBy'] = slTriggerBy;
             }
             if (isTakeProfit) {
-                const tpTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice', takeProfit);
-                request['takeProfit'] = tpTriggerPrice;
+                let tpTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice', takeProfit);
+                tpTriggerPrice = tpTriggerPrice.toString ();
+                const takeProfitRequest = (tpTriggerPrice === '0') ? tpTriggerPrice : this.priceToPrecision (symbol, tpTriggerPrice);
+                request['takeProfit'] = takeProfitRequest;
+                const tpTriggerBy = this.safeString (params, 'tpTriggerBy', 'LastPrice');
+                request['tpTriggerBy'] = tpTriggerBy;
             }
         }
         const clientOrderId = this.safeString (params, 'clientOrderId');


### PR DESCRIPTION
Set triggerPrice, stopLoss and takeProfit queries to strings, and set those parameters to use priceToPrecision if the value is not zero, added triggerBy, slTriggerBy and tpTriggerBy requests:
fixes: #19421

```
bybit editOrder "'520ea9d9-1799-4ec7-839d-7f2b6ef40f2f'" BTC/USDT:USDT limit buy undefined undefined '{"stopLoss":0,"takeProfit":0}'

{
  info: {
    retCode: '0',
    retMsg: 'OK',
    result: {
      orderId: '520ea9d9-1799-4ec7-839d-7f2b6ef40f2f',
      orderLinkId: ''
    },
    retExtInfo: {},
    time: '1696188541826'
  },
  id: '520ea9d9-1799-4ec7-839d-7f2b6ef40f2f',
  fees: [],
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  trades: [],
  reduceOnly: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  status: undefined,
  fee: undefined
}
```
```
bybit editOrder "'520ea9d9-1799-4ec7-839d-7f2b6ef40f2f'" BTC/USDT:USDT limit buy undefined undefined '{"stopLoss":21000}'

bybit.editOrder (520ea9d9-1799-4ec7-839d-7f2b6ef40f2f, BTC/USDT:USDT, limit, buy, , , [object Object])
2023-10-01T19:39:05.592Z iteration 0 passed in 1643 ms

{
  info: {
    retCode: '0',
    retMsg: 'OK',
    result: {
      orderId: '520ea9d9-1799-4ec7-839d-7f2b6ef40f2f',
      orderLinkId: ''
    },
    retExtInfo: {},
    time: '1696189146476'
  },
  id: '520ea9d9-1799-4ec7-839d-7f2b6ef40f2f',
  fees: [],
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  symbol: undefined,
  type: undefined,
  side: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  price: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  trades: [],
  reduceOnly: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  status: undefined,
  fee: undefined
}
```