### PR TITLE
Bitstamp: fetchOHLCV end time calculation

### DIFF
--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -1050,6 +1050,7 @@ export default class bitstamp extends Exchange {
          * @method
          * @name bitstamp#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://www.bitstamp.net/api/#tag/Market-info/operation/GetOHLCData
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -1071,14 +1072,14 @@ export default class bitstamp extends Exchange {
                 limit = 1000;
                 const start = this.parseToInt (since / 1000);
                 request['start'] = start;
-                request['end'] = this.sum (start, limit * duration);
+                request['end'] = this.sum (start, (limit - 1) * duration);
                 request['limit'] = limit;
             }
         } else {
             if (since !== undefined) {
                 const start = this.parseToInt (since / 1000);
                 request['start'] = start;
-                request['end'] = this.sum (start, limit * duration);
+                request['end'] = this.sum (start, (limit - 1) * duration);
             }
             request['limit'] = Math.min (limit, 1000); // min 1, max 1000
         }

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -1072,14 +1072,14 @@ export default class bitstamp extends Exchange {
                 limit = 1000;
                 const start = this.parseToInt (since / 1000);
                 request['start'] = start;
-                request['end'] = this.sum (start, (limit - 1) * duration);
+                request['end'] = this.sum (start, duration * (limit - 1));
                 request['limit'] = limit;
             }
         } else {
             if (since !== undefined) {
                 const start = this.parseToInt (since / 1000);
                 request['start'] = start;
-                request['end'] = this.sum (start, (limit - 1) * duration);
+                request['end'] = this.sum (start, duration * (limit - 1));
             }
             request['limit'] = Math.min (limit, 1000); // min 1, max 1000
         }


### PR DESCRIPTION
Fixed an error with the end time calculation that prevented the candle with the specified since time from being returned:
fixes: #20222

```
bitstamp.fetchOHLCV (BTC/USDT, 1m, 1673131800000, 3)
2023-12-04T23:50:51.308Z iteration 0 passed in 597 ms

1673131800000 | 16936 | 16936 | 16936 | 16936 | 0
1673131860000 | 16936 | 16936 | 16936 | 16936 | 0
1673131920000 | 16936 | 16936 | 16936 | 16936 | 0
3 objects
```