### PR TITLE
fix(coinex): infer order type from parseOrder

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1769,7 +1769,8 @@ export default class coinex extends Exchange {
         const remainingString = this.safeString (order, 'left');
         const marketId = this.safeString (order, 'market');
         const defaultType = this.safeString (this.options, 'defaultType');
-        market = this.safeMarket (marketId, market, undefined, defaultType);
+        const orderType = ('source' in order) ? 'swap' : defaultType;
+        market = this.safeMarket (marketId, market, undefined, orderType);
         const feeCurrencyId = this.safeString (order, 'fee_asset');
         let feeCurrency = this.safeCurrencyCode (feeCurrencyId);
         if (feeCurrency === undefined) {


### PR DESCRIPTION
DEMO

```
 p coinex fetchOpenOrders --spot
Python v3.11.5
CCXT v4.1.30
coinex.fetchOpenOrders()
[{'amount': 0.1,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-10-29T14:15:33.000Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'fees': [{'cost': 0.0, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '106185729491',
  'info': {'account_id': '0',
           'amount': '0.1',
           'amount_asset': 'USDT',
           'asset_fee': '0',
           'avg_price': '0.00',
           'client_id': '',
           'create_time': '1698588933',
           'deal_amount': '0',
           'deal_fee': '0',
           'deal_money': '0',
           'fee_asset': None,
           'fee_discount': '1',
           'finished_time': '0',
           'id': '106185729491',
           'left': '0.1',
           'maker_fee_rate': '0.002',
           'market': 'LTCUSDT',
           'money_fee': '0',
           'order_type': 'limit',
           'price': '50',
           'status': 'not_deal',
           'stock_fee': '0',
           'taker_fee_rate': '0.002',
           'type': 'buy'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 50.0,
  'reduceOnly': None,
  'remaining': 0.1,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1698588933000,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
```
p coinex fetchOpenOrders "ADA/USDT:USDT"          
Python v3.11.5
CCXT v4.1.30
coinex.fetchOpenOrders(ADA/USDT:USDT)
[{'amount': 50.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-10-29T14:19:18.635Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'fees': [{'cost': 0.0, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '110807500734',
  'info': {'amount': '50',
           'client_id': '',
           'create_time': '1698589158.635874',
           'deal_asset_fee': '0.00000000000000000000',
           'deal_fee': '0.00000000000000000000',
           'deal_profit': '0.00000000000000000000',
           'deal_stock': '0.00000000000000000000',
           'effect_type': '1',
           'fee_asset': '',
           'fee_discount': '0.00000000000000000000',
           'last_deal_amount': '0.00000000000000000000',
           'last_deal_id': '0',
           'last_deal_price': '0.00000000000000000000',
           'last_deal_role': '0',
           'last_deal_time': '0',
           'last_deal_type': '0',
           'left': '50',
           'leverage': '3',
           'maker_fee': '0.00030',
           'market': 'ADAUSDT',
           'option': '0',
           'order_id': '110807500734',
           'position_id': '0',
           'position_type': '2',
           'price': '0.250000',
           'side': '2',
           'source': 'web',
           'stop_id': '0',
           'taker_fee': '0.00050',
           'target': '0',
           'type': '1',
           'update_time': '1698589158.635874',
           'user_id': '3707264'},
  'lastTradeTimestamp': 1698589158635,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 0.25,
  'reduceOnly': None,
  'remaining': 50.0,
  'side': 'buy',
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'ADA/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1698589158635,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
