### PR TITLE
rename `assertTimestamp` into `assertTimestampAndDatetime` and create a separate method for `assertTimestamp`

### DIFF
--- a/ts/src/test/Exchange/base/test.borrowInterest.ts
+++ b/ts/src/test/Exchange/base/test.borrowInterest.ts
@@ -14,7 +14,7 @@ function testBorrowInterest (exchange, skippedProperties, method, entry, request
     };
     const emptyAllowedFor = [ 'account' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry);
     testSharedMethods.assertCurrencyCode (exchange, skippedProperties, method, entry, entry['currency'], requestedCode);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, entry, entry['account'], requestedSymbol);
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'interest', '0');

--- a/ts/src/test/Exchange/base/test.borrowRate.ts
+++ b/ts/src/test/Exchange/base/test.borrowRate.ts
@@ -11,7 +11,7 @@ function testBorrowRate (exchange, skippedProperties, method, entry, requestedCo
         'period': 86400000, // Amount of time the interest rate is based on in milliseconds
     };
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry);
     testSharedMethods.assertCurrencyCode (exchange, skippedProperties, method, entry, entry['currency'], requestedCode);
     //
     // assert (borrowRate['period'] === 86400000 || borrowRate['period'] === 3600000) // Milliseconds in an hour or a day

--- a/ts/src/test/Exchange/base/test.depositWithdrawal.ts
+++ b/ts/src/test/Exchange/base/test.depositWithdrawal.ts
@@ -24,7 +24,7 @@ function testDepositWithdrawal (exchange, skippedProperties, method, entry, requ
     };
     const emptyAllowedFor = [ 'address', 'addressTo', 'addressFrom', 'tag', 'tagTo', 'tagFrom' ]; // below we still do assertion for to/from
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry, now);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, now);
     testSharedMethods.assertCurrencyCode (exchange, skippedProperties, method, entry, entry['currency'], requestedCode);
     //
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'status', [ 'ok', 'pending', 'failed', 'rejected', 'canceled' ]);

--- a/ts/src/test/Exchange/base/test.fundingRateHistory.ts
+++ b/ts/src/test/Exchange/base/test.fundingRateHistory.ts
@@ -11,7 +11,7 @@ function testFundingRateHistory (exchange, skippedProperties, method, entry, sym
     };
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, entry, 'symbol', symbol);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry);
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'fundingRate', '-100');
     testSharedMethods.assertLess (exchange, skippedProperties, method, entry, 'fundingRate', '100');
 }

--- a/ts/src/test/Exchange/base/test.ledgerEntry.ts
+++ b/ts/src/test/Exchange/base/test.ledgerEntry.ts
@@ -21,7 +21,7 @@ function testLedgerEntry (exchange, skippedProperties, method, entry, requestedC
     };
     const emptyAllowedFor = [ 'referenceId', 'referenceAccount', 'id' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry, now);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, now);
     testSharedMethods.assertCurrencyCode (exchange, skippedProperties, method, entry, entry['currency'], requestedCode);
     //
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'direction', [ 'in', 'out' ]);

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -51,10 +51,9 @@ function testMarket (exchange, skippedProperties, method, market) {
                 'max': exchange.parseNumber ('1000'), // order cost should be < max
             },
         },
-        'created': 1601234567890, // pair "creation" timestamp
         'info': {},
     };
-    const emptyAllowedFor = [ 'linear', 'inverse', 'settle', 'settleId', 'expiry', 'expiryDatetime', 'optionType', 'strike', 'margin', 'contractSize', 'created' ];
+    const emptyAllowedFor = [ 'linear', 'inverse', 'settle', 'settleId', 'expiry', 'expiryDatetime', 'optionType', 'strike', 'margin', 'contractSize' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, market, format, emptyAllowedFor);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, market, 'symbol');
     const logText = testSharedMethods.logTemplate (exchange, method, market);
