### PR TITLE
feat(bingx): add clientOrderId to cancelOrder

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2240,6 +2240,7 @@ export default class bingx extends Exchange {
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.clientOrderId] a unique id for the order
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
@@ -2249,8 +2250,14 @@ export default class bingx extends Exchange {
         const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
-            'orderId': id,
         };
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'clientOrderID');
+        params = this.omit (params, [ 'clientOrderId' ]);
+        if (clientOrderId !== undefined) {
+            request['clientOrderID'] = clientOrderId;
+        } else {
+            request['orderId'] = id;
+        }
         let response = undefined;
         const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
         if (marketType === 'spot') {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -394,6 +394,30 @@
                     "1720647776204967936",
                     "BTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "Spot cancel order with clientOrderId",
+                "method": "cancelOrder",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/trade/cancel?clientOrderID=myorder2&symbol=LTC-USDT&timestamp=1704380693563&signature=6ac964ce62bb594df37c7529ae4bd2010ff025ca06644efee2f0dcd1f5e0805f",
+                "input": [
+                  "",
+                  "LTC/USDT",
+                  {
+                    "clientOrderId": "myorder2"
+                  }
+                ]
+            },
+            {
+                "description": "Swap cancel order with clientOrderId",
+                "method": "cancelOrder",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?clientOrderID=myorder2&symbol=LTC-USDT&timestamp=1704380774663&signature=0f091dc8f55fb10ab73e69d675fdf902a86daf14c3383227a4047190390c1dfb",
+                "input": [
+                  "",
+                  "LTC/USDT:USDT",
+                  {
+                    "clientOrderId": "myorder2"
+                  }
+                ]
             }
         ],
         "cancelOrders":[


### PR DESCRIPTION
```
 bingx cancelOrder "" "LTC/USDT:USDT" '{"clientOrderId":"myorder2"}' --report               
Debugger attached.
2024-01-04T15:06:06.816Z
Node.js: v18.18.0
CCXT v4.2.5
bingx.cancelOrder (, LTC/USDT:USDT, [object Object])
2024-01-04T15:06:14.940Z iteration 0 passed in 1277 ms

{
  info: {
    symbol: 'LTC-USDT',
    orderId: '1742925323563134976',
    side: 'BUY',
    positionSide: 'LONG',
    type: 'LIMIT',
    origQty: '0.1',
    price: '50.00',
    executedQty: '0.0',
    avgPrice: '0.00',
    cumQuote: '0',
    stopPrice: '',
    profit: '0.0000',
    commission: '0.000000',
    status: 'CANCELLED',
    time: '1704380753780',
    updateTime: '1704380753801',
    clientOrderId: 'myorder2',
    leverage: '',
    takeProfit: {
      type: '',
      quantity: '0',
      stopPrice: '0',
      price: '0',
      workingType: ''
    },
    stopLoss: {
      type: '',
      quantity: '0',
      stopPrice: '0',
      price: '0',
      workingType: ''
    },
    advanceAttr: '0',
    positionID: '0',
    takeProfitEntrustPrice: '0',
    stopLossEntrustPrice: '0',
    orderType: '',
    workingType: '',
    onlyOnePosition: false,
    reduceOnly: false
  },
```
```
n bingx cancelOrder "" "LTC/USDT" '{"clientOrderId":"myorder2"}' --report               
Debugger attached.
2024-01-04T15:04:45.692Z
Node.js: v18.18.0
CCXT v4.2.5
bingx.cancelOrder (, LTC/USDT, [object Object])
2024-01-04T15:04:53.971Z iteration 0 passed in 1409 ms

{
  info: {
    symbol: 'LTC-USDT',
    orderId: '1742924924877537280',
    price: '50',
    stopPrice: '0',
    origQty: '0.1',
```
