### PR TITLE
Okcoin: fix market sell orders

### DIFF
--- a/ts/src/okcoin.ts
+++ b/ts/src/okcoin.ts
@@ -1433,7 +1433,7 @@ export default class okcoin extends Exchange {
         }
         if (isMarketOrder || marketIOC) {
             request['ordType'] = 'market';
-            if ((side === 'buy')) {
+            if (side === 'buy') {
                 // spot market buy: "sz" can refer either to base currency units or to quote currency units
                 // see documentation: https://www.okx.com/docs-v5/en/#rest-api-trade-place-order
                 if (tgtCcy === 'quote_ccy') {
@@ -1461,6 +1461,8 @@ export default class okcoin extends Exchange {
                 } else {
                     request['sz'] = this.amountToPrecision (symbol, amount);
                 }
+            } else {
+                request['sz'] = this.amountToPrecision (symbol, amount);
             }
         } else {
             request['sz'] = this.amountToPrecision (symbol, amount);

--- a/ts/src/test/static/request/okcoin.json
+++ b/ts/src/test/static/request/okcoin.json
@@ -43,7 +43,7 @@
         ],
         "createOrder": [
             {
-                "description": "create Order",
+                "description": "Spot market buy order",
                 "method": "createOrder",
                 "url": "https://www.okcoin.com/api/v5/trade/batch-orders",
                 "input": [
@@ -55,7 +55,7 @@
                 "output": "[{\"instId\":\"BTC-USD\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"1\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\"}]"
             },
             {
-                "description": "create Order",
+                "description": "Spot market buy order with triggerPrice",
                 "method": "createOrder",
                 "url": "https://www.okcoin.com/api/v5/trade/order-algo",
                 "input": [
@@ -69,6 +69,53 @@
                     }
                 ],
                 "output": "{\"instId\":\"BTC-USD\",\"side\":\"buy\",\"ordType\":\"trigger\",\"sz\":\"1\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"triggerPx\":\"40000\",\"orderPx\":\"-1\"}"
+            },
+            {
+                "description": "Spot market sell order",
+                "method": "createOrder",
+                "url": "https://www.okcoin.com/api/v5/trade/batch-orders",
+                "input": [
+                  "USDT/USD",
+                  "market",
+                  "sell",
+                  11,
+                  null
+                ],
+                "output": "[{\"instId\":\"USDT-USD\",\"side\":\"sell\",\"ordType\":\"market\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"sz\":\"11\"}]"
+            },
+            {
+                "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false and tgtCcy set to quote",
+                "method": "createOrder",
+                "url": "https://www.okcoin.com/api/v5/trade/batch-orders",
+                "input": [
+                  "BTC/USD",
+                  "market",
+                  "buy",
+                  5,
+                  null,
+                  {
+                    "createMarketBuyOrderRequiresPrice": false,
+                    "tgtCcy": "quote_ccy"
+                  }
+                ],
+                "output": "[{\"instId\":\"BTC-USD\",\"side\":\"buy\",\"ordType\":\"market\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"sz\":\"5\"}]"
+            },
+            {
+                "description": "Spot market buy order using the cost param and tgtCcy set to quote",
+                "method": "createOrder",
+                "url": "https://www.okcoin.com/api/v5/trade/batch-orders",
+                "input": [
+                  "BTC/USD",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 5,
+                    "tgtCcy": "quote_ccy"
+                  }
+                ],
+                "output": "[{\"instId\":\"BTC-USD\",\"side\":\"buy\",\"ordType\":\"market\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"sz\":\"5\"}]"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Added some createOrder market order static request tests and set the `sz` param for spot market sell orders:

```
okcoin.createOrder (USDT/USD, market, sell, 11, )
2023-12-15T05:19:45.745Z iteration 0 passed in 104 ms

{
  info: {
    clOrdId: '',
    ordId: '655760915727126528',
    sCode: '0',
    sMsg: '',
    tag: ''
  },
  id: '655760915727126528',
  symbol: 'USDT/USD',
  type: 'market',
  side: 'sell',
  trades: [],
  reduceOnly: false,
  fees: []
}
```