### PR TITLE
Phemex: add auth error for "401 Failed to load API KEY."

### DIFF
--- a/js/src/phemex.js
+++ b/js/src/phemex.js
@@ -281,7 +281,6 @@ export default class phemex extends Exchange {
             'exceptions': {
                 'exact': {
                     // not documented
-                    '401': AuthenticationError, // {"code":"401","msg":"401 Failed to load API KEY."}
                     '412': BadRequest,
                     '6001': BadRequest,
                     // documented

--- a/js/src/phemex.js
+++ b/js/src/phemex.js
@@ -281,6 +281,7 @@ export default class phemex extends Exchange {
             'exceptions': {
                 'exact': {
                     // not documented
+                    '401': AuthenticationError, // {"code":"401","msg":"401 Failed to load API KEY."}
                     '412': BadRequest,
                     '6001': BadRequest,
                     // documented

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -280,6 +280,7 @@ export default class phemex extends Exchange {
             'exceptions': {
                 'exact': {
                     // not documented
+                    '401': AuthenticationError, // {"code":"401","msg":"401 Failed to load API KEY."}
                     '412': BadRequest, // {"code":412,"msg":"Missing parameter - resolution","data":null}
                     '6001': BadRequest, // {"error":{"code":6001,"message":"invalid argument"},"id":null,"result":null}
                     // documented


### PR DESCRIPTION
`{"code":"401","msg":"401 Failed to load API KEY."}`