### PR TITLE
feat(coinex): fetchTime - uses safeInteger instead of safeNumber

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -897,7 +897,7 @@ export default class coinex extends Exchange {
         //         message: 'OK'
         //     }
         //
-        return this.safeNumber (response, 'data');
+        return this.safeInteger (response, 'data');
     }
 
     async fetchOrderBook (symbol: string, limit = 20, params = {}) {


### PR DESCRIPTION
```
% py coinex fetchTime
Python v3.11.3
CCXT v4.0.109
coinex.fetchTime()
1696475472370
```