### PR TITLE
feat(bingx): swap ticker with change %

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1331,22 +1331,30 @@ export default class bingx extends Exchange {
         //    }
         //
         const marketId = this.safeString (ticker, 'symbol');
-        // const change = this.safeString (ticker, 'priceChange'); // this is not ccxt's change because it does high-low instead of last-open
         const lastQty = this.safeString (ticker, 'lastQty');
         // in spot markets, lastQty is not present
         // it's (bad, but) the only way we can check the tickers origin
         const type = (lastQty === undefined) ? 'spot' : 'swap';
-        const symbol = this.safeSymbol (marketId, market, undefined, type);
+        market = this.safeMarket (marketId, market, undefined, type);
+        const symbol = market['symbol'];
         const open = this.safeString (ticker, 'openPrice');
         const high = this.safeString (ticker, 'highPrice');
         const low = this.safeString (ticker, 'lowPrice');
         const close = this.safeString (ticker, 'lastPrice');
         const quoteVolume = this.safeString (ticker, 'quoteVolume');
         const baseVolume = this.safeString (ticker, 'volume');
+        let percentage = undefined;
+        let change = undefined;
+        if (market['swap']) {
+            // right now only swap uses the 24h change, spot will be added soon
+            percentage = this.safeString (ticker, 'priceChangePercent');
+            change = this.safeString (ticker, 'priceChange');
+        }
         // let percentage = this.safeString (ticker, 'priceChangePercent');
         // if (percentage !== undefined) {
         //     percentage = percentage.replace ('%', '');
         // } similarly to change, it's not ccxt's percentage because it does priceChange/open, and priceChange is high-low
+        // const change = this.safeString (ticker, 'priceChange'); // this is not ccxt's change because it does high-low instead of last-open
         const ts = this.safeInteger (ticker, 'closeTime');
         const datetime = this.iso8601 (ts);
         const bid = this.safeString (ticker, 'bidPrice');
@@ -1368,8 +1376,8 @@ export default class bingx extends Exchange {
             'close': close,
             'last': undefined,
             'previousClose': undefined,
-            'change': undefined,
-            'percentage': undefined,
+            'change': change,
+            'percentage': percentage,
             'average': undefined,
             'baseVolume': baseVolume,
             'quoteVolume': quoteVolume,


### PR DESCRIPTION

DEMO
```
p bingx fetchTicker "BTC/USDT:USDT" 
Python v3.11.5
CCXT v4.2.1
bingx.fetchTicker(BTC/USDT:USDT)
{'ask': 42749.2,
 'askVolume': 6.5431,
 'average': 42962.15,
 'baseVolume': 70240.1918,
 'bid': 42748.8,
 'bidVolume': 13.4395,
 'change': -416.9,
 'close': 42753.7,
 'datetime': '2023-12-29T10:49:49.618Z',
 'high': 43159.5,
 'info': {'askPrice': '42749.2',
          'askQty': '6.5431',
          'bidPrice': '42748.8',
          'bidQty': '13.4395',
          'closeTime': '1703846989618',
          'highPrice': '43159.5',
          'lastPrice': '42753.7',
          'lastQty': '0.6395',
          'lowPrice': '42113.0',
          'openPrice': '43170.6',
          'openTime': '1703847003227',
          'priceChange': '-416.9',
          'priceChangePercent': '-0.97',
          'quoteVolume': '2997057456.05',
          'symbol': 'BTC-USDT',
          'volume': '70240.1918'},
 'last': 42753.7,
 'low': 42113.0,
 'open': 43170.6,
 'percentage': -0.97,
 'previousClose': None,
 'quoteVolume': 2997057456.05,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1703846989618,
 'vwap': 42668.69692759011}
```
