### PR TITLE
binance: add sor.order.test

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1655,18 +1655,25 @@ export default class binance extends binanceRest {
         const url = this.urls['api']['ws']['ws'];
         const requestId = this.requestId (url);
         const messageHash = requestId.toString ();
+        const sor = this.safeValue2 (params, 'sor', 'SOR', false);
+        params = this.omit (params, 'sor', 'SOR');
         const payload = this.createOrderRequest (symbol, type, side, amount, price, params);
         let returnRateLimits = false;
         [ returnRateLimits, params ] = this.handleOptionAndParams (params, 'createOrderWs', 'returnRateLimits', false);
         payload['returnRateLimits'] = returnRateLimits;
+        const test = this.safeValue (params, 'test', false);
+        params = this.omit (params, 'test');
         const message = {
             'id': messageHash,
             'method': 'order.place',
             'params': this.signParams (this.extend (payload, params)),
         };
-        const test = this.safeValue (params, 'test', false);
         if (test) {
-            message['method'] = 'order.test';
+            if (sor) {
+                message['method'] = 'sor.order.test';
+            } else {
+                message['method'] = 'order.test';
+            }
         }
         const subscription = {
             'method': this.handleOrderWs,


### PR DESCRIPTION
```
$ n binance createOrderWs BTC/USDC limit buy 1 1000 '{"sor":true,"test":true}' --test          
CCXT v4.1.77
binance.createOrderWs (BTC/USDC, limit, buy, 1, 1000, [object Object])
InvalidOrder binance {"code":-1013,"msg":"This symbol has no SOR."}
```