### PR TITLE
feat(bitmart): handleOHLCV - string math

### DIFF
--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -7,6 +7,7 @@ import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../ba
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
 import { Int } from '../base/types.js';
 import Client from '../base/ws/Client.js';
+import Precise from '../base/Precise.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -369,15 +370,15 @@ export default class bitmart extends bitmartRest {
         // use a reverse lookup in a static map instead
         const timeframes = this.safeValue (this.options, 'timeframes', {});
         const timeframe = this.findTimeframe (interval, timeframes);
-        const duration = this.parseTimeframe (timeframe);
-        const durationInMs = duration * 1000;
+        const duration = this.numberToString (this.parseTimeframe (timeframe));
+        const durationInMs = Precise.stringMul (duration, '1000');
         for (let i = 0; i < data.length; i++) {
             const marketId = this.safeString (data[i], 'symbol');
             const candle = this.safeValue (data[i], 'candle');
             const market = this.safeMarket (marketId);
             const symbol = market['symbol'];
             const parsed = this.parseOHLCV (candle, market);
-            parsed[0] = this.parseToInt (parsed[0] / durationInMs) * durationInMs;
+            parsed[0] = this.parseToInt (Precise.stringMul (Precise.stringDiv (this.numberToString (parsed[0]), durationInMs), durationInMs));
             this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
             let stored = this.safeValue (this.ohlcvs[symbol], timeframe);
             if (stored === undefined) {


### PR DESCRIPTION
```
 % py bitmart watchOHLCV BTC/USDT
Python v3.11.3
CCXT v4.0.109
bitmart.watchOHLCV(BTC/USDT)
[[1696472228000, 27711.7, 27711.7, 27711.69, 27711.69, 0.35719]]
[[1696472229000, 27711.7, 27711.7, 27711.69, 27711.69, 0.36652]]
```