### PR TITLE
Coinbase: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -43,7 +43,10 @@ export default class coinbase extends Exchange {
                 'createLimitBuyOrder': true,
                 'createLimitSellOrder': true,
                 'createMarketBuyOrder': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
                 'createMarketSellOrder': true,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createPostOnlyOrder': true,
                 'createReduceOnlyOrder': false,
@@ -2110,6 +2113,26 @@ export default class coinbase extends Exchange {
         return request;
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name coinbase#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
@@ -2130,6 +2153,7 @@ export default class coinbase extends Exchange {
          * @param {string} [params.timeInForce] 'GTC', 'IOC', 'GTD' or 'PO'
          * @param {string} [params.stop_direction] 'UNKNOWN_STOP_DIRECTION', 'STOP_DIRECTION_STOP_UP', 'STOP_DIRECTION_STOP_DOWN' the direction the stopPrice is triggered from
          * @param {string} [params.end_time] '2023-05-25T17:01:05.092Z' for 'GTD' orders
+         * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -2226,19 +2250,24 @@ export default class coinbase extends Exchange {
                 throw new NotSupported (this.id + ' createOrder() only stop limit orders are supported');
             }
             if (side === 'buy') {
-                const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
                 let total = undefined;
-                if (createMarketBuyOrderRequiresPrice) {
+                let createMarketBuyOrderRequiresPrice = true;
+                [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+                const cost = this.safeNumber (params, 'cost');
+                params = this.omit (params, 'cost');
+                if (cost !== undefined) {
+                    total = this.costToPrecision (symbol, cost);
+                } else if (createMarketBuyOrderRequiresPrice) {
                     if (price === undefined) {
-                        throw new InvalidOrder (this.id + ' createOrder() requires a price argument for market buy orders on spot markets to calculate the total amount to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option to false and pass in the cost to spend into the amount parameter');
+                        throw new InvalidOrder (this.id + ' createOrder() requires a price argument for market buy orders on spot markets to calculate the total amount to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                     } else {
                         const amountString = this.numberToString (amount);
                         const priceString = this.numberToString (price);
-                        const cost = this.parseNumber (Precise.stringMul (amountString, priceString));
-                        total = this.priceToPrecision (symbol, cost);
+                        const costRequest = Precise.stringMul (amountString, priceString);
+                        total = this.costToPrecision (symbol, costRequest);
                     }
                 } else {
-                    total = this.priceToPrecision (symbol, amount);
+                    total = this.costToPrecision (symbol, amount);
                 }
                 request['order_configuration'] = {
                     'market_market_ioc': {

--- a/ts/src/test/static/markets/coinbase.json
+++ b/ts/src/test/static/markets/coinbase.json
@@ -1,4 +1,152 @@
 {
+    "BTC/USDC": {
+        "id": "BTC-USDC",
+        "symbol": "BTC/USDC",
+        "base": "BTC",
+        "quote": "USDC",
+        "baseId": "BTC",
+        "quoteId": "USDC",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "contract": false,
+        "precision": {
+            "amount": 1e-8,
+            "price": 0.01
+        },
+        "limits": {
+            "amount": {
+                "min": 0.000016,
+                "max": 2500
+            },
+            "price": {},
+            "cost": {
+                "min": 1,
+                "max": 75000000
+            },
+            "leverage": {}
+        },
+        "info": {
+            "product_id": "BTC-USDC",
+            "price": "41879.12",
+            "price_percentage_change_24h": "1.42975853736571",
+            "volume_24h": "19891.16722555",
+            "volume_percentage_change_24h": "74.81477259994482",
+            "base_increment": "0.00000001",
+            "quote_increment": "0.01",
+            "quote_min_size": "1",
+            "quote_max_size": "75000000",
+            "base_min_size": "0.000016",
+            "base_max_size": "2500",
+            "base_name": "Bitcoin",
+            "quote_name": "USDC",
+            "watched": false,
+            "is_disabled": false,
+            "new": false,
+            "status": "online",
+            "cancel_only": false,
+            "limit_only": false,
+            "post_only": false,
+            "trading_disabled": false,
+            "auction_mode": false,
+            "product_type": "SPOT",
+            "quote_currency_id": "USDC",
+            "base_currency_id": "BTC",
+            "fcm_trading_session_details": null,
+            "mid_market_price": "",
+            "alias": "BTC-USD",
+            "alias_to": [],
+            "base_display_symbol": "BTC",
+            "quote_display_symbol": "USDC",
+            "view_only": false,
+            "price_increment": "0.01"
+        },
+        "tierBased": true,
+        "percentage": true,
+        "taker": 0.008,
+        "maker": 0.006,
+        "tiers": {
+            "taker": [
+                [
+                    0,
+                    0.006
+                ],
+                [
+                    10000,
+                    0.004
+                ],
+                [
+                    50000,
+                    0.0025
+                ],
+                [
+                    100000,
+                    0.002
+                ],
+                [
+                    1000000,
+                    0.0018
+                ],
+                [
+                    15000000,
+                    0.0016
+                ],
+                [
+                    75000000,
+                    0.0012
+                ],
+                [
+                    250000000,
+                    0.0008
+                ],
+                [
+                    400000000,
+                    0.0005
+                ]
+            ],
+            "maker": [
+                [
+                    0,
+                    0.004
+                ],
+                [
+                    10000,
+                    0.0025
+                ],
+                [
+                    50000,
+                    0.0015
+                ],
+                [
+                    100000,
+                    0.001
+                ],
+                [
+                    1000000,
+                    0.0008
+                ],
+                [
+                    15000000,
+                    0.0006
+                ],
+                [
+                    75000000,
+                    0.0003
+                ],
+                [
+                    250000000,
+                    0
+                ],
+                [
+                    400000000,
+                    0
+                ]
+            ]
+        }
+    },
     "BTC/USDT": {
         "id": "BTC-USDT",
         "symbol": "BTC/USDT",

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -73,6 +73,50 @@
                   }
                 ],
                 "output": "{\"client_order_id\":\"e5297ce3-a3da-4360-80aa-563602fe2bf1\",\"product_id\":\"ADA-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_gtc\":{\"base_size\":\"10\",\"limit_price\":\"0.25\",\"post_only\":true}}}"
+            },
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.coinbase.com/api/v3/brokerage/orders",
+                "input": [
+                  "BTC/USDC",
+                  "market",
+                  "buy",
+                  5,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "{\"client_order_id\":\"523b539c-f99a-477e-ae29-c63570221d9a\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+            },
+            {
+                "description": "Spot market buy using the cost param",
+                "method": "createOrder",
+                "url": "https://api.coinbase.com/api/v3/brokerage/orders",
+                "input": [
+                  "BTC/USDC",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 5
+                  }
+                ],
+                "output": "{\"client_order_id\":\"c6449e15-78c0-4ff8-a603-2047c131faa3\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot market buy order with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.coinbase.com/api/v3/brokerage/orders",
+                "input": [
+                  "BTC/USDC",
+                  5
+                ],
+                "output": "{\"client_order_id\":\"e5e5b341-360a-48d3-9a2a-dc8a9f529237\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
             }
         ],
         "fetchBalance": [


### PR DESCRIPTION
Added `createMarketBuyOrderWithCost`, and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createMarketBuyOrderWithCost`, `createMarketBuyOrderRequiresPrice` and using the `cost` param to create a market buy order:

```
coinbase createOrder BTC/USDC market buy 5 undefined '{"createMarketBuyOrderRequiresPrice":false}'

coinbase.createOrder (BTC/USDC, market, buy, 5, , [object Object])
2023-12-05T06:51:12.629Z iteration 0 passed in 638 ms

{
  info: {
    order_id: 'c9448f93-2862-4466-9977-bbe5a879fa40',
    product_id: 'BTC-USDC',
    side: 'BUY',
    client_order_id: '523b539c-f99a-477e-ae29-c63570221d9a'
  },
  id: 'c9448f93-2862-4466-9977-bbe5a879fa40',
  clientOrderId: '523b539c-f99a-477e-ae29-c63570221d9a',
  symbol: 'BTC/USDC',
  side: 'buy',
  fee: {},
  trades: [],
  fees: [ {} ]
}
```
```
coinbase createOrder BTC/USDC market buy undefined undefined '{"cost":5}'

coinbase.createOrder (BTC/USDC, market, buy, , , [object Object])
2023-12-05T06:54:47.604Z iteration 0 passed in 632 ms

{
  info: {
    order_id: 'b50d87cf-3edf-43a1-b2e5-be65790009b9',
    product_id: 'BTC-USDC',
    side: 'BUY',
    client_order_id: 'c6449e15-78c0-4ff8-a603-2047c131faa3'
  },
  id: 'b50d87cf-3edf-43a1-b2e5-be65790009b9',
  clientOrderId: 'c6449e15-78c0-4ff8-a603-2047c131faa3',
  symbol: 'BTC/USDC',
  side: 'buy',
  fee: {},
  trades: [],
  fees: [ {} ]
}
```
```
coinbase.createMarketBuyOrderWithCost (BTC/USDC, 5)
2023-12-05T06:53:06.054Z iteration 0 passed in 635 ms

{
  info: {
    order_id: '854b9357-e8eb-4d41-b4a1-44244eeb4c58',
    product_id: 'BTC-USDC',
    side: 'BUY',
    client_order_id: 'e5e5b341-360a-48d3-9a2a-dc8a9f529237'
  },
  id: '854b9357-e8eb-4d41-b4a1-44244eeb4c58',
  clientOrderId: 'e5e5b341-360a-48d3-9a2a-dc8a9f529237',
  symbol: 'BTC/USDC',
  side: 'buy',
  fee: {},
  trades: [],
  fees: [ {} ]
}
```