### PR TITLE
fix(mexc): swap fetchOpenOrders

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2807,7 +2807,6 @@ export default class mexc extends Exchange {
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            request['symbol'] = market['id'];
         }
         const [ marketType ] = this.handleMarketTypeAndParams ('fetchOrdersByState', market, params);
         if (marketType === 'spot') {

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2699,16 +2699,16 @@ export default class mexc extends Exchange {
         await this.loadMarkets ();
         const request = {};
         let market = undefined;
+        let marketType = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
-            request['symbol'] = market['id'];
         }
-        let marketType = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
         if (marketType === 'spot') {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires a symbol argument for spot market');
             }
+            request['symbol'] = market['id'];
             let method = 'spotPrivateGetOpenOrders';
             const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOpenOrders', params);
             if (marginMode !== undefined) {


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/pull/19821

DEMO

```
 p mexc fetchOpenOrders "LTC/USDT:USDT"          
Python v3.11.5
CCXT v4.1.37
mexc.fetchOpenOrders(LTC/USDT:USDT)
[{'amount': 10.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-11-04T12:34:28.000Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'fees': [{'cost': 0.0, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '475763544453924356',
  'info': {'category': '1',
           'createTime': '1699101268000',
           'dealAvgPrice': '0',
           'dealAvgPriceStr': '0.000000000000000000',
           'dealVol': '0',
           'errorCode': '0',
           'externalOid': '_m_eb877179ccd64b23a388bd01c9f62acf',
           'feeCurrency': 'USDT',
           'leverage': '20',
           'makerFee': '0',
           'openType': '1',
           'orderId': '475763544453924356',
           'orderMargin': '0.2761',
           'orderType': '1',
           'positionId': '0',
           'positionMode': '1',
           'price': '55',
           'priceStr': '55.000000000000000000',
           'profit': '0',
           'showCancelReason': '1',
           'showProfitRateShare': '0',
           'side': '1',
           'state': '2',
           'symbol': 'LTC_USDT',
           'takerFee': '0',
           'updateTime': '1699101268000',
           'usedMargin': '0',
           'version': '1',
           'vol': '10'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 55.0,
  'reduceOnly': None,
  'remaining': 10.0,
  'side': 'buy',
  'states': 2,
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'LTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1699101268000,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```
```
 p mexc fetchOpenOrders "TRX/USDT"      
Python v3.11.5
CCXT v4.1.37
mexc.fetchOpenOrders(TRX/USDT)
[{'amount': 78.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-11-04T12:51:24.366Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': 'C01__349469612703801345',
  'info': {'clientOrderId': '',
           'cummulativeQuoteQty': '0',
           'executedQty': '0',
           'icebergQty': None,
           'isWorking': True,
           'orderId': 'C01__349469612703801345',
           'orderListId': '-1',
           'origQty': '78',
           'origQuoteOrderQty': '5.46',
           'price': '0.07',
           'side': 'BUY',
           'status': 'NEW',
           'stopPrice': None,
           'symbol': 'TRXUSDT',
           'time': '1699102284366',
           'timeInForce': None,
           'type': 'LIMIT',
           'updateTime': None},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 0.07,
  'reduceOnly': None,
  'remaining': 78.0,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'TRX/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1699102284366,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```
