### PR TITLE
kucoin revert WAXP mapping

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -492,6 +492,7 @@ export default class kucoin extends Exchange {
             'commonCurrencies': {
                 'BIFI': 'BIFIF',
                 'VAI': 'VAIOT',
+                'WAX': 'WAXP',
             },
             'options': {
                 'version': 'v1',


### PR DESCRIPTION
https://github.com/ccxt/ccxt/pull/20328 I've delete `'WAX': 'WAXP'` cause on Kucoin site I see:

<img width="358" alt="image" src="https://github.com/ccxt/ccxt/assets/38309641/c72f15cf-c9b2-4ecb-8f3a-0dd5c9cc2781">

But now I found that id is still WAX https://www.kucoin.com/trade/WAX-USDT. On all other exchanges we have WAXP https://coinmarketcap.com/currencies/wax/#Markets