### PR TITLE
feat(woo): remove brokerId from sandbox mode

### DIFF
--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -245,6 +245,7 @@ export default class woo extends Exchange {
                 },
             },
             'options': {
+                'sandboxMode': false,
                 'createMarketBuyOrderRequiresPrice': true,
                 // these network aliases require manual mapping here
                 'network-aliases-for-tokens': {
@@ -2173,13 +2174,16 @@ export default class woo extends Exchange {
         } else {
             this.checkRequiredCredentials ();
             if (method === 'POST' && (path === 'algo/order' || path === 'order')) {
-                const applicationId = 'bc830de7-50f3-460b-9ee0-f430f83f9dad';
-                const brokerId = this.safeString (this.options, 'brokerId', applicationId);
-                const isStop = path.indexOf ('algo') > -1;
-                if (isStop) {
-                    params['brokerId'] = brokerId;
-                } else {
-                    params['broker_id'] = brokerId;
+                const isSandboxMode = this.safeValue (this.options, 'sandbox', false);
+                if (!isSandboxMode) {
+                    const applicationId = 'bc830de7-50f3-460b-9ee0-f430f83f9dad';
+                    const brokerId = this.safeString (this.options, 'brokerId', applicationId);
+                    const isStop = path.indexOf ('algo') > -1;
+                    if (isStop) {
+                        params['brokerId'] = brokerId;
+                    } else {
+                        params['broker_id'] = brokerId;
+                    }
                 }
                 params = this.keysort (params);
             }
@@ -2643,5 +2647,10 @@ export default class woo extends Exchange {
         }
         // if it was not returned according to above options, then return the first network of currency
         return this.safeValue (networkKeys, 0);
+    }
+
+    setSandboxMode (enable) {
+        super.setSandboxMode (enable);
+        this.options['sandboxMode'] = enable;
     }
 }

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2174,7 +2174,7 @@ export default class woo extends Exchange {
         } else {
             this.checkRequiredCredentials ();
             if (method === 'POST' && (path === 'algo/order' || path === 'order')) {
-                const isSandboxMode = this.safeValue (this.options, 'sandbox', false);
+                const isSandboxMode = this.safeValue (this.options, 'sandboxMode', false);
                 if (!isSandboxMode) {
                     const applicationId = 'bc830de7-50f3-460b-9ee0-f430f83f9dad';
                     const brokerId = this.safeString (this.options, 'brokerId', applicationId);


### PR DESCRIPTION
- If we send the brokerId in sandbox mode, the request fails

DEMO
```
 p woo createOrder "LTC/USDT" limit buy 0.1 55 --sandbox
Python v3.11.5
CCXT v4.1.32
woo.createOrder(LTC/USDT,limit,buy,0.1,55)
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': '2023-10-31T09:52:23.419Z',
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '516281043',
 'info': {'client_order_id': '0',
          'order_amount': None,
          'order_id': '516281043',
          'order_price': '55',
          'order_quantity': '0.1',
          'order_type': 'LIMIT',
          'success': True,
          'timestamp': '1698745943.419'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 55.0,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': 1698745943419,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
Mainnet

```
✗ p woo createOrder "LTC/USDT" limit buy 0.1 55  --verbose
Python v3.11.5
CCXT v4.1.32
woo.createOrder(LTC/USDT,limit,buy,0.1,55)

fetch Request: woo POST https://api.woo.org/v1/order RequestHeaders: {'x-api-key': '72EIr2euE6I8/8MuZb4TAQ==', 'x-api-timestamp': '1698745979991', 'content-type': 'application/x-www-form-urlencoded', 'x-api-signature': 'b9fbb4c82cd8c3c24475c42c97baaa367e0a9225d4f3a9d0fea3f2450a74e29b', 'User-Agent': 'python-requests/2.28.2', 'Accept-Encoding': 'gzip, deflate'} RequestBody: broker_id=bc830de7-50f3-460b-9ee0-f430f83f9dad&order_price=55&order_quantity=0.1&order_type=LIMIT&side=BUY&symbol=SPOT_LTC_USDT

fetch Response: woo POST https://api.woo.org/v1/order 200 ResponseHeaders: {'x-request-id': '4cbc8b4d0936b101adb2b5eaf93c33c3', 'Vary': 'Origin, Origin, Origin', 'Content-Type': 'application/json', 'Date': 'Tue, 31 Oct 2023 09:53:00 GMT', 'Via': '1.1 google', 'Alt-Svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000', 'Transfer-Encoding': 'chunked'} ResponseBody: {"success":true,"timestamp":"1698745980.303","order_id":1051839540,"order_type":"LIMIT","order_price":55,"order_quantity":0.1,"order_amount":null,"client_order_id":0}
{'amount': 0.1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': '2023-10-31T09:53:00.303Z',
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '1051839540',
 'info': {'client_order_id': '0',
          'order_amount': None,
          'order_id': '1051839540',
          'order_price': '55',
          'order_quantity': '0.1',
          'order_type': 'LIMIT',
          'success': True,
          'timestamp': '1698745980.303'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 55.0,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': 1698745980303,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```
