### PR TITLE
fix(exchange): have inflate return byte[] to match JS implementation

### DIFF
--- a/python/ccxt/async_support/base/ws/functions.py
+++ b/python/ccxt/async_support/base/ws/functions.py
@@ -9,7 +9,7 @@ import datetime
 
 
 def inflate(data):
-    return decompress(data, -MAX_WBITS).decode('utf-8')
+    return decompress(data, -MAX_WBITS)
 
 
 def inflate64(data):


### PR DESCRIPTION
- fix #19683
- alternative solution to #19687

I searched for the use of inflate, and I think it doesn't break anything but please cheack as I have not touched much these functions before.