### PR TITLE
fix(exchange): safeOrder trade fees parse to number not string

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2613,6 +2613,11 @@ export default class Exchange {
             if ('rate' in tradeFee) {
                 tradeFee['rate'] = this.safeNumber (tradeFee, 'rate');
             }
+            const entryFees = this.safeValue (entry, 'fees', []);
+            for (let j = 0; j < entryFees.length; j++) {
+                entryFees[j]['cost'] = this.safeNumber (entryFees[j], 'cost');
+            }
+            entry['fees'] = entryFees;
             entry['fee'] = tradeFee;
         }
         let timeInForce = this.safeString (order, 'timeInForce');

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4221,6 +4221,15 @@ export default class binance extends Exchange {
         }
         const stopPriceString = this.safeString (order, 'stopPrice');
         const stopPrice = this.parseNumber (this.omitZero (stopPriceString));
+        const feeCost = this.safeNumber (order, 'fee');
+        let fee = undefined;
+        if (feeCost !== undefined) {
+            fee = {
+                'currency': this.safeString (order, 'quoteAsset'),
+                'cost': feeCost,
+                'rate': undefined,
+            };
+        }
         return this.safeOrder ({
             'info': order,
             'id': id,
@@ -4243,11 +4252,7 @@ export default class binance extends Exchange {
             'filled': filled,
             'remaining': undefined,
             'status': status,
-            'fee': {
-                'currency': this.safeString (order, 'quoteAsset'),
-                'cost': this.safeNumber (order, 'fee'),
-                'rate': undefined,
-            },
+            'fee': fee,
             'trades': fills,
         }, market);
     }

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -78,19 +78,9 @@
           "filled": 0.1,
           "remaining": 0,
           "status": "closed",
-          "fee": {
-            "currency": null,
-            "cost": null,
-            "rate": null
-          },
+          "fee": null,
           "trades": [],
-          "fees": [
-            {
-              "currency": null,
-              "cost": null,
-              "rate": null
-            }
-          ],
+          "fees": [],
           "stopPrice": null,
           "takeProfitPrice": null,
           "stopLossPrice": null
@@ -174,19 +164,9 @@
             "filled": 0,
             "remaining": 0.2,
             "status": "open",
-            "fee": {
-              "currency": null,
-              "cost": null,
-              "rate": null
-            },
+            "fee": null,
             "trades": [],
-            "fees": [
-              {
-                "currency": null,
-                "cost": null,
-                "rate": null
-              }
-            ],
+            "fees": [],
             "stopPrice": null,
             "takeProfitPrice": null,
             "stopLossPrice": null


### PR DESCRIPTION
Solves the issue that fees insides the trades of an order where being returned as strings