### PR TITLE
docker: update dockerfile to support new nodejs installation steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg git 
 RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:ondrej/php
 RUN apt-get update && apt-get install -y --no-install-recommends php8.1 php8.1-curl php8.1-iconv php8.1-mbstring php8.1-bcmath php8.1-gmp
 # Node
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=16
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 # Python 3
 RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip
@@ -40,4 +45,3 @@ RUN composer install
 ## Remove apt sources
 RUN apt-get -y autoremove && apt-get clean && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=16
+ENV NODE_MAJOR=20
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 # Python 3


### PR DESCRIPTION
![nodesource-dep](https://github.com/ccxt/ccxt/assets/92561827/c9658ace-0a9e-4be1-a89a-ecf0b1cae3d4)

replaced old nodejs shell script with [the installation steps from the repository. ](https://github.com/nodesource/distributions#installation-instructions)

testing performed: built docker container and successfully built ccxt w `npm run build` from within the container.

closes #19781 