### PR TITLE
bitmart order status

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2109,7 +2109,7 @@ export default class bitmart extends Exchange {
                 '7': 'canceling', // Canceling
                 '8': 'canceled', // Canceled
                 'new': 'open',
-                'partially_filled': 'filled',
+                'partially_filled': 'open',
                 'filled': 'filled',
                 'partially_canceled': 'canceled',
             },


### PR DESCRIPTION
https://developer-pro.bitmart.com/en/spot/#current-open-orders-v4-signed
`partially_filled` is status of opened order which was filled partially. For closed order which was partially filled status is `partially_canceled` (https://developer-pro.bitmart.com/en/spot/#account-orders-v4-signed)