### PR TITLE
Coinex: createOrders, cancelOrders

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -2200,7 +2200,7 @@ export default class coinex extends Exchange {
         return this.parseOrder (data, market);
     }
 
-    async createOrders (orders: OrderRequest[], params = {}) {
+    async createOrders (orders: OrderRequest[], params = {}): Promise<Order[]> {
         /**
          * @method
          * @name coinex#createOrders

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -2321,12 +2321,13 @@ export default class coinex extends Exchange {
         const request = {
             'market': market['id'],
         };
+        const idsString = ids.join (',');
         let response = undefined;
         if (market['spot']) {
-            request['batch_ids'] = ids.toString ();
+            request['batch_ids'] = idsString;
             response = await this.privateDeleteOrderPendingBatch (this.extend (request, params));
         } else {
-            request['order_ids'] = ids.toString ();
+            request['order_ids'] = idsString;
             response = await this.perpetualPrivatePostOrderCancelBatch (this.extend (request, params));
         }
         //

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -7,7 +7,7 @@ import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { md5 } from './static_dependencies/noble-hashes/md5.js';
-import { Balances, Currency, FundingHistory, FundingRateHistory, Int, Market, OHLCV, Order, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction } from './base/types.js';
+import { Balances, Currency, FundingHistory, FundingRateHistory, Int, Market, OHLCV, Order, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, OrderRequest } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -46,6 +46,7 @@ export default class coinex extends Exchange {
                 'cancelOrder': true,
                 'createDepositAddress': true,
                 'createOrder': true,
+                'createOrders': true,
                 'createReduceOnlyOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
@@ -1551,6 +1552,8 @@ export default class coinex extends Exchange {
 
     parseOrderStatus (status) {
         const statuses = {
+            'rejected': 'rejected',
+            'open': 'open',
             'not_deal': 'open',
             'part_deal': 'open',
             'done': 'closed',
@@ -1585,7 +1588,7 @@ export default class coinex extends Exchange {
         //         "client_id": "",
         //     }
         //
-        // Spot and Margin createOrder, cancelOrder, fetchOrder
+        // Spot and Margin createOrder, createOrders, cancelOrder, fetchOrder
         //
         //      {
         //          "amount":"1.5",
@@ -1784,13 +1787,8 @@ export default class coinex extends Exchange {
         //         "user_id": 3620173
         //     }
         //
+        const rawStatus = this.safeString (order, 'status');
         const timestamp = this.safeTimestamp (order, 'create_time');
-        const priceString = this.safeString (order, 'price');
-        const costString = this.safeString (order, 'deal_money');
-        const amountString = this.safeString (order, 'amount');
-        const filledString = this.safeString (order, 'deal_amount');
-        const averageString = this.safeString (order, 'avg_price');
-        const remainingString = this.safeString (order, 'left');
         const marketId = this.safeString (order, 'market');
         const defaultType = this.safeString (this.options, 'defaultType');
         const orderType = ('source' in order) ? 'swap' : defaultType;
@@ -1800,7 +1798,6 @@ export default class coinex extends Exchange {
         if (feeCurrency === undefined) {
             feeCurrency = market['quote'];
         }
-        const status = this.parseOrderStatus (this.safeString (order, 'status'));
         const rawSide = this.safeInteger (order, 'side');
         let side: Str = undefined;
         if (rawSide === 1) {
@@ -1832,21 +1829,21 @@ export default class coinex extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'timestamp': timestamp,
             'lastTradeTimestamp': this.safeTimestamp (order, 'update_time'),
-            'status': status,
+            'status': this.parseOrderStatus (rawStatus),
             'symbol': market['symbol'],
             'type': type,
             'timeInForce': undefined,
             'postOnly': undefined,
             'reduceOnly': undefined,
             'side': side,
-            'price': priceString,
+            'price': this.safeString (order, 'price'),
             'stopPrice': this.safeString (order, 'stop_price'),
             'triggerPrice': this.safeString (order, 'stop_price'),
-            'cost': costString,
-            'average': averageString,
-            'amount': amountString,
-            'filled': filledString,
-            'remaining': remainingString,
+            'cost': this.safeString (order, 'deal_money'),
+            'average': this.safeString (order, 'avg_price'),
+            'amount': this.safeString (order, 'amount'),
+            'filled': this.safeString (order, 'deal_amount'),
+            'remaining': this.safeString (order, 'left'),
             'trades': undefined,
             'fee': {
                 'currency': feeCurrency,
@@ -1856,34 +1853,7 @@ export default class coinex extends Exchange {
         }, market);
     }
 
-    async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
-        /**
-         * @method
-         * @name coinex#createOrder
-         * @description create a trade order
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http017_put_limit
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http018_put_market
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http019_put_limit_stop
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http020_put_market_stop
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http031_market_close
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http030_limit_close
-         * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit'
-         * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
-         * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {float} triggerPrice price at which to triger stop orders
-         * @param {float} stopPrice price at which to triger stop orders
-         * @param {float} stopLossPrice price at which to trigger stop-loss orders
-         * @param {float} takeProfitPrice price at which to trigger take-profit orders
-         * @param {string} [params.timeInForce] "GTC", "IOC", "FOK", "PO"
-         * @param {bool} params.postOnly
-         * @param {bool} params.reduceOnly
-         * @param {bool} [params.position_id] *required for reduce only orders* the position id to reduce
-         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
-         */
-        await this.loadMarkets ();
+    createOrderRequest (symbol, type, side, amount, price = undefined, params = {}) {
         const market = this.market (symbol);
         const swap = market['swap'];
         const clientOrderId = this.safeString2 (params, 'client_id', 'clientOrderId');
@@ -1904,7 +1874,6 @@ export default class coinex extends Exchange {
                 throw new ArgumentsRequired (this.id + ' createOrder() requires a position_id/positionId parameter for reduceOnly orders');
             }
         }
-        let method = undefined;
         const request = {
             'market': market['id'],
         };
@@ -1923,14 +1892,11 @@ export default class coinex extends Exchange {
                 }
                 request['position_id'] = positionId;
                 if (stopLossPrice) {
-                    method = 'perpetualPrivatePostPositionStopLoss';
                     request['stop_loss_price'] = this.priceToPrecision (symbol, stopLossPrice);
                 } else if (takeProfitPrice) {
-                    method = 'perpetualPrivatePostPositionTakeProfit';
                     request['take_profit_price'] = this.priceToPrecision (symbol, takeProfitPrice);
                 }
             } else {
-                method = 'perpetualPrivatePostOrderPut' + this.capitalize (type);
                 const requestSide = (side === 'buy') ? 2 : 1;
                 if (stopPrice !== undefined) {
                     request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
@@ -1938,10 +1904,7 @@ export default class coinex extends Exchange {
                     request['amount'] = this.amountToPrecision (symbol, amount);
                     request['side'] = requestSide;
                     if (type === 'limit') {
-                        method = 'perpetualPrivatePostOrderPutStopLimit';
                         request['price'] = this.priceToPrecision (symbol, price);
-                    } else if (type === 'market') {
-                        method = 'perpetualPrivatePostOrderPutStopMarket';
                     }
                     request['amount'] = this.amountToPrecision (symbol, amount);
                 }
@@ -1962,7 +1925,6 @@ export default class coinex extends Exchange {
                 }
                 if (type === 'limit' && stopPrice === undefined) {
                     if (reduceOnly) {
-                        method = 'perpetualPrivatePostOrderCloseLimit';
                         request['position_id'] = positionId;
                     } else {
                         request['side'] = requestSide;
@@ -1971,7 +1933,6 @@ export default class coinex extends Exchange {
                     request['amount'] = this.amountToPrecision (symbol, amount);
                 } else if (type === 'market' && stopPrice === undefined) {
                     if (reduceOnly) {
-                        method = 'perpetualPrivatePostOrderCloseMarket';
                         request['position_id'] = positionId;
                     } else {
                         request['side'] = requestSide;
@@ -1980,7 +1941,6 @@ export default class coinex extends Exchange {
                 }
             }
         } else {
-            method = 'privatePostOrder' + this.capitalize (type);
             request['type'] = side;
             if ((type === 'market') && (side === 'buy')) {
                 if (this.options['createMarketBuyOrderRequiresPrice']) {
@@ -2004,11 +1964,6 @@ export default class coinex extends Exchange {
             }
             if (stopPrice !== undefined) {
                 request['stop_price'] = this.priceToPrecision (symbol, stopPrice);
-                if (type === 'limit') {
-                    method = 'privatePostOrderStopLimit';
-                } else if (type === 'market') {
-                    method = 'privatePostOrderStopMarket';
-                }
             }
             if ((type !== 'market') || (stopPrice !== undefined)) {
                 // following options cannot be applied to vanilla market orders (but can be applied to stop-market orders)
@@ -2035,7 +1990,90 @@ export default class coinex extends Exchange {
             request['account_id'] = accountId;
         }
         params = this.omit (params, [ 'reduceOnly', 'positionId', 'timeInForce', 'postOnly', 'stopPrice', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice' ]);
-        const response = await this[method] (this.extend (request, params));
+        return this.extend (request, params);
+    }
+
+    async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
+        /**
+         * @method
+         * @name coinex#createOrder
+         * @description create a trade order
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http017_put_limit
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http018_put_market
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http019_put_limit_stop
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http020_put_market_stop
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http031_market_close
+         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http030_limit_close
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much you want to trade in units of the base currency
+         * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} [params.triggerPrice] price to trigger stop orders
+         * @param {float} [params.stopLossPrice] price to trigger stop loss orders
+         * @param {float} [params.takeProfitPrice] price to trigger take profit orders
+         * @param {string} [params.timeInForce] 'GTC', 'IOC', 'FOK', 'PO'
+         * @param {boolean} [params.postOnly] set to true if you wish to make a post only order
+         * @param {boolean} [params.reduceOnly] *contract only* indicates if this order is to reduce the size of a position
+         * @param {int} [params.position_id] *required for reduce only orders* the position id to reduce
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        const triggerPrice = this.safeNumber2 (params, 'stopPrice', 'triggerPrice');
+        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice');
+        const takeProfitTriggerPrice = this.safeNumber (params, 'takeProfitPrice');
+        const isTriggerOrder = triggerPrice !== undefined;
+        const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
+        const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
+        const isStopLossOrTakeProfitTrigger = isStopLossTriggerOrder || isTakeProfitTriggerOrder;
+        const request = this.createOrderRequest (symbol, type, side, amount, price, params);
+        let response = undefined;
+        if (market['spot']) {
+            if (isTriggerOrder) {
+                if (type === 'limit') {
+                    response = await this.privatePostOrderStopLimit (request);
+                } else {
+                    response = await this.privatePostOrderStopMarket (request);
+                }
+            } else {
+                if (type === 'limit') {
+                    response = await this.privatePostOrderLimit (request);
+                } else {
+                    response = await this.privatePostOrderMarket (request);
+                }
+            }
+        } else {
+            if (isTriggerOrder) {
+                if (type === 'limit') {
+                    response = await this.perpetualPrivatePostOrderPutStopLimit (request);
+                } else {
+                    response = await this.perpetualPrivatePostOrderPutStopMarket (request);
+                }
+            } else if (isStopLossOrTakeProfitTrigger) {
+                if (isStopLossTriggerOrder) {
+                    response = await this.perpetualPrivatePostPositionStopLoss (request);
+                } else if (isTakeProfitTriggerOrder) {
+                    response = await this.perpetualPrivatePostPositionTakeProfit (request);
+                }
+            } else {
+                if (reduceOnly) {
+                    if (type === 'limit') {
+                        response = await this.perpetualPrivatePostOrderCloseLimit (request);
+                    } else {
+                        response = await this.perpetualPrivatePostOrderCloseMarket (request);
+                    }
+                } else {
+                    if (type === 'limit') {
+                        response = await this.perpetualPrivatePostOrderPutLimit (request);
+                    } else {
+                        response = await this.perpetualPrivatePostOrderPutMarket (request);
+                    }
+                }
+            }
+        }
         //
         // Spot and Margin
         //
@@ -2113,8 +2151,109 @@ export default class coinex extends Exchange {
         //
         //     {"code":0,"data":{"status":"success"},"message":"OK"}
         //
-        const data = this.safeValue (response, 'data');
+        const data = this.safeValue (response, 'data', {});
         return this.parseOrder (data, market);
+    }
+
+    async createOrders (orders: OrderRequest[], params = {}) {
+        /**
+         * @method
+         * @name coinex#createOrders
+         * @description create a list of trade orders (all orders should be of the same symbol)
+         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot003_trade002_batch_limit_orders
+         * @param {array} orders list of orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+         * @param {object} [params] extra parameters specific to the api endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const ordersRequests = [];
+        let symbol = undefined;
+        for (let i = 0; i < orders.length; i++) {
+            const rawOrder = orders[i];
+            const marketId = this.safeString (rawOrder, 'symbol');
+            if (symbol === undefined) {
+                symbol = marketId;
+            } else {
+                if (symbol !== marketId) {
+                    throw new BadRequest (this.id + ' createOrders() requires all orders to have the same symbol');
+                }
+            }
+            const type = this.safeString (rawOrder, 'type');
+            const side = this.safeString (rawOrder, 'side');
+            const amount = this.safeValue (rawOrder, 'amount');
+            const price = this.safeValue (rawOrder, 'price');
+            const orderParams = this.safeValue (rawOrder, 'params', {});
+            if (type !== 'limit') {
+                throw new NotSupported (this.id + ' createOrders() does not support ' + type + ' orders, only limit orders are accepted');
+            }
+            const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
+            ordersRequests.push (orderRequest);
+        }
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createOrders() does not support ' + market['type'] + ' orders, only spot orders are accepted');
+        }
+        const request = {
+            'market': market['id'],
+            'batch_orders': this.json (ordersRequests),
+        };
+        const response = await this.privatePostOrderLimitBatch (request);
+        //
+        //     {
+        //         "code": 0,
+        //         "data": [
+        //             {
+        //                 "code": 0,
+        //                 "data": {
+        //                     "amount": "0.0005",
+        //                     "asset_fee": "0",
+        //                     "avg_price": "0.00",
+        //                     "client_id": "x-167673045-d34bfb41242d8fd1",
+        //                     "create_time": 1701229157,
+        //                     "deal_amount": "0",
+        //                     "deal_fee": "0",
+        //                     "deal_money": "0",
+        //                     "fee_asset": null,
+        //                     "fee_discount": "1",
+        //                     "finished_time": null,
+        //                     "id": 107745856676,
+        //                     "left": "0.0005",
+        //                     "maker_fee_rate": "0.002",
+        //                     "market": "BTCUSDT",
+        //                     "money_fee": "0",
+        //                     "order_type": "limit",
+        //                     "price": "23000",
+        //                     "source_id": "",
+        //                     "status": "not_deal",
+        //                     "stock_fee": "0",
+        //                     "taker_fee_rate": "0.002",
+        //                     "type": "buy"
+        //                 },
+        //                 "message": "OK"
+        //             },
+        //         ],
+        //         "message": "Success"
+        //     }
+        //
+        const data = this.safeValue (response, 'data', []);
+        const results = [];
+        for (let i = 0; i < data.length; i++) {
+            const entry = data[i];
+            let status = undefined;
+            const code = this.safeInteger (entry, 'code');
+            if (code !== undefined) {
+                if (code !== 0) {
+                    status = 'rejected';
+                } else {
+                    status = 'open';
+                }
+            }
+            const item = this.safeValue (entry, 'data', {});
+            item['status'] = status;
+            const order = this.parseOrder (item, market);
+            results.push (order);
+        }
+        return results;
     }
 
     async editOrder (id, symbol, type, side, amount = undefined, price = undefined, params = {}) {

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1912,7 +1912,7 @@ export default class coinex extends Exchange {
         const timeInForceRaw = this.safeString (params, 'timeInForce'); // Spot: IOC, FOK, PO, GTC, ... NORMAL (default), MAKER_ONLY
         const reduceOnly = this.safeValue (params, 'reduceOnly');
         if (reduceOnly) {
-            if (market['type'] !== 'swap') {
+            if (!market['swap']) {
                 throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + market['type'] + ' orders, reduceOnly orders are supported for swap markets only');
             }
             if (positionId === undefined) {

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -163,6 +163,150 @@
                     50
                 ],
                 "output": "{\"access_id\":\"53DD577FFFD741D4B53A5424ECD33196\",\"amount\":\"0.1\",\"market\":\"LTCUSDT\",\"price\":\"50\",\"tonce\":\"1699460637215\",\"type\":\"buy\"}"
+            },
+            {
+                "description": "Spot limit trigger buy order",
+                "method": "createOrder",
+                "url": "https://api.coinex.com/v1/order/stop/limit",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.0005,
+                  25000,
+                  {
+                    "triggerPrice": 26000
+                  }
+                ],
+                "output": "{\"access_id\":\"86AC33D5904F432C9C9DDD4708233F38\",\"amount\":\"0.0005\",\"client_id\":\"x-167673045-de0c9f4634898ab2\",\"market\":\"BTCUSDT\",\"price\":\"25000\",\"stop_price\":\"26000\",\"tonce\":\"1701227312608\",\"type\":\"buy\"}"
+            },
+            {
+                "description": "Swap limit buy",
+                "method": "createOrder",
+                "url": "https://api.coinex.com/perpetual/v1/order/put_limit",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.0005,
+                  25000
+                ],
+                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&amount=0.0005&client_id=x-167673045-fa8a1fff84199157&market=BTCUSDT&price=25000&side=2&timestamp=1701232436828"
+            },
+            {
+                "description": "Swap limit trigger buy order",
+                "method": "createOrder",
+                "url": "https://api.coinex.com/perpetual/v1/order/put_stop_limit",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.0005,
+                  27000,
+                  {
+                    "triggerPrice": 28000
+                  }
+                ],
+                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&amount=0.0005&client_id=x-167673045-bcae965354bfaf26&market=BTCUSDT&price=27000&side=2&stop_price=28000&stop_type=1&timestamp=1701232792670"
+            }
+        ],
+        "createOrders": [
+            {
+                "description": "Create multiple spot orders at once",
+                "method": "createOrders",
+                "url": "https://api.coinex.com/v1/order/limit/batch",
+                "input": [
+                  [
+                    {
+                      "symbol": "BTC/USDT",
+                      "type": "limit",
+                      "side": "buy",
+                      "amount": 0.0005,
+                      "price": 23000
+                    },
+                    {
+                      "symbol": "BTC/USDT",
+                      "type": "limit",
+                      "side": "buy",
+                      "amount": 0.0005,
+                      "price": 22000
+                    }
+                  ]
+                ],
+                "output": "{\"access_id\":\"86AC33D5904F432C9C9DDD4708233F38\",\"batch_orders\":\"[{\\\"market\\\":\\\"BTCUSDT\\\",\\\"client_id\\\":\\\"x-167673045-d34bfb41242d8fd1\\\",\\\"type\\\":\\\"buy\\\",\\\"amount\\\":\\\"0.0005\\\",\\\"price\\\":\\\"23000\\\"},{\\\"market\\\":\\\"BTCUSDT\\\",\\\"client_id\\\":\\\"x-167673045-d4e03c38f4d19b4e\\\",\\\"type\\\":\\\"buy\\\",\\\"amount\\\":\\\"0.0005\\\",\\\"price\\\":\\\"22000\\\"}]\",\"market\":\"BTCUSDT\",\"tonce\":\"1701229156016\"}"
+            }
+        ],
+        "cancelOrder": [
+            {
+                "description": "Spot cancel order",
+                "method": "cancelOrder",
+                "url": "https://api.coinex.com/v1/order/pending?access_id=86AC33D5904F432C9C9DDD4708233F38&id=107745260032&market=BTCUSDT&tonce=1701228187975",
+                "input": [
+                  "107745260032",
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Spot cancel trigger order",
+                "method": "cancelOrder",
+                "url": "https://api.coinex.com/v1/order/stop/pending/107744772540?access_id=86AC33D5904F432C9C9DDD4708233F38&id=107744772540&market=BTCUSDT&tonce=1701228118229",
+                "input": [
+                  "107744772540",
+                  "BTC/USDT",
+                  {
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Swap cancel order",
+                "method": "cancelOrder",
+                "url": "https://api.coinex.com/perpetual/v1/order/cancel",
+                "input": [
+                  "115939084611",
+                  "BTC/USDT:USDT"
+                ],
+                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_id=115939084611&timestamp=1701232671805"
+            },
+            {
+                "description": "Swap cancel trigger order",
+                "method": "cancelOrder",
+                "url": "https://api.coinex.com/perpetual/v1/order/cancel_stop",
+                "input": [
+                  "115940250059",
+                  "BTC/USDT:USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_id=115940250059&timestamp=1701233531405"
+            }
+        ],
+        "cancelOrders": [
+            {
+                "description": "Cancel multiple spot orders at once",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/v1/order/pending/batch?access_id=86AC33D5904F432C9C9DDD4708233F38&batch_ids=107745856682,107745856676&market=BTCUSDT&tonce=1701230333560",
+                "input": [
+                  [
+                    "107745856682",
+                    "107745856676"
+                  ],
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Cancel multiple swap orders at once",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/perpetual/v1/order/cancel_batch",
+                "input": [
+                  [
+                    "115938781741",
+                    "115938847458"
+                  ],
+                  "BTC/USDT:USDT"
+                ],
+                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_ids=115938781741,115938847458&timestamp=1701232526724"
             }
         ],
         "fetchIsolatedBorrowRate": [

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -170,14 +170,14 @@
                 "method": "createOrder",
                 "url": "https://api.coinex.com/v1/order/stop/limit",
                 "input": [
-                  "BTC/USDT",
-                  "limit",
-                  "buy",
-                  0.0005,
-                  25000,
-                  {
-                    "triggerPrice": 26000
-                  }
+                    "BTC/USDT",
+                    "limit",
+                    "buy",
+                    0.0005,
+                    25000,
+                    {
+                        "triggerPrice": 26000
+                    }
                 ],
                 "output": "{\"access_id\":\"86AC33D5904F432C9C9DDD4708233F38\",\"amount\":\"0.0005\",\"client_id\":\"x-167673045-de0c9f4634898ab2\",\"market\":\"BTCUSDT\",\"price\":\"25000\",\"stop_price\":\"26000\",\"tonce\":\"1701227312608\",\"type\":\"buy\"}"
             },
@@ -186,11 +186,11 @@
                 "method": "createOrder",
                 "url": "https://api.coinex.com/perpetual/v1/order/put_limit",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "limit",
-                  "buy",
-                  0.0005,
-                  25000
+                    "BTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.0005,
+                    25000
                 ],
                 "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&amount=0.0005&client_id=x-167673045-fa8a1fff84199157&market=BTCUSDT&price=25000&side=2&timestamp=1701232436828"
             },
@@ -199,14 +199,14 @@
                 "method": "createOrder",
                 "url": "https://api.coinex.com/perpetual/v1/order/put_stop_limit",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "limit",
-                  "buy",
-                  0.0005,
-                  27000,
-                  {
-                    "triggerPrice": 28000
-                  }
+                    "BTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.0005,
+                    27000,
+                    {
+                        "triggerPrice": 28000
+                    }
                 ],
                 "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&amount=0.0005&client_id=x-167673045-bcae965354bfaf26&market=BTCUSDT&price=27000&side=2&stop_price=28000&stop_type=1&timestamp=1701232792670"
             }
@@ -217,22 +217,22 @@
                 "method": "createOrders",
                 "url": "https://api.coinex.com/v1/order/limit/batch",
                 "input": [
-                  [
-                    {
-                      "symbol": "BTC/USDT",
-                      "type": "limit",
-                      "side": "buy",
-                      "amount": 0.0005,
-                      "price": 23000
-                    },
-                    {
-                      "symbol": "BTC/USDT",
-                      "type": "limit",
-                      "side": "buy",
-                      "amount": 0.0005,
-                      "price": 22000
-                    }
-                  ]
+                    [
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 0.0005,
+                            "price": 23000
+                        },
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 0.0005,
+                            "price": 22000
+                        }
+                    ]
                 ],
                 "output": "{\"access_id\":\"86AC33D5904F432C9C9DDD4708233F38\",\"batch_orders\":\"[{\\\"market\\\":\\\"BTCUSDT\\\",\\\"client_id\\\":\\\"x-167673045-d34bfb41242d8fd1\\\",\\\"type\\\":\\\"buy\\\",\\\"amount\\\":\\\"0.0005\\\",\\\"price\\\":\\\"23000\\\"},{\\\"market\\\":\\\"BTCUSDT\\\",\\\"client_id\\\":\\\"x-167673045-d4e03c38f4d19b4e\\\",\\\"type\\\":\\\"buy\\\",\\\"amount\\\":\\\"0.0005\\\",\\\"price\\\":\\\"22000\\\"}]\",\"market\":\"BTCUSDT\",\"tonce\":\"1701229156016\"}"
             }
@@ -243,8 +243,8 @@
                 "method": "cancelOrder",
                 "url": "https://api.coinex.com/v1/order/pending?access_id=86AC33D5904F432C9C9DDD4708233F38&id=107745260032&market=BTCUSDT&tonce=1701228187975",
                 "input": [
-                  "107745260032",
-                  "BTC/USDT"
+                    "107745260032",
+                    "BTC/USDT"
                 ]
             },
             {
@@ -252,11 +252,11 @@
                 "method": "cancelOrder",
                 "url": "https://api.coinex.com/v1/order/stop/pending/107744772540?access_id=86AC33D5904F432C9C9DDD4708233F38&id=107744772540&market=BTCUSDT&tonce=1701228118229",
                 "input": [
-                  "107744772540",
-                  "BTC/USDT",
-                  {
-                    "stop": true
-                  }
+                    "107744772540",
+                    "BTC/USDT",
+                    {
+                        "stop": true
+                    }
                 ]
             },
             {
@@ -264,8 +264,8 @@
                 "method": "cancelOrder",
                 "url": "https://api.coinex.com/perpetual/v1/order/cancel",
                 "input": [
-                  "115939084611",
-                  "BTC/USDT:USDT"
+                    "115939084611",
+                    "BTC/USDT:USDT"
                 ],
                 "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_id=115939084611&timestamp=1701232671805"
             },
@@ -274,40 +274,13 @@
                 "method": "cancelOrder",
                 "url": "https://api.coinex.com/perpetual/v1/order/cancel_stop",
                 "input": [
-                  "115940250059",
-                  "BTC/USDT:USDT",
-                  {
-                    "stop": true
-                  }
+                    "115940250059",
+                    "BTC/USDT:USDT",
+                    {
+                        "stop": true
+                    }
                 ],
                 "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_id=115940250059&timestamp=1701233531405"
-            }
-        ],
-        "cancelOrders": [
-            {
-                "description": "Cancel multiple spot orders at once",
-                "method": "cancelOrders",
-                "url": "https://api.coinex.com/v1/order/pending/batch?access_id=86AC33D5904F432C9C9DDD4708233F38&batch_ids=107745856682,107745856676&market=BTCUSDT&tonce=1701230333560",
-                "input": [
-                  [
-                    "107745856682",
-                    "107745856676"
-                  ],
-                  "BTC/USDT"
-                ]
-            },
-            {
-                "description": "Cancel multiple swap orders at once",
-                "method": "cancelOrders",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel_batch",
-                "input": [
-                  [
-                    "115938781741",
-                    "115938847458"
-                  ],
-                  "BTC/USDT:USDT"
-                ],
-                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_ids=115938781741,115938847458&timestamp=1701232526724"
             }
         ],
         "fetchIsolatedBorrowRate": [
@@ -316,7 +289,7 @@
                 "method": "fetchIsolatedBorrowRate",
                 "url": "https://api.coinex.com/v1/margin/config?access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&tonce=1700201048704",
                 "input": [
-                  "BTC/USDT"
+                    "BTC/USDT"
                 ]
             }
         ],
@@ -326,6 +299,35 @@
                 "method": "fetchIsolatedBorrowRates",
                 "url": "https://api.coinex.com/v1/margin/config?access_id=86AC33D5904F432C9C9DDD4708233F38&tonce=1700202207814",
                 "input": []
+            }
+        ]
+    },
+    "disabledTests": {
+        "cancelOrders": [
+            {
+                "description": "Cancel multiple spot orders at once",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/v1/order/pending/batch?access_id=86AC33D5904F432C9C9DDD4708233F38&batch_ids=107745856682,107745856676&market=BTCUSDT&tonce=1701230333560",
+                "input": [
+                    [
+                        "107745856682",
+                        "107745856676"
+                    ],
+                    "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Cancel multiple swap orders at once",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/perpetual/v1/order/cancel_batch",
+                "input": [
+                    [
+                        "115938781741",
+                        "115938847458"
+                    ],
+                    "BTC/USDT:USDT"
+                ],
+                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_ids=115938781741,115938847458&timestamp=1701232526724"
             }
         ]
     }

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -300,9 +300,7 @@
                 "url": "https://api.coinex.com/v1/margin/config?access_id=86AC33D5904F432C9C9DDD4708233F38&tonce=1700202207814",
                 "input": []
             }
-        ]
-    },
-    "disabledTests": {
+        ],
         "cancelOrders": [
             {
                 "description": "Cancel multiple spot orders at once",
@@ -330,5 +328,7 @@
                 "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_ids=115938781741,115938847458&timestamp=1701232526724"
             }
         ]
+    },
+    "disabledTests": {
     }
 }

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -3,7 +3,8 @@
     "skipKeys": [
         "access_id",
         "timestamp",
-        "tonce"
+        "tonce",
+        "client_id"
     ],
     "outputType": "urlencoded",
     "methods": {


### PR DESCRIPTION
Added createOrders, cancelOrders and some static request tests to coinex:

### createOrders:
```
coinex createOrders ['{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":0.0005,"price":23000}','{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":0.0005,"price":28000}']

coinex.createOrders ([object Object],[object Object])
2023-11-29T04:29:14.040Z iteration 0 passed in 307 ms

          id |                clientOrderId |                 datetime |     timestamp |   status |        symbol |  type | side | price | cost | amount | filled | remaining | trades |                            fee |                    fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
107747632263 | x-167673045-53d56c0c742b8436 | 2023-11-29T04:29:14.000Z | 1701232154000 |     open | BTC/USDT:USDT | limit |  buy | 23000 |    0 | 0.0005 |      0 |    0.0005 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
             |                              |                          |               | rejected |      BTC/USDT |       |      |       |      |        |        |           |     [] |            {"currency":"USDT"} |          [{"currency":"USDT"}]
2 objects
```

### spot cancelOrders:
```
coinex.cancelOrders (107749091617,107749098322, BTC/USDT)
2023-11-29T05:12:31.563Z iteration 0 passed in 393 ms

          id |                clientOrderId |                 datetime |     timestamp | status |        symbol |  type | side | price | cost | amount | filled | remaining | trades |                            fee |                  fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
107749091617 | x-167673045-57b44fd504f1876f | 2023-11-29T05:11:51.000Z | 1701234711000 |   open | BTC/USDT:USDT | limit |  buy | 23000 |    0 | 0.0005 |      0 |         0 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
107749098322 | x-167673045-d4ca3366b488a84f | 2023-11-29T05:12:03.000Z | 1701234723000 |   open | BTC/USDT:USDT | limit |  buy | 24000 |    0 | 0.0005 |      0 |         0 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
2 objects
```

### swap cancelOrders:
```
coinex.cancelOrders (115941112837,115941121912, BTC/USDT:USDT)
2023-11-29T05:03:08.730Z iteration 0 passed in 260 ms

          id |                clientOrderId |                 datetime |     timestamp | lastTradeTimestamp |        symbol |  type | side | price | cost | amount | filled | remaining | trades |                                                 fee |                           fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
115941121912 | x-167673045-c4a5fe39242891fa | 2023-11-29T05:02:37.383Z | 1701234157383 |      1701234189534 | BTC/USDT:USDT | limit |  buy | 27000 |    0 | 0.0005 |      0 |    0.0005 |     [] | {"currency":"USDT","cost":"0.00000000000000000000"} | [{"currency":"USDT","cost":0}]
115941112837 | x-167673045-e7c6b3ebb4b9a5dd | 2023-11-29T05:02:32.581Z | 1701234152581 |      1701234189534 | BTC/USDT:USDT | limit |  buy | 25000 |    0 | 0.0005 |      0 |    0.0005 |     [] | {"currency":"USDT","cost":"0.00000000000000000000"} | [{"currency":"USDT","cost":0}]
2 objects
```