### PR TITLE
probit fetchTransactions fix

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -1518,11 +1518,11 @@ export default class probit extends Exchange {
         if (since !== undefined) {
             request['start_time'] = this.iso8601 (since);
         } else {
-            request['start_time'] = this.iso8601(1);
+            request['start_time'] = this.iso8601 (1);
         }
         const until = this.safeInteger2 (params, 'till', 'until');
         if (until !== undefined) {
-            request['end_time'] = this.iso8601(until);
+            request['end_time'] = this.iso8601 (until);
             params = this.omit (params, [ 'until', 'till' ]);
         } else {
             request['end_time'] = this.iso8601 (this.milliseconds ());

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -1504,6 +1504,7 @@ export default class probit extends Exchange {
          * @param {string} code unified currency code
          * @param {int} [since] the earliest time in ms to fetch transactions for
          * @param {int} [limit] the maximum number of transaction structures to retrieve
+         * @param {int} [params.until] the latest time in ms to fetch transactions for
          * @param {object} [params] extra parameters specific to the probit api endpoint
          * @returns {object[]} a list of [transaction structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#transaction-structure}
          */
@@ -1516,6 +1517,15 @@ export default class probit extends Exchange {
         }
         if (since !== undefined) {
             request['start_time'] = this.iso8601 (since);
+        } else {
+            request['start_time'] = this.iso8601(1);
+        }
+        const until = this.safeInteger2 (params, 'till', 'until');
+        if (until !== undefined) {
+            request['end_time'] = this.iso8601(until);
+            params = this.omit (params, [ 'until', 'till' ]);
+        } else {
+            request['end_time'] = this.iso8601 (this.milliseconds ());
         }
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -1552,7 +1562,29 @@ export default class probit extends Exchange {
     }
 
     parseTransaction (transaction, currency = undefined) {
+        //
+        //     {
+        //         "id": "01211d4b-0e68-41d6-97cb-298bfe2cab67",
+        //         "type": "deposit",
+        //         "status": "done",
+        //         "amount": "0.01",
+        //         "address": "0x9e7430fc0bdd14745bd00a1b92ed25133a7c765f",
+        //         "time": "2023-06-14T12:03:11.000Z",
+        //         "hash": "0x0ff5bedc9e378f9529acc6b9840fa8c2ef00fd0275e0bac7fa0589a9b5d1712e",
+        //         "currency_id": "ETH",
+        //         "confirmations":0,
+        //         "fee": "0",
+        //         "destination_tag": null,
+        //         "platform_id": "ETH",
+        //         "fee_currency_id": "ETH",
+        //         "payment_service_name":null,
+        //         "payment_service_display_name":null,
+        //         "crypto":null
+        //     }
+        //
         const id = this.safeString (transaction, 'id');
+        const networkId = this.safeString (transaction, 'platform_id');
+        const networkCode = this.networkIdToCode (networkId);
         const amount = this.safeNumber (transaction, 'amount');
         const address = this.safeString (transaction, 'address');
         const tag = this.safeString (transaction, 'destination_tag');
@@ -1574,7 +1606,7 @@ export default class probit extends Exchange {
             'id': id,
             'currency': code,
             'amount': amount,
-            'network': undefined,
+            'network': networkCode,
             'addressFrom': undefined,
             'address': address,
             'addressTo': address,

--- a/ts/src/test/static/data/probit.json
+++ b/ts/src/test/static/data/probit.json
@@ -1,0 +1,47 @@
+{
+    "exchange": "probit",
+    "skipKeys": [],
+    "outputType": "json",
+    "methods": {
+        "createOrder": [
+          {
+            "description": "Spot limit buy order",
+            "method": "createOrder",
+            "url": "https://api.probit.com/api/exchange/v1/new_order",
+            "input": [
+              "LTC/USDT",
+              "limit",
+              "buy",
+              0.1,
+              50
+            ],
+            "output": "{\"market_id\":\"LTC-USDT\",\"type\":\"limit\",\"side\":\"buy\",\"time_in_force\":\"gtc\",\"limit_price\":\"50\",\"quantity\":\"0.1\"}"
+          },
+          {
+            "description": "Spot market buy order",
+            "method": "createOrder",
+            "url": "https://api.probit.com/api/exchange/v1/new_order",
+            "input": [
+              "LTC/USDT",
+              "market",
+              "buy",
+              1,
+              5
+            ],
+            "output": "{\"market_id\":\"LTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"5\"}"
+          },
+          {
+            "description": "Spot market sell order",
+            "method": "createOrder",
+            "url": "https://api.probit.com/api/exchange/v1/new_order",
+            "input": [
+              "LTC/USDT",
+              "market",
+              "sell",
+              0.05
+            ],
+            "output": "{\"market_id\":\"LTC-USDT\",\"type\":\"market\",\"side\":\"sell\",\"time_in_force\":\"ioc\",\"quantity\":\"0.05\"}"
+          }
+        ]
+    }
+}

--- a/ts/src/test/static/markets/probit.json
+++ b/ts/src/test/static/markets/probit.json
@@ -1,0 +1,292 @@
+{
+    "BTC/USDT": {
+        "id": "BTC-USDT",
+        "symbol": "BTC/USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "contract": false,
+        "precision": {
+            "amount": 0.000001,
+            "price": 0.1,
+            "cost": 1e-8
+        },
+        "limits": {
+            "amount": {
+                "min": 0.000001,
+                "max": 10000000000000000
+            },
+            "price": {
+                "min": 0.1,
+                "max": 10000000000000000
+            },
+            "cost": {
+                "min": 1,
+                "max": 10000000000000000
+            },
+            "leverage": {}
+        },
+        "info": {
+            "id": "BTC-USDT",
+            "base_currency_id": "BTC",
+            "quote_currency_id": "USDT",
+            "min_price": "0.1",
+            "max_price": "9999999999999999",
+            "price_increment": "0.1",
+            "min_quantity": "0.000001",
+            "max_quantity": "9999999999999999",
+            "quantity_precision": "6",
+            "min_cost": "1",
+            "max_cost": "9999999999999999",
+            "cost_precision": "8",
+            "maker_fee_rate": "0.2",
+            "taker_fee_rate": "0.2",
+            "show_in_ui": true,
+            "closed": false
+        },
+        "tierBased": false,
+        "percentage": true,
+        "taker": 0.002,
+        "maker": 0.002
+    },
+    "LTC/USDT": {
+        "id": "LTC-USDT",
+        "symbol": "LTC/USDT",
+        "base": "LTC",
+        "quote": "USDT",
+        "baseId": "LTC",
+        "quoteId": "USDT",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "contract": false,
+        "precision": {
+            "amount": 0.00001,
+            "price": 0.01,
+            "cost": 1e-8
+        },
+        "limits": {
+            "amount": {
+                "min": 0.00001,
+                "max": 10000000000000000
+            },
+            "price": {
+                "min": 0.01,
+                "max": 10000000000000000
+            },
+            "cost": {
+                "min": 1,
+                "max": 10000000000000000
+            },
+            "leverage": {}
+        },
+        "info": {
+            "id": "LTC-USDT",
+            "base_currency_id": "LTC",
+            "quote_currency_id": "USDT",
+            "min_price": "0.01",
+            "max_price": "9999999999999999",
+            "price_increment": "0.01",
+            "min_quantity": "0.00001",
+            "max_quantity": "9999999999999999",
+            "quantity_precision": "5",
+            "min_cost": "1",
+            "max_cost": "9999999999999999",
+            "cost_precision": "8",
+            "maker_fee_rate": "0.2",
+            "taker_fee_rate": "0.2",
+            "show_in_ui": true,
+            "closed": false
+        },
+        "tierBased": false,
+        "percentage": true,
+        "taker": 0.002,
+        "maker": 0.002
+    },
+    "XRP/USDT": {
+        "id": "XRP-USDT",
+        "symbol": "XRP/USDT",
+        "base": "XRP",
+        "quote": "USDT",
+        "baseId": "XRP",
+        "quoteId": "USDT",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "contract": false,
+        "precision": {
+            "amount": 0.1,
+            "price": 0.00001,
+            "cost": 1e-8
+        },
+        "limits": {
+            "amount": {
+                "min": 0.1,
+                "max": 10000000000000000
+            },
+            "price": {
+                "min": 0.00001,
+                "max": 10000000000000000
+            },
+            "cost": {
+                "min": 1,
+                "max": 10000000000000000
+            },
+            "leverage": {}
+        },
+        "info": {
+            "id": "XRP-USDT",
+            "base_currency_id": "XRP",
+            "quote_currency_id": "USDT",
+            "min_price": "0.00001",
+            "max_price": "9999999999999999",
+            "price_increment": "0.00001",
+            "min_quantity": "0.1",
+            "max_quantity": "9999999999999999",
+            "quantity_precision": "1",
+            "min_cost": "1",
+            "max_cost": "9999999999999999",
+            "cost_precision": "8",
+            "maker_fee_rate": "0.2",
+            "taker_fee_rate": "0.2",
+            "show_in_ui": true,
+            "closed": false
+        },
+        "tierBased": false,
+        "percentage": true,
+        "taker": 0.002,
+        "maker": 0.002
+    },
+    "SOL/USDT": {
+        "id": "SOL-USDT",
+        "symbol": "SOL/USDT",
+        "base": "SOL",
+        "quote": "USDT",
+        "baseId": "SOL",
+        "quoteId": "USDT",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "contract": false,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.001,
+            "cost": 1e-8
+        },
+        "limits": {
+            "amount": {
+                "min": 0.1,
+                "max": 10000000000000000
+            },
+            "price": {
+                "min": 0.001,
+                "max": 10000000000000000
+            },
+            "cost": {
+                "min": 1,
+                "max": 10000000000000000
+            },
+            "leverage": {}
+        },
+        "info": {
+            "id": "SOL-USDT",
+            "base_currency_id": "SOL",
+            "quote_currency_id": "USDT",
+            "min_price": "0.001",
+            "max_price": "9999999999999999",
+            "price_increment": "0.001",
+            "min_quantity": "0.1",
+            "max_quantity": "9999999999999999",
+            "quantity_precision": "4",
+            "min_cost": "1",
+            "max_cost": "9999999999999999",
+            "cost_precision": "8",
+            "maker_fee_rate": "0.2",
+            "taker_fee_rate": "0.2",
+            "show_in_ui": true,
+            "closed": false
+        },
+        "tierBased": false,
+        "percentage": true,
+        "taker": 0.002,
+        "maker": 0.002
+    },
+    "TRX/USDT": {
+        "id": "TRX-USDT",
+        "symbol": "TRX/USDT",
+        "base": "TRX",
+        "quote": "USDT",
+        "baseId": "TRX",
+        "quoteId": "USDT",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "contract": false,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.00001,
+            "cost": 1e-8
+        },
+        "limits": {
+            "amount": {
+                "min": 0.0001,
+                "max": 10000000000000000
+            },
+            "price": {
+                "min": 0.00001,
+                "max": 10000000000000000
+            },
+            "cost": {
+                "min": 1,
+                "max": 10000000000000000
+            },
+            "leverage": {}
+        },
+        "info": {
+            "id": "TRX-USDT",
+            "base_currency_id": "TRX",
+            "quote_currency_id": "USDT",
+            "min_price": "0.00001",
+            "max_price": "9999999999999999",
+            "price_increment": "0.00001",
+            "min_quantity": "0.0001",
+            "max_quantity": "9999999999999999",
+            "quantity_precision": "4",
+            "min_cost": "1",
+            "max_cost": "9999999999999999",
+            "cost_precision": "8",
+            "maker_fee_rate": "0.2",
+            "taker_fee_rate": "0.2",
+            "show_in_ui": true,
+            "closed": false
+        },
+        "tierBased": false,
+        "percentage": true,
+        "taker": 0.002,
+        "maker": 0.002
+    }
+}

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -952,7 +952,7 @@ export default class testMainClass extends baseMainTestClass {
 
     initOfflineExchange (exchangeName: string) {
         const markets = this.loadMarketsFromFile (exchangeName);
-        return initExchange (exchangeName, { 'markets': markets, 'rateLimit': 1, 'httpsProxy': 'http://fake:8080', 'apiKey': 'key', 'secret': 'secretsecret', 'password': 'password', 'uid': 'uid', 'accounts': [ { 'id': 'myAccount' } ], 'options': { 'enableUnifiedAccount': true, 'enableUnifiedMargin': false }});
+        return initExchange (exchangeName, { 'markets': markets, 'rateLimit': 1, 'httpsProxy': 'http://fake:8080', 'apiKey': 'key', 'secret': 'secretsecret', 'password': 'password', 'uid': 'uid', 'accounts': [ { 'id': 'myAccount' } ], 'options': { 'enableUnifiedAccount': true, 'enableUnifiedMargin': false, 'accessToken': 'token', 'expires': 999999999999999 }});
     }
 
     async testExchangeStatically (exchangeName: string, exchangeData: object, testName: string = undefined) {


### PR DESCRIPTION
Probit made some changes and now `start_time` and `end_time` are mandatory
`{"errorCode":"INVALID_ARGUMENT","message":"","details":{"start_time":"missing","end_time":"missing"}}`