### PR TITLE
Binance check symbols type

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2651,16 +2651,16 @@ export default class Exchange {
             const market = this.market (symbols[i]);
             if (sameTypeOnly && (marketType !== undefined)) {
                 if (market['type'] !== marketType) {
-                    throw new BadRequest (this.id + ' symbols must be of same type, either ' + marketType + ' or ' + market['type'] + '.');
+                    throw new BadRequest (this.id + ' symbols must be of the same type, either ' + marketType + ' or ' + market['type'] + '.');
                 }
             }
             if (sameSubTypeOnly && (isLinearSubType !== undefined)) {
                 if (market['linear'] !== isLinearSubType) {
-                    throw new BadRequest (this.id + ' symbols must be of same subType, either linear or inverse.');
+                    throw new BadRequest (this.id + ' symbols must be of the same subType, either linear or inverse.');
                 }
             }
             if (type !== undefined && market['type'] !== type) {
-                throw new BadRequest (this.id + ' symbols must be of same type ' + type + '. If the type is incorrect you can change it in options or the params of the request');
+                throw new BadRequest (this.id + ' symbols must be of the same type ' + type + '. If the type is incorrect you can change it in options or the params of the request');
             }
             marketType = market['type'];
             if (!market['spot']) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2630,7 +2630,7 @@ export default class Exchange {
         return result;
     }
 
-    marketSymbols (symbols, type: string = undefined, allowEmpty = true, sameTypeOnly = false) {
+    marketSymbols (symbols, type: string = undefined, allowEmpty = true, sameTypeOnly = false, sameSubTypeOnly = false) {
         if (symbols === undefined) {
             if (!allowEmpty) {
                 throw new ArgumentsRequired (this.id + ' empty list of symbols is not supported');
@@ -2646,6 +2646,7 @@ export default class Exchange {
         }
         const result = [];
         let marketType = undefined;
+        let isLinearSubType = undefined;
         for (let i = 0; i < symbols.length; i++) {
             const market = this.market (symbols[i]);
             if (sameTypeOnly && (marketType !== undefined)) {
@@ -2653,10 +2654,18 @@ export default class Exchange {
                     throw new BadRequest (this.id + ' symbols must be of same type, either ' + marketType + ' or ' + market['type'] + '.');
                 }
             }
+            if (sameSubTypeOnly && (isLinearSubType !== undefined)) {
+                if (market['linear'] !== isLinearSubType) {
+                    throw new BadRequest (this.id + ' symbols must be of same subType, either linear or inverse.');
+                }
+            }
             if (type !== undefined && market['type'] !== type) {
                 throw new BadRequest (this.id + ' symbols must be of same type ' + type + '. If the type is incorrect you can change it in options or the params of the request');
             }
             marketType = market['type'];
+            if (!market['spot']) {
+                isLinearSubType = market['linear'];
+            }
             const symbol = this.safeString (market, 'symbol', symbols[i]);
             result.push (symbol);
         }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2630,7 +2630,7 @@ export default class Exchange {
         return result;
     }
 
-    marketSymbols (symbols, type: string = undefined, allowEmpty = true) {
+    marketSymbols (symbols, type: string = undefined, allowEmpty = true, sameTypeOnly = false) {
         if (symbols === undefined) {
             if (!allowEmpty) {
                 throw new ArgumentsRequired (this.id + ' empty list of symbols is not supported');
@@ -2645,11 +2645,18 @@ export default class Exchange {
             return symbols;
         }
         const result = [];
+        let marketType = undefined;
         for (let i = 0; i < symbols.length; i++) {
             const market = this.market (symbols[i]);
+            if (sameTypeOnly && (marketType !== undefined)) {
+                if (market['type'] !== marketType) {
+                    throw new BadRequest (this.id + ' symbols must be of same type, either ' + marketType + ' or ' + market['type'] + '.');
+                }
+            }
             if (type !== undefined && market['type'] !== type) {
                 throw new BadRequest (this.id + ' symbols must be of same type ' + type + '. If the type is incorrect you can change it in options or the params of the request');
             }
+            marketType = market['type'];
             const symbol = this.safeString (market, 'symbol', symbols[i]);
             result.push (symbol);
         }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3199,6 +3199,7 @@ export default class binance extends Exchange {
         await this.loadMarkets ();
         let type = undefined;
         let market = undefined;
+        symbols = this.marketSymbols (symbols, undefined, true, true);
         if (symbols !== undefined) {
             const first = this.safeString (symbols, 0);
             market = this.market (first);

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3199,7 +3199,7 @@ export default class binance extends Exchange {
         await this.loadMarkets ();
         let type = undefined;
         let market = undefined;
-        symbols = this.marketSymbols (symbols, undefined, true, true);
+        symbols = this.marketSymbols (symbols, undefined, true, true, true);
         if (symbols !== undefined) {
             const first = this.safeString (symbols, 0);
             market = this.market (first);

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -233,7 +233,7 @@ export default class binance extends binanceRest {
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols, undefined, false, true);
+        symbols = this.marketSymbols (symbols, undefined, false, true, true);
         const firstMarket = this.market (symbols[0]);
         let type = firstMarket['type'];
         if (firstMarket['contract']) {
@@ -496,7 +496,7 @@ export default class binance extends binanceRest {
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html?#public-trades}
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols, undefined, false, true);
+        symbols = this.marketSymbols (symbols, undefined, false, true, true);
         const options = this.safeValue (this.options, 'watchTradesForSymbols', {});
         const name = this.safeString (options, 'name', 'trade');
         const firstMarket = this.market (symbols[0]);
@@ -979,7 +979,7 @@ export default class binance extends binanceRest {
          * @returns {object} a [ticker structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#ticker-structure}
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols, undefined, true, true);
+        symbols = this.marketSymbols (symbols, undefined, true, true, true);
         const marketIds = this.marketIds (symbols);
         let market = undefined;
         let type = undefined;

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -232,14 +232,8 @@ export default class binance extends binanceRest {
          * @param {object} [params] extra parameters specific to the binance api endpoint
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
          */
-        if (limit !== undefined) {
-            if ((limit !== 5) && (limit !== 10) && (limit !== 20) && (limit !== 50) && (limit !== 100) && (limit !== 500) && (limit !== 1000)) {
-                throw new ExchangeError (this.id + ' watchOrderBook limit argument must be undefined, 5, 10, 20, 50, 100, 500 or 1000');
-            }
-        }
-        //
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols);
+        symbols = this.marketSymbols (symbols, undefined, false, true);
         const firstMarket = this.market (symbols[0]);
         let type = firstMarket['type'];
         if (firstMarket['contract']) {
@@ -502,7 +496,7 @@ export default class binance extends binanceRest {
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/en/latest/manual.html?#public-trades}
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols);
+        symbols = this.marketSymbols (symbols, undefined, false, true);
         const options = this.safeValue (this.options, 'watchTradesForSymbols', {});
         const name = this.safeString (options, 'name', 'trade');
         const firstMarket = this.market (symbols[0]);
@@ -985,7 +979,7 @@ export default class binance extends binanceRest {
          * @returns {object} a [ticker structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#ticker-structure}
          */
         await this.loadMarkets ();
-        symbols = this.marketSymbols (symbols);
+        symbols = this.marketSymbols (symbols, undefined, true, true);
         const marketIds = this.marketIds (symbols);
         let market = undefined;
         let type = undefined;


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19513

```
p binance fetchTickers '["BTC/USDT:USDT", "BTC/USDT"]'
Python v3.11.5
CCXT v4.1.9
binance.fetchTickers(['BTC/USDT:USDT', 'BTC/USDT'])
ccxt.base.errors.BadRequest: binance symbols must be of same type, either swap or spot.
```
```
p binance fetchTickers '["BTC/USD:BTC", "BTC/USDT:USDT"]'
Python v3.11.5
CCXT v4.1.9
binance.fetchTickers(['BTC/USD:BTC', 'BTC/USDT:USDT'])
ccxt.base.errors.BadRequest: binance symbols must be of same subType, either linear or inverse.
```
```
 p binance fetchTickers '["BTC/USDT:USDT", "LTC/USDT:USDT"]'
Python v3.11.5
CCXT v4.1.9
binance.fetchTickers(['BTC/USDT:USDT', 'LTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': None,
                   'askVolume': None,
                   'average': 27406.0,
                   'baseVolume': 316363.293,
                   'bid': None,
                   'bidVolume': None,
                   'change': -473.4,
                   'close': 27169.3,
                   'datetime': '2023-10-11T09:43:25.705Z',
                   'high': 27663.6,
                   'info': {'closeTime': '1697017405705',
                            'count': '2995728',
                            'firstId': '4158203309',
                            'highPrice': '27663.60',
                            'lastId': '4161199055',
                            'lastPrice': '27169.30',
                            'lastQty': '0.007',
                            'lowPrice': '26951.70',
                            'openPrice': '27642.70',
                            'openTime': '1696930980000',
                            'priceChange': '-473.40',
                            'priceChangePercent': '-1.713',
                            'quoteVolume': '8638090159.75',
                            'symbol': 'BTCUSDT',
                            'volume': '316363.293',
                            'weightedAvgPrice': '27304.34'},
                   'last': 27169.3,
                   'low': 26951.7,
                   'open': 27642.7,
                   'percentage': -1.713,
                   'previousClose': None,
                   'quoteVolume': 8638090159.75,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1697017405705,
                   'vwap': 27304.34},
 'LTC/USDT:USDT': {'ask': None,
                   'askVolume': None,
                   'average': 62.835,
                   'baseVolume': 1993445.848,
                   'bid': None,
                   'bidVolume': None,
                   'change': -0.59,
                   'close': 62.54,
                   'datetime': '2023-10-11T09:43:25.508Z',
                   'high': 63.79,
                   'info': {'closeTime': '1697017405508',
                            'count': '301253',
                            'firstId': '799954971',
                            'highPrice': '63.79',
                            'lastId': '800256237',
                            'lastPrice': '62.54',
                            'lastQty': '0.087',
                            'lowPrice': '62.12',
                            'openPrice': '63.13',
                            'openTime': '1696930980000',
                            'priceChange': '-0.59',
                            'priceChangePercent': '-0.935',
                            'quoteVolume': '125610613.22',
                            'symbol': 'LTCUSDT',
                            'volume': '1993445.848',
                            'weightedAvgPrice': '63.01'},
                   'last': 62.54,
                   'low': 62.12,
                   'open': 63.13,
                   'percentage': -0.935,
                   'previousClose': None,
                   'quoteVolume': 125610613.22,
                   'symbol': 'LTC/USDT:USDT',
                   'timestamp': 1697017405508,
                   'vwap': 63.01}}
```
```
 p binance watchTradesForSymbols '["BTC/USDT", "LTC/USDT:USDT"]'
Python v3.11.5
CCXT v4.1.9
binance.watchTradesForSymbols(['BTC/USDT', 'LTC/USDT:USDT'])
ccxt.base.errors.BadRequest: binance symbols must be of same type, either spot or swap.
```
```
 p binance watchTickers '["BTC/USDT:USDT", "LTC/USD:LTC"]'
Python v3.11.5
CCXT v4.1.9
binance.watchTickers(['BTC/USDT:USDT', 'LTC/USD:LTC'])
ccxt.base.errors.BadRequest: binance symbols must be of same subType, either linear or inverse.
```
