### PR TITLE
Lbank: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/lbank.js';
-import { ExchangeError, InvalidAddress, DuplicateOrderId, InsufficientFunds, InvalidOrder, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, BadRequest, BadSymbol, ArgumentsRequired } from './base/errors.js';
+import { ExchangeError, InvalidAddress, DuplicateOrderId, InsufficientFunds, InvalidOrder, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, BadRequest, BadSymbol, ArgumentsRequired, NotSupported } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { md5 } from './static_dependencies/noble-hashes/md5.js';
@@ -36,6 +36,9 @@ export default class lbank extends Exchange {
                 'addMargin': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createReduceOnlyOrder': false,
                 'createStopLimitOrder': false,
@@ -1274,13 +1277,34 @@ export default class lbank extends Exchange {
         return result;
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name lbank#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://www.lbank.com/en-US/docs/index.html#place-order
+         * @see https://www.lbank.com/en-US/docs/index.html#place-an-order
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
          * @name lbank2#createOrder
          * @description create a trade order
-         * @see https://www.lbank.info/en-US/docs/index.html#place-order
-         * @see https://www.lbank.info/en-US/docs/index.html#place-an-order
+         * @see https://www.lbank.com/en-US/docs/index.html#place-order
+         * @see https://www.lbank.com/en-US/docs/index.html#place-an-order
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -1321,19 +1345,27 @@ export default class lbank extends Exchange {
                 request['amount'] = this.amountToPrecision (symbol, amount);
             } else if (side === 'buy') {
                 request['type'] = side + '_' + 'market';
-                if (this.options['createMarketBuyOrderRequiresPrice']) {
+                let quoteAmount = undefined;
+                let createMarketBuyOrderRequiresPrice = true;
+                [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+                const cost = this.safeNumber (params, 'cost');
+                params = this.omit (params, 'cost');
+                if (cost !== undefined) {
+                    quoteAmount = this.costToPrecision (symbol, cost);
+                } else if (createMarketBuyOrderRequiresPrice) {
                     if (price === undefined) {
-                        throw new InvalidOrder (this.id + " createOrder () requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply the price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
+                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                     } else {
                         const amountString = this.numberToString (amount);
                         const priceString = this.numberToString (price);
-                        const quoteAmount = Precise.stringMul (amountString, priceString);
-                        const cost = this.parseNumber (quoteAmount);
-                        request['price'] = this.priceToPrecision (symbol, cost);
+                        const costRequest = Precise.stringMul (amountString, priceString);
+                        quoteAmount = this.costToPrecision (symbol, costRequest);
                     }
                 } else {
-                    request['price'] = amount;
+                    quoteAmount = this.costToPrecision (symbol, amount);
                 }
+                // market buys require filling the price param instead of the amount param, for market buys the price is treated as the cost by lbank
+                request['price'] = quoteAmount;
             }
         }
         if (clientOrderId !== undefined) {

--- a/ts/src/test/static/currencies/lbank.json
+++ b/ts/src/test/static/currencies/lbank.json
@@ -1,4 +1,15 @@
 {
+    "LBK": {
+        "id": "lbk",
+        "code": "LBK",
+        "precision": 1,
+        "fees": {},
+        "networks": {},
+        "limits": {
+            "deposit": {},
+            "withdraw": {}
+        }
+    },
     "BTC": {
         "id": "btc",
         "code": "BTC",

--- a/ts/src/test/static/markets/lbank.json
+++ b/ts/src/test/static/markets/lbank.json
@@ -1,4 +1,39 @@
 {
+    "LBK/USDT": {
+        "id": "lbk_usdt",
+        "symbol": "LBK/USDT",
+        "base": "LBK",
+        "quote": "USDT",
+        "baseId": "lbk",
+        "quoteId": "usdt",
+        "active": true,
+        "type": "spot",
+        "spot": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "precision": {
+            "amount": 1,
+            "price": 0.000001
+        },
+        "limits": {
+            "amount": {
+                "min": 1
+            },
+            "price": {},
+            "cost": {},
+            "leverage": {}
+        },
+        "info": {
+            "symbol": "lbk_usdt",
+            "quantityAccuracy": "0",
+            "minTranQua": "1",
+            "priceAccuracy": "6"
+        },
+        "taker": 0.001,
+        "maker": 0.001
+    },
     "BTC/USDT": {
         "id": "btc_usdt",
         "symbol": "BTC/USDT",

--- a/ts/src/test/static/request/lbank.json
+++ b/ts/src/test/static/request/lbank.json
@@ -29,6 +29,107 @@
                 ],
                 "output": "api_key=ab14677d-2555-4280-856d-4ccb60f8f1e8&sign=4235e196a21ec34b6dc07030102170eeade2e9b7fbfc2aa87b0d63f0955797bc"
             }
+        ],
+        "createOrder": [
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to true",
+                "method": "createOrder",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  "market",
+                  "buy",
+                  2,
+                  0.01376,
+                  {
+                    "createMarketBuyOrderRequiresPrice": true
+                  }
+                ],
+                "output": "api_key=41b03aa0-69d1-4d93-93cb-274470458c35&price=0.02752&sign=QIrm9%2B04WUXBs0608OwKVHxW%2FX38r%2Bbt91u6R9ryFqepDN7BrgG2KX0rt50caLXexE0r%2FuQNUvWgHbr7XxynccbahsDRzFN4rPnkyEfWwRLjKuWD3iwJNbAKlHL7yxifjHG1%2Fbhg1%2FqWbdy3GuhU9q1K9mvsOqUjU1vQw0Z00Qg%3D&symbol=lbk_usdt&type=buy_market"
+            },
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  "market",
+                  "buy",
+                  2,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "api_key=41b03aa0-69d1-4d93-93cb-274470458c35&price=2&sign=oZ9YdxFx%2F4HonQcO7z3XlorAkwXAmrYGrV49pVfMsALWMJOoeBySPUwssOcD7BolCf%2BVHxReXXhz7FtbblsMGdxxTwHUo7P34vWXlQilCAhI4ErpxZ251KftVL%2FGIadkIAp9PjTlAH9r%2BVDL8gmhnIb%2BGCnXqS5VXS%2BPINSfDDc%3D&symbol=lbk_usdt&type=buy_market"
+            },
+            {
+                "description": "Spot market buy using the cost param",
+                "method": "createOrder",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 2
+                  }
+                ],
+                "output": "api_key=41b03aa0-69d1-4d93-93cb-274470458c35&price=2&sign=NBYGa7S42oCh1677mRZoM8jSUDJz6ucU86gfbYw7FseeoKK8gC0797t%2BvuhxYk4QzxutD3eGi6iiAylgaMQ1pjfJQUpu3ouR4DkaekJGe0pWSz2HzbvDkoyHedEdsE8maYlt7CVYeQmj5fNSGwKdSoi6yo6Gnym1CoeNNqTcMfY%3D&symbol=lbk_usdt&type=buy_market"
+            },
+            {
+                "description": "Spot market sell order",
+                "method": "createOrder",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  "market",
+                  "sell",
+                  579,
+                  null
+                ],
+                "output": "amount=579&api_key=41b03aa0-69d1-4d93-93cb-274470458c35&sign=pYy6x8l3taHsI30AEf7Awo0kqcX%2FOvl5qPtid2kYjQvJ9ZuJquXwQO77zWFG0EdwVJZTEM6TxkfkWRDgUgQgnerp%2FUvMdkQTfQRjiECDPRkVYdkYk5fr1IsvWIZCEbY%2FndRHMrgpvdLnxRkNpaMms%2BOJEf7T7HADfMFJTzEqq%2F8%3D&symbol=lbk_usdt&type=sell_market"
+            },
+            {
+                "description": "Spot limit sell order",
+                "method": "createOrder",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  "limit",
+                  "sell",
+                  145,
+                  0.015
+                ],
+                "output": "amount=145&api_key=41b03aa0-69d1-4d93-93cb-274470458c35&price=0.015&sign=YXclgHSvuBTBmbgsgLCNXfF6WSJr6mMR0Z8YoSvGadS9DUfPlttQAnEBHDT7YGB%2BmG6JHkfDPGom5LH3HPnFyCjcpXXtcPTl8uKNDELGCaeSe58cwutHvbxI%2BlE55gc3XFr6xAfCMpprAKFOIHm93r1ncUvQFqhyihxVV%2B7Sros%3D&symbol=lbk_usdt&type=sell"
+            },
+            {
+                "description": "Spot limit buy order",
+                "method": "createOrder",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  "limit",
+                  "buy",
+                  145,
+                  0.012
+                ],
+                "output": "amount=145&api_key=41b03aa0-69d1-4d93-93cb-274470458c35&price=0.012&sign=eEUmqDcJID4jWhU3V%2FBYwPKaper6uu5%2FiTOMNed3mQLH12VSGa1VqbjZvPxYFg8Ui5EyaffGo7IN%2BtgClOOKYbSYSS%2F%2F4QAh07TRtap31zLsTtnQcHUVAaNsgPfaLUbK4m5s3bWTTXu1IappCeTkJY6Te%2B0WQ8mkrfvdalZA2tE%3D&symbol=lbk_usdt&type=buy"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot market buy order using the cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.lbank.info/v2/supplement/create_order.do",
+                "input": [
+                  "LBK/USDT",
+                  2
+                ],
+                "output": "api_key=41b03aa0-69d1-4d93-93cb-274470458c35&price=2&sign=bBXd3WzsftbFBDrQMrY42WfTESsAVn80Z072XMyL25qq7Dv8BUtuGeIpuOH0J7tM8kzCoJ6Q6L%2BOO82TU3rlq23ier7eitWlUeoCXh4AB3Qs4PqQ7ea%2Bnj%2BzLwkbyaYbxOy%2Bos%2FxIXljuiTFNIXk29ZulaYIioqU%2BbQzH3fbjcg%3D&symbol=lbk_usdt&type=buy_market"
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `createMarketBuyOrderWithCost`, and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for spot `createOrder` and `createMarketBuyOrderWithCost`

