### PR TITLE
bitget fetchBalance fix for swap

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3522,10 +3522,15 @@ export default class bitget extends Exchange {
                 // Use transferable instead of available for swap and margin https://github.com/ccxt/ccxt/pull/19127
                 const spotAccountFree = this.safeString (entry, 'available');
                 const contractAccountFree = this.safeString (entry, 'maxTransferOut');
-                account['free'] = (contractAccountFree !== undefined) ? contractAccountFree : spotAccountFree;
-                const frozen = this.safeString (entry, 'frozen');
-                const locked = this.safeString (entry, 'locked');
-                account['used'] = Precise.stringAdd (frozen, locked);
+                if (contractAccountFree !== undefined) {
+                    account['free'] = contractAccountFree;
+                    account['total'] = this.safeString (entry, 'accountEquity');
+                } else {
+                    account['free'] = spotAccountFree;
+                    const frozen = this.safeString (entry, 'frozen');
+                    const locked = this.safeString (entry, 'locked');
+                    account['used'] = Precise.stringAdd (frozen, locked);
+                }
             }
             result[code] = account;
         }


### PR DESCRIPTION
This is response with opened order and opened position. So `locked` doesn't include opened position. 
I'm not sure should we use `maxTransferOut` or `crossedMaxAvailable/isolatedMaxAvailable` as `free`, cause in web I see Available `34.67687977` but in Transfer menu I can transfer really only `34.59767977`
```
{
      marginCoin: 'USDT',
      locked: '6.063618',
      available: '47.99149777',
      crossedMaxAvailable: '34.67687977',
      isolatedMaxAvailable: '34.67687977',
      maxTransferOut: '34.59767977',
      accountEquity: '48.07069777',
      usdtEquity: '48.070697779',
      btcEquity: '0.001141811097',
      crossedRiskRate: '0.002956887389',
      unrealizedPL: '0.0792',
      coupon: '0',
      crossedUnrealizedPL: null,
      isolatedUnrealizedPL: null
    }
```

![2023-12-26_21h08_46](https://github.com/ccxt/ccxt/assets/38309641/99f3e2af-956e-4a0c-b7da-90dc7279eec1)
