### PR TITLE
fix(bingx): clientOrderID is missing

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2424,7 +2424,7 @@ export default class bingx extends Exchange {
             request[spotReqKey] = parsedIds.join (',');
             response = await this.spotV1PrivatePostTradeCancelOrders (this.extend (request, params));
         } else {
-            const swapReqKey = areClientOrderIds ? 'ClientOrderIDList' : 'orderIdList';
+            const swapReqKey = areClientOrderIds ? 'clientOrderIDList' : 'orderIdList';
             request[swapReqKey] = parsedIds;
             response = await this.swapV2PrivateDeleteTradeBatchOrders (this.extend (request, params));
         }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2157,7 +2157,7 @@ export default class bingx extends Exchange {
             'currency': feeCurrencyCode,
             'cost': Precise.stringAbs (feeCost),
         };
-        const clientOrderId = this.safeStringN (order, [ 'clientOrderId', 'c', 'clientOrderID' ]);
+        const clientOrderId = this.safeStringN (order, [ 'clientOrderId', 'c', 'clientOrderID', 'origClientOrderId' ]);
         let stopLoss = this.safeValue (order, 'stopLoss');
         let stopLossPrice = undefined;
         if (stopLoss !== undefined) {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2406,6 +2406,7 @@ export default class bingx extends Exchange {
             'symbol': market['id'],
         };
         const clientOrderIds = this.safeValue (params, 'clientOrderIds');
+        params = this.omit (params, 'clientOrderIds');
         let idsToParse = ids;
         const areClientOrderIds = (clientOrderIds !== undefined);
         if (areClientOrderIds) {
@@ -2419,7 +2420,7 @@ export default class bingx extends Exchange {
         }
         let response = undefined;
         if (market['spot']) {
-            const spotReqKey = areClientOrderIds ? 'clientOrderIds' : 'orderIds';
+            const spotReqKey = areClientOrderIds ? 'clientOrderIDs' : 'orderIds';
             request[spotReqKey] = parsedIds.join (',');
             response = await this.spotV1PrivatePostTradeCancelOrders (this.extend (request, params));
         } else {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2157,7 +2157,7 @@ export default class bingx extends Exchange {
             'currency': feeCurrencyCode,
             'cost': Precise.stringAbs (feeCost),
         };
-        const clientOrderId = this.safeString2 (order, 'clientOrderId', 'c');
+        const clientOrderId = this.safeStringN (order, [ 'clientOrderId', 'c', 'clientOrderID' ]);
         let stopLoss = this.safeValue (order, 'stopLoss');
         let stopLossPrice = undefined;
         if (stopLoss !== undefined) {


### PR DESCRIPTION
```BASH
$ n bingx createOrder LTC/USDT:USDT limit buy 0.1 50 '{"clientOrderID":"test3"}'   
2024-01-04T03:12:14.221Z
Node.js: v20.9.0
CCXT v4.2.4
bingx.createOrder (LTC/USDT:USDT, limit, buy, 0.1, 50, [object Object])

{
  info: {
    orderId: '1742745759348125696',
    symbol: 'LTC-USDT',
    positionSide: 'LONG',
    side: 'BUY',
    type: 'LIMIT',
    price: '50',
    quantity: '0.1',
    stopPrice: '0',
    workingType: 'MARK_PRICE',
    clientOrderID: 'test3',
    timeInForce: 'GTC',
    priceRate: '0',
    stopLoss: '',
    takeProfit: '',
    reduceOnly: false
  },
  id: '1742745759348125696',
  clientOrderId: 'test3',
  symbol: 'LTC/USDT:USDT',
  type: 'limit',
  side: 'buy',
  price: 50,
  stopPrice: 0,
  triggerPrice: 0,
  fee: { currency: 'USDT' },
  trades: [],
  fees: [ { currency: 'USDT' } ]
}

$ n bingx createOrder LTC/USDT limit buy 0.1 50 '{"newClientOrderId":"test4"}'
2024-01-04T03:16:07.477Z
Node.js: v20.9.0
CCXT v4.2.4
bingx.createOrder (LTC/USDT, limit, buy, 0.1, 50, [object Object])

{
  info: {
    symbol: 'LTC-USDT',
    orderId: '1742746736788504576',
    transactTime: '1704338175376',
    price: '50',
    stopPrice: '0',
    origQty: '0.1',
    executedQty: '0',
    cummulativeQuoteQty: '0',
    status: 'PENDING',
    type: 'LIMIT',
    side: 'BUY',
    origClientOrderId: 'test4'
  },
  id: '1742746736788504576',
  clientOrderId: 'test4',
  timestamp: 1704338175376,
  datetime: '2024-01-04T03:16:15.376Z',
  symbol: 'LTC/USDT',
  type: 'limit',
  side: 'buy',
  price: 50,
  stopPrice: 0,
  triggerPrice: 0,
  cost: 0,
  amount: 0.1,
  filled: 0,
  remaining: 0.1,
  status: 'open',
  fee: { currency: 'LTC' },
  trades: [],
  fees: [ { currency: 'LTC' } ]
}

p bingx cancelOrders '[]' LTC/USDT:USDT '{"clientOrderIds":["xxxx"]}'
p bingx cancelOrders '[]' LTC/USDT '{"clientOrderIds":["xxxxx"]}'
```
