### PR TITLE
feat(kucoinfutures): fetchTime uses safeInteger instead of safeNumber

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -530,7 +530,7 @@ export default class kucoinfutures extends kucoin {
         //        data: 1637385119302,
         //    }
         //
-        return this.safeNumber (response, 'data');
+        return this.safeInteger (response, 'data');
     }
 
     async fetchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}) {


### PR DESCRIPTION
```
% kucoinfutures fetchTime
2023-10-05T04:14:21.469Z
Node.js: v18.15.0
CCXT v4.0.109
kucoinfutures.fetchTime ()
2023-10-05T04:14:22.555Z iteration 0 passed in 373 ms

1696479262531
2023-10-05T04:14:22.555Z iteration 1 passed in 373 ms
```
```
% py kucoinfutures fetchTime
Python v3.11.3
CCXT v4.0.109
kucoinfutures.fetchTime()
1696479271845
```