### PR TITLE
fix(binance): parseWsPosition symbol [ci deploy]

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2525,7 +2525,7 @@ export default class binance extends binanceRest {
         return this.safePosition ({
             'info': position,
             'id': undefined,
-            'symbol': this.safeSymbol (marketId),
+            'symbol': this.safeSymbol (marketId, undefined, undefined, 'future'),
             'notional': undefined,
             'marginMode': this.safeString (position, 'mt'),
             'liquidationPrice': undefined,


### PR DESCRIPTION
DEMO

```
 p binance watchMyTrades "NEO/USDT:USDT"            
Python v3.11.5
CCXT v4.1.51
binance.watchMyTrades(NEO/USDT:USDT)
[{'amount': 1.0,
  'cost': 11.405,
  'datetime': '2023-11-14T11:41:51.635Z',
  'fee': {'cost': 0.0057025, 'currency': 'USDT'},
  'fees': [{'cost': 0.0057025, 'currency': 'USDT'}],
  'id': '252631221',
  'info': {'L': '11.405',
           'N': 'USDT',
           'R': False,
           'S': 'SELL',
           'T': 1699962111635,
           'V': 'NONE',
           'X': 'FILLED',
           'a': '0',
           'ap': '11.40500',
           'b': '0',
           'c': 'x-xcKtGhcu0cb9ab0be25f4aba9a585c',
           'cp': False,
           'f': 'GTC',
           'gtd': 0,
           'i': 7054089845,
           'l': '1',
           'm': False,
           'n': '0.00570250',
           'o': 'MARKET',
           'ot': 'MARKET',
           'p': '0',
           'pP': False,
           'pm': 'NONE',
           'ps': 'BOTH',
           'q': '1',
           'rp': '0.03400000',
           's': 'NEOUSDT',
           'si': 0,
           'sp': '0',
           'ss': 0,
           't': 252631221,
           'wt': 'CONTRACT_PRICE',
           'x': 'TRADE',
           'z': '1'},
  'order': '7054089845',
  'price': 11.405,
  'side': 'sell',
  'symbol': 'NEO/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1699962111635,
  'type': 'market'}]
```
