### PR TITLE
Bitget: closePosition, closeAllPositions, v2

### DIFF
--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -776,14 +776,30 @@
                 ]
             }
         ],
+        "closePosition": [
+          {
+            "description": "Swap close linear position",
+            "method": "closePosition",
+            "url": "https://api.bitget.com/api/v2/mix/order/close-positions",
+            "input": [
+              "BTC/USDT:USDT",
+              null
+            ],
+            "output": "{\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\"}"
+          }
+        ],
         "closeAllPositions": [
-            {
-                "description": "Close linear USDT positions",
-                "method": "closeAllPositions",
-                "url": "https://api.bitget.com/api/mix/v1/order/close-all-positions",
-                "input": [],
-                "output": "{\"productType\":\"umcbl\"}"
-            }
+          {
+            "description": "Swap close all USDT margined positions",
+            "method": "closeAllPositions",
+            "url": "https://api.bitget.com/api/v2/mix/order/close-positions",
+            "input": [
+              {
+                "productType": "USDT-FUTURES"
+              }
+            ],
+            "output": "{\"productType\":\"USDT-FUTURES\"}"
+          }
         ]
     }
 }


### PR DESCRIPTION
Added `closePosition` and updated `closeAllPositions` to v2:

### closePosition:
```
bitget.closePosition (BTC/USDT:USDT, )
2023-12-19T08:45:55.242Z iteration 0 passed in 852 ms

{
  info: { orderId: '1120926210981511172', clientOid: '1120926210985705472' },
  id: '1120926210981511172',
  clientOrderId: '1120926210985705472',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fees: []
}
```

### closeAllPositions:
```
bitget.closeAllPositions ([object Object])
2023-12-19T08:52:24.811Z iteration 0 passed in 301 ms

                 id
-------------------
1120927845082349570
1 objects
```