### PR TITLE
fix(htx) - commonCurrencies

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -1208,17 +1208,17 @@ export default class htx extends Exchange {
                 // https://github.com/ccxt/ccxt/issues/6081
                 // https://github.com/ccxt/ccxt/issues/3365
                 // https://github.com/ccxt/ccxt/issues/2873
-                'GET': 'Themis', // conflict with GET (Guaranteed Entrance Token, GET Protocol)
-                'GTC': 'Game.com', // conflict with Gitcoin and Gastrocoin
-                'HIT': 'HitChain',
+                'GET': 'THEMIS', // conflict with GET (Guaranteed Entrance Token, GET Protocol)
+                'GTC': 'GAMECOM', // conflict with Gitcoin and Gastrocoin
+                'HIT': 'HITCHAIN',
                 // https://github.com/ccxt/ccxt/issues/7399
                 // https://coinmarketcap.com/currencies/pnetwork/
                 // https://coinmarketcap.com/currencies/penta/markets/
                 // https://en.cryptonomist.ch/blog/eidoo/the-edo-to-pnt-upgrade-what-you-need-to-know-updated/
-                'PNT': 'Penta',
-                'SBTC': 'Super Bitcoin',
-                'SOUL': 'Soulsaver',
-                'BIFI': 'Bitcoin File', // conflict with Beefy.Finance https://github.com/ccxt/ccxt/issues/8706
+                'PNT': 'PENTA',
+                'SBTC': 'SUPERBITCOIN',
+                'SOUL': 'SOULSAVER',
+                'BIFI': 'BITCOINFILE', // conflict with Beefy.Finance https://github.com/ccxt/ccxt/issues/8706
             },
         });
     }


### PR DESCRIPTION
lowercase ids cause issues/conflicts, like `if (baseCoin === currency['code'])`  (in tests or in userland codes) where in market['symbol'], base coin is in uppercase always, and currency-code being in lower/mixed case bcz of lowercase  `commonCurrencies`.
we should always use UPPERCASE CODES

such PRs shouldnt not cause any important userland breaks, they might already by uppercasing them, but anyway, we should move into correct formatting once and for all