@@ -197,7 +196,6 @@ function testMarket (exchange, skippedProperties, method, market) {
         testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['quoteId'], market['quote']);
         testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['settleId'], market['settle']);
     }
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, market, undefined, 'created');
 }
 
 export default testMarket;

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -51,9 +51,10 @@ function testMarket (exchange, skippedProperties, method, market) {
                 'max': exchange.parseNumber ('1000'), // order cost should be < max
             },
         },
+        'created': 1601234567890, // pair "creation" timestamp
         'info': {},
     };
-    const emptyAllowedFor = [ 'linear', 'inverse', 'settle', 'settleId', 'expiry', 'expiryDatetime', 'optionType', 'strike', 'margin', 'contractSize' ];
+    const emptyAllowedFor = [ 'linear', 'inverse', 'settle', 'settleId', 'expiry', 'expiryDatetime', 'optionType', 'strike', 'margin', 'contractSize', 'created' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, market, format, emptyAllowedFor);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, market, 'symbol');
     const logText = testSharedMethods.logTemplate (exchange, method, market);

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -154,6 +154,7 @@ function testMarket (exchange, skippedProperties, method, market) {
     if (market['future'] || market['option']) {
         // future or option markets need 'expiry' and 'expiryDatetime'
         assert (market['expiry'] !== undefined, '"expiry" must be defined when "future" is true' + logText);
+        testSharedMethods.assertTimestamp (exchange, skippedProperties, method, market, undefined, 'expiry');
         assert (market['expiryDatetime'] !== undefined, '"expiryDatetime" must be defined when "future" is true' + logText);
         // expiry datetime should be correct
         const isoString = exchange.iso8601 (market['expiry']);
@@ -196,6 +197,7 @@ function testMarket (exchange, skippedProperties, method, market) {
         testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['quoteId'], market['quote']);
         testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['settleId'], market['settle']);
     }
+    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, market, undefined, 'created');
 }
 
 export default testMarket;

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -153,7 +153,6 @@ function testMarket (exchange, skippedProperties, method, market) {
     if (market['future'] || market['option']) {
         // future or option markets need 'expiry' and 'expiryDatetime'
         assert (market['expiry'] !== undefined, '"expiry" must be defined when "future" is true' + logText);
-        testSharedMethods.assertTimestamp (exchange, skippedProperties, method, market, undefined, 'expiry');
         assert (market['expiryDatetime'] !== undefined, '"expiryDatetime" must be defined when "future" is true' + logText);
         // expiry datetime should be correct
         const isoString = exchange.iso8601 (market['expiry']);

--- a/ts/src/test/Exchange/base/test.ohlcv.ts
+++ b/ts/src/test/Exchange/base/test.ohlcv.ts
@@ -13,7 +13,7 @@ function testOHLCV (exchange, skippedProperties, method, entry, symbol, now) {
     ];
     const emptyNotAllowedFor = [ 0, 1, 2, 3, 4, 5 ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyNotAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry, now, 0);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, now, 0);
     const logText = testSharedMethods.logTemplate (exchange, method, entry);
     //
     const length = entry.length;

--- a/ts/src/test/Exchange/base/test.openInterest.ts
+++ b/ts/src/test/Exchange/base/test.openInterest.ts
@@ -15,7 +15,7 @@ function testOpenInterest (exchange, skippedProperties, method, entry) {
     const emptyAllowedFor = [ 'symbol', 'timestamp', 'openInterestAmount', 'openInterestValue', 'datetime' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, entry, 'symbol');
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry);
     //
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'openInterestAmount', '0');
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'openInterestValue', '0');

--- a/ts/src/test/Exchange/base/test.order.ts
+++ b/ts/src/test/Exchange/base/test.order.ts
@@ -28,7 +28,7 @@ function testOrder (exchange, skippedProperties, method, entry, symbol, now) {
     };
     const emptyAllowedFor = [ 'clientOrderId', 'stopPrice', 'trades', 'timestamp', 'datetime', 'lastTradeTimestamp', 'average', 'type', 'timeInForce', 'postOnly', 'side', 'price', 'amount', 'cost', 'filled', 'remaining', 'status', 'fee' ]; // there are exchanges that return only order id, so we don't need to strictly requite all props to be set.
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry, now);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, now);
     //
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'timeInForce', [ 'GTC', 'GTK', 'IOC', 'FOK', 'PO' ]);
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'status', [ 'open', 'closed', 'canceled' ]);

