### PR TITLE
bingx parseOrder fee fix

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1971,15 +1971,17 @@ export default class bingx extends Exchange {
         //       "symbol": "XRP-USDT",
         //       "orderId": 1514073325788200960,
         //       "price": "0.5",
+        //       "StopPrice": "0",
         //       "origQty": "20",
-        //       "executedQty": "0",
-        //       "cummulativeQuoteQty": "0",
+        //       "executedQty": "10",
+        //       "cummulativeQuoteQty": "5",
         //       "status": "PENDING",
         //       "type": "LIMIT",
         //       "side": "BUY",
         //       "time": 1649818185647,
         //       "updateTime": 1649818185647,
         //       "origQuoteOrderQty": "0"
+        //       "fee": "-0.01"
         //   }
         //
         //
@@ -2039,9 +2041,18 @@ export default class bingx extends Exchange {
         const amount = this.safeString2 (order, 'origQty', 'q');
         const filled = this.safeString2 (order, 'executedQty', 'z');
         const statusId = this.safeString2 (order, 'status', 'X');
+        let feeCurrencyCode = this.safeString2 (order, 'feeAsset', 'N');
+        const feeCost = this.safeStringN (order, [ 'fee', 'commission', 'n' ]);
+        if (feeCurrencyCode === undefined) {
+            if (side === 'buy') {
+                feeCurrencyCode = market['base'];
+            } else {
+                feeCurrencyCode = market['quote'];
+            }
+        }
         const fee = {
-            'currency': this.safeString2 (order, 'feeAsset', 'N'),
-            'rate': this.safeStringN (order, [ 'fee', 'commission', 'n' ]),
+            'currency': feeCurrencyCode,
+            'cost': Precise.stringAbs (feeCost),
         };
         const clientOrderId = this.safeString2 (order, 'clientOrderId', 'c');
         return this.safeOrder ({

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2043,7 +2043,7 @@ export default class bingx extends Exchange {
         const statusId = this.safeString2 (order, 'status', 'X');
         let feeCurrencyCode = this.safeString2 (order, 'feeAsset', 'N');
         const feeCost = this.safeStringN (order, [ 'fee', 'commission', 'n' ]);
-        if (feeCurrencyCode === undefined) {
+        if ((feeCurrencyCode === undefined) && market['spot']) {
             if (side === 'buy') {
                 feeCurrencyCode = market['base'];
             } else {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2043,9 +2043,13 @@ export default class bingx extends Exchange {
         const statusId = this.safeString2 (order, 'status', 'X');
         let feeCurrencyCode = this.safeString2 (order, 'feeAsset', 'N');
         const feeCost = this.safeStringN (order, [ 'fee', 'commission', 'n' ]);
-        if ((feeCurrencyCode === undefined) && market['spot']) {
-            if (side === 'buy') {
-                feeCurrencyCode = market['base'];
+        if ((feeCurrencyCode === undefined)) {
+            if (market['spot']) {
+                if (side === 'buy') {
+                    feeCurrencyCode = market['base'];
+                } else {
+                    feeCurrencyCode = market['quote'];
+                }
             } else {
                 feeCurrencyCode = market['quote'];
             }

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -1,0 +1,231 @@
+{
+    "exchange": "bingx",
+    "options": {},
+    "methods": {
+        "fetchClosedOrders": [
+            {
+                "description": "Spot closed order",
+                "method": "fetchClosedOrders",
+                "input": [
+                  "LTC/USDT",
+                  null,
+                  "1"
+                ],
+                "httpResponse": {
+                  "code": "0",
+                  "msg": "",
+                  "debugMsg": "",
+                  "data": {
+                    "orders": [
+                      {
+                        "symbol": "LTC-USDT",
+                        "orderId": "1721596796393750528",
+                        "price": "73.56",
+                        "StopPrice": "0",
+                        "origQty": "0",
+                        "executedQty": "0.0679",
+                        "cummulativeQuoteQty": "4.9954709",
+                        "status": "FILLED",
+                        "type": "MARKET",
+                        "side": "BUY",
+                        "time": "1699295637000",
+                        "updateTime": "1699295637000",
+                        "origQuoteOrderQty": "5",
+                        "fee": "-0.0000679"
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "symbol": "LTC-USDT",
+                      "orderId": "1721596796393750528",
+                      "price": "73.56",
+                      "StopPrice": "0",
+                      "origQty": "0",
+                      "executedQty": "0.0679",
+                      "cummulativeQuoteQty": "4.9954709",
+                      "status": "FILLED",
+                      "type": "MARKET",
+                      "side": "BUY",
+                      "time": "1699295637000",
+                      "updateTime": "1699295637000",
+                      "origQuoteOrderQty": "5",
+                      "fee": "-0.0000679"
+                    },
+                    "id": "1721596796393750528",
+                    "clientOrderId": null,
+                    "timestamp": 1699295637000,
+                    "datetime": "2023-11-06T18:33:57.000Z",
+                    "lastTradeTimestamp": 1699295637000,
+                    "lastUpdateTimestamp": 1699295637000,
+                    "symbol": "LTC/USDT",
+                    "type": "market",
+                    "timeInForce": "IOC",
+                    "postOnly": null,
+                    "side": "buy",
+                    "price": 73.56,
+                    "stopPrice": null,
+                    "triggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": null,
+                    "cost": 4.994724,
+                    "amount": 0.0679,
+                    "filled": 0.0679,
+                    "remaining": 0,
+                    "status": "closed",
+                    "fee": {
+                      "currency": "LTC",
+                      "cost": "0.0000679"
+                    },
+                    "trades": [],
+                    "fees": [
+                      {
+                        "currency": "LTC",
+                        "cost": 0.0000679
+                      }
+                    ],
+                    "reduceOnly": null
+                  }
+                ]
+            },
+            {
+                "description": "Swap closed order",
+                "method": "fetchClosedOrders",
+                "input": [
+                  "LTC/USDT:USDT",
+                  null,
+                  "1"
+                ],
+                "httpResponse": {
+                  "code": "0",
+                  "msg": "",
+                  "data": {
+                    "orders": [
+                      {
+                        "symbol": "LTC-USDT",
+                        "orderId": "1729799444544843776",
+                        "side": "BUY",
+                        "positionSide": "SHORT",
+                        "type": "MARKET",
+                        "origQty": "0.1",
+                        "price": "70.17",
+                        "executedQty": "0.1",
+                        "avgPrice": "70.17",
+                        "cumQuote": "7",
+                        "stopPrice": "",
+                        "profit": "0.0000",
+                        "commission": "-0.003509",
+                        "status": "FILLED",
+                        "time": "1701251300000",
+                        "updateTime": "1701251300000",
+                        "clientOrderId": "",
+                        "leverage": "",
+                        "takeProfit": {
+                          "type": "",
+                          "quantity": "0",
+                          "stopPrice": "0",
+                          "price": "0",
+                          "workingType": ""
+                        },
+                        "stopLoss": {
+                          "type": "",
+                          "quantity": "0",
+                          "stopPrice": "0",
+                          "price": "0",
+                          "workingType": ""
+                        },
+                        "advanceAttr": "0",
+                        "positionID": "0",
+                        "takeProfitEntrustPrice": "0",
+                        "stopLossEntrustPrice": "0",
+                        "orderType": "",
+                        "workingType": "MARK_PRICE"
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "symbol": "LTC-USDT",
+                      "orderId": "1729799444544843776",
+                      "side": "BUY",
+                      "positionSide": "SHORT",
+                      "type": "MARKET",
+                      "origQty": "0.1",
+                      "price": "70.17",
+                      "executedQty": "0.1",
+                      "avgPrice": "70.17",
+                      "cumQuote": "7",
+                      "stopPrice": "",
+                      "profit": "0.0000",
+                      "commission": "-0.003509",
+                      "status": "FILLED",
+                      "time": "1701251300000",
+                      "updateTime": "1701251300000",
+                      "clientOrderId": "",
+                      "leverage": "",
+                      "takeProfit": {
+                        "type": "",
+                        "quantity": "0",
+                        "stopPrice": "0",
+                        "price": "0",
+                        "workingType": ""
+                      },
+                      "stopLoss": {
+                        "type": "",
+                        "quantity": "0",
+                        "stopPrice": "0",
+                        "price": "0",
+                        "workingType": ""
+                      },
+                      "advanceAttr": "0",
+                      "positionID": "0",
+                      "takeProfitEntrustPrice": "0",
+                      "stopLossEntrustPrice": "0",
+                      "orderType": "",
+                      "workingType": "MARK_PRICE"
+                    },
+                    "id": "1729799444544843776",
+                    "clientOrderId": null,
+                    "timestamp": 1701251300000,
+                    "datetime": "2023-11-29T09:48:20.000Z",
+                    "lastTradeTimestamp": 1701251300000,
+                    "lastUpdateTimestamp": 1701251300000,
+                    "symbol": "LTC/USDT:USDT",
+                    "type": "market",
+                    "timeInForce": "IOC",
+                    "postOnly": null,
+                    "side": "buy",
+                    "price": 70.17,
+                    "stopPrice": null,
+                    "triggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": 70.17,
+                    "cost": 0.7017,
+                    "amount": 0.1,
+                    "filled": 0.1,
+                    "remaining": 0,
+                    "status": "closed",
+                    "fee": {
+                      "currency": "USDT",
+                      "cost": "0.003509"
+                    },
+                    "trades": [],
+                    "fees": [
+                      {
+                        "currency": "USDT",
+                        "cost": 0.003509
+                      }
+                    ],
+                    "reduceOnly": null
+                  }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
https://bingx-api.github.io/docs/#/en-us/spot/trade-api.html#Query%20Order%20History
For buy `fee currency` is `base`, for sell - `quote`. I didn't find any information that BingX has rebate, so `stringAbs` should work properly 