### PR TITLE
Huobi: remove Hydro Protocol from commonCurrencies

### DIFF
--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -1050,7 +1050,6 @@ export default class huobi extends Exchange {
                 'GET': 'Themis', // conflict with GET (Guaranteed Entrance Token, GET Protocol)
                 'GTC': 'Game.com', // conflict with Gitcoin and Gastrocoin
                 'HIT': 'HitChain',
-                'HOT': 'Hydro Protocol', // conflict with HOT (Holo) https://github.com/ccxt/ccxt/issues/4929
                 // https://github.com/ccxt/ccxt/issues/7399
                 // https://coinmarketcap.com/currencies/pnetwork/
                 // https://coinmarketcap.com/currencies/penta/markets/

--- a/ts/src/huobijp.ts
+++ b/ts/src/huobijp.ts
@@ -318,7 +318,6 @@ export default class huobijp extends Exchange {
                 'GET': 'Themis', // conflict with GET (Guaranteed Entrance Token, GET Protocol)
                 'GTC': 'Game.com', // conflict with Gitcoin and Gastrocoin
                 'HIT': 'HitChain',
-                'HOT': 'Hydro Protocol', // conflict with HOT (Holo) https://github.com/ccxt/ccxt/issues/4929
                 // https://github.com/ccxt/ccxt/issues/7399
                 // https://coinmarketcap.com/currencies/pnetwork/
                 // https://coinmarketcap.com/currencies/penta/markets/


### PR DESCRIPTION
Removed the `delisted` Hydro Protocol from commonCurrencies because it caused a conflict with Holochain (HOT): 
https://www.htx.com/support/en-us/detail/94925759702925#:~:text=the%20delisting%20of%20HOT(Hydro%20Protocol)

#4929
#6873

fixes: #19688

```
huobi.fetchMarkets ()
2023-10-27T01:59:30.398Z iteration 0 passed in 717 ms

             id |     lowercaseId |               symbol |          base | quote | settle |    baseId | lowercaseBaseId | quoteId | settleId |   type |  spot | margin |  swap | future | option | active | contract | linear | inverse | taker | maker | contractSize |        expiry |           expiryDatetime | strike | optionType |                                        precision |                                                                                       limits |       created
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

        hotusdt |         hotusdt |             HOT/USDT |           HOT |  USDT |        |       hot |             hot |    usdt |          |   spot |  true |  false | false |  false |  false |   true |    false |        |         | 0.002 | 0.002 |              |               |                          |        |            |   {"amount":0.0001,"price":0.000001,"cost":1e-8} |                                                                              [object Object] |
```