### PR TITLE
probit fetchTransactions limit

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -1518,6 +1518,8 @@ export default class probit extends Exchange {
         }
         if (limit !== undefined) {
             request['limit'] = limit;
+        } else {
+            request['limit'] = 100;
         }
         const response = await this.privateGetTransferPayment (this.extend (request, params));
         //


### PR DESCRIPTION
https://docs-en.probit.com/reference/transferpayment there is no info that `limit` is mandatory but I've started to get error
`{"errorCode":"INVALID_ARGUMENT","message":"","details":{"limit":"limit should be a number"}}`