### PR TITLE
Bitget: add auth error for "Apikey does not exist"

### DIFF
--- a/js/src/bitget.js
+++ b/js/src/bitget.js
@@ -825,6 +825,7 @@ export default class bitget extends Exchange {
                     '40017': ExchangeError,
                     '40018': PermissionDenied,
                     '40019': BadRequest,
+                    '40037': AuthenticationError,
                     '40102': BadRequest,
                     '40103': BadRequest,
                     '40104': ExchangeError,

--- a/js/src/bitget.js
+++ b/js/src/bitget.js
@@ -825,7 +825,6 @@ export default class bitget extends Exchange {
                     '40017': ExchangeError,
                     '40018': PermissionDenied,
                     '40019': BadRequest,
-                    '40037': AuthenticationError,
                     '40102': BadRequest,
                     '40103': BadRequest,
                     '40104': ExchangeError,

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -824,6 +824,7 @@ export default class bitget extends Exchange {
                     '40017': ExchangeError, // Parameter verification failed
                     '40018': PermissionDenied, // Invalid IP
                     '40019': BadRequest, // {"code":"40019","msg":"Parameter QLCUSDT_SPBL cannot be empty","requestTime":1679196063659,"data":null}
+                    '40037': AuthenticationError, // Apikey does not exist
                     '40102': BadRequest, // Contract configuration does not exist, please check the parameters
                     '40103': BadRequest, // Request method cannot be empty
                     '40104': ExchangeError, // Lever adjustment failure


### PR DESCRIPTION
`{"code":"40037","msg":"Apikey does not exist","requestTime":"1698871811447","data":null}`