### PR TITLE
fix(bit2c): fetchTicker - removed timestamp data because it wasnt parsed from the response

### DIFF
--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -282,14 +282,13 @@ export default class bit2c extends Exchange {
 
     parseTicker (ticker, market: Market = undefined): Ticker {
         const symbol = this.safeSymbol (undefined, market);
-        const timestamp = this.milliseconds ();
         const averagePrice = this.safeString (ticker, 'av');
         const baseVolume = this.safeString (ticker, 'a');
         const last = this.safeString (ticker, 'll');
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': undefined,
             'low': undefined,
             'bid': this.safeString (ticker, 'h'),


### PR DESCRIPTION
```
% py bit2c fetchTicker BTC/NIS      
Python v3.9.6
CCXT v4.1.95
bit2c.fetchTicker(BTC/NIS)
{'ask': 160895.19,
 'askVolume': None,
 'average': 159679.34207813034,
 'baseVolume': 13.27510912,
 'bid': 159800.0,
 'bidVolume': None,
 'change': None,
 'close': 161216.15,
 'datetime': None,
 'high': None,
 'info': {'a': '13.27510912',
          'av': '159679.34207813033443192439549',
          'c': '2.4671321293168376929408362400',
          'h': '159800.0',
          'l': '160895.19',
          'll': '161216.15',
          'up': True},
 'last': 161216.15,
 'low': None,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/NIS',
 'timestamp': None,
 'vwap': None}
 ```