### PR TITLE
bybit: support spot order in editOrder

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4167,7 +4167,9 @@ export default class bybit extends Exchange {
             // Valid for option only.
             // 'orderIv': '0', // Implied volatility; parameters are passed according to the real value; for example, for 10%, 0.1 is passed
         };
-        if (market['linear']) {
+        if (market['spot']) {
+            request['category'] = 'spot';
+        } else if (market['linear']) {
             request['category'] = 'linear';
         } else if (market['inverse']) {
             request['category'] = 'inverse';


### PR DESCRIPTION
Remember to use str(id) in bybit.py first.
```BASH

$ p bybit create_order BTC/USDT LIMIT BUY 0.01 10000 --test

$ p bybit edit_order '1544921997782549248' BTC/USDT LIMIT BUY 0.01 10012 --test --verbose 

bybit.edit_order(1544921997782549248,BTC/USDT,LIMIT,BUY,0.01,10012)

{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '1544921997782549248',
 'info': {'result': {'orderId': '1544921997782549248',
                     'orderLinkId': '1544921997782549249'},
          'retCode': '0',
          'retExtInfo': {},
          'retMsg': 'OK',
          'time': ''},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': None,
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```