### PR TITLE
feat(bingx): add snapshot and track used and free balance, fix #20356

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1364,7 +1364,7 @@ export default class bingx extends Exchange {
     async fetchBalance (params = {}): Promise<Balances> {
         /**
          * @method
-         * @name cryptocom#fetchBalance
+         * @name bingx#fetchBalance
          * @description query for balance and get the amount of funds available for trading or funds locked in orders
          * @see https://bingx-api.github.io/docs/#/spot/trade-api.html#Query%20Assets
          * @see https://bingx-api.github.io/docs/#/swapV2/account-api.html#Get%20Perpetual%20Swap%20Account%20Asset%20Information

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -6,6 +6,7 @@ import { BadRequest, NetworkError } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import type { Int, OHLCV, Str, OrderBook, Order, Trade, Balances } from '../base/types.js';
 import Client from '../base/ws/Client.js';
+import Precise from '../base/Precise.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -62,6 +63,10 @@ export default class bingx extends bingxRest {
                         '1h': '60min',
                         '1d': '1day',
                     },
+                },
+                'watchBalance': {
+                    'fetchBalanceSnapshot': true, // needed to be true to keep track of used and free balance
+                    'awaitBalanceSnapshot': true, // whether to wait for the balance snapshot before providing updates
                 },
             },
             'streaming': {
@@ -557,7 +562,39 @@ export default class bingx extends bingxRest {
                 'dataType': 'ACCOUNT_UPDATE',
             };
         }
+        const client = this.client (url);
+        this.setBalanceCache (client, type, subscriptionHash, params);
+        const fetchBalanceSnapshot = this.handleOptionAndParams (params, 'watchBalance', 'fetchBalanceSnapshot', true);
+        const awaitBalanceSnapshot = this.handleOptionAndParams (params, 'watchBalance', 'awaitBalanceSnapshot', false);
+        if (fetchBalanceSnapshot && awaitBalanceSnapshot) {
+            await client.future (type + ':fetchBalanceSnapshot');
+        }
         return await this.watch (url, messageHash, request, subscriptionHash);
+    }
+
+    setBalanceCache (client: Client, type, subscriptionHash, params) {
+        if (subscriptionHash in client.subscriptions) {
+            return undefined;
+        }
+        const fetchBalanceSnapshot = this.handleOptionAndParams (params, 'watchBalance', 'fetchBalanceSnapshot', true);
+        if (fetchBalanceSnapshot) {
+            const messageHash = type + ':fetchBalanceSnapshot';
+            if (!(messageHash in client.futures)) {
+                client.future (messageHash);
+                this.spawn (this.loadBalanceSnapshot, client, messageHash, type);
+            }
+        } else {
+            this.balance[type] = {};
+        }
+    }
+
+    async loadBalanceSnapshot (client, messageHash, type) {
+        const response = await this.fetchBalance ({ 'type': type });
+        this.balance[type] = this.extend (response, this.safeValue (this.balance, type, {}));
+        // don't remove the future from the .futures cache
+        const future = client.futures[messageHash];
+        future.resolve ();
+        client.resolve (this.balance[type], type + ':balance');
     }
 
     handleErrorMessage (client, message) {
@@ -844,9 +881,6 @@ export default class bingx extends bingxRest {
         const data = this.safeValue (a, 'B', []);
         const timestamp = this.safeInteger2 (message, 'T', 'E');
         const type = ('P' in a) ? 'swap' : 'spot';
-        if (!(type in this.balance)) {
-            this.balance[type] = {};
-        }
         this.balance[type]['info'] = data;
         this.balance[type]['timestamp'] = timestamp;
         this.balance[type]['datetime'] = this.iso8601 (timestamp);
@@ -854,8 +888,12 @@ export default class bingx extends bingxRest {
             const balance = data[i];
             const currencyId = this.safeString (balance, 'a');
             const code = this.safeCurrencyCode (currencyId);
-            const account = (code in this.balance) ? this.balance[code] : this.account ();
-            account['total'] = this.safeString (balance, 'wb');
+            const account = (code in this.balance[type]) ? this.balance[type][code] : this.account ();
+            account['free'] = this.safeString (balance, 'wb');
+            const balanceChange = this.safeString (balance, 'bc');
+            if (account['used'] !== undefined) {
+                account['used'] = Precise.stringSub (this.safeString (account, 'used'), balanceChange);
+            }
             this.balance[type][code] = account;
         }
         this.balance[type] = this.safeBalance (this.balance[type]);

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -66,7 +66,7 @@ export default class bingx extends bingxRest {
                 },
                 'watchBalance': {
                     'fetchBalanceSnapshot': true, // needed to be true to keep track of used and free balance
-                    'awaitBalanceSnapshot': true, // whether to wait for the balance snapshot before providing updates
+                    'awaitBalanceSnapshot': false, // whether to wait for the balance snapshot before providing updates
                 },
             },
             'streaming': {
@@ -564,8 +564,10 @@ export default class bingx extends bingxRest {
         }
         const client = this.client (url);
         this.setBalanceCache (client, type, subscriptionHash, params);
-        const fetchBalanceSnapshot = this.handleOptionAndParams (params, 'watchBalance', 'fetchBalanceSnapshot', true);
-        const awaitBalanceSnapshot = this.handleOptionAndParams (params, 'watchBalance', 'awaitBalanceSnapshot', false);
+        let fetchBalanceSnapshot = undefined;
+        let awaitBalanceSnapshot = undefined;
+        [ fetchBalanceSnapshot, params ] = this.handleOptionAndParams (params, 'watchBalance', 'fetchBalanceSnapshot', true);
+        [ awaitBalanceSnapshot, params ] = this.handleOptionAndParams (params, 'watchBalance', 'awaitBalanceSnapshot', false);
         if (fetchBalanceSnapshot && awaitBalanceSnapshot) {
             await client.future (type + ':fetchBalanceSnapshot');
         }

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -1,231 +1,664 @@
 {
-    "exchange": "bingx",
-    "options": {},
-    "methods": {
-        "fetchClosedOrders": [
+  "exchange": "bingx",
+  "options": {},
+  "methods": {
+    "cancelOrder": [
+      {
+        "description": "spot cancel order",
+        "method": "cancelOrder",
+        "input": [
+          "1735116010161176576",
+          "LTC/USDT"
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "debugMsg": "",
+          "data": {
+            "symbol": "LTC-USDT",
+            "orderId": "1735116010161176576",
+            "price": "30",
+            "origQty": "0.17",
+            "executedQty": "0",
+            "cummulativeQuoteQty": "0",
+            "status": "CANCELED",
+            "type": "LIMIT",
+            "side": "BUY"
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "LTC-USDT",
+            "orderId": "1735116010161176576",
+            "price": "30",
+            "origQty": "0.17",
+            "executedQty": "0",
+            "cummulativeQuoteQty": "0",
+            "status": "CANCELED",
+            "type": "LIMIT",
+            "side": "BUY"
+          },
+          "id": "1735116010161176576",
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "LTC/USDT",
+          "type": "limit",
+          "timeInForce": null,
+          "postOnly": null,
+          "side": "buy",
+          "price": 30,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "stopLossPrice": null,
+          "takeProfitPrice": null,
+          "average": null,
+          "cost": 0,
+          "amount": 0.17,
+          "filled": 0,
+          "remaining": 0.17,
+          "status": "canceled",
+          "fee": {
+            "currency": "LTC",
+            "cost": null
+          },
+          "trades": [],
+          "fees": [
             {
-                "description": "Spot closed order",
-                "method": "fetchClosedOrders",
-                "input": [
-                  "LTC/USDT",
-                  null,
-                  1
-                ],
-                "httpResponse": {
-                  "code": "0",
-                  "msg": "",
-                  "debugMsg": "",
-                  "data": {
-                    "orders": [
-                      {
-                        "symbol": "LTC-USDT",
-                        "orderId": "1721596796393750528",
-                        "price": "73.56",
-                        "StopPrice": "0",
-                        "origQty": "0",
-                        "executedQty": "0.0679",
-                        "cummulativeQuoteQty": "4.9954709",
-                        "status": "FILLED",
-                        "type": "MARKET",
-                        "side": "BUY",
-                        "time": "1699295637000",
-                        "updateTime": "1699295637000",
-                        "origQuoteOrderQty": "5",
-                        "fee": "-0.0000679"
-                      }
-                    ]
-                  }
-                },
-                "parsedResponse": [
-                  {
-                    "info": {
-                      "symbol": "LTC-USDT",
-                      "orderId": "1721596796393750528",
-                      "price": "73.56",
-                      "StopPrice": "0",
-                      "origQty": "0",
-                      "executedQty": "0.0679",
-                      "cummulativeQuoteQty": "4.9954709",
-                      "status": "FILLED",
-                      "type": "MARKET",
-                      "side": "BUY",
-                      "time": "1699295637000",
-                      "updateTime": "1699295637000",
-                      "origQuoteOrderQty": "5",
-                      "fee": "-0.0000679"
-                    },
-                    "id": "1721596796393750528",
-                    "clientOrderId": null,
-                    "timestamp": 1699295637000,
-                    "datetime": "2023-11-06T18:33:57.000Z",
-                    "lastTradeTimestamp": 1699295637000,
-                    "lastUpdateTimestamp": 1699295637000,
-                    "symbol": "LTC/USDT",
-                    "type": "market",
-                    "timeInForce": "IOC",
-                    "postOnly": null,
-                    "side": "buy",
-                    "price": 73.56,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "stopLossPrice": null,
-                    "takeProfitPrice": null,
-                    "average": null,
-                    "cost": 4.994724,
-                    "amount": 0.0679,
-                    "filled": 0.0679,
-                    "remaining": 0,
-                    "status": "closed",
-                    "fee": {
-                      "currency": "LTC",
-                      "cost": "0.0000679"
-                    },
-                    "trades": [],
-                    "fees": [
-                      {
-                        "currency": "LTC",
-                        "cost": 0.0000679
-                      }
-                    ],
-                    "reduceOnly": null
-                  }
-                ]
-            },
-            {
-                "description": "Swap closed order",
-                "method": "fetchClosedOrders",
-                "input": [
-                  "LTC/USDT:USDT",
-                  null,
-                  1
-                ],
-                "httpResponse": {
-                  "code": "0",
-                  "msg": "",
-                  "data": {
-                    "orders": [
-                      {
-                        "symbol": "LTC-USDT",
-                        "orderId": "1729799444544843776",
-                        "side": "BUY",
-                        "positionSide": "SHORT",
-                        "type": "MARKET",
-                        "origQty": "0.1",
-                        "price": "70.17",
-                        "executedQty": "0.1",
-                        "avgPrice": "70.17",
-                        "cumQuote": "7",
-                        "stopPrice": "",
-                        "profit": "0.0000",
-                        "commission": "-0.003509",
-                        "status": "FILLED",
-                        "time": "1701251300000",
-                        "updateTime": "1701251300000",
-                        "clientOrderId": "",
-                        "leverage": "",
-                        "takeProfit": {
-                          "type": "",
-                          "quantity": "0",
-                          "stopPrice": "0",
-                          "price": "0",
-                          "workingType": ""
-                        },
-                        "stopLoss": {
-                          "type": "",
-                          "quantity": "0",
-                          "stopPrice": "0",
-                          "price": "0",
-                          "workingType": ""
-                        },
-                        "advanceAttr": "0",
-                        "positionID": "0",
-                        "takeProfitEntrustPrice": "0",
-                        "stopLossEntrustPrice": "0",
-                        "orderType": "",
-                        "workingType": "MARK_PRICE"
-                      }
-                    ]
-                  }
-                },
-                "parsedResponse": [
-                  {
-                    "info": {
-                      "symbol": "LTC-USDT",
-                      "orderId": "1729799444544843776",
-                      "side": "BUY",
-                      "positionSide": "SHORT",
-                      "type": "MARKET",
-                      "origQty": "0.1",
-                      "price": "70.17",
-                      "executedQty": "0.1",
-                      "avgPrice": "70.17",
-                      "cumQuote": "7",
-                      "stopPrice": "",
-                      "profit": "0.0000",
-                      "commission": "-0.003509",
-                      "status": "FILLED",
-                      "time": "1701251300000",
-                      "updateTime": "1701251300000",
-                      "clientOrderId": "",
-                      "leverage": "",
-                      "takeProfit": {
-                        "type": "",
-                        "quantity": "0",
-                        "stopPrice": "0",
-                        "price": "0",
-                        "workingType": ""
-                      },
-                      "stopLoss": {
-                        "type": "",
-                        "quantity": "0",
-                        "stopPrice": "0",
-                        "price": "0",
-                        "workingType": ""
-                      },
-                      "advanceAttr": "0",
-                      "positionID": "0",
-                      "takeProfitEntrustPrice": "0",
-                      "stopLossEntrustPrice": "0",
-                      "orderType": "",
-                      "workingType": "MARK_PRICE"
-                    },
-                    "id": "1729799444544843776",
-                    "clientOrderId": null,
-                    "timestamp": 1701251300000,
-                    "datetime": "2023-11-29T09:48:20.000Z",
-                    "lastTradeTimestamp": 1701251300000,
-                    "lastUpdateTimestamp": 1701251300000,
-                    "symbol": "LTC/USDT:USDT",
-                    "type": "market",
-                    "timeInForce": "IOC",
-                    "postOnly": null,
-                    "side": "buy",
-                    "price": 70.17,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "stopLossPrice": null,
-                    "takeProfitPrice": null,
-                    "average": 70.17,
-                    "cost": 0.7017,
-                    "amount": 0.1,
-                    "filled": 0.1,
-                    "remaining": 0,
-                    "status": "closed",
-                    "fee": {
-                      "currency": "USDT",
-                      "cost": "0.003509"
-                    },
-                    "trades": [],
-                    "fees": [
-                      {
-                        "currency": "USDT",
-                        "cost": 0.003509
-                      }
-                    ],
-                    "reduceOnly": null
-                  }
-                ]
+              "currency": "LTC",
+              "cost": null
             }
+          ],
+          "reduceOnly": null
+        }
+      }
+    ],
+    "closeAllPositions": [
+      {
+        "description": "Fill this with a description of the method call",
+        "method": "closeAllPositions",
+        "input": [],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "data": {
+            "success": [
+              1735124421028573200
+            ],
+            "failed": null
+          }
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "positionId": 1735124421028573200
+            },
+            "id": "1735124421028573200",
+            "symbol": "",
+            "notional": null,
+            "marginMode": null,
+            "liquidationPrice": null,
+            "entryPrice": null,
+            "unrealizedPnl": null,
+            "realizedPnl": null,
+            "percentage": null,
+            "contracts": null,
+            "contractSize": null,
+            "markPrice": null,
+            "lastPrice": null,
+            "side": null,
+            "hedged": null,
+            "timestamp": null,
+            "datetime": null,
+            "lastUpdateTimestamp": null,
+            "maintenanceMargin": null,
+            "maintenanceMarginPercentage": null,
+            "collateral": null,
+            "initialMargin": null,
+            "initialMarginPercentage": null,
+            "leverage": null,
+            "marginRatio": null,
+            "stopLossPrice": null,
+            "takeProfitPrice": null
+          }
         ]
-    }
+      }
+    ],
+    "createOrder": [
+      {
+        "description": "spot create order limit buy",
+        "method": "createOrder",
+        "input": [
+          "LTC/USDT",
+          "limit",
+          "buy",
+          0.17,
+          30
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "debugMsg": "",
+          "data": {
+            "symbol": "LTC-USDT",
+            "orderId": "1735115105391083520",
+            "transactTime": "1702518652662",
+            "price": "30",
+            "origQty": "0.17",
+            "executedQty": "0",
+            "cummulativeQuoteQty": "0",
+            "status": "PENDING",
+            "type": "LIMIT",
+            "side": "BUY"
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "LTC-USDT",
+            "orderId": "1735115105391083520",
+            "transactTime": "1702518652662",
+            "price": "30",
+            "origQty": "0.17",
+            "executedQty": "0",
+            "cummulativeQuoteQty": "0",
+            "status": "PENDING",
+            "type": "LIMIT",
+            "side": "BUY"
+          },
+          "id": "1735115105391083520",
+          "clientOrderId": null,
+          "timestamp": 1702518652662,
+          "datetime": "2023-12-14T01:50:52.662Z",
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "LTC/USDT",
+          "type": "limit",
+          "timeInForce": null,
+          "postOnly": null,
+          "side": "buy",
+          "price": 30,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "stopLossPrice": null,
+          "takeProfitPrice": null,
+          "average": null,
+          "cost": 0,
+          "amount": 0.17,
+          "filled": 0,
+          "remaining": 0.17,
+          "status": "open",
+          "fee": {
+            "currency": "LTC",
+            "cost": null
+          },
+          "trades": [],
+          "fees": [
+            {
+              "currency": "LTC",
+              "cost": null
+            }
+          ],
+          "reduceOnly": null
+        }
+      },
+      {
+        "description": "swap create order limit",
+        "method": "createOrder",
+        "input": [
+          "LTC/USDT:USDT",
+          "limit",
+          "buy",
+          0.17,
+          30
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "data": {
+            "order": {
+              "symbol": "LTC-USDT",
+              "orderId": "1735119588833849344",
+              "side": "BUY",
+              "positionSide": "LONG",
+              "type": "LIMIT",
+              "clientOrderID": "",
+              "workingType": "MARK_PRICE"
+            }
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "LTC-USDT",
+            "orderId": "1735119588833849344",
+            "side": "BUY",
+            "positionSide": "LONG",
+            "type": "LIMIT",
+            "clientOrderID": "",
+            "workingType": "MARK_PRICE"
+          },
+          "id": "1735119588833849344",
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "LTC/USDT:USDT",
+          "type": "limit",
+          "timeInForce": null,
+          "postOnly": null,
+          "side": "buy",
+          "price": null,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "stopLossPrice": null,
+          "takeProfitPrice": null,
+          "average": null,
+          "cost": null,
+          "amount": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": {
+            "currency": "USDT",
+            "cost": null
+          },
+          "trades": [],
+          "fees": [
+            {
+              "currency": "USDT",
+              "cost": null
+            }
+          ],
+          "reduceOnly": null
+        }
+      }
+    ],
+    "fetchClosedOrders": [
+      {
+        "description": "Spot closed order",
+        "method": "fetchClosedOrders",
+        "input": [
+          "LTC/USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "debugMsg": "",
+          "data": {
+            "orders": [
+              {
+                "symbol": "LTC-USDT",
+                "orderId": "1721596796393750528",
+                "price": "73.56",
+                "StopPrice": "0",
+                "origQty": "0",
+                "executedQty": "0.0679",
+                "cummulativeQuoteQty": "4.9954709",
+                "status": "FILLED",
+                "type": "MARKET",
+                "side": "BUY",
+                "time": "1699295637000",
+                "updateTime": "1699295637000",
+                "origQuoteOrderQty": "5",
+                "fee": "-0.0000679"
+              }
+            ]
+          }
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "LTC-USDT",
+              "orderId": "1721596796393750528",
+              "price": "73.56",
+              "StopPrice": "0",
+              "origQty": "0",
+              "executedQty": "0.0679",
+              "cummulativeQuoteQty": "4.9954709",
+              "status": "FILLED",
+              "type": "MARKET",
+              "side": "BUY",
+              "time": "1699295637000",
+              "updateTime": "1699295637000",
+              "origQuoteOrderQty": "5",
+              "fee": "-0.0000679"
+            },
+            "id": "1721596796393750528",
+            "clientOrderId": null,
+            "timestamp": 1699295637000,
+            "datetime": "2023-11-06T18:33:57.000Z",
+            "lastTradeTimestamp": 1699295637000,
+            "lastUpdateTimestamp": 1699295637000,
+            "symbol": "LTC/USDT",
+            "type": "market",
+            "timeInForce": "IOC",
+            "postOnly": null,
+            "side": "buy",
+            "price": 73.56,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "stopLossPrice": null,
+            "takeProfitPrice": null,
+            "average": null,
+            "cost": 4.994724,
+            "amount": 0.0679,
+            "filled": 0.0679,
+            "remaining": 0,
+            "status": "closed",
+            "fee": {
+              "currency": "LTC",
+              "cost": "0.0000679"
+            },
+            "trades": [],
+            "fees": [
+              {
+                "currency": "LTC",
+                "cost": 0.0000679
+              }
+            ],
+            "reduceOnly": null
+          }
+        ]
+      },
+      {
+        "description": "Swap closed order",
+        "method": "fetchClosedOrders",
+        "input": [
+          "LTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "data": {
+            "orders": [
+              {
+                "symbol": "LTC-USDT",
+                "orderId": "1729799444544843776",
+                "side": "BUY",
+                "positionSide": "SHORT",
+                "type": "MARKET",
+                "origQty": "0.1",
+                "price": "70.17",
+                "executedQty": "0.1",
+                "avgPrice": "70.17",
+                "cumQuote": "7",
+                "stopPrice": "",
+                "profit": "0.0000",
+                "commission": "-0.003509",
+                "status": "FILLED",
+                "time": "1701251300000",
+                "updateTime": "1701251300000",
+                "clientOrderId": "",
+                "leverage": "",
+                "takeProfit": {
+                  "type": "",
+                  "quantity": "0",
+                  "stopPrice": "0",
+                  "price": "0",
+                  "workingType": ""
+                },
+                "stopLoss": {
+                  "type": "",
+                  "quantity": "0",
+                  "stopPrice": "0",
+                  "price": "0",
+                  "workingType": ""
+                },
+                "advanceAttr": "0",
+                "positionID": "0",
+                "takeProfitEntrustPrice": "0",
+                "stopLossEntrustPrice": "0",
+                "orderType": "",
+                "workingType": "MARK_PRICE"
+              }
+            ]
+          }
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "LTC-USDT",
+              "orderId": "1729799444544843776",
+              "side": "BUY",
+              "positionSide": "SHORT",
+              "type": "MARKET",
+              "origQty": "0.1",
+              "price": "70.17",
+              "executedQty": "0.1",
+              "avgPrice": "70.17",
+              "cumQuote": "7",
+              "stopPrice": "",
+              "profit": "0.0000",
+              "commission": "-0.003509",
+              "status": "FILLED",
+              "time": "1701251300000",
+              "updateTime": "1701251300000",
+              "clientOrderId": "",
+              "leverage": "",
+              "takeProfit": {
+                "type": "",
+                "quantity": "0",
+                "stopPrice": "0",
+                "price": "0",
+                "workingType": ""
+              },
+              "stopLoss": {
+                "type": "",
+                "quantity": "0",
+                "stopPrice": "0",
+                "price": "0",
+                "workingType": ""
+              },
+              "advanceAttr": "0",
+              "positionID": "0",
+              "takeProfitEntrustPrice": "0",
+              "stopLossEntrustPrice": "0",
+              "orderType": "",
+              "workingType": "MARK_PRICE"
+            },
+            "id": "1729799444544843776",
+            "clientOrderId": null,
+            "timestamp": 1701251300000,
+            "datetime": "2023-11-29T09:48:20.000Z",
+            "lastTradeTimestamp": 1701251300000,
+            "lastUpdateTimestamp": 1701251300000,
+            "symbol": "LTC/USDT:USDT",
+            "type": "market",
+            "timeInForce": "IOC",
+            "postOnly": null,
+            "side": "buy",
+            "price": 70.17,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "stopLossPrice": null,
+            "takeProfitPrice": null,
+            "average": 70.17,
+            "cost": 0.7017,
+            "amount": 0.1,
+            "filled": 0.1,
+            "remaining": 0,
+            "status": "closed",
+            "fee": {
+              "currency": "USDT",
+              "cost": "0.003509"
+            },
+            "trades": [],
+            "fees": [
+              {
+                "currency": "USDT",
+                "cost": 0.003509
+              }
+            ],
+            "reduceOnly": null
+          }
+        ]
+      }
+    ],
+    "fetchBalance": [
+      {
+        "description": "spot fetchBalance",
+        "method": "fetchBalance",
+        "input": [],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "debugMsg": "",
+          "data": {
+            "balances": [
+              {
+                "asset": "USDT",
+                "free": "54.049459260000006",
+                "locked": "5"
+              },
+              {
+                "asset": "ADA",
+                "free": "19.06092",
+                "locked": "0"
+              },
+              {
+                "asset": "LTC",
+                "free": "0.6921067",
+                "locked": "0"
+              },
+              {
+                "asset": "VST",
+                "free": "0",
+                "locked": "0"
+              }
+            ]
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "code": "0",
+            "msg": "",
+            "debugMsg": "",
+            "data": {
+              "balances": [
+                {
+                  "asset": "USDT",
+                  "free": "54.049459260000006",
+                  "locked": "5"
+                },
+                {
+                  "asset": "ADA",
+                  "free": "19.06092",
+                  "locked": "0"
+                },
+                {
+                  "asset": "LTC",
+                  "free": "0.6921067",
+                  "locked": "0"
+                },
+                {
+                  "asset": "VST",
+                  "free": "0",
+                  "locked": "0"
+                }
+              ]
+            }
+          },
+          "USDT": {
+            "free": 54.049459260000006,
+            "used": 5,
+            "total": 59.049459260000006
+          },
+          "ADA": {
+            "free": 19.06092,
+            "used": 0,
+            "total": 19.06092
+          },
+          "LTC": {
+            "free": 0.6921067,
+            "used": 0,
+            "total": 0.6921067
+          },
+          "VST": {
+            "free": 0,
+            "used": 0,
+            "total": 0
+          },
+          "free": {
+            "USDT": 54.049459260000006,
+            "ADA": 19.06092,
+            "LTC": 0.6921067,
+            "VST": 0
+          },
+          "used": {
+            "USDT": 5,
+            "ADA": 0,
+            "LTC": 0,
+            "VST": 0
+          },
+          "total": {
+            "USDT": 59.049459260000006,
+            "ADA": 19.06092,
+            "LTC": 0.6921067,
+            "VST": 0
+          }
+        }
+      },
+      {
+        "description": "swap fetch balance",
+        "method": "fetchBalance",
+        "input": [],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "data": {
+            "balance": {
+              "userId": "1177064765068660742",
+              "asset": "USDT",
+              "balance": "44.1897",
+              "equity": "44.1897",
+              "unrealizedProfit": "0.0000",
+              "realisedProfit": "0.0000",
+              "availableMargin": "43.5882",
+              "usedMargin": "0.0000",
+              "freezedMargin": "0.6015"
+            }
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "code": "0",
+            "msg": "",
+            "data": {
+              "balance": {
+                "userId": "1177064765068660742",
+                "asset": "USDT",
+                "balance": "44.1897",
+                "equity": "44.1897",
+                "unrealizedProfit": "0.0000",
+                "realisedProfit": "0.0000",
+                "availableMargin": "43.5882",
+                "usedMargin": "0.0000",
+                "freezedMargin": "0.6015"
+              }
+            }
+          },
+          "USDT": {
+            "free": 43.5882,
+            "used": 0,
+            "total": 43.5882
+          },
+          "free": {
+            "USDT": 43.5882
+          },
+          "used": {
+            "USDT": 0
+          },
+          "total": {
+            "USDT": 43.5882
+          }
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
- Allow to fetchBalanceSnapshot when calling watchBalance
- Use snapshot if avaiblable and websocket balance change to give user used, free and total balance
- Add bingx static tests