### PR TITLE
fix(bingx): add spotV1PrivateGetUserCommissionRate & spotV1PrivatePostTradeCancelOpenOrders to bingx abstract

### DIFF
--- a/ts/src/abstract/bingx.ts
+++ b/ts/src/abstract/bingx.ts
@@ -17,11 +17,13 @@ interface Exchange {
     spotV1PrivateGetTradeQuery (params?: {}): Promise<implicitReturnType>;
     spotV1PrivateGetTradeOpenOrders (params?: {}): Promise<implicitReturnType>;
     spotV1PrivateGetTradeHistoryOrders (params?: {}): Promise<implicitReturnType>;
+    spotV1PrivateGetUserCommissionRate (params?: {}): Promise<implicitReturnType>;
     spotV1PrivateGetAccountBalance (params?: {}): Promise<implicitReturnType>;
     spotV1PrivatePostTradeOrder (params?: {}): Promise<implicitReturnType>;
     spotV1PrivatePostTradeCancel (params?: {}): Promise<implicitReturnType>;
     spotV1PrivatePostTradeBatchOrders (params?: {}): Promise<implicitReturnType>;
     spotV1PrivatePostTradeCancelOrders (params?: {}): Promise<implicitReturnType>;
+    spotV1PrivatePostTradeCancelOpenOrders (params?: {}): Promise<implicitReturnType>;
     spotV3PrivateGetGetAssetTransfer (params?: {}): Promise<implicitReturnType>;
     spotV3PrivateGetAssetTransfer (params?: {}): Promise<implicitReturnType>;
     spotV3PrivateGetCapitalDepositHisrec (params?: {}): Promise<implicitReturnType>;


### PR DESCRIPTION
This should be a part of the build already, I keep receiving the error below and can only get rid of this error by running `npm run build`
```js
error TS2339: Property "spotV1PrivatePostTradeCancelOpenOrders" does not exist on type "bingx"
```