### PR TITLE
feat(binance): error handling for public ws endpoints

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2365,6 +2365,15 @@ export default class binance extends binanceRest {
     }
 
     handleWsError (client: Client, message) {
+        //
+        //    {
+        //        "error": {
+        //            "code": 2,
+        //            "msg": "Invalid request: invalid stream"
+        //        },
+        //        "id": 1
+        //    }
+        //
         const id = this.safeString (message, 'id');
         let rejected = false;
         const error = this.safeValue (message, 'error', {});
@@ -2374,7 +2383,17 @@ export default class binance extends binanceRest {
             this.handleErrors (code, msg, client.url, undefined, undefined, this.json (error), error, undefined, undefined);
         } catch (e) {
             rejected = true;
+            // private endpoint uses id as messageHash
             client.reject (e, id);
+            // public endpoint stores messageHash in subscriptios
+            const subscriptionKeys = Object.keys (client.subscriptions);
+            for (let i = 0; i < subscriptionKeys.length; i++) {
+                const subscriptionHash = subscriptionKeys[i];
+                const subscriptionId = this.safeString (client.subscriptions[subscriptionHash], 'id');
+                if (id === subscriptionId) {
+                    client.reject (e, subscriptionHash);
+                }
+            }
         }
         if (!rejected) {
             client.reject (message, id);
@@ -2388,7 +2407,8 @@ export default class binance extends binanceRest {
     handleMessage (client: Client, message) {
         // handle WebSocketAPI
         const status = this.safeString (message, 'status');
-        if (status !== undefined && status !== '200') {
+        const error = this.safeValue (message, 'error');
+        if ((error !== undefined) || (status !== undefined && status !== '200')) {
             return this.handleWsError (client, message);
         }
         const id = this.safeString (message, 'id');


### PR DESCRIPTION
To test grab a public ws endpoint like `watchTickers` and pass an invalid params. 
In my case I changed line 846 from:
```js
const request = {
            'method': 'SUBSCRIBE',
            'params': wsParams,
            'id': requestId,
        };
```

to 
```js
        const request = {
            'method': 'SUBSCRIBE',
            'params': ['not asdfads'],
            'id': requestId,
        };
```