### PR TITLE
bybit: update fetchMarkets

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -946,6 +946,7 @@ export default class bybit extends Exchange {
             },
             'precisionMode': TICK_SIZE,
             'options': {
+                'fetchMarkets': [ 'spot', 'linear', 'inverse', 'option' ],
                 'enableUnifiedMargin': undefined,
                 'enableUnifiedAccount': undefined,
                 'createMarketBuyOrderRequiresPrice': true,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1451,21 +1451,31 @@ export default class bybit extends Exchange {
         if (this.options['adjustForTimeDifference']) {
             await this.loadTimeDifference ();
         }
-        const promisesUnresolved = [
-            this.fetchSpotMarkets (params),
-            this.fetchFutureMarkets ({ 'category': 'linear' }),
-            this.fetchFutureMarkets ({ 'category': 'inverse' }),
-            this.fetchOptionMarkets ({ 'baseCoin': 'BTC' }),
-            this.fetchOptionMarkets ({ 'baseCoin': 'ETH' }),
-            this.fetchOptionMarkets ({ 'baseCoin': 'SOL' }),
-        ];
+        const promisesUnresolved = [];
+        const fetchMarkets = this.safeValue (this.options, 'fetchMarkets', [ 'spot', 'linear', 'inverse' ]);
+        for (let i = 0; i < fetchMarkets.length; i++) {
+            const marketType = fetchMarkets[i];
+            if (marketType === 'spot') {
+                promisesUnresolved.push (this.fetchSpotMarkets (params));
+            } else if (marketType === 'linear') {
+                promisesUnresolved.push (this.fetchFutureMarkets ({ 'category': 'linear' }));
+            } else if (marketType === 'inverse') {
+                promisesUnresolved.push (this.fetchFutureMarkets ({ 'category': 'inverse' }));
+            } else if (marketType === 'option') {
+                promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': 'BTC' }));
+                promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': 'ETH' }));
+                promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': 'SOL' }));
+            } else {
+                throw new ExchangeError (this.id + ' fetchMarkets() this.options fetchMarkets "' + marketType + '" is not a supported market type');
+            }
+        }
         const promises = await Promise.all (promisesUnresolved);
-        const spotMarkets = promises[0];
-        const linearMarkets = promises[1];
-        const inverseMarkets = promises[2];
-        const btcOptionMarkets = promises[3];
-        const ethOptionMarkets = promises[4];
-        const solOptionMarkets = promises[5];
+        const spotMarkets = this.safeValue (promises, 0, []);
+        const linearMarkets = this.safeValue (promises, 1, []);
+        const inverseMarkets = this.safeValue (promises, 2, []);
+        const btcOptionMarkets = this.safeValue (promises, 3, []);
+        const ethOptionMarkets = this.safeValue (promises, 4, []);
+        const solOptionMarkets = this.safeValue (promises, 5, []);
         const futureMarkets = this.arrayConcat (linearMarkets, inverseMarkets);
         let optionMarkets = this.arrayConcat (btcOptionMarkets, ethOptionMarkets);
         optionMarkets = this.arrayConcat (optionMarkets, solOptionMarkets);


### PR DESCRIPTION
fix: ccxt/ccxt#20386

```BASH
# "spot"
$ n bybit market BTC/USDT --test            
bybit.market (BTC/USDT)

{
  id: 'BTCUSDT',
  symbol: 'BTC/USDT',
  base: 'BTC',
  quote: 'USDT',
  baseId: 'BTC',
  quoteId: 'USDT',
  type: 'spot',
  spot: true,
  swap: false,
  future: false,
  option: false,
  active: true,
  contract: false,
  taker: 0.001,
  maker: 0.001,
  precision: { amount: 0.000001, price: 0.01 },
  limits: {
    leverage: { min: 1 },
    amount: { min: 0.000048, max: 200 },
    price: {},
    cost: { min: 1, max: 2000000 }
  },
  info: {
    symbol: 'BTCUSDT',
    baseCoin: 'BTC',
    quoteCoin: 'USDT',
    innovation: '0',
    status: 'Trading',
    marginTrading: 'both',
    lotSizeFilter: {
      basePrecision: '0.000001',
      quotePrecision: '0.00000001',
      minOrderQty: '0.000048',
      maxOrderQty: '200',
      minOrderAmt: '1',
      maxOrderAmt: '2000000'
    },
    priceFilter: { tickSize: '0.01' }
  },
  tierBased: true,
  percentage: true,
  feeSide: 'get'
}

$ n bybit market BTC/USDT:USDT --test
bybit.market (BTC/USDT:USDT)
BadSymbol bybit does not have market symbol BTC/USDT:USDT

# "spot", "linear"
$ n bybit market BTC/USDT --test            
bybit.market (BTC/USDT)

{
  id: 'BTCUSDT',
  symbol: 'BTC/USDT',
  base: 'BTC',
  quote: 'USDT',
  baseId: 'BTC',
  quoteId: 'USDT',
  type: 'spot',
  spot: true,
  swap: false,
  future: false,
  option: false,
  active: true,
  contract: false,
  taker: 0.001,
  maker: 0.001,
  precision: { amount: 0.000001, price: 0.01 },
  limits: {
    leverage: { min: 1 },
    amount: { min: 0.000048, max: 200 },
    price: {},
    cost: { min: 1, max: 2000000 }
  },
  info: {
    symbol: 'BTCUSDT',
    baseCoin: 'BTC',
    quoteCoin: 'USDT',
    innovation: '0',
    status: 'Trading',
    marginTrading: 'both',
    lotSizeFilter: {
      basePrecision: '0.000001',
      quotePrecision: '0.00000001',
      minOrderQty: '0.000048',
      maxOrderQty: '200',
      minOrderAmt: '1',
      maxOrderAmt: '2000000'
    },
    priceFilter: { tickSize: '0.01' }
  },
  tierBased: true,
  percentage: true,
  feeSide: 'get'
}

$ n bybit market BTC/USDT:USDT --test
bybit.market (BTC/USDT:USDT)
{
  id: 'BTCUSDT',
  symbol: 'BTC/USDT:USDT',
  base: 'BTC',
  quote: 'USDT',
  settle: 'USDT',
  baseId: 'BTC',
  quoteId: 'USDT',
  settleId: 'USDT',
  type: 'swap',
  spot: false,
  swap: true,
  future: false,
  option: false,
  active: true,
  contract: true,
  linear: true,
  inverse: false,
  subType: 'linear',
  taker: 0.0006,
  maker: 0.0001,
  contractSize: 1,
  precision: { amount: 0.001, price: 0.1 },
  limits: {
    leverage: { min: 1, max: 100 },
    amount: { min: 0.001, max: 100 },
    price: { min: 0.1, max: 199999.8 },
    cost: {}
  },
  created: 1585526400000,
  info: {
    symbol: 'BTCUSDT',
    contractType: 'LinearPerpetual',
    status: 'Trading',
    baseCoin: 'BTC',
    quoteCoin: 'USDT',
    launchTime: '1585526400000',
    deliveryTime: '0',
    deliveryFeeRate: '',
    priceScale: '2',
    leverageFilter: { minLeverage: '1', maxLeverage: '100.00', leverageStep: '0.01' },
    priceFilter: { minPrice: '0.10', maxPrice: '199999.80', tickSize: '0.10' },
    lotSizeFilter: {
      maxOrderQty: '100.000',
      minOrderQty: '0.001',
      qtyStep: '0.001',
      postOnlyMaxOrderQty: '1000.000'
    },
    unifiedMarginTrade: true,
    fundingInterval: '480',
    settleCoin: 'USDT',
    copyTrading: 'both'
  },
  tierBased: true,
  percentage: true,
  feeSide: 'get'
}
```

We don't implement this feature in some exchanges yet. Do we want to add this feature to all exchanges?