### PR TITLE
Bitmart: standardize createMarketBuyOrderRequiresPrice

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -38,6 +38,9 @@ export default class bitmart extends Exchange {
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': false,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': true,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createPostOnlyOrder': true,
                 'createStopLimitOrder': false,
@@ -2167,12 +2170,57 @@ export default class bitmart extends Exchange {
         return this.safeString (statuses, status, status);
     }
 
+    async createMarketOrderWithCost (symbol: string, side: OrderSide, cost, params = {}) {
+        /**
+         * @method
+         * @name bitmart#createMarketOrderWithCost
+         * @description create a market order by providing the symbol, side and cost
+         * @see https://developer-pro.bitmart.com/en/spot/#new-order-v2-signed
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketOrderWithCost() supports spot orders only');
+        }
+        if (side === 'buy') {
+            params['createMarketBuyOrderRequiresPrice'] = false;
+        } else {
+            throw new NotSupported (this.id + ' createMarketOrderWithCost() supports buy orders only');
+        }
+        return await this.createOrder (symbol, 'market', side, cost, undefined, params);
+    }
+
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name bitmart#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://developer-pro.bitmart.com/en/spot/#new-order-v2-signed
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
          * @name bitmart#createOrder
          * @description create a trade order
-         * @see https://developer-pro.bitmart.com/en/spot/#place-spot-order
+         * @see https://developer-pro.bitmart.com/en/spot/#new-order-v2-signed
          * @see https://developer-pro.bitmart.com/en/spot/#place-margin-order
          * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
          * @param {string} symbol unified symbol of the market to create an order in
@@ -2343,17 +2391,17 @@ export default class bitmart extends Exchange {
         } else if (isMarketOrder) {
             // for market buy it requires the amount of quote currency to spend
             if (side === 'buy') {
-                let notional = this.safeNumber (params, 'notional');
-                const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
+                let notional = this.safeNumber2 (params, 'cost', 'notional');
+                params = this.omit (params, 'cost');
+                let createMarketBuyOrderRequiresPrice = true;
+                [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
                 if (createMarketBuyOrderRequiresPrice) {
-                    if (price !== undefined) {
-                        if (notional === undefined) {
-                            const amountString = this.numberToString (amount);
-                            const priceString = this.numberToString (price);
-                            notional = this.parseNumber (Precise.stringMul (amountString, priceString));
-                        }
-                    } else if (notional === undefined) {
-                        throw new InvalidOrder (this.id + " createOrder () requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false and supply the total cost value in the 'amount' argument or in the 'notional' extra parameter (the exchange-specific behaviour)");
+                    if ((price === undefined) && (notional === undefined)) {
+                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument or in the "notional" extra parameter (the exchange-specific behaviour)');
+                    } else {
+                        const amountString = this.numberToString (amount);
+                        const priceString = this.numberToString (price);
+                        notional = this.parseNumber (Precise.stringMul (amountString, priceString));
                     }
                 } else {
                     notional = (notional === undefined) ? amount : notional;

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -39,7 +39,7 @@ export default class bitmart extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': false,
                 'createMarketBuyOrderWithCost': true,
-                'createMarketOrderWithCost': true,
+                'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createPostOnlyOrder': true,
@@ -2168,31 +2168,6 @@ export default class bitmart extends Exchange {
         };
         const statuses = this.safeValue (statusesByType, type, {});
         return this.safeString (statuses, status, status);
-    }
-
-    async createMarketOrderWithCost (symbol: string, side: OrderSide, cost, params = {}) {
-        /**
-         * @method
-         * @name bitmart#createMarketOrderWithCost
-         * @description create a market order by providing the symbol, side and cost
-         * @see https://developer-pro.bitmart.com/en/spot/#new-order-v2-signed
-         * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} side 'buy' or 'sell'
-         * @param {float} cost how much you want to trade in units of the quote currency
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
-         */
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        if (!market['spot']) {
-            throw new NotSupported (this.id + ' createMarketOrderWithCost() supports spot orders only');
-        }
-        if (side === 'buy') {
-            params['createMarketBuyOrderRequiresPrice'] = false;
-        } else {
-            throw new NotSupported (this.id + ' createMarketOrderWithCost() supports buy orders only');
-        }
-        return await this.createOrder (symbol, 'market', side, cost, undefined, params);
     }
 
     async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -185,19 +185,6 @@
                 "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
             }
         ],
-        "createMarketOrderWithCost": [
-            {
-                "description": "Spot create market order with cost and set the side to buy",
-                "method": "createMarketOrderWithCost",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
-                "input": [
-                    "BTC/USDT",
-                    "buy",
-                    5
-                ],
-                "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
-            }
-        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -155,6 +155,47 @@
                     }
                 ],
                 "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"limit\",\"size\":1,\"mode\":4,\"price\":\"55\",\"side\":1,\"open_type\":\"cross\",\"client_order_id\":\"myClientOrderId\",\"leverage\":\"1\"}"
+            },
+            {
+                "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "input": [
+                    "BTC/USDT",
+                    "market",
+                    "buy",
+                    5,
+                    null,
+                    {
+                        "createMarketBuyOrderRequiresPrice": false
+                    }
+                ],
+                "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot create market buy order with the quote amount as the cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "input": [
+                    "BTC/USDT",
+                    5
+                ],
+                "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
+            }
+        ],
+        "createMarketOrderWithCost": [
+            {
+                "description": "Spot create market order with cost and set the side to buy",
+                "method": "createMarketOrderWithCost",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "input": [
+                    "BTC/USDT",
+                    "buy",
+                    5
+                ],
+                "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
             }
         ],
         "fetchMyTrades": [


### PR DESCRIPTION
Standardized `createMarketBuyOrderRequiresPrice`, added `createMarketBuyOrderWithCost` and `createMarketOrderWithCost` to Bitmart:
```
bitmart createOrder BTC/USDT market buy 5 undefined '{"createMarketBuyOrderRequiresPrice":false}'

bitmart.createOrder (BTC/USDT, market, buy, 5, , [object Object])
2023-12-02T04:16:47.113Z iteration 0 passed in 495 ms

{
  id: '208480014660628222',
  info: { order_id: '208480014660628222' },
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  amount: 5,
  trades: [],
  fees: []
}
```
```
bitmart.createMarketBuyOrderWithCost (BTC/USDT, 5)
2023-12-02T04:29:23.139Z iteration 0 passed in 454 ms

{
  id: '208481449179710189',
  info: { order_id: '208481449179710189' },
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  amount: 5,
  trades: [],
  fees: []
}
```
```
bitmart.createMarketOrderWithCost (BTC/USDT, buy, 5)
2023-12-02T04:30:59.940Z iteration 0 passed in 466 ms

{
  id: '208479305991008479',
  info: { order_id: '208479305991008479' },
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  amount: 5,
  trades: [],
  fees: []
}
```