### PR TITLE
feat(htx): setPositionMode

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -122,7 +122,7 @@ export default class htx extends Exchange {
                 'repayIsolatedMargin': true,
                 'setLeverage': true,
                 'setMarginMode': false,
-                'setPositionMode': false,
+                'setPositionMode': true,
                 'signIn': undefined,
                 'transfer': true,
                 'withdraw': true,
@@ -8780,5 +8780,75 @@ export default class htx extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
         });
+    }
+
+    async setPositionMode (hedged, symbol: Str = undefined, params = {}) {
+        /**
+         * @method
+         * @name htx#setPositionMode
+         * @description set hedged to true or false
+         * @see https://huobiapi.github.io/docs/usdt_swap/v1/en/#isolated-switch-position-mode
+         * @see https://huobiapi.github.io/docs/usdt_swap/v1/en/#cross-switch-position-mode
+         * @param {bool} hedged set to true to for hedged mode, must be set separately for each market in isolated margin mode, and each settle currency in cross margin mode
+         * @param {string} [symbol] unified market symbol, required for isolated margin mode and for cross margin mode when params["settle"] is undefined
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.marginMode] "cross" (default) or "isolated"
+         * @param {string} [params.settle] required for cross margin mode if symbol is undefined
+         * @returns {object} response from the exchange
+         */
+        await this.loadMarkets ();
+        const posMode = hedged ? 'dual_side' : 'single_side';
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('setPositionMode', params, 'cross');
+        const request = {
+            'position_mode': posMode,
+        };
+        let response = undefined;
+        if (marginMode === 'isolated') {
+            if (symbol === undefined) {
+                throw new ArgumentsRequired (this.id + ' setPositionMode requires a symbol argument for isolated margin mode');
+            }
+            request['margin_account'] = market['id'];
+            response = await this.contractPrivatePostLinearSwapApiV1SwapSwitchPositionMode (this.extend (request, params));
+            //
+            //    {
+            //        "status": "ok",
+            //        "data": [
+            //            {
+            //                "margin_account": "BTC-USDT",
+            //                "position_mode": "single_side"
+            //            }
+            //        ],
+            //        "ts": 1566899973811
+            //    }
+            //
+        } else {
+            let settle = this.safeString2 (params, 'settle', 'margin_account');
+            if ((settle === undefined) && (symbol === undefined)) {
+                throw new ArgumentsRequired (this.id + ' requires either a symbol argument or an extra argument params["settle"] for cross margin mode');
+            } else if (settle === undefined) {
+                settle = market['settle'];
+            }
+            const currency = this.currency (settle);
+            request['margin_account'] = currency['id'].toUpperCase ();
+            response = await this.contractPrivatePostLinearSwapApiV1SwapCrossSwitchPositionMode (this.extend (request, params));
+            //
+            //    {
+            //        "status": "ok",
+            //        "data": [
+            //            {
+            //                "margin_account": "USDT",
+            //                "position_mode": "single_side"
+            //            }
+            //        ],
+            //        "ts": 1566899973811
+            //    }
+            //
+        }
+        return response;
     }
 }

--- a/ts/src/test/static/request/huobi.json
+++ b/ts/src/test/static/request/huobi.json
@@ -1036,6 +1036,39 @@
                 ],
                 "output": "{\"type\":\"30,31\",\"symbol\":\"BTC231124\"}"
             }
+        ],
+        "setPositionMode": [
+            {
+                "description": "set the position mode to one-way in an isolated market",
+                "method": "setPositionMode",
+                "url": "https://api.hbdm.com/linear-swap-api/v1/swap_switch_position_mode?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2024-01-04T06%3A44%3A13&Signature=e%2BJpiijAu1PQRjrKNJOKBluTLmmiMMvxMXHfgDVQSyg%3D",
+                "input": [
+                  false,
+                  "ADA/USDT:USDT",
+                  {
+                    "marginMode": "isolated"
+                  }
+                ],
+                "output": "{\"position_mode\":\"single_side\",\"margin_account\":\"ADA-USDT\"}"
+            },
+            {
+                "description": "Set the position mode to one way for cross margin mode",
+                "method": "setPositionMode",
+                "url": "https://api.hbdm.com/linear-swap-api/v1/swap_cross_switch_position_mode?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2024-01-04T06%3A46%3A05&Signature=NxnMjvMQQue%2FGR4VpDDl3auOxIhDdKUhF0Vlh7ySTgQ%3D",
+                "input": [
+                  false
+                ],
+                "output": "{\"position_mode\":\"single_side\",\"margin_account\":\"USDT\"}"
+            },
+            {
+                "description": "Set the position mode to hedged for cross margin mode",
+                "method": "setPositionMode",
+                "url": "https://api.hbdm.com/linear-swap-api/v1/swap_cross_switch_position_mode?AccessKeyId=bgbfh5tv3f-83da6485-1bbb64ae-3231b&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2024-01-04T06%3A47%3A02&Signature=HuWNFYDIjJqC1YL%2BAVTjjxNF54h6MN6l13Q91JzkyMA%3D",
+                "input": [
+                  true
+                ],
+                "output": "{\"position_mode\":\"dual_side\",\"margin_account\":\"USDT\"}"
+            }
         ]
     }
 }


### PR DESCRIPTION
```
% py htx setPositionMode false ADA/USDT:USDT '{"marginMode": "isolated"}'
Python v3.9.6
CCXT v4.2.4
htx.setPositionMode(false,ADA/USDT:USDT,{'marginMode': 'isolated'})
{'data': {'margin_account': 'ADA-USDT', 'position_mode': 'dual_side'},
 'status': 'ok',
 'ts': '1704350488445'}
```

```
% ph htx setPositionMode false ADA/USDT:USDT '{"marginMode": "isolated"}'
PHP v8.3.0
CCXT version :4.2.4
htx->setPositionMode(false, ADA/USDT:USDT, Array)
Array
(
    [status] => ok
    [data] => Array
        (
            [margin_account] => ADA-USDT
            [position_mode] => dual_side
        )

    [ts] => 1704350499319
)
```

```
% ph htx setPositionMode false                                
PHP v8.3.0
CCXT version :4.2.4
htx->setPositionMode(false)
Array
(
    [status] => ok
    [data] => Array
        (
            [margin_account] => USDT
            [position_mode] => dual_side
        )

    [ts] => 1704350508382
)
```

```
% py htx setPositionMode false 
Python v3.9.6
CCXT v4.2.4
htx.setPositionMode(false)
{'data': {'margin_account': 'USDT', 'position_mode': 'dual_side'},
 'status': 'ok',
 'ts': '1704350520762'}
```