### PR TITLE
Bitmart: trailing stop orders

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2324,7 +2324,7 @@ export default class bitmart extends Exchange {
             reduceOnly = true;
             request['activation_price'] = this.priceToPrecision (symbol, price);
             request['activation_price_type'] = this.safeInteger (params, 'activation_price_type', 1);
-            request['callback_rate'] = this.safeString (params, 'callback_rate', "1");
+            request['callback_rate'] = this.safeString (params, 'callback_rate', '1');
         }
         if (side === 'buy') {
             if (reduceOnly) {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2302,7 +2302,7 @@ export default class bitmart extends Exchange {
         const mode = this.safeInteger (params, 'mode'); // only for swap
         const isMarketOrder = type === 'market';
         let postOnly = undefined;
-        const reduceOnly = this.safeValue (params, 'reduceOnly');
+        let reduceOnly = this.safeValue (params, 'reduceOnly');
         const isExchangeSpecificPo = (mode === 4);
         [ postOnly, params ] = this.handlePostOnly (isMarketOrder, isExchangeSpecificPo, params);
         params = this.omit (params, [ 'timeInForce', 'postOnly', 'reduceOnly' ]);
@@ -2321,6 +2321,7 @@ export default class bitmart extends Exchange {
         if (isLimitOrder) {
             request['price'] = this.priceToPrecision (symbol, price);
         } else if (type === 'trailing') {
+            reduceOnly = true;
             request['activation_price'] = this.priceToPrecision (symbol, price);
             request['activation_price_type'] = this.safeInteger (params, 'activation_price_type', 1);
             request['callback_rate'] = this.safeString (params, 'callback_rate', "1");

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2079,7 +2079,7 @@ export default class bitmart extends Exchange {
         //        "updateTime" : 1681701559408
         //    }
         //
-        // swap: fetchOrder, fetchOpenOrders
+        // swap: fetchOrder, fetchOpenOrders, fetchClosedOrders
         //
         //     {
         //         "order_id": "230935812485489",
@@ -2095,7 +2095,10 @@ export default class bitmart extends Exchange {
         //         "deal_avg_price": "0",
         //         "deal_size": "0",
         //         "create_time": 1695702258629,
-        //         "update_time": 1695702258642
+        //         "update_time": 1695702258642,
+        //         "activation_price_type": 0,
+        //         "activation_price": "",
+        //         "callback_rate": ""
         //     }
         //
         let id = undefined;
@@ -2125,6 +2128,7 @@ export default class bitmart extends Exchange {
         if (priceString === 'market price') {
             priceString = undefined;
         }
+        const trailingStopActivationPrice = this.safeNumber (order, 'activation_price');
         return this.safeOrder ({
             'id': id,
             'clientOrderId': this.safeString (order, 'client_order_id'),
@@ -2138,8 +2142,8 @@ export default class bitmart extends Exchange {
             'postOnly': postOnly,
             'side': this.parseOrderSide (this.safeString (order, 'side')),
             'price': this.omitZero (priceString),
-            'stopPrice': undefined,
-            'triggerPrice': undefined,
+            'stopPrice': trailingStopActivationPrice,
+            'triggerPrice': trailingStopActivationPrice,
             'amount': this.omitZero (this.safeString (order, 'size')),
             'cost': this.safeString2 (order, 'filled_notional', 'filledNotional'),
             'average': this.safeStringN (order, [ 'price_avg', 'priceAvg', 'deal_avg_price' ]),
@@ -2216,7 +2220,7 @@ export default class bitmart extends Exchange {
          * @see https://developer-pro.bitmart.com/en/spot/#place-margin-order
          * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
          * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit'
+         * @param {string} type 'market', 'limit' or 'trailing' for swap markets only
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
@@ -2275,7 +2279,7 @@ export default class bitmart extends Exchange {
          * @description create a trade order
          * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
          * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit'
+         * @param {string} type 'market', 'limit' or 'trailing'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
@@ -2283,7 +2287,9 @@ export default class bitmart extends Exchange {
          * @param {int} [params.leverage] leverage level
          * @param {boolean} [params.reduceOnly] *swap only* reduce only
          * @param {string} [params.marginMode] 'cross' or 'isolated', default is 'cross'
-         *  @param {string} [params.clientOrderId] client order id of the order
+         * @param {string} [params.clientOrderId] client order id of the order
+         * @param {int} [params.activation_price_type] *swap trailing order only* 1: last price, 2: fair price, default is 1
+         * @param {string} [params.callback_rate] *swap trailing order only* min 0.1, max 5 where 1 is 1%, default is "1"
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         const market = this.market (symbol);
@@ -2314,10 +2320,14 @@ export default class bitmart extends Exchange {
         }
         if (isLimitOrder) {
             request['price'] = this.priceToPrecision (symbol, price);
+        } else if (type === 'trailing') {
+            request['activation_price'] = this.priceToPrecision (symbol, price);
+            request['activation_price_type'] = this.safeInteger (params, 'activation_price_type', 1);
+            request['callback_rate'] = this.safeString (params, 'callback_rate', "1");
         }
         if (side === 'buy') {
             if (reduceOnly) {
-                request['side'] = 2; // sell close long
+                request['side'] = 2; // buy close short
             } else {
                 request['side'] = 1; // buy open long
             }
@@ -2623,6 +2633,7 @@ export default class bitmart extends Exchange {
          * @param {int} [params.until] *spot* the latest time in ms to fetch orders for
          * @param {string} [params.type] *swap* order type, 'limit' or 'market'
          * @param {string} [params.order_state] *swap* the order state, 'all' or 'partially_filled', default is 'all'
+         * @param {string} [params.orderType] *swap only* 'limit', 'market', or 'trailing'
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -2654,6 +2665,11 @@ export default class bitmart extends Exchange {
             }
             response = await this.privatePostSpotV4QueryOpenOrders (this.extend (request, params));
         } else if (type === 'swap') {
+            const orderType = this.safeString (params, 'orderType');
+            params = this.omit (params, 'orderType');
+            if (orderType !== undefined) {
+                request['type'] = orderType;
+            }
             response = await this.privateGetContractPrivateGetOpenOrders (this.extend (request, params));
         } else {
             throw new NotSupported (this.id + ' fetchOpenOrders() does not support ' + type + ' orders, only spot and swap orders are accepted');
@@ -2796,6 +2812,7 @@ export default class bitmart extends Exchange {
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.clientOrderId] *spot* fetch the order by client order id instead of order id
+         * @param {string} [params.orderType] *swap only* 'limit', 'market', 'liquidate', 'bankruptcy', 'adl' or 'trailing'
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -2820,6 +2837,11 @@ export default class bitmart extends Exchange {
         } else if (type === 'swap') {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
+            }
+            const orderType = this.safeString (params, 'orderType');
+            params = this.omit (params, 'orderType');
+            if (orderType !== undefined) {
+                request['type'] = orderType;
             }
             request['symbol'] = market['id'];
             request['order_id'] = id;

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -171,6 +171,24 @@
                     }
                 ],
                 "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
+            },
+            {
+                "description": "Swap trailing stop order",
+                "method": "createOrder",
+                "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "trailing",
+                  "sell",
+                  1,
+                  55000,
+                  {
+                    "marginMode": "isolated",
+                    "leverage": "10",
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"type\":\"trailing\",\"size\":1,\"activation_price\":\"55000\",\"activation_price_type\":1,\"callback_rate\":\"1\",\"side\":3,\"open_type\":\"isolated\",\"leverage\":\"10\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -224,6 +242,33 @@
                 "url": "https://api-cloud.bitmart.com/contract/private/get-open-orders?symbol=LTCUSDT",
                 "input": [
                     "LTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "Swap open trailing stop orders",
+                "method": "fetchOpenOrders",
+                "url": "https://api-cloud.bitmart.com/contract/private/get-open-orders?symbol=BTCUSDT&type=trailing",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "orderType": "trailing"
+                  }
+                ]
+            }
+        ],
+        "fetchOrder": [
+            {
+                "description": "Swap trailing stop order by id",
+                "method": "fetchOrder",
+                "url": "https://api-cloud.bitmart.com/contract/private/order?type=trailing&symbol=BTCUSDT&order_id=2312139250106560",
+                "input": [
+                  "2312139250106560",
+                  "BTC/USDT:USDT",
+                  {
+                    "orderType": "trailing"
+                  }
                 ]
             }
         ],


### PR DESCRIPTION
Added support for trailing stop orders to bitmart:

The exchange specific param `type` is the same as the CCXT `type` param that we use for determining the `marketType` so I used `orderType` as the name instead.

```
bitmart createOrder BTC/USDT:USDT trailing sell 1 55000 '{"marginMode":"isolated","leverage":"10","reduceOnly":true}'

bitmart.createOrder (BTC/USDT:USDT, trailing, sell, 1, 55000, [object Object])
2023-12-13T01:44:12.024Z iteration 0 passed in 581 ms

{
  id: '2312139250106560',
  info: { order_id: '2312139250106560' },
  symbol: 'BTC/USDT:USDT',
  type: 'trailing',
  side: 'sell',
  price: 55000,
  amount: 1,
  trades: [],
  fees: []
}
```
```
bitmart fetchOpenOrders BTC/USDT:USDT undefined undefined '{"orderType":"trailing"}'

bitmart.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2023-12-13T01:47:39.440Z iteration 0 passed in 529 ms

              id |     timestamp |                 datetime | lastTradeTimestamp |        symbol |     type | side | stopPrice | triggerPrice | amount | status | trades | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2312139250106560 | 1702431852508 | 2023-12-13T01:44:12.508Z |      1702431852508 | BTC/USDT:USDT | trailing | sell |     55000 |        55000 |      1 |   open |     [] |   []
1 objects
```
```
bitmart fetchOrder '"2312139250106560"' BTC/USDT:USDT '{"orderType":"trailing"}'

bitmart.fetchOrder (2312139250106560, BTC/USDT:USDT, [object Object])
2023-12-13T01:50:22.838Z iteration 0 passed in 512 ms

{
  id: '2312139250106560',
  info: {
    order_id: '2312139250106560',
    client_order_id: '',
    size: '1',
    symbol: 'BTCUSDT',
    state: '1',
    side: '3',
    type: 'trailing',
    leverage: '10',
    deal_avg_price: '',
    deal_size: '',
    create_time: '1702431852508',
    update_time: '1702431852508',
    activation_price_type: '1',
    activation_price: '55000',
    callback_rate: '1'
  },
  timestamp: 1702431852508,
  datetime: '2023-12-13T01:44:12.508Z',
  lastTradeTimestamp: 1702431852508,
  symbol: 'BTC/USDT:USDT',
  type: 'trailing',
  side: 'sell',
  stopPrice: 55000,
  triggerPrice: 55000,
  amount: 1,
  status: 'open',
  trades: [],
  fees: []
}
```