### PR TITLE
Feat: Add a Binance Implicit Api Entry

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -593,6 +593,7 @@ export default class binance extends Exchange {
                 'sapiV2': {
                     'get': {
                         'sub-account/futures/account': 0.1,
+                        'sub-account/futures/accountSummary': 1,
                         'sub-account/futures/positionRisk': 0.1,
                     },
                     'post': {


### PR DESCRIPTION
This api entry is added in Apr 2021, but haven't show in implicit api list.

https://binance-docs.github.io/apidocs/spot/en/#get-summary-of-sub-account-39-s-futures-account-v2-for-master-account