### PR TITLE
bitget parseTrade fix

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2899,7 +2899,7 @@ export default class bitget extends Exchange {
             const currencyCode = this.safeCurrencyCode (this.safeString (feeStructure, 'feeCoin'));
             fee = {
                 'currency': currencyCode,
-                'cost': Precise.stringNeg (this.safeString (feeStructure, 'totalFee')),
+                'cost': this.safeString (feeStructure, 'totalFee'),
             };
         }
         return this.safeTrade ({

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2899,7 +2899,7 @@ export default class bitget extends Exchange {
             const currencyCode = this.safeCurrencyCode (this.safeString (feeStructure, 'feeCoin'));
             fee = {
                 'currency': currencyCode,
-                'cost': this.safeString (feeStructure, 'totalFee'),
+                'cost': Precise.stringAbs (this.safeString (feeStructure, 'totalFee')),
             };
         }
         return this.safeTrade ({


### PR DESCRIPTION
https://www.bitget.com/api-doc/spot/trade/Get-Fills
I don't have any rebate and i get in response:
```
feeDetail: {
      deduction: 'yes',
      feeCoin: 'BGB',
      totalDeductionFee: '0',
      totalFee: '0.0028387569687715'
    },
```

<img width="329" alt="2023-12-22_14h57_49" src="https://github.com/ccxt/ccxt/assets/38309641/125ddf25-5ca4-4334-a3ee-68bc532c9f14">

So no need to use `stringNeg` here