### PR TITLE
Htx: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -40,6 +40,9 @@ export default class htx extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': true,
                 'createDepositAddress': undefined,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createOrders': true,
                 'createReduceOnlyOrder': false,
@@ -4777,6 +4780,26 @@ export default class htx extends Exchange {
         }, market);
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name htx#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://www.htx.com/en-us/opend/newApiPages/?id=7ec4ee16-7773-11ed-9966-0242ac110003
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createSpotOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
@@ -4790,6 +4813,7 @@ export default class htx extends Exchange {
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.timeInForce] supports 'IOC' and 'FOK'
+         * @param {float} [params.cost] the quote quantity that can be used as an alternative for the amount for market buy orders
          * @returns {object} request to be sent to the exchange
          */
         await this.loadMarkets ();
@@ -4858,9 +4882,16 @@ export default class htx extends Exchange {
             request['source'] = 'c2c-margin-api';
         }
         if ((orderType === 'market') && (side === 'buy')) {
-            if (this.options['createMarketBuyOrderRequiresPrice']) {
+            let quoteAmount = undefined;
+            let createMarketBuyOrderRequiresPrice = true;
+            [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+            const cost = this.safeNumber (params, 'cost');
+            params = this.omit (params, 'cost');
+            if (cost !== undefined) {
+                quoteAmount = this.amountToPrecision (symbol, cost);
+            } else if (createMarketBuyOrderRequiresPrice) {
                 if (price === undefined) {
-                    throw new InvalidOrder (this.id + " market buy order requires price argument to calculate cost (total amount of quote currency to spend for buying, amount * price). To switch off this warning exception and specify cost in the amount argument, set .options['createMarketBuyOrderRequiresPrice'] = false. Make sure you know what you're doing.");
+                    throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                 } else {
                     // despite that cost = amount * price is in quote currency and should have quote precision
                     // the exchange API requires the cost supplied in 'amount' to be of base precision
@@ -4870,11 +4901,12 @@ export default class htx extends Exchange {
                     // we use amountToPrecision here because the exchange requires cost in base precision
                     const amountString = this.numberToString (amount);
                     const priceString = this.numberToString (price);
-                    request['amount'] = this.costToPrecision (symbol, Precise.stringMul (amountString, priceString));
+                    quoteAmount = this.amountToPrecision (symbol, Precise.stringMul (amountString, priceString));
                 }
             } else {
-                request['amount'] = this.costToPrecision (symbol, amount);
+                quoteAmount = this.amountToPrecision (symbol, amount);
             }
+            request['amount'] = quoteAmount;
         } else {
             request['amount'] = this.amountToPrecision (symbol, amount);
         }
@@ -5003,6 +5035,7 @@ export default class htx extends Exchange {
          * @param {bool} [params.postOnly] *contract only* true or false
          * @param {int} [params.leverRate] *contract only* required for all contract orders except tpsl, leverage greater than 20x requires prior approval of high-leverage agreement
          * @param {string} [params.timeInForce] supports 'IOC' and 'FOK'
+         * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/huobijp.ts
+++ b/ts/src/huobijp.ts
@@ -2,7 +2,7 @@
 // ---------------------------------------------------------------------------
 
 import Exchange from './abstract/huobijp.js';
-import { AuthenticationError, ExchangeError, PermissionDenied, ExchangeNotAvailable, OnMaintenance, InvalidOrder, OrderNotFound, InsufficientFunds, BadSymbol, BadRequest, RequestTimeout, NetworkError, ArgumentsRequired } from './base/errors.js';
+import { AuthenticationError, ExchangeError, PermissionDenied, ExchangeNotAvailable, OnMaintenance, InvalidOrder, OrderNotFound, InsufficientFunds, BadSymbol, BadRequest, RequestTimeout, NetworkError, ArgumentsRequired, NotSupported } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TRUNCATE, TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
@@ -36,6 +36,9 @@ export default class huobijp extends Exchange {
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createStopLimitOrder': false,
                 'createStopMarketOrder': false,
@@ -1387,6 +1390,25 @@ export default class huobijp extends Exchange {
         }, market);
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name huobijp#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
@@ -1418,9 +1440,16 @@ export default class huobijp extends Exchange {
         }
         params = this.omit (params, [ 'clientOrderId', 'client-order-id' ]);
         if ((type === 'market') && (side === 'buy')) {
-            if (this.options['createMarketBuyOrderRequiresPrice']) {
+            let quoteAmount = undefined;
+            let createMarketBuyOrderRequiresPrice = true;
+            [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+            const cost = this.safeNumber (params, 'cost');
+            params = this.omit (params, 'cost');
+            if (cost !== undefined) {
+                quoteAmount = this.amountToPrecision (symbol, cost);
+            } else if (createMarketBuyOrderRequiresPrice) {
                 if (price === undefined) {
-                    throw new InvalidOrder (this.id + " market buy order requires price argument to calculate cost (total amount of quote currency to spend for buying, amount * price). To switch off this warning exception and specify cost in the amount argument, set .options['createMarketBuyOrderRequiresPrice'] = false. Make sure you know what you're doing.");
+                    throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                 } else {
                     // despite that cost = amount * price is in quote currency and should have quote precision
                     // the exchange API requires the cost supplied in 'amount' to be of base precision
@@ -1430,12 +1459,12 @@ export default class huobijp extends Exchange {
                     // we use amountToPrecision here because the exchange requires cost in base precision
                     const amountString = this.numberToString (amount);
                     const priceString = this.numberToString (price);
-                    const baseAmount = Precise.stringMul (amountString, priceString);
-                    request['amount'] = this.costToPrecision (symbol, baseAmount);
+                    quoteAmount = this.amountToPrecision (symbol, Precise.stringMul (amountString, priceString));
                 }
             } else {
-                request['amount'] = this.costToPrecision (symbol, amount);
+                quoteAmount = this.amountToPrecision (symbol, amount);
             }
+            request['amount'] = quoteAmount;
         } else {
             request['amount'] = this.amountToPrecision (symbol, amount);
         }

--- a/ts/src/test/static/request/huobi.json
+++ b/ts/src/test/static/request/huobi.json
@@ -131,7 +131,51 @@
                   }
                 ],
                 "output": "{\"contract_code\":\"LTC-USDT\",\"volume\":\"1\",\"direction\":\"sell\",\"tp_order_price_type\":\"limit\",\"tp_trigger_price\":\"101\",\"tp_order_price\":\"100\",\"channel_code\":\"AA03022abc\"}"
-              }
+            },
+            {
+                "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.huobi.pro/v1/order/orders/place?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2023-12-09T00%3A58%3A56&Signature=aYxrWOj2EKmUfd9VhYYhxQBYFr%2BYAvXdkQWCvtG87fg%3D",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  10,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abcae7ce25d-1a09-46ff-aaad-ae2d4c5dcc95\",\"amount\":\"10\"}"
+            },
+            {
+                "description": "Spot market buy order using the cost param",
+                "method": "createOrder",
+                "url": "https://api.huobi.pro/v1/order/orders/place?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2023-12-09T01%3A00%3A56&Signature=JyUX4C0b4tXzbBUQi5sbXK7DgnH4dZw6XbqPgdbtaKc%3D",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 10
+                  }
+                ],
+                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abc72f0bcb9-5138-42ee-b20a-4ef2002461ea\",\"amount\":\"10\"}"
+            },
+            {
+                "description": "Spot market sell order",
+                "method": "createOrder",
+                "url": "https://api.huobi.pro/v1/order/orders/place?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2023-12-09T01%3A06%3A18&Signature=whknIV1TEOp8w8MtmTtdsCwfAaeWLeMMASzBRY8YqBk%3D",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "sell",
+                  0.000776
+                ],
+                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"sell-market\",\"client-order-id\":\"AA03022abc20c197bc-30a9-4806-b114-1b257819b0a4\",\"amount\":\"0.000776\"}"
+            }
         ],
         "createOrders": [
             {
@@ -259,6 +303,18 @@
                   ]
                 ],
                 "output": "{\"orders_data\":[{\"contract_code\":\"BTC231124\",\"volume\":\"1\",\"direction\":\"buy\",\"price\":\"25000\",\"offset\":\"open\",\"lever_rate\":1,\"order_price_type\":\"limit\",\"channel_code\":\"AA03022abc\"},{\"contract_code\":\"BTC231124\",\"volume\":\"1\",\"direction\":\"buy\",\"price\":\"27000\",\"offset\":\"open\",\"lever_rate\":1,\"order_price_type\":\"limit\",\"channel_code\":\"AA03022abc\"}]}"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot market buy order using the cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.huobi.pro/v1/order/orders/place?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2023-12-09T01%3A03%3A10&Signature=PbyATPz3DSTYLhTIIkDybElKJc1Kk8s0yHZ0kPVifSw%3D",
