### PR TITLE
whitebit: fetchOrderBook - parseToInt instead of parseNumber

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -863,7 +863,7 @@ export default class whitebit extends Exchange {
         //          ]
         //      }
         //
-        const timestamp = this.parseNumber (Precise.stringMul (this.safeString (response, 'timestamp'), '1000'));
+        const timestamp = this.parseToInt (Precise.stringMul (this.safeString (response, 'timestamp'), '1000'));
         return this.parseOrderBook (response, symbol, timestamp);
     }
 


### PR DESCRIPTION
```
% whitebit fetchOrderBook BTC/USDT
2023-10-05T04:18:09.851Z
Node.js: v18.15.0
CCXT v4.0.109
whitebit.fetchOrderBook (BTC/USDT)
2023-10-05T04:18:12.856Z iteration 0 passed in 895 ms

{
  symbol: 'BTC/USDT',
  bids: [
    [ 27659.6, 0.3 ],       [ 27659.32, 0.032202 ], [ 27658.21, 0.749792 ],
    [ 27657.1, 0.244058 ],  [ 27656, 0.741091 ],    [ 27654.89, 0.51446 ],
    [ 27653.78, 0.497456 ], [ 27652.68, 0.847723 ], [ 27652.41, 0.000199 ],
...
    [ 27651.57, 0.41827 ],  [ 27650.46, 0.312031 ], [ 27649.36, 0.54985 ],
    [ 27629.51, 0.39767 ],  [ 27629.44, 8.381666 ], [ 27629.43, 0.35525 ],
    [ 27629.33, 0.00421 ],  [ 27629.31, 0.03876 ],  [ 27629.26, 0.78695 ],
    [ 27629.24, 0.00711 ]
  ],
  asks: [
    [ 27660.42, 0.022224 ], [ 27661.53, 0.376958 ], [ 27662.64, 0.448436 ],
    [ 27663.75, 1.643891 ], [ 27664.85, 3.059776 ], [ 27665.96, 1.570938 ],
    [ 27667.07, 4.518603 ], [ 27668.18, 1.597385 ], [ 27669, 0.000199 ],
    [ 27669.28, 2.726158 ], [ 27670.39, 2.674712 ], [ 27671.5, 3.521436 ],
   ...
    [ 27697.83, 0.01804 ],  [ 27697.98, 0.36161 ],  [ 27698, 0.18249 ],
    [ 27698.09, 1.60704 ],  [ 27698.44, 0.27615 ],  [ 27698.45, 0.46012 ],
    [ 27698.95, 0.00635 ]
  ],
  timestamp: 1696479492000,
  datetime: '2023-10-05T04:18:12.000Z',
  nonce: undefined
}
2023-10-05T04:18:12.856Z iteration 1 passed in 895 ms
```

```
 % py whitebit fetchOrderBook BTC/USDT
Python v3.11.3
CCXT v4.0.109
whitebit.fetchOrderBook(BTC/USDT)
{'asks': [[27657.1, 0.021351],
          [27657.31, 0.3],
          [27658.21, 0.393143],
          [27659.32, 0.064252],
...
          [27693.84, 0.14519],
          [27694.39, 0.62511],
          [27694.56, 0.27208]],
 'bids': [[27656.0, 0.194775],
          [27654.89, 0.110253],
          [27653.78, 1.257482],
...
          [27626.15, 0.71526],
          [27626.13, 5.318322],
          [27626.11, 0.07205]],
 'datetime': '2023-10-05T04:19:38.000Z',
 'nonce': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1696479578000}
 ```