### PR TITLE
okcoin: createMarketBuyOrderRequiresPrice

### DIFF
--- a/ts/src/okcoin.ts
+++ b/ts/src/okcoin.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/okcoin.js';
-import { ExchangeError, ExchangeNotAvailable, OnMaintenance, ArgumentsRequired, BadRequest, AccountSuspended, InvalidAddress, PermissionDenied, NetworkError, InsufficientFunds, InvalidNonce, CancelPending, InvalidOrder, OrderNotFound, AuthenticationError, RequestTimeout, AccountNotEnabled, BadSymbol, RateLimitExceeded } from './base/errors.js';
+import { ExchangeError, ExchangeNotAvailable, OnMaintenance, ArgumentsRequired, BadRequest, AccountSuspended, InvalidAddress, PermissionDenied, NetworkError, InsufficientFunds, InvalidNonce, CancelPending, InvalidOrder, OrderNotFound, AuthenticationError, RequestTimeout, AccountNotEnabled, BadSymbol, RateLimitExceeded, NotSupported } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
@@ -33,6 +33,9 @@ export default class okcoin extends Exchange {
                 'future': true,
                 'option': undefined,
                 'cancelOrder': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketOrderWithCost': false,
+                'createMarketSellOrderWithCost': false,
                 'createOrder': true,
                 'fetchBalance': true,
                 'fetchClosedOrders': true,
@@ -1265,6 +1268,27 @@ export default class okcoin extends Exchange {
         return this.safeBalance (result);
     }
 
+    async createMarketBuyOrderWithCost (symbol: string, cost, params = {}) {
+        /**
+         * @method
+         * @name okcoin#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol and cost
+         * @see https://www.okcoin.com/docs-v5/en/#rest-api-trade-place-order
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['createMarketBuyOrderRequiresPrice'] = false;
+        params['tgtCcy'] = 'quote_ccy';
+        return await this.createOrder (symbol, 'market', 'buy', cost, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
         /**
          * @method
@@ -1291,6 +1315,7 @@ export default class okcoin extends Exchange {
          * @param {float} [params.stopLoss.triggerPrice] stop loss trigger price
          * @param {float} [params.stopLoss.price] used for stop loss limit orders, not used for stop loss market price orders
          * @param {string} [params.stopLoss.type] 'market' or 'limit' used to specify the stop loss price type
+         * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1337,7 +1362,7 @@ export default class okcoin extends Exchange {
             'ordType': type,
             // 'ordType': type, // privatePostTradeOrder: market, limit, post_only, fok, ioc, optimal_limit_ioc
             // 'ordType': type, // privatePostTradeOrderAlgo: conditional, oco, trigger, move_order_stop, iceberg, twap
-            'sz': this.amountToPrecision (symbol, amount),
+            // 'sz': this.amountToPrecision (symbol, amount),
             // 'px': this.priceToPrecision (symbol, price), // limit orders only
             // 'reduceOnly': false,
             //
@@ -1403,27 +1428,32 @@ export default class okcoin extends Exchange {
                 // see documentation: https://www.okx.com/docs-v5/en/#rest-api-trade-place-order
                 if (tgtCcy === 'quote_ccy') {
                     // quote_ccy: sz refers to units of quote currency
-                    let notional = this.safeNumber2 (params, 'cost', 'sz');
-                    const createMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'createMarketBuyOrderRequiresPrice', true);
-                    if (createMarketBuyOrderRequiresPrice) {
-                        if (price !== undefined) {
-                            if (notional === undefined) {
-                                const amountString = this.numberToString (amount);
-                                const priceString = this.numberToString (price);
-                                const quoteAmount = Precise.stringMul (amountString, priceString);
-                                notional = this.parseNumber (quoteAmount);
-                            }
-                        } else if (notional === undefined) {
-                            throw new InvalidOrder (this.id + " createOrder() requires the price argument with market buy orders to calculate total order cost (amount to spend), where cost = amount * price. Supply a price argument to createOrder() call if you want the cost to be calculated for you from price and amount, or, alternatively, add .options['createMarketBuyOrderRequiresPrice'] = false and supply the total cost value in the 'amount' argument or in the 'cost' unified extra parameter or in exchange-specific 'sz' extra parameter (the exchange-specific behaviour)");
+                    let quoteAmount = undefined;
+                    let createMarketBuyOrderRequiresPrice = true;
+                    [ createMarketBuyOrderRequiresPrice, params ] = this.handleOptionAndParams (params, 'createOrder', 'createMarketBuyOrderRequiresPrice', true);
+                    const cost = this.safeNumber2 (params, 'cost', 'sz');
+                    params = this.omit (params, [ 'cost', 'sz' ]);
+                    if (cost !== undefined) {
+                        quoteAmount = this.costToPrecision (symbol, cost);
+                    } else if (createMarketBuyOrderRequiresPrice) {
+                        if (price === undefined) {
+                            throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend (quote quantity) in the amount argument');
+                        } else {
+                            const amountString = this.numberToString (amount);
+                            const priceString = this.numberToString (price);
+                            const costRequest = Precise.stringMul (amountString, priceString);
+                            quoteAmount = this.costToPrecision (symbol, costRequest);
                         }
                     } else {
-                        notional = (notional === undefined) ? amount : notional;
+                        quoteAmount = this.costToPrecision (symbol, amount);
                     }
-                    request['sz'] = this.costToPrecision (symbol, notional);
-                    params = this.omit (params, [ 'cost', 'sz' ]);
+                    request['sz'] = quoteAmount;
+                } else {
+                    request['sz'] = this.amountToPrecision (symbol, amount);
                 }
             }
         } else {
+            request['sz'] = this.amountToPrecision (symbol, amount);
             if ((!trigger) && (!conditional)) {
                 request['px'] = this.priceToPrecision (symbol, price);
             }

--- a/ts/src/test/static/markets/okcoin.json
+++ b/ts/src/test/static/markets/okcoin.json
@@ -130,5 +130,71 @@
         "taker": 0.0015,
         "maker": 0.001,
         "created": 1671521075000
+    },
+    "USDT/USD": {
+        "id": "USDT-USD",
+        "symbol": "USDT/USD",
+        "base": "USDT",
+        "quote": "USD",
+        "baseId": "USDT",
+        "quoteId": "USD",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0015,
+        "maker": 0.001,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.0001
+        },
+        "limits": {
+            "leverage": {
+                "min": 1,
+                "max": 1
+            },
+            "amount": {
+                "min": 1
+            },
+            "price": {},
+            "cost": {
+                "max": 1000000
+            }
+        },
+        "created": 1671521075000,
+        "info": {
+            "alias": "",
+            "baseCcy": "USDT",
+            "category": "1",
+            "ctMult": "",
+            "ctType": "",
+            "ctVal": "",
+            "ctValCcy": "",
+            "expTime": "",
+            "instFamily": "",
+            "instId": "USDT-USD",
+            "instType": "SPOT",
+            "lever": "",
+            "listTime": "1671521075000",
+            "lotSz": "0.0001",
+            "maxIcebergSz": "99999999999999",
+            "maxLmtSz": "99999999999999",
+            "maxMktSz": "1000000",
+            "maxStopSz": "1000000",
+            "maxTriggerSz": "99999999999999",
+            "maxTwapSz": "99999999999999",
+            "minSz": "1",
+            "optType": "",
+            "quoteCcy": "USD",
+            "settleCcy": "",
+            "state": "live",
+            "stk": "",
+            "tickSz": "0.0001",
+            "uly": ""
+        }
     }
 }

--- a/ts/src/test/static/request/okcoin.json
+++ b/ts/src/test/static/request/okcoin.json
@@ -71,6 +71,18 @@
                 "output": "{\"instId\":\"BTC-USD\",\"side\":\"buy\",\"ordType\":\"trigger\",\"sz\":\"1\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"triggerPx\":\"40000\",\"orderPx\":\"-1\"}"
             }
         ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "spot market buy",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://www.okcoin.com/api/v5/trade/batch-orders",
+                "input": [
+                  "USDT/USD",
+                  3
+                ],
+                "output": "[{\"instId\":\"USDT-USD\",\"side\":\"buy\",\"ordType\":\"market\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"sz\":\"3\"}]"
+            }
+        ],
         "fetchLedger": [
             {
                 "description": "fetch Ledger",


### PR DESCRIPTION
Updated createOrder to use the new unified approach for `createMarketBuyOrderRequiresPrice` and added support for `createMarketBuyOrderWithCost`

I don't have access to an updated API key for okcoin at the moment so these changes haven't been tested yet