### PR TITLE
fix(exchange):python3 decode

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1389,7 +1389,7 @@ class Exchange(object):
 
     @staticmethod
     def decode(string):
-        return string.decode('latin-1')
+        return string.encode().decode('latin-1')
 
     @staticmethod
     def to_array(value):


### PR DESCRIPTION
- fix #19683 
- By default python3 strings are decoded.
- This function is used only in bittrex (test below) and wavesexcahnge