### PR TITLE
Coinsph: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/coinsph.ts
+++ b/ts/src/coinsph.ts
@@ -34,6 +34,9 @@ export default class coinsph extends Exchange {
                 'closeAllPositions': false,
                 'closePosition': false,
                 'createDepositAddress': false,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createPostOnlyOrder': false,
                 'createReduceOnlyOrder': false,
@@ -1071,12 +1074,14 @@ export default class coinsph extends Exchange {
          * @method
          * @name coinsph#createOrder
          * @description create a trade order
+         * @see https://coins-docs.github.io/rest-api/#new-order--trade
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market', 'limit', 'stop_loss', 'take_profit', 'stop_loss_limit', 'take_profit_limit' or 'limit_maker'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} [params.cost] the quote quantity that can be used as an alternative for the amount for market buy orders
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         // todo: add test order low priority
@@ -1110,22 +1115,26 @@ export default class coinsph extends Exchange {
             if (orderSide === 'SELL') {
                 request['quantity'] = this.amountToPrecision (symbol, amount);
             } else if (orderSide === 'BUY') {
-                const quoteOrderQty = this.safeNumber2 (params, 'cost', 'quoteOrderQty');
-                const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
-                if (quoteOrderQty !== undefined) {
-                    amount = quoteOrderQty;
+                let quoteAmount = undefined;
+                let createMarketBuyOrderRequiresPrice = true;
+                [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+                const cost = this.safeNumber2 (params, 'cost', 'quoteOrderQty');
+                params = this.omit (params, 'cost');
+                if (cost !== undefined) {
+                    quoteAmount = this.costToPrecision (symbol, cost);
                 } else if (createMarketBuyOrderRequiresPrice) {
                     if (price === undefined) {
-                        throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false to supply the cost in the amount argument (the exchange-specific behaviour)");
+                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                     } else {
                         const amountString = this.numberToString (amount);
                         const priceString = this.numberToString (price);
-                        const quoteAmount = Precise.stringMul (amountString, priceString);
-                        amount = this.parseNumber (quoteAmount);
+                        const costRequest = Precise.stringMul (amountString, priceString);
+                        quoteAmount = this.costToPrecision (symbol, costRequest);
                     }
+                } else {
+                    quoteAmount = this.costToPrecision (symbol, amount);
                 }
-                request['quoteOrderQty'] = this.costToPrecision (symbol, amount);
-                params = this.omit (params, 'cost', 'quoteOrderQty');
+                request['quoteOrderQty'] = quoteAmount;
             }
         }
         if (orderType === 'STOP_LOSS' || orderType === 'STOP_LOSS_LIMIT' || orderType === 'TAKE_PROFIT' || orderType === 'TAKE_PROFIT_LIMIT') {

--- a/ts/src/test/static/request/coinsph.json
+++ b/ts/src/test/static/request/coinsph.json
@@ -43,6 +43,100 @@
                 "url": "https://api.pro.coins.ph/openapi/wallet/v1/withdraw/history?timestamp=1699460471679&&signature=992cefbe195e98dc0a0d18777d4cc764375f8e21800cfc2ab6ce9a1f3ad6218b",
                 "input": []
             }
+        ],
+        "createOrder": [
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=MARKET&side=BUY&quoteOrderQty=2&newOrderRespType=FULL&timestamp=1702186727894&&signature=d1031c5fb2f8afe32eff6af331904522bc703e6de4f785cf18b50603b906fd62",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  2,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ]
+            },
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to true",
+                "method": "createOrder",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=MARKET&side=BUY&quoteOrderQty=2.19&newOrderRespType=FULL&timestamp=1702189547198&&signature=3546694e8823c70c439a82945977e389089ad68015d19a824cabccce52684263",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  0.00005,
+                  43964.92,
+                  {
+                    "createMarketBuyOrderRequiresPrice": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot market buy using the cost param",
+                "method": "createOrder",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=MARKET&side=BUY&quoteOrderQty=2&newOrderRespType=FULL&timestamp=1702189330305&&signature=6ef187d65548da4edffea284e4a250702e5ae378ed0d376906a75ea15d7b1c22",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 2
+                  }
+                ]
+            },
+            {
+                "description": "Spot limit buy",
+                "method": "createOrder",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=LIMIT&side=BUY&price=40000&quantity=0.00005&timeInForce=GTC&newOrderRespType=FULL&timestamp=1702189604069&&signature=5d1c98c77e37c1279a2e1fe0d7dc650d05936056ba59415b6007bf4cacbbeba3",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.00005,
+                  40000
+                ]
+            },
+            {
+                "description": "Spot limit sell",
+                "method": "createOrder",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=LIMIT&side=SELL&price=50000&quantity=0.00005&timeInForce=GTC&newOrderRespType=FULL&timestamp=1702189639303&&signature=ed9e0f27e821dd3fd92cbee96a79411838cafe76f5590e4b0ce7081ddc83e8bc",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "sell",
+                  0.00005,
+                  50000
+                ]
+            },
+            {
+                "description": "Spot market sell",
+                "method": "createOrder",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=MARKET&side=SELL&quantity=0.0001854&newOrderRespType=FULL&timestamp=1702189732038&&signature=b19f78019ac7d7c0fe197963d5d15b812f667bc7279c9d4bc60e32df07e856e0",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "sell",
+                  0.00018544,
+                  null
+                ]
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot market buy order with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.pro.coins.ph/openapi/v1/order?symbol=BTCUSDT&type=MARKET&side=BUY&quoteOrderQty=2&newOrderRespType=FULL&timestamp=1702189422251&&signature=5cd28d7b59d7fe0cf6f1bb747d312759cd5c77d7878cdb24aef1840fc1f4ca5c",
+                "input": [
+                  "BTC/USDT",
+                  2
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createOrder`

```
coinsph createOrder BTC/USDT market buy 2 undefined '{"createMarketBuyOrderRequiresPrice":false}'

coinsph.createOrder (BTC/USDT, market, buy, 2, , [object Object])
2023-12-10T05:38:48.975Z iteration 0 passed in 1583 ms

{
  id: '1572450685156352000',
  clientOrderId: 'cfb940ee-19d3-4b12-98da-41e0bc340111',
  timestamp: 1702186729031,
  datetime: '2023-12-10T05:38:49.031Z',
  status: 'closed',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'GTC',
  side: 'buy',
  price: 44024.3,
  average: 44024.3,
  amount: 0.0000454,
  cost: 1.99870322,
  filled: 0.0000454,
  remaining: 0,
  fee: { currency: 'BTC', cost: 1.362e-7 },
  fees: [ { currency: 'BTC', cost: 1.362e-7 } ],
  trades: [
    {
      id: '1572450685156352001',
      symbol: 'BTC/USDT',
      price: 44024.3,
      amount: 0.0000454,
      cost: 1.99870322,
      fee: { cost: 1.362e-7, currency: 'BTC' },
      info: {
        price: '44024.3',
        qty: '0.0000454',
        commission: '0.0000001362',
        commissionAsset: 'BTC',
        tradeId: '1572450685156352001'
      },
      fees: [ { cost: '0.0000001362', currency: 'BTC' } ]
    }
  ],
  info: {
    symbol: 'BTCUSDT',
    orderId: '1572450685156352000',
    clientOrderId: 'cfb940ee-19d3-4b12-98da-41e0bc340111',
    transactTime: '1702186729031',
    price: '0',
    origQty: '0',
    executedQty: '0.0000454',
    cummulativeQuoteQty: '1.99870322',
    status: 'FILLED',
    timeInForce: 'GTC',
    type: 'MARKET',
    side: 'BUY',
    stopPrice: '0',
    origQuoteOrderQty: '2',
    fills: [
      {
        price: '44024.3',
        qty: '0.0000454',
        commission: '0.0000001362',
        commissionAsset: 'BTC',
        tradeId: '1572450685156352001'
      }
    ]
  },
  postOnly: false
}
```
```
coinsph createOrder BTC/USDT market buy undefined undefined '{"cost":2}'

coinsph.createOrder (BTC/USDT, market, buy, , , [object Object])
2023-12-10T06:22:10.617Z iteration 0 passed in 816 ms

{
  id: '1572472509638402048',
  clientOrderId: '60d5e245-148a-4c2b-abb2-214b4790dad3',
  timestamp: 1702189330712,
  datetime: '2023-12-10T06:22:10.712Z',
  status: 'closed',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'GTC',
  side: 'buy',
  price: 43976.1,
  average: 43976.1,
  amount: 0.0000454,
  cost: 1.99651494,
  filled: 0.0000454,
  remaining: 0,
  fee: { currency: 'BTC', cost: 1.362e-7 },
  fees: [ { currency: 'BTC', cost: 1.362e-7 } ],
  trades: [
    {
      id: '1572472509638402049',
      symbol: 'BTC/USDT',
      price: 43976.1,
      amount: 0.0000454,
      cost: 1.99651494,
      fee: { cost: 1.362e-7, currency: 'BTC' },
      info: {
        price: '43976.1',
        qty: '0.0000454',
        commission: '0.0000001362',
        commissionAsset: 'BTC',
        tradeId: '1572472509638402049'
      },
      fees: [ { cost: '0.0000001362', currency: 'BTC' } ]
    }
  ],
  info: {
    symbol: 'BTCUSDT',
    orderId: '1572472509638402048',
    clientOrderId: '60d5e245-148a-4c2b-abb2-214b4790dad3',
    transactTime: '1702189330712',
    price: '0',
    origQty: '0',
    executedQty: '0.0000454',
    cummulativeQuoteQty: '1.99651494',
    status: 'FILLED',
    timeInForce: 'GTC',
    type: 'MARKET',
    side: 'BUY',
    stopPrice: '0',
    origQuoteOrderQty: '2',
    fills: [
      {
        price: '43976.1',
        qty: '0.0000454',
        commission: '0.0000001362',
        commissionAsset: 'BTC',
        tradeId: '1572472509638402049'
      }
    ]
  },
  postOnly: false
}
```
```
coinsph.createMarketBuyOrderWithCost (BTC/USDT, 2)
2023-12-10T06:23:42.597Z iteration 0 passed in 855 ms

{
  id: '1572473281205788672',
  clientOrderId: 'd44641f5-6f0a-493a-a6ec-5d36518c66da',
  timestamp: 1702189422690,
  datetime: '2023-12-10T06:23:42.690Z',
  status: 'closed',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'GTC',
  side: 'buy',
  price: 43964.92,
  average: 43964.92,
  amount: 0.0000454,
  cost: 1.996007368,
  filled: 0.0000454,
  remaining: 0,
  fee: { currency: 'BTC', cost: 1.362e-7 },
  fees: [ { currency: 'BTC', cost: 1.362e-7 } ],
  trades: [
    {
      id: '1572473281205788673',
      symbol: 'BTC/USDT',
      price: 43964.92,
      amount: 0.0000454,
      cost: 1.996007368,
      fee: { cost: 1.362e-7, currency: 'BTC' },
      info: {
        price: '43964.92',
        qty: '0.0000454',
        commission: '0.0000001362',
        commissionAsset: 'BTC',
        tradeId: '1572473281205788673'
      },
      fees: [ { cost: '0.0000001362', currency: 'BTC' } ]
    }
  ],
  info: {
    symbol: 'BTCUSDT',
    orderId: '1572473281205788672',
    clientOrderId: 'd44641f5-6f0a-493a-a6ec-5d36518c66da',
    transactTime: '1702189422690',
    price: '0',
    origQty: '0',
    executedQty: '0.0000454',
    cummulativeQuoteQty: '1.996007368',
    status: 'FILLED',
    timeInForce: 'GTC',
    type: 'MARKET',
    side: 'BUY',
    stopPrice: '0',
    origQuoteOrderQty: '2',
    fills: [
      {
        price: '43964.92',
        qty: '0.0000454',
        commission: '0.0000001362',
        commissionAsset: 'BTC',
        tradeId: '1572473281205788673'
      }
    ]
  },
  postOnly: false
}
```