### PR TITLE
Kraken: update trailing stop unification

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1377,7 +1377,9 @@ export default class kraken extends Exchange {
          * @param {bool} [params.reduceOnly] *margin only* indicates if this order is to reduce the size of a position
          * @param {float} [params.stopLossPrice] *margin only* the price that a stop loss order is triggered at
          * @param {float} [params.takeProfitPrice] *margin only* the price that a take profit order is triggered at
-         * @param {string} [params.trailingStopPrice] *margin only* the quote amount to trail away from the current market price
+         * @param {string} [params.trailingStopAmount] *margin only* the quote amount to trail away from the current market price
+         * @param {string} [params.trailingStopLimitAmount] *margin only* the quote amount away from the trailingStopAmount
+         * @param {string} [params.offset] *margin only* '+' or '-' whether you want the trailingStopLimitAmount value to be positive or negative, default is negative '-'
          * @param {string} [params.trigger] *margin only* the activation price type, 'last' or 'index', default is 'last'
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
@@ -1637,9 +1639,10 @@ export default class kraken extends Exchange {
         const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
         const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
         const isStopLossOrTakeProfitTrigger = isStopLossTriggerOrder || isTakeProfitTriggerOrder;
-        const trailingStopPrice = this.safeString (params, 'trailingStopPrice');
-        const isTrailingStopPriceOrder = trailingStopPrice !== undefined;
-        if (type === 'limit') {
+        const trailingStopAmount = this.safeString (params, 'trailingStopAmount');
+        const trailingStopLimitAmount = this.safeString (params, 'trailingStopLimitAmount');
+        const isTrailingStopAmountOrder = trailingStopAmount !== undefined;
+        if ((type === 'limit') && !isTrailingStopAmountOrder) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
         let reduceOnly = this.safeValue2 (params, 'reduceOnly', 'reduce_only');
@@ -1653,18 +1656,18 @@ export default class kraken extends Exchange {
             }
             request['price2'] = this.priceToPrecision (symbol, price);
             reduceOnly = true;
-        } else if (isTrailingStopPriceOrder) {
+        } else if (isTrailingStopAmountOrder) {
             const trailingStopActivationPriceType = this.safeString (params, 'trigger', 'last');
-            const trailingStopPriceString = '+' + trailingStopPrice;
+            const trailingStopAmountString = '+' + trailingStopAmount;
             request['trigger'] = trailingStopActivationPriceType;
-            reduceOnly = true;
-            if (type === 'limit') {
-                const trailingStopLimitPriceString = '+' + this.numberToString (price);
-                request['price'] = trailingStopPriceString;
-                request['price2'] = trailingStopLimitPriceString;
+            if ((type === 'limit') || (trailingStopLimitAmount !== undefined)) {
+                const offset = this.safeString (params, 'offset', '-');
+                const trailingStopLimitAmountString = offset + this.numberToString (trailingStopLimitAmount);
+                request['price'] = trailingStopAmountString;
+                request['price2'] = trailingStopLimitAmountString;
                 request['ordertype'] = 'trailing-stop-limit';
             } else {
-                request['price'] = trailingStopPriceString;
+                request['price'] = trailingStopAmountString;
                 request['ordertype'] = 'trailing-stop';
             }
         }
@@ -1694,7 +1697,7 @@ export default class kraken extends Exchange {
         if (postOnly) {
             request['oflags'] = 'post';
         }
-        params = this.omit (params, [ 'timeInForce', 'reduceOnly', 'stopLossPrice', 'takeProfitPrice', 'trailingStopPrice' ]);
+        params = this.omit (params, [ 'timeInForce', 'reduceOnly', 'stopLossPrice', 'takeProfitPrice', 'trailingStopAmount', 'trailingStopLimitAmount', 'offset' ]);
         return [ request, params ];
     }
 
@@ -1713,7 +1716,9 @@ export default class kraken extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {float} [params.stopLossPrice] *margin only* the price that a stop loss order is triggered at
          * @param {float} [params.takeProfitPrice] *margin only* the price that a take profit order is triggered at
-         * @param {string} [params.trailingStopPrice] *margin only* the quote price away from the current market price
+         * @param {string} [params.trailingStopAmount] *margin only* the quote price away from the current market price
+         * @param {string} [params.trailingStopLimitAmount] *margin only* the quote amount away from the trailingStopAmount
+         * @param {string} [params.offset] *margin only* '+' or '-' whether you want the trailingStopLimitAmount value to be positive or negative, default is negative '-'
          * @param {string} [params.trigger] *margin only* the activation price type, 'last' or 'index', default is 'last'
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -65,21 +65,41 @@
                 "output": "nonce=1703055164304&pair=XXBTZUSD&type=sell&ordertype=take-profit-limit&volume=0.0001&price=45000&price2=46000&reduce_only=true&leverage=5"
             },
             {
-                "description": "Margin trailing stop price order",
+                "description": "Margin trailing stop order",
                 "method": "createOrder",
                 "url": "https://api.kraken.com/0/private/AddOrder",
                 "input": [
                   "BTC/USD",
                   "market",
                   "sell",
-                  0.00012,
+                  0.0002,
                   null,
                   {
-                    "trailingStopPrice": 10,
-                    "leverage": 5
+                    "trailingStopAmount": 100,
+                    "leverage": 5,
+                    "reduceOnly": true
                   }
                 ],
-                "output": "nonce=1702712084560&pair=XXBTZUSD&type=sell&ordertype=trailing-stop&volume=0.00012&trigger=last&price=%2B10&reduce_only=true&leverage=5"
+                "output": "nonce=1703236727221&pair=XXBTZUSD&type=sell&ordertype=trailing-stop&volume=0.0002&trigger=last&price=%2B100&reduce_only=true&leverage=5"
+            },
+            {
+                "description": "Margin trailing stop limit order",
+                "method": "createOrder",
+                "url": "https://api.kraken.com/0/private/AddOrder",
+                "input": [
+                  "BTC/USD",
+                  "limit",
+                  "sell",
+                  0.0002,
+                  null,
+                  {
+                    "trailingStopAmount": 100,
+                    "trailingStopLimitAmount": 100,
+                    "leverage": 5,
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "nonce=1703236604802&pair=XXBTZUSD&type=sell&ordertype=trailing-stop-limit&volume=0.0002&trigger=last&price=%2B100&price2=-100&reduce_only=true&leverage=5"
             }
         ],
         "fetchMyTrades": [


### PR DESCRIPTION
Edit kraken trailing stop implementation to use the parameter `trailingStopAmount` instead of `trailingStopPrice` and add a static request test for a trailing stop limit order:
```
kraken createOrder BTC/USD limit sell 0.0002 undefined '{"trailingStopAmount":100,"trailingStopLimitAmount":100,"leverage":5,"reduceOnly":true}'

kraken.createOrder (BTC/USD, limit, sell, 0.0002, , [object Object])
2023-12-22T09:16:44.941Z iteration 0 passed in 1143 ms

{
  id: 'OVRCDJ-E5I3V-BFX5CK',
  info: {
    txid: [ 'OVRCDJ-E5I3V-BFX5CK' ],
    descr: {
      order: 'sell 0.00020000 XBTUSD @ trailing stop -100.0 -> limit -100.0 with 5:1 leverage'
    }
  },
  symbol: 'BTC/USD',
  type: 'trailing',
  postOnly: false,
  side: 'sell',
  amount: 0.0002,
  trades: [],
  fees: []
}
```