### PR TITLE
feat(idex): fetchTime uses safeInteger instead of safeNumber

### DIFF
--- a/ts/src/idex.ts
+++ b/ts/src/idex.ts
@@ -1537,7 +1537,7 @@ export default class idex extends Exchange {
         //
         //    { serverTime: '1655258263236' }
         //
-        return this.safeNumber (response, 'serverTime');
+        return this.safeInteger (response, 'serverTime');
     }
 
     async fetchWithdrawal (id: string, code: string = undefined, params = {}) {


### PR DESCRIPTION
```
% idex fetchTime
2023-10-05T04:03:45.665Z
Node.js: v18.15.0
CCXT v4.0.109
idex.fetchTime ()
2023-10-05T04:03:48.733Z iteration 0 passed in 660 ms

1696478628735
2023-10-05T04:03:48.733Z iteration 1 passed in 660 ms
```
```
% py idex fetchTime
Python v3.11.3
CCXT v4.0.109
idex.fetchTime()
1696478636855
```