### PR TITLE
mexc: BEP20 network

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -444,7 +444,7 @@ export default class mexc extends Exchange {
                     'BCH': 'BCH',
                     'TRC20': 'Tron(TRC20)',
                     'ERC20': 'Ethereum(ERC20)',
-                    'BEP20': 'BNBSmartChain(BEP20)',
+                    'BEP20': 'BNB Smart Chain(BEP20)',
                     'OPTIMISM': 'Optimism(OP)',
                     'SOL': 'Solana(SOL)',
                     'CRC20': 'CRONOS',
@@ -1044,7 +1044,7 @@ export default class mexc extends Exchange {
             'Algorand(ALGO)': 'ALGO',
             'ArbitrumOne(ARB)': 'ARBONE',
             'AvalancheCChain(AVAXCCHAIN)': 'AVAXC',
-            'BNBSmartChain(BEP20)': 'BEP20',
+            'BNB Smart Chain(BEP20)': 'BEP20',
             'Polygon(MATIC)': 'MATIC',
             'Optimism(OP)': 'OPTIMISM',
             'Solana(SOL)': 'SOL',
@@ -4354,8 +4354,8 @@ export default class mexc extends Exchange {
         /**
          * @method
          * @name mexc3#createDepositAddress
-         * @see https://mexcdevelop.github.io/apidocs/spot_v3_en/#generate-deposit-address-supporting-network
          * @description create a currency deposit address
+         * @see https://mexcdevelop.github.io/apidocs/spot_v3_en/#generate-deposit-address-supporting-network
          * @param {string} code unified currency code of the currency for the deposit address
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.network] the blockchain network name


### PR DESCRIPTION
Fixed the BEP20 network name on mexc, changed from `BNBSmartChain(BEP20)` to `BNB Smart Chain(BEP20)`:
fixes: #20554
```
mexc createDepositAddress BNB '{"network":"BEP20"}'

{
  info: {
    coin: 'BNB',
    network: 'BNB Smart Chain(BEP20)',
    address: '0x...',
    memo: null
  },
  currency: 'BNB',
  network: 'BNB Smart Chain(BEP20)',
  address: '0x...'
}
```