### PR TITLE
Digifinex: setMarginMode

### DIFF
--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -84,7 +84,7 @@ export default class digifinex extends Exchange {
                 'reduceMargin': false,
                 'setLeverage': true,
                 'setMargin': false,
-                'setMarginMode': false,
+                'setMarginMode': true,
                 'setPositionMode': false,
                 'transfer': true,
                 'withdraw': true,
@@ -3840,6 +3840,31 @@ export default class digifinex extends Exchange {
             depositWithdrawFees[code] = this.assignDefaultDepositWithdrawFees (depositWithdrawFees[code], currency);
         }
         return depositWithdrawFees;
+    }
+
+    async setMarginMode (marginMode, symbol: string = undefined, params = {}) {
+        /**
+         * @method
+         * @name digifinex#setMarginMode
+         * @description set margin mode to 'cross' or 'isolated'
+         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#positionmode
+         * @param {string} marginMode 'cross' or 'isolated'
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the digifinex api endpoint
+         * @returns {object} response from the exchange
+         */
+        this.checkRequiredSymbol ('setMarginMode', symbol);
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        marginMode = marginMode.toLowerCase ();
+        if (marginMode === 'cross') {
+            marginMode = 'crossed';
+        }
+        const request = {
+            'instrument_id': market['id'],
+            'margin_mode': marginMode,
+        };
+        return await this.privateSwapPostAccountPositionMode (this.extend (request, params));
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
Added setMarginMode to digifinex:
```
digifinex.setMarginMode (cross, BTC/USDT:USDT)
2023-10-31T23:55:48.145Z iteration 0 passed in 1204 ms

{
  code: '0',
  data: { instrument_id: 'BTCUSDTPERP', margin_mode: 'crossed' }
}
```
```
digifinex.setMarginMode (isolated, BTC/USDT:USDT)
2023-10-31T23:57:24.202Z iteration 0 passed in 1178 ms

{
  code: '0',
  data: { instrument_id: 'BTCUSDTPERP', margin_mode: 'isolated' }
}
```