### PR TITLE
Binance: sign, origclientorderidlist length

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -8516,7 +8516,7 @@ export default class binance extends Exchange {
                     extendedParams = this.omit (extendedParams, [ 'orderidlist', 'origclientorderidlist' ]);
                     query = this.rawencode (extendedParams);
                     const orderidlistLength = orderidlist.length;
-                    const origclientorderidlistLength = orderidlist.length;
+                    const origclientorderidlistLength = origclientorderidlist.length;
                     if (orderidlistLength > 0) {
                         query = query + '&' + 'orderidlist=[' + orderidlist.join (',') + ']';
                     }

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -263,7 +263,7 @@
           {
             "description": "Swap cancelOrders",
             "method": "cancelOrders",
-            "url": "https://testnet.binancefuture.com/fapi/v1/batchOrders?timestamp=1699384523218&symbol=LTCUSDT&recvWindow=10000&orderidlist=[652511506]&origclientorderidlist=[]&signature=ced41362438af4b529b81484e1713dc0108b2715453e403d3e46fa93ba8a0a83",
+            "url": "https://testnet.binancefuture.com/fapi/v1/batchOrders?timestamp=1699384523218&symbol=LTCUSDT&recvWindow=10000&orderidlist=[652511506]&signature=ced41362438af4b529b81484e1713dc0108b2715453e403d3e46fa93ba8a0a83",
             "input": [
               [
                 "652511506"


### PR DESCRIPTION
Edited the variable `origclientorderidlistLength` to check the length of `origclientorderidlist` instead of `orderidlist`
fixes: #20304