### PR TITLE
Cex: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -798,9 +798,9 @@ export default class cex extends Exchange {
             } else {
                 quoteAmount = this.costToPrecision (symbol, amount);
             }
-            request['amount'] = quoteAmount;
+            request['amount'] = this.numberToString (quoteAmount);
         } else {
-            request['amount'] = this.amountToPrecision (symbol, amount);
+            request['amount'] = this.numberToString (this.amountToPrecision (symbol, amount));
         }
         if (type === 'limit') {
             request['price'] = price;

--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -782,7 +782,7 @@ export default class cex extends Exchange {
             let quoteAmount = undefined;
             let createMarketBuyOrderRequiresPrice = true;
             [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
-            const cost = this.safeNumber (params, 'cost');
+            const cost = this.safeString (params, 'cost');
             params = this.omit (params, 'cost');
             if (cost !== undefined) {
                 quoteAmount = this.costToPrecision (symbol, cost);
@@ -798,12 +798,12 @@ export default class cex extends Exchange {
             } else {
                 quoteAmount = this.costToPrecision (symbol, amount);
             }
-            request['amount'] = this.numberToString (quoteAmount);
+            request['amount'] = quoteAmount;
         } else {
-            request['amount'] = this.numberToString (this.amountToPrecision (symbol, amount));
+            request['amount'] = this.amountToPrecision (symbol, amount);
         }
         if (type === 'limit') {
-            request['price'] = price;
+            request['price'] = this.numberToString (price);
         } else {
             request['order_type'] = type;
         }

--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -34,6 +34,9 @@ export default class cex extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': false,
                 'createDepositAddress': false,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createStopLimitOrder': false,
                 'createStopMarketOrder': false,
@@ -765,28 +768,40 @@ export default class cex extends Exchange {
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} [params.cost] the quote quantity that can be used as an alternative for the amount for market buy orders
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        // for market buy it requires the amount of quote currency to spend
-        if ((type === 'market') && (side === 'buy')) {
-            if (this.options['createMarketBuyOrderRequiresPrice']) {
-                if (price === undefined) {
-                    throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
-                } else {
-                    const amountString = this.numberToString (amount);
-                    const priceString = this.numberToString (price);
-                    const baseAmount = Precise.stringMul (amountString, priceString);
-                    amount = this.parseNumber (baseAmount);
-                }
-            }
-        }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
             'pair': market['id'],
             'type': side,
-            'amount': amount,
         };
+        // for market buy it requires the amount of quote currency to spend
+        if ((type === 'market') && (side === 'buy')) {
+            let quoteAmount = undefined;
+            let createMarketBuyOrderRequiresPrice = true;
+            [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+            const cost = this.safeNumber (params, 'cost');
+            params = this.omit (params, 'cost');
+            if (cost !== undefined) {
+                quoteAmount = this.costToPrecision (symbol, cost);
+            } else if (createMarketBuyOrderRequiresPrice) {
+                if (price === undefined) {
+                    throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
+                } else {
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    const costRequest = Precise.stringMul (amountString, priceString);
+                    quoteAmount = this.costToPrecision (symbol, costRequest);
+                }
+            } else {
+                quoteAmount = this.costToPrecision (symbol, amount);
+            }
+            request['amount'] = quoteAmount;
+        } else {
+            request['amount'] = this.amountToPrecision (symbol, amount);
+        }
         if (type === 'limit') {
             request['price'] = price;
         } else {

--- a/ts/src/test/static/request/cex.json
+++ b/ts/src/test/static/request/cex.json
@@ -101,6 +101,18 @@
                 ],
                 "output": "{\"key\":\"X6IegCdOnRhIT8yETezmQ9Y6mc\",\"signature\":\"34129B378E0BC9314449554ACFF58EB594D0BFF8C6C1C85B5FFD0C6486BEF258\",\"nonce\":\"1701456852632\"}"
             }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Fill this with a description of the method call",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://cex.io/api/place_order/LTC/USDT/",
+                "input": [
+                  "LTC/USDT",
+                  10
+                ],
+                "output": "{\"key\":\"X6IegCdOnRhIT8yETezmQ9Y6mc\",\"signature\":\"B451A19ED09702E88B96F77CA230264F5FC4DBA812F3922F1F3C08414D00C0AC\",\"nonce\":\"1702114325194\",\"type\":\"buy\",\"amount\":\"10\",\"order_type\":\"market\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/cex.json
+++ b/ts/src/test/static/request/cex.json
@@ -75,7 +75,7 @@
                   "sell",
                   25
                 ],
-                "output": "{\"key\":\"X6IegCdOnRhIT8yETezmQ9Y6mc\",\"signature\":\"2CB04E933B6879A267FFA72AE044F8844F9DCDBB4727AE8B1CD63202A3B4182E\",\"nonce\":\"1701456773083\",\"type\":\"sell\",\"amount\":25,\"order_type\":\"market\"}"
+                "output": "{\"key\":\"X6IegCdOnRhIT8yETezmQ9Y6mc\",\"signature\":\"2CB04E933B6879A267FFA72AE044F8844F9DCDBB4727AE8B1CD63202A3B4182E\",\"nonce\":\"1701456773083\",\"type\":\"sell\",\"amount\":\"25\",\"order_type\":\"market\"}"
             },
             {
                 "description": "Spot limit buy",
@@ -88,7 +88,7 @@
                   100,
                   0.1
                 ],
-                "output": "{\"key\":\"X6IegCdOnRhIT8yETezmQ9Y6mc\",\"signature\":\"07AEF74E40D9F94DC04BF2BDC5E224CF75D3E482A7578E92FF31C992744307E2\",\"nonce\":\"1701456826846\",\"type\":\"buy\",\"amount\":100,\"price\":0.1}"
+                "output": "{\"key\":\"X6IegCdOnRhIT8yETezmQ9Y6mc\",\"signature\":\"07AEF74E40D9F94DC04BF2BDC5E224CF75D3E482A7578E92FF31C992744307E2\",\"nonce\":\"1701456826846\",\"type\":\"buy\",\"amount\":\"100\",\"price\":\"0.1\"}"
             }
         ],
         "cancelAllOrders": [


### PR DESCRIPTION
I was unable to test properly because I kept receiving this error:
```
[InvalidOrder] cex {"error":"There was an error while placing your order: Wrong currency pair.","safe":true}
```
Different from:
```
[BadSymbol] cex does not have market symbol USD/USDT
```

The API docs are also blocked for people in my country