### PR TITLE
Coinex: createMarketBuyOrderRequiresPrice

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1898,6 +1898,23 @@ export default class coinex extends Exchange {
         }, market);
     }
 
+    async createMarketBuyWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name coinex#createMarketBuyWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} params.createMarketBuyOrderRequiresPrice automatically set to false for this method
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        params = {
+            'createMarketBuyOrderRequiresPrice': false,
+        };
+        return this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     createOrderRequest (symbol, type, side, amount, price = undefined, params = {}) {
         const market = this.market (symbol);
         const swap = market['swap'];
@@ -1988,15 +2005,19 @@ export default class coinex extends Exchange {
         } else {
             request['type'] = side;
             if ((type === 'market') && (side === 'buy')) {
-                if (this.options['createMarketBuyOrderRequiresPrice']) {
-                    if (price === undefined) {
-                        throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
+                let createMarketBuyOrderRequiresPrice = true;
+                [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+                const cost = this.safeNumber (params, 'cost');
+                params = this.omit (params, 'cost');
+                if (createMarketBuyOrderRequiresPrice) {
+                    if ((price === undefined) && (cost === undefined)) {
+                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                     } else {
-                        const amountString = this.amountToPrecision (symbol, amount);
-                        const priceString = this.priceToPrecision (symbol, price);
-                        const costString = Precise.stringMul (amountString, priceString);
-                        const costNumber = this.parseNumber (costString);
-                        request['amount'] = this.costToPrecision (symbol, costNumber);
+                        const amountString = this.numberToString (amount);
+                        const priceString = this.numberToString (price);
+                        const quoteAmount = this.parseToNumeric (Precise.stringMul (amountString, priceString));
+                        const costRequest = (cost !== undefined) ? cost : quoteAmount;
+                        request['amount'] = this.costToPrecision (symbol, costRequest);
                     }
                 } else {
                     request['amount'] = this.costToPrecision (symbol, amount);

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -182,6 +182,22 @@
                 "output": "{\"access_id\":\"86AC33D5904F432C9C9DDD4708233F38\",\"amount\":\"0.0005\",\"client_id\":\"x-167673045-de0c9f4634898ab2\",\"market\":\"BTCUSDT\",\"price\":\"25000\",\"stop_price\":\"26000\",\"tonce\":\"1701227312608\",\"type\":\"buy\"}"
             },
             {
+                "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.coinex.com/v1/order/market",
+                "input": [
+                    "BTC/USDT",
+                    "market",
+                    "buy",
+                    20,
+                    null,
+                    {
+                        "createMarketBuyOrderRequiresPrice": false
+                    }
+                ],
+                "output": "{\"access_id\":\"86AC33D5904F432C9C9DDD4708233F38\",\"amount\":\"20\",\"client_id\":\"x-167673045-c652179664b5b9b7\",\"market\":\"BTCUSDT\",\"tonce\":\"1701315225775\",\"type\":\"buy\"}"
+            },
+            {
                 "description": "Swap limit buy",
                 "method": "createOrder",
                 "url": "https://api.coinex.com/perpetual/v1/order/put_limit",


### PR DESCRIPTION
Added the method `createMarketBuyWithCost` to coinex and adjusted `createMarketBuyOrderRequiresPrice`

- use handleOptionAndParams so createMarketBuyOrderRequiresPrice can be controlled through the params or options

- accept cost in the params of createOrder

```
coinex createOrder BTC/USDT market buy 20 undefined '{"createMarketBuyOrderRequiresPrice":false}'

coinex.createOrder (BTC/USDT, market, buy, 20, , [object Object])
2023-11-30T03:33:46.077Z iteration 0 passed in 306 ms

{
  id: '107799961378',
  clientOrderId: 'x-167673045-c652179664b5b9b7',
  datetime: '2023-11-30T03:33:47.000Z',
  timestamp: 1701315227000,
  status: 'closed',
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  price: 37861,
  cost: 19.99969464,
  average: 37861,
  amount: 20,
  filled: 0.00052824,
  remaining: 0.00030536,
  trades: [],
  fee: { currency: 'USDT', cost: '0.03999938928' },
  info: {
    amount: '20',
    amount_asset: 'USDT',
    asset_fee: '0',
    avg_price: '37861',
    client_id: 'x-167673045-c652179664b5b9b7',
    create_time: '1701315227',
    deal_amount: '0.00052824',
    deal_fee: '0.03999938928',
    deal_money: '19.99969464',
    fee_asset: null,
    fee_discount: '1',
    finished_time: null,
    id: '107799961378',
    left: '0.00030536',
    maker_fee_rate: '0',
    market: 'BTCUSDT',
    money_fee: '0.03999938928',
    order_type: 'market',
    price: '0',
    status: 'done',
    stock_fee: '0',
    taker_fee_rate: '0.002',
    type: 'buy'
  },
  fees: [ { currency: 'USDT', cost: 0.03999938928 } ]
}
```
```
coinex.createMarketBuyWithCost (BTC/USDT, 20)
2023-11-30T03:39:49.786Z iteration 0 passed in 230 ms

{
  id: '107800160994',
  clientOrderId: 'x-167673045-1053ee5e4475a882',
  datetime: '2023-11-30T03:39:51.000Z',
  timestamp: 1701315591000,
  status: 'closed',
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  price: 37947.13,
  cost: 19.9996553952,
  average: 37947.13,
  amount: 20,
  filled: 0.00052704,
  remaining: 0.0003446048,
  trades: [],
  fee: { currency: 'USDT', cost: '0.0399993107904' },
  info: {
    amount: '20',
    amount_asset: 'USDT',
    asset_fee: '0',
    avg_price: '37947.13',
    client_id: 'x-167673045-1053ee5e4475a882',
    create_time: '1701315591',
    deal_amount: '0.00052704',
    deal_fee: '0.0399993107904',
    deal_money: '19.9996553952',
    fee_asset: null,
    fee_discount: '1',
    finished_time: null,
    id: '107800160994',
    left: '0.0003446048',
    maker_fee_rate: '0',
    market: 'BTCUSDT',
    money_fee: '0.0399993107904',
    order_type: 'market',
    price: '0',
    status: 'done',
    stock_fee: '0',
    taker_fee_rate: '0.002',
    type: 'buy'
  },
  fees: [ { currency: 'USDT', cost: 0.0399993107904 } ]
}
```