### PR TITLE
Okx: createOrder, postOnly, stopLoss and takeProfit

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2621,7 +2621,8 @@ export default class okx extends Exchange {
             request['ordType'] = 'ioc';
         } else if (fok) {
             request['ordType'] = 'fok';
-        } else if (stopLossDefined || takeProfitDefined) {
+        }
+        if (stopLossDefined || takeProfitDefined) {
             if (stopLossDefined) {
                 const stopLossTriggerPrice = this.safeValueN (stopLoss, [ 'triggerPrice', 'stopPrice', 'slTriggerPx' ]);
                 if (stopLossTriggerPrice === undefined) {

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -182,6 +182,29 @@
               }
             ],
             "output": "[{\"instId\":\"BTC-USD-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"25000\",\"clOrdId\":\"e847386590ce4dBC9febcde144e6b64b\",\"tag\":\"e847386590ce4dBC\",\"posSide\":\"net\"}]"
+          },
+          {
+            "description": "Create a swap postOnly limit order with tp + sl attached (type 3)",
+            "method": "createOrder",
+            "url": "https://www.okx.com/api/v5/trade/batch-orders",
+            "input": [
+              "BTC/USDT:USDT",
+              "limit",
+              "buy",
+              1,
+              25000,
+              {
+                "posSide": "long",
+                "postOnly": true,
+                "stopLoss": {
+                  "triggerPrice": 24000
+                },
+                "takeProfit": {
+                  "triggerPrice": 26000
+                }
+              }
+            ],
+            "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"post_only\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"25000\",\"slTriggerPx\":\"24000\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"tpTriggerPx\":\"26000\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\",\"clOrdId\":\"e847386590ce4dBC6798012df444b042\",\"tag\":\"e847386590ce4dBC\",\"posSide\":\"long\"}]"
           }
         ],
         "createOrders": [


### PR DESCRIPTION
Edited okx so postOnly orders can be created with attached stopLoss and takeProfits:
```
okx createOrder BTC/USDT:USDT limit buy 1 25000 '{"posSide":"long","postOnly":true,"stopLoss":{"triggerPrice":24000},"takeProfit":{"triggerPrice":26000}}'

{
  info: {
    clOrdId: 'e847386590ce4dBC6798012df444b042',
    ordId: '645574008498380800',
    sCode: '0',
    sMsg: 'Order placed',
    tag: 'e847386590ce4dBC'
  },
  id: '645574008498380800',
  clientOrderId: 'e847386590ce4dBC6798012df444b042',
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  side: 'buy',
  trades: [],
  reduceOnly: false,
  fees: []
}
```
```
okx.fetchOrder (645574008498380800, BTC/USDT:USDT)
2023-11-17T03:00:55.139Z iteration 0 passed in 391 ms

{
  info: {
    accFillSz: '0',
    algoClOrdId: '',
    algoId: '',
    attachAlgoClOrdId: '',
    attachAlgoOrds: [],
    avgPx: '',
    cTime: '1700188837811',
    cancelSource: '',
    cancelSourceReason: '',
    category: 'normal',
    ccy: '',
    clOrdId: 'e847386590ce4dBC6798012df444b042',
    fee: '0',
    feeCcy: 'USDT',
    fillPx: '',
    fillSz: '0',
    fillTime: '',
    instId: 'BTC-USDT-SWAP',
    instType: 'SWAP',
    lever: '3',
    ordId: '645574008498380800',
    ordType: 'post_only',
    pnl: '0',
    posSide: 'long',
    px: '25000',
    pxType: '',
    pxUsd: '',
    pxVol: '',
    quickMgnType: '',
    rebate: '0',
    rebateCcy: 'USDT',
    reduceOnly: 'false',
    side: 'buy',
    slOrdPx: '-1',
    slTriggerPx: '24000',
    slTriggerPxType: 'last',
    source: '',
    state: 'live',
    stpId: '',
    stpMode: '',
    sz: '1',
    tag: 'e847386590ce4dBC',
    tdMode: 'cross',
    tgtCcy: '',
    tpOrdPx: '-1',
    tpTriggerPx: '26000',
    tpTriggerPxType: 'last',
    tradeId: '',
    uTime: '1700188837811'
  },
  id: '645574008498380800',
  clientOrderId: 'e847386590ce4dBC6798012df444b042',
  timestamp: 1700188837811,
  datetime: '2023-11-17T02:40:37.811Z',
  lastUpdateTimestamp: 1700188837811,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: 'PO',
  postOnly: true,
  side: 'buy',
  price: 25000,
  stopLossPrice: 24000,
  takeProfitPrice: 26000,
  cost: 0,
  amount: 1,
  filled: 0,
  remaining: 1,
  status: 'open',
  fee: { cost: 0, currency: 'USDT' },
  trades: [],
  reduceOnly: false,
  fees: [ { cost: 0, currency: 'USDT' } ]
}
```