### PR TITLE
binance: update watchOrders

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2060,24 +2060,22 @@ export default class binance extends binanceRest {
          * @returns {object[]} a list of [order structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();
-        let messageHash = 'orders';
-        let market = undefined;
-        if (symbol !== undefined) {
-            market = this.market (symbol);
-            symbol = market['symbol'];
-            messageHash += ':' + symbol;
-            params = this.extend (params, { 'symbol': symbol }); // needed inside authenticate for isolated margin
-        }
-        await this.authenticate (params);
-        let type = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params);
+        const defaultType = this.safeString2 (this.options, 'watchOrders', 'defaultType', 'spot');
+        let type = this.safeString (params, 'type', defaultType);
         let subType = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchOrders', market, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('watchOrders', undefined, params);
         if (this.isLinear (type, subType)) {
             type = 'future';
         } else if (this.isInverse (type, subType)) {
             type = 'delivery';
         }
+        let messageHash = 'orders';
+        if (symbol !== undefined) {
+            symbol = this.symbol (symbol);
+            messageHash += ':' + symbol;
+            params = this.extend (params, { 'symbol': symbol }); // needed inside authenticate for isolated margin
+        }
+        await this.authenticate (params);
         const url = this.urls['api']['ws'][type] + '/' + this.options[type]['listenKey'];
         const client = this.client (url);
         this.setBalanceCache (client, type);


### PR DESCRIPTION
related issue: ccxt/ccxt#19768

Note: should create order in another UI.

```BASH
$ p binance watchOrders BTC/USDT --verbose
Python v3.11.4
CCXT v4.1.35
binance.watchOrders(BTC/USDT)

fetch Request: binance POST https://api.binance.com/sapi/v1/userDataStream/isolated RequestHeaders: {'X-MBX-APIKEY': 'ccxttothemoon', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'python-requests/2.28.2', 'Accept-Encoding': 'gzip, deflate'} RequestBody: timestamp=1698996530942&symbol=BTCUSDT&recvWindow=10000&signature=nicesignature

fetch Response: binance POST https://api.binance.com/sapi/v1/userDataStream/isolated 200 ResponseHeaders: {'Content-Type': 'application/json', 'Content-Length': '76', 'Connection': 'keep-alive', 'Date': 'Fri, 03 Nov 2023 07:28:51 GMT', 'Server': 'nginx', 'X-SAPI-USED-UID-WEIGHT-1M': '1', 'Strict-Transport-Security': 'max-age=31536000; includeSubdomains', 'X-Frame-Options': 'SAMEORIGIN', 'X-Xss-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'Content-Security-Policy': "default-src 'self'", 'X-Content-Security-Policy': "default-src 'self'", 'X-WebKit-CSP': "default-src 'self'", 'Cache-Control': 'no-cache, no-store, must-revalidate', 'Pragma': 'no-cache', 'Expires': '0', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS', 'X-Cache': 'Miss from cloudfront', 'Via': '1.1 a55d34628b043ad0c3a5f728ad027e04.cloudfront.net (CloudFront)', 'X-Amz-Cf-Pop': 'TPE51-C1', 'X-Amz-Cf-Id': ''} ResponseBody: {"listenKey":"ccxttothemoon"}
2023-11-03T07:28:51.131Z connecting to wss://stream.binance.com:9443/ws/xxxxxxx with timeout 10000 ms
2023-11-03T07:28:51.757Z connected
2023-11-03T07:28:51.758Z ping loop
2023-11-03T07:28:51.850Z pong WSMessage(type=<WSMsgType.PONG: 10>, data=bytearray(b''), extra='')
```