### PR TITLE
Fix python asyncio proxy example

### DIFF
--- a/examples/py/proxy-asyncio-aiohttp-socks.py
+++ b/examples/py/proxy-asyncio-aiohttp-socks.py
@@ -1,5 +1,6 @@
 # pip install aiohttp_socks
 
+import asyncio
 import ccxt.async_support as ccxt
 import aiohttp
 import aiohttp_socks
@@ -16,8 +17,9 @@ async def test():
 
     # ...
 
+    await exchange.close()  # Close the exchange
     await session.close()  # don't forget to close the session
 
     # ...
 
-test()
+asyncio.run(test())


### PR DESCRIPTION
This way, it's runnable (the coroutine wasn't executed previously), and properly releases ccxt resources afterwards.
It's obviously still a sample that does nothing - but it's no longer raising errors / warnings.