### PR TITLE
BingX: watchOHLCV, add timestamp for swap markets

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -314,8 +314,11 @@ export default class bingx extends bingxRest {
         //        "t": 1696687440000
         //    }
         //
+        // for spot, opening-time (t) is used instead of closing-time (T), to be compatible with fetchOHLCV
+        // for swap, (T) is the opening time
+        const timestamp = (market['spot']) ? 't' : 'T';
         return [
-            this.safeInteger (ohlcv, 't'), // needs to be opening-time (t) instead of closing-time (T), to be compatible with fetchOHLCV
+            this.safeInteger (ohlcv, timestamp),
             this.safeNumber (ohlcv, 'o'),
             this.safeNumber (ohlcv, 'h'),
             this.safeNumber (ohlcv, 'l'),


### PR DESCRIPTION
Added a timestamp value for swap markets to `watchOHLCV`:
fixes: #20515
```
bingx.watchOHLCV (BTC/USDT:USDT)

onMessage {
  code: 0,
  dataType: 'BTC-USDT@kline_1m',
  s: 'BTC-USDT',
  data: [
    {
      c: '43561.3',
      o: '43557.5',
      h: '43563.0',
      l: '43553.0',
      v: '13.8908',
      T: 1703300820000
    }
  ]
}
[ [ 1703300820000, 43557.5, 43563, 43553, 43561.3, 13.8908 ] ]
```