### PR TITLE
Bitrue contract implicit API

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -2083,9 +2083,6 @@ export default class bitrue extends Exchange {
                 url += '?' + query;
             } else {
                 body = isContract ? this.json (params) : query;
-                if (!isContract) {
-                    headers['Content-Type'] = 'application/x-www-form-urlencoded';
-                }
             }
             if (isContract) {
                 headers = {
@@ -2097,6 +2094,7 @@ export default class bitrue extends Exchange {
             } else {
                 headers = {
                     'X-MBX-APIKEY': this.apiKey,
+                    'Content-Type': 'application/x-www-form-urlencoded',
                 };
             }
         } else {

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -2057,8 +2057,8 @@ export default class bitrue extends Exchange {
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         const version = this.safeString (api, 0);
         const access = this.safeString (api, 1);
-        const requestPath = this.implodeParams (path, params);
-        let url = this.urls['api'][version] + '/' + requestPath;
+        const requestPath = '/' + this.implodeParams (path, params);
+        let url = this.urls['api'][version] + requestPath;
         params = this.omit (params, this.extractParams (path));
         if (access === 'private') {
             this.checkRequiredCredentials ();
@@ -2068,9 +2068,9 @@ export default class bitrue extends Exchange {
             if (!isContract) {
                 params = this.extend ({
                     'timestamp': timestamp,
+                    'recvWindow': recvWindow,
                 }, params);
             }
-            params = this.extend ({ 'recvWindow': recvWindow }, params);
             let signature = undefined;
             let query = this.urlencode (params);
             if (isContract) {
@@ -2082,7 +2082,7 @@ export default class bitrue extends Exchange {
             if ((method === 'GET') || (method === 'DELETE')) {
                 url += '?' + query;
             } else {
-                body = query;
+                body = isContract ? this.json (params) : query;
                 if (!isContract) {
                     headers['Content-Type'] = 'application/x-www-form-urlencoded';
                 }


### PR DESCRIPTION
I can't test in python due to this error, which also happens on master

```
% py binance publicGetTime
Python v3.11.6
CCXT v4.1.35
binance.publicGetTime()
<coroutine object binance.request at 0x10729a0c0>
/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/events.py:80: RuntimeWarning: coroutine 'binance.request' was never awaited
  self._context.run(self._callback, *self._args)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

# Testing

bitrue fapiPrivateGetV2LeverageBracket '{"contractName": "E-SAND-USDT"}'

```
2023-11-02T06:58:05.808Z
Node.js: v18.15.0
CCXT v4.1.34
bitrue.fapiPrivateGetV2LeverageBracket ([object Object])
2023-11-02T06:58:11.583Z iteration 0 passed in 2542 ms

{
  code: '0',
  msg: 'Success',
  data: {
    contractName: 'E-SAND-USDT',
    brackets: [
      {
        bracket: '1',
        initialLeverage: '50',
        maxPositionValue: '50000',
        minPositionValue: '0',
        maintMarginRatio: '0.015'
      },
      ...
   ]
  }
}
2023-11-02T06:58:11.583Z iteration 1 passed in 2542 ms
```

```
% bitrue fapiPrivatePostV2Order '{"contractName": "E-SOL-USDT", "side": "SELL", "type": "LIMIT", "positionType": 1, "open": "OPEN", "price": 50, "amount": 0.2, "volume": 0.2, "leverage": 3}'   
2023-11-02T06:59:30.714Z
Node.js: v18.15.0
CCXT v4.1.34
bitrue.fapiPrivatePostV2Order ([object Object])
2023-11-02T06:59:36.943Z iteration 0 passed in 2718 ms

{ code: '0', msg: 'Success', data: { orderId: '1898153082724915125' } }
2023-11-02T06:59:36.943Z iteration 1 passed in 2718 ms
```

```
% bitrue fapiPublicGetV1Time
2023-11-02T07:01:32.305Z
Node.js: v18.15.0
CCXT v4.1.34
bitrue.fapiPublicGetV1Time ()
2023-11-02T07:01:38.921Z iteration 0 passed in 2453 ms

{ serverTime: '1698908499896', timezone: 'China Standard Time' }
2023-11-02T07:01:38.921Z iteration 1 passed in 2453 ms
```

```
 % bitrue fetchMarkets | condense
2023-11-02T07:02:15.763Z
Node.js: v18.15.0
CCXT v4.1.34
bitrue.fetchMarkets ()
2023-11-02T07:02:21.221Z iteration 0 passed in 1905 ms
            id |    lowercaseId |          symbol |       base | quote | settle |     baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |                                                             precision |                                                                                              limits | created
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      SYLOUSDT |       sylousdt |       SYLO/USDT |       SYLO |  USDT |        |       sylo |    usdt |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            |         {"amount":0.01,"price":0.000001,"base":0.01,"quote":0.000001} |                                                                                     [object Object] |        
...
     NKN3LUSDT |      nkn3lusdt |      NKN3L/USDT |      NKN3L |  USDT |        |      nkn3l |    usdt |          | spot | true |  false | false |  false |  false |   true |    false |        |         |              |        |                |        |            |         {"amount":0.000001,"price":1e-8,"base":0.000001,"quote":1e-8} |                                                                                     [object Object] |        
1445 objects
2023-11-02T07:02:21.221Z iteration 1 passed in 1905 ms
```

```
% bitrue fetchMyTrades SOL/USDT
(node:11783) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2023-11-02T07:16:22.718Z
Node.js: v18.15.0
CCXT v4.1.34
bitrue.fetchMyTrades (SOL/USDT)
2023-11-02T07:16:27.395Z iteration 0 passed in 1423 ms

    timestamp |                 datetime |   symbol |       id |              order | type | side | takerOrMaker |  price | amount |    cost |                                  fee |                                   fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1698907261668 | 2023-11-02T06:41:01.668Z | SOL/USDT | 66375841 | 474693384636006400 |      | sell |        taker | 42.382 |   0.45 | 19.0719 | {"cost":0.0762876,"currency":"USDT"} | [{"cost":0.0762876,"currency":"USDT"}]
1 objects
2023-11-02T07:16:27.395Z iteration 1 passed in 1423 ms
```