### PR TITLE
Coinbase: parseOrder, stop orders

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -2385,6 +2385,12 @@ export default class coinbase extends Exchange {
         //                 "base_size": "0.2",
         //                 "limit_price": "0.006",
         //                 "post_only": false
+        //             },
+        //             "stop_limit_stop_limit_gtc": {
+        //                 "base_size": "48.54",
+        //                 "limit_price": "6.998",
+        //                 "stop_price": "7.0687",
+        //                 "stop_direction": "STOP_DIRECTION_STOP_DOWN"
         //             }
         //         },
         //         "side": "SELL",
@@ -2418,11 +2424,11 @@ export default class coinbase extends Exchange {
             market = this.market (symbol);
         }
         const orderConfiguration = this.safeValue (order, 'order_configuration', {});
-        const limitGTC = this.safeValue (orderConfiguration, 'limit_limit_gtc', {});
-        const limitGTD = this.safeValue (orderConfiguration, 'limit_limit_gtd', {});
-        const stopLimitGTC = this.safeValue (orderConfiguration, 'stop_limit_stop_limit_gtc', {});
-        const stopLimitGTD = this.safeValue (orderConfiguration, 'stop_limit_stop_limit_gtd', {});
-        const marketIOC = this.safeValue (orderConfiguration, 'market_market_ioc', {});
+        const limitGTC = this.safeValue (orderConfiguration, 'limit_limit_gtc');
+        const limitGTD = this.safeValue (orderConfiguration, 'limit_limit_gtd');
+        const stopLimitGTC = this.safeValue (orderConfiguration, 'stop_limit_stop_limit_gtc');
+        const stopLimitGTD = this.safeValue (orderConfiguration, 'stop_limit_stop_limit_gtd');
+        const marketIOC = this.safeValue (orderConfiguration, 'market_market_ioc');
         const isLimit = ((limitGTC !== undefined) || (limitGTD !== undefined));
         const isStop = ((stopLimitGTC !== undefined) || (stopLimitGTD !== undefined));
         let price = undefined;


### PR DESCRIPTION
Fix parseOrder so that stop orders can return the triggerPrice:
fixes: #20487

```
coinbase.fetchOpenOrders (BTC/USDC)
2023-12-22T05:47:59.696Z iteration 0 passed in 571 ms

                                  id |                        clientOrderId |     timestamp |                    datetime |   symbol | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | filled | remaining | cost | status |                            fee | trades |                           fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
d6e85291-ff38-4bbf-8d86-e0b94c2298c6 | bb968f90-07ea-43c2-b54c-892a2205c7ef | 1703223891794 | 2023-12-22T05:44:51.794143Z | BTC/USDC |         GTC |    false |  buy | 35000 |     36000 |        36000 | 0.0001 |      0 |    0.0001 |    0 |   open | {"cost":"0","currency":"USDC"} |     [] | [{"cost":0,"currency":"USDC"}]
1 objects
```