### PR TITLE
Probit: createMarketBuyOrderWithCost

### DIFF
--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -42,6 +42,7 @@ class Argv(object):
     spot = False
     swap = False
     future = False
+    signIn = False
     args = []
 
 
@@ -60,6 +61,7 @@ parser.add_argument('--spot', action='store_true', help='enable spot markets')
 parser.add_argument('--swap', action='store_true', help='enable swap markets')
 parser.add_argument('--future', action='store_true', help='enable future markets')
 parser.add_argument('--option', action='store_true', help='enable option markets')
+parser.add_argument('--signIn', action='store_true', help='sign in')
 parser.add_argument('exchange_id', type=str, help='exchange id in lowercase', nargs='?')
 parser.add_argument('method', type=str, help='method or property', nargs='?')
 parser.add_argument('args', type=str, help='arguments', nargs='*')
@@ -204,6 +206,9 @@ async def main():
         await exchange.load_markets()
 
     exchange.verbose = argv.verbose  # now set verbose mode
+
+    if argv.signIn:
+        await exchange.sign_in()
 
     is_ws_method = False
 

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -64,7 +64,7 @@ export interface MarketInterface {
     precision: {
         amount: Num
         price: Num
-        cost: Num
+        cost?: Num
     };
     limits: {
         amount?: MinMax,

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -64,6 +64,7 @@ export interface MarketInterface {
     precision: {
         amount: Num
         price: Num
+        cost: Num
     };
     limits: {
         amount?: MinMax,

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -322,6 +322,7 @@ export default class probit extends Exchange {
             'precision': {
                 'amount': this.parseNumber (this.parsePrecision (this.safeString (market, 'quantity_precision'))),
                 'price': this.safeNumber (market, 'price_increment'),
+                'cost': this.parseNumber (this.parsePrecision (this.safeString (market, 'cost_precision'))),
             },
             'limits': {
                 'leverage': {

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -30,7 +30,10 @@ export default class probit extends Exchange {
                 'option': false,
                 'addMargin': false,
                 'cancelOrder': true,
+                'createMarketBuyOrderWithCost': true,
                 'createMarketOrder': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'createReduceOnlyOrder': false,
                 'createStopLimitOrder': false,
@@ -1200,21 +1203,22 @@ export default class probit extends Exchange {
     }
 
     costToPrecision (symbol, cost) {
-        return this.decimalToPrecision (cost, TRUNCATE, this.markets[symbol]['precision']['cost'], this.precisionMode);
+        return this.decimalToPrecision (cost, TRUNCATE, this.markets[symbol]['info']['cost_precision'], this.precisionMode);
     }
 
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
          * @name probit#createOrder
-         * @see https://docs-en.probit.com/reference/order-1
          * @description create a trade order
+         * @see https://docs-en.probit.com/reference/order-1
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float} amount how much you want to trade in units of the base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} [params.cost] the quote quantity that can be used as an alternative for the amount for market buy orders
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1232,30 +1236,32 @@ export default class probit extends Exchange {
         if (clientOrderId !== undefined) {
             request['client_order_id'] = clientOrderId;
         }
-        let costToPrecision = undefined;
+        let quoteAmount = undefined;
         if (type === 'limit') {
             request['limit_price'] = this.priceToPrecision (symbol, price);
             request['quantity'] = this.amountToPrecision (symbol, amount);
         } else if (type === 'market') {
             // for market buy it requires the amount of quote currency to spend
             if (side === 'buy') {
-                let cost = this.safeNumber (params, 'cost');
-                const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
-                if (createMarketBuyOrderRequiresPrice) {
-                    if (price !== undefined) {
-                        if (cost === undefined) {
-                            const amountString = this.numberToString (amount);
-                            const priceString = this.numberToString (price);
-                            cost = this.parseNumber (Precise.stringMul (amountString, priceString));
-                        }
-                    } else if (cost === undefined) {
-                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options["createMarketBuyOrderRequiresPrice"] = false and supply the total cost value in the "amount" argument or in the "cost" extra parameter (the exchange-specific behaviour)');
+                let createMarketBuyOrderRequiresPrice = true;
+                [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+                const cost = this.safeString (params, 'cost');
+                params = this.omit (params, 'cost');
+                if (cost !== undefined) {
+                    quoteAmount = this.costToPrecision (symbol, cost);
+                } else if (createMarketBuyOrderRequiresPrice) {
+                    if (price === undefined) {
+                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
+                    } else {
+                        const amountString = this.numberToString (amount);
+                        const priceString = this.numberToString (price);
+                        const costRequest = Precise.stringMul (amountString, priceString);
+                        quoteAmount = this.costToPrecision (symbol, costRequest);
                     }
                 } else {
-                    cost = (cost === undefined) ? amount : cost;
+                    quoteAmount = this.costToPrecision (symbol, amount);
                 }
-                costToPrecision = this.costToPrecision (symbol, cost);
-                request['cost'] = costToPrecision;
+                request['cost'] = quoteAmount;
             } else {
                 request['quantity'] = this.amountToPrecision (symbol, amount);
             }
@@ -1289,7 +1295,7 @@ export default class probit extends Exchange {
         // returned by the exchange on market buys
         if ((type === 'market') && (side === 'buy')) {
             order['amount'] = undefined;
-            order['cost'] = this.parseNumber (costToPrecision);
+            order['cost'] = this.parseNumber (quoteAmount);
             order['remaining'] = undefined;
         }
         return order;

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -1203,7 +1203,7 @@ export default class probit extends Exchange {
     }
 
     costToPrecision (symbol, cost) {
-        return this.decimalToPrecision (cost, TRUNCATE, this.markets[symbol]['info']['cost_precision'], this.precisionMode);
+        return this.decimalToPrecision (cost, TRUNCATE, this.markets[symbol]['precision']['cost'], this.precisionMode);
     }
 
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {

--- a/ts/src/test/static/request/probit.json
+++ b/ts/src/test/static/request/probit.json
@@ -41,7 +41,51 @@
                     0.05
                 ],
                 "output": "{\"market_id\":\"LTC-USDT\",\"type\":\"market\",\"side\":\"sell\",\"time_in_force\":\"ioc\",\"quantity\":\"0.05\"}"
+            },
+            {
+                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://api.probit.com/api/exchange/v1/new_order",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  10,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"8\"}"
+            },
+            {
+                "description": "Spot market buy order using the cost param",
+                "method": "createOrder",
+                "url": "https://api.probit.com/api/exchange/v1/new_order",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 10
+                  }
+                ],
+                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"8\"}"
             }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Spot market buy order with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.probit.com/api/exchange/v1/new_order",
+                "input": [
+                  "BTC/USDT",
+                  10
+                ],
+                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"8\"}"
+              }
         ]
     }
 }

--- a/ts/src/test/static/request/probit.json
+++ b/ts/src/test/static/request/probit.json
@@ -56,7 +56,7 @@
                     "createMarketBuyOrderRequiresPrice": false
                   }
                 ],
-                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"8\"}"
+                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"10\"}"
             },
             {
                 "description": "Spot market buy order using the cost param",
@@ -72,7 +72,7 @@
                     "cost": 10
                   }
                 ],
-                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"8\"}"
+                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"10\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -84,7 +84,7 @@
                   "BTC/USDT",
                   10
                 ],
