### PR TITLE
fix(cli.ts, cli.js): small numbers parse numbers, large numbers keep as string

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -266,7 +266,7 @@ async function run () {
         let args = params
             .map (s => s.match (/^[0-9]{4}[-][0-9]{2}[-][0-9]{2}[T\s]?[0-9]{2}[:][0-9]{2}[:][0-9]{2}/g) ? exchange.parse8601 (s) : s)
             .map (s => (() => { 
-                if (s.match ( /^\d+$/g)) return s
+                if (s.match ( /^\d+$/g)) return s < Number.MAX_SAFE_INTEGER ? Number (s) : s
                 try {return eval ('(() => (' + s + ')) ()') } catch (e) { return s }
             }) ())
 

--- a/examples/ts/cli.ts
+++ b/examples/ts/cli.ts
@@ -246,7 +246,7 @@ async function run () {
         let args = params
             .map (s => s.match (/^[0-9]{4}[-][0-9]{2}[-][0-9]{2}[T\s]?[0-9]{2}[:][0-9]{2}[:][0-9]{2}/g) ? exchange.parse8601 (s) : s)
             .map (s => (() => { 
-                if (s.match ( /^\d+$/g)) return s
+                if (s.match ( /^\d+$/g)) return s < Number.MAX_SAFE_INTEGER ? Number (s) : s
                 try {return eval ('(() => (' + s + ')) ()') } catch (e) { return s }
             }) ())
 


### PR DESCRIPTION
- Very large numbers are kept as strings to allow calls like `t cryptocom fetchOrder '6142909896902261394' XRP/USDT`
- Smaller digits are converted to numbers for: `t binance fetchOrderBook BTC/USDT 10`

Note: Because all args are passed as strings, I couldn't find a way to know if the user intends to pass a string or a number, therefore there might be a potential issue in the future if the user intends to pass in a string of only digits it can be converted to a number unintentionally