### PR TITLE
kraken: add start in fetchDeposits

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2225,6 +2225,9 @@ export default class kraken extends Exchange {
         const request = {
             'asset': currency['id'],
         };
+        if (since !== undefined) {
+            request['start'] = since;
+        }
         const response = await this.privatePostDepositStatus (this.extend (request, params));
         //
         //     {  error: [],

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1283,7 +1283,7 @@ export default class kraken extends Exchange {
         /**
          * @method
          * @name kraken#createOrder
-         * @see https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder
+         * @see https://docs.kraken.com/rest/#tag/Trading/operation/addOrder
          * @description create a trade order
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
@@ -1620,7 +1620,7 @@ export default class kraken extends Exchange {
          * @method
          * @name kraken#editOrder
          * @description edit a trade order
-         * @see https://docs.kraken.com/rest/#tag/User-Trading/operation/editOrder
+         * @see https://docs.kraken.com/rest/#tag/Trading/operation/editOrder
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -195,12 +195,6 @@ export default class kraken extends Exchange {
                         'WithdrawInfo': 3,
                         'WithdrawStatus': 3,
                         'WalletTransfer': 3,
-                        // staking
-                        'Stake': 3,
-                        'Unstake': 3,
-                        'Staking/Assets': 3,
-                        'Staking/Pending': 3,
-                        'Staking/Transactions': 3,
                         // sub accounts
                         'CreateSubaccount': 3,
                         'AccountTransfer': 3,

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2455,7 +2455,7 @@ export default class kraken extends Exchange {
             const request = {
                 'asset': currency['id'],
                 'amount': amount,
-                // 'address': address, // they don't allow withdrawals to direct addresses
+                'address': address,
             };
             const response = await this.privatePostWithdraw (this.extend (request, params));
             //

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -490,7 +490,7 @@ export default class kraken extends Exchange {
                         'max': undefined,
                     },
                     'cost': {
-                        'min': undefined,
+                        'min': this.safeNumber (market, 'costmin'),
                         'max': undefined,
                     },
                 },

--- a/ts/src/test/static/data/kraken.json
+++ b/ts/src/test/static/data/kraken.json
@@ -133,6 +133,28 @@
                 ],
                 "output": "nonce=1699460637341&asset=USDT"
             }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "Fetch deposit",
+                "method": "fetchDeposits",
+                "url": "https://api.kraken.com/0/private/DepositStatus",
+                "input": [
+                    "USDT"
+                ],
+                "output": "nonce=1699458295995&asset=USDT"
+            },
+            {
+                "description": "Fetch deposit",
+                "method": "fetchDeposits",
+                "url": "https://api.kraken.com/0/private/DepositStatus",
+                "input": [
+                    "USDT",
+                    1670935203
+
+                ],
+                "output": "nonce=1699458295995&asset=USDT&start=1670935203"
+            }
         ]
     }
 }


### PR DESCRIPTION
In this PR, I made some updates for kraken.

```BASH
$ p kraken fetchDeposits USDT 1670930000 --verbose
Python v3.11.4
CCXT v4.1.50
[{'address': '',
  'addressFrom': None,
  'addressTo': None,
  'amount': 0.2,
  'currency': 'USDT',
  'datetime': '2022-12-13T12:40:03.000Z',
  'fee': {'cost': 0.0, 'currency': 'USDT'},
  'id': 'RSOSIT7-ALBZPK-3RQX73',
  'info': {'aclass': 'currency',
           'amount': '0.20000000',
           'asset': 'USDT',
           'fee': '0.00000000',
           'info': '',
           'method': 'Tether USD (TRC20)',
           'refid': 'XYZ-CCXT-TO-THE-MOON',
           'status': 'Success',
           'time': '1670935203',
           'txid': '',
           'type': 'deposit'},
  'network': None,
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp': 1670935203000,
  'txid': '',
  'type': 'deposit',
  'updated': None}]
```