-                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"8\"}"
+                "output": "{\"market_id\":\"BTC-USDT\",\"type\":\"market\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"cost\":\"10\"}"
               }
         ]
     }


### PR DESCRIPTION
Fixed the exchange specific `costToPrecision` implementation because this line was removed from fetchMarkets a few weeks ago:
```
'cost': this.parseNumber (this.parsePrecision (this.safeString (market, 'cost_precision'))),
```

Added `createMarketBuyOrderWithCost`, and updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createMarketBuyOrderWithCost`, `createMarketBuyOrderRequiresPrice`, and using the `cost` param to create a market buy order

```
probit createOrder BTC/USDT market buy 10 undefined '{"createMarketBuyOrderRequiresPrice":false}'

probit.createOrder (BTC/USDT, market, buy, 10, , [object Object])
2023-12-12T02:27:31.775Z iteration 0 passed in 542 ms

{
  id: '6792755410',
  info: {
    id: '6792755410',
    user_id: '26202efb-f5f0-4f89-977d-4eb28882df9e',
    market_id: 'BTC-USDT',
    type: 'market',
    side: 'buy',
    limit_price: '0',
    time_in_force: 'ioc',
    filled_cost: '0',
    filled_quantity: '0',
    status: 'open',
    time: '2023-12-12T02:27:32.937Z',
    client_order_id: '',
    cost: '8'
  },
  timestamp: 1702348052937,
  datetime: '2023-12-12T02:27:32.937Z',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  status: 'open',
  filled: 0,
  cost: 8,
  trades: [],
  fees: [],
  postOnly: false
}
```
```
probit createOrder BTC/USDT market buy undefined undefined '{"cost":10}'

probit.createOrder (BTC/USDT, market, buy, , , [object Object])
2023-12-12T02:38:14.791Z iteration 0 passed in 502 ms

{
  id: '6792798956',
  info: {
    id: '6792798956',
    user_id: '26202efb-f5f0-4f89-977d-4eb28882df9e',
    market_id: 'BTC-USDT',
    type: 'market',
    side: 'buy',
    limit_price: '0',
    time_in_force: 'ioc',
    filled_cost: '0',
    filled_quantity: '0',
    status: 'open',
    time: '2023-12-12T02:38:15.965Z',
    client_order_id: '',
    cost: '8'
  },
  timestamp: 1702348695965,
  datetime: '2023-12-12T02:38:15.965Z',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  status: 'open',
  filled: 0,
  cost: 8,
  trades: [],
  fees: [],
  postOnly: false
}
```
```
probit.createMarketBuyOrderWithCost (BTC/USDT, 10)
2023-12-12T02:39:44.386Z iteration 0 passed in 1011 ms

{
  id: '6792804842',
  info: {
    id: '6792804842',
    user_id: '26202efb-f5f0-4f89-977d-4eb28882df9e',
    market_id: 'BTC-USDT',
    type: 'market',
    side: 'buy',
    limit_price: '0',
    time_in_force: 'ioc',
    filled_cost: '0',
    filled_quantity: '0',
    status: 'open',
    time: '2023-12-12T02:39:45.553Z',
    client_order_id: '',
    cost: '8'
  },
  timestamp: 1702348785553,
  datetime: '2023-12-12T02:39:45.553Z',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  status: 'open',
  filled: 0,
  cost: 8,
  trades: [],
  fees: [],
  postOnly: false
}
```