### PR TITLE
fix(okx) - removal of incorrect map (QUICK)

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1056,13 +1056,7 @@ export default class okx extends Exchange {
             'commonCurrencies': {
                 // the exchange refers to ERC20 version of Aeternity (AEToken)
                 'AE': 'AET', // https://github.com/ccxt/ccxt/issues/4981
-                'BOX': 'DefiBox',
-                'HOT': 'Hydro Protocol',
                 'HSR': 'HC',
-                'MAG': 'Maggie',
-                'SBTC': 'Super Bitcoin',
-                'TRADE': 'Unitrade',
-                'YOYO': 'YOYOW',
                 'WIN': 'WINTOKEN', // https://github.com/ccxt/ccxt/issues/5701
             },
         });

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1063,7 +1063,7 @@ export default class okx extends Exchange {
                 'SBTC': 'Super Bitcoin',
                 'TRADE': 'Unitrade',
                 'YOYO': 'YOYOW',
-                'WIN': 'WinToken', // https://github.com/ccxt/ccxt/issues/5701
+                'WIN': 'WINTOKEN', // https://github.com/ccxt/ccxt/issues/5701
             },
         });
     }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1056,7 +1056,6 @@ export default class okx extends Exchange {
             'commonCurrencies': {
                 // the exchange refers to ERC20 version of Aeternity (AEToken)
                 'AE': 'AET', // https://github.com/ccxt/ccxt/issues/4981
-                'HSR': 'HC',
                 'WIN': 'WINTOKEN', // https://github.com/ccxt/ccxt/issues/5701
             },
         });


### PR DESCRIPTION
OKX had since removed most of those coins: https://www.okx.com/api/v5/public/instruments?instType=SPOT
