### PR TITLE
fix(cex) - watchOrders removed default timestamp value of this.milliseconds from the response

### DIFF
--- a/ts/src/pro/cex.ts
+++ b/ts/src/pro/cex.ts
@@ -755,7 +755,7 @@ export default class cex extends cexRest {
                 'rate': undefined,
             };
         }
-        const timestamp = this.safeInteger (data, 'time', this.milliseconds ());
+        const timestamp = this.safeInteger (data, 'time');
         order['timestamp'] = timestamp;
         order['datetime'] = this.iso8601 (timestamp);
         order = this.safeOrder (order);


### PR DESCRIPTION


I'm having trouble testing it out because calling `cex watchOrders XRP/USD` produces the error `cex open-orders Invalid pair:XRP:USD`, but it's a small change