### PR TITLE
Update build-ohlcv-many-symbols.py

### DIFF
--- a/examples/ccxt.pro/py/build-ohlcv-many-symbols.py
+++ b/examples/ccxt.pro/py/build-ohlcv-many-symbols.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import asyncio
 import ccxt.pro
 
@@ -7,7 +6,7 @@ import ccxt.pro
 print('CCXT Version:', ccxt.__version__)
 
 
-async def loop(exchange, symbol, timeframe, complete_candles_only = False):
+async def loop(exchange, symbol, timeframe, complete_candles_only=False):
     duration_in_seconds = exchange.parse_timeframe(timeframe)
     duration_in_ms = duration_in_seconds * 1000
     while True:
@@ -17,21 +16,21 @@ async def loop(exchange, symbol, timeframe, complete_candles_only = False):
                 current_minute = int(exchange.milliseconds() / duration_in_ms)
                 ohlcvc = exchange.build_ohlcvc(trades, timeframe)
                 if complete_candles_only:
-                    ohlcvc = [candle for candle in ohlcvc if int( candle[0] / duration_in_ms ) < current_minute]
-                if (len(ohlcvc) > 0):
-                    print ('-----------------------------------------------------------')
+                    ohlcvc = [candle for candle in ohlcvc if int(candle[0] / duration_in_ms) < current_minute]
+                if len(ohlcvc) > 0:
+                    print('-----------------------------------------------------------')
                     print("Symbol:", symbol, "timeframe:", timeframe)
-                    print (ohlcvc)
+                    print(ohlcvc)
 
         except Exception as e:
-            print(str(e))
-            # raise e  # uncomment to break all loops in case of an error in any one of them
+            print(f"{type(e).__name__}: {(str(e))}")
+            # raise type(e)(str(e))  # uncomment to break all loops in case of an error in any one of them
             # break  # you can also break just this one loop if it fails
 
 
 async def main():
     # select the exchange
-    exchange = ccxt.pro.ftx()
+    exchange = ccxt.pro.binance()
     if exchange.has['watchTrades']:
         markets = await exchange.load_markets()
         # Change this value accordingly
@@ -44,7 +43,8 @@ async def main():
         # Use this variable to choose if only complete candles
         # should be considered
         complete_candles_only = True
-        await asyncio.gather(*[loop(exchange, symbol, timeframe, complete_candles_only) for symbol in selected_symbols])
+        await asyncio.gather(*[loop(exchange, symbol['symbol'], timeframe, complete_candles_only)
+                               for symbol in selected_symbols])
         await exchange.close()
     else:
         print(exchange.id, 'does not support watchTrades yet')


### PR DESCRIPTION
Apply PEP and modify Exception bloc to increase precision. Modified the code to run. 

However it doesn't work properly, With only one symbol, the line 17 return:
```
[[1699557120000, 0.05518, 0.05518, 0.05518, 0.05518, 0.002, 1]]
[[1699557120000, 0.05517, 0.05517, 0.05517, 0.05517, 0.0226, 1]]
[[1699557180000, 0.05518, 0.05518, 0.05518, 0.05518, 0.081, 1]]
[[1699557180000, 0.05518, 0.05518, 0.05518, 0.05518, 0.0025, 1]]
[[1699557180000, 0.05518, 0.05518, 0.05518, 0.05518, 0.0024, 1]]
```

Trades are not grouped. I'm not familiar with the normal operation of build_ohlcv, so I don't know where the error is.