### PR TITLE
fix(Bybit): watchTickers

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -360,17 +360,6 @@ export default class bybit extends bybitRest {
         this.tickers[symbol] = parsed;
         const messageHash = 'ticker:' + symbol;
         client.resolve (this.tickers[symbol], messageHash);
-        // watchTickers part
-        const messageHashes = this.findMessageHashes (client, 'tickers::');
-        for (let i = 0; i < messageHashes.length; i++) {
-            const messageHashTicker = messageHashes[i];
-            const parts = messageHashTicker.split ('::');
-            const symbolsString = parts[1];
-            const symbols = symbolsString.split (',');
-            if (this.inArray (parsed['symbol'], symbols)) {
-                client.resolve (parsed, messageHashTicker);
-            }
-        }
     }
 
     async watchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -212,7 +212,7 @@ export default class bybit extends bybitRest {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false);
-        const messageHash = 'tickers::' + symbols.join (',');
+        const messageHashes = [];
         const url = this.getUrlByMarketType (symbols[0], false, params);
         params = this.cleanParams (params);
         const options = this.safeValue (this.options, 'watchTickers', {});
@@ -222,8 +222,9 @@ export default class bybit extends bybitRest {
         for (let i = 0; i < marketIds.length; i++) {
             const marketId = marketIds[i];
             topics.push (topic + '.' + marketId);
+            messageHashes.push ('ticker:' + symbols[i]);
         }
-        const ticker = await this.watchTopics (url, messageHash, topics, params);
+        const ticker = await this.watchTopics (url, messageHashes, topics, params);
         if (this.newUpdates) {
             return ticker;
         }


### PR DESCRIPTION
DEMO

```
 p bybit watchTickers '["BTC/USDT:USDT", "ETH/USDT:USDT"]' --sandbox          
Python v3.11.5
CCXT v4.2.2
bybit.watchTickers(['BTC/USDT:USDT', 'ETH/USDT:USDT'])
{'ask': 42647.6,
 'askVolume': 171.124,
 'average': 42291.15,
 'baseVolume': 24861.12,
 'bid': 42645.3,
 'bidVolume': 71.686,
 'change': 708.9,
 'close': 42645.6,
 'datetime': '2023-12-31T11:10:58.746Z',
 'high': 42944.3,
 'info': {'ask1Price': '42647.60',
          'ask1Size': '171.124',
          'bid1Price': '42645.30',
          'bid1Size': '71.686',
          'fundingRate': '0.000343',
          'highPrice24h': '42944.30',
          'indexPrice': '42604.35',
          'lastPrice': '42645.60',
          'lowPrice24h': '41880.00',
          'markPrice': '42645.60',
          'nextFundingTime': '1704038400000',
          'openInterest': '138233.5',
          'openInterestValue': '5895050547.60',
          'prevPrice1h': '42740.70',
          'prevPrice24h': '41936.70',
          'price24hPcnt': '0.016904',
          'symbol': 'BTCUSDT',
          'tickDirection': 'MinusTick',
          'turnover24h': '1053648296.0986',
          'volume24h': '24861.1200'},
 'last': 42645.6,
 'low': 41880.0,
 'open': 41936.7,
 'percentage': 1.6904,
 'previousClose': None,
 'quoteVolume': 1053648296.0986,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1704021058746,
 'vwap': 42381.36882403528}
{'ask': 2310.13,
 'askVolume': 2860.94,
 'average': 2301.085,
 'baseVolume': 5974840.13,
 'bid': 2309.81,
 'bidVolume': 1248.3,
 'change': 17.45,
 'close': 2309.81,
 'datetime': '2023-12-31T11:11:00.663Z',
 'high': 2323.52,
 'info': {'ask1Price': '2310.13',
          'ask1Size': '2860.94',
          'bid1Price': '2309.81',
          'bid1Size': '1248.30',
          'fundingRate': '0.0001',
          'highPrice24h': '2323.52',
          'indexPrice': '2309.09',
          'lastPrice': '2309.81',
          'lowPrice24h': '2278.61',
          'markPrice': '2309.81',
          'nextFundingTime': '1704038400000',
          'openInterest': '112812.69',
          'openInterestValue': '260575879.49',
          'prevPrice1h': '2309.63',
          'prevPrice24h': '2292.36',
          'price24hPcnt': '0.007612',
          'symbol': 'ETHUSDT',
          'tickDirection': 'ZeroMinusTick',
          'turnover24h': '13735426582.6909',
          'volume24h': '5974840.1300'},
 'last': 2309.81,
 'low': 2278.61,
 'open': 2292.36,
 'percentage': 0.7612,
 'previousClose': None,
 'quoteVolume': 13735426582.6909,
 'symbol': 'ETH/USDT:USDT',
 'timestamp': 1704021060663,
 'vwap': 2298.8776743539247}
```
