### PR TITLE
Bitrue: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -34,6 +34,9 @@ export default class bitrue extends Exchange {
                 'option': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createStopLimitOrder': true,
                 'createStopMarketOrder': true,
@@ -1881,6 +1884,27 @@ export default class bitrue extends Exchange {
         }, market);
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name bitrue#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://www.bitrue.com/api-docs#new-order-trade-hmac-sha256
+         * @see https://www.bitrue.com/api_docs_includes_file/delivery.html#new-order-trade-hmac-sha256
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports swap orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
@@ -1904,6 +1928,7 @@ export default class bitrue extends Exchange {
          * EXCHANGE SPECIFIC PARAMETERS
          * @param {decimal} [params.icebergQty]
          * @param {long} [params.recvWindow]
+         * @param {float} [params.cost] *swap market buy only* the quote quantity that can be used as an alternative for the amount
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1938,7 +1963,9 @@ export default class bitrue extends Exchange {
                 request['type'] = 'IOC';
             }
             request['contractName'] = market['id'];
-            if (isMarket && (side === 'buy') && (this.options['createMarketBuyOrderRequiresPrice'])) {
+            let createMarketBuyOrderRequiresPrice = true;
+            [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+            if (isMarket && (side === 'buy') && createMarketBuyOrderRequiresPrice) {
                 const cost = this.safeString (params, 'cost');
                 params = this.omit (params, 'cost');
                 if (price === undefined && cost === undefined) {

--- a/ts/src/test/static/markets/bitrue.json
+++ b/ts/src/test/static/markets/bitrue.json
@@ -635,5 +635,61 @@
         "tierBased": false,
         "percentage": true,
         "feeSide": "get"
+      },
+      "BTC/USDT:USDT":  {
+        "id": "E-BTC-USDT",
+        "lowercaseId": "e-btc-usdt",
+        "symbol": "BTC/USDT:USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": false,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "taker": 0.00098,
+        "maker": 0.00098,
+        "contractSize": 0.0001,
+        "precision": {
+          "price": 0.1
+        },
+        "limits": {
+          "leverage": {},
+          "amount": {
+            "max": 50
+          },
+          "price": {},
+          "cost": {
+            "min": 50
+          }
+        },
+        "info": {
+          "symbol": "E-BTC-USDT",
+          "pricePrecision": "1",
+          "side": "1",
+          "maxMarketVolume": "10000",
+          "multiplier": "0.0001000000000000000",
+          "minOrderVolume": "10",
+          "maxMarketMoney": "300000.0000000000000000",
+          "type": "E",
+          "maxLimitVolume": "150000",
+          "maxValidOrder": "50",
+          "multiplierCoin": "BTC",
+          "minOrderMoney": "50.0000000000000000",
+          "maxLimitMoney": "1000000.0000000000000000",
+          "status": "1"
+        },
+        "tierBased": false,
+        "percentage": true,
+        "feeSide": "get"
       }
 }

--- a/ts/src/test/static/request/bitrue.json
+++ b/ts/src/test/static/request/bitrue.json
@@ -92,6 +92,56 @@
                   }
                 ],
                 "output": "{\"recvWindow\":5000,\"side\":\"BUY\",\"type\":\"MARKET\",\"contractName\":\"E-LTC-USDT\",\"amount\":\"15\",\"volume\":\"15\",\"positionType\":1,\"open\":\"OPEN\",\"leverage\":1}"
+            },
+            {
+                "description": "Swap market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://fapi.bitrue.com/fapi/v2/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "buy",
+                  50,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false,
+                    "leverage": 10
+                  }
+                ],
+                "output": "{\"recvWindow\":5000,\"side\":\"BUY\",\"type\":\"MARKET\",\"contractName\":\"E-BTC-USDT\",\"amount\":50,\"volume\":50,\"positionType\":1,\"open\":\"OPEN\",\"leverage\":10}"
+            },
+            {
+                "description": "Swap market sell",
+                "method": "createOrder",
+                "url": "https://fapi.bitrue.com/fapi/v2/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0011,
+                  null,
+                  {
+                    "reduceOnly": true,
+                    "leverage": 10
+                  }
+                ],
+                "output": "{\"recvWindow\":5000,\"side\":\"SELL\",\"type\":\"MARKET\",\"contractName\":\"E-BTC-USDT\",\"amount\":0.0011,\"volume\":0.0011,\"positionType\":1,\"open\":\"CLOSE\",\"leverage\":10}"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Swap market buy order with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://fapi.bitrue.com/fapi/v2/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  50,
+                  {
+                    "leverage": 10,
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "{\"recvWindow\":5000,\"side\":\"BUY\",\"type\":\"MARKET\",\"contractName\":\"E-BTC-USDT\",\"amount\":50,\"volume\":50,\"positionType\":1,\"open\":\"OPEN\",\"leverage\":10}"
             }
         ],
         "fetchMyTrades": [


### PR DESCRIPTION
Added `createMarketBuyOrderWithCost` and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`:

```
bitrue createOrder BTC/USDT:USDT market buy 50 undefined '{"createMarketBuyOrderRequiresPrice":false,"leverage":10}'

bitrue.createOrder (BTC/USDT:USDT, market, buy, 50, , [object Object])
2023-12-05T02:18:05.211Z iteration 0 passed in 2119 ms

{
  info: { orderId: '1959009264617016050' },
  id: '1959009264617016050',
  symbol: 'BTC/USDT:USDT',
  postOnly: false,
  trades: [],
  fees: []
}
```
```
bitrue createMarketBuyOrderWithCost BTC/USDT:USDT 50 '{"leverage":10}'

bitrue.createMarketBuyOrderWithCost (BTC/USDT:USDT, 50, [object Object])
2023-12-05T02:26:05.644Z iteration 0 passed in 1762 ms

{
  info: { orderId: '1959007580989806743' },
  id: '1959007580989806743',
  symbol: 'BTC/USDT:USDT',
  postOnly: false,
  trades: [],
  fees: []
}
```