### PR TITLE
Bitmart: createOrder, trailingStopPercent, triggerPrice

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2236,7 +2236,7 @@ export default class bitmart extends Exchange {
          * @param {int} [params.price_way] *swap only* 1: price way long, 2: price way short
          * @param {int} [params.activation_price_type] *swap trailing stop order only* 1: last price, 2: fair price, default is 1
          * @param {string} [params.trailingStopPercent] *swap only* the percent to trail away from the current market price, min 0.1 max 5
-         * @param {string} [params.trailingStopTriggerPrice] *swap only* the price to trigger a trailing stop order, default uses the price argument
+         * @param {string} [params.trailingTriggerPrice] *swap only* the price to trigger a trailing stop order, default uses the price argument
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -2308,7 +2308,7 @@ export default class bitmart extends Exchange {
          * @param {int} [params.price_way] *swap only* 1: price way long, 2: price way short
          * @param {int} [params.activation_price_type] *swap trailing stop order only* 1: last price, 2: fair price, default is 1
          * @param {string} [params.trailingStopPercent] *swap only* the percent to trail away from the current market price, min 0.1 max 5
-         * @param {string} [params.trailingStopTriggerPrice] *swap only* the price to trigger a trailing stop order, default uses the price argument
+         * @param {string} [params.trailingTriggerPrice] *swap only* the price to trigger a trailing stop order, default uses the price argument
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         const market = this.market (symbol);
@@ -2338,14 +2338,14 @@ export default class bitmart extends Exchange {
         }
         const triggerPrice = this.safeStringN (params, [ 'triggerPrice', 'stopPrice', 'trigger_price' ]);
         const isTriggerOrder = triggerPrice !== undefined;
-        const trailingStopTriggerPrice = this.safeString2 (params, 'trailingStopTriggerPrice', 'activation_price', price);
+        const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activation_price', price);
         const trailingStopPercent = this.safeString2 (params, 'trailingStopPercent', 'callback_rate');
         const isTrailingStopPercentOrder = trailingStopPercent !== undefined;
         if (isLimitOrder) {
             request['price'] = this.priceToPrecision (symbol, price);
         } else if (type === 'trailing' || isTrailingStopPercentOrder) {
             request['callback_rate'] = trailingStopPercent;
-            request['activation_price'] = this.priceToPrecision (symbol, trailingStopTriggerPrice);
+            request['activation_price'] = this.priceToPrecision (symbol, trailingTriggerPrice);
             request['activation_price_type'] = this.safeInteger (params, 'activation_price_type', 1);
         }
         if (isTriggerOrder) {
@@ -2388,7 +2388,7 @@ export default class bitmart extends Exchange {
             request['client_order_id'] = clientOrderId;
         }
         const leverage = this.safeInteger (params, 'leverage', 1);
-        params = this.omit (params, [ 'timeInForce', 'postOnly', 'reduceOnly', 'leverage', 'trailingStopTriggerPrice', 'trailingStopPercent', 'triggerPrice', 'stopPrice' ]);
+        params = this.omit (params, [ 'timeInForce', 'postOnly', 'reduceOnly', 'leverage', 'trailingTriggerPrice', 'trailingStopPercent', 'triggerPrice', 'stopPrice' ]);
         request['leverage'] = this.numberToString (leverage);
         return this.extend (request, params);
     }

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2321,7 +2321,7 @@ export default class bitmart extends Exchange {
         const mode = this.safeInteger (params, 'mode'); // only for swap
         const isMarketOrder = type === 'market';
         let postOnly = undefined;
-        let reduceOnly = this.safeValue (params, 'reduceOnly');
+        const reduceOnly = this.safeValue (params, 'reduceOnly');
         const isExchangeSpecificPo = (mode === 4);
         [ postOnly, params ] = this.handlePostOnly (isMarketOrder, isExchangeSpecificPo, params);
         const ioc = ((timeInForce === 'IOC') || (mode === 3));

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -111,7 +111,7 @@
                 "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"market\",\"size\":1,\"side\":1,\"open_type\":\"cross\",\"leverage\":\"1\"}"
             },
             {
-                "description": "Fill this with a description of the method call",
+                "description": "Swap limit sell order",
                 "method": "createOrder",
                 "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
                 "input": [
@@ -178,17 +178,35 @@
                 "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
                 "input": [
                   "BTC/USDT:USDT",
-                  "trailing",
+                  "market",
                   "sell",
                   1,
-                  55000,
+                  null,
                   {
-                    "marginMode": "isolated",
                     "leverage": "10",
+                    "marginMode": "isolated",
+                    "trailingStopPercent": "10",
+                    "trailingStopTriggerPrice": "50000",
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"type\":\"trailing\",\"size\":1,\"activation_price\":\"55000\",\"activation_price_type\":1,\"callback_rate\":\"1\",\"side\":3,\"open_type\":\"isolated\",\"leverage\":\"10\"}"
+                "output": "{\"symbol\":\"BTCUSDT\",\"type\":\"market\",\"size\":1,\"activation_price\":\"50000\",\"activation_price_type\":1,\"callback_rate\":\"10\",\"side\":3,\"open_type\":\"isolated\",\"leverage\":\"10\"}"
+            },
+            {
+                "description": "Swap stop limit buy order using the triggerPrice param (type 1)",
+                "method": "createOrder",
+                "url": "https://api-cloud.bitmart.com/contract/private/submit-plan-order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  1,
+                  30000,
+                  {
+                    "triggerPrice": "31000"
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"type\":\"limit\",\"size\":1,\"price\":\"30000\",\"executive_price\":\"30000\",\"trigger_price\":\"31000\",\"price_type\":1,\"price_way\":1,\"side\":1,\"open_type\":\"cross\",\"leverage\":\"1\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -313,6 +331,19 @@
                     "LTC/USDT"
                 ],
                 "output": "{\"symbol\":\"LTC_USDT\",\"order_id\":\"200683008340521505\"}"
+            },
+            {
+                "description": "Swap cancel plan order",
+                "method": "cancelOrder",
+                "url": "https://api-cloud.bitmart.com/contract/private/cancel-plan-order",
+                "input": [
+                  "2312213461000000",
+                  "BTC/USDT:USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"order_id\":\"2312213461000000\"}"
             }
         ],
         "cancelAllOrders": [

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -186,7 +186,7 @@
                     "leverage": "10",
                     "marginMode": "isolated",
                     "trailingStopPercent": "10",
-                    "trailingStopTriggerPrice": "50000",
+                    "trailingTriggerPrice": "50000",
                     "reduceOnly": true
                   }
                 ],

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -173,7 +173,7 @@
                 "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"5\"}"
             },
             {
-                "description": "Swap trailing stop order",
+                "description": "Swap trailing order",
                 "method": "createOrder",
                 "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
                 "input": [
@@ -185,7 +185,7 @@
                   {
                     "leverage": "10",
                     "marginMode": "isolated",
-                    "trailingStopPercent": "10",
+                    "trailingPercent": "10",
                     "trailingTriggerPrice": "50000",
                     "reduceOnly": true
                   }
@@ -263,7 +263,7 @@
                 ]
             },
             {
-                "description": "Swap open trailing stop orders",
+                "description": "Swap open trailing orders",
                 "method": "fetchOpenOrders",
                 "url": "https://api-cloud.bitmart.com/contract/private/get-open-orders?symbol=BTCUSDT&type=trailing",
                 "input": [
@@ -278,7 +278,7 @@
         ],
         "fetchOrder": [
             {
-                "description": "Swap trailing stop order by id",
+                "description": "Swap trailing order by id",
                 "method": "fetchOrder",
                 "url": "https://api-cloud.bitmart.com/contract/private/order?type=trailing&symbol=BTCUSDT&order_id=2312139250106560",
                 "input": [


### PR DESCRIPTION
Added support for `trailingPercent` and `triggerPrice` (type 1) orders to Bitmart:

### triggerPrice:
```
bitmart createOrder BTC/USDT:USDT limit buy 1 30000 '{"triggerPrice":"31000"}'

{
  id: '2312213461000000',
  info: { order_id: '2312213461000000' },
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  side: 'buy',
  price: 30000,
  amount: 1,
  trades: [],
  fees: []
}
```

### trailingPercent:
```
bitmart createOrder BTC/USDT:USDT market sell 1 undefined '{"leverage":"10","marginMode":"isolated","trailingPercent":"10","trailingTriggerPrice":"50000","reduceOnly":true}'

bitmart.createOrder (BTC/USDT:USDT, market, sell, 1, , [object Object])
2023-12-21T06:45:58.953Z iteration 0 passed in 553 ms

{
  id: '2312213463715881',
  info: { order_id: '2312213463715881', price: 'market price' },
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  side: 'sell',
  amount: 1,
  trades: [],
  fees: []
}
```