### PR TITLE
fix(bitrue): ticker percantage scale

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -842,7 +842,7 @@ export default class bitrue extends Exchange {
             'last': last,
             'previousClose': undefined,
             'change': undefined,
-            'percentage': this.safeString (ticker, 'percentChange'),
+            'percentage': Precise.stringMul (this.safeString (ticker, 'percentChange'), '10000'),
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'baseVolume'),
             'quoteVolume': this.safeString (ticker, 'quoteVolume'),


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19428

```
p bitrue fetchTickers '["LTC/USDT"]'
Python v3.11.5
CCXT v4.1.1
bitrue.fetchTickers(['LTC/USDT'])
{'LTC/USDT': {'ask': 67.2,
              'askVolume': None,
              'average': None,
              'baseVolume': 10728.084,
              'bid': 66.96,
              'bidVolume': None,
              'change': None,
              'close': 67.09,
              'datetime': None,
              'high': 68.78,
              'info': {'baseVolume': '10728.084',
                       'high24hr': '68.78',
                       'highestBid': '66.96',
                       'id': '482159113',
                       'isFrozen': '0',
                       'last': '67.09',
                       'low24hr': '68.78',
                       'lowestAsk': '67.20',
                       'percentChange': '-0.000011',
                       'quoteVolume': '735825.69'},
              'last': 67.09,
              'low': 68.78,
              'open': None,
              'percentage': -0.11,
              'previousClose': None,
              'quoteVolume': 735825.69,
              'symbol': 'LTC/USDT',
              'timestamp': None,
              'vwap': 68.58873308598255}}
```

![image](https://github.com/ccxt/ccxt/assets/43336371/7edca555-33d2-411e-9167-3aa3c407f74e)