--- a/ts/src/test/Exchange/base/test.orderBook.ts
+++ b/ts/src/test/Exchange/base/test.orderBook.ts
@@ -21,7 +21,7 @@ function testOrderBook (exchange, skippedProperties, method, entry, symbol) {
     };
     const emptyAllowedFor = [ 'symbol', 'nonce', 'datetime', 'timestamp' ]; // todo: make timestamp required
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, entry, 'symbol', symbol);
     const logText = testSharedMethods.logTemplate (exchange, method, entry);
     //

--- a/ts/src/test/Exchange/base/test.position.ts
+++ b/ts/src/test/Exchange/base/test.position.ts
@@ -27,7 +27,7 @@ function testPosition (exchange, skippedProperties, method, entry, symbol, now) 
     };
     const emptyotAllowedFor = [ 'liquidationPrice', 'initialMargin', 'initialMarginPercentage', 'maintenanceMargin', 'maintenanceMarginPercentage', 'marginRatio' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyotAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry, now);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, now);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, entry, 'symbol', symbol);
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'side', [ 'long', 'short' ]);
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'marginMode', [ 'cross', 'isolated' ]);

--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -88,10 +88,10 @@ function assertTimestamp (exchange, skippedProperties, method, entry, nowToCheck
     const logText = logTemplate (exchange, method, entry);
     const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
     if (skipValue !== undefined) {
-        return;
+        return; // skipped
     }
-    const isObject = typeof keyNameOrIndex === 'string';
-    if (isObject) {
+    const isDateTimeObject = typeof keyNameOrIndex === 'string';
+    if (isDateTimeObject) {
         assert ((keyNameOrIndex in entry), 'timestamp key "' + keyNameOrIndex + '" is missing from structure' + logText);
     } else {
         // if index was provided (mostly from fetchOHLCV) then we check if it exists, as mandatory
@@ -107,7 +107,7 @@ function assertTimestamp (exchange, skippedProperties, method, entry, nowToCheck
         assert (ts < maxTs, 'timestamp more than ' + maxTs.toString () + ' (19.01.2038)' + logText); // 19 Jan 2038 - int32 overflows // 7258118400000  -> Jan 1 2200
         if (nowToCheck !== undefined) {
             const maxMsOffset = 60000; // 1 min
-            assert (ts < nowToCheck + maxMsOffset, 'returned timestamp (' + exchange.iso8601 (ts) + ') is ahead of the current time (' + exchange.iso8601 (nowToCheck) + ')' + logText);
+            assert (ts < nowToCheck + maxMsOffset, 'returned item timestamp (' + exchange.iso8601 (ts) + ') is ahead of the current time (' + exchange.iso8601 (nowToCheck) + ')' + logText);
         }
     }
 }
@@ -119,9 +119,9 @@ function assertTimestampAndDatetime (exchange, skippedProperties, method, entry,
         return;
     }
     assertTimestamp (exchange, skippedProperties, method, entry, nowToCheck, keyNameOrIndex);
-    const isObject = typeof keyNameOrIndex === 'string';
+    const isDateTimeObject = typeof keyNameOrIndex === 'string';
     // only in case if the entry is a dictionary, thus it must have 'timestamp' & 'datetime' string keys
-    if (isObject) {
+    if (isDateTimeObject) {
         // we also test 'datetime' here because it's certain sibling of 'timestamp'
         assert (('datetime' in entry), '"datetime" key is missing from structure' + logText);
         const dt = entry['datetime'];

--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -88,10 +88,10 @@ function assertTimestamp (exchange, skippedProperties, method, entry, nowToCheck
     const logText = logTemplate (exchange, method, entry);
     const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
     if (skipValue !== undefined) {
-        return; // skipped
+        return;
     }
-    const isDateTimeObject = typeof keyNameOrIndex === 'string';
-    if (isDateTimeObject) {
+    const isObject = typeof keyNameOrIndex === 'string';
+    if (isObject) {
         assert ((keyNameOrIndex in entry), 'timestamp key "' + keyNameOrIndex + '" is missing from structure' + logText);
     } else {
         // if index was provided (mostly from fetchOHLCV) then we check if it exists, as mandatory
@@ -107,11 +107,21 @@ function assertTimestamp (exchange, skippedProperties, method, entry, nowToCheck
         assert (ts < maxTs, 'timestamp more than ' + maxTs.toString () + ' (19.01.2038)' + logText); // 19 Jan 2038 - int32 overflows // 7258118400000  -> Jan 1 2200
         if (nowToCheck !== undefined) {
             const maxMsOffset = 60000; // 1 min
-            assert (ts < nowToCheck + maxMsOffset, 'returned trade timestamp (' + exchange.iso8601 (ts) + ') is ahead of the current time (' + exchange.iso8601 (nowToCheck) + ')' + logText);
+            assert (ts < nowToCheck + maxMsOffset, 'returned timestamp (' + exchange.iso8601 (ts) + ') is ahead of the current time (' + exchange.iso8601 (nowToCheck) + ')' + logText);
         }
     }
+}
+
+function assertTimestampAndDatetime (exchange, skippedProperties, method, entry, nowToCheck = undefined, keyNameOrIndex : any = 'timestamp') {
+    const logText = logTemplate (exchange, method, entry);
+    const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
+    if (skipValue !== undefined) {
+        return;
+    }
+    assertTimestamp (exchange, skippedProperties, method, entry, nowToCheck, keyNameOrIndex);
+    const isObject = typeof keyNameOrIndex === 'string';
     // only in case if the entry is a dictionary, thus it must have 'timestamp' & 'datetime' string keys
-    if (isDateTimeObject) {
+    if (isObject) {
         // we also test 'datetime' here because it's certain sibling of 'timestamp'
         assert (('datetime' in entry), '"datetime" key is missing from structure' + logText);
         const dt = entry['datetime'];
@@ -320,6 +330,7 @@ function checkPrecisionAccuracy (exchange, skippedProperties, method, entry, key
 export default {
     logTemplate,
     assertTimestamp,
+    assertTimestampAndDatetime,
     assertStructure,
     assertSymbol,
     assertCurrencyCode,

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -29,7 +29,7 @@ function testTicker (exchange, skippedProperties, method, entry, symbol) {
     // todo: atm, many exchanges fail, so temporarily decrease stict mode
     const emptyAllowedFor = [ 'timestamp', 'datetime', 'open', 'high', 'low', 'close', 'last', 'ask', 'bid', 'bidVolume', 'askVolume', 'baseVolume', 'quoteVolume', 'previousClose', 'vwap', 'change', 'percentage', 'average' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry);
     const logText = testSharedMethods.logTemplate (exchange, method, entry);
     //
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'open', '0');

--- a/ts/src/test/Exchange/base/test.trade.ts
+++ b/ts/src/test/Exchange/base/test.trade.ts
@@ -21,7 +21,7 @@ function testTrade (exchange, skippedProperties, method, entry, symbol, now) {
     // removed side because some public endpoints return trades without side
     const emptyAllowedFor = [ 'fees', 'fee', 'symbol', 'order', 'id', 'takerOrMaker', 'timestamp', 'datetime' ];
     testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
-    testSharedMethods.assertTimestamp (exchange, skippedProperties, method, entry, now);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, now);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, entry, 'symbol', symbol);
     //
     testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'side', [ 'buy', 'sell' ]);


### PR DESCRIPTION
Carlos, 
this PR is absolutely plain rename of method (and separation of some part into another function) and no other unrelated changes.