### PR TITLE
fix(base) - inarray/isarray

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -72,6 +72,7 @@ const {
     , safeTimestamp2
     , rawencode
     , keysort
+    , isArray
     , inArray
     , isEmpty
     , ordered
@@ -110,6 +111,7 @@ import {
     keys as keysFunc,
     values as valuesFunc,
     inArray as inArrayFunc,
+    isArray as isArrayFunc,
     vwap as vwapFunc
 } from './functions.js'
 // import exceptions from "./errors.js"
@@ -405,6 +407,7 @@ export default class Exchange {
     rawencode = rawencode
     keysort = keysort
     inArray = inArray
+    isArray = isArray
     safeStringLower2 = safeStringLower2
     safeStringUpper2 = safeStringUpper2
     isEmpty = isEmpty
@@ -427,7 +430,6 @@ export default class Exchange {
     urlencodeNested = urlencodeNested
     parseDate = parseDate
     ymd = ymd
-    isArray = inArrayFunc
     base64ToString = base64ToString
     crc32 = crc32
 
@@ -2093,11 +2095,11 @@ export default class Exchange {
             }
             this.number = oldNumber;
             let tradesLength = 0;
-            const isArray = Array.isArray (trades);
-            if (isArray) {
+            const valueIsArray = Array.isArray (trades);
+            if (valueIsArray) {
                 tradesLength = trades.length;
             }
-            if (isArray && (tradesLength > 0)) {
+            if (valueIsArray && (tradesLength > 0)) {
                 // move properties that are defined in trades up into the order
                 if (order['symbol'] === undefined) {
                     order['symbol'] = trades[0]['symbol'];
@@ -4513,15 +4515,15 @@ export default class Exchange {
          */
         const depositWithdrawFees = {};
         codes = this.marketCodes (codes);
-        const isArray = Array.isArray (response);
+        const valueIsArray = Array.isArray (response);
         let responseKeys = response;
-        if (!isArray) {
+        if (!valueIsArray) {
             responseKeys = Object.keys (response);
         }
         for (let i = 0; i < responseKeys.length; i++) {
             const entry = responseKeys[i];
-            const dictionary = isArray ? entry : response[entry];
-            const currencyId = isArray ? this.safeString (dictionary, currencyIdKey) : entry;
+            const dictionary = valueIsArray ? entry : response[entry];
+            const currencyId = valueIsArray ? this.safeString (dictionary, currencyIdKey) : entry;
             const currency = this.safeValue (this.currencies_by_id, currencyId);
             const code = this.safeString (currency, 'code', currencyId);
             if ((codes === undefined) || (this.inArray (code, codes))) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -72,7 +72,6 @@ const {
     , safeTimestamp2
     , rawencode
     , keysort
-    , isArray
     , inArray
     , isEmpty
     , ordered
@@ -111,7 +110,6 @@ import {
     keys as keysFunc,
     values as valuesFunc,
     inArray as inArrayFunc,
-    isArray as isArrayFunc,
     vwap as vwapFunc
 } from './functions.js'
 // import exceptions from "./errors.js"
@@ -407,7 +405,6 @@ export default class Exchange {
     rawencode = rawencode
     keysort = keysort
     inArray = inArray
-    isArray = isArray
     safeStringLower2 = safeStringLower2
     safeStringUpper2 = safeStringUpper2
     isEmpty = isEmpty
@@ -2095,11 +2092,11 @@ export default class Exchange {
             }
             this.number = oldNumber;
             let tradesLength = 0;
-            const valueIsArray = Array.isArray (trades);
-            if (valueIsArray) {
+            const isArray = Array.isArray (trades);
+            if (isArray) {
                 tradesLength = trades.length;
             }
-            if (valueIsArray && (tradesLength > 0)) {
+            if (isArray && (tradesLength > 0)) {
                 // move properties that are defined in trades up into the order
                 if (order['symbol'] === undefined) {
                     order['symbol'] = trades[0]['symbol'];
@@ -4515,15 +4512,15 @@ export default class Exchange {
          */
         const depositWithdrawFees = {};
         codes = this.marketCodes (codes);
-        const valueIsArray = Array.isArray (response);
+        const isArray = Array.isArray (response);
         let responseKeys = response;
-        if (!valueIsArray) {
+        if (!isArray) {
             responseKeys = Object.keys (response);
         }
         for (let i = 0; i < responseKeys.length; i++) {
             const entry = responseKeys[i];
-            const dictionary = valueIsArray ? entry : response[entry];
-            const currencyId = valueIsArray ? this.safeString (dictionary, currencyIdKey) : entry;
+            const dictionary = isArray ? entry : response[entry];
+            const currencyId = isArray ? this.safeString (dictionary, currencyIdKey) : entry;
             const currency = this.safeValue (this.currencies_by_id, currencyId);
             const code = this.safeString (currency, 'code', currencyId);
             if ((codes === undefined) || (this.inArray (code, codes))) {


### PR DESCRIPTION
namely this PR fixes the name conflicts of function vs local variable:
https://imgsh.net/a/kSd9XVm.png

however, i am not in context of historical reasons why do we need to have the methods also declared in instance, which are nowhere used (for example, we nowhere use `this.isArray` because we everywhere use `Array.isArray`)