### PR TITLE
Manuals rewriting for exceptions & troubleshooting

### DIFF
--- a/ts/src/base/errorHierarchy.ts
+++ b/ts/src/base/errorHierarchy.ts
@@ -17,7 +17,6 @@ const errorHierarchy = {
             'BadResponse': {
                 'NullResponse': {},
             },
-            'OperationFailed': {},
             'InsufficientFunds': {},
             'InvalidAddress': {
                 'AddressPending': {},
@@ -42,6 +41,7 @@ const errorHierarchy = {
             },
             'InvalidNonce': {},
             'RequestTimeout': {},
+            'OperationFailed': {},
         },
     },
 };

--- a/ts/src/base/errors.ts
+++ b/ts/src/base/errors.ts
@@ -59,12 +59,6 @@ class ExchangeError extends Error {
         this.name = 'ExchangeError';
     }
 }
-class OperationFailed extends ExchangeError {
-    constructor (message) {
-        super (message);
-        this.name = 'OperationFailed';
-    }
-}
 class AuthenticationError extends ExchangeError {
     constructor (message) {
         super (message);
@@ -250,6 +244,12 @@ class RequestTimeout extends NetworkError {
     constructor (message) {
         super (message);
         this.name = 'RequestTimeout';
+    }
+}
+class OperationFailed extends NetworkError {
+    constructor (message) {
+        super (message);
+        this.name = 'OperationFailed';
     }
 }
 /*  ------------------------------------------------------------------------ */

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -5955,25 +5955,24 @@ class BaseError extends \Exception {}
 
 Here is an outline of exception inheritance hierarchy: https://github.com/ccxt/ccxt/blob/master/ts/src/base/errorHierarchy.ts
 
-The `BaseError` class is a generic error class for all sorts of errors, including accessibility and request/response mismatch. Users should catch this exception at the very least, if no error differentiation is required.
+The `BaseError` class is a generic root error class for all sorts of errors, including accessibility and request/response mismatch. If you don't need to catch any specific subclass of exceptions, you can just use `BaseError`, where all exception types are being caught.
 
-There's two generic families of special cases or subtrees in the error hierarchy, both derived from `BaseError`:
+From `BaseError` there are derived two different families of the error hierarchy:
 
 - `NetworkError`
 - `ExchangeError`
 
+Which collect multiple different specific exception subclasses, as explained below.
+
 ### NetworkError
 
-A `NetworkError` is mostly a temporary unavailability situation, that could be caused by any factor, including maintenance, internet connectivitiy issues, DDoS protections, and temporary bans. This error is a root of all exceptions sub-groups, that can reappear or disappear upon a later retry or upon a retry from a different location (without need to change parameters in the request).
+A `NetworkError` is mostly a temporary unavailability situation, that could be caused by any unexpected factor, including maintenance, internet connectivitiy issues, DDoS protections, and temporary bans. This error is a root of all exceptions sub-groups, that can reappear or disappear upon a later retry or upon a retry from a different location (without need to change parameters in the request). Such network-related exceptions are time-dependent and re-trying the request later might be enough, but if the error still happens, then it may indicate some persistent problem with the exchange or with your connection.
 
-All errors related to networking are usually recoverable, meaning that networking problems, traffic congestion, unavailability is usually time-dependent. Making a retry later is usually enough to recover from a NetworkError, but if it doesn't go away, then it may indicate some persistent problem with the exchange or with your connection.
+It has the following subclasses: 
 
 #### DDoSProtection
 
-This exception is thrown in either of two cases:
-
-- when Cloudflare or Incapsula rate limiter restrictions are enforced per user or region/location
-- when the exchange restricts user access for requesting the endpoints in question too frequently
+This exception is thrown in cases when cloud/hosting services (Cloudflare, Incapsula or etc..) limits reqeusts from user/region/location or when the exchange API restricts user because of making too frequent requests.
 
 #### RequestTimeout
 
@@ -5991,9 +5990,7 @@ Thus it's advised to handle this type of exception in the following manner:
 
 #### ExchangeNotAvailable
 
-This type of exception is thrown when the underlying exchange is unreachable.
-
-The ccxt library also throws this error if it detects any of the following keywords in response:
+This type of exception is thrown when the underlying exchange is unreachable. The ccxt library also throws this error if it detects any of the following keywords in response:
 
   - `offline`
   - `unavailable`

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -6140,7 +6140,7 @@ In case you experience any difficulty connecting to a particular exchange, do th
 - Check if there were any news from the exchange recently regarding downtime for maintenance. Some exchanges go offline for updates regularly (like once a week).
 - Make sure that your system time in sync with the rest of the world's clocks since otherwise you may get invalid nonce errors.
 
-Further notes: 
+**Further Notes:**
 
 - Use the `verbose = true` option or instantiate your troublesome exchange with `new ccxt.exchange ({ 'verbose': true })` to see the HTTP requests and responses in details. The verbose output will also be of use for us to debug it if you submit an issue on GitHub.
 - Use DEBUG logging in Python!

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -5953,65 +5953,7 @@ class BaseError (Exception):
 class BaseError extends \Exception {}
 ```
 
-Below is an outline of exception inheritance hierarchy:
-
-```text
-+ BaseError
-|
-+---+ ExchangeError
-|   |
-|   +---+ AuthenticationError
-|   |   |
-|   |   +---+ PermissionDenied
-|   |   |
-|   |   +---+ AccountSuspended
-|   |
-|   +---+ ArgumentsRequired
-|   |
-|   +---+ BadRequest
-|   |   |
-|   |   +---+ BadSymbol
-|   |
-|   +---+ BadResponse
-|   |   |
-|   |   +---+ NullResponse
-|   |
-|   +---+ InsufficientFunds
-|   |
-|   +---+ InvalidAddress
-|   |   |
-|   |   +---+ AddressPending
-|   |
-|   +---+ InvalidOrder
-|   |   |
-|   |   +---+ OrderNotFound
-|   |   |
-|   |   +---+ OrderNotCached
-|   |   |
-|   |   +---+ CancelPending
-|   |   |
-|   |   +---+ OrderImmediatelyFillable
-|   |   |
-|   |   +---+ OrderNotFillable
-|   |   |
-|   |   +---+ DuplicateOrderId
-|   |
-|   +---+ NotSupported
-|
-+---+ NetworkError (recoverable)
-    |
-    +---+ InvalidNonce
-    |
-    +---+ RequestTimeout
-    |
-    +---+ ExchangeNotAvailable
-    |   |
-    |   +---+ OnMaintenance
-    |
-    +---+ DDoSProtection
-        |
-        +---+ RateLimitExceeded
-```
+Here is an outline of exception inheritance hierarchy: https://github.com/ccxt/ccxt/blob/master/ts/src/base/errorHierarchy.ts
 
 The `BaseError` class is a generic error class for all sorts of errors, including accessibility and request/response mismatch. Users should catch this exception at the very least, if no error differentiation is required.
 
@@ -6020,33 +5962,9 @@ There's two generic families of special cases or subtrees in the error hierarchy
 - `NetworkError`
 - `ExchangeError`
 
-A `NetworkError` is a non-critical non-breaking error, not really an error in a full sense, but more like a temporary unavailability situation, that could be caused by any condition or by any factor, including maintenance, DDoS protections, and temporary bans. The reason for having a big family of `NetworkError` is to group all exceptions that can reappear or disappear upon a later retry or upon a retry from a different location, all the rest being equal (with the same user input, put simply, same order price and amount, same symbol, etc...).
-
-In contrast, the `ExchangeError` is a critical error indeed, and it differs from the `NetworkError` in a very specific way – if you get an `ExchangeError` with your input, then you should always get the same `ExchangeError` with that same input.
-
-The distinction between the two families of exceptions is such that one family is recoverable and the other family is unrecoverable. `NetworkError` means you can retry later and it can magically go away by itself, so a subsequent retry may succeed and the user may be able to recover from a `NetworkError` just by waiting. An `ExchangeError` is a fatal error, so, it means, something went bad and it will go bad every time, unless you change the input.
-
-### ExchangeError
-
-This exception is thrown when an exchange server replies with an error in JSON. Possible reasons:
-
-  - endpoint is switched off by the exchange
-  - symbol not found on the exchange
-  - required parameter is missing
-  - the format of parameters is incorrect
-  - an exchange replies with an unclear answer
-
-Other exceptions derived from `ExchangeError`:
-
-  - `NotSupported`: This exception is raised if the endpoint is not offered/not supported by the exchange API.
-  - `AuthenticationError`: Raised when an exchange requires one of the API credentials that you've missed to specify, or when there's a mistake in the keypair or an outdated nonce. Most of the time you need `apiKey` and `secret`, sometimes you also need `uid` and/or `password`.
-  - `PermissionDenied`: Raised when there's no access for specified action or insufficient permissions on the specified `apiKey`.
-  - `InsufficientFunds`: This exception is raised when you don't have enough currency on your account balance to place an order.
-  - `InvalidAddress`: This exception is raised upon encountering a bad funding address or a funding address shorter than `.minFundingAddressLength` (10 characters by default) in a call to `fetchDepositAddress`, `createDepositAddress` or `withdraw`.
-  - `InvalidOrder`: This exception is the base class for all exceptions related to the unified order API.
-  - `OrderNotFound`: Raised when you are trying to fetch or cancel a non-existent order.
-
 ### NetworkError
+
+A `NetworkError` is mostly a temporary unavailability situation, that could be caused by any factor, including maintenance, internet connectivitiy issues, DDoS protections, and temporary bans. This error is a root of all exceptions sub-groups, that can reappear or disappear upon a later retry or upon a retry from a different location (without need to change parameters in the request).
 
 All errors related to networking are usually recoverable, meaning that networking problems, traffic congestion, unavailability is usually time-dependent. Making a retry later is usually enough to recover from a NetworkError, but if it doesn't go away, then it may indicate some persistent problem with the exchange or with your connection.
 
@@ -6085,6 +6003,28 @@ The ccxt library also throws this error if it detects any of the following keywo
   - `maintain`
   - `maintenance`
   - `maintenancing`
+
+### ExchangeError
+
+In contrast to `NetworkError`, the `ExchangeError` is mostly happening when the request is impossible to succeed (because of factors listed below), so even if you retry the same request hundreds of times, it will not help, because the request is being made incorrectly (The only exclusion is its subclass type `OperationFailed` which can be retried to make the request successfull).
+
+This exception is thrown when an exchange server replies with an error in JSON. Possible reasons:
+
+  - endpoint is switched off by the exchange
+  - symbol not found on the exchange
+  - required parameter is missing
+  - the format of parameters is incorrect
+  - an exchange replies with an unclear answer
+
+Other exceptions derived from `ExchangeError`:
+
+  - `NotSupported`: This exception is raised if the endpoint is not offered/not supported by the exchange API.
+  - `AuthenticationError`: Raised when an exchange requires one of the API credentials that you've missed to specify, or when there's a mistake in the keypair or an outdated nonce. Most of the time you need `apiKey` and `secret`, sometimes you also need `uid` and/or `password`.
+  - `PermissionDenied`: Raised when there's no access for specified action or insufficient permissions on the specified `apiKey`.
+  - `InsufficientFunds`: This exception is raised when you don't have enough currency on your account balance to place an order.
+  - `InvalidAddress`: This exception is raised upon encountering a bad funding address or a funding address shorter than `.minFundingAddressLength` (10 characters by default) in a call to `fetchDepositAddress`, `createDepositAddress` or `withdraw`.
+  - `InvalidOrder`: This exception is the base class for all exceptions related to the unified order API.
+  - `OrderNotFound`: Raised when you are trying to fetch or cancel a non-existent order.
 
 #### InvalidNonce
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -5955,6 +5955,68 @@ class BaseError extends \Exception {}
 
 Here is an outline of exception inheritance hierarchy: https://github.com/ccxt/ccxt/blob/master/ts/src/base/errorHierarchy.ts
 
+```text
++ BaseError
+|
++---+ ExchangeError
+|   |
+|   +---+ AuthenticationError
+|   |   |
+|   |   +---+ PermissionDenied
+|   |   |
+|   |   +---+ AccountSuspended
+|   |
+|   +---+ ArgumentsRequired
+|   |
+|   +---+ BadRequest
+|   |   |
+|   |   +---+ BadSymbol
+|   |   |
+|   |   +---+ OperationRejected
+|   |
+|   +---+ OperationFailed
+|   |
+|   +---+ BadResponse
+|   |   |
+|   |   +---+ NullResponse
+|   |
+|   +---+ InsufficientFunds
+|   |
+|   +---+ InvalidAddress
+|   |   |
+|   |   +---+ AddressPending
+|   |
+|   +---+ InvalidOrder
+|   |   |
+|   |   +---+ OrderNotFound
+|   |   |
+|   |   +---+ OrderNotCached
+|   |   |
+|   |   +---+ CancelPending
+|   |   |
+|   |   +---+ OrderImmediatelyFillable
+|   |   |
+|   |   +---+ OrderNotFillable
+|   |   |
+|   |   +---+ DuplicateOrderId
+|   |
+|   +---+ NotSupported
+|
++---+ NetworkError (recoverable)
+    |
+    +---+ InvalidNonce
+    |
+    +---+ RequestTimeout
+    |
+    +---+ ExchangeNotAvailable
+    |   |
+    |   +---+ OnMaintenance
+    |
+    +---+ DDoSProtection
+        |
+        +---+ RateLimitExceeded
+```
+
 The `BaseError` class is a generic root error class for all sorts of errors, including accessibility and request/response mismatch. If you don't need to catch any specific subclass of exceptions, you can just use `BaseError`, where all exception types are being caught.
 
 From `BaseError` there are derived two different families of the error hierarchy:


### PR DESCRIPTION
Have been trying to rewrite manuals to be compact, better browsable and not with repeated/duplicate information, as too much stretched explanations could be distracting for users. Better to be compact informative.