### PR TITLE
Bitget: fetchOrder, type error

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4952,6 +4952,9 @@ export default class bitget extends Exchange {
         //         }
         //     }
         //
+        if (typeof response === 'string') {
+            response = JSON.parse (response);
+        }
         const data = this.safeValue (response, 'data');
         const first = this.safeValue (data, 0, data);
         return this.parseOrder (first, market);


### PR DESCRIPTION
If the response is a string, parse it into an object.
fixes: #20555