### PR TITLE
crypocom orderbooks websockets topic error

### DIFF
--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -95,10 +95,13 @@ export default class cryptocom extends cryptocomRest {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
         const topics = [];
+        if (!limit) {
+            limit = 150;
+        }
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             const market = this.market (symbol);
-            const currentTopic = 'book' + '.' + market['id'];
+            const currentTopic = 'book' + '.' + market['id'] + '.' + limit;
             topics.push (currentTopic);
         }
         const orderbook = await this.watchPublicMultiple (topics, topics, params);


### PR DESCRIPTION
In cryptocom pro, the correct topic for an orderbook topic _must_ include the depth parameter (limit in ccxt) . 

This fixes the problem that incoming orderbook messages were not handled correctly, resulting in a dangling Promise (never fulfilled, never rejected).

For instance, for BTC/USDT without limit parameter, the correct topic is **book.BTC_USDT.150** (contrary to crypto.com documentation, the default depth is 150 and not 50). FYI: Not all values for depth are supported; 50 and 150 work, 100 doesn't.


