### PR TITLE
fix(bitget): cancelAllOrders simplified

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3320,7 +3320,6 @@ export default class bitget extends Exchange {
          * @see https://bitgetlimited.github.io/apidoc/en/mix/#cancel-all-trigger-order-tpsl
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the bitget api endpoint
-         * @param {string} [params.code] marginCoin unified currency code
          * @returns {object[]} a list of [order structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         const sandboxMode = this.safeValue (this.options, 'sandboxMode', false);
@@ -3335,32 +3334,27 @@ export default class bitget extends Exchange {
         if (sandboxMode) {
             productType = 'S' + productType;
         }
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         if (marketType === 'spot') {
             throw new NotSupported (this.id + ' cancelAllOrders () does not support spot markets');
         }
         const request = {
             'productType': productType,
+            'marginCoin': market['settleId'],
         };
-        let method = undefined;
-        const stop = this.safeValue (query, 'stop');
-        const planType = this.safeString (query, 'planType');
+        const stop = this.safeValue2 (params, 'stop', 'trigger');
+        const planType = this.safeString (params, 'planType');
+        params = this.omit (params, [ 'stop', 'trigger' ]);
+        let response = undefined;
         if (stop !== undefined || planType !== undefined) {
             if (planType === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelOrder() requires a planType parameter for stop orders, either normal_plan, profit_plan, loss_plan, pos_profit, pos_loss, moving_plan or track_plan');
             }
-            method = 'privateMixPostPlanCancelAllPlan';
+            response = await this.privateMixPostPlanCancelAllPlan (this.extend (request, params));
         } else {
-            const code = this.safeString2 (params, 'code', 'marginCoin');
-            if (code === undefined) {
-                throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a code argument [marginCoin] in the params');
-            }
-            const currency = this.currency (code);
-            request['marginCoin'] = this.safeCurrencyCode (code, currency);
-            method = 'privateMixPostOrderCancelAllOrders';
+            response = await this.privateMixPostOrderCancelAllOrders (this.extend (request, params));
         }
-        const ommitted = this.omit (query, [ 'stop', 'code', 'marginCoin' ]);
-        const response = await this[method] (this.extend (request, ommitted));
         //
         //     {
         //         "code": "00000",


### PR DESCRIPTION
DEMO

```
p bitget cancelAllOrders "LTC/USDT:USDT"             
Python v3.11.5
CCXT v4.1.9
bitget.cancelAllOrders(LTC/USDT:USDT)
{'code': '00000',
 'data': {'client_order_ids': ['1095587435564912642', '1093497829205889024'],
          'fail_infos': [],
          'order_ids': ['1095587435506192385', '1093497829151363072'],
          'result': True},
 'msg': 'success',
 'requestTime': '1696934344017'}
```
