### PR TITLE
fix: bitrue fetch tickers return spot price only for first symbol

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -1539,14 +1539,7 @@ export default class bitrue extends Exchange {
             const first = this.safeString (symbols, 0);
             const market = this.market (first);
             if (market['swap']) {
-                request['contractName'] = market['id'];
-                if (market['linear']) {
-                    response = await this.fapiV1PublicGetTicker (this.extend (request, params));
-                } else if (market['inverse']) {
-                    response = await this.dapiV1PublicGetTicker (this.extend (request, params));
-                }
-                response['symbol'] = market['id'];
-                data = [ response ];
+                throw new NotSupported (this.id + ' fetchTickers does not support swap markets, please use fetchTicker instead');
             } else if (market['spot']) {
                 response = await this.spotV1PublicGetTicker24hr (this.extend (request, params));
                 data = response;

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -1548,7 +1548,7 @@ export default class bitrue extends Exchange {
                 response['symbol'] = market['id'];
                 data = [ response ];
             } else if (market['spot']) {
-                [params] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+                request['symbol'] = market['id'];
                 response = await this.spotV1PublicGetTicker24hr (this.extend (request, params));
                 data = response;
             } else {

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -1548,7 +1548,6 @@ export default class bitrue extends Exchange {
                 response['symbol'] = market['id'];
                 data = [ response ];
             } else if (market['spot']) {
-                request['symbol'] = market['id'];
                 response = await this.spotV1PublicGetTicker24hr (this.extend (request, params));
                 data = response;
             } else {
@@ -1557,7 +1556,7 @@ export default class bitrue extends Exchange {
         } else {
             [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params);
             if (type !== 'spot') {
-                throw new NotSupported (this.id + ' fetchTickers only support spot when symbols is not set');
+                throw new NotSupported (this.id + ' fetchTickers only support spot when symbols are not proved');
             }
             response = await this.spotV1PublicGetTicker24hr (this.extend (request, params));
             data = response;

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -1548,7 +1548,7 @@ export default class bitrue extends Exchange {
                 response['symbol'] = market['id'];
                 data = [ response ];
             } else if (market['spot']) {
-                request['symbol'] = market['id'];
+                [params] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
                 response = await this.spotV1PublicGetTicker24hr (this.extend (request, params));
                 data = response;
             } else {


### PR DESCRIPTION
After updating ccxt library to version 4.1.61 fetch tickers function for bitrue exchanges started to return data only for the first symbol. 