### PR TITLE
Mexc: set future and option to false

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -29,8 +29,8 @@ export default class mexc extends Exchange {
                 'spot': true,
                 'margin': true,
                 'swap': true,
-                'future': true,
-                'option': undefined,
+                'future': false,
+                'option': false,
                 'addMargin': true,
                 'borrowMargin': true,
                 'cancelAllOrders': true,
@@ -398,10 +398,6 @@ export default class mexc extends Exchange {
                 'fetchMarkets': {
                     'types': {
                         'spot': true,
-                        'future': {
-                            'linear': false,
-                            'inverse': false,
-                        },
                         'swap': {
                             'linear': true,
                             'inverse': false,


### PR DESCRIPTION
Mexc currently only supports `spot`, `margin` and `swap` markets so I set `future` and `option` to false.