### PR TITLE
fix(bitfinex): watchTicker - removed timestamp data because it wasnt parsed from the response

### DIFF
--- a/ts/src/pro/bitfinex.ts
+++ b/ts/src/pro/bitfinex.ts
@@ -217,7 +217,6 @@ export default class bitfinex extends bitfinexRest {
         //         220.05,        // 10 LOW float Daily low
         //     ]
         //
-        const timestamp = this.milliseconds ();
         const marketId = this.safeString (subscription, 'pair');
         const symbol = this.safeSymbol (marketId);
         const channel = 'ticker';
@@ -230,8 +229,8 @@ export default class bitfinex extends bitfinexRest {
         }
         const result = {
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeFloat (message, 9),
             'low': this.safeFloat (message, 10),
             'bid': this.safeFloat (message, 1),


### PR DESCRIPTION


```
 % py bitfinex watchTicker BTC/USDT
Python v3.9.6
CCXT v4.1.95
bitfinex.watchTicker(BTC/USDT)
{'ask': 43637.0,
 'askVolume': None,
 'average': None,
 'baseVolume': 816.70333249,
 'bid': 43635.0,
 'bidVolume': None,
 'change': -639.0,
 'close': 43635.0,
 'datetime': '2023-12-21T15:13:05.913Z',
 'high': 44274.0,
 'info': [112684,
          43635,
          10.15332827,
          43637,
          5.10664131,
          -639,
          -0.01443285,
          43635,
          816.70333249,
          44274,
          43200],
 'last': 43635.0,
 'low': 43200.0,
 'open': 44274.0,
 'percentage': -0.01443285,
 'previousClose': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT',
 'timestamp': 1703171585913,
 'vwap': None}
```