### PR TITLE
Mexc: keepAliveListenKey catch error missing ['spot'] from URL

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1097,7 +1097,7 @@ export default class mexc extends mexcRest {
             const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
             this.delay (listenKeyRefreshRate, this.keepAliveListenKey, listenKey, params);
         } catch (error) {
-            const url = this.urls['api']['ws'] + '?listenKey=' + listenKey;
+            const url = this.urls['api']['ws']['spot'] + '?listenKey=' + listenKey;
             const client = this.client (url);
             this.options['listenKey'] = undefined;
             client.reject (error);


### PR DESCRIPTION
fixes: #19867

In the `keepAliveListenKey` catch statement I changed:
`const url = this.urls['api']['ws'] + '?listenKey=' + listenKey;`
to:
`const url = this.urls['api']['ws']['spot'] + '?listenKey=' + listenKey;`

`keepAliveListenKey` is used by `authenticate` which is used by `watchSpotPrivate`