### PR TITLE
fix(bitfinex2,btcbox,kraken): fetchTicker - removed timestamp data because it wasnt parsed from the response

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1076,15 +1076,14 @@ export default class bitfinex2 extends Exchange {
         //         FRR_AMOUNT_AVAILABLE
         //     ]
         //
-        const timestamp = this.milliseconds ();
         const symbol = this.safeSymbol (undefined, market);
         const length = ticker.length;
         const last = this.safeString (ticker, length - 4);
         const percentage = this.safeString (ticker, length - 5);
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeString (ticker, length - 2),
             'low': this.safeString (ticker, length - 1),
             'bid': this.safeString (ticker, length - 10),

--- a/ts/src/btcbox.ts
+++ b/ts/src/btcbox.ts
@@ -180,13 +180,12 @@ export default class btcbox extends Exchange {
     }
 
     parseTicker (ticker, market: Market = undefined): Ticker {
-        const timestamp = this.milliseconds ();
         const symbol = this.safeSymbol (undefined, market);
         const last = this.safeString (ticker, 'last');
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeString (ticker, 'high'),
             'low': this.safeString (ticker, 'low'),
             'bid': this.safeString (ticker, 'buy'),

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -835,7 +835,6 @@ export default class kraken extends Exchange {
         //         "o":"2571.56000"
         //     }
         //
-        const timestamp = this.milliseconds ();
         const symbol = this.safeSymbol (undefined, market);
         const v = this.safeValue (ticker, 'v', []);
         const baseVolume = this.safeString (v, 1);
@@ -850,8 +849,8 @@ export default class kraken extends Exchange {
         const ask = this.safeValue (ticker, 'a', []);
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeString (high, 1),
             'low': this.safeString (low, 1),
             'bid': this.safeString (bid, 0),


### PR DESCRIPTION


```
% py bitfinex2 fetchTicker BTC/USDT
Python v3.9.6
CCXT v4.1.95
bitfinex2.fetchTicker(BTC/USDT)
{'ask': 43755.0,
 'askVolume': 8.01289863,
 'average': None,
 'baseVolume': 816.42173565,
 'bid': 43750.0,
 'bidVolume': 8.45502153,
 'change': -528.0,
 'close': 43747.0,
 'datetime': None,
 'high': 44275.0,
 'info': ['43750',
          '8.45502153',
          '43755',
          '8.01289863',
          '-528',
          '-0.01192547',
          '43747',
          '816.42173565',
          '44275',
          '43200'],
 'last': 43747.0,
 'low': 43200.0,
 'open': 44275.0,
 'percentage': -1.192547,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': None}
```

```
% py btcbox fetchTicker BTC/JPY   
Python v3.9.6
CCXT v4.1.95
btcbox.fetchTicker(BTC/JPY)
{'ask': 6237061.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 524.3689,
 'bid': 6226998.0,
 'bidVolume': None,
 'change': None,
 'close': 6226451.0,
 'datetime': None,
 'high': 6356263.0,
 'info': {'buy': '6226998',
          'high': '6356263',
          'last': '6226451',
          'low': '6210070',
          'sell': '6237061',
          'vol': '524.3689'},
 'last': 6226451.0,
 'low': 6210070.0,
 'open': None,
 'percentage': None,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/JPY',
 'timestamp': None,
 'vwap': None}
```

```
% py kraken fetchTicker BTC/USDT
Python v3.9.6
CCXT v4.1.95
kraken.fetchTicker(BTC/USDT)
{'ask': 43717.8,
 'askVolume': None,
 'average': 43681.6,
 'baseVolume': 308.42475908,
 'bid': 43716.4,
 'bidVolume': None,
 'change': 81.4,
 'close': 43722.3,
 'datetime': None,
 'high': 44250.0,
 'info': {'a': ['43717.80000', '1', '1.000'],
          'b': ['43716.40000', '1', '1.000'],
          'c': ['43722.30000', '0.05000062'],
          'h': ['44216.90000', '44250.00000'],
          'l': ['43329.10000', '43186.60000'],
          'o': '43640.90000',
          'p': ['43842.13183', '43881.83222'],
          't': ['2454', '5417'],
          'v': ['147.10810124', '308.42475908']},
 'last': 43722.3,
 'low': 43186.6,
 'open': 43640.9,
 'percentage': 0.1865222761217115,
 'previousClose': None,
 'quoteVolume': 13534243.530442482,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': 43881.83222}
 ```