### PR TITLE
fix(bybitWs): watchTickers

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -1722,7 +1722,7 @@ export default class bybit extends bybitRest {
             'args': topics,
         };
         const message = this.extend (request, params);
-        return await this.watch (url, messageHash, message, subscriptionHash);
+        return await this.watch (url, messageHash, message, messageHash, subscriptionHash);
     }
 
     async authenticate (url, params = {}) {


### PR DESCRIPTION
- I think the watchPositions PR broke it accidentally `
```
 p bybit watchTickers '["BTC/USDT:USDT", "ETH/USDT:USDT"]' --sandbox
Python v3.11.5
CCXT v4.1.60
bybit.watchTickers(['BTC/USDT:USDT', 'ETH/USDT:USDT'])
{'ask': 36672.4,
 'askVolume': 64.052,
 'average': 37009.4,
 'baseVolume': 130295.069,
 'bid': 36671.4,
 'bidVolume': 186.537,
 'change': -674.0,
 'close': 36672.4,
 'datetime': '2023-11-22T09:54:33.221Z',
 'high': None,
 'info': {'ask1Price': '36672.40',
          'ask1Size': '64.052',
          'bid1Price': '36671.40',
          'bid1Size': '186.537',
          'fundingRate': '0.0001',
          'highPrice24h': '39972.60',
          'indexPrice': '36673.74',
          'lastPrice': '36672.40',
          'lowPrice24h': '34000.00',
          'markPrice': '36671.40',
          'nextFundingTime': '1700668800000',
          'openInterest': '147298.928',
          'openInterestValue': '5401657908.26',
          'prevPrice1h': '36553.10',
          'prevPrice24h': '37346.40',
          'price24hPcnt': '-0.018047',
          'symbol': 'BTCUSDT',
          'tickDirection': 'PlusTick',
          'turnover24h': '4734684340.3137',
          'volume24h': '130295.0690'},
 'last': 36672.4,
 'low': 34000.0,
 'open': 37346.4,
 'percentage': -1.8047,
 'previousClose': None,
 'quoteVolume': 4734684340.3137,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1700646873221,
 'vwap': 36338.169791473076}
{'ask': 36672.4,
 'askVolume': 64.052,
 'average': 37009.4,
 'baseVolume': 130295.069,
 'bid': 36671.4,
 'bidVolume': 186.537,
 'change': -674.0,
 'close': 36672.4,
 'datetime': '2023-11-22T09:54:33.920Z',
 'high': None,
 'info': {'ask1Price': '36672.40',
          'ask1Size': '64.052',
          'bid1Price': '36671.40',
          'bid1Size': '186.537',
          'fundingRate': '0.0001',
          'highPrice24h': '39972.60',
          'indexPrice': '36673.86',
          'lastPrice': '36672.40',
          'lowPrice24h': '34000.00',
          'markPrice': '36672.40',
          'nextFundingTime': '1700668800000',
          'openInterest': '147298.928',
          'openInterestValue': '5401805207.19',
          'prevPrice1h': '36553.10',
          'prevPrice24h': '37346.40',
          'price24hPcnt': '-0.018047',
          'symbol': 'BTCUSDT',
          'tickDirection': 'PlusTick',
          'turnover24h': '4734684340.3137',
          'volume24h': '130295.0690'},
 'last': 36672.4,
 'low': 34000.0,
 'open': 37346.4,
 'percentage': -1.8047,
 'previousClose': None,
 'quoteVolume': 4734684340.3137,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1700646873920,
 'vwap': 36338.169791473076}
{'ask': 36672.4,
```

```
 p bybit watchPositions --sandbox                                   
Python v3.11.5
CCXT v4.1.60
bybit.watchPositions()
[{'info': {'symbol': 'TRXUSDT', 'leverage': '10', 'autoAddMargin': '0', 'avgPrice': '0.09811', 'liqPrice': '', 'riskLimitValue': '100000', 'takeProfit': '1', 'positionValue': '0.19622', 'isReduceOnly': False, 'tpslMode': 'Full', 'riskId': '311', 'trailingStop': '0', 'unrealisedPnl': '-0.00052', 'markPrice': '0.09785', 'adlRankIndicator': '2', 'cumRealisedPnl': '-0.00106745', 'positionMM': '0.00402153', 'createdTime': '1699285678250', 'positionIdx': '0', 'positionIM': '0.01971913', 'seq': '19607167106', 'updatedTime': '1700640000031', 'side': 'Buy', 'bustPrice': '', 'positionBalance': '0.01971913', 'leverageSysUpdatedTime': '', 'size': '2', 'positionStatus': 'Normal', 'mmrSysUpdatedTime': '', 'stopLoss': '0.04', 'tradeMode': '0', 'nextPageCursor': 'LTCUSDT%2C1700640000011%2C0'}, 'id': None, 'symbol': 'TRX/USDT:USDT', 'timestamp': 1700640000031, 'datetime': '2023-11-22T08:00:00.031Z', 'lastUpdateTimestamp': None, 'initialMargin': 0.01971913, 'initialMarginPercentage': 0.10049500560595251, 'maintenanceMargin': 0.00402153, 'maintenanceMarginPercentage': 0.020495005605952504, 'entryPrice': 0.09811, 'notional': 0.19622, 'leverage': 10.0, 'unrealizedPnl': -0.00052, 'contracts': 2.0, 'contractSize': 1.0, 'marginRatio': 0.2039, 'liquidationPrice': None, 'markPrice': 0.09785, 'lastPrice': None, 'collateral': 0.01971913, 'marginMode': 'cross', 'side': 'long', 'percentage': None, 'stopLossPrice': 0.04, 'takeProfitPrice': 1.0}, {'info': {'symbol': 'LTCUSDT', 'leverage': '6', 'autoAddMargin': '0', 'avgPrice': '64.59947917', 'liqPrice': '', 'riskLimitValue': '200000', 'takeProfit': '', 'positionValue': '77.519375', 'isReduceOnly': False, 'tpslMode': 'Full', 'riskId': '71', 'trailingStop': '0', 'unrealisedPnl': '3.900625', 'markPrice': '67.85', 'adlRankIndicator': '2', 'cumRealisedPnl': '-52.07293808', 'positionMM': '0.81072399', 'createdTime': '1677168085779', 'positionIdx': '0', 'positionIM': '12.95542633', 'seq': '15441364825', 'updatedTime': '1700640000011', 'side': 'Buy', 'bustPrice': '', 'positionBalance': '11.699649', 'leverageSysUpdatedTime': '', 'size': '1.2', 'positionStatus': 'Normal', 'mmrSysUpdatedTime': '1698293363950', 'stopLoss': '', 'tradeMode': '0'}, 'id': None, 'symbol': 'LTC/USDT:USDT', 'timestamp': 1700640000011, 'datetime': '2023-11-22T08:00:00.011Z', 'lastUpdateTimestamp': None, 'initialMargin': 12.95542633, 'initialMarginPercentage': 0.16712501010231312, 'maintenanceMargin': 0.81072399, 'maintenanceMarginPercentage': 0.010458340124646257, 'entryPrice': 64.59947917, 'notional': 77.519375, 'leverage': 6.0, 'unrealizedPnl': 3.900625, 'contracts': 1.2, 'contractSize': 1.0, 'marginRatio': 0.0692, 'liquidationPrice': None, 'markPrice': 67.85, 'lastPrice': None, 'collateral': 11.699649, 'marginMode': 'cross', 'side': 'long', 'percentage': None, 'stopLossPrice': None, 'takeProfitPrice': None}]
```

