### PR TITLE
Bitget: fetchOpenOrders, fetchCanceledOrders, fetchClosedOrders, add margin support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3753,15 +3753,15 @@ export default class bitget extends Exchange {
         let marketType = undefined;
         let marginMode = undefined;
         let response = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
-        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchOpenOrders', params);
         if (symbol !== undefined) {
             market = this.market (symbol);
             const symbolRequest = (marginMode !== undefined) ? (market['info']['symbolName']) : (market['id']);
             request['symbol'] = symbolRequest;
         }
-        const stop = this.safeValue (params, 'stop');
-        params = this.omit (params, 'stop');
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchOpenOrders', params);
+        const stop = this.safeValue2 (params, 'stop', 'trigger');
+        params = this.omit (params, [ 'stop', 'trigger' ]);
         if (stop) {
             this.checkRequiredSymbol ('fetchOpenOrders', symbol);
             if (marketType === 'spot') {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4058,7 +4058,7 @@ export default class bitget extends Exchange {
         const request = {
             'symbol': symbolRequest,
         };
-        const now = this.milliseconds ().toString ();
+        const now = this.milliseconds ();
         const endTime = this.safeIntegerN (params, [ 'endTime', 'until', 'till' ]);
         const stop = this.safeValue (params, 'stop');
         params = this.omit (params, [ 'until', 'till', 'stop' ]);
@@ -4069,9 +4069,7 @@ export default class bitget extends Exchange {
             request['pageSize'] = limit;
             if (since === undefined) {
                 if (marketType === 'spot') {
-                    const ninetyDaysMilliseconds = '7776000000';
-                    const sinceString = Precise.stringSub (now, ninetyDaysMilliseconds);
-                    since = this.parseNumber (sinceString);
+                    since = now - 7776000000;
                 } else {
                     since = 0;
                 }
@@ -4095,9 +4093,7 @@ export default class bitget extends Exchange {
             } else {
                 if (marginMode !== undefined) {
                     if (since === undefined) {
-                        const ninetyDaysMilliseconds = '7776000000';
-                        const sinceString = Precise.stringSub (now, ninetyDaysMilliseconds);
-                        since = this.parseNumber (sinceString);
+                        since = now - 7776000000;
                     }
                     request['startTime'] = since;
                     if (endTime !== undefined) {


### PR DESCRIPTION
Added margin support to fetchOpenOrders, fetchCanceledOrders and fetchClosedOrders:
#19440

### Cross fetchOpenOrders:
```
bitget fetchOpenOrders BTC/USDT undefined undefined '{"marginMode":"cross"}'

bitget.fetchOpenOrders (BTC/USDT, , , [object Object])
2023-10-20T04:22:08.190Z iteration 0 passed in 297 ms

                 id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining | status | fee | trades | fees | reduceOnly | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1099108898629627904 | f9b55416029e4cc2bbbe2f40ac368c38 | 1697773902588 | 2023-10-20T03:51:42.588Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 |   open |     |     [] |   [] |            |                 |

1 objects
```

### Isolated fetchOpenOrders:
```
bitget fetchOpenOrders BTC/USDT undefined undefined '{"marginMode":"isolated"}'

bitget.fetchOpenOrders (BTC/USDT, , , [object Object])
2023-10-20T04:24:51.486Z iteration 0 passed in 750 ms

                 id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining | status | fee | trades | fees | reduceOnly | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1099116994957553664 | 05321047ad2545c7916a2f913b8de12f | 1697775832884 | 2023-10-20T04:23:52.884Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 |   open |     |     [] |   [] |            |                 |

1 objects
```

### Cross fetchCanceledOrders:
```
bitget fetchCanceledOrders BTC/USDT undefined undefined '{"marginMode":"cross"}'

bitget.fetchCanceledOrders (BTC/USDT, , , [object Object])
2023-10-20T05:32:47.732Z iteration 0 passed in 341 ms

                 id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining |   status | fee | trades | fees | reduceOnly | takeProfitPrice | stopLossPrice
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1098396464990269440 | 5eacd939f8d14a7a95a5242c32e4b537 | 1697604045166 | 2023-10-18T04:40:45.166Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 | canceled |     |     [] |   [] |            |                 |

1098751730051067906 | ecb50ca373374c5bb814bc724e36b0eb | 1697688746944 | 2023-10-19T04:12:26.944Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 | canceled |     |     [] |   [] |            |                 |

1098753302176870400 | c87e31cf696840fbabb301bf959623cc | 1697689121769 | 2023-10-19T04:18:41.769Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 | canceled |     |     [] |   [] |            |                 |
...
4 objects
```

### Isolated fetchCanceledOrders:
```
bitget fetchCanceledOrders BTC/USDT undefined undefined '{"marginMode":"isolated"}'

bitget.fetchCanceledOrders (BTC/USDT, , , [object Object])
2023-10-20T07:08:56.152Z iteration 0 passed in 299 ms

                 id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining |   status | fee | trades | fees | reduceOnly | takeProfitPrice | stopLossPrice
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1098394690472521728 | 9d80f1a41fa54ba4b602c2a6d80b847c | 1697603622088 | 2023-10-18T04:33:42.088Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 | canceled |     |     [] |   [] |            |                 |

1098749943604719616 | 0ec8d262b3d2436aa651095a745b9b8d | 1697688321044 | 2023-10-19T04:05:21.044Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 | canceled |     |     [] |   [] |            |                 |

1098751221042917376 | 0bfc1a26e53245d19eda1585c0eaaa4e | 1697688625587 | 2023-10-19T04:10:25.587Z |                    |                     | BTC/USDT | limit |             |          |  buy | 25000 |           |              |         |    0 | 0.0002 |      0 |    0.0002 | canceled |     |     [] |   [] |            |                 |
...
5 objects
```