### PR TITLE
fix(bitmex) - empty numbers

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1531,7 +1531,8 @@ export default class bitmex extends Exchange {
         //         "trdMatchID": "b9a42432-0a46-6a2f-5ecc-c32e9ca4baf8",
         //         "grossValue": 28958000,
         //         "homeNotional": 0.28958,
-        //         "foreignNotional": 2000
+        //         "foreignNotional": 2000,
+        //         "trdType": "Regular"
         //     }
         //
         // fetchMyTrades (private)
@@ -1591,13 +1592,22 @@ export default class bitmex extends Exchange {
         const timestamp = this.parse8601 (this.safeString (trade, 'timestamp'));
         const priceString = this.safeString2 (trade, 'avgPx', 'price');
         const amountString = this.convertFromRawQuantity (symbol, this.safeString2 (trade, 'size', 'lastQty'));
-        const execCost = this.numberToString (this.convertFromRawCost (symbol, this.safeString (trade, 'execCost')));
+        const execCost = this.safeString (trade, 'execCost');
+        let cost = undefined;
+        if (execCost !== undefined) {
+            const execCostReal = this.numberToString (this.convertFromRawCost (symbol, execCost));
+            cost = Precise.stringAbs (execCostReal);
+        }
         const id = this.safeString (trade, 'trdMatchID');
         const order = this.safeString (trade, 'orderID');
         const side = this.safeStringLower (trade, 'side');
         // price * amount doesn't work for all symbols (e.g. XBT, ETH)
         let fee = undefined;
-        const feeCostString = this.numberToString (this.convertFromRawCost (symbol, this.safeString (trade, 'execComm')));
+        const execComm = this.safeString (trade, 'execComm');
+        let feeCostString = undefined;
+        if (execComm !== undefined) {
+            feeCostString = this.numberToString (this.convertFromRawCost (symbol, execComm));
+        }
         if (feeCostString !== undefined) {
             const currencyId = this.safeString (trade, 'settlCurrency');
             const feeCurrencyCode = this.safeCurrencyCode (currencyId);
@@ -1626,7 +1636,7 @@ export default class bitmex extends Exchange {
             'takerOrMaker': takerOrMaker,
             'side': side,
             'price': priceString,
-            'cost': Precise.stringAbs (execCost),
+            'cost': cost,
             'amount': amountString,
             'fee': fee,
         }, market);

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -393,7 +393,9 @@ export default class bitmex extends Exchange {
     }
 
     convertToRealAmount (code: Str, amount: Str) {
-        if (code === undefined || amount === undefined) {
+        if (code === undefined) {
+            return amount;
+        } else if (amount === undefined) {
             return undefined;
         }
         const currency = this.currency (code);

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -174,6 +174,16 @@
         ],
         "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"stopPx\":36944,\"price\":36000}"
       }
+    ],
+    "fetchTrades": [
+      {
+        "description": "spot",
+        "method": "fetchTrades",
+        "url": "https://www.bitmex.com/api/v1/trade?symbol=XBT_USDT&reverse=true",
+        "input": [
+          "BTC/USDT"
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
to fix this - https://app.travis-ci.com/github/ccxt/ccxt/builds/267635264#L2253

```
    timestamp |                 datetime |   symbol |                                   id | order | type | takerOrMaker | side |   price |       cost | amount | fee | fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1701721082066 | 2023-12-04T20:18:02.066Z | BTC/USDT | 00000000-006d-1000-0000-0002cdd79af1 |       |      |              |  buy | 41630.5 |    4.16305 | 0.0001 |     |   []
1701761617163 | 2023-12-05T07:33:37.163Z | BTC/USDT | 00000000-006d-1000-0000-0002ce1e4347 |       |      |              |  buy |   41500 |       4.15 | 0.0001 |     |   []
1701761643557 | 2023-12-05T07:34:03.557Z | BTC/USDT | 00000000-006d-1000-0000-0002ce1f842c |       |      |              |  buy |   41507 |    20.7535 | 0.0005 |     |   []
1701761929661 | 2023-12-05T07:38:49.661Z | BTC/USDT | 00000000-006d-1000-0000-0002ce2dd84d |       |      |              |  buy | 41488.5 |    49.7862 | 0.0012 |     |   []
1701761998249 | 2023-12-05T07:39:58.249Z | BTC/USDT | 00000000-006d-1000-0000-0002ce317bcb |       |      |              | sell |   41488 |     4.1488 | 0.0001 |     |   []
```