### PR TITLE
Bybit: adjust ratelimit weights

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -231,35 +231,35 @@ export default class bybit extends Exchange {
                         'derivatives/v3/public/open-interest': 1,
                         'derivatives/v3/public/insurance': 1,
                         // v5
-                        'v5/announcements/index': 2.5,
+                        'v5/announcements/index': 5, // 10/s = 1000 / (20 * 5)
                         // market
-                        'v5/market/time': 2.5,
-                        'v5/market/kline': 2.5,
-                        'v5/market/mark-price-kline': 2.5,
-                        'v5/market/index-price-kline': 2.5,
-                        'v5/market/premium-index-price-kline': 2.5,
-                        'v5/market/instruments-info': 2.5,
-                        'v5/market/orderbook': 2.5,
-                        'v5/market/tickers': 2.5,
-                        'v5/market/funding/history': 2.5,
-                        'v5/market/recent-trade': 2.5,
-                        'v5/market/open-interest': 2.5,
-                        'v5/market/historical-volatility': 2.5,
-                        'v5/market/insurance': 2.5,
-                        'v5/market/risk-limit': 2.5,
-                        'v5/market/delivery-price': 2.5,
-                        'v5/market/account-ratio': 2.5,
+                        'v5/market/time': 5,
+                        'v5/market/kline': 5,
+                        'v5/market/mark-price-kline': 5,
+                        'v5/market/index-price-kline': 5,
+                        'v5/market/premium-index-price-kline': 5,
+                        'v5/market/instruments-info': 5,
+                        'v5/market/orderbook': 5,
+                        'v5/market/tickers': 5,
+                        'v5/market/funding/history': 5,
+                        'v5/market/recent-trade': 5,
+                        'v5/market/open-interest': 5,
+                        'v5/market/historical-volatility': 5,
+                        'v5/market/insurance': 5,
+                        'v5/market/risk-limit': 5,
+                        'v5/market/delivery-price': 5,
+                        'v5/market/account-ratio': 5,
                         // spot leverage token
-                        'v5/spot-lever-token/info': 2.5,
-                        'v5/spot-lever-token/reference': 2.5,
+                        'v5/spot-lever-token/info': 5,
+                        'v5/spot-lever-token/reference': 5,
                         // spot margin trade
-                        'v5/spot-margin-trade/data': 2.5,
-                        'v5/spot-cross-margin-trade/data': 2.5,
-                        'v5/spot-cross-margin-trade/pledge-token': 2.5,
-                        'v5/spot-cross-margin-trade/borrow-token': 2.5,
+                        'v5/spot-margin-trade/data': 5,
+                        'v5/spot-cross-margin-trade/data': 5,
+                        'v5/spot-cross-margin-trade/pledge-token': 5,
+                        'v5/spot-cross-margin-trade/borrow-token': 5,
                         // institutional lending
-                        'v5/ins-loan/product-infos': 2.5,
-                        'v5/ins-loan/ensure-tokens-convert': 2.5,
+                        'v5/ins-loan/product-infos': 5,
+                        'v5/ins-loan/ensure-tokens-convert': 5,
                     },
                 },
                 'private': {
@@ -328,11 +328,11 @@ export default class bybit extends Exchange {
                         'spot/v3/private/margin-ltv': 10,
                         // account
                         'asset/v1/private/transfer/list': 50, // 60 per minute = 1 per second => cost = 50 / 1 = 50
-                        'asset/v3/private/transfer/inter-transfer/list/query': 0.84, // 60/s
+                        'asset/v3/private/transfer/inter-transfer/list/query': 50,
                         'asset/v1/private/sub-member/transfer/list': 50,
-                        'asset/v3/private/transfer/sub-member/list/query': 0.84, // 60/s
-                        'asset/v3/private/transfer/sub-member-transfer/list/query': 0.84, // 60/s
-                        'asset/v3/private/transfer/universal-transfer/list/query': 0.84, // 60/s
+                        'asset/v3/private/transfer/sub-member/list/query': 50,
+                        'asset/v3/private/transfer/sub-member-transfer/list/query': 50,
+                        'asset/v3/private/transfer/universal-transfer/list/query': 25,
                         'asset/v1/private/sub-member/member-ids': 50,
                         'asset/v1/private/deposit/record/query': 50,
                         'asset/v1/private/withdraw/record/query': 25,
@@ -340,11 +340,11 @@ export default class bybit extends Exchange {
                         'asset/v3/private/coin-info/query': 25, // 2/s
                         'asset/v1/private/asset-info/query': 50,
                         'asset/v1/private/deposit/address': 100,
-                        'asset/v3/private/deposit/address/query': 0.17, // 300/s
+                        'asset/v3/private/deposit/address/query': 10,
                         'asset/v1/private/universal/transfer/list': 50,
-                        'contract/v3/private/copytrading/order/list': 1,
-                        'contract/v3/private/copytrading/position/list': 1,
-                        'contract/v3/private/copytrading/wallet/balance': 1,
+                        'contract/v3/private/copytrading/order/list': 30, // 100 req/min = 1000 / (20 * 30) = 1.66666666667/s
+                        'contract/v3/private/copytrading/position/list': 40, // 75 req/min = 1000 / (20 * 40) = 1.25/s
+                        'contract/v3/private/copytrading/wallet/balance': 25, // 120 req/min = 1000 / (20 * 25) = 2/s
                         'contract/v3/private/position/limit-info': 25, // 120 per minute = 2 per second => cost = 50 / 2 = 25
                         'contract/v3/private/order/unfilled-orders': 1,
                         'contract/v3/private/order/list': 1,
@@ -371,43 +371,43 @@ export default class bybit extends Exchange {
                         'user/v3/private/query-sub-members': 5, // 10/s
                         'user/v3/private/query-api': 5, // 10/s
                         'user/v3/private/get-member-type': 1,
-                        'asset/v3/private/transfer/transfer-coin/list/query': 0.84, // 60/s
-                        'asset/v3/private/transfer/account-coin/balance/query': 0.84, // 60/s
-                        'asset/v3/private/transfer/account-coins/balance/query': 50,
-                        'asset/v3/private/transfer/asset-info/query': 0.84, // 60/s
+                        'asset/v3/private/transfer/transfer-coin/list/query': 50,
+                        'asset/v3/private/transfer/account-coin/balance/query': 50,
+                        'asset/v3/private/transfer/account-coins/balance/query': 25,
+                        'asset/v3/private/transfer/asset-info/query': 50,
                         'asset/v3/public/deposit/allowed-deposit-list/query': 0.17, // 300/s
-                        'asset/v3/private/deposit/record/query': 0.17, // 300/s
-                        'asset/v3/private/withdraw/record/query': 0.17, // 300/s
+                        'asset/v3/private/deposit/record/query': 10,
+                        'asset/v3/private/withdraw/record/query': 10,
                         // v5
                         // trade
                         'v5/order/realtime': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/order/history': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/order/spot-borrow-check': 2.5,
+                        'v5/order/spot-borrow-check': 1, // 50/s = 1000 / (20 * 1)
                         // position
                         'v5/position/list': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/execution/list': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/position/closed-pnl': 5, // 10/s => cost = 50 / 10 = 5
                         // pre-upgrade
-                        'v5/pre-upgrade/order/history': 2.5,
-                        'v5/pre-upgrade/execution/list': 2.5,
-                        'v5/pre-upgrade/position/closed-pnl': 2.5,
-                        'v5/pre-upgrade/account/transaction-log': 2.5,
-                        'v5/pre-upgrade/asset/delivery-record': 2.5,
-                        'v5/pre-upgrade/asset/settlement-record': 2.5,
+                        'v5/pre-upgrade/order/history': 5,
+                        'v5/pre-upgrade/execution/list': 5,
+                        'v5/pre-upgrade/position/closed-pnl': 5,
+                        'v5/pre-upgrade/account/transaction-log': 5,
+                        'v5/pre-upgrade/asset/delivery-record': 5,
+                        'v5/pre-upgrade/asset/settlement-record': 5,
                         // account
-                        'v5/account/wallet-balance': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/account/borrow-history': 2.5,
-                        'v5/account/set-collateral-switch': 2.5,
-                        'v5/account/collateral-info': 2.5,
-                        'v5/asset/coin-greeks': 2.5,
-                        'v5/account/fee-rate': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/account/info': 2.5,
-                        'v5/account/transaction-log': 2.5,
-                        'v5/account/mmp-state': 2.5,
+                        'v5/account/wallet-balance': 1,
+                        'v5/account/borrow-history': 1,
+                        'v5/account/set-collateral-switch': 5,
+                        'v5/account/collateral-info': 1,
+                        'v5/asset/coin-greeks': 1,
+                        'v5/account/fee-rate': 10, // 5/s = 1000 / (20 * 10)
+                        'v5/account/info': 5,
+                        'v5/account/transaction-log': 1,
+                        'v5/account/mmp-state': 5,
                         // asset
                         'v5/asset/exchange/order-record': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/asset/delivery-record': 2.5,
-                        'v5/asset/settlement-record': 2.5,
+                        'v5/asset/delivery-record': 5,
+                        'v5/asset/settlement-record': 5,
                         'v5/asset/transfer/query-asset-info': 50, // 1/s => cost = 50 / 1 = 50
                         'v5/asset/transfer/query-account-coins-balance': 25, // 2/s => cost = 50 / 2 = 25
                         'v5/asset/transfer/query-account-coin-balance': 50, // 1/s => cost = 50 / 1 = 50
@@ -415,38 +415,38 @@ export default class bybit extends Exchange {
                         'v5/asset/transfer/query-inter-transfer-list': 50, // 1/s => cost = 50 / 1 = 50
                         'v5/asset/transfer/query-sub-member-list': 50, // 1/s => cost = 50 / 1 = 50
                         'v5/asset/transfer/query-universal-transfer-list': 25, // 2/s => cost = 50 / 2 = 25
-                        'v5/asset/deposit/query-allowed-list': 2.5,
+                        'v5/asset/deposit/query-allowed-list': 5,
                         'v5/asset/deposit/query-record': 10, // 5/s => cost = 50 / 5 = 10
                         'v5/asset/deposit/query-sub-member-record': 10, // 5/s => cost = 50 / 5 = 10
-                        'v5/asset/deposit/query-internal-record': 2.5,
+                        'v5/asset/deposit/query-internal-record': 5,
                         'v5/asset/deposit/query-address': 10, // 5/s => cost = 50 / 5 = 10
                         'v5/asset/deposit/query-sub-member-address': 10, // 5/s => cost = 50 / 5 = 10
                         'v5/asset/coin/query-info': 25, // 2/s => cost = 50 / 2 = 25
                         'v5/asset/withdraw/query-record': 10, // 5/s => cost = 50 / 5 = 10
-                        'v5/asset/withdraw/withdrawable-amount': 2.5,
+                        'v5/asset/withdraw/withdrawable-amount': 5,
                         // user
                         'v5/user/query-sub-members': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/user/query-api': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/user/get-member-type': 2.5,
-                        'v5/user/aff-customer-info': 2.5,
+                        'v5/user/get-member-type': 5,
+                        'v5/user/aff-customer-info': 5,
                         // spot leverage token
                         'v5/spot-lever-token/order-record': 1, // 50/s => cost = 50 / 50 = 1
                         // spot margin trade
-                        'v5/spot-margin-trade/state': 2.5,
+                        'v5/spot-margin-trade/state': 5,
                         'v5/spot-cross-margin-trade/loan-info': 1, // 50/s => cost = 50 / 50 = 1
                         'v5/spot-cross-margin-trade/account': 1, // 50/s => cost = 50 / 50 = 1
                         'v5/spot-cross-margin-trade/orders': 1, // 50/s => cost = 50 / 50 = 1
                         'v5/spot-cross-margin-trade/repay-history': 1, // 50/s => cost = 50 / 50 = 1
                         // institutional lending
-                        'v5/ins-loan/loan-order': 2.5,
-                        'v5/ins-loan/repaid-history': 2.5,
-                        'v5/ins-loan/ltv-convert': 2.5,
+                        'v5/ins-loan/loan-order': 5,
+                        'v5/ins-loan/repaid-history': 5,
+                        'v5/ins-loan/ltv-convert': 5,
                         // c2c lending
-                        'v5/lending/info': 2.5,
-                        'v5/lending/history-order': 2.5,
-                        'v5/lending/account': 2.5,
+                        'v5/lending/info': 5,
+                        'v5/lending/history-order': 5,
+                        'v5/lending/account': 5,
                         // broker
-                        'v5/broker/earning-record': 2.5,
+                        'v5/broker/earning-record': 5,
                     },
                     'post': {
                         // inverse swap
@@ -512,17 +512,17 @@ export default class bybit extends Exchange {
                         'spot/v3/private/cross-margin-repay': 10,
                         // account
                         'asset/v1/private/transfer': 150, // 20 per minute = 0.333 per second => cost = 50 / 0.3333 = 150
-                        'asset/v3/private/transfer/inter-transfer': 2.5, // 20/s
+                        'asset/v3/private/transfer/inter-transfer': 150,
                         'asset/v1/private/sub-member/transfer': 150,
                         'asset/v1/private/withdraw': 50,
-                        'asset/v3/private/withdraw/create': 1, // 10/s
+                        'asset/v3/private/withdraw/create': 300,
                         'asset/v1/private/withdraw/cancel': 50,
-                        'asset/v3/private/withdraw/cancel': 0.84, // 60/s
+                        'asset/v3/private/withdraw/cancel': 50,
                         'asset/v1/private/transferable-subs/save': 3000,
                         'asset/v1/private/universal/transfer': 1500,
-                        'asset/v3/private/transfer/sub-member-transfer': 2.5, // 20/s
-                        'asset/v3/private/transfer/transfer-sub-member-save': 2.5, // 20/s
-                        'asset/v3/private/transfer/universal-transfer': 2.5, // 20/s
+                        'asset/v3/private/transfer/sub-member-transfer': 150,
+                        'asset/v3/private/transfer/transfer-sub-member-save': 150,
+                        'asset/v3/private/transfer/universal-transfer': 10, // 5/s
                         'user/v3/private/create-sub-member': 10, // 5/s
                         'user/v3/private/create-sub-api': 10, // 5/s
                         'user/v3/private/update-api': 10, // 5/s
@@ -561,12 +561,12 @@ export default class bybit extends Exchange {
                         'perpetual/usdc/openapi/public/v1/risk-limit/list': 2.5,
                         'perpetual/usdc/openapi/private/v1/position/set-risk-limit': 2.5,
                         'perpetual/usdc/openapi/private/v1/predicted-funding': 2.5,
-                        'contract/v3/private/copytrading/order/create': 2.5,
-                        'contract/v3/private/copytrading/order/cancel': 2.5,
-                        'contract/v3/private/copytrading/order/close': 2.5,
-                        'contract/v3/private/copytrading/position/close': 2.5,
-                        'contract/v3/private/copytrading/position/set-leverage': 2.5,
-                        'contract/v3/private/copytrading/wallet/transfer': 2.5,
+                        'contract/v3/private/copytrading/order/create': 30, // 100 req/min = 1000 / (20 * 30) = 1.66666666667/s
+                        'contract/v3/private/copytrading/order/cancel': 30,
+                        'contract/v3/private/copytrading/order/close': 30,
+                        'contract/v3/private/copytrading/position/close': 40, // 75 req/min = 1000 / (20 * 40) = 1.25/s
+                        'contract/v3/private/copytrading/position/set-leverage': 40,
+                        'contract/v3/private/copytrading/wallet/transfer': 25, // 120 req/min = 1000 / (20 * 25) = 2/s
                         'contract/v3/private/copytrading/order/trading-stop': 2.5,
                         'contract/v3/private/order/create': 1,
                         'contract/v3/private/order/cancel': 1,
@@ -581,13 +581,13 @@ export default class bybit extends Exchange {
                         'contract/v3/private/position/set-risk-limit': 1,
                         'contract/v3/private/account/setMarginMode': 1,
                         // derivative
-                        'unified/v3/private/order/create': 2.5,
-                        'unified/v3/private/order/replace': 2.5,
-                        'unified/v3/private/order/cancel': 2.5,
-                        'unified/v3/private/order/create-batch': 2.5,
-                        'unified/v3/private/order/replace-batch': 2.5,
-                        'unified/v3/private/order/cancel-batch': 2.5,
-                        'unified/v3/private/order/cancel-all': 2.5,
+                        'unified/v3/private/order/create': 30, // 100 req/min (shared) = 1000 / (20 * 30) = 1.66666666667/s
+                        'unified/v3/private/order/replace': 30,
+                        'unified/v3/private/order/cancel': 30,
+                        'unified/v3/private/order/create-batch': 30,
+                        'unified/v3/private/order/replace-batch': 30,
+                        'unified/v3/private/order/cancel-batch': 30,
+                        'unified/v3/private/order/cancel-all': 30,
                         'unified/v3/private/position/set-leverage': 2.5,
                         'unified/v3/private/position/tpsl/switch-mode': 2.5,
                         'unified/v3/private/position/set-risk-limit': 2.5,
@@ -601,34 +601,34 @@ export default class bybit extends Exchange {
                         'fht/compliance/tax/v3/private/url': 50,
                         // v5
                         // trade
-                        'v5/order/create': 5, // 10/s => cost = 50 / 10 = 5
+                        'v5/order/create': 2.5, // 20/s = 1000 / (20 * 2.5)
                         'v5/order/amend': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/order/cancel': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/order/cancel-all': 5, // 10/s => cost = 50 / 10 = 5
+                        'v5/order/cancel': 2.5,
+                        'v5/order/cancel-all': 50, // 1/s = 1000 / (20 * 50)
                         'v5/order/create-batch': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/order/amend-batch': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/order/cancel-batch': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/order/disconnected-cancel-all': 2.5,
+                        'v5/order/disconnected-cancel-all': 5,
                         // position
                         'v5/position/set-leverage': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/position/switch-isolated': 2.5,
+                        'v5/position/switch-isolated': 5,
                         'v5/position/set-tpsl-mode': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/position/switch-mode': 2.5,
+                        'v5/position/switch-mode': 5,
                         'v5/position/set-risk-limit': 5, // 10/s => cost = 50 / 10 = 5
                         'v5/position/trading-stop': 5, // 10/s => cost = 50 / 10 = 5
-                        'v5/position/set-auto-add-margin': 2.5,
-                        'v5/position/add-margin': 2.5,
-                        'v5/position/confirm-pending-mmr': 2.5,
+                        'v5/position/set-auto-add-margin': 5,
+                        'v5/position/add-margin': 5,
+                        'v5/position/confirm-pending-mmr': 5,
                         // account
-                        'v5/account/upgrade-to-uta': 2.5,
-                        'v5/account/set-margin-mode': 2.5,
-                        'v5/account/mmp-modify': 2.5,
-                        'v5/account/mmp-reset': 2.5,
+                        'v5/account/upgrade-to-uta': 5,
+                        'v5/account/set-margin-mode': 5,
+                        'v5/account/mmp-modify': 5,
+                        'v5/account/mmp-reset': 5,
                         // asset
                         'v5/asset/transfer/inter-transfer': 150, // 1/3/s => cost = 50 / 1/3 = 150
                         'v5/asset/transfer/save-transfer-sub-member': 150, // 1/3/s => cost = 50 / 1/3 = 150
                         'v5/asset/transfer/universal-transfer': 10, // 5/s => cost = 50 / 5 = 10
-                        'v5/asset/deposit/deposit-to-account': 2.5,
+                        'v5/asset/deposit/deposit-to-account': 5,
                         'v5/asset/withdraw/create': 300, // 1/6/s => cost = 50 / 1/6 = 300
                         'v5/asset/withdraw/cancel': 50, // 1/s => cost = 50 / 1 = 50
                         // user
@@ -643,15 +643,15 @@ export default class bybit extends Exchange {
                         'v5/spot-lever-token/purchase': 2.5, // 20/s => cost = 50 / 20 = 2.5
                         'v5/spot-lever-token/redeem': 2.5, // 20/s => cost = 50 / 20 = 2.5
                         // spot margin trade
-                        'v5/spot-margin-trade/switch-mode': 2.5,
-                        'v5/spot-margin-trade/set-leverage': 2.5,
+                        'v5/spot-margin-trade/switch-mode': 5,
+                        'v5/spot-margin-trade/set-leverage': 5,
                         'v5/spot-cross-margin-trade/loan': 2.5, // 20/s => cost = 50 / 20 = 2.5
                         'v5/spot-cross-margin-trade/repay': 2.5, // 20/s => cost = 50 / 20 = 2.5
                         'v5/spot-cross-margin-trade/switch': 2.5, // 20/s => cost = 50 / 20 = 2.5
                         // c2c lending
-                        'v5/lending/purchase': 2.5,
-                        'v5/lending/redeem': 2.5,
-                        'v5/lending/redeem-cancel': 2.5,
+                        'v5/lending/purchase': 5,
+                        'v5/lending/redeem': 5,
+                        'v5/lending/redeem-cancel': 5,
                     },
                     'delete': {
                         // spot


### PR DESCRIPTION
The default ratelimit for v5 endpoints should be 10 requests-per-second, other endpoint weights aren't matching the provided ratelimit tables.

Adjusted the ratelimit weights using this formula:
`requests-per-second = 1000ms / ( rateLimit * weight)`

### Common Weights:
rateLimit = 20
1000 = 0.05 rps
300 = 0.16666 rps
150 = 0.33333 rps
50 = 1 rps
40 = 1.25 rps
30 = 1.66667 rps
25 = 2 rps
10 = 5 rps
5 = 10 rps
2.5 = 20 rps
1 = 50 rps

### Resources:
https://bybit-exchange.github.io/docs/v5/rate-limit
https://bybit-exchange.github.io/docs/derivatives/rate-limit
https://bybit-exchange.github.io/docs/copy-trade/rate-limit
https://bybit-exchange.github.io/docs/account-asset/rate-limit

![image](https://github.com/ccxt/ccxt/assets/83686770/20b55bde-a8e3-4840-83e9-feae2c2ca2cb)
