### PR TITLE
Upbit: createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/test/static/markets/upbit.json
+++ b/ts/src/test/static/markets/upbit.json
@@ -130,5 +130,37 @@
             "korean_name": "이더리움",
             "english_name": "Ethereum"
         }
+    },
+    "BTC/USDT": {
+        "id": "USDT-BTC",
+        "symbol": "BTC/USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0005,
+        "maker": 0.0005,
+        "precision": {
+            "price": 1e-8,
+            "amount": 1e-8
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {}
+        },
+        "info": {
+            "market": "USDT-BTC",
+            "english_name": "Bitcoin"
+        }
     }
 }

--- a/ts/src/test/static/request/upbit.json
+++ b/ts/src/test/static/request/upbit.json
@@ -38,6 +38,117 @@
                 ],
                 "output": "{\"amount\":1}"
             }
+        ],
+        "createOrder": [
+            {
+                "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to true",
+                "method": "createOrder",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  0.00015,
+                  49998,
+                  {
+                    "createMarketBuyOrderRequiresPrice": true
+                  }
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"7.4997\"}"
+            },
+            {
+                "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
+                "method": "createOrder",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  5,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false
+                  }
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5\"}"
+            },
+            {
+                "description": "Spot market buy order using the cost param",
+                "method": "createOrder",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 5
+                  }
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5\"}"
+            },
+            {
+                "description": "Spot limit buy order",
+                "method": "createOrder",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.00015,
+                  42000
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"price\":\"42000\",\"ord_type\":\"limit\",\"volume\":\"0.00015\"}"
+            },
+            {
+                "description": "Spot limit sell order",
+                "method": "createOrder",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "sell",
+                  0.00015,
+                  55000
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"ask\",\"price\":\"55000\",\"ord_type\":\"limit\",\"volume\":\"0.00015\"}"
+            },
+            {
+                "description": "Spot market sell order",
+                "method": "createOrder",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "sell",
+                  0.00015,
+                  null
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"ask\",\"ord_type\":\"market\",\"volume\":\"0.00015\"}"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "Create market buy order with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://sg-api.upbit.com/v1/orders",
+                "input": [
+                  "BTC/USDT",
+                  5
+                ],
+                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5\"}"
+            }
+        ],
+        "cancelOrder": [
+            {
+                "description": "Spot cancel sell order",
+                "method": "cancelOrder",
+                "url": "https://sg-api.upbit.com/v1/order?uuid=4321cb06-94cc-4fd5-bb15-a514c721ff56",
+                "input": [
+                  "4321cb06-94cc-4fd5-bb15-a514c721ff56"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -35,7 +35,10 @@ export default class upbit extends Exchange {
                 'option': false,
                 'cancelOrder': true,
                 'createDepositAddress': true,
+                'createMarketBuyOrderWithCost': true,
                 'createMarketOrder': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'fetchBalance': true,
                 'fetchCanceledOrders': true,
@@ -1033,28 +1036,19 @@ export default class upbit extends Exchange {
         /**
          * @method
          * @name upbit#createOrder
-         * @see https://docs.upbit.com/reference/%EC%A3%BC%EB%AC%B8%ED%95%98%EA%B8%B0
          * @description create a trade order
+         * @see https://docs.upbit.com/reference/%EC%A3%BC%EB%AC%B8%ED%95%98%EA%B8%B0
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float} amount how much you want to trade in units of the base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} [params.cost] for market buy orders, the quote quantity that can be used as an alternative for the amount
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        if (type === 'market') {
-            // for market buy it requires the amount of quote currency to spend
-            if (side === 'buy') {
-                if (this.options['createMarketBuyOrderRequiresPrice']) {
-                    if (price === undefined) {
-                        throw new InvalidOrder (this.id + ' createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options["createMarketBuyOrderRequiresPrice"] = false to supply the cost in the amount argument (the exchange-specific behaviour)');
-                    } else {
-                        amount = amount * price;
-                    }
-                }
-            }
-        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
         let orderSide = undefined;
         if (side === 'buy') {
             orderSide = 'bid';
@@ -1063,24 +1057,39 @@ export default class upbit extends Exchange {
         } else {
             throw new InvalidOrder (this.id + ' createOrder() allows buy or sell side only!');
         }
-        await this.loadMarkets ();
-        const market = this.market (symbol);
         const request = {
             'market': market['id'],
             'side': orderSide,
         };
         if (type === 'limit') {
-            request['volume'] = this.amountToPrecision (symbol, amount);
             request['price'] = this.priceToPrecision (symbol, price);
-            request['ord_type'] = type;
-        } else if (type === 'market') {
-            if (side === 'buy') {
-                request['ord_type'] = 'price';
-                request['price'] = this.priceToPrecision (symbol, amount);
-            } else if (side === 'sell') {
-                request['ord_type'] = type;
-                request['volume'] = this.amountToPrecision (symbol, amount);
+        }
+        if ((type === 'market') && (side === 'buy')) {
+            // for market buy it requires the amount of quote currency to spend
+            let quoteAmount = undefined;
+            let createMarketBuyOrderRequiresPrice = true;
+            [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+            const cost = this.safeNumber (params, 'cost');
+            params = this.omit (params, 'cost');
+            if (cost !== undefined) {
+                quoteAmount = this.costToPrecision (symbol, cost);
+            } else if (createMarketBuyOrderRequiresPrice) {
+                if (price === undefined) {
+                    throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend (quote quantity) in the amount argument');
+                } else {
+                    const amountString = this.numberToString (amount);
+                    const priceString = this.numberToString (price);
+                    const costRequest = Precise.stringMul (amountString, priceString);
+                    quoteAmount = this.costToPrecision (symbol, costRequest);
+                }
+            } else {
+                quoteAmount = this.costToPrecision (symbol, amount);
             }
+            request['ord_type'] = 'price';
+            request['price'] = quoteAmount;
+        } else {
+            request['ord_type'] = type;
+            request['volume'] = this.amountToPrecision (symbol, amount);
         }
         const clientOrderId = this.safeString2 (params, 'clientOrderId', 'identifier');
         if (clientOrderId !== undefined) {


### PR DESCRIPTION
Updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice`

Added static request tests for `createMarketBuyOrderWithCost`, `createOrder`, and `cancelOrder`

```
upbit createOrder BTC/USDT market buy 5 undefined '{"createMarketBuyOrderRequiresPrice":false}'

upbit.createOrder (BTC/USDT, market, buy, 5, , [object Object])
2023-12-12T07:03:52.973Z iteration 0 passed in 1527 ms

{
  info: {
    uuid: '23787eed-3760-45a6-a893-fe55fe45ee58',
    side: 'bid',
    ord_type: 'price',
    price: '5',
    state: 'wait',
    market: 'USDT-BTC',
    created_at: '2023-12-12T07:03:52Z',
    reserved_fee: '0.01',
    remaining_fee: '0.01',
    paid_fee: '0',
    locked: '5.01',
    executed_volume: '0',
    trades_count: '0'
  },
  id: '23787eed-3760-45a6-a893-fe55fe45ee58',
  timestamp: 1702364632000,
  datetime: '2023-12-12T07:03:52.000Z',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  cost: 5,
  filled: 0,
  status: 'open',
  fee: { currency: 'USDT', cost: '0' },
  trades: [],
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```
```
upbit createOrder BTC/USDT market buy undefined undefined '{"cost":5}'

upbit.createOrder (BTC/USDT, market, buy, , , [object Object])
2023-12-12T07:04:36.659Z iteration 0 passed in 1399 ms

{
  info: {
    uuid: 'd11c5e89-18dd-48e3-aae0-b4ce63bfb62c',
    side: 'bid',
    ord_type: 'price',
    price: '5',
    state: 'wait',
    market: 'USDT-BTC',
    created_at: '2023-12-12T07:04:36Z',
    reserved_fee: '0.01',
    remaining_fee: '0.01',
    paid_fee: '0',
    locked: '5.01',
    executed_volume: '0',
    trades_count: '0'
  },
  id: 'd11c5e89-18dd-48e3-aae0-b4ce63bfb62c',
  timestamp: 1702364676000,
  datetime: '2023-12-12T07:04:36.000Z',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  cost: 5,
  filled: 0,
  status: 'open',
  fee: { currency: 'USDT', cost: '0' },
  trades: [],
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```
```
upbit.createMarketBuyOrderWithCost (BTC/USDT, 5)
2023-12-12T07:07:01.003Z iteration 0 passed in 1504 ms

{
  info: {
    uuid: '39c1295d-664e-4870-83cf-cef2e1f6e857',
    side: 'bid',
    ord_type: 'price',
    price: '5',
    state: 'wait',
    market: 'USDT-BTC',
    created_at: '2023-12-12T07:07:00Z',
    reserved_fee: '0.01',
    remaining_fee: '0.01',
    paid_fee: '0',
    locked: '5.01',
    executed_volume: '0',
    trades_count: '0'
  },
  id: '39c1295d-664e-4870-83cf-cef2e1f6e857',
  timestamp: 1702364820000,
  datetime: '2023-12-12T07:07:00.000Z',
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  side: 'buy',
  cost: 5,
  filled: 0,
  status: 'open',
  fee: { currency: 'USDT', cost: '0' },
  trades: [],
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```