### PR TITLE
binance: patch watchOrders

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1314,18 +1314,21 @@ export default class binance extends binanceRest {
             return;
         }
         let method = 'publicPutUserDataStream';
+        const request = {};
+        const symbol = this.safeString (params, 'symbol');
+        const sendParams = this.omit (params, [ 'type', 'symbol' ]);
         if (type === 'future') {
             method = 'fapiPrivatePutListenKey';
         } else if (type === 'delivery') {
             method = 'dapiPrivatePutListenKey';
-        } else if (type === 'margin') {
-            method = 'sapiPutUserDataStream';
+        } else {
+            request['listenKey'] = listenKey;
+            if (type === 'margin') {
+                request['symbol'] = symbol;
+                method = 'sapiPutUserDataStream';
+            }
         }
-        const request = {
-            'listenKey': listenKey,
-        };
         const time = this.milliseconds ();
-        const sendParams = this.omit (params, 'type');
         try {
             await this[method] (this.extend (request, sendParams));
         } catch (error) {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2090,9 +2090,7 @@ export default class binance extends binanceRest {
             market = this.market (symbol);
             symbol = market['symbol'];
             messageHash += ':' + symbol;
-            params = this.extend (params, { 'type': market['type'], 'symbol': symbol }); // needed inside authenticate for isolated margin
         }
-        await this.authenticate (params);
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params);
         let subType = undefined;
@@ -2102,6 +2100,8 @@ export default class binance extends binanceRest {
         } else if (this.isInverse (type, subType)) {
             type = 'delivery';
         }
+        params = this.extend (params, { 'type': type, 'symbol': symbol }); // needed inside authenticate for isolated margin
+        await this.authenticate (params);
         let urlType = type;
         if (type === 'margin') {
             urlType = 'spot'; // spot-margin shares the same stream as regular spot


### PR DESCRIPTION
In this PR, I fixed these issues:

* sending different parameters when renew the listen key, see: ccxt/ccxt#20034

```BASH
# remember to set listenKeyRefreshRate to a small number, eg 20
$ p binance watchOrders ETH/USDT
$ n binance createOrder ETH/USDT limit buy 0.005 1000
$ n binance cancelAllOrders ETH/USDT

$ p binance watchOrders ETH/USDT:USDT
$ n binance createOrder ETH/USDT:USDT limit buy 0.02 1000
$ n binance cancelAllOrders ETH/USDT:USDT

$ p binance watchOrders ETH/USD:ETH
$ n binance createOrder ETH/USD:ETH limit sell 1 10000
$ n binance cancelAllOrders ETH/USD:ETH
```

* The type in `watchOrders` was broken with inverse market (would be future).

> There might be the same issue in other private watch function.

```BASH
$ n binance watchOrders ETH/USD:ETH
```

@carlosmiei let me know if the type fix is okay (`watchOrders`), I'll check other private functions and push update if need.