### PR TITLE
Bitmex: createOrder, editOrder, add trailing support

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1848,14 +1848,15 @@ export default class bitmex extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {object} [params.triggerPrice] the price at which a trigger order is triggered at
          * @param {object} [params.triggerDirection] the direction whenever the trigger happens with relation to price - 'above' or 'below'
+         * @param {float} [params.trailingAmount] the quote amount to trail away from the current market price
          * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const orderType = this.capitalize (type);
+        let orderType = this.capitalize (type);
         const reduceOnly = this.safeValue (params, 'reduceOnly');
         if (reduceOnly !== undefined) {
-            if ((market['type'] !== 'swap') && (market['type'] !== 'future')) {
+            if ((!market['swap']) && (!market['future'])) {
                 throw new InvalidOrder (this.id + ' createOrder() does not support reduceOnly for ' + market['type'] + ' orders, reduceOnly orders are supported for swap and future markets only');
             }
         }
@@ -1868,40 +1869,50 @@ export default class bitmex extends Exchange {
             'ordType': orderType,
             'text': brokerId,
         };
-        const customTriggerType = (orderType === 'Stop') || (orderType === 'StopLimit') || (orderType === 'MarketIfTouched') || (orderType === 'LimitIfTouched');
         // support for unified trigger format
         const triggerPrice = this.safeNumberN (params, [ 'triggerPrice', 'stopPx', 'stopPrice' ]);
-        if ((triggerPrice !== undefined) && !customTriggerType) {
-            request['stopPx'] = parseFloat (this.priceToPrecision (symbol, triggerPrice));
+        let trailingAmount = this.safeString2 (params, 'trailingAmount', 'pegOffsetValue');
+        const isTriggerOrder = triggerPrice !== undefined;
+        const isTrailingAmountOrder = trailingAmount !== undefined;
+        if (isTriggerOrder || isTrailingAmountOrder) {
             const triggerDirection = this.safeString (params, 'triggerDirection');
-            params = this.omit (params, [ 'triggerPrice', 'stopPrice', 'stopPx', 'triggerDirection' ]);
             const triggerAbove = (triggerDirection === 'above');
-            this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'above', 'below' ]);
-            this.checkRequiredArgument ('createOrder', side, 'side', [ 'buy', 'sell' ]);
+            if ((type === 'limit') || (type === 'market')) {
+                this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'above', 'below' ]);
+            }
             if (type === 'limit') {
-                request['price'] = parseFloat (this.priceToPrecision (symbol, price));
                 if (side === 'buy') {
-                    request['ordType'] = triggerAbove ? 'StopLimit' : 'LimitIfTouched';
+                    orderType = triggerAbove ? 'StopLimit' : 'LimitIfTouched';
                 } else {
-                    request['ordType'] = triggerAbove ? 'LimitIfTouched' : 'StopLimit';
+                    orderType = triggerAbove ? 'LimitIfTouched' : 'StopLimit';
                 }
             } else if (type === 'market') {
                 if (side === 'buy') {
-                    request['ordType'] = triggerAbove ? 'Stop' : 'MarketIfTouched';
+                    orderType = triggerAbove ? 'Stop' : 'MarketIfTouched';
                 } else {
-                    request['ordType'] = triggerAbove ? 'MarketIfTouched' : 'Stop';
+                    orderType = triggerAbove ? 'MarketIfTouched' : 'Stop';
                 }
             }
