### PR TITLE
feat(gate): edit swap orders

### DIFF
--- a/ts/src/test/static/data/gate.json
+++ b/ts/src/test/static/data/gate.json
@@ -31,6 +31,36 @@
                 "output": "{\"contract\":\"LTC_USDT\",\"size\":1,\"price\":\"50\"}"
             }
         ],
+        "editOrder": [
+            {
+                "description": "Edit amount on spot order",
+                "method": "editOrder",
+                "url": "https://api.gateio.ws/api/v4/spot/orders/435305377913?currency_pair=LTC_USDT&account=spot&amount=0.11",
+                "input": [
+                  "435305377913",
+                  "LTC/USDT",
+                  "limit",
+                  "buy",
+                  0.11,
+                  null
+                ],
+                "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"spot\",\"amount\":\"0.11\"}"
+            },
+            {
+                "description": "Edit price on swap order",
+                "method": "editOrder",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/orders/362934422366",
+                "input": [
+                  "362934422366",
+                  "LTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  null,
+                  55
+                ],
+                "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"futures\",\"price\":\"55\"}"
+              }
+        ],
         "fetchPositions": [
             {
                 "description": "Fetch positions without parameters (all usdt positions)",


### PR DESCRIPTION
```
 n gate editOrder "'362934422366'" "LTC/USDT:USDT" limit buy undefined 55 --report --verbose

{
  id: '362934422366',
  clientOrderId: 'api',
  timestamp: 1699801438599,
  datetime: '2023-11-12T15:03:58.599Z',
  lastTradeTimestamp: undefined,
  status: 'open',
  symbol: 'LTC/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 55,
  stopPrice: undefined,
  triggerPrice: undefined,
  average: undefined,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  fee: undefined,
  fees: [],
  trades: [],
  info: {
    stp_id: '0',
    id: '362934422366',
    biz_info: 'ch:ccxt',
    mkfr: '0.00015',
    tkfr: '0.0005',
    tif: 'gtc',
    refu: '0',
    create_time: '1699801438.599',
    price: '55',
    size: '1',
```
