### PR TITLE
Fix safe integer product

### DIFF
--- a/ts/src/btcalpha.ts
+++ b/ts/src/btcalpha.ts
@@ -313,7 +313,8 @@ export default class btcalpha extends Exchange {
         //        sell: '22521.11'
         //    }
         //
-        const timestamp = this.safeTimestamp (ticker, 'timestamp') * 1000;
+        const timestampStr = this.safeString (ticker, 'timestamp');
+        const timestamp = parseInt (Precise.stringMul (timestampStr, '1000000'));
         const marketId = this.safeString (ticker, 'pair');
         market = this.safeMarket (marketId, market, '_');
         const last = this.safeString (ticker, 'last');

--- a/ts/src/btcalpha.ts
+++ b/ts/src/btcalpha.ts
@@ -313,7 +313,7 @@ export default class btcalpha extends Exchange {
         //        sell: '22521.11'
         //    }
         //
-        const timestamp = this.safeIntegerProduct (ticker, 'timestamp', 1000000);
+        const timestamp = this.safeTimestamp (ticker, 'timestamp') * 1000;
         const marketId = this.safeString (ticker, 'pair');
         market = this.safeMarket (marketId, market, '_');
         const last = this.safeString (ticker, 'last');


### PR DESCRIPTION
the implementation was wrong, as the ticker timestamp there is provided in format:
```
{
  timestamp: "1697485.027329",
  pair: "ETZ_ETH",
  last: "0",
  diff: "0",
  vol: "0",
  high: "0",
  low: "0",
  buy: "0",
  sell: "0",
}
```

see the bug in live: https://jsfiddle.net/gLh01r3w/

after fix:
```
{
  info: {
    timestamp: "1697485.027329",
    pair: "ETZ_ETH",
    last: "0",
    diff: "0",
    vol: "0",
    high: "0",
    low: "0",
    buy: "0",
    sell: "0",
  },
  symbol: "ETZ/ETH",
  timestamp: 1697485027329,
  datetime: "2023-10-16T19:37:07.329Z",
  high: undefined,
  low: undefined,
  bid: undefined,
  bidVolume: undefined,
  ask: undefined,
  askVolume: undefined,
  vwap: undefined,
  open: undefined,
  close: undefined,
  last: undefined,
  previousClose: undefined,
  change: 0,
  percentage: undefined,
  average: undefined,
  baseVolume: undefined,
  quoteVolume: 0,
}
```
