### PR TITLE
feat(changelog): show PR link and title

### DIFF
--- a/change.sh
+++ b/change.sh
@@ -8,11 +8,9 @@ do
         if [ "$previous_tag" != 0 ]; then
             tag_date=$(git log -1 --pretty=format:'%ad' --date=short ${previous_tag})
             printf "## ${previous_tag} (${tag_date})\n\n"
-            git log ${current_tag}...${previous_tag} --pretty=format:'*  %s [%h](https://github.com/ccxt/ccxt/commits/%H)' --reverse | grep -v Merge | grep -v skip | grep -v '-'
-            # print $commits
+            gh pr list --limit 100 --state all | awk -F"\t" '{print "* [" $1 "](https://github.com/ccxt/ccxt/pull/" $1 ") " $2}'
             printf "\n\n"
         fi
         previous_tag=${current_tag}
     fi
-
 done


### PR DESCRIPTION
I couldn't find were change.sh is called, but I think we could change to using github cli and show like this the link and title of the PRs.

# Generated Example:


## 4.1.34 (2023-11-01)

* [19855](https://github.com/ccxt/ccxt/pull/19855) fix(gate): take into position left when calculating liquidation size
* [19854](https://github.com/ccxt/ccxt/pull/19854) okx(feat): update error codes for upcoming changes
* [19853](https://github.com/ccxt/ccxt/pull/19853) fix(okcoin) - fetchohlcv limit fixes
* [19852](https://github.com/ccxt/ccxt/pull/19852) fix(Exchange.py): urlEncode stop mutating arg
* [19851](https://github.com/ccxt/ccxt/pull/19851) fix(staticTests): null exchange [ci skip]
* [19850](https://github.com/ccxt/ccxt/pull/19850) fix(binance): watchOrders and watchMyTrades type
* [19849](https://github.com/ccxt/ccxt/pull/19849) feat(staticTests): add testing granularity [ci skip]
* [19848](https://github.com/ccxt/ccxt/pull/19848) [WIP] hitbtc: add apis, update rate limit
* [19847](https://github.com/ccxt/ccxt/pull/19847) bybit: add apis