### PR TITLE
HTX: fetchOrders, fetchOpenOrders, cancelOrder, cancelAllOrders, trailing support

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -5413,8 +5413,9 @@ export default class htx extends Exchange {
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {bool} [params.stop] *contract only* if the order is a stop trigger order or not
-         * @param {bool} [params.stopLossTakeProfit] *contract only* if the order is a stop-loss or take-profit order
+         * @param {boolean} [params.stop] *contract only* if the order is a stop trigger order or not
+         * @param {boolean} [params.stopLossTakeProfit] *contract only* if the order is a stop-loss or take-profit order
+         * @param {boolean} [params.trailing] *contract only* set to true if you want to cancel a trailing order
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -5465,7 +5466,8 @@ export default class htx extends Exchange {
             }
             const stop = this.safeValue (params, 'stop');
             const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
-            params = this.omit (params, [ 'stop', 'stopLossTakeProfit' ]);
+            const trailing = this.safeValue (params, 'trailing', false);
+            params = this.omit (params, [ 'stop', 'stopLossTakeProfit', 'trailing' ]);
             if (market['linear']) {
                 let marginMode = undefined;
                 [ marginMode, params ] = this.handleMarginModeAndParams ('cancelOrder', params);
@@ -5475,6 +5477,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapTriggerCancel (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapTpslCancel (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapTrackCancel (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCancel (this.extend (request, params));
                     }
@@ -5483,6 +5487,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTriggerCancel (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTpslCancel (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTrackCancel (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCrossCancel (this.extend (request, params));
                     }
@@ -5493,6 +5499,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostSwapApiV1SwapTriggerCancel (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostSwapApiV1SwapTpslCancel (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostSwapApiV1SwapTrackCancel (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostSwapApiV1SwapCancel (this.extend (request, params));
                     }
@@ -5501,6 +5509,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostApiV1ContractTriggerCancel (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostApiV1ContractTpslCancel (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostApiV1ContractTrackCancel (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostApiV1ContractCancel (this.extend (request, params));
                     }

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -5716,8 +5716,9 @@ export default class htx extends Exchange {
          * @description cancel all open orders
          * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {bool} [params.stop] *contract only* if the orders are stop trigger orders or not
-         * @param {bool} [params.stopLossTakeProfit] *contract only* if the orders are stop-loss or take-profit orders
+         * @param {boolean} [params.stop] *contract only* if the orders are stop trigger orders or not
+         * @param {boolean} [params.stopLossTakeProfit] *contract only* if the orders are stop-loss or take-profit orders
+         * @param {boolean} [params.trailing] *contract only* set to true if you want to cancel all trailing orders
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -5757,7 +5758,8 @@ export default class htx extends Exchange {
             request['contract_code'] = market['id'];
             const stop = this.safeValue (params, 'stop');
             const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
-            params = this.omit (params, [ 'stop', 'stopLossTakeProfit' ]);
+            const trailing = this.safeValue (params, 'trailing', false);
+            params = this.omit (params, [ 'stop', 'stopLossTakeProfit', 'trailing' ]);
             if (market['linear']) {
                 let marginMode = undefined;
                 [ marginMode, params ] = this.handleMarginModeAndParams ('cancelAllOrders', params);
@@ -5767,6 +5769,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapTriggerCancelall (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapTpslCancelall (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapTrackCancelall (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCancelall (this.extend (request, params));
                     }
@@ -5775,6 +5779,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTriggerCancelall (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTpslCancelall (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTrackCancelall (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostLinearSwapApiV1SwapCrossCancelall (this.extend (request, params));
                     }
@@ -5785,6 +5791,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostSwapApiV1SwapTriggerCancelall (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostSwapApiV1SwapTpslCancelall (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostSwapApiV1SwapTrackCancelall (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostSwapApiV1SwapCancelall (this.extend (request, params));
                     }
@@ -5793,6 +5801,8 @@ export default class htx extends Exchange {
                         response = await this.contractPrivatePostApiV1ContractTriggerCancelall (this.extend (request, params));
                     } else if (stopLossTakeProfit) {
                         response = await this.contractPrivatePostApiV1ContractTpslCancelall (this.extend (request, params));
+                    } else if (trailing) {
+                        response = await this.contractPrivatePostApiV1ContractTrackCancelall (this.extend (request, params));
                     } else {
                         response = await this.contractPrivatePostApiV1ContractCancelall (this.extend (request, params));
                     }

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -3804,8 +3804,9 @@ export default class htx extends Exchange {
         let response = undefined;
         const stop = this.safeValue (params, 'stop');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
-        params = this.omit (params, [ 'stop', 'stopLossTakeProfit' ]);
-        if (stop || stopLossTakeProfit) {
+        const trailing = this.safeValue (params, 'trailing', false);
+        params = this.omit (params, [ 'stop', 'stopLossTakeProfit', 'trailing' ]);
+        if (stop || stopLossTakeProfit || trailing) {
             if (limit !== undefined) {
                 request['page_size'] = limit;
             }
@@ -3829,6 +3830,8 @@ export default class htx extends Exchange {
                     response = await this.contractPrivatePostLinearSwapApiV1SwapTriggerHisorders (this.extend (request, params));
                 } else if (stopLossTakeProfit) {
                     response = await this.contractPrivatePostLinearSwapApiV1SwapTpslHisorders (this.extend (request, params));
+                } else if (trailing) {
+                    response = await this.contractPrivatePostLinearSwapApiV1SwapTrackHisorders (this.extend (request, params));
                 } else {
                     response = await this.contractPrivatePostLinearSwapApiV3SwapHisorders (this.extend (request, params));
                 }
@@ -3837,6 +3840,8 @@ export default class htx extends Exchange {
                     response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTriggerHisorders (this.extend (request, params));
                 } else if (stopLossTakeProfit) {
                     response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTpslHisorders (this.extend (request, params));
+                } else if (trailing) {
+                    response = await this.contractPrivatePostLinearSwapApiV1SwapCrossTrackHisorders (this.extend (request, params));
                 } else {
                     response = await this.contractPrivatePostLinearSwapApiV3SwapCrossHisorders (this.extend (request, params));
                 }
@@ -3847,6 +3852,8 @@ export default class htx extends Exchange {
                     response = await this.contractPrivatePostSwapApiV1SwapTriggerHisorders (this.extend (request, params));
                 } else if (stopLossTakeProfit) {
                     response = await this.contractPrivatePostSwapApiV1SwapTpslHisorders (this.extend (request, params));
+                } else if (trailing) {
+                    response = await this.contractPrivatePostSwapApiV1SwapTrackHisorders (this.extend (request, params));
                 } else {
                     response = await this.contractPrivatePostSwapApiV3SwapHisorders (this.extend (request, params));
                 }
@@ -3856,6 +3863,8 @@ export default class htx extends Exchange {
                     response = await this.contractPrivatePostApiV1ContractTriggerHisorders (this.extend (request, params));
                 } else if (stopLossTakeProfit) {
                     response = await this.contractPrivatePostApiV1ContractTpslHisorders (this.extend (request, params));
+                } else if (trailing) {
+                    response = await this.contractPrivatePostApiV1ContractTrackHisorders (this.extend (request, params));
                 } else {
                     response = await this.contractPrivatePostApiV3ContractHisorders (this.extend (request, params));
                 }
@@ -4035,6 +4044,7 @@ export default class htx extends Exchange {
          * @param {bool} [params.stop] *contract only* if the orders are stop trigger orders or not
          * @param {bool} [params.stopLossTakeProfit] *contract only* if the orders are stop-loss or take-profit orders
          * @param {int} [params.until] the latest time in ms to fetch entries for
+         * @param {boolean} [params.trailing] set to true if you want to fetch trailing stop orders
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/test/static/request/huobi.json
+++ b/ts/src/test/static/request/huobi.json
@@ -470,6 +470,18 @@
                     "LTC/USDT"
                 ],
                 "output": "{\"symbol\":\"ltcusdt\"}"
+            },
+            {
+                "description": "Swap cancel all trailing orders",
+                "method": "cancelAllOrders",
+                "url": "https://api.hbdm.com/linear-swap-api/v1/swap_cross_track_cancelall?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2024-01-03T01%3A01%3A08&Signature=ug%2FwGTlkVE%2BmL5C%2BkBJV83nXrF8%2B8pLKOtSpdflruCU%3D",
+                "input": [
+                  "BTC/USDT:USDT",
+                  {
+                    "trailing": true
+                  }
+                ],
+                "output": "{\"contract_code\":\"BTC-USDT\"}"
             }
         ],
         "fetchPositions": [

--- a/ts/src/test/static/request/huobi.json
+++ b/ts/src/test/static/request/huobi.json
@@ -354,6 +354,20 @@
                     "LTC/USDT:USDT"
                 ],
                 "output": "{\"trade_type\":0,\"status\":\"0\",\"contract\":\"LTC-USDT\",\"type\":1}"
+            },
+            {
+                "description": "Swap trailing orders",
+                "method": "fetchOrders",
+                "url": "https://api.hbdm.com/linear-swap-api/v1/swap_cross_track_hisorders?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2024-01-03T01%3A04%3A36&Signature=I6EJNAfLRNWZfi6wOmVkBY9AB8KAmYfePQ7zPXRMz9E%3D",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "trailing": true
+                  }
+                ],
+                "output": "{\"trade_type\":0,\"status\":\"0\",\"contract_code\":\"BTC-USDT\",\"create_date\":90}"
             }
         ],
         "fetchOrder": [


### PR DESCRIPTION
Added `trailing` support to fetchOrders, fetchOpenOrders, cancelOrder, and cancelAllOrders:

```
htx fetchOrders BTC/USDT:USDT undefined undefined '{"trailing":true}'

htx.fetchOrders (BTC/USDT:USDT, , , [object Object])
2024-01-03T01:04:37.215Z iteration 0 passed in 368 ms

                 id |     timestamp |                 datetime |        symbol |          type | side | amount | filled | remaining | status | reduceOnly | trades | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1191741930475552768 | 1704175017720 | 2024-01-02T05:56:57.720Z | BTC/USDT:USDT | formula_price | sell |      1 |      1 |         0 | closed |       true |     [] |   []
1192021437253877761 | 1704241657328 | 2024-01-03T00:27:37.328Z | BTC/USDT:USDT | formula_price | sell |      1 |      1 |         0 | closed |       true |     [] |   []
2 objects
```
```
htx fetchOpenOrders BTC/USDT:USDT undefined undefined '{"trailing":true}'

htx.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2024-01-03T00:48:44.916Z iteration 0 passed in 373 ms

                 id |     timestamp |                 datetime |        symbol |          type | side | amount | status | reduceOnly | trades | fees
----------------------------------------------------------------------------------------------------------------------------------------------------
1191741930475552768 | 1704175017720 | 2024-01-02T05:56:57.720Z | BTC/USDT:USDT | formula_price | sell |      1 |   open |       true |     [] |   []
1192021437253877761 | 1704241657328 | 2024-01-03T00:27:37.328Z | BTC/USDT:USDT | formula_price | sell |      1 |   open |       true |     [] |   []
2 objects
```
```
htx cancelOrder '"1191741930475552768"' BTC/USDT:USDT '{"trailing":true}'

htx.cancelOrder (1191741930475552768, BTC/USDT:USDT, [object Object])
2024-01-03T00:55:47.667Z iteration 0 passed in 369 ms

{
  info: {
    status: 'ok',
    data: { errors: [], successes: '1191741930475552768' },
    ts: '1704243348363'
  },
  id: '1191741930475552768',
  symbol: 'BTC/USDT:USDT',
  status: 'canceled',
  trades: [],
  fees: []
}
```
```
htx cancelAllOrders BTC/USDT:USDT '{"trailing":true}'

htx.cancelAllOrders (BTC/USDT:USDT, [object Object])
2024-01-03T01:01:09.091Z iteration 0 passed in 361 ms

{
  status: 'ok',
  data: { errors: [], successes: '1192021437253877761' },
  ts: '1704243669801'
}
```