### PR TITLE
fix(cli): fix cli.js and cli.ts for parsing large numbers

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -264,8 +264,11 @@ async function run () {
     } else {
 
         let args = params
-            .map (s => s.match (/^[0-9]{4}[-]?[0-9]{2}[-]?[0-9]{2}[T\s]?[0-9]{2}[:]?[0-9]{2}[:]?[0-9]{2}/g) ? exchange.parse8601 (s) : s)
-            .map (s => (() => { try { return eval ('(() => (' + s + ')) ()') } catch (e) { return s } }) ())
+            .map (s => s.match (/^[0-9]{4}[-][0-9]{2}[-][0-9]{2}[T\s]?[0-9]{2}[:][0-9]{2}[:][0-9]{2}/g) ? exchange.parse8601 (s) : s)
+            .map (s => (() => { 
+                if (s.match ( /^\d+$/g)) return s
+                try {return eval ('(() => (' + s + ')) ()') } catch (e) { return s }
+            }) ())
 
         const www = Array.isArray (exchange.urls.www) ? exchange.urls.www[0] : exchange.urls.www
 

--- a/examples/ts/cli.ts
+++ b/examples/ts/cli.ts
@@ -244,8 +244,11 @@ async function run () {
     } else {
 
         let args = params
-            .map (s => s.match (/^[0-9]{4}[-]?[0-9]{2}[-]?[0-9]{2}[T\s]?[0-9]{2}[:]?[0-9]{2}[:]?[0-9]{2}/g) ? exchange.parse8601 (s) : s)
-            .map (s => (() => { try { return eval ('(() => (' + s + ')) ()') } catch (e) { return s } }) ())
+            .map (s => s.match (/^[0-9]{4}[-][0-9]{2}[-][0-9]{2}[T\s]?[0-9]{2}[:][0-9]{2}[:][0-9]{2}/g) ? exchange.parse8601 (s) : s)
+            .map (s => (() => { 
+                if (s.match ( /^\d+$/g)) return s
+                try {return eval ('(() => (' + s + ')) ()') } catch (e) { return s }
+            }) ())
 
         const www = Array.isArray (exchange.urls.www) ? exchange.urls.www[0] : exchange.urls.www
 


### PR DESCRIPTION
### Problem
When passing large numbers in the cli it was parsing to undefined:
For example: ` j cryptocom fetchOrder 6142909896902261394 XRP/USDT`

### Solution
- Change date regex to require dash and colons, as the `exchange.parse8601` requires them
- If it's a single number return it as is, as the eval was failing for very large numbers and rounding them off.
