### PR TITLE
fix(kucoin): reset url store when token is expired

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -54,8 +54,9 @@ export default class kucoin extends kucoinRest {
     negotiate (privateChannel, params = {}) {
         const connectId = privateChannel ? 'private' : 'public';
         const urls = this.safeValue (this.options, 'urls', {});
-        if (connectId in urls) {
-            return urls[connectId];
+        const spawaned = this.safeValue (urls, connectId);
+        if (spawaned !== undefined) {
+            return spawaned;
         }
         // we store an awaitable to the url
         // so that multiple calls don't asynchronously
@@ -1055,6 +1056,10 @@ export default class kucoin extends kucoinRest {
         //    }
         //
         const data = this.safeString (message, 'data', '');
+        if (data === "token is expired") {
+            const type = client.url.substring (client.url.indexOf ('connectId=') + 10);
+            this.options['urls'][type] = undefined;
+        }
         this.handleErrors (undefined, undefined, client.url, undefined, undefined, data, message, undefined, undefined);
     }
 

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1057,7 +1057,10 @@ export default class kucoin extends kucoinRest {
         //
         const data = this.safeString (message, 'data', '');
         if (data === 'token is expired') {
-            const type = client.url.substring (client.url.indexOf ('connectId=') + 10);
+            let type = 'public';
+            if (client.url.indexOf ('connectId=private') >= 0) {
+                type = 'private';
+            }
             this.options['urls'][type] = undefined;
         }
         this.handleErrors (undefined, undefined, client.url, undefined, undefined, data, message, undefined, undefined);

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1056,7 +1056,7 @@ export default class kucoin extends kucoinRest {
         //    }
         //
         const data = this.safeString (message, 'data', '');
-        if (data === "token is expired") {
+        if (data === 'token is expired') {
             const type = client.url.substring (client.url.indexOf ('connectId=') + 10);
             this.options['urls'][type] = undefined;
         }

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -983,7 +983,7 @@ export default class kucoinfutures extends kucoinfuturesRest {
         //    }
         //
         const data = this.safeString (message, 'data', '');
-        if (data === "token is expired") {
+        if (data === 'token is expired') {
             const type = client.url.substring (client.url.indexOf ('connectId=') + 10);
             this.options['urls'][type] = undefined;
         }

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -63,8 +63,9 @@ export default class kucoinfutures extends kucoinfuturesRest {
     negotiate (privateChannel, params = {}) {
         const connectId = privateChannel ? 'private' : 'public';
         const urls = this.safeValue (this.options, 'urls', {});
-        if (connectId in urls) {
-            return urls[connectId];
+        const spawaned = this.safeValue (urls, connectId);
+        if (spawaned !== undefined) {
+            return spawaned;
         }
         // we store an awaitable to the url
         // so that multiple calls don't asynchronously
@@ -982,6 +983,10 @@ export default class kucoinfutures extends kucoinfuturesRest {
         //    }
         //
         const data = this.safeString (message, 'data', '');
+        if (data === "token is expired") {
+            const type = client.url.substring (client.url.indexOf ('connectId=') + 10);
+            this.options['urls'][type] = undefined;
+        }
         this.handleErrors (undefined, undefined, client.url, undefined, undefined, data, message, undefined, undefined);
     }
 

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -984,7 +984,10 @@ export default class kucoinfutures extends kucoinfuturesRest {
         //
         const data = this.safeString (message, 'data', '');
         if (data === 'token is expired') {
-            const type = client.url.substring (client.url.indexOf ('connectId=') + 10);
+            let type = 'public';
+            if (client.url.indexOf ('connectId=private') >= 0) {
+                type = 'private';
+            }
             this.options['urls'][type] = undefined;
         }
         this.handleErrors (undefined, undefined, client.url, undefined, undefined, data, message, undefined, undefined);


### PR DESCRIPTION
fix: ccxt/ccxt#19749

I didn't get token expired error, but can simulate this by edit `handleMessage`. The token will change in this patch.

```JS
        const method = this.safeValue(methods, 'error');
        if (method !== undefined) {
            return method.call(this, client, {code: 401, data: 'token is expired'});
        }
```

```PHP
        $method = $this->safe_value($methods, 'error');
        if ($method !== null) {
            return $method($client, [
                'data' => 'token is expired'
            ]);
        }
```

```PY
        method = self.safe_value(methods, 'error')
        if method is not None:
            return method(client, {
                'data': 'token is expired'
            })
```