### PR TITLE
bitget: remove after when use spot pair (represent order id)

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4998,9 +4998,6 @@ export default class bitget extends Exchange {
                 }
             } else {
                 [ request, params ] = this.handleUntilOption ('before', request, params);
-                if (since !== undefined) {
-                    request['after'] = since;
-                }
                 if (limit !== undefined) {
                     request['limit'] = limit;
                 }


### PR DESCRIPTION
The `after` represents orderId for spot pair (https://bitgetlimited.github.io/apidoc/en/spot/#get-transaction-details). It's might be confused to users.

I think we can remove `after` parameter or clarify in the jsdoc. In this PR, I removed the parameter.

Let me know if you don't want to remove this parameter (we probably use as pagination).