### PR TITLE
feat(hitbtc): add closePosition

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -37,6 +37,7 @@ export default class hitbtc extends Exchange {
                 'createStopLimitOrder': true,
                 'createStopMarketOrder': true,
                 'createStopOrder': true,
+                'closePosition': false,
                 'editOrder': true,
                 'fetchAccounts': false,
                 'fetchBalance': true,
@@ -2859,6 +2860,9 @@ export default class hitbtc extends Exchange {
         let marketType = undefined;
         let marginMode = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchPositions', undefined, params);
+        if (marketType === 'spot') {
+            marketType = 'swap';
+        }
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchPositions', params);
         params = this.omit (params, [ 'marginMode', 'margin' ]);
         let response = undefined;
@@ -3516,6 +3520,44 @@ export default class hitbtc extends Exchange {
             };
         }
         return result;
+    }
+
+    async closePosition (symbol: string, side: OrderSide = undefined, params = {}): Promise<Order> {
+        /**
+         * @method
+         * @name hitbtc#closePosition
+         * @description closes open positions for a market
+         * @see https://api.hitbtc.com/#close-all-futures-margin-positions
+         * @param {object} [params] extra parameters specific to the okx api endpoint
+         * @param {string} [params.symbol] *required* unified market symbol
+         * @param {string} [params.marginMode] 'cross' or 'isolated', default is 'cross'
+         * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('closePosition', params, 'cross');
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+            'margin_mode': marginMode,
+        };
+        const response = await this.privateDeleteFuturesPositionMarginModeSymbol (this.extend (request, params));
+        //
+        // {
+        //     "id":"202471640",
+        //     "symbol":"TRXUSDT_PERP",
+        //     "margin_mode":"Cross",
+        //     "leverage":"1.00",
+        //     "quantity":"0",
+        //     "price_entry":"0",
+        //     "price_margin_call":"0",
+        //     "price_liquidation":"0",
+        //     "pnl":"0.001234100000",
+        //     "created_at":"2023-10-29T14:46:13.235Z",
+        //     "updated_at":"2023-12-19T09:34:40.014Z"
+        // }
+        //
+        return this.parseOrder (response, market);
     }
 
     handleMarginModeAndParams (methodName, params = {}, defaultValue = undefined) {

--- a/ts/src/test/static/request/hitbtc.json
+++ b/ts/src/test/static/request/hitbtc.json
@@ -673,6 +673,17 @@
                     }
                 ]
             }
+        ],
+        "closePosition": [
+            {
+                "description": "close position",
+                "method": "closePosition",
+                "url": "https://api.hitbtc.com/api/3/futures/position/cross/TRXUSDT_PERP",
+                "input": [
+                  "TRX/USDT:USDT"
+                ],
+                "output": "{\"symbol\":\"TRXUSDT_PERP\",\"margin_mode\":\"cross\"}"
+            }
         ]
     }
 }


### PR DESCRIPTION
Node.js: v18.18.0
CCXT v4.1.91
hitbtc.closePosition (TRX/USDT:USDT)
{
  info: {
    id: '235035720',
    symbol: 'TRXUSDT_PERP',
    margin_mode: 'Cross',
    leverage: '50.00',
    quantity: '1',
    price_entry: '0.1009846',
    price_margin_call: '0',
    price_liquidation: '0',
    pnl: '0',
    created_at: '2023-12-19T09:45:09.895Z',
    updated_at: '2023-12-19T09:45:17.794Z'
  },
  timestamp: 1702979109895,
  datetime: '2023-12-19T09:45:09.895Z',
  lastTradeTimestamp: 1702979117794,
  lastUpdateTimestamp: 1702979117794,
  symbol: 'TRX/USDT:USDT',
  amount: 1,
  trades: [],
  fees: []
}
2023-12-19T09:45:17.709Z iteration 1 passed in 2980 ms