### PR TITLE
Ascendex: createOrders

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -1700,7 +1700,7 @@ export default class ascendex extends Exchange {
             const amount = this.safeValue (rawOrder, 'amount');
             const price = this.safeValue (rawOrder, 'price');
             const orderParams = this.safeValue (rawOrder, 'params', {});
-            const marginResult = this.handleMarginModeAndParams ('createOrders', params);
+            const marginResult = this.handleMarginModeAndParams ('createOrders', orderParams);
             const currentMarginMode = marginResult[0];
             if (currentMarginMode !== undefined) {
                 if (marginMode === undefined) {

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2,11 +2,11 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/ascendex.js';
-import { ArgumentsRequired, AuthenticationError, ExchangeError, InsufficientFunds, InvalidOrder, BadSymbol, PermissionDenied, BadRequest } from './base/errors.js';
+import { ArgumentsRequired, AuthenticationError, ExchangeError, InsufficientFunds, InvalidOrder, BadSymbol, PermissionDenied, BadRequest, NotSupported } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import { FundingHistory, Int, OHLCV, Order, OrderSide, OrderType } from './base/types.js';
+import { FundingHistory, Int, OHLCV, Order, OrderSide, OrderType, OrderRequest } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -37,6 +37,7 @@ export default class ascendex extends Exchange {
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,
+                'createOrders': true,
                 'createPostOnlyOrder': true,
                 'createReduceOnlyOrder': true,
                 'createStopLimitOrder': true,
@@ -1478,30 +1479,33 @@ export default class ascendex extends Exchange {
         return result;
     }
 
-    async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
+    createOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
-         * @name ascendex#createOrder
-         * @description Create an order on the exchange
-         * @param {string} symbol Unified CCXT market symbol
-         * @param {string} type "limit" or "market"
-         * @param {string} side "buy" or "sell"
-         * @param {float} amount the amount of currency to trade
-         * @param {float} [price] *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
-         * @param {object} [params] Extra parameters specific to the exchange API endpoint
+         * @ignore
+         * @name ascendex#createOrderRequest
+         * @description helper function to build request
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much you want to trade in units of the base currency
+         * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {object} [params] extra parameters specific to the ascendex api endpoint
          * @param {string} [params.timeInForce] "GTC", "IOC", "FOK", or "PO"
          * @param {bool} [params.postOnly] true or false
-         * @param {float} [params.stopPrice] The price at which a trigger order is triggered at
-         * @returns [An order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
+         * @param {float} [params.stopPrice] the price at which a trigger order is triggered at
+         * @returns {object} request to be sent to the exchange
          */
-        await this.loadMarkets ();
-        await this.loadAccounts ();
         const market = this.market (symbol);
+        let marginMode = undefined;
         let marketType = undefined;
-        [ marketType, params ] = this.handleMarketTypeAndParams ('createOrder', market, params);
-        const options = this.safeValue (this.options, 'createOrder', {});
+        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrderRequest', params);
+        [ marketType, params ] = this.handleMarketTypeAndParams ('createOrderRequest', market, params);
         const accountsByType = this.safeValue (this.options, 'accountsByType', {});
-        const accountCategory = this.safeString (accountsByType, marketType, 'cash');
+        let accountCategory = this.safeString (accountsByType, marketType, 'cash');
+        if (marginMode !== undefined) {
+            accountCategory = 'margin';
+        }
         const account = this.safeValue (this.accounts, 0, {});
         const accountGroup = this.safeValue (account, 'id');
         const clientOrderId = this.safeString2 (params, 'clientOrderId', 'id');
@@ -1522,13 +1526,6 @@ export default class ascendex extends Exchange {
         const postOnly = this.isPostOnly (isMarketOrder, false, params);
         const reduceOnly = this.safeValue (params, 'reduceOnly', false);
         const stopPrice = this.safeValue2 (params, 'triggerPrice', 'stopPrice');
-        params = this.omit (params, [ 'timeInForce', 'postOnly', 'reduceOnly', 'stopPrice', 'triggerPrice' ]);
-        if (reduceOnly) {
-            if (marketType !== 'swap') {
-                throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + marketType + ' orders, reduceOnly orders are supported for perpetuals only');
-            }
-            request['execInst'] = 'ReduceOnly';
-        }
         if (isLimitOrder) {
             request['orderPrice'] = this.priceToPrecision (symbol, price);
         }
@@ -1552,20 +1549,55 @@ export default class ascendex extends Exchange {
         if (clientOrderId !== undefined) {
             request['id'] = clientOrderId;
         }
-        const defaultMethod = this.safeString (options, 'method', 'v1PrivateAccountCategoryPostOrder');
-        const method = this.getSupportedMapping (marketType, {
-            'spot': defaultMethod,
-            'margin': defaultMethod,
-            'swap': 'v2PrivateAccountGroupPostFuturesOrder',
-        });
-        if (method === 'v1PrivateAccountCategoryPostOrder') {
+        if (market['spot']) {
             if (accountCategory !== undefined) {
                 request['category'] = accountCategory;
             }
         } else {
             request['account-category'] = accountCategory;
+            if (reduceOnly) {
+                request['execInst'] = 'ReduceOnly';
+            }
+            if (postOnly) {
+                request['execInst'] = 'Post';
+            }
         }
-        const response = await this[method] (this.extend (request, params));
+        params = this.omit (params, [ 'reduceOnly', 'triggerPrice' ]);
+        return this.extend (request, params);
+    }
+
+    async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
+        /**
+         * @method
+         * @name ascendex#createOrder
+         * @description create a trade order on the exchange
+         * @see https://ascendex.github.io/ascendex-pro-api/#place-order
+         * @see https://ascendex.github.io/ascendex-futures-pro-api-v2/#new-order
+         * @param {string} symbol unified CCXT market symbol
+         * @param {string} type "limit" or "market"
+         * @param {string} side "buy" or "sell"
+         * @param {float} amount the amount of currency to trade
+         * @param {float} [price] *ignored in "market" orders* the price at which the order is to be fullfilled at in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.timeInForce] "GTC", "IOC", "FOK", or "PO"
+         * @param {bool} [params.postOnly] true or false
+         * @param {float} [params.stopPrice] the price at which a trigger order is triggered at
+         * @param {object} [params.takeProfit] *takeProfit object in params* containing the triggerPrice that the attached take profit order will be triggered (perpetual swap markets only)
+         * @param {float} [params.takeProfit.triggerPrice] *swap only* take profit trigger price
+         * @param {object} [params.stopLoss] *stopLoss object in params* containing the triggerPrice that the attached stop loss order will be triggered (perpetual swap markets only)
+         * @param {float} [params.stopLoss.triggerPrice] *swap only* stop loss trigger price
+         * @returns [An order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
+         */
+        await this.loadMarkets ();
+        await this.loadAccounts ();
+        const market = this.market (symbol);
+        const request = this.createOrderRequest (symbol, type, side, amount, price, params);
+        let response = undefined;
+        if (market['swap']) {
+            response = await this.v2PrivateAccountGroupPostFuturesOrder (request);
+        } else {
+            response = await this.v1PrivateAccountCategoryPostOrder (request);
+        }
         //
         // spot
         //
@@ -1585,7 +1617,6 @@ export default class ascendex extends Exchange {
         //              }
         //          }
         //      }
-        //
         //
         // swap
         //
@@ -1633,6 +1664,103 @@ export default class ascendex extends Exchange {
         const data = this.safeValue (response, 'data', {});
         const order = this.safeValue2 (data, 'order', 'info', {});
         return this.parseOrder (order, market);
+    }
+
+    async createOrders (orders: OrderRequest[], params = {}) {
+        /**
+         * @method
+         * @name ascendex#createOrders
+         * @description create a list of trade orders
+         * @see https://ascendex.github.io/ascendex-pro-api/#place-batch-orders
+         * @see https://ascendex.github.io/ascendex-futures-pro-api-v2/#place-batch-orders
+         * @param {array} orders list of orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+         * @param {object} [params] extra parameters specific to the ascendex api endpoint
+         * @param {string} [params.timeInForce] "GTC", "IOC", "FOK", or "PO"
+         * @param {bool} [params.postOnly] true or false
+         * @param {float} [params.stopPrice] the price at which a trigger order is triggered at
+         * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
+         */
+        await this.loadMarkets ();
+        await this.loadAccounts ();
+        const ordersRequests = [];
+        let symbol = undefined;
+        let marginMode = undefined;
+        for (let i = 0; i < orders.length; i++) {
+            const rawOrder = orders[i];
+            const marketId = this.safeString (rawOrder, 'symbol');
+            if (symbol === undefined) {
+                symbol = marketId;
+            } else {
+                if (symbol !== marketId) {
+                    throw new BadRequest (this.id + ' createOrders() requires all orders to have the same symbol');
+                }
+            }
+            const type = this.safeString (rawOrder, 'type');
+            const side = this.safeString (rawOrder, 'side');
+            const amount = this.safeValue (rawOrder, 'amount');
+            const price = this.safeValue (rawOrder, 'price');
+            const orderParams = this.safeValue (rawOrder, 'params', {});
+            const marginResult = this.handleMarginModeAndParams ('createOrders', params);
+            const currentMarginMode = marginResult[0];
+            if (currentMarginMode !== undefined) {
+                if (marginMode === undefined) {
+                    marginMode = currentMarginMode;
+                } else {
+                    if (marginMode !== currentMarginMode) {
+                        throw new BadRequest (this.id + ' createOrders() requires all orders to have the same margin mode (isolated or cross)');
+                    }
+                }
+            }
+            const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
+            ordersRequests.push (orderRequest);
+        }
+        const market = this.market (symbol);
+        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        let accountCategory = this.safeString (accountsByType, market['type'], 'cash');
+        if (marginMode !== undefined) {
+            accountCategory = 'margin';
+        }
+        const account = this.safeValue (this.accounts, 0, {});
+        const accountGroup = this.safeValue (account, 'id');
+        const request = {};
+        let response = undefined;
+        if (market['swap']) {
+            throw new NotSupported (this.id + ' createOrders() is not currently supported for swap markets on ascendex');
+            // request['account-group'] = accountGroup;
+            // request['category'] = accountCategory;
+            // request['orders'] = ordersRequests;
+            // response = await this.v2PrivateAccountGroupPostFuturesOrderBatch (request);
+        } else {
+            request['account-group'] = accountGroup;
+            request['account-category'] = accountCategory;
+            request['orders'] = ordersRequests;
+            response = await this.v1PrivateAccountCategoryPostOrderBatch (request);
+        }
+        //
+        // spot
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "accountId": "cshdAKBO43TKIh2kJtq7FVVb42KIePyS",
+        //             "ac": "CASH",
+        //             "action": "batch-place-order",
+        //             "status": "Ack",
+        //             "info": [
+        //                 {
+        //                     "symbol": "BTC/USDT",
+        //                     "orderType": "Limit",
+        //                     "timestamp": 1699326589344,
+        //                     "id": "",
+        //                     "orderId": "a18ba7c1f6efU0711043490p3HvjjN5x"
+        //                 }
+        //             ]
+        //         }
+        //     }
+        //
+        const data = this.safeValue (response, 'data', {});
+        const info = this.safeValue (data, 'info', []);
+        return this.parseOrders (info, market);
     }
 
     async fetchOrder (id: string, symbol: string = undefined, params = {}) {

--- a/ts/src/test/static/data/ascendex.json
+++ b/ts/src/test/static/data/ascendex.json
@@ -1,0 +1,92 @@
+{
+    "exchange": "ascendex",
+    "skipKeys": ["time", "account-group"],
+    "outputType": "json",
+    "methods": {
+        "createOrder": [
+            {
+                "description": "Spot limit order",
+                "method": "createOrder",
+                "url": "https://ascendex.com/myAccount/api/pro/v1/cash/order",
+                "input": [
+                    "BTC/USDT",
+                    "limit",
+                    "buy",
+                    0.0002,
+                    25000
+                ],
+                "output": "{\"symbol\":\"BTC/USDT\",\"time\":1699323490303,\"orderQty\":\"0.0002\",\"orderType\":\"limit\",\"side\":\"buy\",\"orderPrice\":\"25000\",\"category\":\"cash\"}"
+            },
+            {
+                "description": "Spot market order",
+                "method": "createOrder",
+                "url": "https://ascendex.com/myAccount/api/pro/v1/cash/order",
+                "input": [
+                    "BTC/USDT",
+                    "market",
+                    "buy",
+                    0.0002
+                ],
+                "output": "{\"symbol\":\"BTC/USDT\",\"time\":1699323995691,\"orderQty\":\"0.0002\",\"orderType\":\"market\",\"side\":\"buy\",\"category\":\"cash\"}"
+            },
+            {
+                "description": "Spot margin limit order",
+                "method": "createOrder",
+                "url": "https://ascendex.com/myAccount/api/pro/v1/margin/order",
+                "input": [
+                    "BTC/USDT",
+                    "limit",
+                    "buy",
+                    0.0002,
+                    25000,
+                    {
+                        "marginMode": "cross"
+                    }
+                ],
+                "output": "{\"symbol\":\"BTC/USDT\",\"time\":1699323658409,\"orderQty\":\"0.0002\",\"orderType\":\"limit\",\"side\":\"buy\",\"orderPrice\":\"25000\",\"category\":\"margin\"}"
+            },
+            {
+                "description": "Spot margin market order",
+                "method": "createOrder",
+                "url": "https://ascendex.com/myAccount/api/pro/v1/margin/order",
+                "input": [
+                    "BTC/USDT",
+                    "market",
+                    "buy",
+                    0.0002,
+                    null,
+                    {
+                        "marginMode": "cross"
+                    }
+                ],
+                "output": "{\"symbol\":\"BTC/USDT\",\"time\":1699324274612,\"orderQty\":\"0.0002\",\"orderType\":\"market\",\"side\":\"buy\",\"category\":\"margin\"}"
+            }
+        ],
+        "createOrders": [
+            {
+                "description": "Spot create multiple limit orders at once",
+                "method": "createOrders",
+                "url": "https://ascendex.com/myAccount/api/pro/v1/cash/order/batch",
+                "input": [
+                    [
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": "0.0002",
+                            "price": "25000"
+                        },
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": "0.0002",
+                            "price": "27000"
+                        }
+                    ]
+                ],
+                "output": "{\"orders\":[{\"account-group\":\"6\",\"account-category\":\"cash\",\"symbol\":\"BTC/USDT\",\"time\":1699329018603,\"orderQty\":\"0.0002\",\"orderType\":\"limit\",\"side\":\"buy\",\"orderPrice\":\"25000\",\"category\":\"cash\"},{\"account-group\":\"6\",\"account-category\":\"cash\",\"symbol\":\"BTC/USDT\",\"time\":1699329018604,\"orderQty\":\"0.0002\",\"orderType\":\"limit\",\"side\":\"buy\",\"orderPrice\":\"27000\",\"category\":\"cash\"}]}"
+            }
+        ]
+    }
+}

--- a/ts/src/test/static/markets/ascendex.json
+++ b/ts/src/test/static/markets/ascendex.json
@@ -1,0 +1,630 @@
+{
+    "BTC/USDT": {
+        "id": "BTC/USDT",
+        "symbol": "BTC/USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "precision": {
+            "amount": 0.00001,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.000000001,
+                "max": 1000000000
+            },
+            "price": {
+                "min": 0.01
+            },
+            "cost": {
+                "min": 5,
+                "max": 400000
+            }
+        },
+        "info": {
+            "symbol": "BTC/USDT",
+            "displayName": "BTC/USDT",
+            "domain": "USDS",
+            "tradingStartTime": 1546329600000,
+            "collapseDecimals": "1,0.1,0.01",
+            "minQty": "0.000000001",
+            "maxQty": "1000000000",
+            "minNotional": "5",
+            "maxNotional": "400000",
+            "statusCode": "Normal",
+            "statusMessage": "",
+            "tickSize": "0.01",
+            "useTick": false,
+            "lotSize": "0.00001",
+            "useLot": false,
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "qtyScale": 5,
+            "priceScale": 2,
+            "notionalScale": 4
+        }
+    },
+    "BTC/USDT:USDT": {
+        "id": "BTC-PERP",
+        "symbol": "BTC/USDT:USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "contractSize": 1,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.1
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.0001,
+                "max": 100000000000
+            },
+            "price": {
+                "min": 0.1,
+                "max": 1000000
+            },
+            "cost": {}
+        },
+        "info": {
+            "symbol": "BTC-PERP",
+            "status": "Normal",
+            "displayName": "BTCUSDT",
+            "settlementAsset": "USDT",
+            "underlying": "BTC/USDT",
+            "tradingStartTime": 1688432400000,
+            "priceFilter": {
+                "minPrice": "0.1",
+                "maxPrice": "1000000",
+                "tickSize": "0.1"
+            },
+            "lotSizeFilter": {
+                "minQty": "0.0001",
+                "maxQty": "100000000000",
+                "lotSize": "0.0001"
+            },
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "marketOrderPriceMarkup": "0.005",
+            "marginRequirements": [
+                {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"100000","initialMarginRate":"0.005","maintenanceMarginRate":"0.004"},
+                {"positionNotionalLowerBound":"100000","positionNotionalUpperBound":"300000","initialMarginRate":"0.006666","maintenanceMarginRate":"0.005"},
+                {"positionNotionalLowerBound":"300000","positionNotionalUpperBound":"600000","initialMarginRate":"0.01","maintenanceMarginRate":"0.007"},
+                {"positionNotionalLowerBound":"600000","positionNotionalUpperBound":"1200000","initialMarginRate":"0.013333","maintenanceMarginRate":"0.009"},
+                {"positionNotionalLowerBound":"1200000","positionNotionalUpperBound":"1500000","initialMarginRate":"0.02","maintenanceMarginRate":"0.014"},
+                {"positionNotionalLowerBound":"1500000","positionNotionalUpperBound":"2000000","initialMarginRate":"0.04","maintenanceMarginRate":"0.024"},
+                {"positionNotionalLowerBound":"2000000","positionNotionalUpperBound":"5000000","initialMarginRate":"0.1","maintenanceMarginRate":"0.09"},
+                {"positionNotionalLowerBound":"5000000","positionNotionalUpperBound":"10000000","initialMarginRate":"0.2","maintenanceMarginRate":"0.18"},
+                {"positionNotionalLowerBound":"10000000","positionNotionalUpperBound":"1000000000","initialMarginRate":"0.333333","maintenanceMarginRate":"0.3"}
+            ]
+        }
+    },
+    "LTC/USDT": {
+        "id": "LTC/USDT",
+        "symbol": "LTC/USDT",
+        "base": "LTC",
+        "quote": "USDT",
+        "baseId": "LTC",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "precision": {
+            "amount": 0.001,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.000000001,
+                "max": 1000000000
+            },
+            "price": {
+                "min": 0.01
+            },
+            "cost": {
+                "min": 5,
+                "max": 400000
+            }
+        },
+        "info": {
+            "symbol": "LTC/USDT",
+            "displayName": "LTC/USDT",
+            "domain": "USDS",
+            "tradingStartTime": 1546329600000,
+            "collapseDecimals": "1,0.1,0.01",
+            "minQty": "0.000000001",
+            "maxQty": "1000000000",
+            "minNotional": "5",
+            "maxNotional": "400000",
+            "statusCode": "Normal",
+            "statusMessage": "",
+            "tickSize": "0.01",
+            "useTick": false,
+            "lotSize": "0.001",
+            "useLot": false,
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "qtyScale": 3,
+            "priceScale": 2,
+            "notionalScale": 4
+        }
+    },
+    "ADA/USDT": {
+        "id": "ADA/USDT",
+        "symbol": "ADA/USDT",
+        "base": "ADA",
+        "quote": "USDT",
+        "baseId": "ADA",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "precision": {
+            "amount": 1,
+            "price": 0.00001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.000000001,
+                "max": 1000000000
+            },
+            "price": {
+                "min": 0.00001
+            },
+            "cost": {
+                "min": 5,
+                "max": 400000
+            }
+        },
+        "info": {
+            "symbol": "ADA/USDT",
+            "displayName": "ADA/USDT",
+            "domain": "USDS",
+            "tradingStartTime": 1559685600000,
+            "collapseDecimals": "0.01,0.0001,0.00001",
+            "minQty": "0.000000001",
+            "maxQty": "1000000000",
+            "minNotional": "5",
+            "maxNotional": "400000",
+            "statusCode": "Normal",
+            "statusMessage": "",
+            "tickSize": "0.00001",
+            "useTick": false,
+            "lotSize": "1",
+            "useLot": false,
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "qtyScale": 0,
+            "priceScale": 5,
+            "notionalScale": 4
+        }
+    },
+    "XRP/USDT": {
+        "id": "XRP/USDT",
+        "symbol": "XRP/USDT",
+        "base": "XRP",
+        "quote": "USDT",
+        "baseId": "XRP",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "precision": {
+            "amount": 1,
+            "price": 0.00001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.000000001,
+                "max": 1000000000
+            },
+            "price": {
+                "min": 0.00001
+            },
+            "cost": {
+                "min": 5,
+                "max": 400000
+            }
+        },
+        "info": {
+            "symbol": "XRP/USDT",
+            "displayName": "XRP/USDT",
+            "domain": "USDS",
+            "tradingStartTime": 1546329600000,
+            "collapseDecimals": "0.01,0.0001,0.00001",
+            "minQty": "0.000000001",
+            "maxQty": "1000000000",
+            "minNotional": "5",
+            "maxNotional": "400000",
+            "statusCode": "Normal",
+            "statusMessage": "",
+            "tickSize": "0.00001",
+            "useTick": false,
+            "lotSize": "1",
+            "useLot": false,
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "qtyScale": 0,
+            "priceScale": 5,
+            "notionalScale": 4
+        }
+    },
+    "LTC/USDT:USDT": {
+        "id": "LTC-PERP",
+        "symbol": "LTC/USDT:USDT",
+        "base": "LTC",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "LTC",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "contractSize": 1,
+        "precision": {
+            "amount": 0.1,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.1,
+                "max": 100000000000000
+            },
+            "price": {
+                "min": 0.01,
+                "max": 1000000
+            },
+            "cost": {}
+        },
+        "info": {
+            "symbol": "LTC-PERP", 
+            "status": "Normal",
+            "displayName": "LTCUSDT",
+            "settlementAsset": "USDT",
+            "underlying": "LTC/USDT",
+            "tradingStartTime": 1688437800000,
+            "priceFilter": {
+                "minPrice": "0.01",
+                "maxPrice": "1000000",
+                "tickSize": "0.01"
+            },
+            "lotSizeFilter": {
+                "minQty": "0.1",
+                "maxQty": "100000000000000",
+                "lotSize": "0.1"
+            },
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "marketOrderPriceMarkup": "0.1",
+            "marginRequirements": [
+                {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"5000","initialMarginRate":"0.02","maintenanceMarginRate":"0.018"},
+                {"positionNotionalLowerBound":"5000","positionNotionalUpperBound":"30000","initialMarginRate":"0.033333","maintenanceMarginRate":"0.03"},
+                {"positionNotionalLowerBound":"30000","positionNotionalUpperBound":"80000","initialMarginRate":"0.05","maintenanceMarginRate":"0.049"},
+                {"positionNotionalLowerBound":"80000","positionNotionalUpperBound":"100000","initialMarginRate":"0.1","maintenanceMarginRate":"0.09"},
+                {"positionNotionalLowerBound":"100000","positionNotionalUpperBound":"200000","initialMarginRate":"0.2","maintenanceMarginRate":"0.12"},
+                {"positionNotionalLowerBound":"200000","positionNotionalUpperBound":"1000000000","initialMarginRate":"1","maintenanceMarginRate":"0.6"}
+            ]
+        }
+    },
+    "ADA/USDT:USDT": {
+        "id": "ADA-PERP",
+        "symbol": "ADA/USDT:USDT",
+        "base": "ADA",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "ADA",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1,
+            "price": 0.0001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 1,
+                "max": 1000000000000000
+            },
+            "price": {
+                "min": 0.0001,
+                "max": 400000
+            },
+            "cost": {}
+        },
+        "info": {
+            "symbol": "ADA-PERP",
+            "status": "Normal",
+            "displayName": "ADAUSDT",
+            "settlementAsset": "USDT",
+            "underlying": "ADA/USDT",
+            "tradingStartTime": 1688437800000,
+            "priceFilter": {
+                "minPrice": "0.0001",
+                "maxPrice": "400000",
+                "tickSize": "0.0001"
+            },
+            "lotSizeFilter": {
+                "minQty": "1",
+                "maxQty": "1000000000000000",
+                "lotSize": "1"
+            },
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "marketOrderPriceMarkup": "0.1",
+            "marginRequirements": [
+                {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"5000","initialMarginRate":"0.02","maintenanceMarginRate":"0.018"},
+                {"positionNotionalLowerBound":"5000","positionNotionalUpperBound":"30000","initialMarginRate":"0.033333","maintenanceMarginRate":"0.03"},
+                {"positionNotionalLowerBound":"30000","positionNotionalUpperBound":"80000","initialMarginRate":"0.05","maintenanceMarginRate":"0.049"},
+                {"positionNotionalLowerBound":"80000","positionNotionalUpperBound":"100000","initialMarginRate":"0.1","maintenanceMarginRate":"0.09"},
+                {"positionNotionalLowerBound":"100000","positionNotionalUpperBound":"200000","initialMarginRate":"0.2","maintenanceMarginRate":"0.12"},
+                {"positionNotionalLowerBound":"200000","positionNotionalUpperBound":"1000000000","initialMarginRate":"1","maintenanceMarginRate":"0.6"}
+            ]
+        }
+    },
+    "XRP/USDT:USDT": {
+        "id": "XRP-PERP",
+        "symbol": "XRP/USDT:USDT",
+        "base": "XRP",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "XRP",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1,
+            "price": 0.0001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 1,
+                "max": 1000000000000000
+            },
+            "price": {
+                "min": 0.0001,
+                "max": 400000
+            },
+            "cost": {}
+        },
+        "info": {
+            "symbol": "XRP-PERP",
+            "status": "Normal",
+            "displayName": "XRPUSDT",
+            "settlementAsset": "USDT",
+            "underlying": "XRP/USDT",
+            "tradingStartTime": 1688437800000,
+            "priceFilter": {
+                "minPrice": "0.0001",
+                "maxPrice": "400000",
+                "tickSize": "0.0001"
+            },
+            "lotSizeFilter": {
+                "minQty": "1",
+                "maxQty": "1000000000000000",
+                "lotSize": "1"
+            },
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "marketOrderPriceMarkup": "0.1",
+            "marginRequirements": [
+                {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"5000","initialMarginRate":"0.02","maintenanceMarginRate":"0.018"},
+                {"positionNotionalLowerBound":"5000","positionNotionalUpperBound":"30000","initialMarginRate":"0.033333","maintenanceMarginRate":"0.03"},
+                {"positionNotionalLowerBound":"30000","positionNotionalUpperBound":"80000","initialMarginRate":"0.05","maintenanceMarginRate":"0.049"},
+                {"positionNotionalLowerBound":"80000","positionNotionalUpperBound":"100000","initialMarginRate":"0.1","maintenanceMarginRate":"0.09"},
+                {"positionNotionalLowerBound":"100000","positionNotionalUpperBound":"200000","initialMarginRate":"0.2","maintenanceMarginRate":"0.12"},
+                {"positionNotionalLowerBound":"200000","positionNotionalUpperBound":"1000000000","initialMarginRate":"1","maintenanceMarginRate":"0.6"}
+            ]
+        }
+    },
+    "TRX/USDT": {
+        "id": "TRX/USDT",
+        "symbol": "TRX/USDT",
+        "base": "TRX",
+        "quote": "USDT",
+        "baseId": "TRX",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "precision": {
+            "amount": 1,
+            "price": 0.00001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.000000001,
+                "max": 1000000000
+            },
+            "price": {
+                "min": 0.00001
+            },
+            "cost": {
+                "min": 5,
+                "max": 400000
+            }
+        },
+        "info": {
+            "symbol": "TRX/USDT",
+            "displayName": "TRX/USDT",
+            "domain": "USDS",
+            "tradingStartTime": 1546329600000,
+            "collapseDecimals": "0.01,0.0001,0.00001",
+            "minQty": "0.000000001",
+            "maxQty": "1000000000",
+            "minNotional": "5",
+            "maxNotional": "400000",
+            "statusCode": "Normal",
+            "statusMessage": "",
+            "tickSize": "0.00001",
+            "useTick": false,
+            "lotSize": "1",
+            "useLot": false,
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "qtyScale": 0,
+            "priceScale": 5,
+            "notionalScale": 4
+        }
+    },
+    "TRX/USDT:USDT": {
+        "id": "TRX-PERP",
+        "symbol": "TRX/USDT:USDT",
+        "base": "TRX",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "TRX",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "taker": 0.001,
+        "maker": 0.001,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1,
+            "price": 0.00001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 1,
+                "max": 1000000000000000
+            },
+            "price": {
+                "min": 0.00001,
+                "max": 400000
+            },
+            "cost": {}
+        },
+        "info": {
+            "symbol": "TRX-PERP",
+            "status": "Normal",
+            "displayName": "TRXUSDT",
+            "settlementAsset": "USDT",
+            "underlying": "TRX/USDT",
+            "tradingStartTime": 1688437800000,
+            "priceFilter": {
+                "minPrice": "0.00001",
+                "maxPrice": "400000",
+                "tickSize": "0.00001"
+            },
+            "lotSizeFilter": {
+                "minQty": "1",
+                "maxQty": "1000000000000000",
+                "lotSize": "1"
+            },
+            "commissionType": "Quote",
+            "commissionReserveRate": "0.001",
+            "marketOrderPriceMarkup": "0.1",
+            "marginRequirements": [
+                {"positionNotionalLowerBound":"0","positionNotionalUpperBound":"5000","initialMarginRate":"0.02","maintenanceMarginRate":"0.018"},
+                {"positionNotionalLowerBound":"5000","positionNotionalUpperBound":"30000","initialMarginRate":"0.033333","maintenanceMarginRate":"0.03"},
+                {"positionNotionalLowerBound":"30000","positionNotionalUpperBound":"80000","initialMarginRate":"0.05","maintenanceMarginRate":"0.049"},
+                {"positionNotionalLowerBound":"80000","positionNotionalUpperBound":"100000","initialMarginRate":"0.1","maintenanceMarginRate":"0.09"},
+                {"positionNotionalLowerBound":"100000","positionNotionalUpperBound":"200000","initialMarginRate":"0.2","maintenanceMarginRate":"0.12"},
+                {"positionNotionalLowerBound":"200000","positionNotionalUpperBound":"1000000000","initialMarginRate":"1","maintenanceMarginRate":"0.6"}
+            ]
+        }
+    }
+}

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -869,7 +869,20 @@ export default class testMainClass extends baseMainTestClass {
             }
             const storedValue = storedOutput[key];
             const newValue = newOutput[key];
