### PR TITLE
Digifinex: createOrders python sign error

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -1711,8 +1711,7 @@ export default class ascendex extends Exchange {
                     }
                 }
             }
-            let orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
-            orderRequest = this.omit (orderRequest, 'marginMode');
+            const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
             ordersRequests.push (orderRequest);
         }
         const market = this.market (symbol);

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -1644,8 +1644,7 @@ export default class digifinex extends Exchange {
                     }
                 }
             }
-            let orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
-            orderRequest = this.omit (orderRequest, 'marginMode');
+            const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
             ordersRequests.push (orderRequest);
         }
         const market = this.market (symbol);
@@ -4178,7 +4177,12 @@ export default class digifinex extends Exchange {
         const payload = pathPart + request;
         let url = this.urls['api']['rest'] + payload;
         const query = this.omit (params, this.extractParams (path));
-        let urlencoded = this.urlencode (this.keysort (query));
+        let urlencoded = undefined;
+        if (signed && (pathPart === '/swap/v2') && (method === 'POST')) {
+            urlencoded = JSON.stringify (params);
+        } else {
+            urlencoded = this.urlencode (this.keysort (query));
+        }
         if (signed) {
             let auth = undefined;
             let nonce = undefined;
@@ -4190,9 +4194,7 @@ export default class digifinex extends Exchange {
                         auth += '?' + urlencoded;
                     }
                 } else if (method === 'POST') {
-                    const swapPostParams = JSON.stringify (params);
-                    urlencoded = swapPostParams;
-                    auth += swapPostParams;
+                    auth += urlencoded;
                 }
             } else {
                 nonce = this.nonce ().toString ();

--- a/ts/src/test/static/data/digifinex.json
+++ b/ts/src/test/static/data/digifinex.json
@@ -29,6 +29,34 @@
                     69.51
                 ],
                 "output": "amount=6.95&market=spot&symbol=LTC_USDT&type=buy_market"
+            },
+            {
+                "description": "Swap market buy",
+                "method": "createOrder",
+                "url": "https://openapi.digifinex.com/swap/v2/trade/order_place",
+                "input": [
+                  "LTC/USDT:USDT",
+                  "market",
+                  "buy",
+                  1
+                ],
+                "output": "{\"instrument_id\":\"LTCUSDTPERP\",\"type\":1,\"order_type\":14,\"size\":1}"
+            },
+            {
+                "description": "Swap market sell with reduceOnly",
+                "method": "createOrder",
+                "url": "https://openapi.digifinex.com/swap/v2/trade/order_place",
+                "input": [
+                  "LTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  1,
+                  null,
+                  {
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "{\"instrument_id\":\"LTCUSDTPERP\",\"type\":3,\"order_type\":14,\"size\":1}"
             }
         ],
         "createOrders": [

--- a/ts/src/test/static/data/digifinex.json
+++ b/ts/src/test/static/data/digifinex.json
@@ -85,6 +85,30 @@
                   ]
                 ],
                 "output": "list=%5B%7B%22symbol%22%3A%22BTC_USDT%22%2C%22market%22%3A%22margin%22%2C%22price%22%3A%2225000%22%2C%22type%22%3A%22buy%22%2C%22amount%22%3A%220.0001%22%7D%2C%7B%22symbol%22%3A%22BTC_USDT%22%2C%22market%22%3A%22margin%22%2C%22price%22%3A%2227000%22%2C%22type%22%3A%22buy%22%2C%22amount%22%3A%220.0001%22%7D%5D&symbol=BTC_USDT"
+            },
+            {
+                "description": "Swap create multiple orders at once",
+                "method": "createOrders",
+                "url": "https://openapi.digifinex.com/swap/v2/trade/batch_order",
+                "input": [
+                  [
+                    {
+                      "symbol": "BTC/USDT:USDT",
+                      "type": "limit",
+                      "side": "buy",
+                      "amount": 1,
+                      "price": "25000"
+                    },
+                    {
+                      "symbol": "BTC/USDT:USDT",
+                      "type": "limit",
+                      "side": "buy",
+                      "amount": 1,
+                      "price": "27000"
+                    }
+                  ]
+                ],
+                "output": "[{\"instrument_id\":\"BTCUSDTPERP\",\"type\":1,\"price\":\"25000\",\"order_type\":0,\"size\":1},{\"instrument_id\":\"BTCUSDTPERP\",\"type\":1,\"price\":\"27000\",\"order_type\":0,\"size\":1}]"
             }
         ],
         "fetchOrders": [
@@ -239,31 +263,5 @@
                 ]
             }
         ]
-    },
-    "disabled": [
-        {
-            "description": "Swap create multiple orders at once",
-            "method": "createOrders",
-            "url": "https://openapi.digifinex.com/swap/v2/trade/batch_order",
-            "input": [
-              [
-                {
-                  "symbol": "BTC/USDT:USDT",
-                  "type": "limit",
-                  "side": "buy",
-                  "amount": 1,
-                  "price": "25000"
-                },
-                {
-                  "symbol": "BTC/USDT:USDT",
-                  "type": "limit",
-                  "side": "buy",
-                  "amount": 1,
-                  "price": "27000"
-                }
-              ]
-            ],
-            "output": "[{\"instrument_id\":\"BTCUSDTPERP\",\"type\":1,\"price\":\"25000\",\"order_type\":0,\"size\":1},{\"instrument_id\":\"BTCUSDTPERP\",\"type\":1,\"price\":\"27000\",\"order_type\":0,\"size\":1}]"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
Fixed a sign error in the python implementation of digifinex createOrders where it was trying to keysort and urlencode an array:
```
python3 examples/py/cli.py digifinex createOrders ['{"symbol":"BTC/USDT:USDT","type":"limit","side":"buy","amount":1,"price":"25000"}','{"symbol":"BTC/USDT:USDT","type":"limit","side":"buy","amount":1,"price":"27000"}']

[{'amount': 1.0,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': {'cost': None},
  'fees': [{'cost': None}],
  'filled': None,
  'id': '1724582308033335296',
  'info': {'amount': 1.0,
           'instrument_id': 'BTCUSDTPERP',
           'order_id': '1724582308033335296',
           'price': 25000.0},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 25000.0,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None},
 {'amount': 1.0,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': {'cost': None},
  'fees': [{'cost': None}],
  'filled': None,
  'id': '1724582308033335297',
  'info': {'amount': 1.0,
           'instrument_id': 'BTCUSDTPERP',
           'order_id': '1724582308033335297',
           'price': 27000.0},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 27000.0,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT:USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```