### PR TITLE
Deribit: trailing order support

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -1771,7 +1771,7 @@ export default class deribit extends Exchange {
         const stopLossPrice = this.safeValue (params, 'stopLossPrice');
         // only take profit buy orders are allowed when price crossed from below
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
-        const trailingAmount = this.safeNumber2 (params, 'trailingAmount', 'trigger_offset');
+        const trailingAmount = this.safeString2 (params, 'trailingAmount', 'trigger_offset');
         const isTrailingAmountOrder = trailingAmount !== undefined;
         const isStopLimit = type === 'stop_limit';
         const isStopMarket = type === 'stop_market';
@@ -1796,7 +1796,7 @@ export default class deribit extends Exchange {
         if (isTrailingAmountOrder) {
             request['trigger'] = trigger;
             request['type'] = 'trailing_stop';
-            request['trigger_offset'] = trailingAmount;
+            request['trigger_offset'] = this.parseToNumeric (trailingAmount);
         } else if (isStopOrder) {
             const triggerPrice = (stopLossPrice !== undefined) ? stopLossPrice : takeProfitPrice;
             request['trigger_price'] = this.priceToPrecision (symbol, triggerPrice);
@@ -1935,10 +1935,10 @@ export default class deribit extends Exchange {
         if (price !== undefined) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
-        const trailingAmount = this.safeNumber2 (params, 'trailingAmount', 'trigger_offset');
+        const trailingAmount = this.safeString2 (params, 'trailingAmount', 'trigger_offset');
         const isTrailingAmountOrder = trailingAmount !== undefined;
         if (isTrailingAmountOrder) {
-            request['trigger_offset'] = trailingAmount;
+            request['trigger_offset'] = this.parseToNumeric (trailingAmount);
             params = this.omit (params, 'trigger_offset');
         }
         const response = await this.privateGetEdit (this.extend (request, params));

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -1740,7 +1740,7 @@ export default class deribit extends Exchange {
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade. For perpetual and futures the amount is in USD. For options it is in corresponding cryptocurrency contracts currency.
+         * @param {float} amount how much you want to trade in units of the base currency. For inverse perpetual and futures the amount is in the quote currency USD. For options it is in the underlying assets base currency.
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.trigger] the trigger type 'index_price', 'mark_price', or 'last_price', default is 'last_price'
@@ -1749,18 +1749,11 @@ export default class deribit extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (market['inverse']) {
-            amount = this.amountToPrecision (symbol, amount);
-        } else if (market['settle'] === 'USDC') {
-            amount = this.amountToPrecision (symbol, amount);
-        } else {
-            amount = this.currencyToPrecision (symbol, amount);
-        }
         const request = {
             'instrument_name': market['id'],
             // for perpetual and futures the amount is in USD
             // for options it is in corresponding cryptocurrency contracts, e.g., BTC or ETH
-            'amount': amount,
+            'amount': this.amountToPrecision (symbol, amount),
             'type': type, // limit, stop_limit, market, stop_market, default is limit
             // 'label': 'string', // user-defined label for the order (maximum 64 characters)
             // 'price': this.priceToPrecision (symbol, 123.45), // only for limit and stop_limit orders

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -1751,8 +1751,6 @@ export default class deribit extends Exchange {
         const market = this.market (symbol);
         const request = {
             'instrument_name': market['id'],
-            // for perpetual and futures the amount is in USD
-            // for options it is in corresponding cryptocurrency contracts, e.g., BTC or ETH
             'amount': this.amountToPrecision (symbol, amount),
             'type': type, // limit, stop_limit, market, stop_market, default is limit
             // 'label': 'string', // user-defined label for the order (maximum 64 characters)
@@ -1915,7 +1913,7 @@ export default class deribit extends Exchange {
          * @param {string} [symbol] unified symbol of the market to edit an order in
          * @param {string} [type] 'market' or 'limit'
          * @param {string} [side] 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of the base currency
+         * @param {float} amount how much you want to trade in units of the base currency, inverse swap and future use the quote currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the base currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {float} [params.trailingAmount] the quote amount to trail away from the current market price
@@ -1927,8 +1925,6 @@ export default class deribit extends Exchange {
         await this.loadMarkets ();
         const request = {
             'order_id': id,
-            // for perpetual and futures the amount is in USD
-            // for options it is in corresponding cryptocurrency contracts, e.g., BTC or ETH
             'amount': this.amountToPrecision (symbol, amount),
             // 'post_only': false, // if the new price would cause the order to be filled immediately (as taker), the price will be changed to be just below the spread.
             // 'reject_post_only': false, // if true the order is put to order book unmodified or request is rejected

--- a/ts/src/test/static/markets/deribit.json
+++ b/ts/src/test/static/markets/deribit.json
@@ -40,5 +40,74 @@
     "created": 1702374650000,
     "strike": "",
     "optionType": ""
+  },
+  "BTC/USDT:USDT": {
+    "id": "BTC_USDT-PERPETUAL",
+    "symbol": "BTC/USDT:USDT",
+    "base": "BTC",
+    "quote": "USDT",
+    "settle": "USDT",
+    "baseId": "BTC",
+    "quoteId": "USDT",
+    "settleId": "USDT",
+    "type": "swap",
+    "spot": false,
+    "margin": false,
+    "swap": true,
+    "future": false,
+    "option": false,
+    "active": true,
+    "contract": true,
+    "linear": true,
+    "inverse": false,
+    "subType": "linear",
+    "taker": 0.0005,
+    "maker": 0,
+    "contractSize": 0.001,
+    "expiry": 32503708800000,
+    "expiryDatetime": "3000-01-01T08:00:00.000Z",
+    "precision": {
+      "amount": 0.001,
+      "price": 1
+    },
+    "limits": {
+      "leverage": {},
+      "amount": {
+        "min": 0.001
+      },
+      "price": {
+        "min": 1
+      },
+      "cost": {}
+    },
+    "created": 1702464293000,
+    "info": {
+      "tick_size_steps": [],
+      "quote_currency": "USDT",
+      "min_trade_amount": "0.001",
+      "expiration_timestamp": "32503708800000",
+      "counter_currency": "USDT",
+      "settlement_currency": "USDT",
+      "block_trade_tick_size": "1.0",
+      "block_trade_min_trade_amount": "200000",
+      "block_trade_commission": "0.0001",
+      "max_liquidation_commission": "0.0075",
+      "max_leverage": "50",
+      "future_type": "linear",
+      "settlement_period": "perpetual",
+      "creation_timestamp": "1702464293000",
+      "base_currency": "BTC",
+      "instrument_id": "282352",
+      "instrument_type": "linear",
+      "taker_commission": "0.0005",
+      "maker_commission": "0.0",
+      "tick_size": "1.0",
+      "contract_size": "0.001",
+      "is_active": true,
+      "instrument_name": "BTC_USDT-PERPETUAL",
+      "kind": "future",
+      "rfq": false,
+      "price_index": "btc_usdt"
+    }
   }
 }

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -50,7 +50,7 @@
             {
                 "description": "Swap trailingAmount order",
                 "method": "createOrder",
-                "url": "https://test.deribit.com/api/v2/private/sell?instrument_name=BTC_USDT-PERPETUAL&amount=0.001&type=trailing_stop&trigger=last_price&trigger_offset=1000",
+                "url": "https://test.deribit.com/api/v2/private/sell?instrument_name=BTC_USDT-PERPETUAL&amount=0.001&type=trailing_stop&trigger=last_price&trigger_offset=1000.0",
                 "input": [
                   "BTC/USDT:USDT",
                   "market",
@@ -58,7 +58,7 @@
                   0.001,
                   null,
                   {
-                    "trailingAmount": 1000
+                    "trailingAmount": 1000.0
                   }
                 ]
             }
@@ -166,7 +166,7 @@
             {
                 "description": "Swap edit a trailingAmount order",
                 "method": "editOrder",
-                "url": "https://test.deribit.com/api/v2/private/edit?order_id=USDT-TSTS-32&amount=0.001&trigger_offset=2500&trailingAmount=2500",
+                "url": "https://test.deribit.com/api/v2/private/edit?order_id=USDT-TSTS-32&amount=0.001&trigger_offset=2500&trailingAmount=2500.0",
                 "input": [
                   "USDT-TSTS-32",
                   "BTC/USDT:USDT",
@@ -175,7 +175,7 @@
                   0.001,
                   null,
                   {
-                    "trailingAmount": 2500
+                    "trailingAmount": 2500.0
                   }
                 ]
             }

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -24,7 +24,7 @@
         ],
         "createOrder": [
             {
-                "description": "create Order",
+                "description": "Spot limit buy order",
                 "method": "createOrder",
                 "url": "https://www.deribit.com/api/v2/private/buy?instrument_name=BTC_USDT&amount=0.0002&type=limit&price=25000",
                 "input": [
@@ -36,7 +36,7 @@
                 ]
             },
             {
-                "description": "create Order",
+                "description": "Spot limit sell order",
                 "method": "createOrder",
                 "url": "https://www.deribit.com/api/v2/private/sell?instrument_name=BTC_USDT&amount=0.0002&type=limit&price=25000",
                 "input": [
@@ -45,6 +45,21 @@
                     "sell",
                     0.0002,
                     25000
+                ]
+            },
+            {
+                "description": "Swap trailingAmount order",
+                "method": "createOrder",
+                "url": "https://test.deribit.com/api/v2/private/sell?instrument_name=BTC_USDT-PERPETUAL&amount=0.001&type=trailing_stop&trigger=last_price&trigger_offset=1000",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.001,
+                  null,
+                  {
+                    "trailingAmount": 1000
+                  }
                 ]
             }
         ],

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -50,7 +50,7 @@
             {
                 "description": "Swap trailingAmount order",
                 "method": "createOrder",
-                "url": "https://test.deribit.com/api/v2/private/sell?instrument_name=BTC_USDT-PERPETUAL&amount=0.001&type=trailing_stop&trigger=last_price&trigger_offset=1000.0",
+                "url": "https://test.deribit.com/api/v2/private/sell?instrument_name=BTC_USDT-PERPETUAL&amount=0.001&type=trailing_stop&trigger=last_price&trigger_offset=1000",
                 "input": [
                   "BTC/USDT:USDT",
                   "market",
@@ -58,7 +58,7 @@
                   0.001,
                   null,
                   {
-                    "trailingAmount": 1000.0
+                    "trailingAmount": 1000
                   }
                 ]
             }
@@ -166,7 +166,7 @@
             {
                 "description": "Swap edit a trailingAmount order",
                 "method": "editOrder",
-                "url": "https://test.deribit.com/api/v2/private/edit?order_id=USDT-TSTS-32&amount=0.001&trigger_offset=2500&trailingAmount=2500.0",
+                "url": "https://test.deribit.com/api/v2/private/edit?order_id=USDT-TSTS-32&amount=0.001&trigger_offset=2500&trailingAmount=2500",
                 "input": [
                   "USDT-TSTS-32",
                   "BTC/USDT:USDT",
@@ -175,7 +175,7 @@
                   0.001,
                   null,
                   {
-                    "trailingAmount": 2500.0
+                    "trailingAmount": 2500
                   }
                 ]
             }

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -161,6 +161,24 @@
                     "toAccount"
                 ]
             }
+        ],
+        "editOrder": [
+            {
+                "description": "Swap edit a trailingAmount order",
+                "method": "editOrder",
+                "url": "https://test.deribit.com/api/v2/private/edit?order_id=USDT-TSTS-32&amount=0.001&trigger_offset=2500&trailingAmount=2500",
+                "input": [
+                  "USDT-TSTS-32",
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.001,
+                  null,
+                  {
+                    "trailingAmount": 2500
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `trailingAmount` support to createOrder and editOrder:

### createOrder:
```
deribit createOrder BTC/USDT:USDT market sell 0.001 undefined '{"trailingAmount":1000}'

deribit.createOrder (BTC/USDT:USDT, market, sell, 0.001, , [object Object])
2024-01-05T07:33:50.933Z iteration 0 passed in 207 ms

{
  info: {
    is_liquidation: false,
    risk_reducing: false,
    trigger_reference_price: '43881.5',
    stop_price: '42881.5',
    order_type: 'trailing_stop',
    creation_timestamp: '1704440031597',
    contracts: '1.0',
    order_state: 'untriggered',
    order_id: 'USDT-TSTS-31',
    reduce_only: false,
    post_only: false,
    last_update_timestamp: '1704440031597',
    replaced: false,
    trigger_offset: '1000.0',
    trigger_price: '42881.5',
    trigger: 'last_price',
    web: false,
    api: true,
    max_show: '0.001',
    time_in_force: 'good_til_cancelled',
    direction: 'sell',
    mmp: false,
    instrument_name: 'BTC_USDT-PERPETUAL',
    triggered: false,
    amount: '0.001',
    price: 'market_price',
    label: '',
    trades: []
  },
  id: 'USDT-TSTS-31',
  timestamp: 1704440031597,
  datetime: '2024-01-05T07:33:51.597Z',
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  stopPrice: 42881.5,
  triggerPrice: 42881.5,
  amount: 0.001,
  status: 'open',
  trades: [],
  fees: []
}
```

### editOrder:
```
deribit editOrder "'USDT-TSTS-32'" BTC/USDT:USDT market sell 0.001 undefined '{"trailingAmount":2500}'

deribit.editOrder (USDT-TSTS-32, BTC/USDT:USDT, market, sell, 0.001, , [object Object])
2024-01-05T07:51:57.810Z iteration 0 passed in 204 ms

{
  info: {
    is_liquidation: false,
    risk_reducing: false,
    trigger_reference_price: '43797.5',
    stop_price: '41305.5',
    order_type: 'trailing_stop',
    creation_timestamp: '1704441016166',
    contracts: '1.0',
    order_state: 'untriggered',
    order_id: 'USDT-TSTS-32',
    reduce_only: false,
    post_only: false,
    last_update_timestamp: '1704441118486',
    replaced: true,
    trigger_offset: '2500.0',
    trigger_price: '41305.5',
    trigger: 'last_price',
    web: false,
    api: true,
    max_show: '0.001',
    time_in_force: 'good_til_cancelled',
    direction: 'sell',
    mmp: false,
    instrument_name: 'BTC_USDT-PERPETUAL',
    triggered: false,
    amount: '0.001',
    price: 'market_price',
    label: '',
    trades: []
  },
  id: 'USDT-TSTS-32',
  timestamp: 1704441016166,
  datetime: '2024-01-05T07:50:16.166Z',
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  stopPrice: 41305.5,
  triggerPrice: 41305.5,
  amount: 0.001,
  status: 'open',
  trades: [],
  fees: []
}
```