### PR TITLE
fix(gate): correct timestamp property in handleBalance

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -736,7 +736,7 @@ export default class gate extends gateRest {
         //   }
         //
         const result = this.safeValue (message, 'result', []);
-        const timestamp = this.safeInteger (message, 'time');
+        const timestamp = this.safeInteger (message, 'time_ms');
         this.balance['info'] = result;
         this.balance['timestamp'] = timestamp;
         this.balance['datetime'] = this.iso8601 (timestamp);


### PR DESCRIPTION
time_ms provides the correct timestamp for conversion to iso8601
![swappy-20231220_173320](https://github.com/ccxt/ccxt/assets/87595097/c1287f89-122a-4bfe-925a-4e34e595d826)
