### PR TITLE
OKX parse order status 'order_failed': 'canceled',

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -3082,6 +3082,7 @@ export default class okx extends Exchange {
     parseOrderStatus (status) {
         const statuses = {
             'canceled': 'canceled',
+            'order_failed': 'canceled',
             'live': 'open',
             'partially_filled': 'open',
             'filled': 'closed',


### PR DESCRIPTION
Yesterday i give a new (or old but i never see) as order_failed. In my case this error appears when a stop/conditional order not placed