### PR TITLE
fix(bingx): update watchBalance

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -891,10 +891,15 @@ export default class bingx extends bingxRest {
             const currencyId = this.safeString (balance, 'a');
             const code = this.safeCurrencyCode (currencyId);
             const account = (code in this.balance[type]) ? this.balance[type][code] : this.account ();
-            account['free'] = this.safeString (balance, 'wb');
+            const free = this.safeString (balance, 'wb');
+            const used = this.safeString (account, 'used');
             const balanceChange = this.safeString (balance, 'bc');
-            if (account['used'] !== undefined) {
-                account['used'] = Precise.stringSub (this.safeString (account, 'used'), balanceChange);
+            account['free'] = free;
+            if (used !== undefined) {
+                account['used'] = Precise.stringSub (used, balanceChange);
+                if (free !== undefined) {
+                    account['total'] = Precise.stringAdd (free, used);
+                }
             }
             this.balance[type][code] = account;
         }


### PR DESCRIPTION
fix: ccxt/ccxt#20508

@carlosmiei the issue can be reproduced when order was executed (buy or sell). I think we probably can't set `used` value only by balance change value. eg, if user has open limit order to sell ada, and he buy ada token in market price, the used value would be correct for limit order, but used value would be smaller after market order execute (bc would be positive, the used value = used - balance change)

Should we remove used value?