-        } else if (customTriggerType) {
-            if (triggerPrice === undefined) {
-                // if exchange specific trigger types were provided
-                throw new ArgumentsRequired (this.id + ' createOrder() requires a triggerPrice (stopPx|stopPrice) parameter for the ' + orderType + ' order type');
+            if (isTrailingAmountOrder) {
+                const isStopSellOrder = (side === 'sell') && ((orderType === 'Stop') || (orderType === 'StopLimit'));
+                const isBuyIfTouchedOrder = (side === 'buy') && ((orderType === 'MarketIfTouched') || (orderType === 'LimitIfTouched'));
+                if (isStopSellOrder || isBuyIfTouchedOrder) {
+                    trailingAmount = '-' + trailingAmount;
+                }
+                request['pegOffsetValue'] = this.parseToNumeric (trailingAmount);
+                request['pegPriceType'] = 'TrailingStopPeg';
+            } else {
+                if (triggerPrice === undefined) {
+                    // if exchange specific trigger types were provided
+                    throw new ArgumentsRequired (this.id + ' createOrder() requires a triggerPrice (stopPx|stopPrice) parameter for the ' + orderType + ' order type');
+                }
+                request['stopPx'] = this.parseToNumeric (this.priceToPrecision (symbol, triggerPrice));
             }
-            params = this.omit (params, [ 'triggerPrice', 'stopPrice', 'stopPx' ]);
-            request['stopPx'] = parseFloat (this.priceToPrecision (symbol, triggerPrice));
+            request['ordType'] = orderType;
+            params = this.omit (params, [ 'triggerPrice', 'stopPrice', 'stopPx', 'triggerDirection', 'trailingAmount' ]);
         }
         if ((orderType === 'Limit') || (orderType === 'StopLimit') || (orderType === 'LimitIfTouched')) {
-            request['price'] = parseFloat (this.priceToPrecision (symbol, price));
+            request['price'] = this.parseToNumeric (this.priceToPrecision (symbol, price));
         }
         const clientOrderId = this.safeString2 (params, 'clOrdID', 'clientOrderId');
         if (clientOrderId !== undefined) {
@@ -1915,6 +1926,11 @@ export default class bitmex extends Exchange {
     async editOrder (id: string, symbol, type, side, amount = undefined, price = undefined, params = {}) {
         await this.loadMarkets ();
         const request = {};
+        const trailingAmount = this.safeNumber2 (params, 'trailingAmount', 'pegOffsetValue');
+        const isTrailingAmountOrder = trailingAmount !== undefined;
+        if (isTrailingAmountOrder) {
+            request['pegOffsetValue'] = trailingAmount;
+        }
         const origClOrdID = this.safeString2 (params, 'origClOrdID', 'clientOrderId');
         if (origClOrdID !== undefined) {
             request['origClOrdID'] = origClOrdID;

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -175,6 +175,22 @@
         "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"stopPx\":36944,\"price\":36000}"
       },
       {
+        "description": "Swap market sell order with reduceOnly",
+        "method": "createOrder",
+        "url": "https://testnet.bitmex.com/api/v1/order",
+        "input": [
+          "BTC/USDT:USDT",
+          "market",
+          "sell",
+          1000,
+          null,
+          {
+            "reduceOnly": true
+          }
+        ],
+        "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"Market\",\"text\":\"CCXT\",\"reduceOnly\":true}"
+      },
+      {
         "description": "Swap market trailing order",
         "method": "createOrder",
         "url": "https://testnet.bitmex.com/api/v1/order",
@@ -217,6 +233,26 @@
         "input": [
           "BTC/USDT"
         ]
+      }
+    ],
+    "editOrder": [
+      {
+        "description": "Swap edit trailing order",
+        "method": "editOrder",
+        "url": "https://testnet.bitmex.com/api/v1/order",
+        "input": [
+          "f21aa11e-3857-4e39-9230-53cb15a04c3f",
+          "BTC/USDT:USDT",
+          "market",
+          "sell",
+          1000,
+          null,
+          {
+            "trailingAmount": 11000,
+            "triggerDirection": "above"
+          }
+        ],
+        "output": "{\"pegOffsetValue\":11000,\"orderID\":\"f21aa11e-3857-4e39-9230-53cb15a04c3f\",\"orderQty\":1000,\"text\":\"CCXT\"}"
       }
     ]
   }

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -173,6 +173,40 @@
           }
         ],
         "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"stopPx\":36944,\"price\":36000}"
