### PR TITLE
Bitget: fetchBorrowRate

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -42,7 +42,7 @@ export default class bitget extends Exchange {
                 'editOrder': true,
                 'fetchAccounts': false,
                 'fetchBalance': true,
-                'fetchBorrowRate': false,
+                'fetchBorrowRate': true,
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
                 'fetchBorrowRates': false,
@@ -6160,6 +6160,196 @@ export default class bitget extends Exchange {
             'quoteValue': this.parseNumber (quoteValueString),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
+        };
+    }
+
+    async fetchBorrowRate (code: string, params = {}) {
+        /**
+         * @method
+         * @name bitget#fetchBorrowRate
+         * @description fetch the rate of interest to borrow a currency for margin trading
+         * @see https://bitgetlimited.github.io/apidoc/en/margin/#get-isolated-margin-interest-rate-and-max-borrowable-amount
+         * @see https://bitgetlimited.github.io/apidoc/en/margin/#get-cross-margin-interest-rate-and-borrowable
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the bitget api endpoint
+         * @param {string} [params.symbol] required for isolated margin
+         * @returns {object} a [borrow rate structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#borrow-rate-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        let market = undefined;
+        const symbol = this.safeString (params, 'symbol');
+        params = this.omit (params, 'symbol');
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request = {};
+        let response = undefined;
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowRate', params, 'cross');
+        if ((symbol !== undefined) || (marginMode === 'isolated')) {
+            this.checkRequiredSymbol ('fetchBorrowRate', symbol);
+            request['symbol'] = market['info']['symbolName'];
+            response = await this.publicMarginGetIsolatedPublicInterestRateAndLimit (this.extend (request, params));
+        } else if (marginMode === 'cross') {
+            request['coin'] = currency['code'];
+            response = await this.publicMarginGetCrossPublicInterestRateAndLimit (this.extend (request, params));
+        }
+        //
+        // isolated
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1698208075332,
+        //         "data": [
+        //             {
+        //                 "symbol": "BTCUSDT",
+        //                 "leverage": "10",
+        //                 "baseCoin": "BTC",
+        //                 "baseTransferInAble": true,
+        //                 "baseBorrowAble": true,
+        //                 "baseDailyInterestRate": "0.00007",
+        //                 "baseYearlyInterestRate": "0.02555",
+        //                 "baseMaxBorrowableAmount": "35",
+        //                 "baseVips": [
+        //                     {
+        //                         "level": "0",
+        //                         "dailyInterestRate": "0.00007",
+        //                         "yearlyInterestRate": "0.02555",
+        //                         "discountRate": "1"
+        //                     },
+        //                 ],
+        //                 "quoteCoin": "USDT",
+        //                 "quoteTransferInAble": true,
+        //                 "quoteBorrowAble": true,
+        //                 "quoteDailyInterestRate": "0.00012627",
+        //                 "quoteYearlyInterestRate": "0.04608855",
+        //                 "quoteMaxBorrowableAmount": "300000",
+        //                 "quoteVips": [
+        //                     {
+        //                         "level": "0",
+        //                         "dailyInterestRate": "0.000126279",
+        //                         "yearlyInterestRate": "0.046091835",
+        //                         "discountRate": "1"
+        //                     },
+        //                 ]
+        //             }
+        //         ]
+        //     }
+        //
+        // cross
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1698208150986,
+        //         "data": [
+        //             {
+        //                 "coin": "BTC",
+        //                 "leverage": "3",
+        //                 "transferInAble": true,
+        //                 "borrowAble": true,
+        //                 "dailyInterestRate": "0.00007",
+        //                 "yearlyInterestRate": "0.02555",
+        //                 "maxBorrowableAmount": "26",
+        //                 "vips": [
+        //                     {
+        //                         "level": "0",
+        //                         "dailyInterestRate": "0.00007",
+        //                         "yearlyInterestRate": "0.02555",
+        //                         "discountRate": "1"
+        //                     },
+        //                 ]
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        return this.parseBorrowRate (data[0], currency);
+    }
+
+    parseBorrowRate (info, currency = undefined) {
+        //
+        // isolated
+        //
+        //     {
+        //         "symbol": "BTCUSDT",
+        //         "leverage": "10",
+        //         "baseCoin": "BTC",
+        //         "baseTransferInAble": true,
+        //         "baseBorrowAble": true,
+        //         "baseDailyInterestRate": "0.00007",
+        //         "baseYearlyInterestRate": "0.02555",
+        //         "baseMaxBorrowableAmount": "35",
+        //         "baseVips": [
+        //             {
+        //                 "level": "0",
+        //                 "dailyInterestRate": "0.00007",
+        //                 "yearlyInterestRate": "0.02555",
+        //                 "discountRate": "1"
+        //             },
+        //         ],
+        //         "quoteCoin": "USDT",
+        //         "quoteTransferInAble": true,
+        //         "quoteBorrowAble": true,
+        //         "quoteDailyInterestRate": "0.00012627",
+        //         "quoteYearlyInterestRate": "0.04608855",
+        //         "quoteMaxBorrowableAmount": "300000",
+        //         "quoteVips": [
+        //             {
+        //                 "level": "0",
+        //                 "dailyInterestRate": "0.000126279",
+        //                 "yearlyInterestRate": "0.046091835",
+        //                 "discountRate": "1"
+        //             },
+        //         ]
+        //     }
+        //
+        // cross
+        //
+        //     {
+        //         "coin": "BTC",
+        //         "leverage": "3",
+        //         "transferInAble": true,
+        //         "borrowAble": true,
+        //         "dailyInterestRate": "0.00007",
+        //         "yearlyInterestRate": "0.02555",
+        //         "maxBorrowableAmount": "26",
+        //         "vips": [
+        //             {
+        //                 "level": "0",
+        //                 "dailyInterestRate": "0.00007",
+        //                 "yearlyInterestRate": "0.02555",
+        //                 "discountRate": "1"
+        //             },
+        //         ]
+        //     }
+        //
+        const code = currency['code'];
+        const baseCoin = this.safeString (info, 'baseCoin');
+        const quoteCoin = this.safeString (info, 'quoteCoin');
+        let currencyId = undefined;
+        let interestRate = undefined;
+        if (baseCoin !== undefined) {
+            if (code === baseCoin) {
+                currencyId = baseCoin;
+                interestRate = this.safeNumber (info, 'baseDailyInterestRate');
+            } else if (code === quoteCoin) {
+                currencyId = quoteCoin;
+                interestRate = this.safeNumber (info, 'quoteDailyInterestRate');
+            }
+        } else {
+            currencyId = this.safeString (info, 'coin');
+            interestRate = this.safeNumber (info, 'dailyInterestRate');
+        }
+        return {
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'rate': interestRate,
+            'period': 86400000, // 1-Day
+            'timestamp': undefined,
+            'datetime': undefined,
+            'info': info,
         };
     }
 

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -6265,8 +6265,11 @@ export default class bitget extends Exchange {
         //         ]
         //     }
         //
+        const timestamp = this.safeInteger (response, 'requestTime');
         const data = this.safeValue (response, 'data', []);
-        return this.parseBorrowRate (data[0], currency);
+        const first = this.safeValue (data, 0, {});
+        first['timestamp'] = timestamp;
+        return this.parseBorrowRate (first, currency);
     }
 
     parseBorrowRate (info, currency = undefined) {
@@ -6343,12 +6346,13 @@ export default class bitget extends Exchange {
             currencyId = this.safeString (info, 'coin');
             interestRate = this.safeNumber (info, 'dailyInterestRate');
         }
+        const timestamp = this.safeInteger (info, 'timestamp');
         return {
             'currency': this.safeCurrencyCode (currencyId, currency),
             'rate': interestRate,
             'period': 86400000, // 1-Day
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'info': info,
         };
     }


### PR DESCRIPTION
Added fetchBorrowRate to Bitget:
#19440

### Isolated:
```
bitget fetchBorrowRate USDT '{"marginMode":"isolated","symbol":"BTC/USDT"}

bitget.fetchBorrowRate (USDT, [object Object])
2023-10-25T04:29:56.214Z iteration 0 passed in 258 ms

{
  currency: 'USDT',
  rate: 0.00012627,
  period: 86400000,
  timestamp: undefined,
  datetime: undefined,
  info: {
    symbol: 'BTCUSDT',
    leverage: '10',
    baseCoin: 'BTC',
    baseTransferInAble: true,
    baseBorrowAble: true,
    baseDailyInterestRate: '0.00007',
    baseYearlyInterestRate: '0.02555',
    baseMaxBorrowableAmount: '35',
    baseVips: [
      {
        level: '0',
        dailyInterestRate: '0.00007',
        yearlyInterestRate: '0.02555',
        discountRate: '1'
      },
      {
        level: '1',
        dailyInterestRate: '0.0000679',
        yearlyInterestRate: '0.0247835',
        discountRate: '0.97'
      },
      {
        level: '2',
        dailyInterestRate: '0.0000644',
        yearlyInterestRate: '0.023506',
        discountRate: '0.92'
      },
      {
        level: '3',
        dailyInterestRate: '0.0000602',
        yearlyInterestRate: '0.021973',
        discountRate: '0.86'
      },
      {
        level: '4',
        dailyInterestRate: '0.0000525',
        yearlyInterestRate: '0.0191625',
        discountRate: '0.75'
      },
      {
        level: '5',
        dailyInterestRate: '0.000042',
        yearlyInterestRate: '0.01533',
        discountRate: '0.6'
      }
    ],
    quoteCoin: 'USDT',
    quoteTransferInAble: true,
    quoteBorrowAble: true,
    quoteDailyInterestRate: '0.00012627',
    quoteYearlyInterestRate: '0.04608855',
    quoteMaxBorrowableAmount: '300000',
    quoteVips: [
      {
        level: '0',
        dailyInterestRate: '0.000126279',
        yearlyInterestRate: '0.046091835',
        discountRate: '1'
      },
      {
        level: '1',
        dailyInterestRate: '0.00012249063',
        yearlyInterestRate: '0.04470907995',
        discountRate: '0.97'
      },
      {
        level: '2',
        dailyInterestRate: '0.00011617668',
        yearlyInterestRate: '0.0424044882',
        discountRate: '0.92'
      },
      {
        level: '3',
        dailyInterestRate: '0.00010859994',
        yearlyInterestRate: '0.0396389781',
        discountRate: '0.86'
      },
      {
        level: '4',
        dailyInterestRate: '0.00009470925',
        yearlyInterestRate: '0.03456887625',
        discountRate: '0.75'
      },
      {
        level: '5',
        dailyInterestRate: '0.0000757674',
        yearlyInterestRate: '0.027655101',
        discountRate: '0.6'
      }
    ]
  }
}
```

### Cross:
```
bitget.fetchBorrowRate (BTC)
2023-10-25T04:30:45.633Z iteration 0 passed in 263 ms

{
  currency: 'BTC',
  rate: 0.00007,
  period: 86400000,
  timestamp: undefined,
  datetime: undefined,
  info: {
    coin: 'BTC',
    leverage: '3',
    transferInAble: true,
    borrowAble: true,
    dailyInterestRate: '0.00007',
    yearlyInterestRate: '0.02555',
    maxBorrowableAmount: '26',
    vips: [
      {
        level: '0',
        dailyInterestRate: '0.00007',
        yearlyInterestRate: '0.02555',
        discountRate: '1'
      },
      {
        level: '1',
        dailyInterestRate: '0.0000679',
        yearlyInterestRate: '0.0247835',
        discountRate: '0.97'
      },
      {
        level: '2',
        dailyInterestRate: '0.0000644',
        yearlyInterestRate: '0.023506',
        discountRate: '0.92'
      },
      {
        level: '3',
        dailyInterestRate: '0.0000602',
        yearlyInterestRate: '0.021973',
        discountRate: '0.86'
      },
      {
        level: '4',
        dailyInterestRate: '0.0000525',
        yearlyInterestRate: '0.0191625',
        discountRate: '0.75'
      },
      {
        level: '5',
        dailyInterestRate: '0.000042',
        yearlyInterestRate: '0.01533',
        discountRate: '0.6'
      }
    ]
  }
}
```