### PR TITLE
Static test exchange name typos

### DIFF
--- a/ts/src/test/static/data/bybit.json
+++ b/ts/src/test/static/data/bybit.json
@@ -1,5 +1,5 @@
 {
-    "exchange": "binance",
+    "exchange": "bybit",
     "skipKeys": [],
     "outputType": "json",
     "methods": {

--- a/ts/src/test/static/data/kraken.json
+++ b/ts/src/test/static/data/kraken.json
@@ -1,5 +1,5 @@
 {
-    "exchange": "krakenfutures",
+    "exchange": "kraken",
     "skipKeys": ["nonce"],
     "outputType": "urlencoded",
     "methods": {


### PR DESCRIPTION
Edited some minor typos that I noticed in the static test exchange names