### PR TITLE
fix(base): sortBy fix

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -793,13 +793,15 @@ class Exchange {
         return $result;
     }
 
-    public static function sort_by($arrayOfArrays, $key, $descending = false) {
+    public static function sort_by($arrayOfArrays, $key, $descending = false, $default = 0) {
         $descending = $descending ? -1 : 1;
-        usort($arrayOfArrays, function ($a, $b) use ($key, $descending) {
-            if ($a[$key] == $b[$key]) {
+        usort($arrayOfArrays, function ($a, $b) use ($key, $descending, $default) {
+            $first = isset($a[$key]) ? $a[$key] : $default;
+            $second = isset($b[$key]) ? $b[$key] : $default;
+            if ($first == $second) {
                 return 0;
             }
-            return $a[$key] < $b[$key] ? -$descending : $descending;
+            return $first < $second ? -$descending : $descending;
         });
         return $arrayOfArrays;
     }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -988,8 +988,8 @@ class Exchange(object):
         return result
 
     @staticmethod
-    def sort_by(array, key, descending=False):
-        return sorted(array, key=lambda k: k[key] if k[key] is not None else "", reverse=descending)
+    def sort_by(array, key, descending=False, default = 0):
+        return sorted(array, key=lambda k: k[key] if k[key] is not None else default, reverse=descending)
 
     @staticmethod
     def sort_by_2(array, key1, key2, descending=False):

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -988,7 +988,7 @@ class Exchange(object):
         return result
 
     @staticmethod
-    def sort_by(array, key, descending=False, default = 0):
+    def sort_by(array, key, descending=False, default=0):
         return sorted(array, key=lambda k: k[key] if k[key] is not None else default, reverse=descending)
 
     @staticmethod
@@ -2140,7 +2140,7 @@ class Exchange(object):
         self.markets_by_id = {}
         # handle marketId conflicts
         # we insert spot markets first
-        marketValues = self.sort_by(self.to_array(markets), 'spot', True)
+        marketValues = self.sort_by(self.to_array(markets), 'spot', True, True)
         for i in range(0, len(marketValues)):
             value = marketValues[i]
             if value['id'] in self.markets_by_id:
@@ -2183,8 +2183,8 @@ class Exchange(object):
                         'precision': self.safe_value_2(marketPrecision, 'quote', 'price', defaultCurrencyPrecision),
                     })
                     quoteCurrencies.append(currency)
-            baseCurrencies = self.sort_by(baseCurrencies, 'code')
-            quoteCurrencies = self.sort_by(quoteCurrencies, 'code')
+            baseCurrencies = self.sort_by(baseCurrencies, 'code', False, '')
+            quoteCurrencies = self.sort_by(quoteCurrencies, 'code', False, '')
             self.baseCurrencies = self.index_by(baseCurrencies, 'code')
             self.quoteCurrencies = self.index_by(quoteCurrencies, 'code')
             allCurrencies = self.array_concat(baseCurrencies, quoteCurrencies)

--- a/ts/src/ace.ts
+++ b/ts/src/ace.ts
@@ -1035,7 +1035,7 @@ export default class ace extends Exchange {
                 'timeStamp': nonce,
             }, params);
             const dataKeys = Object.keys (data);
-            const sortedDataKeys = this.sortBy (dataKeys, 0);
+            const sortedDataKeys = this.sortBy (dataKeys, 0, false, '');
             for (let i = 0; i < sortedDataKeys.length; i++) {
                 const key = sortedDataKeys[i];
                 auth += this.safeString (data, key);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1931,7 +1931,7 @@ export default class Exchange {
         this.markets_by_id = {};
         // handle marketId conflicts
         // we insert spot markets first
-        const marketValues = this.sortBy (this.toArray (markets), 'spot', true);
+        const marketValues = this.sortBy (this.toArray (markets), 'spot', true, true);
         for (let i = 0; i < marketValues.length; i++) {
             const value = marketValues[i];
             if (value['id'] in this.markets_by_id) {
@@ -1979,8 +1979,8 @@ export default class Exchange {
                     quoteCurrencies.push (currency);
                 }
             }
-            baseCurrencies = this.sortBy (baseCurrencies, 'code');
-            quoteCurrencies = this.sortBy (quoteCurrencies, 'code');
+            baseCurrencies = this.sortBy (baseCurrencies, 'code', false, '');
+            quoteCurrencies = this.sortBy (quoteCurrencies, 'code', false, '');
             this.baseCurrencies = this.indexBy (baseCurrencies, 'code');
             this.quoteCurrencies = this.indexBy (quoteCurrencies, 'code');
             const allCurrencies = this.arrayConcat (baseCurrencies, quoteCurrencies);

--- a/ts/src/base/functions/generic.ts
+++ b/ts/src/base/functions/generic.ts
@@ -86,10 +86,12 @@ const filterBy = (x, k, value = undefined, out = []) => {
     return out;
 };
 
-const sortBy = (array, key, descending = false, direction = descending ? -1 : 1) => array.sort ((a, b) => {
-    if (a[key] < b[key]) {
+const sortBy = (array, key, descending = false, defaultValue = 0, direction = descending ? -1 : 1) => array.sort ((a, b) => {
+    const first = (key in a) ? a[key] : defaultValue;
+    const second = (key in b) ? b[key] : defaultValue;
+    if (first < second) {
         return -direction;
-    } else if (a[key] > b[key]) {
+    } else if (first > second) {
         return direction;
     } else {
         return 0;

--- a/ts/src/base/functions/generic.ts
+++ b/ts/src/base/functions/generic.ts
@@ -86,7 +86,7 @@ const filterBy = (x, k, value = undefined, out = []) => {
     return out;
 };
 
-const sortBy = (array, key, descending = false, defaultValue = 0, direction = descending ? -1 : 1) => array.sort ((a, b) => {
+const sortBy = (array, key, descending = false, defaultValue:any = 0, direction = descending ? -1 : 1) => array.sort ((a, b) => {
     const first = (key in a) ? a[key] : defaultValue;
     const second = (key in b) ? b[key] : defaultValue;
     if (first < second) {


### PR DESCRIPTION
- Right now, we were defaulting to a empty string when sorting arrays which could be problematic when were sorting timestamps and one of the elements does not contain a timestsamp.
- This wold break
```
this.sortBy([{'b':0, 'timestamp': 0}, {'b': 1}], 'timestamp')  // timestamp missing from the second element
```