### PR TITLE
Krakenfutures: createOrder, triggerPrice, stopLossPrice, takeProfitPrice

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -843,19 +843,12 @@ export default class krakenfutures extends Exchange {
     }
 
     createOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}) {
+        const market = this.market (symbol);
         type = this.safeString (params, 'orderType', type);
         const timeInForce = this.safeString (params, 'timeInForce');
-        const stopPrice = this.safeString (params, 'stopPrice');
         let postOnly = false;
         [ postOnly, params ] = this.handlePostOnly (type === 'market', type === 'post', params);
-        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'cliOrdId');
-        params = this.omit (params, [ 'clientOrderId', 'cliOrdId' ]);
-        if ((type === 'stp' || type === 'take_profit') && stopPrice === undefined) {
-            throw new ArgumentsRequired (this.id + ' createOrder requires params.stopPrice when type is ' + type);
-        }
-        if (stopPrice !== undefined && type !== 'take_profit') {
-            type = 'stp';
-        } else if (postOnly) {
+        if (postOnly) {
             type = 'post';
         } else if (timeInForce === 'ioc') {
             type = 'ioc';
@@ -865,17 +858,47 @@ export default class krakenfutures extends Exchange {
             type = 'mkt';
         }
         const request = {
-            'orderType': type,
-            'symbol': this.marketId (symbol),
+            'symbol': market['id'],
             'side': side,
             'size': amount,
         };
-        if (price !== undefined) {
-            request['limitPrice'] = price;
-        }
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'cliOrdId');
         if (clientOrderId !== undefined) {
             request['cliOrdId'] = clientOrderId;
         }
+        const triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
+        const isTriggerOrder = triggerPrice !== undefined;
+        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice');
+        const takeProfitTriggerPrice = this.safeNumber (params, 'takeProfitPrice');
+        const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
+        const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
+        const isStopLossOrTakeProfitTrigger = isStopLossTriggerOrder || isTakeProfitTriggerOrder;
+        const triggerSignal = this.safeString (params, 'triggerSignal', 'last');
+        let reduceOnly = this.safeValue (params, 'reduceOnly');
+        if (isStopLossOrTakeProfitTrigger || isTriggerOrder) {
+            request['triggerSignal'] = triggerSignal;
+        }
+        if (isTriggerOrder) {
+            type = 'stp';
+            request['stopPrice'] = this.priceToPrecision (symbol, triggerPrice);
+        } else if (isStopLossOrTakeProfitTrigger) {
+            reduceOnly = true;
+            if (isStopLossTriggerOrder) {
+                type = 'stp';
+                request['stopPrice'] = this.priceToPrecision (symbol, stopLossTriggerPrice);
+            } else if (isTakeProfitTriggerOrder) {
+                type = 'take_profit';
+                request['stopPrice'] = this.priceToPrecision (symbol, takeProfitTriggerPrice);
+            }
+        }
+        if (reduceOnly) {
+            request['reduceOnly'] = true;
+        }
+        request['orderType'] = type;
+        if (price !== undefined) {
+            request['limitPrice'] = price;
+        }
+        params = this.omit (params, [ 'clientOrderId', 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice' ]);
         return this.extend (request, params);
     }
 
@@ -884,19 +907,22 @@ export default class krakenfutures extends Exchange {
          * @method
          * @name krakenfutures#createOrder
          * @description Create an order on the exchange
-         * @param {string} symbol market symbol
-         * @param {string} type One of 'limit', 'market', 'take_profit'
-         * @param {string} side buy or sell
-         * @param {int} amount Contract quantity
-         * @param {float} [price] Limit order price
-         * @param {float} [params.stopPrice] The stop price associated with a stop or take profit order, Required if orderType is stp or take_profit, Must not have more than 2 decimal places, Note that for stop orders, limitPrice denotes the worst price at which the stop or take_profit order can get filled at. If no limitPrice is provided the stop or take_profit order will trigger a market order,
-         * @param {bool} [params.reduceOnly] Set as true if you wish the order to only reduce an existing position, Any order which increases an existing position will be rejected, Default false,
-         * @param {bool} [params.postOnly] Set as true if you wish to make a postOnly order, Default false
-         * @param {string} [params.triggerSignal] If placing a stp or take_profit, the signal used for trigger, One of: 'mark', 'index', 'last', last is market price
-         * @param {string} [params.cliOrdId] UUID The order identity that is specified from the user, It must be globally unique
+         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-send-order
+         * @param {string} symbol unified market symbol
+         * @param {string} type 'limit' or 'market'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount number of contracts
+         * @param {float} [price] limit order price
+         * @param {bool} [params.reduceOnly] set as true if you wish the order to only reduce an existing position, any order which increases an existing position will be rejected, default is false
+         * @param {bool} [params.postOnly] set as true if you wish to make a postOnly order, default is false
          * @param {string} [params.clientOrderId] UUID The order identity that is specified from the user, It must be globally unique
+         * @param {float} [params.triggerPrice] the price that a stop order is triggered at
+         * @param {float} [params.stopLossPrice] the price that a stop loss order is triggered at
+         * @param {float} [params.takeProfitPrice] the price that a take profit order is triggered at
+         * @param {string} [params.triggerSignal] for triggerPrice, stopLossPrice and takeProfitPrice orders, the trigger price type, 'last', 'mark' or 'index', default is 'last'
          */
         await this.loadMarkets ();
+        const market = this.market (symbol);
         const orderRequest = this.createOrderRequest (symbol, type, side, amount, price, params);
         const response = await this.privatePostSendorder (orderRequest);
         //
@@ -932,7 +958,7 @@ export default class krakenfutures extends Exchange {
         const sendStatus = this.safeValue (response, 'sendStatus');
         const status = this.safeString (sendStatus, 'status');
         this.verifyOrderActionSuccess (status, 'createOrder', [ 'filled' ]);
-        return this.parseOrder (sendStatus);
+        return this.parseOrder (sendStatus, market);
     }
 
     async createOrders (orders: OrderRequest[], params = {}) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -866,10 +866,10 @@ export default class krakenfutures extends Exchange {
         if (clientOrderId !== undefined) {
             request['cliOrdId'] = clientOrderId;
         }
-        const triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
+        const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const isTriggerOrder = triggerPrice !== undefined;
-        const stopLossTriggerPrice = this.safeNumber (params, 'stopLossPrice');
-        const takeProfitTriggerPrice = this.safeNumber (params, 'takeProfitPrice');
+        const stopLossTriggerPrice = this.safeString (params, 'stopLossPrice');
+        const takeProfitTriggerPrice = this.safeString (params, 'takeProfitPrice');
         const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
         const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
         const isStopLossOrTakeProfitTrigger = isStopLossTriggerOrder || isTakeProfitTriggerOrder;

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -26,6 +26,51 @@
                     "buy",
                     0.1
                 ]
+            },
+            {
+                "description": "Swap stop buy order using the triggerPrice param (type 1)",
+                "method": "createOrder",
+                "url": "https://demo-futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_XBTUSD&side=buy&size=0.0001&triggerSignal=last&stopPrice=45000&orderType=stp&limitPrice=46000",
+                "input": [
+                  "BTC/USD:USD",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  46000,
+                  {
+                    "triggerPrice": 45000
+                  }
+                ]
+            },
+            {
+                "description": "Swap stopLossPrice order (type 2)",
+                "method": "createOrder",
+                "url": "https://demo-futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_XBTUSD&side=sell&size=0.01&triggerSignal=last&reduceOnly=true&stopPrice=38000&orderType=stp&limitPrice=37000",
+                "input": [
+                  "BTC/USD:USD",
+                  "limit",
+                  "sell",
+                  0.01,
+                  37000,
+                  {
+                    "stopLossPrice": 38000
+                  }
+                ]
+            },
+            {
+                "description": "Swap takeProfitPrice order (type 2)",
+                "method": "createOrder",
+                "url": "https://demo-futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_XBTUSD&side=sell&size=0.01&triggerSignal=last&reduceOnly=true&stopPrice=49000&orderType=take_profit&limitPrice=50000",
+                "input": [
+                  "BTC/USD:USD",
+                  "limit",
+                  "sell",
+                  0.01,
+                  50000,
+                  {
+                    "takeProfitPrice": 49000
+                  }
+                ]
             }
         ],
         "transfer": [


### PR DESCRIPTION
Added support for stop trigger orders and stopLossPrice and takeProfitPrice orders, I was planning on adding trailing stop orders as well but kept receiving a BadRequest error because of the trailing_stop order type.

### trailing stop order:
```
handleRestResponse:
 krakenfutures POST https://demo-futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_XBTUSD&side=sell&size=0.01&triggerSignal=last&reduceOnly=true&trailingStopDeviationUnit=QUOTE_CURRENCY&trailingStopMaxDeviation=100&orderType=trailing_stop 400 Bad Request

handleRestResponse:
 krakenfutures POST https://demo-futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_XBTUSD&side=sell&size=0.01&triggerSignal=last&reduceOnly=true&trailingStopDeviationUnit=PERCENT&trailingStopMaxDeviation=10&orderType=trailing_stop 400 Bad Request

[BadRequest] krakenfutures {"status":"BAD_REQUEST","result":"error","errors":[{"code":11,"message":"invalid order type"}],"serverTime":"2023-12-20T05:06:46.559Z"}
```

### triggerPrice (type 1):
```
krakenfutures createOrder BTC/USD:USD limit buy 0.0001 46000 '{"triggerPrice":45000}'

krakenfutures.createOrder (BTC/USD:USD, limit, buy, 0.0001, 46000, [object Object])
2023-12-20T04:38:20.384Z iteration 0 passed in 769 ms

{
  info: {
    order_id: '769bf9f8-33fc-41f7-a192-82262718a874',
    status: 'placed',
    receivedTime: '2023-12-20T04:38:21.145Z',
    orderEvents: [
      {
        orderTrigger: {
          uid: '769bf9f8-33fc-41f7-a192-82262718a874',
          clientId: null,
          type: 'lmt',
          symbol: 'PF_XBTUSD',
          side: 'buy',
          quantity: '0.0001',
          limitPrice: '46000',
          limitPriceOffsetValue: null,
          limitPriceOffsetUnit: null,
          triggerPrice: '45000',
          triggerSide: 'trigger_above',
          triggerSignal: 'last_price',
          reduceOnly: false,
          timestamp: '2023-12-20T04:38:21.145Z',
          lastUpdateTimestamp: '2023-12-20T04:38:21.145Z',
          startTime: null
        },
        type: 'PLACE'
      }
    ]
  },
  id: '769bf9f8-33fc-41f7-a192-82262718a874',
  timestamp: 1703047101145,
  datetime: '2023-12-20T04:38:21.145Z',
  symbol: 'BTC/USD:USD',
  type: 'limit',
  timeInForce: 'gtc',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 46000,
  stopPrice: 45000,
  triggerPrice: 45000,
  amount: 0.0001,
  cost: 0,
  filled: 0,
  remaining: 0.0001,
  status: 'open',
  fees: [],
  trades: []
}
```

### stopLossPrice (type 2):
```
krakenfutures createOrder BTC/USD:USD limit sell 0.01 37000 '{"stopLossPrice":38000}'

krakenfutures.createOrder (BTC/USD:USD, limit, sell, 0.01, 37000, [object Object])
2023-12-20T04:58:22.280Z iteration 0 passed in 772 ms

{
  info: {
    order_id: '7ce70af3-bcc6-452e-ad4c-81b079888649',
    status: 'placed',
    receivedTime: '2023-12-20T04:58:23.052Z',
    orderEvents: [
      {
        orderTrigger: {
          uid: '7ce70af3-bcc6-452e-ad4c-81b079888649',
          clientId: null,
          type: 'lmt',
          symbol: 'PF_XBTUSD',
          side: 'sell',
          quantity: '0.01',
          limitPrice: '37000',
          limitPriceOffsetValue: null,
          limitPriceOffsetUnit: null,
          triggerPrice: '38000',
          triggerSide: 'trigger_below',
          triggerSignal: 'last_price',
          reduceOnly: true,
          timestamp: '2023-12-20T04:58:23.052Z',
          lastUpdateTimestamp: '2023-12-20T04:58:23.052Z',
          startTime: null
        },
        type: 'PLACE'
      }
    ]
  },
  id: '7ce70af3-bcc6-452e-ad4c-81b079888649',
  timestamp: 1703048303052,
  datetime: '2023-12-20T04:58:23.052Z',
  symbol: 'BTC/USD:USD',
  type: 'limit',
  timeInForce: 'gtc',
  postOnly: false,
  reduceOnly: true,
  side: 'sell',
  price: 37000,
  stopPrice: 38000,
  triggerPrice: 38000,
  amount: 0.01,
  cost: 0,
  filled: 0,
  remaining: 0.01,
  status: 'open',
  fees: [],
  trades: []
}
```

### takeProfitPrice (type 2):
```
krakenfutures createOrder BTC/USD:USD limit sell 0.01 50000 '{"takeProfitPrice":49000}'

krakenfutures.createOrder (BTC/USD:USD, limit, sell, 0.01, 50000, [object Object])
2023-12-20T05:00:20.279Z iteration 0 passed in 778 ms

{
  info: {
    order_id: 'a3758f69-a024-4810-9ccb-40957b3fec75',
    status: 'placed',
    receivedTime: '2023-12-20T05:00:21.048Z',
    orderEvents: [
      {
        orderTrigger: {
          uid: 'a3758f69-a024-4810-9ccb-40957b3fec75',
          clientId: null,
          type: 'lmt',
          symbol: 'PF_XBTUSD',
          side: 'sell',
          quantity: '0.01',
          limitPrice: '50000',
          limitPriceOffsetValue: null,
          limitPriceOffsetUnit: null,
          triggerPrice: '49000',
          triggerSide: 'trigger_above',
          triggerSignal: 'last_price',
          reduceOnly: true,
          timestamp: '2023-12-20T05:00:21.048Z',
          lastUpdateTimestamp: '2023-12-20T05:00:21.048Z',
          startTime: null
        },
        type: 'PLACE'
      }
    ]
  },
  id: 'a3758f69-a024-4810-9ccb-40957b3fec75',
  timestamp: 1703048421048,
  datetime: '2023-12-20T05:00:21.048Z',
  symbol: 'BTC/USD:USD',
  type: 'limit',
  timeInForce: 'gtc',
  postOnly: false,
  reduceOnly: true,
  side: 'sell',
  price: 50000,
  stopPrice: 49000,
  triggerPrice: 49000,
  amount: 0.01,
  cost: 0,
  filled: 0,
  remaining: 0.01,
  status: 'open',
  fees: [],
  trades: []
}
```