### PR TITLE
fix(exchange):IndexedOrderBook order by price and id, fix #19479

### DIFF
--- a/php/pro/OrderBookSide.php
+++ b/php/pro/OrderBookSide.php
@@ -177,11 +177,17 @@ class IndexedOrderBookSide extends OrderBookSide {
                 $delta[0] = abs($index_price);
                 if ($index_price === $old_price) {
                     $index = bisectLeft($this->index, $index_price);
+                    while ($this[$index][2] != $id) {
+                        $index++;
+                    }
                     $this[$index] = $delta;
                     return;
                 } else {
                     // remove old price from index
                     $old_index = bisectLeft($this->index, $old_price);
+                    while ($this[$old_index][2] != $id) {
+                        $old_index++;
+                    }
                     array_splice($this->index, $old_index, 1);
                     $tmp = $this->exchangeArray(tmp);
                     array_splice($tmp, $old_index, 1);
@@ -191,6 +197,9 @@ class IndexedOrderBookSide extends OrderBookSide {
             // insert new price level into the orderbook
             $this->hashmap[$id] = $index_price;
             $index = bisectLeft($this->index, $index_price);
+            while (array_key_exists($index, $this->index) && $this->index[$index] == $index_price && $this[$index][2] < $id) {
+                $index++;
+            }
             array_splice($this->index, $index, 0, $index_price);
             $tmp = $this->exchangeArray(tmp);
             array_splice($tmp, $index, 0, array($delta));
@@ -198,6 +207,9 @@ class IndexedOrderBookSide extends OrderBookSide {
         } else if (array_key_exists($id, $this->hashmap)) {
             $old_price = $this->hashmap[$id];
             $index = bisectLeft($this->index, $old_price);
+            while ($this[$index][2] != $id) {
+                $index++;
+            }
             array_splice($this->index, $index, 1);
             $tmp = $this->exchangeArray(tmp);
             array_splice($tmp, $index, 1);

--- a/python/ccxt/async_support/base/ws/order_book_side.py
+++ b/python/ccxt/async_support/base/ws/order_book_side.py
@@ -124,22 +124,30 @@ class IndexedOrderBookSide(OrderBookSide):
                 if index_price == old_price:
                     # just overwrite the old index
                     index = bisect.bisect_left(self._index, index_price)
+                    while self[index][2] != order_id:
+                        index += 1
                     self._index[index] = index_price
                     self[index] = delta
                     return
                 else:
                     # remove old price level
                     old_index = bisect.bisect_left(self._index, old_price)
+                    while self[old_index][2] != order_id:
+                        old_index += 1
                     del self._index[old_index]
                     del self[old_index]
             # insert new price level
             self._hashmap[order_id] = index_price
             index = bisect.bisect_left(self._index, index_price)
+            while index < len (self._index) and self._index[index] == index_price and self[index][2] < order_id:
+                index += 1
             self._index.insert(index, index_price)
             self.insert(index, delta)
         elif order_id in self._hashmap:
             old_price = self._hashmap[order_id]
             index = bisect.bisect_left(self._index, old_price)
+            while self[index][2] != order_id:
+                index += 1
             del self._index[index]
             del self[index]
             del self._hashmap[order_id]

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -174,7 +174,7 @@
         }
     },
     "bitfinex2": {
-        "skipWs": true,
+        "//skipWs": true,
         "skipMethods": {
             "loadMarkets": {
                 "currencyIdAndCode": "broken currencies"

--- a/ts/src/base/ws/OrderBookSide.ts
+++ b/ts/src/base/ws/OrderBookSide.ts
@@ -182,13 +182,21 @@ class IndexedOrderBookSide extends Array  {
                 // in case price is not sent
                 delta[0] = Math.abs (index_price)
                 if (index_price === old_price) {
-                    const index = bisectLeft (this.index, index_price)
+                    // find index by price and advance till the id is found
+                    let index = bisectLeft (this.index, index_price)
+                    while (this[index][2] !== id) {
+                        index++
+                    }
                     this.index[index] = index_price
                     this[index] = delta
                     return
                 } else {
                     // remove old price from index
-                    const old_index = bisectLeft (this.index, old_price)
+                    // find index by price and advance till the id is found
+                    let old_index = bisectLeft (this.index, old_price)
+                    while (this[old_index][2] !== id) {
+                        old_index++
+                    }
                     this.index.copyWithin (old_index, old_index + 1, this.index.length)
                     this.index[this.length - 1] = Number.MAX_VALUE
                     this.copyWithin (old_index, old_index + 1, this.length)
@@ -197,7 +205,12 @@ class IndexedOrderBookSide extends Array  {
             }
             // insert new price level
             this.hashmap.set (id, index_price)
-            const index = bisectLeft (this.index, index_price)
+            // find index by price to insert
+            let index = bisectLeft (this.index, index_price)
+            // if several with the same price order by id
+            while (index < this.length && this.index[index] === index_price && this[index][2] < id) {
+                index++
+            }
             // insert new price level into index
             this.length++
             this.index.copyWithin (index + 1, index, this.index.length)
@@ -213,7 +226,10 @@ class IndexedOrderBookSide extends Array  {
             }
         } else if (this.hashmap.has (id)) {
             const old_price = this.hashmap.get (id)
-            const index = bisectLeft (this.index, old_price)
+            let index = bisectLeft (this.index, old_price)
+            while (this[index][2] !== id) {
+                index++
+            }
             this.index.copyWithin (index, index + 1, this.index.length)
             this.index[this.length - 1] = Number.MAX_VALUE
             this.copyWithin (index, index + 1, this.length)

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -588,7 +588,6 @@ export default class bitfinex2 extends bitfinex2Rest {
         const messageHash = channel + ':' + marketId;
         const prec = this.safeString (subscription, 'prec', 'P0');
         const isRaw = (prec === 'R0');
-        const id = this.safeString (message, 0);
         // if it is an initial snapshot
         let orderbook = this.safeValue (this.orderbooks, symbol);
         if (orderbook === undefined) {
@@ -625,6 +624,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                     bookside.store (price, size, counter);
                 }
             }
+            orderbook['symbol'] = symbol;
             client.resolve (orderbook, messageHash);
         } else {
             const deltas = message[1];
@@ -636,7 +636,8 @@ export default class bitfinex2 extends bitfinex2Rest {
                 const bookside = orderbookItem[side];
                 // price = 0 means that you have to remove the order from your book
                 const amount = Precise.stringGt (price, '0') ? size : '0';
-                bookside.store (this.parseNumber (price), this.parseNumber (amount), id);
+                const idString = this.safeString (deltas, 0);
+                bookside.store (this.parseNumber (price), this.parseNumber (amount), idString);
             } else {
                 const amount = this.safeString (deltas, 2);
                 const counter = this.safeString (deltas, 1);
@@ -666,16 +667,19 @@ export default class bitfinex2 extends bitfinex2Rest {
         const stringArray = [];
         const bids = book['bids'];
         const asks = book['asks'];
+        const prec = this.safeString (subscription, 'prec', 'P0');
+        const isRaw = (prec === 'R0');
+        const idToCheck = isRaw ? 2 : 0;
         // pepperoni pizza from bitfinex
         for (let i = 0; i < depth; i++) {
             const bid = this.safeValue (bids, i);
             const ask = this.safeValue (asks, i);
             if (bid !== undefined) {
-                stringArray.push (this.numberToString (bids[i][0]));
+                stringArray.push (this.numberToString (bids[i][idToCheck]));
                 stringArray.push (this.numberToString (bids[i][1]));
             }
             if (ask !== undefined) {
-                stringArray.push (this.numberToString (asks[i][0]));
+                stringArray.push (this.numberToString (asks[i][idToCheck]));
                 stringArray.push (this.numberToString (-asks[i][1]));
             }
         }

--- a/ts/src/pro/test/base/test.OrderBook.ts
+++ b/ts/src/pro/test/base/test.OrderBook.ts
@@ -136,7 +136,7 @@ const anotherStoredIncrementalIndexedOrderBookTarget = {
 };
 
 const overwrite1234 = {
-    'bids': [ [ 9.1, 11, '1235' ], [ 8.2, 12, '1236' ], [ 7.3, 13, '1237' ], [ 6.4, 14, '1238' ], [ 4.5, 13, '1239' ] ],
+    'bids': [ [ 9.1, 11, '1235' ], [ 9, 3, '1231' ], [ 9, 1, '1232' ], [ 8.2, 12, '1236' ], [ 7.3, 13, '1237' ], [ 6.4, 14, '1238' ], [ 4.5, 13, '1239' ], [ 4, 2, '12399' ] ],
     'asks': [ [ 11.1, 13, '1244' ], [ 13.3, 13, '1243' ], [ 14.4, 12, '1242' ], [ 15.5, 11, '1241' ], [ 16.6, 10, '1240' ] ],
     'timestamp': 1574827239000,
     'datetime': '2019-11-27T04:00:39.000Z',
@@ -291,6 +291,12 @@ bids = indexedOrderBook['bids'];
 bids.store (1000, 0, '12345');
 assert (equals (indexedOrderBook, indexedOrderBookTarget));
 bids.store (10, 0, '1234');
+bids.store (10, 2, '1231');
+bids.store (10, 1, '1232');
+bids.store (4, 2, '12399');
+bids.store (9, 2, '1231');
+bids.store (9, 3, '1231');
+bids.store (9, 1, '1232');
 indexedOrderBook.limit ();
 assert (equals (indexedOrderBook, overwrite1234));
 indexedOrderBook = new IndexedOrderBook (indexedOrderBookInput);


### PR DESCRIPTION
- **Problem**: Issues in IndexedOrderBook when storing books with different id but same price.
- **Solution**: Use both price and id to find correct index and order books.
- Update tests to catch previous error
- Update bitfinex2 to fix checksum error, fix #19479, and add symbol to orderbook

### How to test
- build and transpile tests `npm run build`
- Run tests in ts, python and php: `node --loader ts-node/esm ts/src/pro/test/base/test.OrderBook.ts && php php/pro/test/OrderBook.php  && python3 python/ccxt/pro/test/test_order_book.py `