### PR TITLE
Bitget: fetchCanceledAndClosedOrders, call without a symbol

### DIFF
--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -461,6 +461,25 @@
         ],
         "fetchClosedOrders": [
             {
+              "description": "spot closed orders without symbol",
+              "method": "fetchClosedOrders",
+              "url": "https://api.bitget.com/api/v2/spot/trade/history-orders",
+              "input": []
+            },
+            {
+              "description": "swap closed orders without symbol",
+              "method": "fetchClosedOrders",
+              "url": "https://api.bitget.com/api/v2/mix/order/orders-history?productType=USDT-FUTURES",
+              "input": [
+                null,
+                null,
+                null,
+                {
+                  "type": "swap"
+                }
+              ]
+            },
+            {
                 "description": "Spot closed orders",
                 "method": "fetchClosedOrders",
                 "url": "https://api.bitget.com/api/v2/spot/trade/history-orders?symbol=BTCUSDT",
@@ -476,6 +495,43 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchCanceledOrders": [
+          {
+            "description": "spot canceled orders",
+            "method": "fetchCanceledOrders",
+            "url": "https://api.bitget.com/api/v2/spot/trade/history-orders",
+            "input": []
+          },
+          {
+            "description": "Swap canceled orders without symbol",
+            "method": "fetchCanceledOrders",
+            "url": "https://api.bitget.com/api/v2/mix/order/orders-history?productType=USDT-FUTURES",
+            "input": [
+              null,
+              null,
+              null,
+              {
+                "type": "swap"
+              }
+            ]
+          },
+          {
+            "description": "spot canceled orders with symbol",
+            "method": "fetchCanceledOrders",
+            "url": "https://api.bitget.com/api/v2/spot/trade/history-orders?symbol=LTCUSDT",
+            "input": [
+              "LTC/USDT"
+            ]
+          },
+          {
+            "description": "swap canceled orders with symbol",
+            "method": "fetchCanceledOrders",
+            "url": "https://api.bitget.com/api/v2/mix/order/orders-history?productType=USDT-FUTURES&symbol=LTCUSDT",
+            "input": [
+              "LTC/USDT:USDT"
+            ]
+          }
         ],
         "fetchBalance": [
             {


### PR DESCRIPTION
I thought I could add support for `fetchOrders` but after testing I realized I couldn't so I ended up just editing `fetchClosedAndOpenOrders` so that it can be called without a symbol argument in most cases