### PR TITLE
fix(gate): conflicting markets handling

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -944,6 +944,13 @@ export default class gate extends Exchange {
                 return this.markets[symbol];
             } else if (symbol in this.markets_by_id) {
                 const markets = this.markets_by_id[symbol];
+                const defaultType = this.safeString2 (this.options, 'defaultType', 'defaultSubType', 'spot');
+                for (let i = 0; i < markets.length; i++) {
+                    const market = markets[i];
+                    if (market[defaultType]) {
+                        return market;
+                    }
+                }
                 return markets[0];
             } else if ((symbol.indexOf ('-C') > -1) || (symbol.indexOf ('-P') > -1)) {
                 return this.createExpiredOptionMarket (symbol);


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/20128


DEMO

```
 p gate fetchFundingRate "BTC_USDT" --swap
Python v3.11.5
CCXT v4.1.64
gate.fetchFundingRate(BTC_USDT)
{'datetime': None,
 'estimatedSettlePrice': None,
 'fundingDatetime': '2023-11-26T00:00:00.000Z',
 'fundingRate': 9e-06,
 'fundingTimestamp': 1700956800000,
 'indexPrice': 37731.86,
```

```
 p gate fetchFundingRate "BTC/USDT:USDT" --swap
Python v3.11.5
CCXT v4.1.64
gate.fetchFundingRate(BTC/USDT:USDT)
{'datetime': None,
 'estimatedSettlePrice': None,
 'fundingDatetime': '2023-11-26T00:00:00.000Z',
 'fundingRate': 9e-06,
 'fundingTimestamp': 1700956800000,
 'indexPrice': 37731.86,
```

