### PR TITLE
fix(binance): watchTicker remove default timestamp value of this.milliseconds

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -955,13 +955,12 @@ export default class binance extends binanceRest {
             event = 'ticker';
         }
         let timestamp = undefined;
-        const now = this.milliseconds ();
         if (event === 'bookTicker') {
             // take the event timestamp, if available, for spot tickers it is not
-            timestamp = this.safeInteger (message, 'E', now);
+            timestamp = this.safeInteger (message, 'E');
         } else {
             // take the timestamp of the closing price for candlestick streams
-            timestamp = this.safeInteger (message, 'C', now);
+            timestamp = this.safeInteger (message, 'C');
         }
         const marketId = this.safeString (message, 's');
         const symbol = this.safeSymbol (marketId, undefined, undefined, marketType);


### PR DESCRIPTION


```
 % py binance watchTicker BTC/USDT                                                   
Python v3.9.6
CCXT v4.1.95
binance.watchTicker(BTC/USDT)
{'ask': 43647.99,
 'askVolume': 6.26465,
 'average': None,
 'baseVolume': 48550.26877,
 'bid': 43647.98,
 'bidVolume': 3.90963,
 'change': 754.65,
 'close': 43647.99,
 'datetime': '2023-12-21T09:24:12.023Z',
 'high': 44283.0,
 'info': {'A': '6.26465000',
          'B': '3.90963000',
          'C': 1703150652023,
          'E': 1703150652024,
          'F': 3329487515,
          'L': 3331335963,
          'O': 1703064252023,
          'P': '1.759',
          'Q': '0.01300000',
          'a': '43647.99000000',
          'b': '43647.98000000',
          'c': '43647.99000000',
          'e': '24hrTicker',
          'h': '44283.00000000',
          'l': '42675.00000000',
          'n': 1848449,
          'o': '42893.34000000',
          'p': '754.65000000',
          'q': '2119705215.93987500',
          's': 'BTCUSDT',
          'v': '48550.26877000',
          'w': '43660.00991635',
          'x': '42893.34000000'},
 'last': 43647.99,
 'low': 42675.0,
 'open': 42893.34,
 'percentage': 1.759,
 'previousClose': 42893.34,
 'quoteVolume': 2119705215.939875,
 'symbol': 'BTC/USDT',
 'timestamp': 1703150652023,
 'vwap': 43660.00991635}
 ```