### PR TITLE
BingX: trailing orders

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1748,7 +1748,7 @@ export default class bingx extends Exchange {
                 if (isTrailingAmountOrder) {
                     request['price'] = trailingAmount;
                 } else if (isTrailingPercentOrder) {
-                    const requestTrailingPercent = Precise.stringDiv (trailingPercent, '100')
+                    const requestTrailingPercent = Precise.stringDiv (trailingPercent, '100');
                     request['priceRate'] = this.parseToNumeric (requestTrailingPercent);
                 }
             }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1746,7 +1746,7 @@ export default class bingx extends Exchange {
             } else if (isTrailing) {
                 request['type'] = 'TRAILING_STOP_MARKET';
                 if (isTrailingAmountOrder) {
-                    request['price'] = trailingAmount;
+                    request['price'] = this.parseToNumeric (trailingAmount);
                 } else if (isTrailingPercentOrder) {
                     const requestTrailingPercent = Precise.stringDiv (trailingPercent, '100');
                     request['priceRate'] = this.parseToNumeric (requestTrailingPercent);

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1703,10 +1703,10 @@ export default class bingx extends Exchange {
             } else if (timeInForce === 'FOK') {
                 request['timeInForce'] = 'FOK';
             }
-            const triggerPrice = this.safeNumber2 (params, 'stopPrice', 'triggerPrice');
-            const stopLossPrice = this.safeNumber (params, 'stopLossPrice');
-            const takeProfitPrice = this.safeNumber (params, 'takeProfitPrice');
-            const trailingAmount = this.safeNumber (params, 'trailingAmount');
+            const triggerPrice = this.safeString2 (params, 'stopPrice', 'triggerPrice');
+            const stopLossPrice = this.safeString (params, 'stopLossPrice');
+            const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
+            const trailingAmount = this.safeString (params, 'trailingAmount');
             const trailingPercent = this.safeString2 (params, 'trailingPercent', 'priceRate');
             const isTriggerOrder = triggerPrice !== undefined;
             const isStopLossPriceOrder = stopLossPrice !== undefined;

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -200,6 +200,38 @@
                         "stopLossPrice": "40000"
                     }
                 ]
+            },
+            {
+                "description": "Swap trailing amount order",
+                "method": "createOrder",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=100&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1703311717708&type=TRAILING_STOP_MARKET&signature=af450249b24a125292d4a81bbcda3445ea20a85dd858734e6ddacf36e999cf21",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  {
+                    "trailingAmount": 100,
+                    "reduceOnly": true
+                  }
+                ]
+            },
+            {
+                "description": "Swap trailing percent order",
+                "method": "createOrder",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&priceRate=0.1&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1703312086044&type=TRAILING_STOP_MARKET&signature=d2f180a1a328e08f679de56f255c452d9ad469f4eb445659397ef297390e6cfe",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  {
+                    "trailingPercent": 10,
+                    "reduceOnly": true
+                  }
+                ]
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Added `trailingAmount` and `trailingPercent` support to BingX:

### trailingAmount:
```
bingx createOrder BTC/USDT:USDT market sell 0.0001 undefined '{"trailingAmount":100,"reduceOnly":true}'

bingx.createOrder (BTC/USDT:USDT, market, sell, 0.0001, , [object Object])
2023-12-23T06:08:38.060Z iteration 0 passed in 1353 ms

{
  info: {
    symbol: 'BTC-USDT',
    orderId: '0',
    side: 'SELL',
    positionSide: 'LONG',
    type: 'TRAILING_STOP_MARKET',
    clientOrderID: '',
    workingType: 'MARK_PRICE',
    reduceOnly: false
  },
  id: '0',
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop_market',
  side: 'sell',
  fee: { currency: 'USDT' },
  trades: [],
  fees: [ { currency: 'USDT' } ]
}
```

### trailingPercent:
```
bingx createOrder BTC/USDT:USDT market sell 0.0001 undefined '{"trailingPercent":10,"reduceOnly":true}'

bingx.createOrder (BTC/USDT:USDT, market, sell, 0.0001, , [object Object])
2023-12-23T06:14:46.350Z iteration 0 passed in 1310 ms

{
  info: {
    symbol: 'BTC-USDT',
    orderId: '0',
    side: 'SELL',
    positionSide: 'LONG',
    type: 'TRAILING_STOP_MARKET',
    clientOrderID: '',
    workingType: 'MARK_PRICE',
    reduceOnly: false
  },
  id: '0',
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop_market',
  side: 'sell',
  fee: { currency: 'USDT' },
  trades: [],
  fees: [ { currency: 'USDT' } ]
}
```