### PR TITLE
bitvavo: add clientOrderId

### DIFF
--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -1090,6 +1090,10 @@ export default class bitvavo extends Exchange {
         if (postOnly) {
             request['postOnly'] = true;
         }
+        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
+        if (clientOrderId !== undefined) {
+            request['clientOrderId'] = clientOrderId;
+        }
         const response = await this.privatePostOrder (this.extend (request, params));
         //
         //      {

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -1028,6 +1028,7 @@ export default class bitvavo extends Exchange {
          * @param {string} [params.selfTradePrevention] "decrementAndCancel", "cancelOldest", "cancelNewest", "cancelBoth"
          * @param {bool} [params.disableMarketProtection] don't cancel if the next fill price is 10% worse than the best fill price
          * @param {bool} [params.responseRequired] Set this to 'false' when only an acknowledgement of success or failure is required, this is faster.
+         * @param {string} [params.clientOrderId] An ID supplied by the client that must be unique among all open orders for the same market
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1089,10 +1090,6 @@ export default class bitvavo extends Exchange {
         }
         if (postOnly) {
             request['postOnly'] = true;
-        }
-        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
         }
         const response = await this.privatePostOrder (this.extend (request, params));
         //
@@ -1156,6 +1153,7 @@ export default class bitvavo extends Exchange {
          * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
          * @param {string} [params.selfTradePrevention] "decrementAndCancel", "cancelOldest", "cancelNewest", "cancelBoth"
          * @param {bool} [params.responseRequired] Set this to 'false' when only an acknowledgement of success or failure is required, this is faster.
+         * @param {string} [params.clientOrderId] An ID supplied by the client
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1163,15 +1161,13 @@ export default class bitvavo extends Exchange {
         const request = {
             'market': market['id'],
         };
-        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
-        } else {
+        const clientOrderId = this.safeString (params, 'clientOrderId');
+        if (clientOrderId === undefined) {
             request['orderId'] = id;
         }
         const amountRemaining = this.safeNumber (params, 'amountRemaining');
         const triggerPrice = this.safeStringN (params, [ 'triggerPrice', 'stopPrice', 'triggerAmount' ]);
-        params = this.omit (params, [ 'amountRemaining', 'triggerPrice', 'stopPrice', 'triggerAmount', 'clientOid', 'clientOrderId' ]);
+        params = this.omit (params, [ 'amountRemaining', 'triggerPrice', 'stopPrice', 'triggerAmount' ]);
         let updateRequest = {};
         if (price !== undefined) {
             updateRequest['price'] = this.priceToPrecision (symbol, price);
@@ -1199,6 +1195,7 @@ export default class bitvavo extends Exchange {
          * @method
          * @name bitvavo#cancelOrder
          * @description cancels an open order
+         * @see https://docs.bitvavo.com/#tag/Trading-endpoints/paths/~1order/delete
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1212,13 +1209,10 @@ export default class bitvavo extends Exchange {
         const request = {
             'market': market['id'],
         };
-        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
-        } else {
+        const clientOrderId = this.safeString (params, 'clientOrderId');
+        if (clientOrderId === undefined) {
             request['orderId'] = id;
         }
-        params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
         const response = await this.privateDeleteOrder (this.extend (request, params));
         //
         //     {
@@ -1260,6 +1254,7 @@ export default class bitvavo extends Exchange {
          * @method
          * @name bitvavo#fetchOrder
          * @description fetches information on an order made by the user
+         * @see https://docs.bitvavo.com/#tag/Trading-endpoints/paths/~1order/get
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -1272,13 +1267,10 @@ export default class bitvavo extends Exchange {
         const request = {
             'market': market['id'],
         };
-        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
-        } else {
+        const clientOrderId = this.safeString (params, 'clientOrderId');
+        if (clientOrderId === undefined) {
             request['orderId'] = id;
         }
-        params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
         const response = await this.privateGetOrder (this.extend (request, params));
         //
         //     {

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -1270,9 +1270,15 @@ export default class bitvavo extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'orderId': id,
             'market': market['id'],
         };
+        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
+        if (clientOrderId !== undefined) {
+            request['clientOrderId'] = clientOrderId;
+        } else {
+            request['orderId'] = id;
+        }
+        params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
         const response = await this.privateGetOrder (this.extend (request, params));
         //
         //     {

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -1183,9 +1183,15 @@ export default class bitvavo extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'orderId': id,
             'market': market['id'],
         };
+        const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId');
+        if (clientOrderId !== undefined) {
+            request['clientOrderId'] = clientOrderId;
+        } else {
+            request['orderId'] = id;
+        }
+        params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
         const response = await this.privateDeleteOrder (this.extend (request, params));
         //
         //     {

--- a/ts/src/test/static/markets/bitvavo.json
+++ b/ts/src/test/static/markets/bitvavo.json
@@ -129,5 +129,137 @@
                 ]
             ]
         }
+    },
+    "LTC/EUR": {
+        "id": "LTC-EUR",
+        "symbol": "LTC/EUR",
+        "base": "LTC",
+        "quote": "EUR",
+        "baseId": "LTC",
+        "quoteId": "EUR",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "index": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0025,
+        "maker": 0.002,
+        "precision": {
+            "amount": 8,
+            "price": 5
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.01
+            },
+            "price": {},
+            "cost": {
+                "min": 5
+            }
+        },
+        "info": {
+            "market": "LTC-EUR",
+            "status": "trading",
+            "base": "LTC",
+            "quote": "EUR",
+            "pricePrecision": "5",
+            "minOrderInBaseAsset": "0.01",
+            "minOrderInQuoteAsset": "5",
+            "maxOrderInBaseAsset": "1000000000",
+            "maxOrderInQuoteAsset": "1000000000",
+            "orderTypes": [
+                "market",
+                "limit",
+                "stopLoss",
+                "stopLossLimit",
+                "takeProfit",
+                "takeProfitLimit"
+            ]
+        },
+        "tierBased": true,
+        "percentage": true,
+        "tiers": {
+            "taker": [
+                [
+                    0,
+                    0.0025
+                ],
+                [
+                    100000,
+                    0.002
+                ],
+                [
+                    250000,
+                    0.0016
+                ],
+                [
+                    500000,
+                    0.0012
+                ],
+                [
+                    1000000,
+                    0.001
+                ],
+                [
+                    2500000,
+                    0.0008
+                ],
+                [
+                    5000000,
+                    0.0006
+                ],
+                [
+                    10000000,
+                    0.0005
+                ],
+                [
+                    25000000,
+                    0.0004
+                ]
+            ],
+            "maker": [
+                [
+                    0,
+                    0.0015
+                ],
+                [
+                    100000,
+                    0.001
+                ],
+                [
+                    250000,
+                    0.0008
+                ],
+                [
+                    500000,
+                    0.0006
+                ],
+                [
+                    1000000,
+                    0.0005
+                ],
+                [
+                    2500000,
+                    0.0004
+                ],
+                [
+                    5000000,
+                    0.0004
+                ],
+                [
+                    10000000,
+                    0.0003
+                ],
+                [
+                    25000000,
+                    0.0003
+                ]
+            ]
+        }
     }
 }

