### PR TITLE
coinbase: patch parse trade

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -873,8 +873,13 @@ export default class coinbase extends Exchange {
         }
         const sizeInQuote = this.safeValue (trade, 'size_in_quote');
         const v3Price = this.safeString (trade, 'price');
-        const v3Amount = (sizeInQuote) ? undefined : this.safeString (trade, 'size');
-        const v3Cost = (sizeInQuote) ? this.safeString (trade, 'size') : undefined;
+        let v3Cost = undefined;
+        let v3Amount = this.safeString (trade, 'size');
+        if (sizeInQuote && (v3Amount !== undefined) && (v3Price !== undefined)) {
+            // calculate base size
+            v3Cost = this.safeString (trade, 'size');
+            v3Amount = this.amountToPrecision (symbol, Precise.stringDiv (v3Amount, v3Price));
+        }
         const v3FeeCost = this.safeString (trade, 'commission');
         const amountString = this.safeString (amountObject, 'amount', v3Amount);
         const costString = this.safeString (subtotalObject, 'amount', v3Cost);

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -875,7 +875,7 @@ export default class coinbase extends Exchange {
         const v3Price = this.safeString (trade, 'price');
         let v3Cost = undefined;
         let v3Amount = this.safeString (trade, 'size');
-        if (sizeInQuote && (v3Amount !== undefined) && (v3Price !== undefined)) {
+        if (sizeInQuote) {
             // calculate base size
             v3Amount = Precise.stringDiv (v3Amount, v3Price);
         }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -877,8 +877,7 @@ export default class coinbase extends Exchange {
         let v3Amount = this.safeString (trade, 'size');
         if (sizeInQuote && (v3Amount !== undefined) && (v3Price !== undefined)) {
             // calculate base size
-            v3Cost = this.safeString (trade, 'size');
-            v3Amount = this.amountToPrecision (symbol, Precise.stringDiv (v3Amount, v3Price));
+            v3Amount = Precise.stringDiv (v3Amount, v3Price);
         }
         const v3FeeCost = this.safeString (trade, 'commission');
         const amountString = this.safeString (amountObject, 'amount', v3Amount);


### PR DESCRIPTION
fix: ccxt/ccxt#19931

```BASH
$ p coinbase fetchMyTrades ETH/USDT
Python v3.11.4
CCXT v4.1.51
coinbase.fetchMyTrades(ETH/USDT)
[{'amount': 0.0496005,
  'cost': 101.839250595,
  'datetime': '',
  'fee': {'cost': 0.61103550357, 'currency': None},
  'fees': [{'cost': 0.61103550357, 'currency': None}],
  'id': '',
  'info': {'commission': '0.61103550357',
           'entry_id': '',
           'liquidity_indicator': 'TAKER',
           'order_id': '',
           'price': '2053.19',
           'product_id': 'ETH-USDT',
           'sequence_timestamp': '',
           'side': 'BUY',
           'size': '101.839250595',
           'size_in_quote': True,
           'trade_id': '',
           'trade_time': '',
           'trade_type': 'FILL',
           'user_id': ''},
  'order': '',
  'price': 2053.19,
  'side': 'buy',
  'symbol': 'ETH/USDT',
  'takerOrMaker': 'taker',
  'timestamp':00000000,
  'type': None}]
```