### PR TITLE
Okx: trailing orders

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -3798,7 +3798,7 @@ export default class okx extends Exchange {
                 query = this.omit (query, [ 'until', 'till' ]);
             }
         }
-        const send = this.omit (query, [ 'method', 'stop', 'ordType', 'trigger', 'trailing' ]);
+        const send = this.omit (query, [ 'method', 'stop', 'trigger', 'trailing' ]);
         let response = undefined;
         if (method === 'privateGetTradeOrdersAlgoHistory') {
             response = await this.privateGetTradeOrdersAlgoHistory (this.extend (request, send));

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -3728,6 +3728,7 @@ export default class okx extends Exchange {
          * @param {string} [params.ordType] "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
          * @param {string} [params.algoId] Algo ID "'433845797218942976'"
          * @param {int} [params.until] timestamp in ms to fetch orders for
+         * @param {boolean} [params.trailing] set to true if you want to fetch trailing orders
          * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -3761,7 +3762,11 @@ export default class okx extends Exchange {
         let method = this.safeString (params, 'method', defaultMethod);
         const ordType = this.safeString (params, 'ordType');
         const stop = this.safeValue2 (params, 'stop', 'trigger');
-        if (stop || (ordType in algoOrderTypes)) {
+        const trailing = this.safeValue (params, 'trailing', false);
+        if (trailing) {
+            method = 'privateGetTradeOrdersAlgoHistory';
+            request['ordType'] = 'move_order_stop';
+        } else if (stop || (ordType in algoOrderTypes)) {
             method = 'privateGetTradeOrdersAlgoHistory';
             const algoId = this.safeString (params, 'algoId');
             if (algoId !== undefined) {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2833,7 +2833,7 @@ export default class okx extends Exchange {
         let request = this.createOrderRequest (symbol, type, side, amount, price, params);
         let method = this.safeString (this.options, 'createOrder', 'privatePostTradeBatchOrders');
         const requestOrdType = this.safeString (request, 'ordType');
-        if ((requestOrdType === 'trigger') || (requestOrdType === 'conditional')  || (requestOrdType === 'move_order_stop') || (type === 'move_order_stop') || (type === 'oco') || (type === 'iceberg') || (type === 'twap')) {
+        if ((requestOrdType === 'trigger') || (requestOrdType === 'conditional') || (requestOrdType === 'move_order_stop') || (type === 'move_order_stop') || (type === 'oco') || (type === 'iceberg') || (type === 'twap')) {
             method = 'privatePostTradeOrderAlgo';
         }
         if ((method !== 'privatePostTradeOrder') && (method !== 'privatePostTradeOrderAlgo') && (method !== 'privatePostTradeBatchOrders')) {
@@ -3968,7 +3968,7 @@ export default class okx extends Exchange {
         if (trailing || stop || (ordType in algoOrderTypes)) {
             method = 'privateGetTradeOrdersAlgoHistory';
             request['state'] = 'effective';
-        } 
+        }
         if (trailing) {
             request['ordType'] = 'move_order_stop';
         } else if (stop || (ordType in algoOrderTypes)) {

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -222,6 +222,24 @@
               }
             ],
             "output": "[{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"e847386590ce4dBCdbc74f1714de86ed\",\"tag\":\"e847386590ce4dBC\"}]"      
+          },
+          {
+            "description": "Swap trailingPercent order",
+            "method": "createOrder",
+            "url": "https://www.okx.com/api/v5/trade/order-algo",
+            "input": [
+              "BTC/USDT:USDT",
+              "market",
+              "sell",
+              1,
+              null,
+              {
+                "trailingPercent": "5",
+                "reduceOnly": true,
+                "posSide": "long"
+              }
+            ],
+            "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"move_order_stop\",\"sz\":\"1\",\"tdMode\":\"cross\",\"callbackRatio\":\"0.05\",\"clOrdId\":\"e847386590ce4dBC5328f747a43e97d9\",\"tag\":\"e847386590ce4dBC\",\"reduceOnly\":true,\"posSide\":\"long\"}"
           }
         ],
         "createMarketBuyOrderWithCost": [

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -517,6 +517,19 @@
                 "ordType": "trigger"
               }
             ]
+          },
+          {
+            "description": "Swap fetch canceled trailing orders",
+            "method": "fetchCanceledOrders",
+            "url": "https://www.okx.com/api/v5/trade/orders-algo-history?instId=BTC-USDT-SWAP&instType=SWAP&state=canceled&ordType=move_order_stop&trailing=true",
+            "input": [
+              "BTC/USDT:USDT",
+              null,
+              null,
+              {
+                "trailing": true
+              }
+            ]
           }
         ],
         "fetchClosedOrders": [

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -642,6 +642,19 @@
               }
             ],
             "output": "[{\"algoId\":\"641788035268431872\",\"instId\":\"LTC-USDT-SWAP\"}]"
+          },
+          {
+            "description": "Swap cancel trailing order",
+            "method": "cancelOrder",
+            "url": "https://www.okx.com/api/v5/trade/cancel-algos",
+            "input": [
+              "663756560224751616",
+              "BTC/USDT:USDT",
+              {
+                "trailing": true
+              }
+            ],
+            "output": "[{\"algoId\":\"663756560224751616\",\"instId\":\"BTC-USDT-SWAP\"}]"
           }
         ],
         "cancelOrders": [
@@ -705,6 +718,21 @@
               }
             ],
             "output": "[{\"algoId\":\"639637720528322560\",\"instId\":\"LTC-USDT-SWAP\"},{\"algoId\":\"635260475386888192\",\"instId\":\"LTC-USDT-SWAP\"}]"
