### PR TITLE
fix(delta): expired option markets conditional check

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -330,7 +330,7 @@ export default class delta extends Exchange {
             } else if (symbol in this.markets_by_id) {
                 const markets = this.markets_by_id[symbol];
                 return markets[0];
-            } else if ((symbol.indexOf ('-C') > -1) || (symbol.indexOf ('-P') > -1) || (symbol.indexOf ('C')) || (symbol.indexOf ('P'))) {
+            } else if ((symbol.endsWith ('-C')) || (symbol.endsWith ('-P')) || (symbol.startsWith ('C-')) || (symbol.startsWith ('P-'))) {
                 return this.createExpiredOptionMarket (symbol);
             }
         }
@@ -338,7 +338,7 @@ export default class delta extends Exchange {
     }
 
     safeMarket (marketId = undefined, market = undefined, delimiter = undefined, marketType = undefined) {
-        const isOption = (marketId !== undefined) && ((marketId.indexOf ('-C') > -1) || (marketId.indexOf ('-P') > -1) || (marketId.indexOf ('C')) || (marketId.indexOf ('P')));
+        const isOption = (marketId !== undefined) && ((marketId.endsWith ('-C')) || (marketId.endsWith ('-P')) || (marketId.startsWith ('C-')) || (marketId.startsWith ('P-')));
         if (isOption && !(marketId in this.markets_by_id)) {
             // handle expired option contracts
             return this.createExpiredOptionMarket (marketId);


### PR DESCRIPTION
Edited the expired option markets conditional logic so that exchange specific market id's are supported in a less error prone way:

```
delta.fetchSettlementHistory (BTC/USDT:USDT-130723-29000-C)
2024-01-02T19:36:18.876Z iteration 0 passed in 5614 ms

                      symbol |             price |     timestamp |             datetime
---------------------------------------------------------------------------------------
BTC/USDT:USDT-130723-29000-C |               200 | 1703505600000 | 2023-12-25T12:00:00Z
```
```
delta.fetchSettlementHistory (C-BTC-29000-130723)
2024-01-02T19:37:13.285Z iteration 0 passed in 5291 ms

                      symbol |             price |     timestamp |             datetime
---------------------------------------------------------------------------------------
BTC/USDT:USDT-130723-29000-C |               200 | 1703505600000 | 2023-12-25T12:00:00Z
```