### PR TITLE
fix(binance): patch watchTickers

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -903,7 +903,7 @@ export default class binance extends binanceRest {
         };
         const newTickers = await this.watch (url, messageHash, this.extend (request, params), messageHash, subscribe);
         if (this.newUpdates) {
-            return newTickers;
+            return this.indexBy (newTickers, 'symbol');
         }
         return this.filterByArray (this.tickers, 'symbol', symbols);
     }


### PR DESCRIPTION
I found `watchTickers` would return list of tickers when `newUpdates` is true. In this PR, I added indexBy for the tickers.

```BASH
$ python3 examples/py/watch-tickers.py
{'symbol': 'BTC/USDT', 'timestamp': 1704364447049, 'datetime': '2024-01-04T10:34:07.049Z', 'high': 45309.58, 'low': 40750.0, 'bid': 42915.02, 'bidVolume': 0.39268, 'ask': 42915.03, 'askVolume': 5.66084, 'vwap': 42816.03547473, 'open': 45291.36, 'close': 42915.02, 'last': 42915.02, 'previousClose': 45291.36, 'change': -2376.34, 'percentage': -5.247, 'average': None, 'baseVolume': 82782.64121, 'quoteVolume': 3544424502.7393317, 'info': {'e': '24hrTicker', 'E': 1704364447050, 's': 'BTCUSDT', 'p': '-2376.34000000', 'P': '-5.247', 'w': '42816.03547473', 'x': '45291.36000000', 'c': '42915.02000000', 'Q': '0.00075000', 'b': '42915.02000000', 'B': '0.39268000', 'a': '42915.03000000', 'A': '5.66084000', 'o': '45291.36000000', 'h': '45309.58000000', 'l': '40750.00000000', 'v': '82782.64121000', 'q': '3544424502.73933160', 'O': 1704278047049, 'C': 1704364447049, 'F': 3348696679, 'L': 3351426577, 'n': 2729899}} {'symbol': 'ETH/USDT', 'timestamp': 1704364446899, 'datetime': '2024-01-04T10:34:06.899Z', 'high': 2375.19, 'low': 2100.0, 'bid': 2217.27, 'bidVolume': 6.7612, 'ask': 2217.28, 'askVolume': 19.9567, 'vwap': 2226.18103705, 'open': 2374.19, 'close': 2217.27, 'last': 2217.27, 'previousClose': 2374.2, 'change': -156.92, 'percentage': -6.609, 'average': None, 'baseVolume': 838776.1114, 'quoteVolume': 1867267473.529049, 'info': {'e': '24hrTicker', 'E': 1704364446901, 's': 'ETHUSDT', 'p': '-156.92000000', 'P': '-6.609', 'w': '2226.18103705', 'x': '2374.20000000', 'c': '2217.27000000', 'Q': '1.03960000', 'b': '2217.27000000', 'B': '6.76120000', 'a': '2217.28000000', 'A': '19.95670000', 'o': '2374.19000000', 'h': '2375.19000000', 'l': '2100.00000000', 'v': '838776.11140000', 'q': '1867267473.52904900', 'O': 1704278046899, 'C': 1704364446899, 'F': 1268240620, 'L': 1269589092, 'n': 1348473}} {'symbol': 'DOGE/USDT', 'timestamp': 1704364446901, 'datetime': '2024-01-04T10:34:06.901Z', 'high': 0.09183, 'low': 0.075, 'bid': 0.08202, 'bidVolume': 67438.0, 'ask': 0.08203, 'askVolume': 77248.0, 'vwap': 0.08266908, 'open': 0.09181, 'close': 0.08203, 'last': 0.08203, 'previousClose': 0.09181, 'change': -0.00978, 'percentage': -10.652, 'average': None, 'baseVolume': 2285376996.0, 'quoteVolume': 188930003.35099, 'info': {'e': '24hrTicker', 'E': 1704364446902, 's': 'DOGEUSDT', 'p': '-0.00978000', 'P': '-10.652', 'w': '0.08266908', 'x': '0.09181000', 'c': '0.08203000', 'Q': '107001.00000000', 'b': '0.08202000', 'B': '67438.00000000', 'a': '0.08203000', 'A': '77248.00000000', 'o': '0.09181000', 'h': '0.09183000', 'l': '0.07500000', 'v': '2285376996.00000000', 'q': '188930003.35099000', 'O': 1704278046901, 'C': 1704364446901, 'F': 543895796, 'L': 544268493, 'n': 372698}}
```