+          },
+          {
+            "description": "Swap cancel multiple trailing orders",
+            "method": "cancelOrders",
+            "url": "https://www.okx.com/api/v5/trade/cancel-algos",
+            "input": [
+              [
+                "663748219972878336"
+              ],
+              "BTC/USDT:USDT",
+              {
+                "trailing": true
+              }
+            ],
+            "output": "[{\"algoId\":\"663748219972878336\",\"instId\":\"BTC-USDT-SWAP\"}]"
           }
         ],
         "closePosition": [

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -479,6 +479,19 @@
                 "ordType": "conditional"
               }
             ]
+          },
+          {
+            "description": "Swap fetch open trailing orders",
+            "method": "fetchOpenOrders",
+            "url": "https://www.okx.com/api/v5/trade/orders-algo-pending?instId=BTC-USDT-SWAP&ordType=move_order_stop",
+            "input": [
+              "BTC/USDT:USDT",
+              null,
+              null,
+              {
+                "trailing": true
+              }
+            ]
           }
         ],
         "fetchCanceledOrders": [

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -521,7 +521,7 @@
           {
             "description": "Swap fetch canceled trailing orders",
             "method": "fetchCanceledOrders",
-            "url": "https://www.okx.com/api/v5/trade/orders-algo-history?instId=BTC-USDT-SWAP&instType=SWAP&state=canceled&ordType=move_order_stop&trailing=true",
+            "url": "https://www.okx.com/api/v5/trade/orders-algo-history?instId=BTC-USDT-SWAP&instType=SWAP&state=canceled&ordType=move_order_stop",
             "input": [
               "BTC/USDT:USDT",
               null,
@@ -579,6 +579,19 @@
               1,
               {
                 "method": "privateGetTradeOrdersHistoryArchive"
+              }
+            ]
+          },
+          {
+            "description": "Swap fetch closed trailing orders",
+            "method": "fetchClosedOrders",
+            "url": "https://www.okx.com/api/v5/trade/orders-algo-history?instId=BTC-USDT-SWAP&instType=SWAP&state=effective&ordType=move_order_stop",
+            "input": [
+              "BTC/USDT:USDT",
+              null,
+              null,
+              {
+                "trailing": true
               }
             ]
           }


### PR DESCRIPTION
Added trailing order support to `createOrder`, `fetchClosedOrders`, `fetchCanceledOrders`, `fetchOpenOrders`, `cancelOrder`, `cancelOrders`:

```
okx createOrder BTC/USDT:USDT market sell 1 undefined '{"trailingPercent":"5","reduceOnly":true,"posSide":"long"}'

okx.createOrder (BTC/USDT:USDT, market, sell, 1, , [object Object])
2024-01-06T06:18:27.176Z iteration 0 passed in 386 ms

{
  info: {
    algoClOrdId: 'e847386590ce4dBC5328f747a43e97d9',
    algoId: '663748219972878336',
    clOrdId: 'e847386590ce4dBC5328f747a43e97d9',
    sCode: '0',
    sMsg: '',
    tag: 'e847386590ce4dBC'
  },
  id: '663748219972878336',
  clientOrderId: 'e847386590ce4dBC5328f747a43e97d9',
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  side: 'sell',
  trades: [],
  reduceOnly: false,
  fees: []
}
```
```
okx fetchOpenOrders BTC/USDT:USDT undefined undefined '{"trailing":true}'

okx.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2024-01-06T06:51:52.743Z iteration 0 passed in 375 ms

                id |                    clientOrderId |     timestamp |                 datetime |        symbol |            type | side | stopPrice | triggerPrice | amount | status | trades | reduceOnly | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
663748219972878336 | e847386590ce4dBC5328f747a43e97d9 | 1704521907488 | 2024-01-06T06:18:27.488Z | BTC/USDT:USDT | move_order_stop | sell |  41480.42 |     41480.42 |      1 |   open |     [] |       true |   []
663756560224751616 | e847386590ce4dBC60532f5dc4b0802f | 1704523895960 | 2024-01-06T06:51:35.960Z | BTC/USDT:USDT | move_order_stop | sell | 41350.365 |    41350.365 |      1 |   open |     [] |       true |   []
2 objects
```
```
okx cancelOrder '"663756560224751616"' BTC/USDT:USDT '{"trailing":true}'

okx.cancelOrder (663756560224751616, BTC/USDT:USDT, [object Object])
2024-01-06T07:07:55.637Z iteration 0 passed in 401 ms

{
  info: {
    algoClOrdId: '',
    algoId: '663756560224751616',
    clOrdId: '',
    sCode: '0',
    sMsg: '',
    tag: ''
  },
  id: '663756560224751616',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  reduceOnly: false,
  fees: [],
  trailing: true
}
```
```
okx cancelOrders '["663748219972878336"]' BTC/USDT:USDT '{"trailing":true}'

okx.cancelOrders (663748219972878336, BTC/USDT:USDT, [object Object])
2024-01-06T07:10:01.890Z iteration 0 passed in 380 ms

                id |        symbol | trades | reduceOnly | fees | trailing
--------------------------------------------------------------------------
663748219972878336 | BTC/USDT:USDT |     [] |      false |   [] |     true
1 objects
```