### PR TITLE
Bitget: createOrder, trailingStopPercent support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3989,7 +3989,7 @@ export default class bitget extends Exchange {
          * @param {string} [params.stopLoss.type] *swap only* the type for a stop loss attached to a trigger order, 'fill_price', 'index_price' or 'mark_price', default is 'mark_price'
          * @param {string} [params.takeProfit.type] *swap only* the type for a take profit attached to a trigger order, 'fill_price', 'index_price' or 'mark_price', default is 'mark_price'
          * @param {string} [params.trailingStopPercent] *swap and future only* the percent to trail away from the current market price, rate can not be greater than 10
-         * @param {string} [params.trailingStopTriggerPrice] *swap and future only* the price to trigger a trailing stop order, default uses the price argument
+         * @param {string} [params.trailingTriggerPrice] *swap and future only* the price to trigger a trailing stop order, default uses the price argument
          * @param {string} [params.triggerType] *swap and future only* 'fill_price', 'mark_price' or 'index_price'
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
@@ -4072,7 +4072,7 @@ export default class bitget extends Exchange {
         const isTakeProfit = takeProfit !== undefined;
         const isStopLossOrTakeProfitTrigger = isStopLossTriggerOrder || isTakeProfitTriggerOrder;
         const isStopLossOrTakeProfit = isStopLoss || isTakeProfit;
-        const trailingStopTriggerPrice = this.safeString (params, 'trailingStopTriggerPrice', price);
+        const trailingTriggerPrice = this.safeString (params, 'trailingTriggerPrice', price);
         const trailingStopPercent = this.safeString2 (params, 'trailingStopPercent', 'callbackRatio');
         const isTrailingStopPercentOrder = trailingStopPercent !== undefined;
         if (this.sum (isTriggerOrder, isStopLossTriggerOrder, isTakeProfitTriggerOrder, isTrailingStopPercentOrder) > 1) {
@@ -4098,7 +4098,7 @@ export default class bitget extends Exchange {
         } else if (timeInForce === 'IOC') {
             request['force'] = 'IOC';
         }
-        params = this.omit (params, [ 'stopPrice', 'triggerType', 'stopLossPrice', 'takeProfitPrice', 'stopLoss', 'takeProfit', 'postOnly', 'reduceOnly', 'clientOrderId', 'trailingStopPercent', 'trailingStopTriggerPrice' ]);
+        params = this.omit (params, [ 'stopPrice', 'triggerType', 'stopLossPrice', 'takeProfitPrice', 'stopLoss', 'takeProfit', 'postOnly', 'reduceOnly', 'clientOrderId', 'trailingStopPercent', 'trailingTriggerPrice' ]);
         if ((marketType === 'swap') || (marketType === 'future')) {
             request['marginCoin'] = market['settleId'];
             request['size'] = this.amountToPrecision (symbol, amount);
@@ -4115,11 +4115,11 @@ export default class bitget extends Exchange {
                 if (!isMarketOrder) {
                     throw new BadRequest (this.id + ' createOrder() bitget trailing stop orders must be market orders');
                 }
-                if (trailingStopTriggerPrice === undefined) {
-                    throw new ArgumentsRequired (this.id + ' createOrder() bitget trailing stop orders must have a trailingStopTriggerPrice param');
+                if (trailingTriggerPrice === undefined) {
+                    throw new ArgumentsRequired (this.id + ' createOrder() bitget trailing stop orders must have a trailingTriggerPrice param');
                 }
                 request['planType'] = 'track_plan';
-                request['triggerPrice'] = this.priceToPrecision (symbol, trailingStopTriggerPrice);
+                request['triggerPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
                 request['callbackRatio'] = trailingStopPercent;
             } else if (isTriggerOrder) {
                 request['planType'] = 'normal_plan';
@@ -4377,7 +4377,7 @@ export default class bitget extends Exchange {
          * @param {string} [params.stopLoss.type] *swap only* the type for a stop loss attached to a trigger order, 'fill_price', 'index_price' or 'mark_price', default is 'mark_price'
          * @param {string} [params.takeProfit.type] *swap only* the type for a take profit attached to a trigger order, 'fill_price', 'index_price' or 'mark_price', default is 'mark_price'
          * @param {string} [params.trailingStopPercent] *swap and future only* the percent to trail away from the current market price, rate can not be greater than 10
-         * @param {string} [params.trailingStopTriggerPrice] *swap and future only* the price to trigger a trailing stop order, default uses the price argument
+         * @param {string} [params.trailingTriggerPrice] *swap and future only* the price to trigger a trailing stop order, default uses the price argument
          * @param {string} [params.newTriggerType] *swap and future only* 'fill_price', 'mark_price' or 'index_price'
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
@@ -4404,7 +4404,7 @@ export default class bitget extends Exchange {
         const takeProfit = this.safeValue (params, 'takeProfit');
         const isStopLoss = stopLoss !== undefined;
         const isTakeProfit = takeProfit !== undefined;
-        const trailingStopTriggerPrice = this.safeString (params, 'trailingStopTriggerPrice', price);
+        const trailingTriggerPrice = this.safeString (params, 'trailingTriggerPrice', price);
         const trailingStopPercent = this.safeString2 (params, 'trailingStopPercent', 'newCallbackRatio');
         const isTrailingStopPercentOrder = trailingStopPercent !== undefined;
         if (this.sum (isTriggerOrder, isStopLossOrder, isTakeProfitOrder, isTrailingStopPercentOrder) > 1) {
@@ -4414,7 +4414,7 @@ export default class bitget extends Exchange {
         if (clientOrderId !== undefined) {
             request['clientOid'] = clientOrderId;
         }
-        params = this.omit (params, [ 'stopPrice', 'triggerType', 'stopLossPrice', 'takeProfitPrice', 'stopLoss', 'takeProfit', 'clientOrderId', 'trailingStopTriggerPrice', 'trailingStopPercent' ]);
+        params = this.omit (params, [ 'stopPrice', 'triggerType', 'stopLossPrice', 'takeProfitPrice', 'stopLoss', 'takeProfit', 'clientOrderId', 'trailingTriggerPrice', 'trailingStopPercent' ]);
         let response = undefined;
         if (market['spot']) {
             const editMarketBuyOrderRequiresPrice = this.safeValue (this.options, 'editMarketBuyOrderRequiresPrice', true);
@@ -4452,8 +4452,8 @@ export default class bitget extends Exchange {
                 if (!isMarketOrder) {
                     throw new BadRequest (this.id + ' editOrder() bitget trailing stop orders must be market orders');
                 }
-                if (trailingStopTriggerPrice !== undefined) {
-                    request['newTriggerPrice'] = this.priceToPrecision (symbol, trailingStopTriggerPrice);
+                if (trailingTriggerPrice !== undefined) {
+                    request['newTriggerPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
                 }
                 request['newCallbackRatio'] = trailingStopPercent;
                 response = await this.privateMixPostV2MixOrderModifyPlanOrder (this.extend (request, params));

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4072,8 +4072,8 @@ export default class bitget extends Exchange {
         const isStopLossOrTakeProfit = isStopLoss || isTakeProfit;
         const trailingStopPercent = this.safeString2 (params, 'trailingStopPercent', 'callbackRatio');
         const isTrailingStopPercentOrder = trailingStopPercent !== undefined;
-        if (this.sum (isTriggerOrder, isStopLossTriggerOrder, isTakeProfitTriggerOrder, isTrailingStopPercentOrder) > 1) {
-            throw new ExchangeError (this.id + ' createOrder() params can only contain one of triggerPrice, stopLossPrice, takeProfitPrice, trailingStopPercent');
+        if (this.sum (isTriggerOrder, isStopLossTriggerOrder, isTakeProfitTriggerOrder) > 1) {
+            throw new ExchangeError (this.id + ' createOrder() params can only contain one of triggerPrice, stopLossPrice, takeProfitPrice');
         }
         if (type === 'limit') {
             request['price'] = this.priceToPrecision (symbol, price);

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -178,7 +178,7 @@
               "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"8\"}"
             },
             {
-              "description": "Swap trailing stop order using trailingStopPercent and setting reduceOnly to true",
+              "description": "Swap trailing order using trailingPercent and setting reduceOnly to true",
               "method": "createOrder",
               "url": "https://api.bitget.com/api/v2/mix/order/place-plan-order",
               "input": [
@@ -188,7 +188,7 @@
                 0.002,
                 null,
                 {
-                  "trailingStopPercent": "10",
+                  "trailingPercent": "10",
                   "trailingTriggerPrice": "45000",
                   "reduceOnly": true
                 }
@@ -391,7 +391,7 @@
             "output": "{\"orderId\":\"1113286462953558017\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"executePrice\":\"25000\",\"triggerPrice\":\"27000\"}"
           },
           {
-            "description": "Swap edit a trailing stop order",
+            "description": "Swap edit a trailing order",
             "method": "editOrder",
             "url": "https://api.bitget.com/api/v2/mix/order/modify-plan-order",
             "input": [
@@ -402,7 +402,7 @@
               0.002,
               null,
               {
-                "trailingStopPercent": "5",
+                "trailingPercent": "5",
                 "trailingTriggerPrice": "46000"
               }
             ],
@@ -514,7 +514,7 @@
               ]
             },
             {
-              "description": "Swap open trailing stop orders",
+              "description": "Swap open trailing orders",
               "method": "fetchOpenOrders",
               "url": "https://api.bitget.com/api/v2/mix/order/orders-plan-pending?planType=track_plan&productType=USDT-FUTURES&symbol=BTCUSDT",
               "input": [
@@ -522,7 +522,7 @@
                 null,
                 null,
                 {
-                  "trailingStop": true
+                  "trailing": true
                 }
               ]
             }
@@ -564,7 +564,7 @@
                 ]
             },
             {
-              "description": "Swap closed trailing stop orders",
+              "description": "Swap closed trailing orders",
               "method": "fetchClosedOrders",
               "url": "https://api.bitget.com/api/v2/mix/order/orders-plan-history?planType=track_plan&productType=USDT-FUTURES&symbol=BTCUSDT",
               "input": [
@@ -572,7 +572,7 @@
                 null,
                 null,
                 {
-                  "trailingStop": true
+                  "trailing": true
                 }
               ]
             }
@@ -614,7 +614,7 @@
             ]
           },
           {
-            "description": "swap canceled trailing stop orders",
+            "description": "swap canceled trailing orders",
             "method": "fetchCanceledOrders",
             "url": "https://api.bitget.com/api/v2/mix/order/orders-plan-history?planType=track_plan&productType=USDT-FUTURES&symbol=BTCUSDT",
             "input": [
@@ -622,7 +622,7 @@
               null,
               null,
               {
-                "trailingStop": true
+                "trailing": true
               }
             ]
           }
@@ -802,14 +802,14 @@
                 "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1112204653770715137\"}"
             },
             {
-              "description": "Swap cancel trailing stop order",
+              "description": "Swap cancel trailing order",
               "method": "cancelOrder",
               "url": "https://api.bitget.com/api/v2/mix/order/cancel-plan-order",
               "input": [
                 "1121635717619453955",
                 "BTC/USDT:USDT",
                 {
-                  "trailingStop": true
+                  "trailing": true
                 }
               ],
               "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1121635717619453955\",\"productType\":\"USDT-FUTURES\",\"orderIdList\":[{\"orderId\":\"1121635717619453955\"}],\"planType\":\"track_plan\"}"

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -512,6 +512,19 @@
                   "type": "swap"
                 }
               ]
+            },
+            {
+              "description": "Swap open trailing stop orders",
+              "method": "fetchOpenOrders",
+              "url": "https://api.bitget.com/api/v2/mix/order/orders-plan-pending?planType=track_plan&productType=USDT-FUTURES&symbol=BTCUSDT",
+              "input": [
+                "BTC/USDT:USDT",
+                null,
+                null,
+                {
+                  "trailingStop": true
+                }
+              ]
             }
         ],
         "fetchClosedOrders": [

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -189,7 +189,7 @@
                 null,
                 {
                   "trailingStopPercent": "10",
-                  "triggerPrice": "45000",
+                  "trailingStopTriggerPrice": "45000",
                   "reduceOnly": true
                 }
               ],

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -549,6 +549,19 @@
                 "input": [
                   "BTC/USDT:USDT"
                 ]
+            },
+            {
+              "description": "Swap closed trailing stop orders",
+              "method": "fetchClosedOrders",
+              "url": "https://api.bitget.com/api/v2/mix/order/orders-plan-history?planType=track_plan&productType=USDT-FUTURES&symbol=BTCUSDT",
+              "input": [
+                "BTC/USDT:USDT",
+                null,
+                null,
+                {
+                  "trailingStop": true
+                }
+              ]
             }
         ],
         "fetchCanceledOrders": [
@@ -585,6 +598,19 @@
             "url": "https://api.bitget.com/api/v2/mix/order/orders-history?productType=USDT-FUTURES&symbol=LTCUSDT",
             "input": [
               "LTC/USDT:USDT"
+            ]
+          },
+          {
+            "description": "swap canceled trailing stop orders",
+            "method": "fetchCanceledOrders",
+            "url": "https://api.bitget.com/api/v2/mix/order/orders-plan-history?planType=track_plan&productType=USDT-FUTURES&symbol=BTCUSDT",
+            "input": [
+              "BTC/USDT:USDT",
+              null,
+              null,
+              {
+                "trailingStop": true
+              }
             ]
           }
         ],

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -176,6 +176,24 @@
                 }
               ],
               "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"8\"}"
+            },
+            {
+              "description": "Swap trailing stop order using trailingStopPercent and setting reduceOnly to true",
+              "method": "createOrder",
+              "url": "https://api.bitget.com/api/v2/mix/order/place-plan-order",
+              "input": [
+                "BTC/USDT:USDT",
+                "market",
+                "sell",
+                0.002,
+                null,
+                {
+                  "trailingStopPercent": "10",
+                  "triggerPrice": "45000",
+                  "reduceOnly": true
+                }
+              ],
+              "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.002\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"planType\":\"track_plan\",\"triggerPrice\":\"45000\",\"callbackRatio\":\"10\",\"marginMode\":\"crossed\",\"reduceOnly\":\"YES\",\"tradeSide\":\"Close\",\"side\":\"buy\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -800,6 +800,19 @@
                   }
                 ],
                 "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1112204653770715137\"}"
+            },
+            {
+              "description": "Swap cancel trailing stop order",
+              "method": "cancelOrder",
+              "url": "https://api.bitget.com/api/v2/mix/order/cancel-plan-order",
+              "input": [
+                "1121635717619453955",
+                "BTC/USDT:USDT",
+                {
+                  "trailingStop": true
+                }
+              ],
+              "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1121635717619453955\",\"productType\":\"USDT-FUTURES\",\"orderIdList\":[{\"orderId\":\"1121635717619453955\"}],\"planType\":\"track_plan\"}"
             }
         ],
         "cancelOrders": [

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -389,6 +389,24 @@
               }
             ],
             "output": "{\"orderId\":\"1113286462953558017\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"executePrice\":\"25000\",\"triggerPrice\":\"27000\"}"
