### PR TITLE
fix(bitget): cancelAllOrders default marginCoin

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3627,7 +3627,7 @@ export default class bitget extends Exchange {
         }
         const request = {
             'productType': productType,
-            'marginCoin': market['settleId'],
+            'marginCoin': this.safeString (market, 'settleId', 'USDT'),
         };
         const stop = this.safeValue2 (params, 'stop', 'trigger');
         const planType = this.safeString (params, 'planType');


### PR DESCRIPTION
- when no symbol is provided cancelAllOrders should still work