### PR TITLE
Bitget: createOrders, add margin support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3342,13 +3342,16 @@ export default class bitget extends Exchange {
             const side = this.safeString (rawOrder, 'side');
             const amount = this.safeValue (rawOrder, 'amount');
             const price = this.safeValue (rawOrder, 'price');
-            let orderParams = this.safeValue (rawOrder, 'params', {});
-            [ marginMode, orderParams ] = this.handleMarginModeAndParams ('createOrders', params);
-            if (marginMode !== undefined) {
-                if (marginMode === 'isolated') {
-                    orderParams['marginMode'] = 'isolated';
-                } else if (marginMode === 'cross') {
-                    orderParams['marginMode'] = 'cross';
+            const orderParams = this.safeValue (rawOrder, 'params', {});
+            const marginResult = this.handleMarginModeAndParams ('createOrders', params);
+            const currentMarginMode = marginResult[0];
+            if (currentMarginMode !== undefined) {
+                if (marginMode === undefined) {
+                    marginMode = currentMarginMode;
+                } else {
+                    if (marginMode !== currentMarginMode) {
+                        throw new BadRequest (this.id + ' createOrders() requires all orders to have the same margin mode (isolated or cross)');
+                    }
                 }
             }
             const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3322,6 +3322,7 @@ export default class bitget extends Exchange {
          * @see https://bitgetlimited.github.io/apidoc/en/margin/#isolated-batch-order
          * @see https://bitgetlimited.github.io/apidoc/en/margin/#cross-batch-order
          * @param {array} orders list of orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+         * @param {object} [params] extra parameters specific to the api endpoint
          * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -27,7 +27,7 @@ export default class bitget extends Exchange {
             'has': {
                 'CORS': undefined,
                 'spot': true,
-                'margin': undefined,
+                'margin': true,
                 'swap': true,
                 'future': true,
                 'option': false,


### PR DESCRIPTION
Added margin support to createOrders:
closes: #19440

### Isolated:
```
bitget createOrders ['{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":"0.0002","price":"30000"}','{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":"0.0004","price":"25000"}'] '{"marginMode":"isolated"}'

bitget.createOrders ([object Object],[object Object], [object Object])
2023-10-27T00:13:12.753Z iteration 0 passed in 430 ms

                 id |                    clientOrderId | timestamp | datetime | lastTradeTimestamp | lastUpdateTimestamp | symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining | status | fee | trades | fees | reduceOnly | takeProfitPrice | stopLossPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1101590627533598721 | 1d5ad7dab67d42f19922a9f8d638c780 |           |          |                    |                     |        |      |             |          |      |       |           |              |         |      |        |        |           |        |     |     [] |   [] |            |                 |
1101590627676205057 | 95baa65a34314cb1b8c9866e491f9256 |           |          |                    |                     |        |      |             |          |      |       |           |              |         |      |        |        |           |        |     |     [] |   [] |            |                 |
2 objects
```

### Cross:
```
bitget createOrders ['{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":"0.0002","price":"25000"}'] '{"marginMode":"cross"}'

bitget.createOrders ([object Object], [object Object])
2023-10-27T00:27:26.354Z iteration 0 passed in 373 ms

                 id |                    clientOrderId | timestamp | datetime | lastTradeTimestamp | lastUpdateTimestamp | symbol | type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | average | cost | amount | filled | remaining | status | fee | trades | fees | reduceOnly | takeProfitPrice | stopLossPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1101594207942488065 | 9b1f00c7975f4a49864590f06a18c4c6 |           |          |                    |                     |        |      |             |          |      |       |           |              |         |      |        |        |           |        |     |     [] |   [] |            |                 |
1 objects
```