### PR TITLE
KrakenFutures : fetchFundingRateHistory() : Fix return value

### DIFF
--- a/js/src/krakenfutures.js
+++ b/js/src/krakenfutures.js
@@ -1920,7 +1920,7 @@ export default class krakenfutures extends Exchange {
             result.push({
                 'info': item,
                 'symbol': symbol,
-                'fundingRate': this.safeNumber(item, 'fundingRate'),
+                'fundingRate': this.safeNumber(item, 'relativeFundingRate'),
                 'timestamp': this.parse8601(datetime),
                 'datetime': datetime,
             });


### PR DESCRIPTION
Kraken uses hourly funding rates and 'relativeFundingRate' is the correct value to return. This is the value that matches what the website displays and is consistent with how relativeFundingRate is implemented for all other exchanges.

The previous value returned 'fundingRate' was not consistent with how other exchanges are implemented in CCXT.