### PR TITLE
Bitmart: fetchPosition, fetchPositions

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -3832,8 +3832,7 @@ export default class bitmart extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         const first = this.safeValue (data, 0, {});
-        const position = this.parsePosition (first, market);
-        return position;
+        return this.parsePosition (first, market);
     }
 
     async fetchPositions (symbols: string[] = undefined, params = {}) {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -3847,12 +3847,14 @@ export default class bitmart extends Exchange {
          */
         await this.loadMarkets ();
         let market = undefined;
+        let symbolsLength = undefined;
         if (symbols !== undefined) {
+            symbolsLength = symbols.length;
             const first = this.safeString (symbols, 0);
             market = this.market (first);
         }
         const request = {};
-        if (symbols !== undefined) {
+        if (symbolsLength === 1) {
             // only supports symbols as undefined or sending one symbol
             request['symbol'] = market['id'];
         }

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -73,6 +73,7 @@ export default class bitmart extends Exchange {
                 'fetchOrderBook': true,
                 'fetchOrders': false,
                 'fetchOrderTrades': true,
+                'fetchPosition': true,
                 'fetchPositionMode': false,
                 'fetchStatus': true,
                 'fetchTicker': true,
@@ -3781,6 +3782,122 @@ export default class bitmart extends Exchange {
             'previousFundingTimestamp': undefined,
             'previousFundingDatetime': undefined,
         };
+    }
+
+    async fetchPosition (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name bitmart#fetchPosition
+         * @description fetch data on a single open contract trade position
+         * @see https://developer-pro.bitmart.com/en/futures/#get-current-position-keyed
+         * @param {string} symbol unified market symbol of the market the position is held in
+         * @param {object} [params] extra parameters specific to the bitmart api endpoint
+         * @returns {object} a [position structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#position-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.privateGetContractPrivatePosition (this.extend (request, params));
+        //
+        //     {
+        //         "code": 1000,
+        //         "message": "Ok",
+        //         "data": [
+        //             {
+        //                 "symbol": "BTCUSDT",
+        //                 "leverage": "10",
+        //                 "timestamp": 1696392515269,
+        //                 "current_fee": "0.0014250028",
+        //                 "open_timestamp": 1696392256998,
+        //                 "current_value": "27.4039",
+        //                 "mark_price": "27.4039",
+        //                 "position_value": "27.4079",
+        //                 "position_cross": "3.75723474",
+        //                 "maintenance_margin": "0.1370395",
+        //                 "close_vol": "0",
+        //                 "close_avg_price": "0",
+        //                 "open_avg_price": "27407.9",
+        //                 "entry_price": "27407.9",
+        //                 "current_amount": "1",
+        //                 "unrealized_value": "-0.004",
+        //                 "realized_value": "-0.01644474",
+        //                 "position_type": 1
+        //             }
+        //         ],
+        //         "trace":"4cad855074664097ac5ba5257c47305d.67.16963925142065945"
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        const first = this.safeValue (data, 0, {});
+        const position = this.parsePosition (first, market);
+        return position;
+    }
+
+    parsePosition (position, market = undefined) {
+        //
+        //     {
+        //         "symbol": "BTCUSDT",
+        //         "leverage": "10",
+        //         "timestamp": 1696392515269,
+        //         "current_fee": "0.0014250028",
+        //         "open_timestamp": 1696392256998,
+        //         "current_value": "27.4039",
+        //         "mark_price": "27.4039",
+        //         "position_value": "27.4079",
+        //         "position_cross": "3.75723474",
+        //         "maintenance_margin": "0.1370395",
+        //         "close_vol": "0",
+        //         "close_avg_price": "0",
+        //         "open_avg_price": "27407.9",
+        //         "entry_price": "27407.9",
+        //         "current_amount": "1",
+        //         "unrealized_value": "-0.004",
+        //         "realized_value": "-0.01644474",
+        //         "position_type": 1
+        //     }
+        //
+        const marketId = this.safeString (position, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const symbol = market['symbol'];
+        const timestamp = this.safeInteger (position, 'timestamp');
+        const side = this.safeInteger (position, 'position_type');
+        const maintenanceMargin = this.safeString (position, 'maintenance_margin');
+        const notional = this.safeString (position, 'current_value');
+        const collateral = this.safeString (position, 'position_cross');
+        const maintenanceMarginPercentage = Precise.stringDiv (maintenanceMargin, notional);
+        const marginRatio = Precise.stringDiv (maintenanceMargin, collateral);
+        return this.safePosition ({
+            'info': position,
+            'id': undefined,
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'lastUpdateTimestamp': undefined,
+            'hedged': undefined,
+            'side': (side === 1) ? 'long' : 'short',
+            'contracts': this.safeNumber (position, 'current_amount'),
+            'contractSize': this.safeNumber (market, 'contractSize'),
+            'entryPrice': this.safeNumber (position, 'entry_price'),
+            'markPrice': this.safeNumber (position, 'mark_price'),
+            'lastPrice': undefined,
+            'notional': this.parseNumber (notional),
+            'leverage': this.safeNumber (position, 'leverage'),
+            'collateral': this.parseNumber (collateral),
+            'initialMargin': undefined,
+            'initialMarginPercentage': undefined,
+            'maintenanceMargin': this.parseNumber (maintenanceMargin),
+            'maintenanceMarginPercentage': this.parseNumber (maintenanceMarginPercentage),
+            'unrealizedPnl': this.safeNumber (position, 'unrealized_value'),
+            'realizedPnl': this.safeNumber (position, 'realized_value'),
+            'liquidationPrice': undefined,
+            'marginMode': undefined,
+            'percentage': undefined,
+            'marginRatio': this.parseNumber (marginRatio),
+            'stopLossPrice': undefined,
+            'takeProfitPrice': undefined,
+        });
     }
 
     nonce () {


### PR DESCRIPTION
Added fetchPosition and fetchPositions to Bitmart:

### fetchPosition:
```
bitmart.fetchPosition (BTC/USDT:USDT)
2023-10-04T04:33:46.961Z iteration 0 passed in 487 ms

{
  info: {
    symbol: 'BTCUSDT',
    leverage: '10',
    timestamp: '1696394027511',
    current_fee: '0.0015614466',
    open_timestamp: '1696392256998',
    current_value: '27.3938',
    mark_price: '27.3938',
    position_value: '27.4079',
    position_cross: '3.75723474',
    maintenance_margin: '0.1370395',
    close_vol: '0',
    close_avg_price: '0',
    open_avg_price: '27407.9',
    entry_price: '27407.9',
    current_amount: '1',
    unrealized_value: '-0.0141',
    realized_value: '-0.01644474',
    position_type: '1'
  },
  id: undefined,
  symbol: 'BTC/USDT:USDT',
  timestamp: 1696394027511,
  datetime: '2023-10-04T04:33:47.511Z',
  lastUpdateTimestamp: undefined,
  hedged: undefined,
  side: 'long',
  contracts: 1,
  contractSize: 0.001,
  entryPrice: 27407.9,
  markPrice: 27.3938,
  lastPrice: undefined,
  notional: 27.3938,
  leverage: 10,
  collateral: 3.75723474,
  initialMargin: undefined,
  initialMarginPercentage: undefined,
  maintenanceMargin: 0.1370395,
  maintenanceMarginPercentage: 0.005002573575042527,
  unrealizedPnl: -0.0141,
  realizedPnl: -0.01644474,
  liquidationPrice: undefined,
  marginMode: undefined,
  percentage: undefined,
  marginRatio: 0.03647349965682474,
  stopLossPrice: undefined,
  takeProfitPrice: undefined
}
```

### fetchPositions:
```
bitmart.fetchPositions ()
2023-10-04T07:40:08.122Z iteration 0 passed in 584 ms

id |        symbol |     timestamp |                 datetime | lastUpdateTimestamp | hedged | side | contracts | contractSize | entryPrice |      markPrice | lastPrice | notional | leverage | collateral | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | unrealizedPnl | realizedPnl | liquidationPrice | marginMode | percentage |          marginRatio | stopLossPrice | takeProfitPrice
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | BTC/USDT:USDT | 1696405208744 | 2023-10-04T07:40:08.744Z |                     |        | long |         1 |        0.001 |    27407.9 | 27.39501090476 |           |  27.3918 |       10 | 3.75723474 |               |                         |         0.1370395 |        0.005002938835709956 |       -0.0161 | -0.01644474 |                  |            |            |  0.03647349965682474 |               |
   | ETH/USDT:USDT | 1696405208746 | 2023-10-04T07:40:08.746Z |                     |        | long |         1 |        0.001 |     1639.1 |  1.64032577408 |           |  1.64016 |        5 | 0.32880346 |               |                         |         0.0081955 |        0.004996768607940688 |       0.00106 | -0.00098346 |                  |            |            | 0.024925224327018942 |               |
2 objects
```