### PR TITLE
feat(binance): improve fetchTickers spot call

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3119,7 +3119,7 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/futures/en/#24hr-ticker-price-change-statistics      // swap
          * @see https://binance-docs.github.io/apidocs/delivery/en/#24hr-ticker-price-change-statistics     // future
          * @see https://binance-docs.github.io/apidocs/voptions/en/#24hr-ticker-price-change-statistics     // option
-         * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
+         * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
@@ -3134,19 +3134,21 @@ export default class binance extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         let subType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params);
-        const query = this.omit (params, 'type');
-        let defaultMethod = undefined;
+        let response = undefined;
         if (type === 'option') {
-            defaultMethod = 'eapiPublicGetTicker';
+            response = await this.eapiPublicGetTicker (params);
         } else if (this.isLinear (type, subType)) {
-            defaultMethod = 'fapiPublicGetTicker24hr';
+            response = await this.fapiPublicGetTicker24hr (params);
         } else if (this.isInverse (type, subType)) {
-            defaultMethod = 'dapiPublicGetTicker24hr';
+            response = await this.dapiPublicGetTicker24hr (params);
         } else {
-            defaultMethod = 'publicGetTicker24hr';
+            const request = {};
+            if (symbols !== undefined) {
+                const marketIds = this.marketIds (symbols);
+                request['symbols'] = this.json (marketIds);
+            }
+            response = await this.publicGetTicker24hr (this.extend (request, params));
         }
-        const method = this.safeString (this.options, 'fetchTickersMethod', defaultMethod);
-        const response = await this[method] (query);
         return this.parseTickers (response, symbols);
     }
 

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -644,6 +644,39 @@
               "USDT"
             ]
           }
+        ],
+        "fetchTickers": [
+          {
+            "description": "spot fetch tickers with symbols",
+            "method": "fetchTickers",
+            "url": "https://testnet.binance.vision/api/v3/ticker/24hr?symbols=%5B%22BTCUSDT%22%2C%22LTCUSDT%22%5D",
+            "input": [
+              [
+                "BTC/USDT",
+                "LTC/USDT"
+              ]
+            ]
+          },
+          {
+            "description": "Swap tickers",
+            "method": "fetchTickers",
+            "url": "https://testnet.binancefuture.com/fapi/v1/ticker/24hr",
+            "input": [
+              [
+                "BTC/USDT:USDT"
+              ]
+            ]
+          },
+          {
+            "description": "Inverse tickers",
+            "method": "fetchTickers",
+            "url": "https://testnet.binancefuture.com/dapi/v1/ticker/24hr",
+            "input": [
+              [
+                "BTC/USD:BTC"
+              ]
+            ]
+          }
         ]
     }
 }


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/20425
- the SPOT endpoint accepts a list of symbols
DEMO
```
p binance fetchTickers '["BTC/USDT"]' --sandbox --verbose 
CCXT v4.1.91
binance.fetchTickers(['BTC/USDT'])

fetch Request: binance GET https://testnet.binance.vision/api/v3/ticker/24hr?symbols=%5B%22BTCUSDT%22%5D 

{'BTC/USDT': {'ask': 43238.85,
              'askVolume': 0.00636,
              'average': 41989.565,
              'baseVolume': 870.5185,
              'bid': 43238.84,
              'bidVolume': 0.01145,
              'change': 2498.87,
              'close': 43239.0,
              'datetime': '2023-12-19T10:55:08.202Z',
              'high': 44575.96,
              'info': {'askPrice': '43238.85000000',
                       'askQty': '0.00636000',
                       'bidPrice': '43238.84000000',
                       'bidQty': '0.01145000',
                       'closeTime': '1702983308202',
                       'count': '170395',
                       'firstId': '988378',
                       'highPrice': '44575.96000000',
                       'lastId': '1158772',
                       'lastPrice': '43239.00000000',
                       'lastQty': '0.00012000',
                       'lowPrice': '10000.01000000',
                       'openPrice': '40740.13000000',
                       'openTime': '1702896908202',
                       'prevClosePrice': '40740.13000000',
                       'priceChange': '2498.87000000',
                       'priceChangePercent': '6.134',
                       'quoteVolume': '36755348.76227710',
                       'symbol': 'BTCUSDT',
                       'volume': '870.51850000',
                       'weightedAvgPrice': '42222.36375479'},
              'last': 43239.0,
              'low': 10000.01,
              'open': 40740.13,
              'percentage': 6.134,
              'previousClose': 40740.13,
              'quoteVolume': 36755348.7622771,
              'symbol': 'BTC/USDT',
              'timestamp': 1702983308202,
              'vwap': 42222.36375479}}
```
