### PR TITLE
fix(bitmart): fetchTicker remove default timestamp value of this.milliseconds

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1088,7 +1088,7 @@ export default class bitmart extends Exchange {
         //          "legal_coin_price":"0.1302699"
         //      }
         //
-        const timestamp = this.safeInteger (ticker, 'timestamp', this.milliseconds ());
+        const timestamp = this.safeInteger (ticker, 'timestamp');
         const marketId = this.safeString2 (ticker, 'symbol', 'contract_symbol');
         market = this.safeMarket (marketId, market);
         const symbol = market['symbol'];


### PR DESCRIPTION


```
% py bitmart fetchTicker BTC/USDT
Python v3.9.6
CCXT v4.1.95
bitmart.fetchTicker(BTC/USDT)
{'ask': 43630.01,
 'askVolume': 0.03084,
 'average': 43293.185,
 'baseVolume': 14487.489,
 'bid': 43629.98,
 'bidVolume': 0.00387,
 'change': 686.95,
 'close': 43636.66,
 'datetime': '2023-12-21T09:30:02.387Z',
 'high': 44280.0,
 'info': {'base_volume_24h': '14487.48900',
          'best_ask': '43630.01',
          'best_ask_size': '0.03084',
          'best_bid': '43629.98',
          'best_bid_size': '0.00387',
          'close_24h': '43636.66',
          'fluctuation': '+0.0160',
          'high_24h': '44280.00',
          'last_price': '43636.66',
          'low_24h': '42684.57',
          'open_24h': '42949.71',
          'quote_volume_24h': '632712191.44',
          'symbol': 'BTC_USDT',
          'timestamp': '1703151002387',
          'url': 'https://www.bitmart.com/trade?symbol=BTC_USDT'},
 'last': 43636.66,
 'low': 42684.57,
 'open': 42949.71,
 'percentage': 1.6,
 'previousClose': None,
 'quoteVolume': 632712191.44,
 'symbol': 'BTC/USDT',
 'timestamp': 1703151002387,
 'vwap': 43673.005821781815}
 ```