### PR TITLE
bitvavo: update fetchMarkets

### DIFF
--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -319,7 +319,10 @@ export default class bitvavo extends Exchange {
          * @returns {object[]} an array of objects representing market data
          */
         const response = await this.publicGetMarkets (params);
-        const currencies = await this.fetchCurrencies ();
+        let currencies = this.currencies;
+        if (this.currencies === undefined) {
+            currencies = await this.fetchCurrencies ();
+        }
         const currenciesById = this.indexBy (currencies, 'id');
         //
         //     [

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -339,6 +339,7 @@ export default class bitvavo extends Exchange {
         //     ]
         //
         const result = [];
+        const fees = this.fees;
         for (let i = 0; i < response.length; i++) {
             const market = response[i];
             const id = this.safeString (market, 'market');
@@ -373,6 +374,8 @@ export default class bitvavo extends Exchange {
                 'expiryDatetime': undefined,
                 'strike': undefined,
                 'optionType': undefined,
+                'taker': fees['trading']['taker'],
+                'maker': fees['trading']['maker'],
                 'precision': {
                     'amount': this.safeInteger (baseCurrency, 'decimals', basePrecision),
                     'price': this.safeInteger (market, 'pricePrecision'),


### PR DESCRIPTION
fix: ccxt/ccxt#19955
fix: ccxt/ccxt#19954

```
$ n bitvavo calculateFee ETH/EUR limit buy 1 2000
Node.js: v20.5.1
CCXT v4.1.51
bitvavo.calculateFee (ETH/EUR, limit, buy, 1, 2000)

{ type: 'taker', currency: 'EUR', rate: 0.0025, cost: 5 }
```
