### PR TITLE
Bitmart: change the fetchOHLCV endpoint

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1520,7 +1520,7 @@ export default class bitmart extends Exchange {
          * @method
          * @name bitmart#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
-         * @see https://developer-pro.bitmart.com/en/spot/#get-latest-k-line-v3
+         * @see https://developer-pro.bitmart.com/en/spot/#get-history-k-line-v3
          * @see https://developer-pro.bitmart.com/en/futures/#get-k-line
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
@@ -1579,7 +1579,7 @@ export default class bitmart extends Exchange {
         if (market['swap']) {
             response = await this.publicGetContractPublicKline (this.extend (request, params));
         } else {
-            response = await this.publicGetSpotQuotationV3LiteKlines (this.extend (request, params));
+            response = await this.publicGetSpotQuotationV3Klines (this.extend (request, params));
         }
         //
         // spot


### PR DESCRIPTION
fixes: #19900

fetchOHLCV was returning an error when the candles requested are not part of the latest 1000 candles: 
### Before:
```
bitmart.fetchOHLCV (BTC/USDT, 1m, 1672527599000, 200)
ExchangeError bitmart {"code":70000,"message":"no data","data":null,"trace":"ce3e6422d8b44d5fab855348a68693ed.65.16995634310873363"}
---------------------------------------------------
[ExchangeError] bitmart {"code":70000,"message":"no data","data":null,"trace":"ce3e6422d8b44d5fab855348a68693ed.65.16995634310873363"}

    at handleErrors               mnt/c/Users/Dan/Documents/GitHub/ccxt/js/src/bitmart.js:4108
    at                            …Users/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:782
    at processTicksAndRejections  node:internal/process/task_queues:95
    at fetch2                     …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2872
    at request                    …sers/Dan/Documents/GitHub/ccxt/js/src/base/Exchange.js:2875
    at fetchOHLCV                 mnt/c/Users/Dan/Documents/GitHub/ccxt/js/src/bitmart.js:1578
    at async run                  mnt/c/Users/Dan/Documents/GitHub/ccxt/examples/js/cli.js:315

bitmart {"code":70000,"message":"no data","data":null,"trace":"ce3e6422d8b44d5fab855348a68693ed.65.16995634310873363"}
```

### After:
```
bitmart.fetchOHLCV (BTC/USDT, 1m, 1672527599000, 200)
2023-11-09T21:01:03.035Z iteration 0 passed in 430 ms

1672527600000 | 16520.04 | 16523.43 | 16517.12 |  16519.1 |  0.81491
1672527660000 | 16518.96 |  16519.2 | 16505.36 | 16505.36 |   1.7759
1672527720000 | 16505.31 |  16515.1 | 16501.15 | 16513.18 |  1.16737
...
1672539420000 |  16553.6 |  16553.6 | 16551.58 | 16552.22 |  0.10623
1672539480000 | 16552.41 | 16552.41 | 16550.51 | 16551.52 |  0.11111
1672539540000 | 16551.58 | 16551.68 | 16551.04 | 16551.06 |  0.51435
200 objects
```