### PR TITLE
bingx: update transaction status

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2995,7 +2995,8 @@ export default class bingx extends Exchange {
 
     parseTransactionStatus (status) {
         const statuses = {
-            '0': 'ok',
+            '0': 'pending',
+            '1': 'ok',
             '10': 'pending',
             '20': 'rejected',
             '30': 'ok',


### PR DESCRIPTION
Binx had updated status, 1 represent ok.
```
$ p bingx fetchDeposits USDT             
bingx.fetchDeposits(USDT)
[{'address': '',
  'addressFrom': None,
  'addressTo': '',
  'amount': 29.82,
  'comment': None,
  'currency': 'USDT',
  'datetime': '',
  'fee': {'cost': None, 'currency': 'USDT', 'rate': None},
  'id': None,
  'internal': None,
  'network': 'BEP20',
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp':,
  'txid': '',
  'type': 'withdrawal',
```