### PR TITLE
Mexc: fix `fetchOrdersByState()` always returning an empty array

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2807,7 +2807,7 @@ export default class mexc extends Exchange {
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            request['symbol'] = market['id'];
+            // request['symbol'] = market['id']; // Adding this line causes fetchOrders() to always return an empty array.
         }
         const [ marketType ] = this.handleMarketTypeAndParams ('fetchOrdersByState', market, params);
         if (marketType === 'spot') {


### PR DESCRIPTION
mexc's `fetchOrdersByState()`, `fetchOpenOrders()`, ... always returns an empty array. However, `fetchOrders(params={"states"="*"})` works. Thus, removing line 2810 (2655 in Python) makes it work correctly. I read the code carefully, but could not figure out why.

Using version 4.1.37.

```python
orders = await exchange.fetch_orders_by_state(state="2", symbol="ETH/USDT:USDT")
print(orders)
orders = await exchange.fetch_orders("ETH/USDT:USDT", params={"states": "2"})
print(orders)
```

Output:
```shell
[]
[{'id': '475662884773393408', 'clientOrderId': None, 'timestamp': 1699077269000, 'datetime': '2023-11-04T05:54:29.000Z', 'lastTradeTimestamp': None, 'status': 'open', 'symbol': 'ETH/USDT:USDT', 'type': None, 'timeInForce': None, 'side': 'buy', 'price': 1000.14, 'stopPrice': None, 'triggerPrice': None, 'average': None, 'amount': 2.0, 'cost': 0.0, 'filled': 0.0, 'remaining': 2.0, 'fee': {'currency': 'USDT', 'cost': 0.0}, 'trades': [], 'info': {'orderId': '475662884773393408', 'symbol': 'ETH_USDT', 'positionId': '0', 'price': '1000.14', 'priceStr': '1000.140000000000000000', 'vol': '2', 'leverage': '20', 'side': '1', 'category': '1', 'orderType': '1', 'dealAvgPrice': '0', 'dealAvgPriceStr': '0.000000000000000000', 'dealVol': '0', 'orderMargin': '1.00414056', 'takerFee': '0', 'makerFee': '0', 'profit': '0', 'feeCurrency': 'USDT', 'openType': '1', 'state': '2', 'externalOid': '_m_4c420f1e7a85498eb92c9e761f9e8e5b', 'errorCode': '0', 'usedMargin': '0', 'createTime': '1699077269000', 'updateTime': '1699077269000', 'positionMode': '2', 'reduceOnly': False, 'version': '1', 'showCancelReason': '1', 'showProfitRateShare': '0'}, 'fees': [{'currency': 'USDT', 'cost': 0.0}], 'lastUpdateTimestamp': None, 'postOnly': None, 'reduceOnly': None, 'takeProfitPrice': None, 'stopLossPrice': None, 'states': '2'}]
```