### PR TITLE
fix(phemex): Update pro URLs

### DIFF
--- a/ts/src/pro/phemex.ts
+++ b/ts/src/pro/phemex.ts
@@ -27,10 +27,10 @@ export default class phemex extends phemexRest {
             },
             'urls': {
                 'test': {
-                    'ws': 'wss://testnet.phemex.com/ws',
+                    'ws': 'wss://testnet-api.phemex.com/ws',
                 },
                 'api': {
-                    'ws': 'wss://phemex.com/ws',
+                    'ws': 'wss://ws.phemex.com',
                 },
             },
             'options': {


### PR DESCRIPTION
DEMO

```
p phemex watchTicker "BTC/USDT:USDT"                              
Python v3.11.5
CCXT v4.1.10
phemex.watchTicker(BTC/USDT:USDT)
{'ask': None,
 'askVolume': None,
 'average': 26931.0,
 'baseVolume': 14209.506,
 'bid': None,
 'bidVolume': None,
 'change': -371.0,
 'close': 26745.5,
 'datetime': '2023-10-12T09:24:53.244Z',
 'high': 27319.6,
 'info': ['BTCUSDT',
          '27116.5',
          '27319.6',
          '26529',
          '26745.5',
          '14209.506',
          '381640006.508',
          '0',
          '26756.0432377',
          '26745.5',
          '-0.00018165',
          '-0.00018165'],
 'last': 26745.5,
 'low': 26529.0,
 'open': 27116.5,
 'percentage': -1.3681706709936754,
 'previousClose': None,
 'quoteVolume': 381640006.508,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1697102693244,
 'vwap': None}
```
```
p phemex watchTicker "BTC/USDT:USDT" --sandbox
Python v3.11.5
CCXT v4.1.10
phemex.watchTicker(BTC/USDT:USDT)
{'ask': None,
 'askVolume': None,
 'average': 26948.6,
 'baseVolume': 37509.201,
 'bid': None,
 'bidVolume': None,
 'change': -372.8,
 'close': 26762.2,
 'datetime': '2023-10-12T09:25:13.559Z',
 'high': 27330.5,
 'info': ['BTCUSDT',
          '27135',
          '27330.5',
          '26542.8',
          '26762.2',
          '37509.201',
          '1008158705.7086',
          '0',
          '26760.6763499',
          '26762.2',
          '0.0001',
          '0.0001'],
 'last': 26762.2,
 'low': 26542.8,
 'open': 27135.0,
 'percentage': -1.3738713838216325,
 'previousClose': None,
 'quoteVolume': 1008158705.7086,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1697102713559,
 'vwap': None}
```