+          },
+          {
+            "description": "Swap edit a trailing stop order",
+            "method": "editOrder",
+            "url": "https://api.bitget.com/api/v2/mix/order/modify-plan-order",
+            "input": [
+              "1121635717619453955",
+              "BTC/USDT:USDT",
+              "market",
+              "sell",
+              0.002,
+              null,
+              {
+                "trailingStopPercent": "5",
+                "trailingStopTriggerPrice": "46000"
+              }
+            ],
+            "output": "{\"orderId\":\"1121635717619453955\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"newSize\":\"0.002\",\"newTriggerPrice\":\"46000\",\"newCallbackRatio\":\"5\"}"
           }
       ],
         "fetchMyTrades": [

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -189,7 +189,7 @@
                 null,
                 {
                   "trailingStopPercent": "10",
-                  "trailingStopTriggerPrice": "45000",
+                  "trailingTriggerPrice": "45000",
                   "reduceOnly": true
                 }
               ],
@@ -403,7 +403,7 @@
               null,
               {
                 "trailingStopPercent": "5",
-                "trailingStopTriggerPrice": "46000"
+                "trailingTriggerPrice": "46000"
               }
             ],
             "output": "{\"orderId\":\"1121635717619453955\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"newSize\":\"0.002\",\"newTriggerPrice\":\"46000\",\"newCallbackRatio\":\"5\"}"


