### PR TITLE
KrakenFutures: relativeFundingRate(): Return correct expected value

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1925,7 +1925,7 @@ export default class krakenfutures extends Exchange {
             result.push ({
                 'info': item,
                 'symbol': symbol,
-                'fundingRate': this.safeNumber (item, 'fundingRate'),
+                'fundingRate': this.safeNumber (item, 'relativeFundingRate'),
                 'timestamp': this.parse8601 (datetime),
                 'datetime': datetime,
             });


### PR DESCRIPTION
Return the value that matches the web interface and that is consistent with how other exchanges are implemented in CCXT.