### PR TITLE
Mexc: createMarketBuyOrderWithCost 

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -39,6 +39,9 @@ export default class mexc extends Exchange {
                 'closeAllPositions': false,
                 'closePosition': false,
                 'createDepositAddress': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createOrders': true,
                 'createReduceOnlyOrder': true,
@@ -2069,11 +2072,34 @@ export default class mexc extends Exchange {
         return this.parseTickers (tickers, symbols);
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name mexc#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://mexcdevelop.github.io/apidocs/spot_v3_en/#new-order
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
          * @name mexc3#createOrder
          * @description create a trade order
+         * @see https://mexcdevelop.github.io/apidocs/spot_v3_en/#new-order
+         * @see https://mexcdevelop.github.io/apidocs/contract_v1_en/#order-under-maintenance
+         * @see https://mexcdevelop.github.io/apidocs/contract_v1_en/#trigger-order-under-maintenance
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -2102,12 +2128,15 @@ export default class mexc extends Exchange {
             'type': type.toUpperCase (),
         };
         if (orderSide === 'BUY' && type === 'market') {
-            const quoteOrderQty = this.safeNumber (params, 'quoteOrderQty');
-            if (quoteOrderQty !== undefined) {
-                amount = quoteOrderQty;
-            } else if (this.options['createMarketBuyOrderRequiresPrice']) {
+            let createMarketBuyOrderRequiresPrice = true;
+            [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+            const cost = this.safeNumber2 (params, 'cost', 'quoteOrderQty');
+            params = this.omit (params, 'cost');
+            if (cost !== undefined) {
+                amount = cost;
+            } else if (createMarketBuyOrderRequiresPrice) {
                 if (price === undefined) {
-                    throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
+                    throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                 } else {
                     const amountString = this.numberToString (amount);
                     const priceString = this.numberToString (price);

--- a/ts/src/test/static/request/mexc.json
+++ b/ts/src/test/static/request/mexc.json
@@ -42,6 +42,36 @@
                   1500,
                   0.007
                 ]
+            },
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&createMarketBuyOrderRequiresPrice=false&timestamp=1701830554641&recvWindow=5000&signature=d759959eda792a05500a913b3607cae54bf02d9ec3da7ea68e7d6df28e54c5fd",
+                "input": [
+                  "ATLAS/USDT",
+                  "market",
+                  "buy",
+                  8,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ]
+            },
+            {
+                "description": "Spot market buy using the cost param",
+                "method": "createOrder",
+                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&cost=8&timestamp=1701830656889&recvWindow=5000&signature=86d3ce4c125affa17221bfb95a77550fedbbb872c0f153d432abe1b1a23348e3",     
+                "input": [
+                  "ATLAS/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 8
+                  }
+                ]
             }
         ],
         "createOrders": [
@@ -66,6 +96,17 @@
                             "price": 0.0054
                         }
                     ]
+                ]
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot market buy order with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&createMarketBuyOrderRequiresPrice=false&timestamp=1701830758140&recvWindow=5000&signature=0e5e245e6ed272d5d0c170259f27c2a7a2344af5037d821ea74e4ac2168538de",
+                "input": [
+                  "ATLAS/USDT",
+                  8
                 ]
             }
         ],


### PR DESCRIPTION
Added `createMarketBuyOrderWithCost`, and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createMarketBuyOrderWithCost`, `createMarketBuyOrderRequiresPrice` and using the `cost` param to create a market buy order:

```
mexc createOrder ATLAS/USDT market buy 8 undefined '{"createMarketBuyOrderRequiresPrice":false}'

mexc.createOrder (ATLAS/USDT, market, buy, 8, , [object Object])
2023-12-06T02:42:34.905Z iteration 0 passed in 5265 ms

{
  id: 'C01__360912809799798787',
  timestamp: 1701830555158,
  datetime: '2023-12-06T02:42:35.158Z',
  symbol: 'ATLAS/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  amount: 8,
  trades: [],
  info: {
    symbol: 'ATLASUSDT',
    orderId: 'C01__360912809799798787',
    orderListId: '-1',
    price: '0.007379',
    origQty: '1084.09',
    type: 'MARKET',
    side: 'BUY',
    transactTime: '1701830555158'
  },
  fees: []
}
```
```
mexc createOrder ATLAS/USDT market buy undefined undefined '{"cost":8}'

mexc.createOrder (ATLAS/USDT, market, buy, , , [object Object])
2023-12-06T02:44:17.161Z iteration 0 passed in 5277 ms

{
  id: 'C01__360913238700888065',
  timestamp: 1701830657416,
  datetime: '2023-12-06T02:44:17.416Z',
  symbol: 'ATLAS/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  trades: [],
  info: {
    symbol: 'ATLASUSDT',
    orderId: 'C01__360913238700888065',
    orderListId: '-1',
    price: '0.007386',
    origQty: '1083.02',
    type: 'MARKET',
    side: 'BUY',
    transactTime: '1701830657416'
  },
  fees: []
}
```
```
mexc.createMarketBuyOrderWithCost (ATLAS/USDT, 8)
2023-12-06T02:45:58.454Z iteration 0 passed in 5310 ms

{
  id: 'C01__360913663512567811',
  timestamp: 1701830758699,
  datetime: '2023-12-06T02:45:58.699Z',
  symbol: 'ATLAS/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  amount: 8,
  trades: [],
  info: {
    symbol: 'ATLASUSDT',
    orderId: 'C01__360913663512567811',
    orderListId: '-1',
    price: '0.007402',
    origQty: '1080.71',
    type: 'MARKET',
    side: 'BUY',
    transactTime: '1701830758699'
  },
  fees: []
}
```