### PR TITLE
kraken: update doc

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5594,7 +5594,7 @@ Some exchanges allow you to specify optional parameters for your order. You can 
 
    # Python
    # add a custom order flag
-   kraken.create_market_buy_order('BTC/USD', 1, {'trading_agreement': 'agree'})
+   kraken.create_market_buy_order('BTC/USD', 1, {'validate': true})
 
 .. code-block:: PHP
 

--- a/doc/readme.rst
+++ b/doc/readme.rst
@@ -2067,7 +2067,7 @@ Python
    print(exmo.id, exmo.create_limit_buy_order('BTC/EUR', 1, 2500.00))
 
    # pass/redefine custom exchange-specific order params: type, amount, price, flags, etc...
-   kraken.create_market_buy_order('BTC/USD', 1, {'trading_agreement': 'agree'})
+   kraken.create_market_buy_order('BTC/USD', 1, {'validate': true})
 
 PHP
 ^^^

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1545,8 +1545,8 @@ export default class kraken extends Exchange {
         //
         //     market
         //     limit (price = limit price)
-        //     stop-loss (price = stop loss price)
-        //     take-profit (price = take profit price)
+        //     stop-loss (price = stop loss trigger price)
+        //     take-profit (price = take profit trigger price)
         //     stop-loss-limit (price = stop loss trigger price, price2 = triggered limit price)
         //     take-profit-limit (price = take profit trigger price, price2 = triggered limit price)
         //     settle-position
@@ -1812,6 +1812,15 @@ export default class kraken extends Exchange {
     }
 
     async fetchOrdersByIds (ids, symbol: Str = undefined, params = {}) {
+        /**
+         * @method
+         * @name kraken#fetchOrdersByIds
+         * @description fetch orders by the list of order id
+         * @see https://docs.kraken.com/rest/#tag/Account-Data/operation/getClosedOrders
+         * @param {string[]|undefined} ids list of order id
+         * @param {object} [params] extra parameters specific to the kraken api endpoint
+         * @returns {object[]} a list of [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
         await this.loadMarkets ();
         const response = await this.privatePostQueryOrders (this.extend ({
             'trades': true, // whether or not to include trades in output (optional, default false)
@@ -2320,6 +2329,15 @@ export default class kraken extends Exchange {
     }
 
     async fetchDepositMethods (code: string, params = {}) {
+        /**
+         * @method
+         * @name kraken#fetchDepositMethods
+         * @description fetch deposit methods for a currency associated with this account
+         * @see https://docs.kraken.com/rest/#tag/Funding/operation/getDepositMethods
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the kraken api endpoint
+         * @returns {object} of deposit methods 
+         */
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2336,7 +2336,7 @@ export default class kraken extends Exchange {
          * @see https://docs.kraken.com/rest/#tag/Funding/operation/getDepositMethods
          * @param {string} code unified currency code
          * @param {object} [params] extra parameters specific to the kraken api endpoint
-         * @returns {object} of deposit methods 
+         * @returns {object} of deposit methods
          */
         await this.loadMarkets ();
         const currency = this.currency (code);


### PR DESCRIPTION
There is no `trading_agreement` in kraken documentation, I replaced with `validate`. BTW, we still have 3 places used `trading_agreement`, should I replace them?