### PR TITLE
fix(coinbasepro): fetchTickers - docs no longer reference okx

### DIFF
--- a/ts/src/pro/coinbasepro.ts
+++ b/ts/src/pro/coinbasepro.ts
@@ -129,8 +129,7 @@ export default class coinbasepro extends coinbaseproRest {
     async watchTickers (symbols: Strings = undefined, params = {}) {
         /**
          * @method
-         * @name okx#watchTickers
-         * @see https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-tickers-channel
+         * @name coinbasepro#watchTickers
          * @description watches a price ticker, a statistical calculation with the information calculated over the past 24 hours for all markets of a specific list
          * @param {string[]} [symbols] unified symbol of the market to fetch the ticker for
          * @param {object} [params] extra parameters specific to the exchange API endpoint


### PR DESCRIPTION
fixes: #20677

---------------

This PR can be closed if #20681 is merged