+      },
+      {
+        "description": "Swap market trailing order",
+        "method": "createOrder",
+        "url": "https://testnet.bitmex.com/api/v1/order",
+        "input": [
+          "BTC/USDT:USDT",
+          "market",
+          "sell",
+          1000,
+          null,
+          {
+            "trailingAmount": 100,
+            "triggerDirection": "above"
+          }
+        ],
+        "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"MarketIfTouched\",\"text\":\"CCXT\",\"pegOffsetValue\":100,\"pegPriceType\":\"TrailingStopPeg\"}"
+      },
+      {
+        "description": "Swap limit trailing order",
+        "method": "createOrder",
+        "url": "https://testnet.bitmex.com/api/v1/order",
+        "input": [
+          "BTC/USDT:USDT",
+          "limit",
+          "sell",
+          1000,
+          45000,
+          {
+            "trailingAmount": 100,
+            "triggerDirection": "above"
+          }
+        ],
+        "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"pegOffsetValue\":100,\"pegPriceType\":\"TrailingStopPeg\",\"price\":45000}"
       }
     ],
     "fetchTrades": [


### PR DESCRIPTION
Added trailing order support to `createOrder` and `editOrder`

```
bitmex createOrder BTC/USDT:USDT market sell 1000 undefined '{"trailingAmount":100,"triggerDirection":"above"}'

bitmex.createOrder (BTC/USDT:USDT, market, sell, 1000, , [object Object])
2024-01-03T22:42:00.728Z iteration 0 passed in 1009 ms

{
  info: {
    orderID: 'f64b651c-8deb-40b5-8733-58eedd84df12',
    clOrdID: '',
    clOrdLinkID: '',
    account: '395724',
    symbol: 'XBTUSDT',
    side: 'Sell',
    orderQty: '1000',
    price: null,
    displayQty: null,
    stopPx: '42797.5',
    pegOffsetValue: '100',
    pegPriceType: 'TrailingStopPeg',
    currency: 'USDT',
    settlCurrency: 'USDt',
    ordType: 'MarketIfTouched',
    timeInForce: 'ImmediateOrCancel',
    execInst: 'MarkPrice',
    contingencyType: '',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: false,
    ordRejReason: '',
    leavesQty: '1000',
    cumQty: '0',
    avgPx: null,
    text: 'CCXT',
    transactTime: '2024-01-03T22:42:02.129Z',
    timestamp: '2024-01-03T22:42:02.129Z'
  },
  id: 'f64b651c-8deb-40b5-8733-58eedd84df12',
  timestamp: 1704321722129,
  datetime: '2024-01-03T22:42:02.129Z',
  lastTradeTimestamp: 1704321722129,
  symbol: 'BTC/USDT:USDT',
  type: 'marketiftouched',
  timeInForce: 'IOC',
  postOnly: false,
  side: 'sell',
  stopPrice: 42797.5,
  triggerPrice: 42797.5,
  amount: 1000,
  filled: 0,
  remaining: 1000,
  status: 'open',
  trades: [],
  fees: []
}
```
```
bitmex createOrder BTC/USDT:USDT limit sell 1000 45000 '{"trailingAmount":100,"triggerDirection":"above"}'

bitmex.createOrder (BTC/USDT:USDT, limit, sell, 1000, 45000, [object Object])
2024-01-03T22:43:44.618Z iteration 0 passed in 681 ms

{
  info: {
    orderID: '6ca73b1b-4bce-4b43-a8d3-c7be492c42e6',
    clOrdID: '',
    clOrdLinkID: '',
    account: '395724',
    symbol: 'XBTUSDT',
    side: 'Sell',
    orderQty: '1000',
    price: '45000',
    displayQty: null,
    stopPx: '42778',
    pegOffsetValue: '100',
    pegPriceType: 'TrailingStopPeg',
    currency: 'USDT',
    settlCurrency: 'USDt',
    ordType: 'LimitIfTouched',
    timeInForce: 'GoodTillCancel',
    execInst: 'MarkPrice',
    contingencyType: '',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: false,
    ordRejReason: '',
    leavesQty: '1000',
    cumQty: '0',
    avgPx: null,
    text: 'CCXT',
    transactTime: '2024-01-03T22:43:46.025Z',
    timestamp: '2024-01-03T22:43:46.025Z'
  },
  id: '6ca73b1b-4bce-4b43-a8d3-c7be492c42e6',
  timestamp: 1704321826025,
  datetime: '2024-01-03T22:43:46.025Z',
  lastTradeTimestamp: 1704321826025,
  symbol: 'BTC/USDT:USDT',
  type: 'limitiftouched',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  price: 45000,
  stopPrice: 42778,
  triggerPrice: 42778,
  amount: 1000,
  cost: 0,
  filled: 0,
  remaining: 1000,
  status: 'open',
  trades: [],
  fees: []
}
```
```
bitmex editOrder '"f21aa11e-3857-4e39-9230-53cb15a04c3f"' BTC/USDT:USDT market sell 1000 undefined '{"trailingAmount":11000,"triggerDirection":"above"}'

bitmex.editOrder (f21aa11e-3857-4e39-9230-53cb15a04c3f, BTC/USDT:USDT, market, sell, 1000, , [object Object])
2024-01-03T22:57:25.726Z iteration 0 passed in 682 ms

{
  info: {
    orderID: 'f21aa11e-3857-4e39-9230-53cb15a04c3f',
    clOrdID: '',
    clOrdLinkID: '',
    account: '395724',
    symbol: 'XBTUSDT',
    side: 'Sell',
    orderQty: '1000',
    price: null,
    displayQty: null,
    stopPx: '53745',
    pegOffsetValue: '11000',
    pegPriceType: 'TrailingStopPeg',
    currency: 'USDT',
    settlCurrency: 'USDt',
    ordType: 'MarketIfTouched',
    timeInForce: 'ImmediateOrCancel',
    execInst: 'MarkPrice',
    contingencyType: '',
    ordStatus: 'New',
    triggered: '',
    workingIndicator: false,
    ordRejReason: '',
    leavesQty: '1000',
    cumQty: '0',
    avgPx: null,
    text: 'Amended orderQty pegOffsetValue: CCXT\nCCXT',
    transactTime: '2024-01-03T22:56:44.946Z',
    timestamp: '2024-01-03T22:57:27.139Z'
  },
  id: 'f21aa11e-3857-4e39-9230-53cb15a04c3f',
  timestamp: 1704322647139,
  datetime: '2024-01-03T22:57:27.139Z',
  lastTradeTimestamp: 1704322604946,
  symbol: 'BTC/USDT:USDT',
  type: 'marketiftouched',
  timeInForce: 'IOC',
  postOnly: false,
  side: 'sell',
  stopPrice: 53745,
  triggerPrice: 53745,
  amount: 1000,
  filled: 0,
  remaining: 1000,
  status: 'open',
  trades: [],
  fees: []
}
```