### PR TITLE
fix(Client.ts): only decompress binary messages

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -292,21 +292,18 @@ export default class Client {
 
         let message : Buffer | string = messageEvent.data
         let arrayBuffer : Uint8Array
-        if (this.gunzip || this.inflate) {
-            if (typeof message === 'string') {
-                arrayBuffer = utf8.decode (message)
-            } else {
-                arrayBuffer = new Uint8Array (message.buffer.slice (message.byteOffset, message.byteOffset + message.byteLength))
-            }
-            if (this.gunzip) {
-                arrayBuffer = gunzipSync (arrayBuffer)
-            } else if (this.inflate) {
-                arrayBuffer = inflateSync (arrayBuffer)
-            }
-            message = utf8.encode (arrayBuffer)
-        }
         if (typeof message !== 'string') {
-            message = message.toString ()
+            if (this.gunzip || this.inflate) {
+                arrayBuffer = new Uint8Array (message.buffer.slice (message.byteOffset, message.byteOffset + message.byteLength))
+                if (this.gunzip) {
+                    arrayBuffer = gunzipSync (arrayBuffer)
+                } else if (this.inflate) {
+                    arrayBuffer = inflateSync (arrayBuffer)
+                }
+                message = utf8.encode (arrayBuffer)
+            } else {
+                message = message.toString ()
+            }
         }
         try {
             if (isJsonEncodedObject (message)) {


### PR DESCRIPTION
- Was getting an EOF error in bitmart when trying to decompress Ws messages. Bitmart uses inflate and returns most messages in binary however it sometimes returns error messages as a regular string and when trying to decompres it would error.
- This changes the client to only decompress binary messages and not strings. This is is how it's already done in python and php library.
- Tested calling exchanges that have gunzip or inflate set to true and all seem to be unaffected by this change.