### PR TITLE
Bitmex: parseOrder, add remaining value for inverse orders

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1697,12 +1697,8 @@ export default class bitmex extends Exchange {
         //         "timestamp":"2021-01-02T21:38:49.246Z"
         //     }
         //
-        const status = this.parseOrderStatus (this.safeString (order, 'ordStatus'));
         const marketId = this.safeString (order, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
-        const timestamp = this.parse8601 (this.safeString (order, 'timestamp'));
-        const lastTradeTimestamp = this.parse8601 (this.safeString (order, 'transactTime'));
-        const price = this.safeString (order, 'price');
         const qty = this.safeString (order, 'orderQty');
         let cost = undefined;
         let amount = undefined;
@@ -1726,38 +1722,35 @@ export default class bitmex extends Exchange {
         } else {
             filled = cumQty;
         }
-        const id = this.safeString (order, 'orderID');
-        const type = this.safeStringLower (order, 'ordType');
-        const side = this.safeStringLower (order, 'side');
-        const clientOrderId = this.safeString (order, 'clOrdID');
-        const timeInForce = this.parseTimeInForce (this.safeString (order, 'timeInForce'));
-        const stopPrice = this.safeNumber (order, 'stopPx');
         const execInst = this.safeString (order, 'execInst');
         let postOnly = undefined;
         if (execInst !== undefined) {
             postOnly = (execInst === 'ParticipateDoNotInitiate');
         }
+        const timestamp = this.parse8601 (this.safeString (order, 'timestamp'));
+        const stopPrice = this.safeNumber (order, 'stopPx');
+        const remaining = this.safeString (order, 'leavesQty');
         return this.safeOrder ({
             'info': order,
-            'id': id,
-            'clientOrderId': clientOrderId,
+            'id': this.safeString (order, 'orderID'),
+            'clientOrderId': this.safeString (order, 'clOrdID'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'lastTradeTimestamp': lastTradeTimestamp,
+            'lastTradeTimestamp': this.parse8601 (this.safeString (order, 'transactTime')),
             'symbol': symbol,
-            'type': type,
-            'timeInForce': timeInForce,
+            'type': this.safeStringLower (order, 'ordType'),
+            'timeInForce': this.parseTimeInForce (this.safeString (order, 'timeInForce')),
             'postOnly': postOnly,
-            'side': side,
-            'price': price,
+            'side': this.safeStringLower (order, 'side'),
+            'price': this.safeString (order, 'price'),
             'stopPrice': stopPrice,
             'triggerPrice': stopPrice,
             'amount': amount,
             'cost': cost,
             'average': average,
             'filled': filled,
-            'remaining': undefined,
-            'status': status,
+            'remaining': this.convertFromRawQuantity (symbol, remaining),
+            'status': this.parseOrderStatus (this.safeString (order, 'ordStatus')),
             'fee': undefined,
             'trades': undefined,
         }, market);

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1698,13 +1698,14 @@ export default class bitmex extends Exchange {
         //     }
         //
         const marketId = this.safeString (order, 'symbol');
-        const symbol = this.safeSymbol (marketId, market);
+        market = this.safeMarket (marketId, market);
+        const symbol = market['symbol'];
         const qty = this.safeString (order, 'orderQty');
         let cost = undefined;
         let amount = undefined;
-        const defaultSubType = this.safeString (this.options, 'defaultSubType', 'linear');
         let isInverse = false;
-        if (market === undefined) {
+        if (marketId === undefined) {
+            const defaultSubType = this.safeString (this.options, 'defaultSubType', 'linear');
             isInverse = (defaultSubType === 'inverse');
         } else {
             isInverse = this.safeValue (market, 'inverse', false);


### PR DESCRIPTION
Added the `remaining` value to parseOrder for inverse market trades:
fixes: #19743
```
bitmex.createOrder (BTC/USD:BTC, limit, buy, 100, 25000)
2023-10-31T02:41:47.512Z iteration 0 passed in 686 ms

{
  info: {
    orderID: '68ecf38c-e278-491c-9090-c28a559b8846',
    clOrdID: '',
    clOrdLinkID: '',
    account: '395724',
    symbol: 'XBTUSD',
    side: 'Buy',
    orderQty: '100',
    price: '25000',
    displayQty: null,
    stopPx: null,
    pegOffsetValue: null,
    pegPriceType: '',
    currency: 'USD',
    settlCurrency: 'XBt',
    ordType: 'Limit',
    timeInForce: 'GoodTillCancel',
    execInst: '',
    contingencyType: '',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: true,
    ordRejReason: '',
    leavesQty: '100',
    cumQty: '0',
    avgPx: null,
    text: 'CCXT',
    transactTime: '2023-10-31T02:41:47.645Z',
    timestamp: '2023-10-31T02:41:47.645Z'
  },
  id: '68ecf38c-e278-491c-9090-c28a559b8846',
  clientOrderId: undefined,
  timestamp: 1698720107645,
  datetime: '2023-10-31T02:41:47.645Z',
  lastTradeTimestamp: 1698720107645,
  symbol: 'BTC/USD:BTC',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 25000,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: undefined,
  cost: 100,
  average: undefined,
  filled: undefined,
  remaining: 100,
  status: 'open',
  fee: undefined,
  trades: [],
  fees: [],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```