### PR TITLE
htx cross swap balance parse

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -3340,14 +3340,16 @@ export default class htx extends Exchange {
         //                 "margin_mode": "cross",
         //                 "margin_account": "USDT",
         //                 "margin_asset": "USDT",
-        //                 "margin_balance": 200.000000000000000000,
-        //                 "margin_static": 200.000000000000000000,
-        //                 "margin_position": 0,
-        //                 "margin_frozen": 0,
-        //                 "profit_real": 0E-18,
-        //                 "profit_unreal": 0,
-        //                 "withdraw_available": 2E+2,
-        //                 "risk_rate": null,
+        //                 "margin_balance": 49.874186030200000000,
+        //                 "money_in": 50,
+        //                 "money_out": 0,
+        //                 "margin_static": 49.872786030200000000,
+        //                 "margin_position": 6.180000000000000000,
+        //                 "margin_frozen": 6.000000000000000000,
+        //                 "profit_unreal": 0.001400000000000000,
+        //                 "withdraw_available": 37.6927860302,
+        //                 "risk_rate": 271.984050521072796934,
+        //                 "new_risk_rate": 0.001858676950514399,
         //                 "contract_detail": [
         //                     {
         //                         "symbol": "MANA",
@@ -3449,8 +3451,8 @@ export default class htx extends Exchange {
                 }
             } else {
                 const account = this.account ();
-                account['free'] = this.safeString (first, 'margin_balance', 'margin_available');
-                account['used'] = this.safeString (first, 'margin_frozen');
+                account['free'] = this.safeString (first, 'withdraw_available');
+                account['total'] = this.safeString (first, 'margin_balance');
                 const currencyId = this.safeString2 (first, 'margin_asset', 'symbol');
                 const code = this.safeCurrencyCode (currencyId);
                 result[code] = account;


### PR DESCRIPTION
https://www.htx.com/en-us/opend/newApiPages/?id=8cb819b6-77b5-11ed-9966-0242ac110003
Maybe some changes in API or mistake, but we use `total` balance (`margin_balance`) as `free`, but it's total money on account (including orders and positions). `used` - is sum of `margin_position` and `margin_frozen`, `withdraw_available` is real `free` money. I'm new in futures but I think my logic is correct. Cause now when I 50 USDT on account and open order on 5 USDT, ccxt show me 55 `total` balance