### PR TITLE
fix(woo): watchBalance

### DIFF
--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -688,8 +688,11 @@ export default class woo extends wooRest {
             const value = balances[key];
             const code = this.safeCurrencyCode (key);
             const account = (code in this.balance) ? this.balance[code] : this.account ();
-            account['total'] = this.safeString (value, 'holding');
-            account['used'] = this.safeString (value, 'frozen');
+            const total = this.safeString (value, 'holding');
+            const used = this.safeString (value, 'frozen');
+            account['total'] = total;
+            account['used'] = used;
+            account['free'] = Precise.stringSub (total, used);
             this.balance[code] = account;
         }
         this.balance = this.safeBalance (this.balance);


### PR DESCRIPTION
Related issue: ccxt/ccxt#19399
```BASH
$ p woo watchBalance --test --verbose
Python v3.9.6
CCXT v4.1.32
woo.watchBalance()
2023-10-31T02:54:18.459Z connecting to wss://wss.staging.woo.org/v2/ws/private/stream/helloworld
2023-10-31T02:54:18.617Z connected
2023-10-31T02:54:18.617Z ping loop
2023-10-31T02:54:18.618Z sending {'event': 'ping'}
2023-10-31T02:54:18.618Z sending {'event': 'auth', 'params': {'apikey': 'helloworld', 'sign': 'helloworld', 'timestamp': '1698720858459'}}
2023-10-31T02:54:18.663Z message {"event":"pong","ts":1698720858633}
2023-10-31T02:54:18.668Z message {"event":"auth","success":true,"ts":1698720858634}
2023-10-31T02:54:18.769Z sending {'id': 1, 'event': 'subscribe', 'topic': 'balance'}
2023-10-31T02:54:18.813Z message {"id":"1","event":"subscribe","success":true,"ts":1698720858783}
2023-10-31T02:54:20.088Z message {"event":"ping","ts":1698720860000}
2023-10-31T02:54:28.621Z sending {'event': 'ping'}
2023-10-31T02:54:28.698Z message {"event":"pong","ts":1698720868644}
2023-10-31T02:54:30.089Z message {"event":"ping","ts":1698720870000}
2023-10-31T02:54:38.642Z sending {'event': 'ping'}
2023-10-31T02:54:38.692Z message {"event":"pong","ts":1698720878659}
2023-10-31T02:54:40.089Z message {"event":"ping","ts":1698720880001}
2023-10-31T02:54:48.644Z sending {'event': 'ping'}
2023-10-31T02:54:48.690Z message {"event":"pong","ts":1698720888659}
2023-10-31T02:54:50.032Z message {"event":"ping","ts":1698720890001}
2023-10-31T02:54:58.646Z sending {'event': 'ping'}
2023-10-31T02:54:58.696Z message {"event":"pong","ts":1698720898664}
2023-10-31T02:55:00.088Z message {"event":"ping","ts":1698720900000}
2023-10-31T02:55:01.089Z message {"topic":"balance","ts":1698720900928,"data":{"balances":{"USDT":{"holding":22145.07422804,"frozen":0.0,"interest":0.0,"pendingShortQty":0.0,"pendingExposure":0.0,"pendingLongQty":0.0,"pendingLongExposure":0.0,"version":144733,"staked":0.0,"unbonding":0.0,"vault":0.0,"averageOpenPrice":0.0,"pnl24H":0.0,"fee24H":0.0,"markPrice":1.0,"pnl24HPercentage":0.0}}}}
{'USDT': {'free': 22145.07422804, 'total': 22145.07422804, 'used': 0.0},
 'datetime': '2023-10-31T02:55:00.928Z',
 'free': {'USDT': 22145.07422804},
 'info': {'balances': {'USDT': {'averageOpenPrice': 0.0,
                                'fee24H': 0.0,
                                'frozen': 0.0,
                                'holding': 22145.07422804,
                                'interest': 0.0,
                                'markPrice': 1.0,
                                'pendingExposure': 0.0,
                                'pendingLongExposure': 0.0,
                                'pendingLongQty': 0.0,
                                'pendingShortQty': 0.0,
                                'pnl24H': 0.0,
                                'pnl24HPercentage': 0.0,
                                'staked': 0.0,
                                'unbonding': 0.0,
                                'vault': 0.0,
                                'version': 144733}}},
 'timestamp': 1698720900928,
 'total': {'USDT': 22145.07422804},
 'used': {'USDT': 0.0}}
2023-10-31T02:55:08.649Z sending {'event': 'ping'}
2023-10-31T02:55:08.697Z message {"event":"pong","ts":1698720908665}
2023-10-31T02:55:10.032Z message {"event":"ping","ts":1698720910001}
2023-10-31T02:55:18.655Z sending {'event': 'ping'}
2023-10-31T02:55:18.719Z message {"event":"pong","ts":1698720918683}
2023-10-31T02:55:20.091Z message {"event":"ping","ts":1698720920000}
2023-10-31T02:55:28.659Z sending {'event': 'ping'}
2023-10-31T02:55:28.753Z message {"event":"pong","ts":1698720928721}
2023-10-31T02:55:30.091Z message {"event":"ping","ts":1698720930001}
2023-10-31T02:55:38.662Z sending {'event': 'ping'}
2023-10-31T02:55:38.797Z message {"event":"pong","ts":1698720938764}
2023-10-31T02:55:40.089Z message {"event":"ping","ts":1698720940000}
2023-10-31T02:55:48.666Z sending {'event': 'ping'}
2023-10-31T02:55:48.790Z message {"event":"pong","ts":1698720948684}
2023-10-31T02:55:50.090Z message {"event":"ping","ts":1698720950000}
2023-10-31T02:55:58.670Z sending {'event': 'ping'}
2023-10-31T02:55:58.831Z message {"event":"pong","ts":1698720958686}
2023-10-31T02:56:00.036Z message {"event":"ping","ts":1698720960000}
2023-10-31T02:56:08.672Z sending {'event': 'ping'}
2023-10-31T02:56:08.722Z message {"event":"pong","ts":1698720968688}
2023-10-31T02:56:10.093Z message {"event":"ping","ts":1698720970000}
2023-10-31T02:56:18.684Z sending {'event': 'ping'}
2023-10-31T02:56:18.731Z message {"event":"pong","ts":1698720978699}
2023-10-31T02:56:20.109Z message {"event":"ping","ts":1698720980000}
2023-10-31T02:56:28.687Z sending {'event': 'ping'}
2023-10-31T02:56:28.743Z message {"event":"pong","ts":1698720988702}
2023-10-31T02:56:30.106Z message {"event":"ping","ts":1698720990000}
2023-10-31T02:56:38.692Z sending {'event': 'ping'}
2023-10-31T02:56:38.771Z message {"event":"pong","ts":1698720998737}
2023-10-31T02:56:40.097Z message {"event":"ping","ts":1698721000000}
2023-10-31T02:56:48.719Z sending {'event': 'ping'}
2023-10-31T02:56:48.806Z message {"event":"pong","ts":1698721008739}
2023-10-31T02:56:50.036Z message {"event":"ping","ts":1698721010000}
2023-10-31T02:56:58.729Z sending {'event': 'ping'}
2023-10-31T02:56:58.785Z message {"event":"pong","ts":1698721018750}
2023-10-31T02:57:00.141Z message {"event":"ping","ts":1698721020006}
2023-10-31T02:57:08.738Z sending {'event': 'ping'}
2023-10-31T02:57:08.786Z message {"event":"pong","ts":1698721028753}
2023-10-31T02:57:10.117Z message {"event":"ping","ts":1698721030000}
2023-10-31T02:57:18.740Z sending {'event': 'ping'}
2023-10-31T02:57:18.791Z message {"event":"pong","ts":1698721038757}
2023-10-31T02:57:20.212Z message {"event":"ping","ts":1698721040001}
2023-10-31T02:57:28.743Z sending {'event': 'ping'}
2023-10-31T02:57:28.828Z message {"event":"pong","ts":1698721048769}
2023-10-31T02:57:30.248Z message {"event":"ping","ts":1698721050000}
2023-10-31T02:57:38.759Z sending {'event': 'ping'}
2023-10-31T02:57:38.814Z message {"event":"pong","ts":1698721058776}
2023-10-31T02:57:40.089Z message {"event":"ping","ts":1698721060001}
2023-10-31T02:57:48.764Z sending {'event': 'ping'}
2023-10-31T02:57:48.812Z message {"event":"pong","ts":1698721068777}
2023-10-31T02:57:50.113Z message {"event":"ping","ts":1698721070000}

2023-10-31T02:57:58.765Z sending {'event': 'ping'}
2023-10-31T02:57:58.818Z message {"event":"pong","ts":1698721078783}
2023-10-31T02:58:00.092Z message {"event":"ping","ts":1698721080001}
2023-10-31T02:58:08.768Z sending {'event': 'ping'}
2023-10-31T02:58:08.816Z message {"event":"pong","ts":1698721088781}
2023-10-31T02:58:10.185Z message {"event":"ping","ts":1698721090000}
2023-10-31T02:58:18.769Z sending {'event': 'ping'}
2023-10-31T02:58:18.822Z message {"event":"pong","ts":1698721098787}
2023-10-31T02:58:20.094Z message {"event":"ping","ts":1698721100000}
2023-10-31T02:58:28.774Z sending {'event': 'ping'}
2023-10-31T02:58:28.842Z message {"event":"pong","ts":1698721108789}
2023-10-31T02:58:30.036Z message {"event":"ping","ts":1698721110000}
2023-10-31T02:58:38.780Z sending {'event': 'ping'}
2023-10-31T02:58:38.838Z message {"event":"pong","ts":1698721118793}
2023-10-31T02:58:40.102Z message {"event":"ping","ts":1698721120000}
2023-10-31T02:58:48.783Z sending {'event': 'ping'}
2023-10-31T02:58:48.834Z message {"event":"pong","ts":1698721128798}
2023-10-31T02:58:50.094Z message {"event":"ping","ts":1698721130000}
2023-10-31T02:58:58.787Z sending {'event': 'ping'}
2023-10-31T02:58:58.854Z message {"event":"pong","ts":1698721138819}
2023-10-31T02:59:00.156Z message {"event":"ping","ts":1698721140000}
2023-10-31T02:59:08.792Z sending {'event': 'ping'}
2023-10-31T02:59:08.841Z message {"event":"pong","ts":1698721148805}
2023-10-31T02:59:10.194Z message {"event":"ping","ts":1698721150001}
2023-10-31T02:59:16.642Z message {"topic":"balance","ts":1698721156258,"data":{"balances":{"USDT":{"holding":22175.47925847,"frozen":0.0,"interest":0.0,"pendingShortQty":0.0,"pendingExposure":0.0,"pendingLongQty":0.0,"pendingLongExposure":0.0,"version":144736,"staked":0.0,"unbonding":0.0,"vault":0.0,"averageOpenPrice":0.0,"pnl24H":0.0,"fee24H":0.0,"markPrice":1.0,"pnl24HPercentage":0.0}}}}
{'USDT': {'free': 22175.47925847, 'total': 22175.47925847, 'used': 0.0},
 'datetime': '2023-10-31T02:59:16.258Z',
 'free': {'USDT': 22175.47925847},
 'info': {'balances': {'USDT': {'averageOpenPrice': 0.0,
                                'fee24H': 0.0,
                                'frozen': 0.0,
                                'holding': 22175.47925847,
                                'interest': 0.0,
                                'markPrice': 1.0,
                                'pendingExposure': 0.0,
                                'pendingLongExposure': 0.0,
                                'pendingLongQty': 0.0,
                                'pendingShortQty': 0.0,
                                'pnl24H': 0.0,
                                'pnl24HPercentage': 0.0,
                                'staked': 0.0,
                                'unbonding': 0.0,
                                'vault': 0.0,
                                'version': 144736}}},
 'timestamp': 1698721156258,
 'total': {'USDT': 22175.47925847},
 'used': {'USDT': 0.0}}
```

should create order in another session
```BASH
$ n woo createOrder ETH/USDT:USDT MARKET SELL 0.1 --test --verbose
$ n woo createOrder ETH/USDT:USDT MARKET SELL 0.1 --test --verbose
```