### PR TITLE
binance: patch watchOrders

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1980,7 +1980,7 @@ export default class binance extends binanceRest {
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);
         }
-        return this.filterBySymbolSinceLimit (this.orders, symbol, since, limit, true);
+        return this.filterBySymbolSinceLimit (orders, symbol, since, limit, true);
     }
 
     parseWsOrder (order, market = undefined) {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1976,9 +1976,9 @@ export default class binance extends binanceRest {
         this.setBalanceCache (client, type);
         this.setPositionsCache (client, type);
         const message = undefined;
-        const newOrder = await this.watch (url, messageHash, message, type);
+        const orders = await this.watch (url, messageHash, message, type);
         if (this.newUpdates) {
-            return newOrder;
+            limit = orders.getLimit (symbol, limit);
         }
         return this.filterBySymbolSinceLimit (this.orders, symbol, since, limit, true);
     }

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2645,8 +2645,8 @@ export default class binance extends binanceRest {
             cachedOrders.append (parsed);
             const messageHash = 'orders';
             const symbolSpecificMessageHash = 'orders:' + symbol;
-            client.resolve (parsed, messageHash);
-            client.resolve (parsed, symbolSpecificMessageHash);
+            client.resolve (cachedOrders, messageHash);
+            client.resolve (cachedOrders, symbolSpecificMessageHash);
         }
     }
 


### PR DESCRIPTION
fix: ccxt/ccxt#20344

```BASH
$ n binance watchOrders ETH/USDT
Node.js: v20.9.0
CCXT v4.1.89
binance.watchOrders (ETH/USDT)
  symbol |          id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | filled | remaining |   status | trades | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USDT | 15123271139 | x-R4BD3S82c518a3e40141416f8e2ca0 | 1702646771689 | 2023-12-15T13:26:11.689Z |       1702646800089 | limit |         GTC |    false |  buy |  1000 |         0 |            0 |   0.01 |    0 |      0 |      0.01 | canceled |     [] |   []
ETH/USDT | 15123274485 | x-R4BD3S8238f4eb100b0b4f788522d6 | 1702646800089 | 2023-12-15T13:26:40.089Z |       1702646800089 | limit |         GTC |    false |  buy |  1000 |         0 |            0 |   0.02 |    0 |      0 |      0.02 |     open |     [] |   []
2 objects
  symbol |          id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | filled | remaining |   status | trades | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USDT | 15123271139 | x-R4BD3S82c518a3e40141416f8e2ca0 | 1702646771689 | 2023-12-15T13:26:11.689Z |       1702646800089 | limit |         GTC |    false |  buy |  1000 |         0 |            0 |   0.01 |    0 |      0 |      0.01 | canceled |     [] |   []
ETH/USDT | 15123274485 | x-R4BD3S8238f4eb100b0b4f788522d6 | 1702646800089 | 2023-12-15T13:26:40.089Z |       1702646835939 | limit |         GTC |    false |  buy |  1000 |         0 |            0 |   0.02 |    0 |      0 |      0.02 | canceled |     [] |   []
2 objects
```