### PR TITLE
feat(errors) - add `ApiEngineFailed` and `OperationFailed`

### DIFF
--- a/ts/src/base/errorHierarchy.ts
+++ b/ts/src/base/errorHierarchy.ts
@@ -12,9 +12,11 @@ const errorHierarchy = {
                 'BadSymbol': {},
                 'MarginModeAlreadySet': {},
                 'NoChange': {},
+                'OperationFailed': {},
             },
             'BadResponse': {
                 'NullResponse': {},
+                'ApiEngineFailed': {},
             },
             'InsufficientFunds': {},
             'InvalidAddress': {

--- a/ts/src/base/errorHierarchy.ts
+++ b/ts/src/base/errorHierarchy.ts
@@ -12,11 +12,11 @@ const errorHierarchy = {
                 'BadSymbol': {},
                 'MarginModeAlreadySet': {},
                 'NoChange': {},
-                'OperationFailed': {},
+                'InvalidOperation': {},
             },
             'BadResponse': {
                 'NullResponse': {},
-                'ApiEngineFailed': {},
+                'OperationFailed': {},
             },
             'InsufficientFunds': {},
             'InvalidAddress': {

--- a/ts/src/base/errorHierarchy.ts
+++ b/ts/src/base/errorHierarchy.ts
@@ -16,8 +16,8 @@ const errorHierarchy = {
             },
             'BadResponse': {
                 'NullResponse': {},
-                'OperationFailed': {},
             },
+            'OperationFailed': {},
             'InsufficientFunds': {},
             'InvalidAddress': {
                 'AddressPending': {},


### PR DESCRIPTION
I've been trying to determine which one should fall under which parent key. please revise and lmk if that's suited.