### PR TITLE
container: replace python3 setup with pip3 install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN npm install
 RUN ln -s /ccxt /usr/lib/node_modules/
 RUN echo "export NODE_PATH=/usr/lib/node_modules" >> $HOME/.bashrc
 RUN cd python \
-    && python3 setup.py develop \
+    && pip3 install -e . \
     && cd ..
 ## Install composer and everything else that it needs and manages
 RUN /ccxt/composer-install.sh


### PR DESCRIPTION
I can't build docker container with python3 setup. This issue is fixed in this PR.

BTW, the size of builded image is over 1GB, I'll switch to alpine linux and see whether the size is smaller (ccxt/ccxt#20059).