### PR TITLE
Digifinex: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/test/static/request/digifinex.json
+++ b/ts/src/test/static/request/digifinex.json
@@ -57,6 +57,51 @@
                   }
                 ],
                 "output": "{\"instrument_id\":\"LTCUSDTPERP\",\"type\":3,\"order_type\":14,\"size\":1}"
+            },
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://openapi.digifinex.com/v3/spot/order/new",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  2,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "amount=2&market=spot&symbol=BTC_USDT&type=buy_market"
+            },
+            {
+                "description": "Spot market buy using the cost param",
+                "method": "createOrder",
+                "url": "https://openapi.digifinex.com/v3/spot/order/new",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 2
+                  }
+                ],
+                "output": "amount=2&market=spot&symbol=BTC_USDT&type=buy_market"
+            },
+            {
+                "description": "Spot market sell order",
+                "method": "createOrder",
+                "url": "https://openapi.digifinex.com/v3/spot/order/new",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "sell",
+                  0.00012,
+                  null
+                ],
+                "output": "amount=0.00012&market=spot&symbol=BTC_USDT&type=sell_market"
             }
         ],
         "createOrders": [
@@ -137,6 +182,18 @@
                   ]
                 ],
                 "output": "[{\"instrument_id\":\"BTCUSDTPERP\",\"type\":1,\"price\":\"25000\",\"order_type\":0,\"size\":1},{\"instrument_id\":\"BTCUSDTPERP\",\"type\":1,\"price\":\"27000\",\"order_type\":0,\"size\":1}]"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot create a market buy order using the cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://openapi.digifinex.com/v3/spot/order/new",
+                "input": [
+                  "BTC/USDT",
+                  2
+                ],
+                "output": "amount=2&market=spot&symbol=BTC_USDT&type=buy_market"
             }
         ],
         "fetchOrders": [


### PR DESCRIPTION
Added `createMarketBuyOrderWithCost`, and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createMarketBuyOrderWithCost`, `createMarketBuyOrderRequiresPrice`, spot market sell order and using the `cost` param to create a market buy order:

```
digifinex createOrder BTC/USDT market buy 2 undefined '{"createMarketBuyOrderRequiresPrice":false}'

digifinex.createOrder (BTC/USDT, market, buy, 2, , [object Object])
2023-12-08T03:13:59.841Z iteration 0 passed in 1767 ms

{
  info: { code: '0', order_id: 'd89cde7db1d6370d7dafb67f308f2962' },
  id: 'd89cde7db1d6370d7dafb67f308f2962',
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  amount: 2,
  fee: {},
  trades: [],
  fees: [ {} ]
}
```
```
digifinex createOrder BTC/USDT market buy undefined undefined '{"cost":2}'

digifinex.createOrder (BTC/USDT, market, buy, , , [object Object])
2023-12-08T03:32:11.019Z iteration 0 passed in 1627 ms

{
  info: { code: '0', order_id: '4c5596d9f133f858fe747e398d142b54' },
  id: '4c5596d9f133f858fe747e398d142b54',
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  fee: {},
  trades: [],
  fees: [ {} ]
}
```
```
digifinex.createMarketBuyOrderWithCost (BTC/USDT, 2)
2023-12-08T03:34:35.896Z iteration 0 passed in 1520 ms

{
  info: { code: '0', order_id: '7f5d3cad1ace735899a467f461951ce0' },
  id: '7f5d3cad1ace735899a467f461951ce0',
  symbol: 'BTC/USDT',
  type: 'market',
  side: 'buy',
  amount: 2,
  fee: {},
  trades: [],
  fees: [ {} ]
}
```