### PR TITLE
probit fetchCurrencies fee fix

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -435,14 +435,22 @@ export default class probit extends Exchange {
                 }
                 const precision = this.parsePrecision (this.safeString (network, 'precision'));
                 const withdrawFee = this.safeValue (network, 'withdrawal_fee', []);
-                const networkfee = this.safeValue (withdrawFee, 0, {});
+                let networkFee = this.safeValue (withdrawFee, 0, {});
+                for (let k = 0; k < withdrawFee.length; k++) {
+                    const withdrawPlatform = withdrawFee[k];
+                    const feeCurrencyId = this.safeString (withdrawPlatform, 'currency_id');
+                    if (feeCurrencyId === id) {
+                        networkFee = withdrawPlatform;
+                        break;
+                    }
+                }
                 networkList[networkCode] = {
                     'id': networkId,
                     'network': networkCode,
                     'active': currentActive,
                     'deposit': currentDeposit,
                     'withdraw': currentWithdraw,
-                    'fee': this.safeNumber (networkfee, 'amount'),
+                    'fee': this.safeNumber (networkFee, 'amount'),
                     'precision': this.parseNumber (precision),
                     'limits': {
                         'withdraw': {


### PR DESCRIPTION
https://api.probit.com/api/exchange/v1/currency_with_platform
Many currencies on Probit has withdraw fee in network main currency (ETH, BNB etc). In ccxt we don't have any `feeCurrency` so we mean that `feeCurrency` === `code`. Sometimes in probit highest priority `feeCurrency` is different from `code` (example - USDT BEP20:
`"withdrawal_fee":[{"amount":"0.0015","priority":1,"currency_id":"BNB"},{"currency_id":"USDT","amount":"1","priority":2}`
So I think that better to parse fee where `feeCurrency` === `code` if we have one