-            if (typeof storedValue === 'object') {
+            if (Array.isArray (storedValue)) {
+                if (Array.isArray (newValue)) {
+                    // recursive arrays
+                    for (let j = 0; j < storedValue.length; j++) {
+                        const storedItem = storedValue[j];
+                        const newItem = newValue[j];
+                        if ((typeof storedItem === 'object') || (Array.isArray (storedItem))) {
+                            return this.assertNewAndStoredOutput (exchange, skipKeys, newItem, storedItem);
+                        }
+                        const innerError = 'output value mismatch for: ' + key + ' : ' + storedItem.toString () + ' != ' + newItem.toString ();
+                        this.assertStaticError (newItem === storedItem, innerError, storedOutput, newOutput);
+                    }
+                }
+            } else if (typeof storedValue === 'object') {
                 if (typeof newValue === 'object') {
                     // recursive objects
                     return this.assertNewAndStoredOutput (exchange, skipKeys, newValue, storedValue);

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -871,9 +871,7 @@ export default class testMainClass extends baseMainTestClass {
                 }
                 const storedValue = storedOutput[key];
                 const newValue = newOutput[key];
-                if (Array.isArray (storedValue) || (typeof storedValue === 'object')) {
-                    this.assertNewAndStoredOutput (exchange, skipKeys, newValue, storedValue);
-                }
+                this.assertNewAndStoredOutput (exchange, skipKeys, newValue, storedValue);
             }
         } else if (Array.isArray (storedOutput) && (Array.isArray (newOutput))) {
             const storedArrayLength = storedOutput.length;

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -920,18 +920,7 @@ export default class testMainClass extends baseMainTestClass {
             storedOutput = this.urlencodedToDict (storedOutput);
             newOutput = this.urlencodedToDict (newOutput);
         }
-        if (Array.isArray (storedOutput)) {
-            if (!Array.isArray (newOutput)) {
-                this.assertStaticError (false, 'output type mismatch', storedOutput, newOutput);
-            }
-            for (let i = 0; i < storedOutput.length; i++) {
-                const storedItem = storedOutput[i];
-                const newItem = newOutput[i];
-                this.assertNewAndStoredOutput (exchange, skipKeys, newItem, storedItem);
-            }
-        } else {
-            this.assertNewAndStoredOutput (exchange, skipKeys, newOutput, storedOutput);
-        }
+        this.assertNewAndStoredOutput (exchange, skipKeys, newOutput, storedOutput);
     }
 
     async testMethodStatically (exchange, method: string, data: object, type: string, skipKeys: string[]) {


### PR DESCRIPTION
Added createOrders to Ascendex, was going to add stopLoss and takeProfit and createOrders for swap orders but API trading is restricted for swap markets:

### spot createOrders:
```
ascendex createOrders ['{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":"0.0002","price":"25000"}','{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":"0.0002","price":"27000"}']

ascendex.createOrders ([object Object],[object Object])
2023-11-07T03:56:59.697Z iteration 0 passed in 1301 ms

                              id | clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   symbol |  type | timeInForce | postOnly | reduceOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
a18ba7ed2748U071104349094OzCled6 |               | 1699329419790 | 2023-11-07T03:56:59.790Z |                    | BTC/USDT | limit |             |          |            |      |       |           |              |        |      |         |        |           |        |     |     [] |   [] |                     |                 |
a18ba7ed2749U0711043490k6AAEW2ZY |               | 1699329419790 | 2023-11-07T03:56:59.790Z |                    | BTC/USDT | limit |             |          |            |      |       |           |              |        |      |         |        |           |        |     |     [] |   [] |                     |                 |
2 objects
```

From the API Documentation, if an order in the createOrders request is invalid:
```
If some order in the batch failed our basic check, then the whole batch request fail.

You may submit up to 10 orders at a time. Server will respond with error if you submit more than 10 orders.
```

### spot createOrder:
```
ascendex.createOrder (BTC/USDT, limit, buy, 0.0002, 25000)
2023-11-07T02:18:10.933Z iteration 0 passed in 1246 ms

{
  info: {
    symbol: 'BTC/USDT',
    orderType: 'Limit',
    timestamp: '1699323490960',
    id: '',
    orderId: 'a18ba792afffU0711043490atepPv0wk'
  },
  id: 'a18ba792afffU0711043490atepPv0wk',
  clientOrderId: undefined,
  timestamp: 1699323490960,
  datetime: '2023-11-07T02:18:10.960Z',
  lastTradeTimestamp: undefined,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: [],
  lastUpdateTimestamp: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```

### margin createOrder:
```
ascendex.createOrder (BTC/USDT, market, buy, 0.0002, [object Object])
2023-11-07T02:30:24.689Z iteration 0 passed in 1306 ms

{
  info: {
    id: '',
    avgPx: '34876.21',
    cumFee: '0.006975242',
    cumFilledQty: '0.0002',
    errorCode: '',
    feeAsset: 'USDT',
    lastExecTime: '1699324224708',
    orderId: 'a18ba79de219U0711043490LZcCYCE15',
    orderQty: '0.0002',
    orderType: 'Market',
    price: '',
    seqNum: '33089958755',
    side: 'Buy',
    status: 'Filled',
    stopPrice: '',
    symbol: 'BTC/USDT',
    execInst: 'NULL_VAL'
  },
  id: 'a18ba79de219U0711043490LZcCYCE15',
  clientOrderId: undefined,
  timestamp: 1699324224708,
  datetime: '2023-11-07T02:30:24.708Z',
  lastTradeTimestamp: 1699324224708,
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: undefined,
  reduceOnly: undefined,
  side: 'buy',
  price: 34876.21,
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: 0.0002,
  cost: 6.975242,
  average: 34876.21,
  filled: 0.0002,
  remaining: 0,
  status: 'closed',
  fee: { cost: 0.006975242, currency: 'USDT' },
  trades: [],
  fees: [ { cost: 0.006975242, currency: 'USDT' } ],
  lastUpdateTimestamp: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```

### swap createOrder:
```
ascendex {"code":300020,"ac":"FUTURES","accountId":"fut2ODPhGiY71Pl4vtXnOZ00ssgD7QGn","action":"place-order","reason":"TRADING_RESTRICTED","message":"Trading is restricted on symbol.","info":{"symbol":"DOGE-PERP"}}
```

Added createOrder and createOrders static tests to ascendex:

[JS][TEST_SUCCESS] 67 static tests passed.