### PR TITLE
fix(deribit): fetchBalance

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -495,7 +495,7 @@ export default class deribit extends Exchange {
         const defaultCode = this.safeValue (this.options, 'code', 'BTC');
         const options = this.safeValue (this.options, methodName, {});
         const code = this.safeValue (options, 'code', defaultCode);
-        return this.safeValue2 (params, 'code', code);
+        return this.safeValue (params, 'code', code);
     }
 
     async fetchStatus (params = {}) {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19514

```
 p deribit fetchBalance --sandbox
Python v3.11.5
CCXT v4.1.10
deribit.fetchBalance()
{'BTC': {'free': 98.99614841, 'total': 98.99618501, 'used': 1.83e-05},
 'free': {'BTC': 98.99614841},
 'info': {'available_funds': '98.99614841',
          'available_withdrawal_funds': '98.996128',
          'balance': '98.9961646',
          'cross_collateral_enabled': False,
          'currency': 'BTC',
          'delta_total': '0.00183',
          'delta_total_map': {'btc_usd': '0.001829663'},
          'deposit_address': 'bcrt1qhe24trh0d34lwh6j5rfmpyr8l9j76g3gey7jgs',
          'equity': '98.99618501',
          'estimated_liquidation_ratio': '0.00001876',
          'estimated_liquidation_ratio_map': {'btc_usd': '0.00001875677733939695'},
          'fee_balance': '0.0',
          'futures_pl': '0.00083995',
          'futures_session_rpl': '-2e-8',
          'futures_session_upl': '0.00002043',
          'initial_margin': '0.00003659',
          'limits': {'matching_engine': {'burst': '20', 'rate': '5'},
                     'non_matching_engine': {'burst': '100', 'rate': '20'}},
          'maintenance_margin': '0.0000183',
          'margin_balance': '98.99618501',
          'options_delta': '0.0',
          'options_gamma': '0.0',
          'options_gamma_map': {},
          'options_pl': '0.0',
          'options_session_rpl': '0.0',
          'options_session_upl': '0.0',
          'options_theta': '0.0',
          'options_theta_map': {},
          'options_value': '0.0',
          'options_vega': '0.0',
          'options_vega_map': {},
          'portfolio_margining_enabled': False,
          'projected_delta_total': '0.00183',
          'projected_initial_margin': '0.00003659',
          'projected_maintenance_margin': '0.0000183',
          'session_rpl': '-2e-8',
          'session_upl': '0.00002043',
          'spot_reserve': '0.0',
          'total_pl': '0.00083995'},
 'total': {'BTC': 98.99618501},
 'used': {'BTC': 1.83e-05}}
```
