### PR TITLE
cli: add str encoding

### DIFF
--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -177,6 +177,10 @@ async def main():
             args.append(json.loads(arg))
         elif arg == 'None':
             args.append(None)
+        elif re.match(r'^\'(.)+\'$', arg):
+            args.append(str(arg.replace('\'', '')))
+        elif re.match(r'^"(.)+"$', arg):
+            args.append(str(arg.replace('"', '')))
         elif re.match(r'^[0-9+-]+$', arg):
             args.append(int(arg))
         elif re.match(r'^[.eE0-9+-]+$', arg):


### PR DESCRIPTION
In cli.py,  the script parse all number as int even if the value was quoted, eg `p xxx xxxx '123456'`. However, the parameter is required as string instead of number. In this PR, I added regular expression to check value looked like `'"xxxxxx"'` or `"'xxxxxxx'"`.

Not sure whether there is another way to set string.