### PR TITLE
fix(bybit): add timestamp to balance

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3186,8 +3186,11 @@ export default class bybit extends Exchange {
         //         "time": 1672125441042
         //     }
         //
+        const timestamp = this.safeInteger (response, 'time');
         const result = {
             'info': response,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
         };
         const responseResult = this.safeValue (response, 'result', {});
         const currencyList = this.safeValueN (responseResult, [ 'loanAccountList', 'list', 'balance' ]);


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/19677

```
p bybit fetchBalance --sandbox       
Python v3.11.5
CCXT v4.1.28
bybit.fetchBalance()
{'ADA': {'debt': 0.0, 'free': 4.995, 'total': 4.995, 'used': 0.0},
 'BTC': {'debt': 0.0, 'free': 0.59307951, 'total': 0.59307951, 'used': 0.0},
 'ETH': {'debt': 0.0, 'free': 0.09074916, 'total': 0.09074916, 'used': 0.0},
 'LTC': {'debt': 0.0, 'free': 0.10599382, 'total': 0.10599382, 'used': 0.0},
 'USDC': {'debt': 0.0, 'free': 91.45750444, 'total': 91.45750444, 'used': 0.0},
 'USDT': {'debt': 0.0,
          'free': 1473.78116781,
          'total': 1535.78116781,
          'used': 62.0},
 'XRP': {'debt': 0.0, 'free': 107.39152, 'total': 107.39152, 'used': 0.0},
 'datetime': '2023-10-26T14:58:51.993Z',
 'debt': {'ADA': 0.0,
          'BTC': 0.0,
          'ETH': 0.0,
          'LTC': 0.0,
          'USDC': 0.0,
          'USDT': 0.0,
          'XRP': 0.0},
 'free': {'ADA': 4.995,
          'BTC': 0.59307951,
          'ETH': 0.09074916,
          'LTC': 0.10599382,
          'USDC': 91.45750444,
          'USDT': 1473.78116781,
          'XRP': 107.39152},
 'info': {'result': {'list': [{'accountIMRate': '0.0076',
                               'accountLTV': '0',
                               'accountMMRate': '0.0006',
                               'accountType': 'UNIFIED',
                               'coin': [{'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '91.45750444',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'USDC',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '-8.55249556',
                                         'equity': '91.45750444',
                                         'locked': '0',
                                         'marginCollateral': True,
                                         'totalOrderIM': '0',
                                         'totalPositionIM': '0',
                                         'totalPositionMM': '0',
                                         'unrealisedPnl': '0',
                                         'usdValue': '91.46074569',
                                         'walletBalance': '91.45750444'},
                                        {'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '0.59307951',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'BTC',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '-0.00000145',
                                         'equity': '0.59307951',
                                         'locked': '0',
                                         'marginCollateral': True,
                                         'totalOrderIM': '0',
                                         'totalPositionIM': '0',
                                         'totalPositionMM': '0',
                                         'unrealisedPnl': '0',
                                         'usdValue': '20275.71603105',
                                         'walletBalance': '0.59307951'},
                                        {'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '0.09074916',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'ETH',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '0',
                                         'equity': '0.09074916',
                                         'locked': '0',
                                         'marginCollateral': True,
                                         'totalOrderIM': '0',
                                         'totalPositionIM': '0',
                                         'totalPositionMM': '0',
                                         'unrealisedPnl': '0',
                                         'usdValue': '162.2124973',
                                         'walletBalance': '0.09074916'},
                                        {'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '4.995',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'ADA',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '-0.005',
                                         'equity': '4.995',
                                         'locked': '0',
                                         'marginCollateral': True,
                                         'totalOrderIM': '0',
                                         'totalPositionIM': '0',
                                         'totalPositionMM': '0',
                                         'unrealisedPnl': '0',
                                         'usdValue': '1.4472475',
                                         'walletBalance': '4.995'},
                                        {'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '107.39152',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'XRP',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '-0.02',
                                         'equity': '107.39152',
                                         'locked': '0',
                                         'marginCollateral': True,
                                         'totalOrderIM': '0',
                                         'totalPositionIM': '0',
                                         'totalPositionMM': '0',
                                         'unrealisedPnl': '0',
                                         'usdValue': '59.17000181',
                                         'walletBalance': '107.39152'},
                                        {'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '1473.78116781',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'USDT',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '-9535.18623334',
                                         'equity': '1540.34479281',
                                         'locked': '62',
                                         'marginCollateral': True,
                                         'totalOrderIM': '153.4690005',
                                         'totalPositionIM': '7.03519017',
                                         'totalPositionMM': '0.73470642',
                                         'unrealisedPnl': '4.563625',
                                         'usdValue': '1540.55343251',
                                         'walletBalance': '1535.78116781'},
                                        {'accruedInterest': '0',
                                         'availableToBorrow': '',
                                         'availableToWithdraw': '0.10599382',
                                         'bonus': '0',
                                         'borrowAmount': '0.000000000000000000',
                                         'coin': 'LTC',
                                         'collateralSwitch': True,
                                         'cumRealisedPnl': '0',
                                         'equity': '0.10599382',
                                         'locked': '0',
                                         'marginCollateral': True,
                                         'totalOrderIM': '0',
                                         'totalPositionIM': '0',
                                         'totalPositionMM': '0',
                                         'unrealisedPnl': '0',
                                         'usdValue': '7.23505806',
                                         'walletBalance': '0.10599382'}],
                               'totalAvailableBalance': '20895.62215324',
                               'totalEquity': '22137.79501395',
                               'totalInitialMargin': '160.52593096',
                               'totalMaintenanceMargin': '14.41715945',
                               'totalMarginBalance': '21106.1548567',
                               'totalPerpUPL': '4.56424314',
                               'totalWalletBalance': '21101.59061356'}]},
          'retCode': '0',
          'retExtInfo': {},
          'retMsg': 'OK',
          'time': '1698332331993'},
 'timestamp': 1698332331993,
 'total': {'ADA': 4.995,
           'BTC': 0.59307951,
           'ETH': 0.09074916,
           'LTC': 0.10599382,
           'USDC': 91.45750444,
           'USDT': 1535.78116781,
           'XRP': 107.39152},
 'used': {'ADA': 0.0,
          'BTC': 0.0,
          'ETH': 0.0,
          'LTC': 0.0,
          'USDC': 0.0,
          'USDT': 62.0,
          'XRP': 0.0}}
```
