### PR TITLE
fix(bybit): tickers handling

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2100,7 +2100,6 @@ export default class bybit extends Exchange {
             // 'expDate': '', Expiry date. e.g., 25DEC22. For option only
         };
         let type = undefined;
-        const isTypeInParams = ('type' in params);
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         if (type === 'spot') {
             request['category'] = 'spot';
@@ -2152,24 +2151,7 @@ export default class bybit extends Exchange {
         //
         const result = this.safeValue (response, 'result', {});
         const tickerList = this.safeValue (result, 'list', []);
-        const tickers = {};
-        if (market === undefined && isTypeInParams) {
-            // create a "fake" market for the type
-            market = {
-                'type': (type === 'swap' || type === 'future') ? 'swap' : type,
-            };
-        }
-        for (let i = 0; i < tickerList.length; i++) {
-            const ticker = this.parseTicker (tickerList[i], market);
-            const symbol = ticker['symbol'];
-            // this is needed because bybit returns
-            // futures with type = swap
-            const marketInner = this.market (symbol);
-            if (marketInner['type'] === type) {
-                tickers[symbol] = ticker;
-            }
-        }
-        return this.filterByArrayTickers (tickers, 'symbol', symbols);
+        return this.parseTickers (tickerList, symbols);
     }
 
     parseOHLCV (ohlcv, market: Market = undefined): OHLCV {

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2100,7 +2100,12 @@ export default class bybit extends Exchange {
                 const symbol = symbols[i];
                 // using safeMarket here because if the user provides for instance BTCUSDT and "type": "spot" in params we should
                 // infer the market type from the type provided and not from the conflicting id (BTCUSDT might be swap or spot)
-                market = this.safeMarket (symbol, undefined, undefined, defaultType);
+                const isExchangeSpecificSymbol = (symbol.indexOf ('/') === -1);
+                if (isExchangeSpecificSymbol) {
+                    market = this.safeMarket (symbol, undefined, undefined, defaultType);
+                } else {
+                    market = this.market (symbol);
+                }
                 if (currentType === undefined) {
                     currentType = market['type'];
                 } else if (market['type'] !== currentType) {

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -464,6 +464,31 @@
                 ],
                 "output": "{\"setMarginMode\":\"REGULAR_MARGIN\"}"
             }
+        ],
+        "fetchTickers": [
+            {
+                "description": "Conflicting id with type in params",
+                "method": "fetchTickers",
+                "url": "https://api-testnet.bybit.com/v5/market/tickers?category=spot",
+                "input": [
+                  [
+                    "BTCUSDT"
+                  ],
+                  {
+                    "type": "spot"
+                  }
+                ]
+            },
+            {
+                "description": "Default conflicting id to swap",
+                "method": "fetchTickers",
+                "url": "https://api-testnet.bybit.com/v5/market/tickers?category=linear",
+                "input": [
+                  [
+                    "BTCUSDT"
+                  ]
+                ]
+            }
         ]
     },
     "disabled": []


### PR DESCRIPTION

```
 p bybit fetchTickers '["BTCUSDT"]' '{"type":"spot"}' --sandbox
Python v3.11.5
CCXT v4.1.64
bybit.fetchTickers(['BTCUSDT'],{'type': 'spot'})
{'BTC/USDT': {'ask': 30386.01,
              'askVolume': 0.000797,
              'average': 30441.93,
              'baseVolume': 891.881201,
              'bid': 30383.95,
              'bidVolume': 0.002604,
              'change': -112.14,
              'close': 30385.86,
              'datetime': None,
              'high': None,
              'info': {'ask1Price': '30386.01',
                       'ask1Size': '0.000797',
                       'bid1Price': '30383.95',
                       'bid1Size': '0.002604',
                       'highPrice24h': '30857.96',
                       'lastPrice': '30385.86',
                       'lowPrice24h': '29200',
                       'prevPrice24h': '30498',
                       'price24hPcnt': '-0.0037',
                       'symbol': 'BTCUSDT',
                       'turnover24h': '26574289.85487386',
                       'usdIndexPrice': '37840.991799875408',
                       'volume24h': '891.881201'},
              'last': 30385.86,
              'low': 29200.0,
              'open': 30498.0,
              'percentage': -0.37,
              'previousClose': None,
              'quoteVolume': 26574289.85487386,
              'symbol': 'BTC/USDT',
              'timestamp': None,
              'vwap': 29795.773052597237}}
```
```
n bybit fetchTickers '["BTCUSDT"]'  --sandbox --report
Debugger attached.
2023-11-24T17:47:32.191Z
Node.js: v18.18.0
CCXT v4.1.64
bybit.fetchTickers (BTCUSDT)
2023-11-24T17:47:37.461Z iteration 0 passed in 3000 ms

{
  'BTC/USDT:USDT': {
    symbol: 'BTC/USDT:USDT',
    low: 37155.8,
    bid: 37863.1,
    bidVolume: 165.775,
    ask: 37864.2,
    askVolume: 164.262,
    vwap: 37710.14260463347,
    open: 37205.8,
    close: 37864.2,
    last: 37864.2,
    change: 658.4,
    percentage: 1.7696,
    average: 37535,
    baseVolume: 34998.076,
    quoteVolume: 1319782436.8478,
    info: {
      symbol: 'BTCUSDT',
      lastPrice: '37864.20',
      indexPrice: '37864.52',
      markPrice: '37863.10',
      prevPrice24h: '37205.80',
      price24hPcnt: '0.017696',
      highPrice24h: '38422.00',
      lowPrice24h: '37155.80',
      prevPrice1h: '37872.90',
      openInterest: '178934.97',
      openInterestValue: '6775032662.61',
      turnover24h: '1319782436.8478',
      volume24h: '34998.0760',
      fundingRate: '0.0001',
      nextFundingTime: '1700870400000',
      predictedDeliveryPrice: '',
      basisRate: '',
      deliveryFeeRate: '',
      deliveryTime: '0',
      ask1Size: '164.262',
      bid1Price: '37863.10',
      ask1Price: '37864.20',
      bid1Size: '165.775',
      basis: ''
    }
  }
}
```
