### PR TITLE
Fix order cost on Kucoin

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -888,6 +888,7 @@ export default class kucoin extends kucoinRest {
         const tradeId = this.safeString (trade, 'tradeId');
         const price = this.safeString (trade, 'price');
         const amount = this.safeString (trade, 'size');
+        const cost = this.safeString (cost, 'dealFunds');
         const order = this.safeString (trade, 'orderId');
         const timestamp = this.safeIntegerProduct (trade, 'time', 0.000001);
         const feeCurrency = market['quote'];
@@ -910,7 +911,7 @@ export default class kucoin extends kucoinRest {
             'side': side,
             'price': price,
             'amount': amount,
-            'cost': undefined,
+            'cost': cost,
             'fee': fee,
         }, market);
     }


### PR DESCRIPTION
Currently cost is not correctly computed and dealFunds from Kucoin return the correct amount paid
      dealFunds: '244.1822198189524',
      