### PR TITLE
fix(btcalpha): add warning to createOrder and jsdocs

### DIFF
--- a/ts/src/btcalpha.ts
+++ b/ts/src/btcalpha.ts
@@ -344,6 +344,7 @@ export default class btcalpha extends Exchange {
         /**
          * @method
          * @name btcalpha#fetchOrderBook
+         * @see https://btc-alpha.github.io/api-docs/#get-orderbook
          * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int} [limit] the maximum amount of order book entries to return
@@ -737,15 +738,19 @@ export default class btcalpha extends Exchange {
         /**
          * @method
          * @name btcalpha#createOrder
+         * @see https://btc-alpha.github.io/api-docs/#create-order
          * @description create a trade order
          * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit'
+         * @param {string} type 'limit'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the btcalpha api endpoint
          * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
+        if (type === 'market') {
+            throw new InvalidOrder (this.id + ' only limits orders are supported');
+        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
@@ -770,6 +775,7 @@ export default class btcalpha extends Exchange {
         /**
          * @method
          * @name btcalpha#cancelOrder
+         * @see https://btc-alpha.github.io/api-docs/#cancel-order
          * @description cancels an open order
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
@@ -787,6 +793,7 @@ export default class btcalpha extends Exchange {
         /**
          * @method
          * @name btcalpha#fetchOrder
+         * @see https://btc-alpha.github.io/api-docs/#retrieve-single-order
          * @description fetches information on an order made by the user
          * @param {string} symbol not used by btcalpha fetchOrder
          * @param {object} [params] extra parameters specific to the btcalpha api endpoint
@@ -804,6 +811,7 @@ export default class btcalpha extends Exchange {
         /**
          * @method
          * @name btcalpha#fetchOrders
+         * @see https://btc-alpha.github.io/api-docs/#list-own-orders
          * @description fetches information on multiple orders made by the user
          * @param {string} symbol unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19490

```
n btcalpha createOrder "LTC/USDT" market buy 0.5
Debugger attached.
2023-10-09T11:16:02.059Z
Node.js: v20.7.0
CCXT v4.1.8
btcalpha.createOrder (LTC/USDT, market, buy, 0.5)
InvalidOrder btcalpha only limits orders are supported
---------------------------------------------------
[InvalidOrder] btcalpha only limits orders are supported

    at createOrder                Users/cjg/Git/ccxt10/ccxt/js/src/btcalpha.js:729  
    at run                        Users/cjg/Git/ccxt10/ccxt/examples/js/cli.js:298  
    at processTicksAndRejections  node:internal/process/task_queues:95              

btcalpha only limits orders are supported
Waiting for the debugger to disconnect...
```
```
n btcalpha createOrder "LTC/USDT" limit buy  0.1 30
Debugger attached.
2023-10-09T11:16:16.167Z
Node.js: v20.7.0
CCXT v4.1.8
btcalpha.createOrder (LTC/USDT, limit, buy, 0.1, 30)
2023-10-09T11:16:18.610Z iteration 0 passed in 2189 ms

{
  id: '1593089966',
  clientOrderId: undefined,
  datetime: '1970-01-01T00:33:43.000Z',
  timestamp: 2023000,
  status: undefined,
  symbol: 'LTC/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 30,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: 0,
  amount: 0.1,
  filled: 0,
  remaining: 0,
  trades: [],
  fee: undefined,
  info: {
    success: true,
    date: '2023-10-09T11:16:18.589677Z',
    type: 'buy',
    oid: '1593089966',
    price: '30.0',
    amount: '0.0',
    amount_filled: '0.0',
    amount_original: '0.1',
    trades: []
  },
  lastTradeTimestamp: undefined,
  average: undefined,
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```
```
n btcalpha cancelOrder "1593089966" "LTC/USDT"     
Debugger attached.
2023-10-09T11:16:35.891Z
Node.js: v20.7.0
CCXT v4.1.8
btcalpha.cancelOrder (1593089966, LTC/USDT)
2023-10-09T11:16:38.354Z iteration 0 passed in 2161 ms

{ order: '1593089966' }
2023-10-09T11:16:38.354Z iteration 1 passed in 2161 ms
```
