### PR TITLE
Bybit: remove commonCurrencies GASDAO

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1200,9 +1200,6 @@ export default class bybit extends Exchange {
                     'deposit': {},
                 },
             },
-            'commonCurrencies': {
-                'GAS': 'GASDAO',
-            },
         });
     }
 


### PR DESCRIPTION
Removed Bybits commonCurrencies because the only value converts GAS to GASDAO but this is not actually for the GASDAO currency it's for NEO's GAS currency which can be seen by comparing it's logo and price on Bybit with the logos and prices on Coingecko
https://www.bybit.com/trade/usdt/GASUSDT

![image](https://github.com/ccxt/ccxt/assets/83686770/b1fa8702-cb08-48b6-9eb9-e0c108125247)

![image](https://github.com/ccxt/ccxt/assets/83686770/34cec275-3c9b-4262-9b68-55ec45cf50cc)

![image](https://github.com/ccxt/ccxt/assets/83686770/dca45056-c519-4f32-9594-480757df6bf9)
