### PR TITLE
feat(php): filter config in ws client

### DIFF
--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -63,6 +63,22 @@ class Client {
     // ratchet/pawl/reactphp stuff
     public $connector = null;
 
+    private $allowedConfig = [
+        'logs',
+        'verbose',
+        'throttle',
+        'options',
+        'connectionTimeout',
+        'keepAlive',
+        'maxPingPongMisses',
+        'ping',
+        'gunzip',
+        'inflate',
+        'noOriginHeader',
+        'heartbeat',
+        'cost',
+    ];
+
 
     // ------------------------------------------------------------------------
 
@@ -128,6 +144,9 @@ class Client {
         $this->on_connected_callback = $on_connected_callback;
 
         foreach ($config as $key => $value) {
+            if (!in_array($key, $this->allowedConfig)) {
+                continue;
+            }
             $this->{$key} =
                 (property_exists($this, $key) && is_array($this->{$key}) && is_array($value)) ?
                     array_replace_recursive($this->{$key}, $value) :


### PR DESCRIPTION
The current config value in ws client wasn't filtered or checked. User can rewrite on_*_callback with ws options, eg on_message_callback, and it would break the client.

In this PR, I added `allowedConfig` to filter the config.