### PR DESCRIPTION
Added support for `trailingPercent` to Bitget:

```
bitget createOrder BTC/USDT:USDT market sell 0.002 undefined '{"trailingPercent":"10","triggerPrice":"45000","reduceOnly":true}'

bitget.createOrder (BTC/USDT:USDT, market, sell, 0.002, , [object Object])
2023-12-21T03:30:27.718Z iteration 0 passed in 358 ms

{
  info: { clientOid: '1121571600170815488', orderId: '1121571600170815489' },
  id: '1121571600170815489',
  clientOrderId: '1121571600170815488',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fees: []
}
```
```
bitget editOrder '"1121635717619453955"' BTC/USDT:USDT market sell 0.002 undefined '{"trailingPercent":"5","trailingTriggerPrice":"46000"}'

bitget.editOrder (1121635717619453955, BTC/USDT:USDT, market, sell, 0.002, , [object Object])
2023-12-21T07:50:27.628Z iteration 0 passed in 427 ms

{
  info: { clientOid: '1121635717619453954', orderId: '1121635717619453955' },
  id: '1121635717619453955',
  clientOrderId: '1121635717619453954',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fees: []
}
```
```
bitget fetchCanceledOrders BTC/USDT:USDT undefined undefined '{"trailing":true}'

bitget.fetchCanceledOrders (BTC/USDT:USDT, , , [object Object])
2023-12-21T08:00:47.143Z iteration 0 passed in 319 ms

                 id |       clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |        symbol |   type | side | amount | filled | remaining | timeInForce | stopPrice | triggerPrice | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1121568423937642497 | 1121568423937642496 | 1703128670677 | 2023-12-21T03:17:50.677Z |      1703128741781 |       1703128741781 | BTC/USDT:USDT | market | sell |  0.002 |      0 |     0.002 |         IOC |     45000 |        45000 |     [] |   []
1121571600170815489 | 1121571600170815488 | 1703129427950 | 2023-12-21T03:30:27.950Z |      1703130080884 |       1703130080884 | BTC/USDT:USDT | market |  buy |  0.002 |      0 |     0.002 |         IOC |     45000 |        45000 |     [] |   []
2 objects
```
```
bitget fetchOpenOrders BTC/USDT:USDT undefined undefined '{"trailing":true}'

bitget.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2023-12-21T08:11:22.225Z iteration 0 passed in 330 ms

                 id |       clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |        symbol |   type | side | amount | timeInForce | stopPrice | triggerPrice | trades | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1121635717619453955 | 1121635717619453954 | 1703144714741 | 2023-12-21T07:45:14.741Z |      1703145028015 |       1703145028015 | BTC/USDT:USDT | market | sell |  0.002 |         IOC |     46000 |        46000 |     [] |   []
1 objects
```
```
bitget cancelOrder '"1121635717619453955"' BTC/USDT:USDT '{"trailing":true}'

bitget.cancelOrder (1121635717619453955, BTC/USDT:USDT, [object Object])
2023-12-21T08:24:27.994Z iteration 0 passed in 546 ms

{
  info: {
    successList: [
      {
        clientOid: '1121635717619453954',
        orderId: '1121635717619453955'
      }
    ],
    failureList: []
  },
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fees: []
}
```