+                "input": [
+                  "BTC/USDT",
+                  10
+                ],
+                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abc148ae2ff-345f-4bf2-a3c3-f3e78d1b1cbd\",\"amount\":\"10\"}"
             }
         ],
         "fetchOrders": [


### PR DESCRIPTION
Added `createMarketBuyOrderWithCost`, and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createMarketBuyOrderWithCost`, `createMarketBuyOrderRequiresPrice`, spot market sell order and using the `cost` param to create a market buy order

Used `amountToPrecision` because of comments stating the exchange uses base precision for the cost

```
htx createOrder BTC/USDT market buy 10 undefined '{"createMarketBuyOrderRequiresPrice":false}'

htx.createOrder (BTC/USDT, market, buy, 10, , [object Object])
2023-12-09T00:58:56.721Z iteration 0 passed in 519 ms

{
  info: { status: 'ok', data: '957025356062384' },
  id: '957025356062384',
  type: 'market',
  side: 'buy',
  amount: 10,
  trades: [],
  fees: [],
  timeInForce: 'IOC'
}
```
```
htx createOrder BTC/USDT market buy undefined undefined '{"cost":10}'

htx.createOrder (BTC/USDT, market, buy, , , [object Object])
2023-12-09T01:00:57.110Z iteration 0 passed in 517 ms

{
  info: { status: 'ok', data: '957025373202219' },
  id: '957025373202219',
  type: 'market',
  side: 'buy',
  trades: [],
  fees: [],
  timeInForce: 'IOC'
}
```
```
htx.createMarketBuyOrderWithCost (BTC/USDT, 10)
2023-12-09T01:03:10.513Z iteration 0 passed in 513 ms

{
  info: { status: 'ok', data: '957025389846796' },
  id: '957025389846796',
  type: 'market',
  side: 'buy',
  amount: 10,
  trades: [],
  fees: [],
  timeInForce: 'IOC'
}
```