### PR TITLE
Bitget: fetchBorrowInterest

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -42,6 +42,7 @@ export default class bitget extends Exchange {
                 'editOrder': true,
                 'fetchAccounts': false,
                 'fetchBalance': true,
+                'fetchBorrowInterest': true,
                 'fetchBorrowRate': true,
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
@@ -6351,6 +6352,147 @@ export default class bitget extends Exchange {
             'currency': this.safeCurrencyCode (currencyId, currency),
             'rate': interestRate,
             'period': 86400000, // 1-Day
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': info,
+        };
+    }
+
+    async fetchBorrowInterest (code: string = undefined, symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitget#fetchBorrowInterest
+         * @description fetch the interest owed by the user for borrowing currency for margin trading
+         * @see https://bitgetlimited.github.io/apidoc/en/margin/#get-isolated-interest-records
+         * @see https://bitgetlimited.github.io/apidoc/en/margin/#get-cross-interest-records
+         * @param {string} [code] unified currency code
+         * @param {string} [symbol] unified market symbol when fetching interest in isolated markets
+         * @param {int} [since] the earliest time in ms to fetch borrow interest for
+         * @param {int} [limit] the maximum number of structures to retrieve
+         * @param {object} [params] extra parameters specific to the bitget api endpoint
+         * @returns {object[]} a list of [borrow interest structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#borrow-interest-structure}
+         */
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request = {};
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+            request['coin'] = currency['id'];
+        }
+        if (since !== undefined) {
+            request['startTime'] = since;
+        } else {
+            request['startTime'] = this.milliseconds () - 7776000000;
+        }
+        if (limit !== undefined) {
+            request['pageSize'] = limit;
+        }
+        let response = undefined;
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params, 'cross');
+        if (marginMode === 'isolated') {
+            this.checkRequiredSymbol ('fetchBorrowInterest', symbol);
+            request['symbol'] = market['info']['symbolName'];
+            response = await this.privateMarginGetIsolatedInterestList (this.extend (request, params));
+        } else if (marginMode === 'cross') {
+            response = await this.privateMarginGetCrossInterestList (this.extend (request, params));
+        }
+        //
+        // isolated
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1698282523888,
+        //         "data": {
+        //             "resultList": [
+        //                 {
+        //                     "interestId": "1100560904468705284",
+        //                     "interestCoin": "USDT",
+        //                     "interestRate": "0.000126279",
+        //                     "loanCoin": "USDT",
+        //                     "amount": "0.00000298",
+        //                     "type": "scheduled",
+        //                     "symbol": "BTCUSDT",
+        //                     "ctime": "1698120000000"
+        //                 },
+        //             ],
+        //             "maxId": "1100560904468705284",
+        //             "minId": "1096915487398965249"
+        //         }
+        //     }
+        //
+        // cross
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1698282552126,
+        //         "data": {
+        //             "resultList": [
+        //                 {
+        //                     "interestId": "1099126154352799744",
+        //                     "interestCoin": "USDT",
+        //                     "interestRate": "0.000126279",
+        //                     "loanCoin": "USDT",
+        //                     "amount": "0.00002631",
+        //                     "type": "scheduled",
+        //                     "ctime": "1697778000000"
+        //                 },
+        //             ],
+        //             "maxId": "1099126154352799744",
+        //             "minId": "1096917004629716993"
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const rows = this.safeValue (data, 'resultList', []);
+        const interest = this.parseBorrowInterests (rows, market);
+        return this.filterByCurrencySinceLimit (interest, code, since, limit);
+    }
+
+    parseBorrowInterest (info, market = undefined) {
+        //
+        // isolated
+        //
+        //     {
+        //         "interestId": "1100560904468705284",
+        //         "interestCoin": "USDT",
+        //         "interestRate": "0.000126279",
+        //         "loanCoin": "USDT",
+        //         "amount": "0.00000298",
+        //         "type": "scheduled",
+        //         "symbol": "BTCUSDT",
+        //         "ctime": "1698120000000"
+        //     }
+        //
+        // cross
+        //
+        //     {
+        //         "interestId": "1099126154352799744",
+        //         "interestCoin": "USDT",
+        //         "interestRate": "0.000126279",
+        //         "loanCoin": "USDT",
+        //         "amount": "0.00002631",
+        //         "type": "scheduled",
+        //         "ctime": "1697778000000"
+        //     }
+        //
+        const marketId = this.safeString (info, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const marginMode = (marketId !== undefined) ? 'isolated' : 'cross';
+        const timestamp = this.safeInteger (info, 'ctime');
+        return {
+            'symbol': this.safeString (market, 'symbol'),
+            'marginMode': marginMode,
+            'currency': this.safeCurrencyCode (this.safeString (info, 'interestCoin')),
+            'interest': this.safeNumber (info, 'amount'),
+            'interestRate': this.safeNumber (info, 'interestRate'),
+            'amountBorrowed': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': info,


### PR DESCRIPTION
Added fetchBorrowInterest to Bitget:
#19440

### Isolated:
```
bitget fetchBorrowInterest undefined BTC/USDT undefined undefined '{"marginMode":"isolated"}'

bitget.fetchBorrowInterest (, BTC/USDT, , , [object Object])
2023-10-26T01:09:46.621Z iteration 0 passed in 288 ms

  symbol | marginMode | currency |   interest | interestRate | amountBorrowed |     timestamp |                 datetime
------------------------------------------------------------------------------------------------------------------------
BTC/USDT |   isolated |     USDT | 0.00000298 |  0.000126279 |                | 1698282000000 | 2023-10-26T01:00:00.000Z
BTC/USDT |   isolated |     USDT | 0.00000298 |  0.000126279 |                | 1698278400000 | 2023-10-26T00:00:00.000Z
BTC/USDT |   isolated |     USDT | 0.00000298 |  0.000126279 |                | 1698274800000 | 2023-10-25T23:00:00.000Z
...
100 objects
```

### Cross:
```
bitget.fetchBorrowInterest ()
2023-10-26T01:11:39.086Z iteration 0 passed in 286 ms

symbol | marginMode | currency |   interest | interestRate | amountBorrowed |     timestamp |                 datetime
----------------------------------------------------------------------------------------------------------------------
       |      cross |     USDT | 0.00002631 |  0.000126279 |                | 1697778000000 | 2023-10-20T05:00:00.000Z
       |      cross |     USDT | 0.00002631 |  0.000126279 |                | 1697774400000 | 2023-10-20T04:00:00.000Z
       |      cross |     USDT | 0.00002631 |  0.000126279 |                | 1697773902578 | 2023-10-20T03:51:42.578Z
...
9 objects
```