### PR TITLE
fix(bitbns): fetchBalance returns amouts of used and total INR instead of undefined

### DIFF
--- a/ts/src/bitbns.ts
+++ b/ts/src/bitbns.ts
@@ -446,13 +446,13 @@ export default class bitbns extends Exchange {
             if (numParts > 1) {
                 let currencyId = this.safeString (parts, 1);
                 // note that "Money" stands for INR - the only fiat in bitbns
+                const account = this.account ();
+                account['free'] = this.safeString (data, key);
+                account['used'] = this.safeString (data, 'inorder' + currencyId);
                 if (currencyId === 'Money') {
                     currencyId = 'INR';
                 }
                 const code = this.safeCurrencyCode (currencyId);
-                const account = this.account ();
-                account['free'] = this.safeString (data, key);
-                account['used'] = this.safeString (data, 'inorder' + currencyId);
                 result[code] = account;
             }
         }


### PR DESCRIPTION
```
2023-10-07T01:44:28.421Z
Node.js: v18.15.0
CCXT v4.1.6
bitbns.fetchBalance ()
2023-10-07T01:44:31.899Z iteration 0 passed in 1974 ms

{
  info: {
    data: {
      availableorderBTC: '0.00003295',
      availableorderMoney: '1297.49',
      inorderMoney: '0',
      inorderBTC: '0',
      inorderXRP: '0',
      availableorderXRP: '0',
      inorderNEO: '0',
      inorderGAS: '0',
      inorderXLM: '0',
      inorderXEM: '0',
      inorderETH: '0',
      availableorderNEO: '0',
      availableorderGAS: '0',
      availableorderXLM: '0',
      availableorderXEM: '0',
      availableorderETH: '0',
      availableorderDBC: '0',
      availableorderRPX: '0',
      inorderDBC: '0',
      inorderRPX: '0',
      availableorderLTC: '0',
      availableorderXMR: '0',
      inorderLTC: '0',
      inorderXMR: '0',
      inorderDASH: '0',
      availableorderDASH: '0',
      inorderDOGE: '0',
      availableorderDOGE: '0',
      inorderBCH: '0',
      availableorderBCH: '0',
      inorderSIA: '0',
      availableorderSIA: '0',
      inorderTRX: '0',
      availableorderTRX: '0',
      inorderETN: '0',
      availableorderETN: '0',
      inorderONT: '0',
      availableorderONT: '0',
      inorderZIL: '0',
      availableorderZIL: '0',
      inorderEOS: '0',
      availableorderEOS: '0',
      inorderPOLY: '0',
      availableorderPOLY: '0',
      inorderDGB: '0',
      availableorderDGB: '0',
      inorderNCASH: '0',
      availableorderNCASH: '0',
      inorderADA: '0',
      availableorderADA: '0',
      inorderTST: '0',
      availableorderTST: '0',
      availableorderFEE: '0',
      inorderFEE: '0',
      availableorderICX: '0',
      inorderICX: '0',
      availableorderVEN: '0',
      inorderVEN: '0',
      availableorderPHB: '0',
      inorderPHB: '0',
      availableorderSC: '0',
      inorderSC: '0',
      availableorderVET: '0',
      inorderVET: '0',
      availableorderOMG: '0',
      inorderOMG: '0',
      availableorderREQ: '0',
      inorderREQ: '0',
      availableorderDGD: '0',
      inorderDGD: '0',
      availableorderQLC: '0',
      inorderQLC: '0',
      availableorderPOWR: '0',
      inorderPOWR: '0',
      availableorderWPR: '0',
      inorderWPR: '0',
      availableorderWAVES: '0',
      inorderWAVES: '0',
      availableorderWAN: '0',
      inorderWAN: '0',
      availableorderACT: '0',
      inorderACT: '0',
      availableorderXVG: '0',
      inorderXVG: '0',
      availableorderNEXO: '0',
      inorderBLZ: '0',
      availableorderBLZ: '0',
      inorderSUB: '0',
      availableorderSUB: '0',
      inorderLRC: '0',
      availableorderLRC: '0',
      inorderEFX: '0',
      availableorderEFX: '0',
      inorderCPX: '0',
      availableorderCPX: '0',
      inorderZRX: '0',
      availableorderZRX: '0',
      inorderREP: '0',
      availableorderREP: '0',
      inorderLOOM: '0',
      availableorderLOOM: '0',
      inorderNEXO: '0',
      availableorderEOSD: '0',
      inorderEOSD: '0',
      availableorderQKC: '0',
      inorderQKC: '0',
      availableorderQTUM: '0',
      inorderQTUM: '0',
      availableorderGNT: '0',
      inorderGNT: '0',
      availableorderSTORM: '0',
      inorderSTORM: '0',
      availableorderLSK: '0',
      inorderLSK: '0',
      availableorderNPXS: '0',
      inorderNPXS: '0',
      availableorderUSDT: '0',
      inorderUSDT: '0',
      availableorderETC: '0',
      inorderETC: '0',
      availableorderDENT: '0',
      inorderDENT: '0',
      availableorderCLOAK: '0',
      inorderCLOAK: '0',
      availableorderKMD: '0',
      inorderKMD: '0',
      availableorderGRS: '0',
      inorderGRS: '0',
      availableorderRAM: '0',
      inorderRAM: '0',
      availableorderLET: '0',
      inorderLET: '0',
      availableorderSOUL: '0',
      inorderSOUL: '0',
      availableorderIXT: '0',
      inorderIXT: '0',
      availableorderSKY: '0',
      inorderSKY: '0',
      availableorderODE: '0',
      inorderODE: '0',
      availableorderBCHSV: '0',
      inorderBCHSV: '0',
      availableorderBCHABC: '0',
      inorderBCHABC: '0',
      availableorderRFR: '0',
      inorderRFR: '0',
      availableorderBTT: '0',
      inorderBTT: '0',
      availableorderFET: '0',
      inorderFET: '0',
      availableorderTEL: '0',
      inorderTEL: '0',
      availableorderZCO: '0',
      inorderZCO: '0',
      availableorderBNB: '0',
      inorderBNB: '0',
      availableorderNRG: '0',
      inorderNRG: '0',
      availableorderPART: '0',
      inorderPART: '0',
      availableorderFUN: '0',
      inorderFUN: '0',
      availableorderBNS: '0',
      inorderBNS: '0',
      availableorderCVT: '0',
      inorderCVT: '0',
      availableorderSERO: '0',
      inorderSERO: '0',
      availableorderATT: '0',
      inorderATT: '0',
      availableorderSYLO: '0',
      inorderSYLO: '0',
      availableorderMATIC: '0',
      inorderMATIC: '0',
      availableorderSNX: '0',
      inorderSNX: '0',
      availableorderBAT: '0',
      inorderBAT: '0',
      availableorderBNT: '0',
      inorderBNT: '0',
      availableorderCHR: '0',
      inorderCHR: '0',
      availableorderLINK: '0',
      inorderLINK: '0',
      availableorderWBTC: '0',
      inorderWBTC: '0',
      availableorderCOMP: '0',
      inorderCOMP: '0',
      availableorderBAL: '0',
      inorderBAL: '0',
      availableorderBNSD: '0',
      inorderBNSD: '0',
      availableorderCUSDT: '0',
      inorderCUSDT: '0',
      availableorderCETH: '0',
      inorderCETH: '0',
      availableorderCZRX: '0',
      inorderCZRX: '0',
      availableorderCREP: '0',
      inorderCREP: '0',
      availableorderUFEE: '0',
      inorderUFEE: '0'
    },
    status: '1',
    error: null,
    code: '200'
  },
  timestamp: undefined,
  datetime: undefined,
  BTC: { free: 0.00003295, used: 0, total: 0.00003295 },
  INR: { free: 1297.49, used: 0, total: 1297.49 },
  XRP: { free: 0, used: 0, total: 0 },
  NEO: { free: 0, used: 0, total: 0 },
  GAS: { free: 0, used: 0, total: 0 },
  XLM: { free: 0, used: 0, total: 0 },
  XEM: { free: 0, used: 0, total: 0 },
  ETH: { free: 0, used: 0, total: 0 },
  DBC: { free: 0, used: 0, total: 0 },
  RPX: { free: 0, used: 0, total: 0 },
  LTC: { free: 0, used: 0, total: 0 },
  XMR: { free: 0, used: 0, total: 0 },
  DASH: { free: 0, used: 0, total: 0 },
  DOGE: { free: 0, used: 0, total: 0 },
  BCH: { free: 0, used: 0, total: 0 },
  SIA: { free: 0, used: 0, total: 0 },
  TRX: { free: 0, used: 0, total: 0 },
  ETN: { free: 0, used: 0, total: 0 },
  ONT: { free: 0, used: 0, total: 0 },
  ZIL: { free: 0, used: 0, total: 0 },
  EOS: { free: 0, used: 0, total: 0 },
  POLY: { free: 0, used: 0, total: 0 },
  DGB: { free: 0, used: 0, total: 0 },
  NCASH: { free: 0, used: 0, total: 0 },
  ADA: { free: 0, used: 0, total: 0 },
  TST: { free: 0, used: 0, total: 0 },
  FEE: { free: 0, used: 0, total: 0 },
  ICX: { free: 0, used: 0, total: 0 },
  VEN: { free: 0, used: 0, total: 0 },
  PHB: { free: 0, used: 0, total: 0 },
  SC: { free: 0, used: 0, total: 0 },
  VET: { free: 0, used: 0, total: 0 },
  OMG: { free: 0, used: 0, total: 0 },
  REQ: { free: 0, used: 0, total: 0 },
  DGD: { free: 0, used: 0, total: 0 },
  QLC: { free: 0, used: 0, total: 0 },
  POWR: { free: 0, used: 0, total: 0 },
  WPR: { free: 0, used: 0, total: 0 },
  WAVES: { free: 0, used: 0, total: 0 },
  WAN: { free: 0, used: 0, total: 0 },
  ACT: { free: 0, used: 0, total: 0 },
  XVG: { free: 0, used: 0, total: 0 },
  NEXO: { free: 0, used: 0, total: 0 },
  BLZ: { free: 0, used: 0, total: 0 },
  SUB: { free: 0, used: 0, total: 0 },
  LRC: { free: 0, used: 0, total: 0 },
  EFX: { free: 0, used: 0, total: 0 },
  CPX: { free: 0, used: 0, total: 0 },
  ZRX: { free: 0, used: 0, total: 0 },
  REP: { free: 0, used: 0, total: 0 },
  LOOM: { free: 0, used: 0, total: 0 },
  EOSD: { free: 0, used: 0, total: 0 },
  QKC: { free: 0, used: 0, total: 0 },
  QTUM: { free: 0, used: 0, total: 0 },
  GNT: { free: 0, used: 0, total: 0 },
  STORM: { free: 0, used: 0, total: 0 },
  LSK: { free: 0, used: 0, total: 0 },
  NPXS: { free: 0, used: 0, total: 0 },
  USDT: { free: 0, used: 0, total: 0 },
  ETC: { free: 0, used: 0, total: 0 },
  DENT: { free: 0, used: 0, total: 0 },
  CLOAK: { free: 0, used: 0, total: 0 },
  KMD: { free: 0, used: 0, total: 0 },
  GRS: { free: 0, used: 0, total: 0 },
  RAM: { free: 0, used: 0, total: 0 },
  LET: { free: 0, used: 0, total: 0 },
  SOUL: { free: 0, used: 0, total: 0 },
  IXT: { free: 0, used: 0, total: 0 },
  SKY: { free: 0, used: 0, total: 0 },
  ODE: { free: 0, used: 0, total: 0 },
  BSV: { free: 0, used: 0, total: 0 },
  BCHABC: { free: 0, used: 0, total: 0 },
  RFR: { free: 0, used: 0, total: 0 },
  BTT: { free: 0, used: 0, total: 0 },
  FET: { free: 0, used: 0, total: 0 },
  TEL: { free: 0, used: 0, total: 0 },
  ZCO: { free: 0, used: 0, total: 0 },
  BNB: { free: 0, used: 0, total: 0 },
  NRG: { free: 0, used: 0, total: 0 },
  PART: { free: 0, used: 0, total: 0 },
  FUN: { free: 0, used: 0, total: 0 },
  BNS: { free: 0, used: 0, total: 0 },
  CVT: { free: 0, used: 0, total: 0 },
  SERO: { free: 0, used: 0, total: 0 },
  ATT: { free: 0, used: 0, total: 0 },
  SYLO: { free: 0, used: 0, total: 0 },
  MATIC: { free: 0, used: 0, total: 0 },
  SNX: { free: 0, used: 0, total: 0 },
  BAT: { free: 0, used: 0, total: 0 },
  BNT: { free: 0, used: 0, total: 0 },
  CHR: { free: 0, used: 0, total: 0 },
  LINK: { free: 0, used: 0, total: 0 },
  WBTC: { free: 0, used: 0, total: 0 },
  COMP: { free: 0, used: 0, total: 0 },
  BAL: { free: 0, used: 0, total: 0 },
  BNSD: { free: 0, used: 0, total: 0 },
  CUSDT: { free: 0, used: 0, total: 0 },
  CETH: { free: 0, used: 0, total: 0 },
  CZRX: { free: 0, used: 0, total: 0 },
  CREP: { free: 0, used: 0, total: 0 },
  UFEE: { free: 0, used: 0, total: 0 },
  free: {
    BTC: 0.00003295,
    INR: 1297.49,
    XRP: 0,
    NEO: 0,
    GAS: 0,
    XLM: 0,
    XEM: 0,
    ETH: 0,
    DBC: 0,
    RPX: 0,
    LTC: 0,
    XMR: 0,
    DASH: 0,
    DOGE: 0,
    BCH: 0,
    SIA: 0,
    TRX: 0,
    ETN: 0,
    ONT: 0,
    ZIL: 0,
    EOS: 0,
    POLY: 0,
    DGB: 0,
    NCASH: 0,
    ADA: 0,
    TST: 0,
    FEE: 0,
    ICX: 0,
    VEN: 0,
    PHB: 0,
    SC: 0,
    VET: 0,
    OMG: 0,
    REQ: 0,
    DGD: 0,
    QLC: 0,
    POWR: 0,
    WPR: 0,
    WAVES: 0,
    WAN: 0,
    ACT: 0,
    XVG: 0,
    NEXO: 0,
    BLZ: 0,
    SUB: 0,
    LRC: 0,
    EFX: 0,
    CPX: 0,
    ZRX: 0,
    REP: 0,
    LOOM: 0,
    EOSD: 0,
    QKC: 0,
    QTUM: 0,
    GNT: 0,
    STORM: 0,
    LSK: 0,
    NPXS: 0,
    USDT: 0,
    ETC: 0,
    DENT: 0,
    CLOAK: 0,
    KMD: 0,
    GRS: 0,
    RAM: 0,
    LET: 0,
    SOUL: 0,
    IXT: 0,
    SKY: 0,
    ODE: 0,
    BSV: 0,
    BCHABC: 0,
    RFR: 0,
    BTT: 0,
    FET: 0,
    TEL: 0,
    ZCO: 0,
    BNB: 0,
    NRG: 0,
    PART: 0,
    FUN: 0,
    BNS: 0,
    CVT: 0,
    SERO: 0,
    ATT: 0,
    SYLO: 0,
    MATIC: 0,
    SNX: 0,
    BAT: 0,
    BNT: 0,
    CHR: 0,
    LINK: 0,
    WBTC: 0,
    COMP: 0,
    BAL: 0,
    BNSD: 0,
    CUSDT: 0,
    CETH: 0,
    CZRX: 0,
    CREP: 0,
    UFEE: 0
  },
  used: {
    BTC: 0,
    INR: 0,
    XRP: 0,
    NEO: 0,
    GAS: 0,
    XLM: 0,
    XEM: 0,
    ETH: 0,
    DBC: 0,
    RPX: 0,
    LTC: 0,
    XMR: 0,
    DASH: 0,
    DOGE: 0,
    BCH: 0,
    SIA: 0,
    TRX: 0,
    ETN: 0,
    ONT: 0,
    ZIL: 0,
    EOS: 0,
    POLY: 0,
    DGB: 0,
    NCASH: 0,
    ADA: 0,
    TST: 0,
    FEE: 0,
    ICX: 0,
    VEN: 0,
    PHB: 0,
    SC: 0,
    VET: 0,
    OMG: 0,
    REQ: 0,
    DGD: 0,
    QLC: 0,
    POWR: 0,
    WPR: 0,
    WAVES: 0,
    WAN: 0,
    ACT: 0,
    XVG: 0,
    NEXO: 0,
    BLZ: 0,
    SUB: 0,
    LRC: 0,
    EFX: 0,
    CPX: 0,
    ZRX: 0,
    REP: 0,
    LOOM: 0,
    EOSD: 0,
    QKC: 0,
    QTUM: 0,
    GNT: 0,
    STORM: 0,
    LSK: 0,
    NPXS: 0,
    USDT: 0,
    ETC: 0,
    DENT: 0,
    CLOAK: 0,
    KMD: 0,
    GRS: 0,
    RAM: 0,
    LET: 0,
    SOUL: 0,
    IXT: 0,
    SKY: 0,
    ODE: 0,
    BSV: 0,
    BCHABC: 0,
    RFR: 0,
    BTT: 0,
    FET: 0,
    TEL: 0,
    ZCO: 0,
    BNB: 0,
    NRG: 0,
    PART: 0,
    FUN: 0,
    BNS: 0,
    CVT: 0,
    SERO: 0,
    ATT: 0,
    SYLO: 0,
    MATIC: 0,
    SNX: 0,
    BAT: 0,
    BNT: 0,
    CHR: 0,
    LINK: 0,
    WBTC: 0,
    COMP: 0,
    BAL: 0,
    BNSD: 0,
    CUSDT: 0,
    CETH: 0,
    CZRX: 0,
    CREP: 0,
    UFEE: 0
  },
  total: {
    BTC: 0.00003295,
    INR: 1297.49,
    XRP: 0,
    NEO: 0,
    GAS: 0,
    XLM: 0,
    XEM: 0,
    ETH: 0,
    DBC: 0,
    RPX: 0,
    LTC: 0,
    XMR: 0,
    DASH: 0,
    DOGE: 0,
    BCH: 0,
    SIA: 0,
    TRX: 0,
    ETN: 0,
    ONT: 0,
    ZIL: 0,
    EOS: 0,
    POLY: 0,
    DGB: 0,
    NCASH: 0,
    ADA: 0,
    TST: 0,
    FEE: 0,
    ICX: 0,
    VEN: 0,
    PHB: 0,
    SC: 0,
    VET: 0,
    OMG: 0,
    REQ: 0,
    DGD: 0,
    QLC: 0,
    POWR: 0,
    WPR: 0,
    WAVES: 0,
    WAN: 0,
    ACT: 0,
    XVG: 0,
    NEXO: 0,
    BLZ: 0,
    SUB: 0,
    LRC: 0,
    EFX: 0,
    CPX: 0,
    ZRX: 0,
    REP: 0,
    LOOM: 0,
    EOSD: 0,
    QKC: 0,
    QTUM: 0,
    GNT: 0,
    STORM: 0,
    LSK: 0,
    NPXS: 0,
    USDT: 0,
    ETC: 0,
    DENT: 0,
    CLOAK: 0,
    KMD: 0,
    GRS: 0,
    RAM: 0,
    LET: 0,
    SOUL: 0,
    IXT: 0,
    SKY: 0,
    ODE: 0,
    BSV: 0,
    BCHABC: 0,
    RFR: 0,
    BTT: 0,
    FET: 0,
    TEL: 0,
    ZCO: 0,
    BNB: 0,
    NRG: 0,
    PART: 0,
    FUN: 0,
    BNS: 0,
    CVT: 0,
    SERO: 0,
    ATT: 0,
    SYLO: 0,
    MATIC: 0,
    SNX: 0,
    BAT: 0,
    BNT: 0,
    CHR: 0,
    LINK: 0,
    WBTC: 0,
    COMP: 0,
    BAL: 0,
    BNSD: 0,
    CUSDT: 0,
    CETH: 0,
    CZRX: 0,
    CREP: 0,
    UFEE: 0
  }
}
2023-10-07T01:44:31.899Z iteration 1 passed in 1974 ms
```

Previously this would set the INR values to undefined

```
  used: {
    BTC: 0,
    INR: undefined,
...
```