### PR TITLE
fix(errors) - move `OperationFailed` exception to root

### DIFF
--- a/ts/src/base/errorHierarchy.ts
+++ b/ts/src/base/errorHierarchy.ts
@@ -32,16 +32,17 @@ const errorHierarchy = {
             },
             'NotSupported': {},
         },
-        'NetworkError': {
-            'DDoSProtection': {
-                'RateLimitExceeded': {},
+        'OperationFailed': {
+            'NetworkError': {
+                'DDoSProtection': {
+                    'RateLimitExceeded': {},
+                },
+                'ExchangeNotAvailable': {
+                    'OnMaintenance': {},
+                },
+                'InvalidNonce': {},
+                'RequestTimeout': {},
             },
-            'ExchangeNotAvailable': {
-                'OnMaintenance': {},
-            },
-            'InvalidNonce': {},
-            'RequestTimeout': {},
-            'OperationFailed': {},
         },
     },
 };

--- a/ts/src/base/errors.ts
+++ b/ts/src/base/errors.ts
@@ -246,7 +246,7 @@ class RequestTimeout extends NetworkError {
         this.name = 'RequestTimeout';
     }
 }
-class OperationFailed extends NetworkError {
+class OperationFailed extends BaseError {
     constructor (message) {
         super (message);
         this.name = 'OperationFailed';


### PR DESCRIPTION
so, as we talked in discord, `NetworkError` should have been under `OperationFailed` (this latter should be the root of "exceptions of temporary nature, that can be repeated")


after this PR gets merged, plz review : https://github.com/ccxt/ccxt/pull/19649