The API key I used is temporary and doesn't allow withdrawals so it's okay that the `api_key` is shown in the test output

```
lbank createOrder LBK/USDT market buy 2 undefined '{"createMarketBuyOrderRequiresPrice":false}'

lbank.createOrder (LBK/USDT, market, buy, 2, , [object Object])
2023-12-08T04:28:23.048Z iteration 0 passed in 494 ms

{
  id: '0fbe70d4-a491-428c-a710-aa27983b9d73',
  info: {
    symbol: 'lbk_usdt',
    order_id: '0fbe70d4-a491-428c-a710-aa27983b9d73'
  },
  fees: [],
  trades: []
}
```
```
lbank createOrder LBK/USDT market buy undefined undefined '{"cost":2}'

lbank.createOrder (LBK/USDT, market, buy, , , [object Object])
2023-12-08T04:36:26.223Z iteration 0 passed in 393 ms

{
  id: '2ea15b75-29da-4ea5-8d30-f5fff9d39235',
  info: {
    symbol: 'lbk_usdt',
    order_id: '2ea15b75-29da-4ea5-8d30-f5fff9d39235'
  },
  fees: [],
  trades: []
}
```
```
lbank.createMarketBuyOrderWithCost (LBK/USDT, 2)
2023-12-08T04:37:51.782Z iteration 0 passed in 402 ms

{
  id: 'ded7e30b-135d-481c-ac8c-9ea1e2da748c',
  info: {
    symbol: 'lbk_usdt',
    order_id: 'ded7e30b-135d-481c-ac8c-9ea1e2da748c'
  },
  fees: [],
  trades: []
}
```