### PR TITLE
Okx: standardize createMarketBuyOrderRequiresPrice

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -38,7 +38,7 @@ export default class okx extends Exchange {
                 'cancelOrders': true,
                 'createDepositAddress': false,
                 'createMarketBuyOrderWithCost': true,
-                'createMarketSellOrderWithCost': undefined,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -37,6 +37,8 @@ export default class okx extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': true,
                 'createDepositAddress': false,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketSellOrderWithCost': undefined,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,
@@ -2503,22 +2505,18 @@ export default class okx extends Exchange {
         return this.parseBalanceByType (marketType, response);
     }
 
-    async createMarketBuyWithCost (symbol: string, cost, params = {}) {
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
         /**
          * @method
-         * @name okx#createMarketBuyWithCost
+         * @name okx#createMarketBuyOrderWithCost
          * @description create a market buy order by providing the symbol and cost
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {float} cost how much you want to trade in units of the quote currency
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {float} params.createMarketBuyOrderRequiresPrice automatically set to false for this method
-         * @param {string} params.tgtCcy automatically set to quote_ccy
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        params = {
-            'createMarketBuyOrderRequiresPrice': false,
-            'tgtCcy': 'quote_ccy',
-        };
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        params['tgtCcy'] = 'quote_ccy';
         return this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
     }
 

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -38,7 +38,7 @@ export default class okx extends Exchange {
                 'cancelOrders': true,
                 'createDepositAddress': false,
                 'createMarketBuyOrderWithCost': true,
-                'createMarketSellOrderWithCost': false,
+                'createMarketSellOrderWithCost': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,
@@ -2509,15 +2509,42 @@ export default class okx extends Exchange {
         /**
          * @method
          * @name okx#createMarketBuyOrderWithCost
+         * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-post-place-order
          * @description create a market buy order by providing the symbol and cost
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {float} cost how much you want to trade in units of the quote currency
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot markets only');
+        }
         params['createMarketBuyOrderRequiresPrice'] = false;
         params['tgtCcy'] = 'quote_ccy';
-        return this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
+    async createMarketSellOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name okx#createMarketSellOrderWithCost
+         * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-post-place-order
+         * @description create a market buy order by providing the symbol and cost
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketSellOrderWithCost() supports spot markets only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        params['tgtCcy'] = 'quote_ccy';
+        return await this.createOrder (symbol, 'market', 'sell', cost, undefined, params);
     }
 
     createOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -224,6 +224,30 @@
             "output": "[{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"e847386590ce4dBCdbc74f1714de86ed\",\"tag\":\"e847386590ce4dBC\"}]"      
           }
         ],
+        "createMarketBuyOrderWithCost": [
+          {
+            "description": "market buy",
+            "method": "createMarketBuyOrderWithCost",
+            "url": "https://www.okx.com/api/v5/trade/batch-orders",
+            "input": [
+              "LTC/USDT",
+              10
+            ],
+            "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"e847386590ce4dBC8ce3873ff4a2839e\",\"tag\":\"e847386590ce4dBC\"}]"
+          }
+        ],
+        "createMarketSellOrderWithCost": [
+          {
+            "description": "Market sell",
+            "method": "createMarketSellOrderWithCost",
+            "url": "https://www.okx.com/api/v5/trade/batch-orders",
+            "input": [
+              "LTC/USDT",
+              10
+            ],
+            "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"e847386590ce4dBC7b6fec7f0455b533\",\"tag\":\"e847386590ce4dBC\",\"createMarketBuyOrderRequiresPrice\":false}]"
+          }
+        ],
         "createOrders": [
           {
             "description": "Create multiple spot orders at the same time",

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -205,6 +205,23 @@
               }
             ],
             "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"post_only\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"25000\",\"slTriggerPx\":\"24000\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"tpTriggerPx\":\"26000\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\",\"clOrdId\":\"e847386590ce4dBC6798012df444b042\",\"tag\":\"e847386590ce4dBC\",\"posSide\":\"long\"}]"
+          },
+          {
+            "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
+            "method": "createOrder",
+            "url": "https://www.okx.com/api/v5/trade/batch-orders",
+            "input": [
+              "BTC/USDT",
+              "market",
+              "buy",
+              10,
+              null,
+              {
+                "createMarketBuyOrderRequiresPrice": false,
+                "tgtCcy": "quote_ccy"
+              }
+            ],
+            "output": "[{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"e847386590ce4dBCdbc74f1714de86ed\",\"tag\":\"e847386590ce4dBC\"}]"      
           }
         ],
         "createOrders": [


### PR DESCRIPTION
Added the method `createMarketBuyOrderWithCost` to okx and standardized the `createMarketBuyOrderRequiresPrice` implementation

- use handleOptionAndParams so createMarketBuyOrderRequiresPrice can be controlled through the params or options

- accept cost in the params of createOrder

- added a static request test for createMarketBuyOrderRequiresPrice

```
okx createOrder BTC/USDT market buy 10 undefined '{"createMarketBuyOrderRequiresPrice":false,"tgtCcy":"quote_ccy"}'

okx.createOrder (BTC/USDT, market, buy, 10, , [object Object])
2023-11-30T07:08:28.639Z iteration 0 passed in 392 ms

{
  info: {
    clOrdId: 'e847386590ce4dBCdbc74f1714de86ed',
    ordId: '650352456622235669',
    sCode: '0',
    sMsg: 'Order placed',
    tag: 'e847386590ce4dBC'
  },
  id: '650352456622235669',
  clientOrderId: 'e847386590ce4dBCdbc74f1714de86ed',
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  trades: [],
  reduceOnly: false,
  fees: []
}
```
```
okx.createMarketBuyOrderWithCost (BTC/USDT, 10)
2023-11-30T07:10:36.452Z iteration 0 passed in 401 ms

{
  info: {
    clOrdId: 'e847386590ce4dBC17bd40076489a6f0',
    ordId: '650352992666869780',
    sCode: '0',
    sMsg: 'Order placed',
    tag: 'e847386590ce4dBC'
  },
  id: '650352992666869780',
  clientOrderId: 'e847386590ce4dBC17bd40076489a6f0',
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  trades: [],
  reduceOnly: false,
  fees: []
}
```