### PR TITLE
fix(binance): watchOrderbook (spot) max limit

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -146,14 +146,19 @@ export default class binance extends binanceRest {
         // valid <levels> are 5, 10, or 20
         //
         // default 100, max 1000, valid limits 5, 10, 20, 50, 100, 500, 1000
-        if (limit !== undefined) {
-            if ((limit !== 5) && (limit !== 10) && (limit !== 20) && (limit !== 50) && (limit !== 100) && (limit !== 500) && (limit !== 1000)) {
-                throw new ExchangeError (this.id + ' watchOrderBook limit argument must be undefined, 5, 10, 20, 50, 100, 500 or 1000');
-            }
-        }
-        //
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (limit !== undefined) {
+            if (market['contract']) {
+                if ((limit !== 5) && (limit !== 10) && (limit !== 20) && (limit !== 50) && (limit !== 100) && (limit !== 500) && (limit !== 1000)) {
+                    throw new ExchangeError (this.id + ' watchOrderBook limit argument must be undefined, 5, 10, 20, 50, 100, 500 or 1000');
+                }
+            } else {
+                if (limit > 5000) {
+                    throw new ExchangeError (this.id + ' watchOrderBook limit argument must be less than or equal to 5000');
+                }
+            }
+        }
         let type = market['type'];
         if (market['contract']) {
             type = market['linear'] ? 'future' : 'delivery';


### PR DESCRIPTION
DEMO
- For spot markets the limit is 5000 and not 1000
```
2023-10-03T16:14:16.063Z
Node.js: v18.18.0
CCXT v4.1.2
binance.watchOrderBook (BTC/USDT, 5000)
OrderBook {
  bids: Bids(5000) [
    [ 27346.51, 7.56829 ], [ 27346.47, 0.20767 ], [ 27346.41, 0.00036 ],
    [ 27346.4, 0.00033 ],  [ 27346.38, 0.0002 ],  [ 27346.34, 0.00036 ],
    [ 27346.3, 0.0002 ],   [ 27346.28, 0.00033 ], [ 27346.27, 0.00036 ],
    [ 27346.22, 0.0002 ],  [ 27
```
