### PR TITLE
Woo: createOrder, fetchOrders, editOrder trailing support

### DIFF
--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -69,6 +69,42 @@
                   }
                 ],
                 "output": "broker_id=bc830de7-50f3-460b-9ee0-f430f83f9dad&order_quantity=0.1&order_type=MARKET&reduce_only=true&side=SELL&symbol=PERP_LTC_USDT"
+            },
+            {
+                "description": "Swap trailingAmount reduceOnly order",
+                "method": "createOrder",
+                "url": "https://api.staging.woo.org/v3/algo/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  {
+                    "trailingAmount": "1000",
+                    "trailingTriggerPrice": "50000",
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "{\"activatedPrice\":\"50000\",\"algoType\":\"TRAILING_STOP\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "Swap trailingPercent reduceOnly order",
+                "method": "createOrder",
+                "url": "https://api.staging.woo.org/v3/algo/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  {
+                    "trailingPercent": "5",
+                    "trailingTriggerPrice": "50000",
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "{\"activatedPrice\":\"50000\",\"algoType\":\"TRAILING_STOP\",\"callbackRate\":\"0.05\",\"quantity\":\"0.0001\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDT\",\"type\":\"MARKET\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [

--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -273,6 +273,43 @@
                     "USDT"
                 ]
             }
+        ],
+        "editOrder": [
+            {
+                "description": "Swap edit trailingPercent order",
+                "method": "editOrder",
+                "url": "https://api.staging.woo.org/v3/algo/order/1111779",
+                "input": [
+                  "1111779",
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  {
+                    "trailingPercent": "4"
+                  }
+                ],
+                "output": "{\"callbackRate\":\"0.04\",\"quantity\":\"0.0001\"}"
+            },
+            {
+                "description": "Swap edit trailingAmount order",
+                "method": "editOrder",
+                "url": "https://api.staging.woo.org/v3/algo/order/1111778",
+                "input": [
+                  "1111778",
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  {
+                    "trailingAmount": "1000",
+                    "trailingTriggerPrice": "51000"
+                  }
+                ],
+                "output": "{\"activatedPrice\":\"51000\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -135,6 +135,19 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "Swap trailing orders",
+                "method": "fetchOrders",
+                "url": "https://api.staging.woo.org/v3/algo/orders?algoType=TRAILING_STOP&symbol=PERP_BTC_USDT",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "trailing": true
+                  }
+                ]
             }
         ],
         "fetchMyTrades": [


### PR DESCRIPTION
Added trailing order support to createOrder, fetchOrders and editOrder:

### createOrder, trailingAmount:
```
woo createOrder BTC/USDT:USDT market sell 0.0001 undefined '{"trailingAmount":"1000","trailingTriggerPrice":"50000","reduceOnly":true}'

woo.createOrder (BTC/USDT:USDT, market, sell, 0.0001, , [object Object])
{
  id: '1111778',
  symbol: 'BTC/USDT:USDT',
  amount: 0.0001,
  trades: [],
  fee: {},
  info: {
    orderId: '1111778',
    clientOrderId: '0',
    algoType: 'TRAILING_STOP',
    quantity: '0.0001'
  },
  fees: [ {} ]
}
```

### createOrder, trailingPercent:
```
woo createOrder BTC/USDT:USDT market sell 0.0001 undefined '{"trailingPercent":"5","trailingTriggerPrice":"50000","reduceOnly":true}'

woo.createOrder (BTC/USDT:USDT, market, sell, 0.0001, , [object Object])
{
  id: '1111779',
  symbol: 'BTC/USDT:USDT',
  amount: 0.0001,
  trades: [],
  fee: {},
  info: {
    orderId: '1111779',
    clientOrderId: '0',
    algoType: 'TRAILING_STOP',
    quantity: '0.0001'
  },
  fees: [ {} ]
}
```

### fetchOrders:
```
woo fetchOrders BTC/USDT:USDT undefined undefined '{"trailing":true}'

woo.fetchOrders (BTC/USDT:USDT, , , [object Object])
2024-01-04T03:24:52.252Z iteration 0 passed in 384 ms

     id |     timestamp |                 datetime | lastUpdateTimestamp | status |        symbol |   type | timeInForce | side | amount | trades |          fee |         fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1111778 | 1704336893790 | 2024-01-04T02:54:53.790Z |       1704336893790 |   open | BTC/USDT:USDT | market |         IOC | sell | 0.0001 |     [] | {"cost":"0"} | [{"cost":0}]
1111779 | 1704337187385 | 2024-01-04T02:59:47.385Z |       1704337187385 |   open | BTC/USDT:USDT | market |         IOC | sell | 0.0001 |     [] | {"cost":"0"} | [{"cost":0}]
2 objects
```

### editOrder, trailingPercent:
```
woo editOrder '"1111779"' BTC/USDT:USDT market sell 0.0001 undefined '{"trailingPercent":"4"}'

woo.editOrder (1111779, BTC/USDT:USDT, market, sell, 0.0001, , [object Object])
2024-01-04T03:38:42.063Z iteration 0 passed in 352 ms

{
  status: 'EDIT_SENT',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fee: {},
  info: { status: 'EDIT_SENT' },
  fees: [ {} ]
}
```

### editOrder, trailingAmount:
```
woo editOrder '"1111778"' BTC/USDT:USDT market sell 0.0001 undefined '{"trailingAmount":"1000","trailingTriggerPrice":"51000"}'

woo.editOrder (1111778, BTC/USDT:USDT, market, sell, 0.0001, , [object Object])

{
  status: 'EDIT_SENT',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fee: {},
  info: { status: 'EDIT_SENT' },
  fees: [ {} ]
}
```