### PR TITLE
build/transpile.js: fix typo.

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1300,7 +1300,7 @@ class Transpiler {
         const sync = syncFilePath
         log.magenta ('Transpiling ' + async .yellow + ' → ' + sync.yellow)
         const fileContents = fs.readFileSync (async, 'utf8')
-        const syncBody = his.transpileAsyncPHPToSyncPHP (fileContents)
+        const syncBody = this.transpileAsyncPHPToSyncPHP (fileContents)
 
         const phpTestRegexes = [
             [ /Async\\coroutine\(\$main\)/, '\$main()' ],


### PR DESCRIPTION
This was introduced in 62716b5a21b6c42aa61348fe5a5f1c029b41b851.