### PR TITLE
fix(zaif): parseTicker remove timestamp from parsed data

### DIFF
--- a/ts/src/zaif.ts
+++ b/ts/src/zaif.ts
@@ -309,15 +309,14 @@ export default class zaif extends Exchange {
         // }
         //
         const symbol = this.safeSymbol (undefined, market);
-        const timestamp = this.milliseconds ();
         const vwap = this.safeString (ticker, 'vwap');
         const baseVolume = this.safeString (ticker, 'volume');
         const quoteVolume = Precise.stringMul (baseVolume, vwap);
         const last = this.safeString (ticker, 'last');
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeString (ticker, 'high'),
             'low': this.safeString (ticker, 'low'),
             'bid': this.safeString (ticker, 'bid'),


### PR DESCRIPTION
timestamp was not in the exchange response

```
% py zaif fetchTicker ETH/BTC
Python v3.9.6
CCXT v4.1.90
zaif.fetchTicker(ETH/BTC)
{'ask': 0.0534,
 'askVolume': None,
 'average': None,
 'baseVolume': 0.057,
 'bid': 0.053,
 'bidVolume': None,
 'change': None,
 'close': 0.0533,
 'datetime': None,
 'high': 0.0535,
 'info': {'ask': '0.0534',
          'bid': '0.053',
          'high': '0.0535',
          'last': '0.0533',
          'low': '0.0531',
          'volume': '0.057',
          'vwap': '0.0533'},
 'last': 0.0533,
 'low': 0.0531,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': 0.0030381,
 'symbol': 'ETH/BTC',
 'timestamp': None,
 'vwap': 0.0533}
 ```