### PR TITLE
feat(krakenfutures): add reduceOnly

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1363,6 +1363,7 @@ export default class krakenfutures extends Exchange {
             'type': this.parseOrderType (type),
             'timeInForce': timeInForce,
             'postOnly': type === 'post',
+            'reduceOnly': this.safeValue (details, 'reduceOnly'),
             'side': this.safeString (details, 'side'),
             'price': price,
             'stopPrice': this.safeString (details, 'triggerPrice'),


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/19625


DEMO
```
 p krakenfutures createOrder "LTC/USD:USD" limit sell 0.1 50  '{"reduceOnly":true}' --sandbox
Python v3.11.5
CCXT v4.1.19
krakenfutures.createOrder(LTC/USD:USD,limit,sell,0.1,50,{'reduceOnly': True})
{'amount': 0.1,
 'average': 63.99,
 'clientOrderId': None,
 'cost': 6.399,
 'datetime': '2023-10-20T10:35:43.520Z',
 'fee': None,
 'fees': [],
 'filled': 0.1,
 'id': '63ebd782-57e8-4df2-a4e4-b9d5ee47ba30',
 'info': {'orderEvents': [{'amount': '0.1',
                           'executionId': 'e357e132-88d7-48fe-ad14-381ba7e0de29',
                           'orderPriorEdit': None,
                           'orderPriorExecution': {'cliOrdId': None,
                                                   'filled': '0',
                                                   'lastUpdateTimestamp': '2023-10-20T10:35:43.520Z',
                                                   'limitPrice': '50',
                                                   'orderId': '63ebd782-57e8-4df2-a4e4-b9d5ee47ba30',
                                                   'quantity': '0.1',
                                                   'reduceOnly': True,
                                                   'side': 'sell',
                                                   'symbol': 'PF_LTCUSD',
                                                   'timestamp': '2023-10-20T10:35:43.520Z',
                                                   'type': 'lmt'},
                           'price': '63.99000000000000000',
                           'takerReducedQuantity': None,
                           'type': 'EXECUTION'}],
          'order_id': '63ebd782-57e8-4df2-a4e4-b9d5ee47ba30',
          'receivedTime': '2023-10-20T10:35:43.519Z',
          'status': 'placed'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 50.0,
 'reduceOnly': True,
 'remaining': 0.0,
 'side': 'sell',
 'status': 'closed',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USD:USD',
 'takeProfitPrice': None,
 'timeInForce': 'gtc',
 'timestamp': 1697798143520,
 'trades': [{'amount': 0.1,
             'cost': 6.399,
             'datetime': None,
             'fee': {'cost': None},
             'fees': [],
             'id': 'e357e132-88d7-48fe-ad14-381ba7e0de29',
             'info': {'amount': '0.1',
                      'executionId': 'e357e132-88d7-48fe-ad14-381ba7e0de29',
                      'orderPriorEdit': None,
                      'orderPriorExecution': {'cliOrdId': None,
                                              'filled': '0',
                                              'lastUpdateTimestamp': '2023-10-20T10:35:43.520Z',
                                              'limitPrice': '50',
                                              'orderId': '63ebd782-57e8-4df2-a4e4-b9d5ee47ba30',
                                              'quantity': '0.1',
                                              'reduceOnly': True,
                                              'side': 'sell',
                                              'symbol': 'PF_LTCUSD',
                                              'timestamp': '2023-10-20T10:35:43.520Z',
                                              'type': 'lmt'},
                      'price': '63.99000000000000000',
                      'takerReducedQuantity': None,
                      'type': 'EXECUTION'},
             'order': '63ebd782-57e8-4df2-a4e4-b9d5ee47ba30',
             'price': 63.99,
             'side': 'sell',
             'symbol': None,
             'takerOrMaker': None,
             'timestamp': None,
             'type': 'limit'}],
 'triggerPrice': None,
 'type': 'limit'}
```
