### PR TITLE
fix(woo,kraken): watchTicker - removed timestamp data because it wasnt parsed from the response

### DIFF
--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -333,11 +333,10 @@ export default class kraken extends krakenRest {
             quoteVolume = Precise.stringMul (baseVolume, vwap);
         }
         const last = this.safeString (ticker['c'], 0);
-        const timestamp = this.milliseconds ();
         const result = this.safeTicker ({
             'symbol': symbol,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeString (ticker['h'], 0),
             'low': this.safeString (ticker['l'], 0),
             'bid': this.safeString (ticker['b'], 0),

--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -151,11 +151,10 @@ export default class woo extends wooRest {
         //         "count": 3689
         //     }
         //
-        const timestamp = this.safeInteger (ticker, 'date', this.milliseconds ());
         return this.safeTicker ({
             'symbol': this.safeSymbol (undefined, market),
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': this.safeString (ticker, 'high'),
             'low': this.safeString (ticker, 'low'),
             'bid': undefined,


### PR DESCRIPTION


```
% py kraken watchTicker BTC/USDT
Python v3.9.6
CCXT v4.1.95
kraken.watchTicker(BTC/USDT)
{'ask': 43713.2,
 'askVolume': 0.10292988,
 'average': 43677.05,
 'baseVolume': 183.82899713,
 'bid': 43712.7,
 'bidVolume': 0.57191241,
 'change': 72.3,
 'close': 43713.2,
 'datetime': None,
 'high': 44216.9,
 'info': {'a': ['43713.20000', 0, '0.10292988'],
          'b': ['43712.70000', 0, '0.57191241'],
          'c': ['43713.20000', '0.01098398'],
          'h': ['44216.90000', '44250.00000'],
          'l': ['43329.10000', '43186.60000'],
          'o': ['43640.90000', '44082.10000'],
          'p': ['43827.53525', '43849.54509'],
          't': [2889, 5367],
          'v': ['183.82899713', '320.09176090']},
 'last': 43713.2,
 'low': 43329.1,
 'open': 43640.9,
 'percentage': 0.1656702771941,
 'previousClose': None,
 'quoteVolume': 8056771.851687224,
 'symbol': 'BTC/USDT',
 'timestamp': None,
 'vwap': 43827.53525}
```

```
% py woo watchTicker BTC/USDT 
Python v3.9.6
CCXT v4.1.95
woo.watchTicker(BTC/USDT)
{'ask': None,
 'askVolume': None,
 'average': 43914.215,
 'baseVolume': 625.26464,
 'bid': None,
 'bidVolume': None,
 'change': -373.23,
 'close': 43727.6,
 'datetime': '2023-12-21T15:54:20.000Z',
 'high': 44262.5,
 'info': {'aggregatedAmount': 1943427135.1559541,
          'aggregatedQuantity': 44405.883502,
          'amount': 27422274.62635382,
          'close': 43727.6,
          'count': 14587,
          'date': 1703174060000,
          'high': 44262.5,
          'lastTs': 1703174059483,
          'low': 43197.4,
          'open': 44100.83,
          'symbol': 'SPOT_BTC_USDT',
          'volume': 625.26464},
 'last': 43727.6,
 'low': 43197.4,
 'open': 44100.83,
 'percentage': -0.846310602317462,
 'previousClose': None,
 'quoteVolume': 27422274.62635382,
 'symbol': 'BTC/USDT',
 'timestamp': 1703174060000,
 'vwap': 43857.06926646903}
```