### PR TITLE
build.sh : only run python linter for exchange changes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -137,8 +137,11 @@ done
 # faster version of post-transpile
 npm run check-php-syntax
 
-echo "$msgPrefix Linting python files: ${PYTHON_FILES[@]}"
-ruff ${PYTHON_FILES[*]}
+# only run the python linter if exchange related files are changed
+if [ ${#REST_EXCHANGES[@]} -gt 0 ] || [ ${#WS_EXCHANGES[@]} -gt 0 ]; then
+  echo "$msgPrefix Linting python files: ${PYTHON_FILES[@]}"
+  ruff ${PYTHON_FILES[*]}
+fi
 
 
 ### RUN SPECIFIC TESTS (ONLY IN TRAVIS) ###

--- a/build.sh
+++ b/build.sh
@@ -138,7 +138,7 @@ done
 npm run check-php-syntax
 
 # only run the python linter if exchange related files are changed
-if [ ${#REST_EXCHANGES[@]} -gt 0 ] || [ ${#WS_EXCHANGES[@]} -gt 0 ]; then
+if [ ${#PYTHON_FILES[@]} -gt 0 ]; then
   echo "$msgPrefix Linting python files: ${PYTHON_FILES[@]}"
   ruff ${PYTHON_FILES[*]}
 fi


### PR DESCRIPTION
Edited the build file so that the python linter is only run if exchange related files have been changed.

Still looking for an efficient way to check if Exchange.ts has been changed and run the python linter if it has been