### PR TITLE
fix(binancePro): snapshot messageHash [ci deploy]

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -240,8 +240,10 @@ export default class binance extends binanceRest {
     }
 
     async fetchOrderBookSnapshot (client, message, subscription) {
-        const messageHash = this.safeString (subscription, 'messageHash');
+        const name = this.safeString (subscription, 'name');
         const symbol = this.safeString (subscription, 'symbol');
+        const market = this.market (symbol);
+        const messageHash = market['lowercaseId'] + '@' + name;
         try {
             const defaultLimit = this.safeInteger (this.options, 'watchOrderBookLimit', 1000);
             const type = this.safeValue (subscription, 'type');


### PR DESCRIPTION

```
p binance watchOrderBook "BTC/USDT" 5 --sandbox
Python v3.11.5
CCXT v4.1.87
binance.watchOrderBook(BTC/USDT,5)
{'asks': [[42345.99, 0.00904], [42346.0, 0.01158], [42346.23, 0.0104], [42346.88, 0.00815], [42347.08, 0.01035]],
 'bids': [[42345.98, 0.00981], [42345.92, 0.00933], [42345.84, 0.05008], [42344.87, 0.01634], [42344.74, 0.00662]],
 'datetime': None,
 'nonce': 6409020,
 'symbol': 'BTC/USDT',
 'timestamp': None}
{'asks': [[42345.99, 0.00503], [42346.0, 0.01158], [42346.23, 0.0104], [42346.88, 0.00815], [42347.08, 0.01035]],
 'bids': [[42345.98, 0.00981], [42345.92, 0.00933], [42345.84, 0.05008], [42344.87, 0.01634], [42344.74, 0.00662]],
 'datetime': '2023-12-13T19:28:43.285Z',
 'nonce': 6409022,
 'symbol': 'BTC/USDT',
 'timestamp': 1702495723285}
{'asks': [[42345.99, 0.00503], [42346.0, 0.01408], [42346.23, 0.0104], [42346.88, 0.00815], [42347.08, 0.01035]],
 'bids': [[42345.98, 0.00981], [42345.97, 0.0025], [42345.92, 0.00933], [42345.84, 0.05008], [42344.87, 0.01634]],
 'datetime': '2023-12-13T19:28:43.885Z',
 'nonce': 6409024,
 'symbol': 'BTC/USDT',
 'timestamp': 1702495723885}
{'asks': [[42345.99, 0.00414], [42346.0, 0.01408], [42346.23, 0.0104], [42346.88, 0.00815], [42347.08, 0.01035]],
 'bids': [[42345.98, 0.00981], [42345.97, 0.0025], [42345.92, 0.00933], [42345.84, 0.05008], [42344.87, 0.01634]],
 'datetime': '2023-12-13T19:28:44.086Z',
 'nonce': 6409025,
 'symbol': 'BTC/USDT',
 'timestamp': 1702495724086}
```
