### PR TITLE
fix(krakenfutures): patch watchOrders

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -630,6 +630,25 @@ export default class krakenfutures extends krakenfuturesRest {
         //        "reason": "cancelled_by_user"
         //    }
         //
+        //     {
+        //         feed: 'open_orders',
+        //         order: {
+        //         instrument: 'PF_XBTUSD',
+        //         time: 1698159920097,
+        //         last_update_time: 1699835622988,
+        //         qty: 1.1,
+        //         filled: 0,
+        //         limit_price: 20000,
+        //         stop_price: 0,
+        //         type: 'limit',
+        //         order_id: '0eaf02b0-855d-4451-a3b7-e2b3070c1fa4',
+        //         direction: 0,
+        //         reduce_only: false
+        //         },
+        //         is_cancel: false,
+        //         reason: 'edited_by_user'
+        //     }
+        //
         let orders = this.orders;
         if (orders === undefined) {
             const limit = this.safeInteger (this.options, 'ordersLimit');
@@ -644,7 +663,8 @@ export default class krakenfutures extends krakenfuturesRest {
             const orderId = this.safeString (order, 'order_id');
             const previousOrders = this.safeValue (orders.hashmap, symbol, {});
             const previousOrder = this.safeValue (previousOrders, orderId);
-            if (previousOrder === undefined) {
+            const reason = this.safeString (message, 'reason');
+            if ((previousOrder === undefined) || (reason === 'edited_by_user')) {
                 const parsed = this.parseWsOrder (order);
                 orders.append (parsed);
                 client.resolve (orders, messageHash);
@@ -669,9 +689,10 @@ export default class krakenfutures extends krakenfuturesRest {
                 }
                 previousOrder['cost'] = totalCost;
                 if (previousOrder['filled'] !== undefined) {
-                    previousOrder['filled'] = Precise.stringAdd (previousOrder['filled'], this.numberToString (trade['amount']));
+                    const stringOrderFilled = this.numberToString (previousOrder['filled']);
+                    previousOrder['filled'] = Precise.stringAdd (stringOrderFilled, this.numberToString (trade['amount']));
                     if (previousOrder['amount'] !== undefined) {
-                        previousOrder['remaining'] = Precise.stringSub (previousOrder['amount'], previousOrder['filled']);
+                        previousOrder['remaining'] = Precise.stringSub (this.numberToString (previousOrder['amount']), stringOrderFilled);
                     }
                 }
                 if (previousOrder['fee'] === undefined) {


### PR DESCRIPTION
fix: ccxt/ccxt#19927

We have these bugs in watchOrder:
* use number when call Precise function
* didn't handle edit order event well

```BASH
$ p krakenfutures watchOrders BTC/USD:USD --test

[{'amount': 1.1,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-10-24T15:05:20.097Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'filled': 0.0,
  'id': '0eaf02b0-855d-4451-a3b7-e2b3070c1fa4',
  'info': {'direction': 0,
           'filled': 0.0,
           'instrument': 'PF_XBTUSD',
           'last_update_time': 1699839826231,
           'limit_price': 20009.0,
           'order_id': '0eaf02b0-855d-4451-a3b7-e2b3070c1fa4',
           'qty': 1.1,
           'reduce_only': False,
           'stop_price': 0.0,
           'time': 1698159920097,
           'type': 'limit'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 20009.0,
  'reduceOnly': None,
  'remaining': 1.1,
  'side': 'buy',
  'status': None,
  'stopLossPrice': None,
  'stopPrice': 0.0,
  'symbol': 'BTC/USD:USD',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1698159920097,
  'trades': [],
  'triggerPrice': 0.0,
  'type': 'limit'}]
[{'amount': 1.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2023-10-24T15:05:20.097Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'filled': 0.0,
  'id': '0eaf02b0-855d-4451-a3b7-e2b3070c1fa4',
  'info': {'direction': 0,
           'filled': 0.0,
           'instrument': 'PF_XBTUSD',
           'last_update_time': 1699839986242,
           'limit_price': 20001.0,
           'order_id': '0eaf02b0-855d-4451-a3b7-e2b3070c1fa4',
           'qty': 1.0,
           'reduce_only': False,
           'stop_price': 0.0,
           'time': 1698159920097,
           'type': 'limit'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 20001.0,
  'reduceOnly': None,
  'remaining': 1.0,
  'side': 'buy',
  'status': None,
  'stopLossPrice': None,
  'stopPrice': 0.0,
  'symbol': 'BTC/USD:USD',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1698159920097,
  'trades': [],
  'triggerPrice': 0.0,
  'type': 'limit'}]
```

Another screen:

```BASH
$ p krakenfutures editOrder '"0eaf02b0-855d-4451-a3b7-e2b3070c1fa4"' BTC/USD:USD limit buy 1 20001 --test
$ p krakenfutures editOrder '"0eaf02b0-855d-4451-a3b7-e2b3070c1fa4"' BTC/USD:USD limit buy 1.1 20009 --test
```