### PR TITLE
the report for static tests gives a directory that exists

### DIFF
--- a/examples/ts/cli.ts
+++ b/examples/ts/cli.ts
@@ -137,7 +137,7 @@ function createTemplate(exchange, methodName, args, result) {
         'input': args,
         'output': exchange.last_request_body ?? undefined
     }
-    log('Report: (paste inside static/data/' + exchange.id + '.json ->' + methodName + ')')
+    log('Report: (paste inside static/request/' + exchange.id + '.json ->' + methodName + ')')
     log.green('-------------------------------------------')
     log (JSON.stringify (final, null, 2))
     log.green('-------------------------------------------')


### PR DESCRIPTION
The result states
```
Report: (paste inside static/data/okx.json ->closePosition)
```
but that dir doesn't exist, it's currencies, markets, requests,  and response

![](https://i.imgur.com/F9KheKG.png)