### PR TITLE
feat(hitbtc): createOrder - unified timeInForce and postOnly

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -3101,9 +3101,10 @@ export default class hitbtc extends Exchange {
         let marginMode = undefined;
         [ marginMode, params ] = super.handleMarginModeAndParams (methodName, params, defaultValue);
         if (marginMode !== undefined) {
-            if (marginMode !== 'isolated') {
-                throw new NotSupported (this.id + ' only isolated margin is supported');
-            }
+            // not true for swaps
+            // if (marginMode !== 'isolated') {
+            //     throw new NotSupported (this.id + ' only isolated margin is supported');
+            // }
         } else {
             if ((defaultType === 'margin') || (isMargin === true)) {
                 marginMode = 'isolated';

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -1,7 +1,7 @@
 import Exchange from './abstract/hitbtc.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
-import { BadSymbol, BadRequest, OnMaintenance, AccountSuspended, PermissionDenied, ExchangeError, RateLimitExceeded, ExchangeNotAvailable, OrderNotFound, InsufficientFunds, InvalidOrder, AuthenticationError, ArgumentsRequired, NotSupported } from './base/errors.js';
+import { BadSymbol, BadRequest, OnMaintenance, AccountSuspended, PermissionDenied, ExchangeError, RateLimitExceeded, ExchangeNotAvailable, OrderNotFound, InsufficientFunds, InvalidOrder, AuthenticationError, ArgumentsRequired } from './base/errors.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { Int, OrderSide, OrderType, FundingRateHistory, OHLCV, Ticker, Order, OrderBook, Dictionary, Position, Trade } from './base/types.js';
 

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -3100,12 +3100,7 @@ export default class hitbtc extends Exchange {
         const isMargin = this.safeValue (params, 'margin', false);
         let marginMode = undefined;
         [ marginMode, params ] = super.handleMarginModeAndParams (methodName, params, defaultValue);
-        if (marginMode !== undefined) {
-            // not true for swaps
-            // if (marginMode !== 'isolated') {
-            //     throw new NotSupported (this.id + ' only isolated margin is supported');
-            // }
-        } else {
+        if (marginMode === undefined) {
             if ((defaultType === 'margin') || (isMargin === true)) {
                 marginMode = 'isolated';
             }


### PR DESCRIPTION
```
% hitbtc createOrder ADA/USDT limit sell 4 0.5 '{"postOnly
": true}'
2023-10-29T09:52:36.030Z
Node.js: v18.15.0
CCXT v4.1.30
hitbtc.createOrder (ADA/USDT, limit, sell, 4, 0.5, [object Object])
2023-10-29T09:52:44.071Z iteration 0 passed in 652 ms

{
  info: {
    id: '1120860650107',
    client_order_id: 'o68AZDnnu6OunU03PXMOjMs040PRAOQX',
    symbol: 'ADAUSDT',
    side: 'sell',
    status: 'new',
    type: 'limit',
    time_in_force: 'GTC',
    quantity: '4',
    quantity_cumulative: '0',
    price: '0.5000000',
    post_only: true,
    created_at: '2023-10-29T09:52:44.53Z',
    updated_at: '2023-10-29T09:52:44.53Z'
  },
  id: 'o68AZDnnu6OunU03PXMOjMs040PRAOQX',
  clientOrderId: 'o68AZDnnu6OunU03PXMOjMs040PRAOQX',
  timestamp: 1698573164530,
  datetime: '2023-10-29T09:52:44.530Z',
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: 'ADA/USDT',
  price: 0.5,
  amount: 4,
  type: 'limit',
  side: 'sell',
  timeInForce: 'GTC',
  postOnly: true,
  reduceOnly: undefined,
  filled: 0,
  remaining: 4,
  cost: 0,
  status: 'open',
  average: undefined,
  trades: [],
  fee: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  fees: []
}
2023-10-29T09:52:44.071Z iteration 1 passed in 652 ms
```

```
% py hitbtc createOrder ADA/USDT limit sell 4 0.5 '{"postOnly": true}'
Python v3.11.6
CCXT v4.1.30
hitbtc.createOrder(ADA/USDT,limit,sell,4,0.5,{'postOnly': True})
{'amount': 4.0,
 'average': None,
 'clientOrderId': '-jDsWjcXh0PpGQ8xILcKR1ypN_Fl5xj6',
 'cost': 0.0,
 'datetime': '2023-10-29T09:58:59.385Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '-jDsWjcXh0PpGQ8xILcKR1ypN_Fl5xj6',
 'info': {'client_order_id': '-jDsWjcXh0PpGQ8xILcKR1ypN_Fl5xj6',
          'created_at': '2023-10-29T09:58:59.385Z',
          'id': '1120861777218',
          'post_only': True,
          'price': '0.5000000',
          'quantity': '4',
          'quantity_cumulative': '0',
          'side': 'sell',
          'status': 'new',
          'symbol': 'ADAUSDT',
          'time_in_force': 'GTC',
          'type': 'limit',
          'updated_at': '2023-10-29T09:58:59.385Z'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': True,
 'price': 0.5,
 'reduceOnly': None,
 'remaining': 4.0,
 'side': 'sell',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1698573539385,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```
 
 ```
 % py hitbtc createOrder ADA/USDT limit sell 4 0.5 '{"timeInForce": "GTC"}'  
Python v3.11.6
CCXT v4.1.30
hitbtc.createOrder(ADA/USDT,limit,sell,4,0.5,{'timeInForce': 'GTC'})
{'amount': 4.0,
 'average': None,
 'clientOrderId': 'xg_s2nH_2hbdxRE0nHpCan6URT_iXUCX',
 'cost': 0.0,
 'datetime': '2023-10-29T10:00:06.519Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': 'xg_s2nH_2hbdxRE0nHpCan6URT_iXUCX',
 'info': {'client_order_id': 'xg_s2nH_2hbdxRE0nHpCan6URT_iXUCX',
          'created_at': '2023-10-29T10:00:06.519Z',
          'id': '1120862001427',
          'post_only': False,
          'price': '0.5000000',
          'quantity': '4',
          'quantity_cumulative': '0',
          'side': 'sell',
          'status': 'new',
          'symbol': 'ADAUSDT',
          'time_in_force': 'GTC',
          'type': 'limit',
          'updated_at': '2023-10-29T10:00:06.519Z'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 0.5,
 'reduceOnly': None,
 'remaining': 4.0,
 'side': 'sell',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1698573606519,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```