### PR TITLE
alpaca: fix us equity undefined quote

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -353,10 +353,16 @@ export default class alpaca extends Exchange {
         //
         const marketId = this.safeString (asset, 'symbol');
         const parts = marketId.split ('/');
+        const assetClass = this.safeString (asset, 'class');
         const baseId = this.safeString (parts, 0);
         const quoteId = this.safeString (parts, 1);
         const base = this.safeCurrencyCode (baseId);
-        const quote = this.safeCurrencyCode (quoteId);
+        let quote = this.safeCurrencyCode (quoteId);
+        // Us equity markets do not include quote in symbol.
+        // We can safely coerce us_equity quote to USD
+        if (quote === undefined && assetClass === 'us_equity') {
+            quote = 'USD';
+        }
         const symbol = base + '/' + quote;
         const status = this.safeString (asset, 'status');
         const active = (status === 'active');


### PR DESCRIPTION
# Problem

When using `asset_class: us_equity` all markets are parsed with an undefined quote, returning symbols like `AAPL/undefined`.

# Solution

Catch the undefined quotes when asset class is `us_equity` and coerce to `USD`