### PR TITLE
feat(bingx): migrate swap ohlcv to v3

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -175,6 +175,13 @@ export default class bingx extends Exchange {
                             },
                         },
                     },
+                    'v3': {
+                        'public': {
+                            'get': {
+                                'quote/klines': 1,
+                            },
+                        },
+                    },
                 },
                 'contract': {
                     'v1': {
@@ -641,12 +648,12 @@ export default class bingx extends Exchange {
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
          * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#K-Line%20Data
          * @see https://bingx-api.github.io/docs/#/spot/market-api.html#Candlestick%20chart%20data
+         * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#%20K-Line%20Data
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
          * @param {int} [limit] the maximum amount of candles to fetch
          * @param {object} [params] extra parameters specific to the bingx api endpoint
-         * @param {string} [params.price] "mark" or "index" for mark price and index price candles
          * @param {int} [params.until] timestamp in ms of the latest candle to fetch
          * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {[[int]]} A list of candles ordered as timestamp, open, high, low, close, volume
@@ -667,19 +674,17 @@ export default class bingx extends Exchange {
         }
         if (limit !== undefined) {
             request['limit'] = limit;
-        } else {
-            request['limit'] = 50;
         }
-        const until = this.safeInteger2 (params, 'until', 'startTime');
+        const until = this.safeInteger2 (params, 'until', 'endTime');
         if (until !== undefined) {
             params = this.omit (params, [ 'until' ]);
-            request['startTime'] = until;
+            request['endTime'] = until;
         }
         let response = undefined;
         if (market['spot']) {
             response = await this.spotV1PublicGetMarketKline (this.extend (request, params));
         } else {
-            response = await this.swapV2PublicGetQuoteKlines (this.extend (request, params));
+            response = await this.swapV3PublicGetQuoteKlines (this.extend (request, params));
         }
         //
         //    {


### PR DESCRIPTION
DEMO

```
 p bingx fetchOHLCV "BTC/USDT:USDT" 1h None 10                           
Python v3.11.5
CCXT v4.1.9
bingx.fetchOHLCV(BTC/USDT:USDT,1h,None,10)
[[1696978800000, 27437.6, 27446.3, 27370.4, 27379.0, 570.63],
 [1696982400000, 27379.0, 27466.6, 27375.9, 27453.7, 782.43],
 [1696986000000, 27453.6, 27466.1, 27406.7, 27429.9, 553.33],
 [1696989600000, 27430.0, 27430.0, 27014.9, 27105.0, 7347.71],
 [1696993200000, 27105.0, 27140.4, 26990.4, 26993.2, 3604.36],
 [1696996800000, 26995.3, 27113.1, 26946.4, 27104.7, 2941.16],
 [1697000400000, 27104.7, 27124.6, 27040.5, 27095.7, 1313.87],
 [1697004000000, 27095.7, 27100.6, 27038.7, 27053.6, 1102.82],
 [1697007600000, 27053.7, 27081.5, 27000.0, 27005.4, 1264.87],
 [1697011200000, 27005.5, 27100.8, 27000.0, 27091.0, 1613.24]]
```