--- a/ts/src/test/static/request/bitvavo.json
+++ b/ts/src/test/static/request/bitvavo.json
@@ -79,6 +79,18 @@
                   "42a876f3-400d-4686-980f-3d6983f251c2",
                   "BTC/EUR"
                 ]
+            },
+            {
+                "description": "Cancel Order",
+                "method": "cancelOrder",
+                "url": "https://api.bitvavo.com/v2/order?clientOrderId=42a876f3-400d-4686-980f-3d6983f251c2&market=BTC-EUR",
+                "input": [
+                  "",
+                  "BTC/EUR",
+                  {
+                    "clientOrderId": "42a876f3-400d-4686-980f-3d6983f251c2"
+                  }
+                ]
             }
         ],
         "editOrder": [

--- a/ts/src/test/static/request/bitvavo.json
+++ b/ts/src/test/static/request/bitvavo.json
@@ -68,6 +68,22 @@
                   }
                 ],
                 "output": "{\"market\":\"BTC-EUR\",\"side\":\"buy\",\"orderType\":\"stopLoss\",\"amount\":\"0.0002\",\"triggerAmount\":\"30000\",\"triggerType\":\"price\",\"triggerReference\":\"lastTrade\"}"
+              },
+              {
+                "description": "Create order with clientOrderId",
+                "method": "createOrder",
+                "url": "https://api.bitvavo.com/v2/order",
+                "input": [
+                  "LTC/EUR",
+                  "market",
+                  "buy",
+                  0.05,
+                  null,
+                  {
+                    "clientOrderId": "2be7d0df-d8dc-7b93-a550-8876f3b393e9"
+                  }
+                ],
+                "output": "{\"market\":\"LTC-EUR\",\"side\":\"buy\",\"orderType\":\"market\",\"amount\":\"0.05\",\"clientOrderId\":\"2be7d0df-d8dc-7b93-a550-8876f3b393e9\"}"
               }
         ],
         "cancelOrder": [
@@ -128,13 +144,25 @@
         ],
         "fetchOrder": [
             {
-                "description": "Fill this with a description of the method call",
+                "description": "fetch order",
                 "method": "fetchOrder",
                 "url": "https://api.bitvavo.com/v2/order?orderId=24bcd0e3-43f7-43f3-97f0-04df043e2d45&market=BTC-EUR",
                 "input": [
                   "24bcd0e3-43f7-43f3-97f0-04df043e2d45",
                   "BTC/EUR"
                 ]
+            },
+            {
+              "description": "fetch order with clientOrderId",
+              "method": "fetchOrder",
+              "url": "https://api.bitvavo.com/v2/order?market=LTC-EUR&clientOrderId=2be7d0df-d8dc-7b93-a550-8876f3b393e9",
+              "input": [
+                "random",
+                "LTC/EUR",
+                {
+                  "clientOrderId": "2be7d0df-d8dc-7b93-a550-8876f3b393e9"
+                }
+              ]
             }
         ],
         "cancelAllOrders": [

--- a/ts/src/test/static/request/bitvavo.json
+++ b/ts/src/test/static/request/bitvavo.json
@@ -95,6 +95,23 @@
                   32000
                 ],
                 "output": "{\"price\":\"32000\",\"orderId\":\"24bcd0e3-43f7-43f3-97f0-04df043e2d45\",\"market\":\"BTC-EUR\"}"
