### PR TITLE
fixed spot/swap symbol error

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1228,35 +1228,6 @@ export default class bingx extends Exchange {
         } else {
             response = await this.swapV2PublicGetQuoteTicker (this.extend (request, params));
         }
-        //
-        //    {
-        //        "code": 0,
-        //        "msg": "",
-        //        "data": {
-        //          "symbol": "BTC-USDT",
-        //          "priceChange": "52.5",
-        //          "priceChangePercent": "0.31",
-        //          "lastPrice": "16880.5",
-        //          "lastQty": "2.2238",
-        //          "highPrice": "16897.5",
-        //          "lowPrice": "16726.0",
-        //          "volume": "245870.1692",
-        //          "quoteVolume": "4151395117.73",
-        //          "openPrice": "16832.0",
-        //          "openTime": 1672026667803,
-        //          "closeTime": 1672026648425,
-        //  added some time ago:
-        //          "firstId": 12345,
-        //          "lastId": 12349,
-        //          "count": 5,
-        //  added 2023-11-10:
-        //          "bidPrice": 16726.0,
-        //          "bidQty": 0.05,
-        //          "askPrice": 16726.0,
-        //          "askQty": 0.05,
-        //        }
-        //    }
-        //
         const data = this.safeValue (response, 'data');
         const ticker = this.safeValue (data, 0, data);
         return this.parseTicker (ticker, market);
@@ -1287,37 +1258,6 @@ export default class bingx extends Exchange {
         } else {
             response = await this.swapV2PublicGetQuoteTicker (params);
         }
-        //
-        //    {
-        //        "code": 0,
-        //        "msg": "",
-        //        "data": [
-        //            {
-        //                "symbol": "BTC-USDT",
-        //                "priceChange": "52.5",
-        //                "priceChangePercent": "0.31",
-        //                "lastPrice": "16880.5",
-        //                "lastQty": "2.2238",
-        //                "highPrice": "16897.5",
-        //                "lowPrice": "16726.0",
-        //                "volume": "245870.1692",
-        //                "quoteVolume": "4151395117.73",
-        //                "openPrice": "16832.0",
-        //                "openTime": 1672026667803,
-        //                "closeTime": 1672026648425,
-        //  added some time ago:
-        //                "firstId": 12345,
-        //                "lastId": 12349,
-        //                "count": 5,
-        //  added 2023-11-10:
-        //                "bidPrice": 16726.0,
-        //                "bidQty": 0.05,
-        //                "askPrice": 16726.0,
-        //                "askQty": 0.05,
-        //            },
-        //        ]
-        //    }
-        //
         const tickers = this.safeValue (response, 'data');
         return this.parseTickers (tickers, symbols);
     }
@@ -1335,10 +1275,6 @@ export default class bingx extends Exchange {
         //        "quoteVolume": "30288466.44",
         //        "openTime": "1693081020762",
         //        "closeTime": "1693167420762",
-        //  added some time ago:
-        //        "firstId": 12345,
-        //        "lastId": 12349,
-        //        "count": 5,
         //  added 2023-11-10:
         //        "bidPrice": 16726.0,
         //        "bidQty": 0.05,
@@ -1352,7 +1288,7 @@ export default class bingx extends Exchange {
         //        "priceChange": "52.5",
         //        "priceChangePercent": "0.31",
         //        "lastPrice": "16880.5",
-        //        "lastQty": "2.2238",
+        //        "lastQty": "2.2238",          // only present in swap!
         //        "highPrice": "16897.5",
         //        "lowPrice": "16726.0",
         //        "volume": "245870.1692",
@@ -1360,10 +1296,6 @@ export default class bingx extends Exchange {
         //        "openPrice": "16832.0",
         //        "openTime": 1672026667803,
         //        "closeTime": 1672026648425,
-        //  added some time ago:
-        //        "firstId": 12345,
-        //        "lastId": 12349,
-        //        "count": 5,
         //  added 2023-11-10:
         //        "bidPrice": 16726.0,
         //        "bidQty": 0.05,
@@ -1373,7 +1305,10 @@ export default class bingx extends Exchange {
         //
         const marketId = this.safeString (ticker, 'symbol');
         const change = this.safeString (ticker, 'priceChange');
-        const type = (change === undefined) ? 'spot' : 'swap';
+        const lastQty = this.safeString (ticker, 'lastQty');
+        // in spot markets, lastQty is not present
+        // it's (bad, but) the only way we can check the tickers origin
+        const type = (lastQty === undefined) ? 'spot' : 'swap';
         const symbol = this.safeSymbol (marketId, market, undefined, type);
         const open = this.safeString (ticker, 'openPrice');
         const high = this.safeString (ticker, 'highPrice');


### PR DESCRIPTION
For bingx spot tickers, the ccxt symbol was obtained from the wrong (swap) market.

Specific example:  "ETH-USDT" was transformed to "ETH/USDT:USDT" where it should have been "ETH/USDT".

In the bingx.ts source, it was (falsely) assumed that spot markets don't have a "priceChange" field in the ticker. It turns out that (at least now) both spot and swap have that field.

In the parseTicker function, the only way to distinguish a spot ticker from a swap ticker is by looking at the "lastQty" field.
This field is not present in spot tickers.

Furthermore, the source contained 3 identical examples of comment, describing the bingx tickers
- Removed two of them and left just one in the parseTicker function
- Removed the false information (none of the tickers have firstId, lastId or count fields (any more))
- Indicated the one difference to distinguish between spot and swap