### PR TITLE
Bitmart: adjusted some ratelimit weights

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -30,7 +30,7 @@ export default class bitmart extends Exchange {
                 'CORS': undefined,
                 'spot': true,
                 'margin': true,
-                'swap': undefined, // has but unimplemented
+                'swap': true,
                 'future': false,
                 'option': undefined,
                 'borrowMargin': true,

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -134,7 +134,7 @@ export default class bitmart extends Exchange {
                         'spot/quotation/v3/books': 4, // 15 times/2 sec = 7.5/s => 30/7.5 = 4
                         'spot/quotation/v3/trades': 4, // 15 times/2 sec = 7.5/s => 30/7.5 = 4
                         'spot/v1/ticker': 5,
-                        'spot/v2/ticker': 5,
+                        'spot/v2/ticker': 30,
                         'spot/v1/ticker_detail': 5, // 12 times/2 sec = 6/s => 30/6 = 5
                         'spot/v1/steps': 30,
                         'spot/v1/symbols/kline': 5,
@@ -179,10 +179,10 @@ export default class bitmart extends Exchange {
                         // margin
                         'spot/v1/margin/isolated/borrow_record': 1,
                         'spot/v1/margin/isolated/repay_record': 1,
-                        'spot/v1/margin/isolated/pairs': 1,
-                        'spot/v1/margin/isolated/account': 6,
-                        'spot/v1/trade_fee': 6,
-                        'spot/v1/user_fee': 6,
+                        'spot/v1/margin/isolated/pairs': 30,
+                        'spot/v1/margin/isolated/account': 5,
+                        'spot/v1/trade_fee': 30,
+                        'spot/v1/user_fee': 30,
                         // broker
                         'spot/v1/broker/rebate': 1,
                         // contract
@@ -222,9 +222,9 @@ export default class bitmart extends Exchange {
                         'spot/v2/submit_order': 1,
                         // margin
                         'spot/v1/margin/submit_order': 1,
-                        'spot/v1/margin/isolated/borrow': 6,
-                        'spot/v1/margin/isolated/repay': 6,
-                        'spot/v1/margin/isolated/transfer': 6,
+                        'spot/v1/margin/isolated/borrow': 30,
+                        'spot/v1/margin/isolated/repay': 30,
+                        'spot/v1/margin/isolated/transfer': 30,
                         // contract
                         'account/v1/transfer-contract-list': 60,
                         'account/v1/transfer-contract': 60,

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -32,7 +32,7 @@ export default class bitmart extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': false,
-                'option': undefined,
+                'option': false,
                 'borrowMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,


### PR DESCRIPTION
Adjusted some ratelimit weights using the formula:
requests-per-second = 1000ms / ( rateLimit * weight)

### common weights:
rateLimit = 33.34
60 = 0.5 rps
30 = 1 rps
15 = 2 rps
10 = 3 rps
7.5 = 4 rps
6 = 5 rps
5 = 6 rps
4 = 7.5 rps
3 = 10 rps
2.5 = 12 rps
1.5 = 20 rps
1.2 = 25 rps
1 = 30 rps

### resources:
https://developer-pro.bitmart.com/en/spot/#rate-limit-2
https://developer-pro.bitmart.com/en/futures/#rate-limit

### fetchOHLCV tests:
```
spot fetchOHLCV endpoint: publicGetSpotQuotationV3Klines weight = 6, 5 requests-per-second

'X-Bm-Ratelimit-Remaining': '1',
'X-Bm-Ratelimit-Limit': '10',
'X-Bm-Ratelimit-Reset': '2',

Can be called 10 times in 2 seconds, currently has been called 1 time
```
```
contract fetchOHLCV endpoint: publicGetContractPublicKline weight = 5, 6 requests-per-second

'X-Bm-Ratelimit-Remaining': '1',
'X-Bm-Ratelimit-Limit': '12',
'X-Bm-Ratelimit-Reset': '2',

Can be called 12 times in 2 seconds, currently has been called 1 time
```