+            },
+            {
+                "description": "Edit Order, edit price",
+                "method": "editOrder",
+                "url": "https://api.bitvavo.com/v2/order",
+                "input": [
+                  "",
+                  "BTC/EUR",
+                  "limit",
+                  "buy",
+                  null,
+                  32000,
+                  {
+                    "clientOrderId": "24bcd0e3-43f7-43f3-97f0-04df043e2d45"
+                  }
+                ],
+                "output": "{\"price\":\"32000\",\"clientOrderId\":\"24bcd0e3-43f7-43f3-97f0-04df043e2d45\",\"market\":\"BTC-EUR\"}"
             }
         ],
         "fetchOrder": [


### PR DESCRIPTION
@carlosmiei the `triggerAmount` seems not work for put order api after test (https://docs.bitvavo.com/#tag/Trading-endpoints/paths/~1order/put).

```BASH
$ p bitvavo fetchOrder '' ETH/EUR 
$ p bitvavo fetchOrder 'None' ETH/EUR '{"clientOrderId":"2be7d0df-d8dc-7b93-a550-8876f3b393e2"}'
$ p bitvavo createOrder ETH/EUR limit buy 0.01 1000 '{"clientOrderId":"2be7d0df-d8dc-7b93-a550-8876f3b393e2","triggerPrice":1100}'
$ p bitvavo editOrder 'None' ETH/EUR limit buy 0.009 1000 '{"clientOrderId":"2be7d0df-d8dc-7b93-a550-8876f3b393e2","triggerPrice":1101}'
$ p bitvavo cancelOrder 'None' ETH/EUR '{"clientOrderId":"2be7d0df-d8dc-7b93-a550-8876f3b393e2"}'
```