### PR TITLE
docs: fix scrolling

### DIFF
--- a/wiki/index.html
+++ b/wiki/index.html
@@ -63,6 +63,7 @@
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-python.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
+    <script src="//cdn.jsdelivr.net/gh/rizdaprasetya/docsify-fix-pageload-scroll@master/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
- Docsify has a known issue with anchor scrolling that it will first scroll and then after rendering fully the page the window will be in the wrong scroll location
- This PR adds a plugin that performs a second scroll after docsify load to make sure the user is scrolled to the correct location