### PR TITLE
Exchange class, create market order with cost methods

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -468,6 +468,7 @@ export default class Exchange {
                 'createMarketOrder': true,
                 'createOrder': true,
                 'createMarketBuyOrderWithCost': undefined,
+                'createMarketOrderWithCost': undefined,
                 'createMarketSellOrderWithCost': undefined,
                 'createOrders': undefined,
                 'createPostOnlyOrder': undefined,
@@ -3960,16 +3961,36 @@ export default class Exchange {
         throw new NotSupported (this.id + ' createOrder() is not supported yet');
     }
 
+    async createMarketOrderWithCost (symbol: string, side: OrderSide, cost, params = {}) {
+        /**
+         * @method
+         * @name createMarketOrderWithCost
+         * @description create a market order by providing the symbol, side and cost
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        if (this.options['createMarketBuyOrderRequiresPrice'] || this.options['createMarketSellOrderRequiresPrice'] || this.options['createMarketOrderWithCost']) {
+            return await this.createOrder (symbol, 'market', side, cost, 1, params);
+        }
+        throw new NotSupported (this.id + ' createMarketOrderWithCost() is not supported yet');
+    }
+
     async createMarketBuyOrderWithCost (symbol: string, cost, params = {}): Promise<Order> {
         /**
          * @method
-         * @name createMarketBuyWithCost
+         * @name createMarketBuyOrderWithCost
          * @description create a market buy order by providing the symbol and cost
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {float} cost how much you want to trade in units of the quote currency
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        if (this.options['createMarketBuyOrderRequiresPrice'] || this.options['createMarketBuyOrderWithCost']) {
+            return await this.createOrder (symbol, 'market', 'buy', cost, 1, params);
+        }
         throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() is not supported yet');
     }
 
@@ -3977,12 +3998,15 @@ export default class Exchange {
         /**
          * @method
          * @name createMarketSellOrderWithCost
-         * @description create a market buy order by providing the symbol and cost
+         * @description create a market sell order by providing the symbol and cost
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {float} cost how much you want to trade in units of the quote currency
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        if (this.options['createMarketSellOrderRequiresPrice'] || this.options['createMarketSellOrderWithCost']) {
+            return await this.createOrder (symbol, 'market', 'sell', cost, 1, params);
+        }
         throw new NotSupported (this.id + ' createMarketSellOrderWithCost() is not supported yet');
     }
 


### PR DESCRIPTION
Updated the implementation of `createMarketBuyOrderWithCost`, `createMarketSellOrderWithCost` and `createMarketOrderWithCost` in the base Exchange class