### PR TITLE
fix(Client.ts): fix error code for browser websocket close

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -1,4 +1,4 @@
-import { RequestTimeout, NetworkError ,NotSupported, BaseError } from '../../base/errors.js';
+import { RequestTimeout, NetworkError, NotSupported, BaseError } from '../../base/errors.js';
 import { inflateSync, gunzipSync } from '../../static_dependencies/fflake/browser.js';
 import { Future, createFuture } from './Future.js';
 
@@ -142,7 +142,7 @@ export default class Client {
         if (!this.isOpen ()) {
             const error = new RequestTimeout ('Connection to ' + this.url + ' failed due to a connection timeout')
             this.onError (error)
-            this.connection.close (1006)
+            this.connection.close (isNode ? 1006 : 1000)
         }
     }
 


### PR DESCRIPTION
Testing ccxt on the browser I found browser websocket does not allow for code 1006. Must be code 1000 or in the range 3000-4999

https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close