### PR TITLE
Manual: add number of contracts explanation to notes on createOrder [ci skip]

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3840,7 +3840,7 @@ Some fields from the returned order structure may be `undefined / None / null` i
 "must be greater than minimum amount precision of 1"
 ```
 
-This error happens when the exchange is expecting the number of contracts in the `amount` argument of `createOrder`. The [market structure](#market-structure) has a key called `contractSize`. Each contract is worth a certain amount of the base asset that is determined by the `contractSize`. The number of contracts multiplied by the `contractSize` is equal to the base amount. `Base amount = (contracts * contractSize)`.
+This error happens when the exchange is expecting the number of contracts in the `amount` argument of `createOrder`. The [market structure](#market-structure) has a key called `contractSize`. Each contract is worth a certain amount of the base asset that is determined by the `contractSize`. The number of contracts multiplied by the `contractSize` is equal to the base amount. `Base amount = (contracts * contractSize)` so to derive the number of contracts you should enter in the `amount` argument you can solve for contracts: `contracts = (Base amount / contractSize)`.
 
 Here is an example of finding the `contractSize`:
 ```python

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3834,6 +3834,22 @@ Some fields from the returned order structure may be `undefined / None / null` i
 }
 ```
 
+- There is a common error that happens when creating orders for contract markets:
+
+```
+"must be greater than minimum amount precision of 1"
+```
+
+This error happens when the exchange is expecting the number of contracts in the `amount` argument of `createOrder`. The [market structure](#market-structure) has a key called `contractSize`. Each contract is worth a certain amount of the base asset that is determined by the `contractSize`. The number of contracts multiplied by the `contractSize` is equal to the base amount. `Base amount = (contracts * contractSize)`.
+
+Here is an example of finding the `contractSize`:
+```python
+await exchange.loadMarkets()
+symbol = 'BTC/USDT:USDT'
+market = exchange.market(symbol)
+print(market['contractSize'])
+```
+
 #### Limit Orders
 
 Limit orders placed on the order book of the exchange for a price specified by the trader. They are fullfilled(closed) when there are no orders in the same market at a better price, and another trader creates a [market order](market-orders) or an opposite order for a price that matches or exceeds the price of the limit order.

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3834,13 +3834,15 @@ Some fields from the returned order structure may be `undefined / None / null` i
 }
 ```
 
+##### Common pitfalls
+
 - There is a common error that happens when creating orders for contract markets:
 
 ```
 "must be greater than minimum amount precision of 1"
 ```
 
-This error happens when the exchange is expecting the number of contracts in the `amount` argument of `createOrder`. The [market structure](#market-structure) has a key called `contractSize`. Each contract is worth a certain amount of the base asset that is determined by the `contractSize`. The number of contracts multiplied by the `contractSize` is equal to the base amount. `Base amount = (contracts * contractSize)` so to derive the number of contracts you should enter in the `amount` argument you can solve for contracts: `contracts = (Base amount / contractSize)`.
+This error happens when the exchange is expecting a natural number of contracts (1,2,3, etc) in the `amount` argument of `createOrder`. The [market structure](#market-structure) has a key called `contractSize`. Each contract is worth a certain amount of the base asset that is determined by the `contractSize`. The number of contracts multiplied by the `contractSize` is equal to the base amount. `Base amount = (contracts * contractSize)` so to derive the number of contracts you should enter in the `amount` argument you can solve for contracts: `contracts = (Base amount / contractSize)`.
 
 Here is an example of finding the `contractSize`:
 ```python
@@ -3848,6 +3850,9 @@ await exchange.loadMarkets()
 symbol = 'BTC/USDT:USDT'
 market = exchange.market(symbol)
 print(market['contractSize'])
+
+# Let's say you want to convert 0.5 BTC to the number of contracts:
+number_contracts = round((0.5 * 1) / market['contractSize'])
 ```
 
 #### Limit Orders


### PR DESCRIPTION
Added some information to the `Notes on createOrder` section of the manual about a common error where the exchange expects the user to use the number of contracts in the amount argument.