### PR TITLE
fix(bybit): order fee spot

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3533,9 +3533,15 @@ export default class bybit extends Exchange {
         let fee = undefined;
         const feeCostString = this.safeString (order, 'cumExecFee');
         if (feeCostString !== undefined) {
+            let feeCurrency = undefined;
+            if (market['spot']) {
+                feeCurrency = (side === 'buy') ? market['quote'] : market['base'];
+            } else {
+                feeCurrency = market['settle'];
+            }
             fee = {
                 'cost': feeCostString,
-                'currency': market['settle'],
+                'currency': feeCurrency,
             };
         }
         let clientOrderId = this.safeString (order, 'orderLinkId');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3628,7 +3628,7 @@ export default class bybit extends Exchange {
         const result = await this.fetchOrders (symbol, undefined, undefined, this.extend (request, params));
         const length = result.length;
         if (length === 0) {
-            throw new OrderNotFound ('Order ' + id + ' does not exist.');
+            throw new OrderNotFound ('Order ' + id.toString () + ' does not exist.');
         }
         if (length > 1) {
             throw new InvalidOrder (this.id + ' returned more than one order');


### PR DESCRIPTION
DEMO

```
p bybit fetchClosedOrders None None  --spot             
Python v3.11.5
CCXT v4.1.15
bybit.fetchClosedOrders(None,None)
[{'amount': 0.15,
  'average': 62.38,
  'clientOrderId': '1533618973311246081',
  'cost': 9.357,
  'datetime': '2023-10-17T15:47:08.250Z',
  'fee': {'cost': 0.009357, 'currency': 'LTC'},
  'fees': [{'cost': 0.009357, 'currency': 'LTC'}],
  'filled': 0.15,
  'id': '1533618973311246080',
  'info': {'avgPrice': '62.38',
           'blockTradeId': '',
           'cancelType': 'UNKNOWN',
           'closeOnTrigger': False,
           'createdTime': '1697557628250',
           'cumExecFee': '0.009357',
           'cumExecQty': '0.15000',
           'cumExecValue': '9.3570000',
           'isLeverage': '0',
           'lastPriceOnCreated': '',
           'leavesQty': '0.00000',
           'leavesValue': '0.0000000',
           'nextPageCursor': '1533618973311246080%3A1697557628250%2C1533618973311246080%3A1697557628250',
           'orderId': '1533618973311246080',
           'orderIv': '',
           'orderLinkId': '1533618973311246081',
           'orderStatus': 'Filled',
           'orderType': 'Market',
           'placeType': '',
           'positionIdx': '0',
           'price': '0',
           'qty': '0.15000',
           'reduceOnly': False,
           'rejectReason': 'EC_NoError',
           'side': 'Sell',
           'slTriggerBy': '',
           'smpGroup': '0',
           'smpOrderId': '',
           'smpType': 'None',
           'stopLoss': '0',
           'stopOrderType': '',
           'symbol': 'LTCUSDT',
           'takeProfit': '0',
           'timeInForce': 'IOC',
           'tpTriggerBy': '',
           'triggerBy': '',
           'triggerDirection': '0',
           'triggerPrice': '0.00',
           'updatedTime': '1697557628253'},
  'lastTradeTimestamp': 1697557628253,
  'lastUpdateTimestamp': 1697557628253,
  'postOnly': False,
  'price': 62.38,
  'reduceOnly': False,
  'remaining': 0.0,
  'side': 'sell',
  'status': 'closed',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1697557628250,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```
```
p bybit fetchOrder "1533631289398402816" "ADA/USDT"                             
Python v3.11.5
CCXT v4.1.15
bybit.fetchOrder(1533631289398402816,ADA/USDT)
{'amount': 5.0,
 'average': 0.2475,
 'clientOrderId': '1533631289406791424',
 'cost': 4.9995,
 'datetime': '2023-10-17T16:11:36.443Z',
 'fee': {'cost': 0.0202, 'currency': 'USDT'},
 'fees': [{'cost': 0.0202, 'currency': 'USDT'}],
 'filled': 20.2,
 'id': '1533631289398402816',
 'info': {'avgPrice': '0.2475',
          'blockTradeId': '',
          'cancelType': 'UNKNOWN',
          'closeOnTrigger': False,
          'createdTime': '1697559096443',
          'cumExecFee': '0.0202',
          'cumExecQty': '20.20',
          'cumExecValue': '4.999500',
          'isLeverage': '0',
          'lastPriceOnCreated': '',
          'leavesQty': '0.00',
          'leavesValue': '0.000500',
          'nextPageCursor': '1533631289398402816%3A1697559096443%2C1533631289398402816%3A1697559096443',
          'orderId': '1533631289398402816',
          'orderIv': '',
          'orderLinkId': '1533631289406791424',
          'orderStatus': 'PartiallyFilledCanceled',
          'orderType': 'Market',
          'placeType': '',
          'positionIdx': '0',
          'price': '0',
          'qty': '5.00',
          'reduceOnly': False,
          'rejectReason': 'EC_CancelForNoFullFill',
          'side': 'Buy',
          'slTriggerBy': '',
          'smpGroup': '0',
          'smpOrderId': '',
          'smpType': 'None',
          'stopLoss': '0',
          'stopOrderType': '',
          'symbol': 'ADAUSDT',
          'takeProfit': '0',
          'timeInForce': 'IOC',
          'tpTriggerBy': '',
          'triggerBy': '',
          'triggerDirection': '0',
          'triggerPrice': '0.0000',
          'updatedTime': '1697559096445'},
 'lastTradeTimestamp': 1697559096445,
 'lastUpdateTimestamp': 1697559096445,
 'postOnly': False,
 'price': 0.2475,
 'reduceOnly': False,
 'remaining': 0.0,
 'side': 'buy',
 'status': 'closed',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'IOC',
 'timestamp': 1697559096443,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```
