### PR TITLE
docs: group api spec by method

### DIFF
--- a/jsdoc2md.js
+++ b/jsdoc2md.js
@@ -78,6 +78,8 @@ const groupedByMethod = templateData.reduce((acc, arr) => {
 }, {});
 
 const templateDataGroupedByMethod = Object.values(groupedByMethod).sort((a, b) =>a[0].name < b[0].name ? -1 : 1)
+console.log (templateDataGroupedByMethod)
+
 
 const outputs = await Promise.all (templateDataGroupedByMethod.map (data => jsdoc2md.render ({ template, data, partial, helper})))
 
@@ -92,15 +94,6 @@ for (const char of alphabet) {
         index[char] = functions[++i]
     } while (char > functions[i])
 }
-
-// add a glossary 🧐
-const result = []
-for (const char of alphabet) {
-    result.push (`[${char}](#${index[char]})`)
-}
-const markdown = '## glossary\n' + result.join (' ') + '\n'
-outputs.unshift (markdown)
-outputs.push (markdown)
 
 fs.writeFileSync (outputFile, outputs.join ('\n---\n'))
 console.log ('📰 finished rendering docs! 🙌 😶‍🌫')

--- a/jsdoc2md.js
+++ b/jsdoc2md.js
@@ -53,22 +53,45 @@ proTemplateData.forEach((proData) => {
 
 console.log ('📰 rendering docs for each exchange...')
 const template = fs.readFileSync ('./wiki/spec.hbs', 'utf8')
-const outputs = await Promise.all (templateData.map (data => jsdoc2md.render ({ template, data, partial, helper })))
 
-console.log ('📰 creating index of exchange classes')
-const classes = templateData.map (data => data[0].id).sort ()
+// Group docs by method
+const groupedByMethod = templateData.reduce((acc, arr) => {
+  arr.filter(obj => obj.kind === 'function' && !obj.ignore).forEach(obj => {
+    const method = obj.name;
+    if (!acc[method]) {
+      acc[method] = [{
+        id: method,
+        longname: method,
+        name: method,
+        kind: "",
+        scope: "instance",
+        description: obj.description,
+        params: obj.params,
+        returns: obj.returns,
+      }];
+    }
+    obj.exchange = obj.memberof
+    obj.memberof = method
+    acc[method].push(obj);
+  });
+  return acc;
+}, {});
+
+const templateDataGroupedByMethod = Object.values(groupedByMethod).sort((a, b) =>a[0].name < b[0].name ? -1 : 1)
+
+const outputs = await Promise.all (templateDataGroupedByMethod.map (data => jsdoc2md.render ({ template, data, partial, helper})))
+
+console.log ('📰 creating index of exchange functions')
+const functions = Object.keys(groupedByMethod).sort ()
 const alphabet = Array.from ( Array (26)).map((e, i) => String.fromCharCode(i + 97));
 
 const index = {}
 let i = -1
 for (const char of alphabet) {
     do {
-        index[char] = classes[++i]
-    } while (char > classes[i])
+        index[char] = functions[++i]
+    } while (char > functions[i])
 }
-index.b = 'binance'
-index.o = 'okx'
-index.h = 'huobi'
 
 // add a glossary 🧐
 const result = []

--- a/wiki/helpers.cjs
+++ b/wiki/helpers.cjs
@@ -6,12 +6,13 @@ exports.getFragment = function (func) {
     // this function allows for links with the same name
     // and caches the link so we can regenerate the same id
     const { id, name, exchange } = func
-    const lower = (exchange + name).toLowerCase ()
-    if (!(id in cache)) {
+    const selector = exchange ? exchange : name
+    const lower = selector.toLowerCase ()
+    if (exchange && !(id in cache)) {
         cache[lower] = cache[lower] || 0
         cache[id] = cache[lower]++
     }
-    const part = (cache[id] > 1) ? '-' + cache[id] : ''
+    const part = (cache[id] >= 1) ? '-' + cache[id] : ''
     return lower + part
 }
 

--- a/wiki/helpers.cjs
+++ b/wiki/helpers.cjs
@@ -5,8 +5,8 @@ const cache = {}
 exports.getFragment = function (func) {
     // this function allows for links with the same name
     // and caches the link so we can regenerate the same id
-    const { id, name } = func
-    const lower = name.toLowerCase ()
+    const { id, name, exchange } = func
+    const lower = (exchange + name).toLowerCase ()
     if (!(id in cache)) {
         cache[lower] = cache[lower] || 0
         cache[id] = cache[lower]++

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -43,6 +43,7 @@
         subMaxLevel: 3,
         coverpage: false,
         onlyCover: false,
+        sidebarDisplayLevel: 1,
       };
     </script>
     <!-- Docsify v4 -->
@@ -54,5 +55,6 @@
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-php.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-python.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
   </body>
 </html>

--- a/wiki/partials/docs.hbs
+++ b/wiki/partials/docs.hbs
@@ -1,5 +1,6 @@
 {{>header~}}
 {{>body}}
+##### Supported exchanges
 {{>member-index-list~}}
 {{>separator~}}
 {{>members~}}

--- a/wiki/partials/header.hbs
+++ b/wiki/partials/header.hbs
@@ -1,5 +1,9 @@
 
-<a name={{name}} id="{{getFragment this}}"></a>
+<a name="{{name}}" id="{{getFragment this}}"></a>
 
+{{#if exchange}}
+{{>heading-indent}}{{exchange}} - {{name}}
+{{else}}
 {{>heading-indent}}{{name}}
+{{/if~}}
 

--- a/wiki/partials/header.hbs
+++ b/wiki/partials/header.hbs
@@ -2,7 +2,7 @@
 <a name="{{name}}" id="{{getFragment this}}"></a>
 
 {{#if exchange}}
-{{>heading-indent}}{{exchange}} - {{name}}
+{{>heading-indent}}{{exchange}}
 {{else}}
 {{>heading-indent}}{{name}}
 {{/if~}}

--- a/wiki/partials/member-index-list.hbs
+++ b/wiki/partials/member-index-list.hbs
@@ -1,5 +1,5 @@
 {{#if (isFunction this)}}
-* [{{name}}](#{{getFragment this}})
+* [{{exchange}}](#{{getFragment this}})
 {{/if}}
 {{#indexChildren ~}}
 {{>member-index-list~}}

--- a/wiki/partials/members.hbs
+++ b/wiki/partials/members.hbs
@@ -3,7 +3,7 @@
 {{>body}}
 
 ```javascript
-{{memberof}}.{{name}} ({{methodSig this}})
+{{exchange}}.{{name}} ({{methodSig this}})
 ```
 
 {{/children~}}


### PR DESCRIPTION
- Group api spec by methods
- Show list of supported exchanges by method
- Add collapsible menu plugin to make navigation easier
- Note: I tried to add the tabs plugin to show several languages on the spec but it would crash the browser
- Note: for the general description of the method it currently uses the jsdoc of the first exchange in the list, in the future it would proably be good to add jsdocs to exchange.ts to have a more general one