### PR TITLE
okx: fix watchMyTrades cost bug

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -810,7 +810,7 @@ export default class okx extends okxRest {
             'side': this.safeString (order, 'side'),
             'price': this.safeNumber (info, 'fillPx'),
             'amount': this.safeNumber (info, 'fillSz'),
-            'cost': undefined,
+            'cost': this.safeNumber (order, 'cost'),
             'fee': {
                 'cost': this.safeNumber (info, 'fillFee'),
                 'currency': this.safeCurrencyCode (feeMarketId),


### PR DESCRIPTION
fix: ccxt/ccxt#20468

```BASH
$ n okx watchMyTrades --verbose --test
2023-12-21T07:09:26.687Z onMessage {
  arg: { channel: 'orders', instType: 'ANY', uid: '441564264411867138' },
  data: [
    {
      accFillSz: '1',
      algoClOrdId: '',
      algoId: '',
      amendResult: '',
      amendSource: '',
      attachAlgoClOrdId: '',
      attachAlgoOrds: [],
      avgPx: '43850.4',
      cTime: '1703142566649',
      cancelSource: '',
      category: 'normal',
      ccy: '',
      clOrdId: 'e847386590ce4dBC81147af8a4aea184',
      code: '0',
      execType: 'T',
      fee: '-0.0219252',
      feeCcy: 'USDT',
      fillFee: '-0.0219252',
      fillFeeCcy: 'USDT',
      fillFwdPx: '',
      fillMarkPx: '43848.4',
      fillMarkVol: '',
      fillNotionalUsd: '43.858731576',
      fillPnl: '-0.0267',
      fillPx: '43850.4',
      fillPxUsd: '',
      fillPxVol: '',
      fillSz: '1',
      fillTime: '1703142566650',
      instId: 'BTC-USDT-SWAP',
      instType: 'SWAP',
      lastPx: '43846.6',
      lever: '3',
      msg: '',
      notionalUsd: '43.858731576',
      ordId: '657962845178535936',
      ordType: 'market',
      pnl: '-0.0267',
      posSide: 'net',
      px: '',
      pxType: '',
      pxUsd: '',
      pxVol: '',
      quickMgnType: '',
      rebate: '0',
      rebateCcy: 'USDT',
      reduceOnly: 'false',
      reqId: '',
      side: 'sell',
      slOrdPx: '',
      slTriggerPx: '',
      slTriggerPxType: '',
      source: '',
      state: 'filled',
      stpId: '',
      stpMode: '',
      sz: '1',
      tag: 'e847386590ce4dBC',
      tdMode: 'cross',
      tgtCcy: '',
      tpOrdPx: '',
      tpTriggerPx: '',
      tpTriggerPxType: '',
      tradeId: '790547349',
      uTime: '1703142566651'
    }
  ]
}
    timestamp |                 datetime |        symbol |        id |              order |   type | takerOrMaker | side |   price | amount |    cost |                                   fee |                                    fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1703142566650 | 2023-12-21T07:09:26.650Z | BTC/USDT:USDT | 790547349 | 657962845178535936 | market |        taker | sell | 43850.4 |      1 | 43.8504 | {"cost":-0.0219252,"currency":"USDT"} | [{"cost":-0.0219252,"currency":"USDT"}]
1 objects

$ n okx createOrder BTC/USDT:USDT market sell 1 --verbose --test
```
