### PR TITLE
Bybit: createOrder, add trailingAmount support

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3486,6 +3486,7 @@ export default class bybit extends Exchange {
          * @name bybit#createOrder
          * @description create a trade order
          * @see https://bybit-exchange.github.io/docs/v5/order/create-order
+         * @see https://bybit-exchange.github.io/docs/derivatives/unified/trading-stop
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -3507,6 +3508,8 @@ export default class bybit extends Exchange {
          * @param {float} [params.takeProfit.triggerPrice] take profit trigger price
          * @param {object} [params.stopLoss] *stopLoss object in params* containing the triggerPrice at which the attached stop loss order will be triggered
          * @param {float} [params.stopLoss.triggerPrice] stop loss trigger price
+         * @param {string} [params.trailingAmount] *linear swap only* the quote amount to trail away from the current market price
+         * @param {string} [params.trailingTriggerPrice] *linear swap only* the price to trigger a trailing order, default uses the price argument
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -3517,8 +3520,15 @@ export default class bybit extends Exchange {
         if (isUsdcSettled && !isUnifiedAccount) {
             return await this.createUsdcOrder (symbol, type, side, amount, price, params);
         }
+        const trailingAmount = this.safeString2 (params, 'trailingAmount', 'trailingStop');
+        const isTrailingAmountOrder = trailingAmount !== undefined;
         const orderRequest = this.createOrderRequest (symbol, type, side, amount, price, params);
-        const response = await this.privatePostV5OrderCreate (orderRequest); // already extended inside createOrderRequest
+        let response = undefined;
+        if (isTrailingAmountOrder) {
+            response = await this.privatePostUnifiedV3PrivatePositionTradingStop (orderRequest);
+        } else {
+            response = await this.privatePostV5OrderCreate (orderRequest); // already extended inside createOrderRequest
+        }
         //
         //     {
         //         "retCode": 0,
@@ -3620,12 +3630,23 @@ export default class bybit extends Exchange {
         const takeProfitTriggerPrice = this.safeValue (params, 'takeProfitPrice');
         const stopLoss = this.safeValue (params, 'stopLoss');
         const takeProfit = this.safeValue (params, 'takeProfit');
+        const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activePrice', price);
+        const trailingAmount = this.safeString2 (params, 'trailingAmount', 'trailingStop');
+        const isTrailingAmountOrder = trailingAmount !== undefined;
         const isStopLossTriggerOrder = stopLossTriggerPrice !== undefined;
         const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
         const isStopLoss = stopLoss !== undefined;
         const isTakeProfit = takeProfit !== undefined;
         const isBuy = side === 'buy';
-        if (triggerPrice !== undefined) {
+        if (isTrailingAmountOrder) {
+            if (!market['swap'] && !market['linear']) {
+                throw new NotSupported (this.id + ' createOrder() supports linear swap markets only');
+            }
+            if (trailingTriggerPrice !== undefined) {
+                request['activePrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+            }
+            request['trailingStop'] = trailingAmount;
+        } else if (triggerPrice !== undefined) {
             const triggerDirection = this.safeString (params, 'triggerDirection');
             params = this.omit (params, [ 'triggerPrice', 'stopPrice', 'triggerDirection' ]);
             if (market['spot']) {
@@ -3675,7 +3696,7 @@ export default class bybit extends Exchange {
             // mandatory field for options
             request['orderLinkId'] = this.uuid16 ();
         }
-        params = this.omit (params, [ 'stopPrice', 'timeInForce', 'stopLossPrice', 'takeProfitPrice', 'postOnly', 'clientOrderId', 'triggerPrice', 'stopLoss', 'takeProfit' ]);
+        params = this.omit (params, [ 'stopPrice', 'timeInForce', 'stopLossPrice', 'takeProfitPrice', 'postOnly', 'clientOrderId', 'triggerPrice', 'stopLoss', 'takeProfit', 'trailingAmount', 'trailingTriggerPrice' ]);
         return this.extend (request, params);
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3486,7 +3486,7 @@ export default class bybit extends Exchange {
          * @name bybit#createOrder
          * @description create a trade order
          * @see https://bybit-exchange.github.io/docs/v5/order/create-order
-         * @see https://bybit-exchange.github.io/docs/derivatives/unified/trading-stop
+         * @see https://bybit-exchange.github.io/docs/v5/position/trading-stop
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -3508,8 +3508,8 @@ export default class bybit extends Exchange {
          * @param {float} [params.takeProfit.triggerPrice] take profit trigger price
          * @param {object} [params.stopLoss] *stopLoss object in params* containing the triggerPrice at which the attached stop loss order will be triggered
          * @param {float} [params.stopLoss.triggerPrice] stop loss trigger price
-         * @param {string} [params.trailingAmount] *linear swap only* the quote amount to trail away from the current market price
-         * @param {string} [params.trailingTriggerPrice] *linear swap only* the price to trigger a trailing order, default uses the price argument
+         * @param {string} [params.trailingAmount] the quote amount to trail away from the current market price
+         * @param {string} [params.trailingTriggerPrice] the price to trigger a trailing order, default uses the price argument
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -3525,7 +3525,7 @@ export default class bybit extends Exchange {
         const orderRequest = this.createOrderRequest (symbol, type, side, amount, price, params);
         let response = undefined;
         if (isTrailingAmountOrder) {
-            response = await this.privatePostUnifiedV3PrivatePositionTradingStop (orderRequest);
+            response = await this.privatePostV5PositionTradingStop (orderRequest);
         } else {
             response = await this.privatePostV5OrderCreate (orderRequest); // already extended inside createOrderRequest
         }
@@ -3639,9 +3639,6 @@ export default class bybit extends Exchange {
         const isTakeProfit = takeProfit !== undefined;
         const isBuy = side === 'buy';
         if (isTrailingAmountOrder) {
-            if (!market['swap'] && !market['linear']) {
-                throw new NotSupported (this.id + ' createOrder() supports linear swap markets only');
-            }
             if (trailingTriggerPrice !== undefined) {
                 request['activePrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
             }

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -308,6 +308,17 @@
                 "output": "{\"symbol\":\"LTCUSDT\",\"orderFilter\":\"Order\",\"orderId\":\"1513125485218108928\",\"category\":\"spot\"}"
             }
         ],
+        "cancelAllOrders": [
+            {
+                "description": "Swap cancel all open orders",
+                "method": "cancelAllOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel-all",
+                "input": [
+                  "BTC/USDT:USDT"
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"linear\"}"
+            }
+        ],
         "fetchOpenOrders": [
             {
                 "description": "Spot fetchOpenOrders",

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -230,6 +230,22 @@
                     }
                 ],
                 "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"20\"}"
+            },
+            {
+                "description": "Swap trailingAmount order",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/unified/v3/private/position/trading-stop",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.001,
+                  null,
+                  {
+                    "trailingAmount": "1000"
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"0.001\",\"trailingStop\":\"1000\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -234,7 +234,7 @@
             {
                 "description": "Swap trailingAmount order",
                 "method": "createOrder",
-                "url": "https://api-testnet.bybit.com/unified/v3/private/position/trading-stop",
+                "url": "https://api-testnet.bybit.com/v5/position/trading-stop",
                 "input": [
                   "BTC/USDT:USDT",
                   "market",


### PR DESCRIPTION
Added trailing order support to bybit:

```
bybit createOrder BTC/USDT:USDT market sell 0.001 undefined '{"trailingAmount":"1000"}'

bybit.createOrder (BTC/USDT:USDT, market, sell, 0.001, , [object Object])
2024-01-05T03:33:58.702Z iteration 0 passed in 1854 ms

{ info: {}, symbol: 'BTC/USDT:USDT', trades: [], fees: [] }
```