### PR TITLE
fix(ascendex): reduceMargin no longer requires a negative number for amount

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2771,7 +2771,7 @@ export default class ascendex extends Exchange {
          * @param {object} [params] extra parameters specific to the ascendex api endpoint
          * @returns {object} a [margin structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#reduce-margin-structure}
          */
-        return await this.modifyMarginHelper (symbol, amount, 'reduce', params);
+        return await this.modifyMarginHelper (symbol, -amount, 'reduce', params);
     }
 
     async addMargin (symbol: string, amount, params = {}) {


### PR DESCRIPTION
```
% ascendex reduceMargin BTC/USDT:USDT 2
2023-10-18T05:36:12.139Z
Node.js: v18.15.0
CCXT v4.1.12
ascendex.reduceMargin (BTC/USDT:USDT, 2)
2023-10-18T05:36:17.228Z iteration 0 passed in 1265 ms

{
  info: { code: '0' },
  type: 'reduce',
  amount: 2,
  code: 'USDT',
  symbol: 'BTC/USDT:USDT',
  status: 'ok'
}
2023-10-18T05:36:17.228Z iteration 1 passed in 1265 ms
```