### PR TITLE
Binance: createOrder, trailingPercent orders

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4438,8 +4438,8 @@ export default class binance extends Exchange {
         const stopLossPrice = this.safeValue (params, 'stopLossPrice', triggerPrice);  // fallback to stopLoss
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
         const trailingDelta = this.safeValue (params, 'trailingDelta');
-        const trailingTriggerPrice = this.safeNumber2 (params, 'trailingTriggerPrice', 'activationPrice', price);
-        const trailingPercent = this.safeNumber2 (params, 'trailingPercent', 'callbackRate');
+        const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activationPrice', price);
+        const trailingPercent = this.safeString2 (params, 'trailingPercent', 'callbackRate');
         const isTrailingPercentOrder = trailingPercent !== undefined;
         const isStopLoss = stopLossPrice !== undefined || trailingDelta !== undefined;
         const isTakeProfit = takeProfitPrice !== undefined;

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4375,6 +4375,8 @@ export default class binance extends Exchange {
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
          * @param {boolean} [params.sor] *spot only* whether to use SOR (Smart Order Routing) or not, default is false
          * @param {boolean} [params.test] *spot only* whether to use the test endpoint or not, default is false
+         * @param {float} [params.trailingPercent] the percent to trail away from the current market price
+         * @param {float} [params.trailingTriggerPrice] the price to trigger a trailing order, default uses the price argument
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -4421,6 +4423,8 @@ export default class binance extends Exchange {
          * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} params extra parameters specific to the exchange API endpoint
          * @param {string|undefined} params.marginMode 'cross' or 'isolated', for spot margin trading
+         * @param {float} [params.trailingPercent] the percent to trail away from the current market price
+         * @param {float} [params.trailingTriggerPrice] the price to trigger a trailing order, default uses the price argument
          * @returns {object} request to be sent to the exchange
          */
         const market = this.market (symbol);
@@ -4434,9 +4438,12 @@ export default class binance extends Exchange {
         const stopLossPrice = this.safeValue (params, 'stopLossPrice', triggerPrice);  // fallback to stopLoss
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
         const trailingDelta = this.safeValue (params, 'trailingDelta');
+        const trailingTriggerPrice = this.safeNumber2 (params, 'trailingTriggerPrice', 'activationPrice', price);
+        const trailingPercent = this.safeNumber2 (params, 'trailingPercent', 'callbackRate');
+        const isTrailingPercentOrder = trailingPercent !== undefined;
         const isStopLoss = stopLossPrice !== undefined || trailingDelta !== undefined;
         const isTakeProfit = takeProfitPrice !== undefined;
-        params = this.omit (params, [ 'type', 'newClientOrderId', 'clientOrderId', 'postOnly', 'stopLossPrice', 'takeProfitPrice', 'stopPrice', 'triggerPrice' ]);
+        params = this.omit (params, [ 'type', 'newClientOrderId', 'clientOrderId', 'postOnly', 'stopLossPrice', 'takeProfitPrice', 'stopPrice', 'triggerPrice', 'trailingTriggerPrice', 'trailingPercent' ]);
         const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
         const request = {
             'symbol': market['id'],
@@ -4457,7 +4464,12 @@ export default class binance extends Exchange {
         }
         let uppercaseType = type.toUpperCase ();
         let stopPrice = undefined;
-        if (isStopLoss) {
+        if (isTrailingPercentOrder) {
+            uppercaseType = 'TRAILING_STOP_MARKET';
+            if (trailingTriggerPrice !== undefined) {
+                request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+            }
+        } else if (isStopLoss) {
             stopPrice = stopLossPrice;
             if (isMarketOrder) {
                 // spot STOP_LOSS market orders are not a valid order type
@@ -4583,9 +4595,8 @@ export default class binance extends Exchange {
             stopPriceIsRequired = true;
         } else if (uppercaseType === 'TRAILING_STOP_MARKET') {
             quantityIsRequired = true;
-            const callbackRate = this.safeNumber (query, 'callbackRate');
-            if (callbackRate === undefined) {
-                throw new InvalidOrder (this.id + ' createOrder() requires a callbackRate extra param for a ' + type + ' order');
+            if (trailingPercent === undefined) {
+                throw new InvalidOrder (this.id + ' createOrder() requires a trailingPercent param for a ' + type + ' order');
             }
         }
         if (quantityIsRequired) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4466,6 +4466,7 @@ export default class binance extends Exchange {
         let stopPrice = undefined;
         if (isTrailingPercentOrder) {
             uppercaseType = 'TRAILING_STOP_MARKET';
+            request['callbackRate'] = trailingPercent;
             if (trailingTriggerPrice !== undefined) {
                 request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
             }

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -216,6 +216,23 @@
                     }
                 ],
                 "output": "timestamp=1699380695835&symbol=LTCUSDT&side=BUY&newClientOrderId=x-xcKtGhcu392bafca1fb740208ee8d3&newOrderRespType=RESULT&type=LIMIT&quantity=0.2&price=50&timeInForce=GTX&recvWindow=10000&signature=27dfce7c02d210d4d88f029e34550f153283e849b34bbf80aebbc7f860937b84"
+            },
+            {
+                "description": "Swap trailingPercent order",
+                "method": "createOrder",
+                "url": "https://testnet.binancefuture.com/fapi/v1/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.1,
+                  null,
+                  {
+                    "trailingPercent": 5,
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "timestamp=1704512493514&symbol=BTCUSDT&side=SELL&callbackRate=5&newClientOrderId=x-xcKtGhcufdcb378c830d451392c9a2&newOrderRespType=RESULT&type=TRAILING_STOP_MARKET&quantity=0.1&reduceOnly=true&recvWindow=10000&signature=381024e31ce5868d69dd3e12668b9b47514c1211e7d0021a7939cb26d07f679a"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Added `trailingPercent` support to binance:

```
binanceusdm createOrder BTC/USDT:USDT market sell 0.1 undefined '{"trailingPercent":5,"reduceOnly":true}'

binanceusdm.createOrder (BTC/USDT:USDT, market, sell, 0.1, , [object Object])
2024-01-06T03:41:34.050Z iteration 0 passed in 589 ms

{
  info: {
    orderId: '3618935426',
    symbol: 'BTCUSDT',
    status: 'NEW',
    clientOrderId: 'x-xcKtGhcufdcb378c830d451392c9a2',
    price: '0.00',
    avgPrice: '0.00',
    origQty: '0.100',
    executedQty: '0.000',
    cumQty: '0.000',
    cumQuote: '0.00000',
    timeInForce: 'GTC',
    activatePrice: '43709.80',
    priceRate: '5.00',
    type: 'TRAILING_STOP_MARKET',
    reduceOnly: true,
    closePosition: false,
    side: 'SELL',
    positionSide: 'BOTH',
    stopPrice: '0.00',
    workingType: 'CONTRACT_PRICE',
    priceProtect: false,
    origType: 'TRAILING_STOP_MARKET',
    priceMatch: 'NONE',
    selfTradePreventionMode: 'NONE',
    goodTillDate: '0',
    updateTime: '1704512494251'
  },
  id: '3618935426',
  clientOrderId: 'x-xcKtGhcufdcb378c830d451392c9a2',
  timestamp: 1704512494251,
  datetime: '2024-01-06T03:41:34.251Z',
  lastUpdateTimestamp: 1704512494251,
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop_market',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: true,
  side: 'sell',
  amount: 0.1,
  cost: 0,
  filled: 0,
  remaining: 0.1,
  status: 'open',
  trades: [],
  fees: []
}
```