### PR TITLE
Bitmart: parseOrderStatusByType

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2667,6 +2667,7 @@ export default class bitmart extends Exchange {
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of  orde structures to retrieve
          * @param {object} [params] extra parameters specific to the bitmart api endpoint
+         * @param {int} [params.until] timestamp in ms of the latest entry
          * @returns {Order[]} a list of [order structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();
@@ -2686,10 +2687,15 @@ export default class bitmart extends Exchange {
         if (marginMode === 'isolated') {
             request['orderMode'] = 'iso_margin';
         }
-        const until = this.safeInteger2 (params, 'until', 'endTime');
+        const startTimeKey = (type === 'spot') ? 'startTime' : 'start_time';
+        if (since !== undefined) {
+            request[startTimeKey] = since;
+        }
+        const endTimeKey = (type === 'spot') ? 'endTime' : 'end_time';
+        const until = this.safeInteger2 (params, 'until', endTimeKey);
         if (until !== undefined) {
-            params = this.omit (params, [ 'endTime' ]);
-            request['endTime'] = until;
+            params = this.omit (params, [ endTimeKey ]);
+            request[endTimeKey] = until;
         }
         let response = undefined;
         if (type === 'spot') {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2668,6 +2668,7 @@ export default class bitmart extends Exchange {
          * @param {int} [limit] the maximum number of  orde structures to retrieve
          * @param {object} [params] extra parameters specific to the bitmart api endpoint
          * @param {int} [params.until] timestamp in ms of the latest entry
+         * @param {string} [params.marginMode] *spot only* 'cross' or 'isolated', for margin trading
          * @returns {Order[]} a list of [order structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2130,17 +2130,17 @@ export default class bitmart extends Exchange {
     parseOrderStatusByType (type, status) {
         const statusesByType = {
             'spot': {
-                '1': 'failed', // Order failure
+                '1': 'rejected', // Order failure
                 '2': 'open', // Placing order
-                '3': 'failed', // Order failure, Freeze failure
+                '3': 'rejected', // Order failure, Freeze failure
                 '4': 'open', // Order success, Pending for fulfilment
                 '5': 'open', // Partially filled
                 '6': 'closed', // Fully filled
-                '7': 'canceling', // Canceling
+                '7': 'canceled', // Canceling
                 '8': 'canceled', // Canceled
                 'new': 'open',
                 'partially_filled': 'open',
-                'filled': 'filled',
+                'filled': 'closed',
                 'partially_canceled': 'canceled',
             },
             'swap': {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2695,7 +2695,7 @@ export default class bitmart extends Exchange {
         const endTimeKey = (type === 'spot') ? 'endTime' : 'end_time';
         const until = this.safeInteger2 (params, 'until', endTimeKey);
         if (until !== undefined) {
-            params = this.omit (params, [ endTimeKey ]);
+            params = this.omit (params, [ 'until' ]);
             request[endTimeKey] = until;
         }
         let response = undefined;
@@ -2704,7 +2704,7 @@ export default class bitmart extends Exchange {
         } else {
             response = await this.privateGetContractPrivateOrderHistory (this.extend (request, params));
         }
-        const data = this.safeValue (response, 'data');
+        const data = this.safeValue (response, 'data', []);
         return this.parseOrders (data, market, since, limit);
     }
 

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -168,6 +168,16 @@
                     "LTC/USDT"
                 ],
                 "output": "{\"symbol\":\"LTC_USDT\"}"
+            },
+            {
+                "description": "Fetch swap closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://api-cloud.bitmart.com/contract/private/order-history?symbol=LTCUSDT",
+                "input": [
+                  "LTC/USDT:USDT",
+                  null,
+                  1
+                ]
             }
         ],
         "cancelOrder": [

--- a/ts/src/test/static/response/bitmart.json
+++ b/ts/src/test/static/response/bitmart.json
@@ -1,0 +1,168 @@
+{
+  "exchange": "okx",
+  "skipKeys": [],
+  "options": {
+  },
+  "methods": {
+    "fetchClosedOrders": [
+      {
+        "description": "Fetch swap closed orders",
+        "method": "fetchClosedOrders",
+        "input": [
+          "LTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "code": "1000",
+          "message": "Ok",
+          "data": [
+            {
+              "order_id": "231116363679831",
+              "client_order_id": "",
+              "price": "100",
+              "size": "1",
+              "symbol": "LTCUSDT",
+              "state": "4",
+              "side": "4",
+              "type": "limit",
+              "leverage": "1",
+              "open_type": "cross",
+              "deal_avg_price": "0",
+              "deal_size": "0",
+              "create_time": "1699638121672",
+              "update_time": "1699638158472"
+            }
+          ],
+          "trace": "4caf855074664097ac6ba5257c47305d.74.17002156265082169"
+        },
+        "parsedResponse": [
+          {
+            "id": "231116363679831",
+            "clientOrderId": null,
+            "info": {
+              "order_id": "231116363679831",
+              "client_order_id": "",
+              "price": "100",
+              "size": "1",
+              "symbol": "LTCUSDT",
+              "state": "4",
+              "side": "4",
+              "type": "limit",
+              "leverage": "1",
+              "open_type": "cross",
+              "deal_avg_price": "0",
+              "deal_size": "0",
+              "create_time": "1699638121672",
+              "update_time": "1699638158472"
+            },
+            "timestamp": 1699638121672,
+            "datetime": "2023-11-10T17:42:01.672Z",
+            "lastTradeTimestamp": 1699638158472,
+            "symbol": "LTC/USDT:USDT",
+            "type": "limit",
+            "timeInForce": null,
+            "postOnly": null,
+            "side": "sell",
+            "price": 100,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "amount": 1,
+            "cost": 0,
+            "average": null,
+            "filled": 0,
+            "remaining": 1,
+            "status": "closed",
+            "fee": null,
+            "trades": [],
+            "fees": [],
+            "lastUpdateTimestamp": null,
+            "reduceOnly": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      },
+      {
+        "description": "Spot closed order",
+        "method": "fetchClosedOrders",
+        "input": [
+          "LTC/USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "code": "1000",
+          "message": "success",
+          "data": [
+            {
+              "orderId": "201060879563236943",
+              "clientOrderId": "201060879563236943",
+              "symbol": "LTC_USDT",
+              "side": "sell",
+              "orderMode": "spot",
+              "type": "market",
+              "state": "filled",
+              "price": "0.0000",
+              "priceAvg": "71.0566",
+              "size": "0.100",
+              "filledSize": "0.100",
+              "notional": "0.00000000",
+              "filledNotional": "7.10566000",
+              "createTime": "1700215845644",
+              "updateTime": "1700215845697"
+            }
+          ],
+          "trace": "f3786e6984b742a8b357ea2377e9883f.59.17002158518723115"
+        },
+        "parsedResponse": [
+          {
+            "id": "201060879563236943",
+            "clientOrderId": null,
+            "info": {
+              "orderId": "201060879563236943",
+              "clientOrderId": "201060879563236943",
+              "symbol": "LTC_USDT",
+              "side": "sell",
+              "orderMode": "spot",
+              "type": "market",
+              "state": "filled",
+              "price": "0.0000",
+              "priceAvg": "71.0566",
+              "size": "0.100",
+              "filledSize": "0.100",
+              "notional": "0.00000000",
+              "filledNotional": "7.10566000",
+              "createTime": "1700215845644",
+              "updateTime": "1700215845697"
+            },
+            "timestamp": 1700215845644,
+            "datetime": "2023-11-17T10:10:45.644Z",
+            "lastTradeTimestamp": null,
+            "symbol": "LTC/USDT",
+            "type": "market",
+            "timeInForce": "IOC",
+            "postOnly": null,
+            "side": "sell",
+            "price": 71.0566,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "amount": 0.1,
+            "cost": 7.10566,
+            "average": 71.0566,
+            "filled": 0.1,
+            "remaining": 0,
+            "status": "closed",
+            "fee": null,
+            "trades": [],
+            "fees": [],
+            "lastUpdateTimestamp": null,
+            "reduceOnly": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
fixes: #20005
Edited `parseOrderStatusByType` so that filled spot orders return `closed`