### PR TITLE
Digifinex: createMarketBuyOrderRequiresPrice

### DIFF
--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -292,6 +292,7 @@ export default class digifinex extends Exchange {
             'options': {
                 'defaultType': 'spot',
                 'types': [ 'spot', 'margin', 'otc' ],
+                'createMarketBuyOrderRequiresPrice': true,
                 'accountsByType': {
                     'spot': '1',
                     'margin': '2',
@@ -1767,7 +1768,21 @@ export default class digifinex extends Exchange {
             }
             request['type'] = side + suffix;
             // limit orders require the amount in the base currency, market orders require the amount in the quote currency
-            request['amount'] = this.amountToPrecision (symbol, amount);
+            let quantity = undefined;
+            const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
+            if (createMarketBuyOrderRequiresPrice && isMarketOrder && (side === 'buy')) {
+                if (price === undefined) {
+                    throw new InvalidOrder (this.id + ' createOrder() requires a price argument for market buy orders on spot markets to calculate the total amount to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option to false and pass in the cost to spend into the amount parameter');
+                } else {
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    const cost = this.parseNumber (Precise.stringMul (amountString, priceString));
+                    quantity = this.priceToPrecision (symbol, cost);
+                }
+            } else {
+                quantity = this.amountToPrecision (symbol, amount);
+            }
+            request['amount'] = quantity;
         }
         if (postOnly) {
             if (postOnlyParsed) {

--- a/ts/src/test/static/data/digifinex.json
+++ b/ts/src/test/static/data/digifinex.json
@@ -16,6 +16,19 @@
               55
             ],
             "output": "amount=0.1&market=spot&price=55&symbol=LTC_USDT&type=buy"
+          },
+          {
+            "description": "Spot market buy, with createMarketBuyOrderRequiresPrice set to true",
+            "method": "createOrder",
+            "url": "https://openapi.digifinex.com/v3/spot/order/new",
+            "input": [
+              "LTC/USDT",
+              "market",
+              "buy",
+              0.1,
+              69.51
+            ],
+            "output": "amount=6.95&market=spot&symbol=LTC_USDT&type=buy_market"
           }
         ]
     }


### PR DESCRIPTION
Added createMarketBuyOrderRequiresPrice to Digfinex spot orders:
```
digifinex.createOrder (LTC/USDT, market, buy, 0.1, 69.51)
2023-11-04T02:32:39.967Z iteration 0 passed in 1486 ms

{
  info: { code: '0', order_id: '2421d8a4c389ca5cee03d78b5ab48007' },
  id: '2421d8a4c389ca5cee03d78b5ab48007',
  clientOrderId: undefined,
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  symbol: 'LTC/USDT',
  type: 'market',
  timeInForce: undefined,
  postOnly: undefined,
  side: 'buy',
  price: 69.51,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: 0.1,
  filled: undefined,
  remaining: undefined,
  cost: undefined,
  average: undefined,
  status: undefined,
  fee: { cost: undefined },
  trades: [],
  fees: [ { cost: undefined } ],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```