### PR TITLE
fix(okx): watchMyTrades

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -866,7 +866,7 @@ export default class okx extends okxRest {
         const request = {
             'instType': uppercaseType,
         };
-        const orders = await this.subscribe ('private', messageHash, channel, symbol, this.extend (request, params));
+        const orders = await this.subscribe ('private', messageHash, channel, undefined, this.extend (request, params));
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);
         }


### PR DESCRIPTION
fix: ccxt/ccxt#19759

After dig into the issue, I think something went wrong when watchMyTrades with single symbol (the message hash would change when symbol is not undefined). Remember to submit market order in another UI (console / web).

In this PR, I fix this issue.

```BASH
$ p okx watchMyTrades BTC/USDT --verbose --test
Python v3.11.3
CCXT v4.1.34
okx.watchMyTrades(BTC/USDT)
2023-11-01T09:05:46.802Z connecting to wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999 with timeout 10000 ms
2023-11-01T09:05:47.032Z connected
2023-11-01T09:05:47.032Z ping loop
2023-11-01T09:05:47.032Z sending ping
2023-11-01T09:05:47.033Z sending {'op': 'login', 'args': [{'apiKey': '', 'passphrase': '', 'timestamp': '1698829546', 'sign': ''}]}
2023-11-01T09:05:47.083Z message pong
2023-11-01T09:05:47.093Z message {"event":"login","msg":"","code":"0","connId":"5c386d75"}
2023-11-01T09:05:47.134Z sending {'op': 'subscribe', 'args': [{'channel': 'orders', 'instType': 'SPOT'}]}
2023-11-01T09:05:47.185Z message {"event":"subscribe","arg":{"channel":"orders","instType":"SPOT"},"connId":"5c386d75"}
2023-11-01T09:05:53.541Z message {"arg":{"channel":"orders","instType":"SPOT","uid":"441564264411867138"},"data":[{"accFillSz":"0","algoClOrdId":"","algoId":"","amendResult":"","amendSource":"","attachAlgoClOrdId":"","avgPx":"0","cTime":"1698829553641","cancelSource":"","category":"normal","ccy":"","clOrdId":"","code":"0","execType":"","fee":"0","feeCcy":"BTC","fillFee":"0","fillFeeCcy":"","fillFwdPx":"","fillMarkPx":"","fillMarkVol":"","fillNotionalUsd":"","fillPnl":"0","fillPx":"","fillPxUsd":"","fillPxVol":"","fillSz":"0","fillTime":"","instId":"BTC-USDT","instType":"SPOT","lastPx":"34429.3","lever":"0","msg":"","notionalUsd":"1.00032","ordId":"639872757467033600","ordType":"market","pnl":"0","posSide":"","px":"","pxType":"","pxUsd":"","pxVol":"","quickMgnType":"","rebate":"0","rebateCcy":"USDT","reduceOnly":"false","reqId":"","side":"buy","slOrdPx":"","slTriggerPx":"","slTriggerPxType":"","source":"","state":"live","stpId":"","stpMode":"","sz":"1","tag":"","tdMode":"cash","tgtCcy":"quote_ccy","tpOrdPx":"","tpTriggerPx":"","tpTriggerPxType":"","tradeId":"","uTime":"1698829553641"}]}
2023-11-01T09:05:53.544Z message {"arg":{"channel":"orders","instType":"SPOT","uid":"441564264411867138"},"data":[{"accFillSz":"0.00002904","algoClOrdId":"","algoId":"","amendResult":"","amendSource":"","attachAlgoClOrdId":"","avgPx":"34431","cTime":"1698829553641","cancelSource":"","category":"normal","ccy":"","clOrdId":"","code":"0","execType":"T","fee":"-0.00000002904","feeCcy":"BTC","fillFee":"-0.00000002904","fillFeeCcy":"BTC","fillFwdPx":"","fillMarkPx":"","fillMarkVol":"","fillNotionalUsd":"1.0001962003968001","fillPnl":"0","fillPx":"34431","fillPxUsd":"","fillPxVol":"","fillSz":"0.00002904","fillTime":"1698829553642","instId":"BTC-USDT","instType":"SPOT","lastPx":"34429.3","lever":"0","msg":"","notionalUsd":"1.00032","ordId":"639872757467033600","ordType":"market","pnl":"0","posSide":"","px":"","pxType":"","pxUsd":"","pxVol":"","quickMgnType":"","rebate":"0","rebateCcy":"USDT","reduceOnly":"false","reqId":"","side":"buy","slOrdPx":"","slTriggerPx":"","slTriggerPxType":"","source":"","state":"partially_filled","stpId":"","stpMode":"","sz":"1","tag":"","tdMode":"cash","tgtCcy":"quote_ccy","tpOrdPx":"","tpTriggerPx":"","tpTriggerPxType":"","tradeId":"697123148","uTime":"1698829553643"}]}
[{'amount': None,
  'average': 34431.0,
  'clientOrderId': None,
  'cost': 1.0,
  'datetime': '2023-11-01T09:05:53.641Z',
  'fee': {'cost': 2.904e-08, 'currency': 'BTC'},
  'fees': [{'cost': 2.904e-08, 'currency': 'BTC'}],
  'filled': 2.904e-05,
  'id': '639872757467033600',
  'info': {'accFillSz': '0.00002904',
           'algoClOrdId': '',
           'algoId': '',
           'amendResult': '',
           'amendSource': '',
           'attachAlgoClOrdId': '',
           'avgPx': '34431',
           'cTime': '1698829553641',
           'cancelSource': '',
           'category': 'normal',
           'ccy': '',
           'clOrdId': '',
           'code': '0',
           'execType': 'T',
           'fee': '-0.00000002904',
           'feeCcy': 'BTC',
           'fillFee': '-0.00000002904',
           'fillFeeCcy': 'BTC',
           'fillFwdPx': '',
'fillMarkPx': '',
           'fillMarkVol': '',
           'fillNotionalUsd': '1.0001962003968001',
           'fillPnl': '0',
           'fillPx': '34431',
           'fillPxUsd': '',
           'fillPxVol': '',
           'fillSz': '0.00002904',
           'fillTime': '1698829553642',
           'instId': 'BTC-USDT',
           'instType': 'SPOT',
           'lastPx': '34429.3',
           'lever': '0',
           'msg': '',
           'notionalUsd': '1.00032',
           'ordId': '639872757467033600',
           'ordType': 'market',
           'pnl': '0',
           'posSide': '',
           'px': '',
           'pxType': '',
           'pxUsd': '',
           'pxVol': '',
           'quickMgnType': '',
           'rebate': '0',
           'rebateCcy': 'USDT',
           'reduceOnly': 'false',
           'reqId': '',
           'side': 'buy',
           'slOrdPx': '',
           'slTriggerPx': '',
           'slTriggerPxType': '',
           'source': '',
           'state': 'partially_filled',
           'stpId': '',
           'stpMode': '',
           'sz': '1',
           'tag': '',
           'tdMode': 'cash',
           'tgtCcy': 'quote_ccy',
           'tpOrdPx': '',
           'tpTriggerPx': '',
           'tpTriggerPxType': '',
           'tradeId': '697123148',
           'uTime': '1698829553643'},
  'lastTradeTimestamp': 1698829553642,
  'lastUpdateTimestamp': 1698829553643,
  'postOnly': None,
  'price': 34431.0,
  'reduceOnly': False,
  'remaining': None,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1698829553641,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]


$ p okx watchMyTrades BTC/USDT:USDT --verbose --test
Python v3.11.3
CCXT v4.1.34
okx.watchMyTrades(BTC/USDT:USDT)
2023-11-01T09:34:17.902Z connecting to wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999 with timeout 10000 ms
2023-11-01T09:34:18.198Z connected
2023-11-01T09:34:18.199Z ping loop
2023-11-01T09:34:18.199Z sending ping
2023-11-01T09:34:18.199Z sending {'op': 'login', 'args': [{'apiKey': '', 'passphrase': '', 'timestamp': '1698831257', 'sign': ''}]}
2023-11-01T09:34:18.252Z message pong
2023-11-01T09:34:18.301Z sending {'op': 'subscribe', 'args': [{'channel': 'orders', 'instType': 'SWAP'}]}
2023-11-01T09:34:18.312Z message {"event":"login","msg":"","code":"0","connId":"6915b62e"}
2023-11-01T09:34:18.352Z message {"event":"subscribe","arg":{"channel":"orders","instType":"SWAP"},"connId":"6915b62e"}
2023-11-01T09:34:23.427Z message {"arg":{"channel":"orders","instType":"SWAP","uid":"441564264411867138"},"data":[{"accFillSz":"0","algoClOrdId":"","algoId":"","amendResult":"","amendSource":"","attachAlgoClOrdId":"","avgPx":"0","cTime":"1698831263534","cancelSource":"","category":"normal","ccy":"","clOrdId":"","code":"0","execType":"","fee":"0","feeCcy":"USDT","fillFee":"0","fillFeeCcy":"","fillFwdPx":"","fillMarkPx":"","fillMarkVol":"","fillNotionalUsd":"","fillPnl":"0","fillPx":"","fillPxUsd":"","fillPxVol":"","fillSz":"0","fillTime":"","instId":"BTC-USDT-SWAP","instType":"SWAP","lastPx":"34476.7","lever":"3","msg":"","notionalUsd":"34.485663941999995","ordId":"639879929278083072","ordType":"market","pnl":"0","posSide":"net","px":"","pxType":"","pxUsd":"","pxVol":"","quickMgnType":"","rebate":"0","rebateCcy":"USDT","reduceOnly":"false","reqId":"","side":"buy","slOrdPx":"","slTriggerPx":"","slTriggerPxType":"","source":"","state":"live","stpId":"","stpMode":"","sz":"1","tag":"","tdMode":"isolated","tgtCcy":"","tpOrdPx":"","tpTriggerPx":"","tpTriggerPxType":"","tradeId":"","uTime":"1698831263534"}]}
2023-11-01T09:34:23.433Z message {"arg":{"channel":"orders","instType":"SWAP","uid":"441564264411867138"},"data":[{"accFillSz":"1","algoClOrdId":"","algoId":"","amendResult":"","amendSource":"","attachAlgoClOrdId":"","avgPx":"34476.9","cTime":"1698831263534","cancelSource":"","category":"normal","ccy":"","clOrdId":"","code":"0","execType":"T","fee":"-0.01723845","feeCcy":"USDT","fillFee":"-0.01723845","fillFeeCcy":"USDT","fillFwdPx":"","fillMarkPx":"34476.7","fillMarkVol":"","fillNotionalUsd":"34.485863994","fillPnl":"0","fillPx":"34476.9","fillPxUsd":"","fillPxVol":"","fillSz":"1","fillTime":"1698831263535","instId":"BTC-USDT-SWAP","instType":"SWAP","lastPx":"34476.7","lever":"3","msg":"","notionalUsd":"34.485863994","ordId":"639879929278083072","ordType":"market","pnl":"0","posSide":"net","px":"","pxType":"","pxUsd":"","pxVol":"","quickMgnType":"","rebate":"0","rebateCcy":"USDT","reduceOnly":"false","reqId":"","side":"buy","slOrdPx":"","slTriggerPx":"","slTriggerPxType":"","source":"","state":"filled","stpId":"","stpMode":"","sz":"1","tag":"","tdMode":"isolated","tgtCcy":"","tpOrdPx":"","tpTriggerPx":"","tpTriggerPxType":"","tradeId":"766281786","uTime":"1698831263536"}]}
[{'amount': 1.0,
  'average': 34476.9,
  'clientOrderId': None,
  'cost': 34.4769,
  'datetime': '2023-11-01T09:34:23.534Z',
  'fee': {'cost': 0.01723845, 'currency': 'USDT'},
  'fees': [{'cost': 0.01723845, 'currency': 'USDT'}],
  'filled': 1.0,
  'id': '639879929278083072',
  'info': {'accFillSz': '1',
           'algoClOrdId': '',
           'algoId': '',
           'amendResult': '',
           'amendSource': '',
           'attachAlgoClOrdId': '',
           'avgPx': '34476.9',
           'cTime': '1698831263534',
           'cancelSource': '',
           'category': 'normal',
           'ccy': '',
           'clOrdId': '',
           'code': '0',
           'execType': 'T',
           'fee': '-0.01723845',
           'feeCcy': 'USDT',
           'fillFee': '-0.01723845',
           'fillFeeCcy': 'USDT',
           'fillFwdPx': '',

'fillMarkPx': '34476.7',
           'fillMarkVol': '',
           'fillNotionalUsd': '34.485863994',
           'fillPnl': '0',
           'fillPx': '34476.9',
           'fillPxUsd': '',
           'fillPxVol': '',
           'fillSz': '1',
           'fillTime': '1698831263535',
           'instId': 'BTC-USDT-SWAP',
           'instType': 'SWAP',
           'lastPx': '34476.7',
           'lever': '3',
           'msg': '',
           'notionalUsd': '34.485863994',
           'ordId': '639879929278083072',
           'ordType': 'market',
           'pnl': '0',
           'posSide': 'net',
           'px': '',
           'pxType': '',
           'pxUsd': '',
           'pxVol': '',
           'quickMgnType': '',
           'rebate': '0',
           'rebateCcy': 'USDT',
           'reduceOnly': 'false',
           'reqId': '',
           'side': 'buy',
           'slOrdPx': '',
           'slTriggerPx': '',
           'slTriggerPxType': '',
           'source': '',
           'state': 'filled',
           'stpId': '',
           'stpMode': '',
           'sz': '1',
           'tag': '',
           'tdMode': 'isolated',
           'tgtCcy': '',
           'tpOrdPx': '',
           'tpTriggerPx': '',
           'tpTriggerPxType': '',
           'tradeId': '766281786',
           'uTime': '1698831263536'},
  'lastTradeTimestamp': 1698831263535,
  'lastUpdateTimestamp': 1698831263536,
  'postOnly': None,
  'price': 34476.9,
  'reduceOnly': False,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1698831263534,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```