### PR TITLE
build: allow camelcase for underscore method name

### DIFF
--- a/build/generateImplicitAPI.js
+++ b/build/generateImplicitAPI.js
@@ -70,7 +70,7 @@ function generateImplicitMethodNames(id, api, paths = []){
                 let camelCasePath = result.map(capitalize).join('');
                 camelCasePath = lowercaseFirstLetter(camelCasePath);
                 storedCamelCaseMethods[id].push (camelCasePath)
-                let underscorePath = result.map (x => x.toLowerCase ()).join ('_')
+                let underscorePath = result.map ((x, i) => i === 0 ? x : x.toLowerCase ()).join ('_')
                 storedUnderscoreMethods[id].push (underscorePath)
                 let config = undefined
                 if (Array.isArray (value)) {


### PR DESCRIPTION
Related issue: ccxt/ccxt#19905

Not sure whether we did this intentionally, but the current build script would generate lowercase function name for underscore method, eg `futuresprivate_post_position_margin_auto_deposit_status` (used to be `futuresPrivate_post_position_margin_auto_deposit_status`.

In this PR, I fix this.