### PR TITLE
feat: test file config

### DIFF
--- a/php/test/config.php
+++ b/php/test/config.php
@@ -1,0 +1,2673 @@
+<?php
+
+// *********************************
+// ***** AUTO-TRANSPILER-START *****
+function config($symbol = 'BTC/USDT', $code = 'USDT', $is_spot = true) {
+    return (array(
+    'exchange' => array(
+        'loadMarkets' => array(
+            'testFile' => 'loadMarkets',
+            'args' => [],
+            'isWs' => false,
+            'public' => true,
+        ),
+        'fetchTicker' => array(
+            'testFile' => 'fetchTicker',
+            'isWs' => false,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'fetchTickers' => array(
+            'testFile' => 'fetchTickers',
+            'isWs' => false,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'fetchOHLCV' => array(
+            'testFile' => 'fetchOHLCV',
+            'isWs' => false,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'fetchTrades' => array(
+            'testFile' => 'fetchTrades',
+            'isWs' => false,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'fetchOrderBook' => array(
+            'testFile' => 'fetchOrderBook',
+            'isWs' => false,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'fetchL2OrderBook' => array(
+            'testFile' => 'fetchL2OrderBook',
+            'isWs' => false,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'fetchOrderBooks' => array(
+            'testFile' => 'fetchOrderBooks',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+        ),
+        'fetchBidsAsks' => array(
+            'testFile' => 'fetchBidsAsks',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+        ),
+        'fetchTime' => array(
+            'testFile' => 'fetchTime',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+        ),
+        'fetchCurrencies - public' => array(
+            'testFile' => 'fetchCurrencies',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? null : 'only run for swap markets',
+        ),
+        'fetchFundingRates' => array(
+            'testFile' => 'fetchFundingRates',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchFundingRate' => array(
+            'testFile' => 'fetchFundingRate',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchFundingRateHistory - public' => array(
+            'testFile' => 'fetchFundingRateHistory',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchIndexOHLCV' => array(
+            'testFile' => 'fetchIndexOHLCV',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchMarkOHLCV' => array(
+            'testFile' => 'fetchMarkOHLCV',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchPremiumIndexOHLCV' => array(
+            'testFile' => 'fetchPremiumIndexOHLCV',
+            'isWs' => false,
+            'public' => true,
+            'args' => [],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'signIn' => array(
+            'testFile' => 'signIn',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+        ),
+        'fetchBalance' => array(
+            'testFile' => 'fetchBalance',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+        ),
+        'fetchAccounts' => array(
+            'testFile' => 'fetchAccounts',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+        ),
+        'fetchTransactionFees' => array(
+            'testFile' => 'fetchTransactionFees',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+        ),
+        'fetchTradingFees' => array(
+            'testFile' => 'fetchTradingFees',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+        ),
+        'fetchStatus' => array(
+            'testFile' => 'fetchStatus',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+        ),
+        'fetchOrders' => array(
+            'testFile' => 'fetchOrders',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'fetchOpenOrders' => array(
+            'testFile' => 'fetchOpenOrders',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'fetchClosedOrders' => array(
+            'testFile' => 'fetchClosedOrders',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'fetchMyTrades' => array(
+            'testFile' => 'fetchMyTrades',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'fetchLeverageTiers' => array(
+            'testFile' => 'fetchLeverageTiers',
+            'isWs' => false,
+            'public' => false,
+            'args' => [[$symbol]],
+        ),
+        'fetchLedger' => array(
+            'testFile' => 'fetchLedger',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchTransactions' => array(
+            'testFile' => 'fetchTransactions',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchDeposits' => array(
+            'testFile' => 'fetchDeposits',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchWithdrawals' => array(
+            'testFile' => 'fetchWithdrawals',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchBorrowInterest' => array(
+            'testFile' => 'fetchBorrowInterest',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code, $symbol],
+        ),
+        'addMargin' => array(
+            'testFile' => 'addMargin',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'reduceMargin' => array(
+            'testFile' => 'reduceMargin',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'setMargin' => array(
+            'testFile' => 'setMargin',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'setMarginMode' => array(
+            'testFile' => 'setMarginMode',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'setLeverage' => array(
+            'testFile' => 'setLeverage',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'cancelAllOrders' => array(
+            'testFile' => 'cancelAllOrders',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'cancelOrder' => array(
+            'testFile' => 'cancelOrder',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'cancelOrders' => array(
+            'testFile' => 'cancelOrders',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchCanceledOrders' => array(
+            'testFile' => 'fetchCanceledOrders',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'fetchClosedOrder' => array(
+            'testFile' => 'fetchClosedOrder',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchOpenOrder' => array(
+            'testFile' => 'fetchOpenOrder',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchOrder' => array(
+            'testFile' => 'fetchOrder',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchOrderTrades' => array(
+            'testFile' => 'fetchOrderTrades',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchDeposit' => array(
+            'testFile' => 'fetchDeposit',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'createDepositAddress' => array(
+            'testFile' => 'createDepositAddress',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchDepositAddress' => array(
+            'testFile' => 'fetchDepositAddress',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchDepositAddresses' => array(
+            'testFile' => 'fetchDepositAddresses',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchDepositAddressesByNetwork' => array(
+            'testFile' => 'fetchDepositAddressesByNetwork',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'editOrder' => array(
+            'testFile' => 'editOrder',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchBorrowRateHistory' => array(
+            'testFile' => 'fetchBorrowRateHistory',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchLedgerEntry' => array(
+            'testFile' => 'fetchLedgerEntry',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'fetchWithdrawal' => array(
+            'testFile' => 'fetchWithdrawal',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'transfer' => array(
+            'testFile' => 'transfer',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'withdraw' => array(
+            'testFile' => 'withdraw',
+            'isWs' => false,
+            'public' => false,
+            'args' => [],
+            'skip' => true,
+        ),
+        'fetchPositions' => array(
+            'testFile' => 'fetchPositions',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchPosition' => array(
+            'testFile' => 'fetchPosition',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchPositionRisk' => array(
+            'testFile' => 'fetchPositionRisk',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'setPositionMode' => array(
+            'testFile' => 'setPositionMode',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchOpenInterestHistory' => array(
+            'testFile' => 'fetchOpenInterestHistory',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchFundingRateHistory - private' => array(
+            'testFile' => 'fetchFundingRateHistory',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'fetchFundingHistory' => array(
+            'testFile' => 'fetchFundingHistory',
+            'isWs' => false,
+            'public' => false,
+            'args' => [$symbol],
+            'skip' => $is_spot ? 'only run for swap markets' : null,
+        ),
+        'watchOHLCV' => array(
+            'testFile' => 'watchOHLCV',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'watchTicker' => array(
+            'testFile' => 'watchTicker',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'watchOrderBook' => array(
+            'testFile' => 'watchOrderBook',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'watchTrades' => array(
+            'testFile' => 'watchTrades',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'watchTickers with symbol' => array(
+            'testFile' => 'watchTickers',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol],
+        ),
+        'watchTickers with symbol channel name' => array(
+            'testFile' => 'watchTickers',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol, array(
+    'name' => 'ticker',
+)],
+        ),
+        'watchTickers with symbol channel bookTicker' => array(
+            'testFile' => 'watchTickers',
+            'isWs' => true,
+            'public' => true,
+            'args' => [$symbol, array(
+    'name' => 'bookTicker',
+)],
+        ),
+        'watchBalance' => array(
+            'testFile' => 'watchBalance',
+            'isWs' => true,
+            'public' => false,
+            'args' => [$code],
+        ),
+        'watchMyTrades' => array(
+            'testFile' => 'watchMyTrades',
+            'isWs' => true,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'watchOrders' => array(
+            'testFile' => 'watchOrders',
+            'isWs' => true,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'watchPosition' => array(
+            'testFile' => 'watchPosition',
+            'isWs' => true,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+        'watchPositions' => array(
+            'testFile' => 'watchPositions',
+            'isWs' => true,
+            'public' => false,
+            'args' => [$symbol],
+        ),
+    ),
+    'ace' => array(
+        'skip' => 'temp',
+        'skipWs' => true,
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'temporary skip, because ids are numeric and we are in wip for numeric id tests',
+                'quoteId' => 'numeric',
+                'quote' => 'numeric',
+                'baseId' => 'numeric',
+                'base' => 'numeric',
+                'settleId' => 'numeric',
+                'settle' => 'numeric',
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'needs reversion of amount/price',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'alpaca' => array(
+        'skip' => 'private endpoints',
+        'skipWs' => 'private endpoints',
+    ),
+    'ascendex' => array(
+        'skipWs' => 'unknown https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2416',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken currencies',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'low' => '16 Aug - happened weird negative 24hr low',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'bequant' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/264802937#L2194',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'broken bid-ask',
+                'ask' => 'broken bid-ask',
+            ),
+        ),
+    ),
+    'binance' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+        'wsProxy' => 'http://5.75.153.75:8002',
+        'fetchStatus' => array(
+            'skip' => 'temporarily failing',
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'i.e. binance does not have currency code BCC',
+                'expiry' => 'expiry not set for future markets',
+                'expiryDatetime' => 'expiry not set for future markets',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided in public api',
+                'networks' => 'not yet unified',
+            ),
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            ),
+        ),
+    ),
+    'binanceus' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'expiry' => 'expiry not set for future markets',
+                'expiryDatetime' => 'expiry not set for future markets',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchStatus' => array(
+            'skip' => 'private endpoints',
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            ),
+        ),
+    ),
+    'binancecoinm' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'expiry' => 'expiry not set for future markets',
+                'expiryDatetime' => 'expiry not set for future markets',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skip' => 'out of order update',
+        ),
+    ),
+    'binanceusdm' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skip' => 'currently returns a lot of default/non open positions',
+        ),
+        'fetchLedger' => array(
+            'skippedProperties' => array(
+                'account' => 'empty',
+                'status' => 'not provided',
+                'before' => 'not provided',
+                'after' => 'not provided',
+                'fee' => 'not provided',
+                'code' => 'not provided',
+                'referenceId' => 'not provided',
+            ),
+        ),
+        'fetchBalance' => array(
+            'skip' => 'tmp skip',
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            ),
+        ),
+    ),
+    'bit2c' => array(
+        'skip' => 'temporary certificate issues',
+        'until' => '2023-11-25',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'active' => 'not provided',
+                'taker' => 'not provided',
+                'maker' => 'not provided',
+                'info' => 'null',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skippedProperties' => array(
+                'bid' => 'sometimes equals to zero: https://app.travis-ci.com/github/ccxt/ccxt/builds/267809189#L2540',
+                'ask' => 'same',
+            ),
+        ),
+    ),
+    'tokocrypto' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+    ),
+    'bitbank' => array(),
+    'bitbay' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'expiry' => 'expiry not set for future markets',
+                'expiryDatetime' => 'expiry not set for future markets',
+            ),
+        ),
+    ),
+    'bitbns' => array(
+        'skip' => 'temp',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'limits' => 'only one market has min>max limit',
+                'active' => 'not provided',
+                'currencyIdAndCode' => 'broken',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skip' => 'unknown symbol might be returned',
+        ),
+    ),
+    'bitcoincom' => array(
+        'skipWs' => true,
+    ),
+    'bitfinex' => array(
+        'loadMarkets' => array(
+            'skip' => 'linear and inverse values are same',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'symbol' => 'something broken with symbol',
+                'ask' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/262965121#L3179',
+                'bid' => 'same',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'symbol' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L3846',
+            ),
+        ),
+    ),
+    'bitfinex2' => array(
+        'skipWs' => true,
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken currencies',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'multiple bids might have same value',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'fetchTickers' => array(
+            'skip' => 'negative values',
+        ),
+    ),
+    'bitflyer' => array(
+        'loadMarkets' => array(
+            'skip' => 'contract is true, but contractSize is undefined',
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'side key has an null value, but is expected to have a value',
+            ),
+        ),
+    ),
+    'bitget' => array(
+        'skipWs' => true,
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'precision' => 'broken precision',
+                'limits' => 'limit max value is zero, lwer than min',
+                'contractSize' => 'not defined when contract',
+                'currencyIdAndCode' => 'broken currencies',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'broken bid-ask',
+                'ask' => 'broken bid-ask',
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'watchTrades' => array(
+            'skippedProperties' => array(
+                'timestamp' => 'ts order is reverted (descending)',
+            ),
+        ),
+    ),
+    'bithumb' => array(
+        'skip' => 'fetchMarkets returning undefined',
+        'until' => '2023-09-05',
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'bitmart' => array(
+        'skipWs' => true,
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'expiry' => 'expiry is expected to be > 0',
+                'settle' => 'not defined when contract',
+                'settleId' => 'not defined when contract',
+                'currencyIdAndCode' => 'broken currencies',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'networks' => 'missing',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'same',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'same',
+            ),
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'bid==ask , https://app.travis-ci.com/github/ccxt/ccxt/builds/263304041#L2170',
+        ),
+        'fetchLOrderBook' => array(
+            'skip' => 'same',
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4256',
+                'bid' => 'wrong data https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4325',
+            ),
+        ),
+        'watchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'not set https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4312',
+            ),
+        ),
+    ),
+    'bitmex' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skip' => 'some market types are out of expected market-types',
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'open might be greater than high',
+        ),
+        'fetchTickers' => array(
+            'skip' => 'negative values',
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'stopLossPrice' => 'undefined',
+                'takeProfitPrice' => 'undefined',
+                'marginRatio' => 'undefined',
+                'lastPrice' => 'undefined',
+                'collateral' => 'undefined',
+                'hedged' => 'undefined',
+                'lastUpdateTimestamp' => 'undefined',
+                'entryPrice' => 'undefined',
+                'markPrice' => 'undefined',
+                'leverage' => 'undefined',
+                'initialMargin' => 'undefined',
+                'maintenanceMargin' => 'can be zero for default position',
+                'notional' => 'can be zero for default position',
+                'contracts' => 'contracts',
+                'unrealizedPnl' => 'undefined',
+                'realizedPnl' => 'undefined',
+                'liquidationPrice' => 'can be 0',
+                'percentage' => 'might be 0',
+            ),
+        ),
+        'fetchMyTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'sometimes side is not available',
+            ),
+        ),
+        'fetchLedger' => array(
+            'skippedProperties' => array(
+                'referenceId' => 'undefined',
+                'amount' => 'undefined',
+                'before' => 'not provided',
+                'tag' => 'undefined',
+                'tagFrom' => 'undefined',
+                'tagTo' => 'undefined',
+                'type' => 'unmapped types',
+                'timestamp' => 'default value might be invalid',
+            ),
+        ),
+        'fetchDepositsWithdrawals' => array(
+            'skippedProperties' => array(
+                'currency' => 'undefined',
+                'currencyIdAndCode' => 'messes codes',
+            ),
+        ),
+        'fetchTransactions' => array(
+            'skip' => 'skip',
+        ),
+    ),
+    'bitopro' => array(
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'networks' => 'missing',
+            ),
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken currencies',
+            ),
+        ),
+        'watchTicker' => array(
+            'skip' => 'datetime error: https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4373',
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4373',
+            ),
+        ),
+    ),
+    'bitpanda' => array(
+        'skipWs' => true,
+        'fetchOrderBook' => array(
+            'skip' => 'some bid might be lower than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+    ),
+    'bitrue' => array(
+        'skipWs' => true,
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken currencies',
+                'limits' => 'max is below min',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'not set',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'bid ask crossed',
+                'ask' => 'bid ask crossed',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'bitso' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'not provided',
+            ),
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'randomly failing with 404 not found',
+        ),
+    ),
+    'bitstamp' => array(
+        'fetchOrderBook' => array(
+            'skip' => 'bid/ask might be 0',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'bid' => 'greater than ask https://app.travis-ci.com/github/ccxt/ccxt/builds/264241638#L3027',
+                'baseVolume' => 'baseVolume * low = 8.43e-6 * 3692.59081464 = 0.03112854056 < 0.0311285405674152',
+                'quoteVolume' => 'quoteVolume >= baseVolume * low <<< bitstamp fetchTickers',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'same',
+                'baseVolume' => 'same',
+                'quoteVolume' => 'same',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skip' => 'something broken https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4473 and https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4504',
+        ),
+    ),
+    'bitstamp1' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'info' => 'null',
+                'precision' => 'not provided',
+                'active' => 'not provided',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid/ask might be 0',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'bid' => 'greater than ask https://app.travis-ci.com/github/ccxt/ccxt/builds/264241638#L3027',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'same',
+            ),
+        ),
+    ),
+    'bl3p' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'active' => 'not provided',
+                'info' => 'null',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'side is undefined',
+            ),
+        ),
+    ),
+    'bitvavo' => array(
+        'skip' => 'temp',
+        'httpsProxy' => 'http://51.83.140.52:11230',
+        'skipWs' => 'temp',
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'networks' => 'missing',
+            ),
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken currencies',
+                'taker' => 'is undefined',
+                'maker' => 'is undefined',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'broken bid-ask',
+                'ask' => 'broken bid-ask',
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing https://app.travis-ci.com/github/ccxt/ccxt/builds/266144312#L2220',
+            ),
+        ),
+    ),
+    'blockchaincom' => array(
+        'skipWs' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/265225134#L2304',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'taker' => 'not provided',
+                'maker' => 'not provided',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid should be greater than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4517 and https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4562',
+            ),
+        ),
+    ),
+    'bkex' => array(
+        'fetchOrderBook' => array(
+            'skip' => 'system busy',
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken currencies',
+                'contractSize' => 'broken for some markets',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'networks' => 'missing',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'open might be greater than high',
+        ),
+    ),
+    'btcbox' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'precision' => 'is undefined',
+                'active' => 'is undefined',
+                'info' => 'null',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bids[0][0] (3787971.0) should be < than asks[0][0] (3787971.0) <<< btcbox ',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'bids[0][0] (3787971.0) should be < than asks[0][0] (3787971.0) <<< btcbox ',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'broken bid-ask',
+                'ask' => 'broken bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'bid' => 'broken bid-ask',
+                'ask' => 'broken bid-ask',
+            ),
+        ),
+    ),
+    'btcex' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+                'limits' => 'sometimes \'max\' value is zero, lower than \'min\'',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'messed bid-ask : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2090',
+                'ask' => 'same as above',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'bid' => 'same as above',
+                'ask' => 'same as above',
+            ),
+        ),
+    ),
+    'btcalpha' => array(
+        'skip' => true,
+        'fetchOrderBook' => array(
+            'skip' => 'bids[0][0] is not < asks[0][0]',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'symbol' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/265171549#L2518',
+                'percentage' => 'broken',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'percentage' => '',
+                'symbol' => '',
+                'bid' => '',
+                'ask' => '',
+            ),
+        ),
+    ),
+    'btcmarkets' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid should be greater than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'btctradeua' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'precision' => 'is undefined',
+                'active' => 'is undefined',
+                'taker' => 'is undefined',
+                'maker' => 'is undefined',
+                'info' => 'null',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid should be greater than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'btcturk' => array(
+        'fetchOrderBook' => array(
+            'skip' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/263287870#L2201',
+        ),
+    ),
+    'bybit' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+        'wsProxy' => 'http://5.75.153.75:8002',
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'symbol' => 'returned symbol is not same as requested symbol. i.e. symbol:code vs symbol',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'symbol' => 'same',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skip' => 'endpoint return Internal System Error',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'temp skip',
+            ),
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'temp skip',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skip' => 'currently returns a lot of default/non open positions',
+        ),
+        'fetchLedger' => array(
+            'skippedProperties' => array(
+                'account' => 'account is not provided',
+                'status' => 'status is not provided',
+                'fee' => 'undefined',
+            ),
+        ),
+        'fetchOpenInterestHistory' => array(
+            'skippedProperties' => array(
+                'openInterestAmount' => 'openInterestAmount is not provided',
+            ),
+        ),
+        'fetchBorrowRate' => array(
+            'skip' => 'does not work with unified account',
+        ),
+    ),
+    'buda' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+    ),
+    'bigone' => array(
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'broken bid-ask',
+                'ask' => 'broken bid-ask',
+                'baseVolume' => 'negative value',
+            ),
+        ),
+    ),
+    'coincheck' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'info' => 'not provided',
+                'precision' => 'not provided',
+                'active' => 'is undefined',
+                'taker' => 'is undefined',
+                'maker' => 'is undefined',
+            ),
+        ),
+    ),
+    'coinbase' => array(
+        'skip' => 'private endpoints',
+        'skipWs' => 'needs auth',
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skip' => 'datetime is not same as timestamp',
+        ),
+    ),
+    'coinbasepro' => array(
+        'skipWs' => 'needs auth',
+        'fetchStatus' => array(
+            'skip' => 'request timeout',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+    ),
+    'coinbaseprime' => array(
+        'fetchStatus' => array(
+            'skip' => 'request timeout',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+    ),
+    'coinone' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quote scale isn\'t right',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quote scale isn\'t right',
+            ),
+        ),
+    ),
+    'coinspot' => array(
+        'skip' => 'temp',
+        'loadMarkets' => array(
+            'skip' => 'precision key has an null value, but is expected to have a value| taker key missing from structure (markets are created from constructor .options, so needs to fill with default values in base)',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'ask' => 'broken bid-ask',
+                'bid' => 'broken bid-ask',
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'coinsph' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'taker' => 'messed',
+                'maker' => 'messed',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'cex' => array(
+        'skipWs' => 'timeouts',
+        'proxies' => array(
+            'skip' => 'probably they do not permit our proxy location',
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+                'currencyIdAndCode' => 'messes codes',
+            ),
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'unexpected issue',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'limits' => 'min is negative',
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+                'networks' => 'missing',
+            ),
+        ),
+    ),
+    'coinex' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'broken',
+                'active' => 'is undefined',
+            ),
+        ),
+    ),
+    'coinmate' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'ask should be less than next ask',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'cryptocom' => array(
+        'skipWs' => 'timeout',
+        'proxies' => array(
+            'skip' => 'probably they do not permit our proxy',
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'limits' => 'max is below min',
+                'active' => 'is undefined',
+                'currencyIdAndCode' => 'from travis location (USA) these webapi endpoints cant be loaded',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'timestamp' => 'timestamp might be of 1970-01-01T00:00:00.000Z',
+                'quoteVolume' => 'can\'t be infered',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'timestamp' => 'timestamp might be of 1970-01-01T00:00:00.000Z',
+                'quoteVolume' => 'can\'t be infered',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'entryPrice' => 'entryPrice is not provided',
+                'markPrice' => 'undefined',
+                'notional' => 'undefined',
+                'leverage' => 'undefined',
+                'liquidationPrice' => 'undefined',
+                'marginMode' => 'undefined',
+                'percentage' => 'undefined',
+                'marginRatio' => 'undefined',
+                'stopLossPrice' => 'undefined',
+                'takeProfitPrice' => 'undefined',
+                'maintenanceMargin' => 'undefined',
+                'initialMarginPercentage' => 'undefined',
+                'maintenanceMarginPercentage' => 'undefined',
+                'hedged' => 'undefined',
+                'side' => 'undefined',
+                'contracts' => 'undefined',
+            ),
+        ),
+        'fetchAccounts' => array(
+            'skippedProperties' => array(
+                'type' => 'type is not provided',
+                'code' => 'not provided',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4756',
+            ),
+        ),
+    ),
+    'currencycom' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'type' => 'unexpected market type',
+                'contractSize' => 'not defined when contract',
+                'settle' => 'not defined when contract',
+                'settleId' => 'not defined when contract',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'ask' => 'not above bid https://app.travis-ci.com/github/ccxt/ccxt/builds/263871244#L2163',
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'ask' => 'not above bid https://app.travis-ci.com/github/ccxt/ccxt/builds/263871244#L2163',
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'delta' => array(
+        'loadMarkets' => array(
+            'skip' => 'expiryDatetime must be equal to expiry in iso8601 format',
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'ask crossing bids test failing',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'failing the test',
+                'bid' => 'failing the test',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'failing the test',
+                'bid' => 'failing the test',
+            ),
+        ),
+    ),
+    'deribit' => array(
+        'skipWs' => 'timeouts',
+        'fetchCurrencies' => array(
+            'skip' => 'deposit/withdraw not provided',
+        ),
+        'loadMarkets' => array(
+            'skip' => 'strike is set when option is not true',
+        ),
+        'fetchTickers' => array(
+            'skip' => 'something wrong',
+        ),
+        'fetchBalance' => array(
+            'skip' => 'does not add up',
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'percentage' => 'undefined',
+                'hedged' => 'undefined',
+                'stopLossPrice' => 'undefined',
+                'takeProfitPrice' => 'undefined',
+                'lastPrice' => 'undefined',
+                'collateral' => 'undefined',
+                'marginMode' => 'undefined',
+                'marginRatio' => 'undefined',
+                'contracts' => 'undefined',
+                'id' => 'undefined',
+            ),
+        ),
+        'fetchDeposits' => array(
+            'skippedProperties' => array(
+                'id' => 'undefined',
+                'network' => 'undefined',
+                'addressFrom' => 'undefined',
+                'tag' => 'undefined',
+                'tagTo' => 'undefined',
+                'tagFrom' => 'undefined',
+                'fee' => 'undefined',
+            ),
+        ),
+    ),
+    'flowbtc' => array(
+        'fetchTrades' => array(
+            'skip' => 'timestamp is more than current utc timestamp',
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'fmfwio' => array(
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'fee' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'gemini' => array(
+        'skipWs' => 'temporary',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed codes',
+                'active' => 'not provided',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4833',
+            ),
+        ),
+    ),
+    'hitbtc' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed codes',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'fee' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'hitbtc3' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'limits' => 'messed min max',
+                'currencyIdAndCode' => 'messed codes',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'fee' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'digifinex' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed codes',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'messed',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skip' => 'unexpected symbol is being returned | safeMarket() requires a fourth argument for BTC_code to disambiguate between different markets with the same market id',
+        ),
+        'fetchTickers' => array(
+            'skip' => 'unexpected symbol is being returned | safeMarket() requires a fourth argument for BTC_code to disambiguate between different markets with the same market id',
+        ),
+        'fetchLeverageTiers' => array(
+            'skippedProperties' => array(
+                'minNotional' => 'undefined',
+                'currencyIdAndCode' => 'messed codes',
+                'currency' => 'messed',
+            ),
+        ),
+        'fetchBorrowRates' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed codes',
+                'currency' => 'messed',
+            ),
+        ),
+        'fetchBorrowInterest' => array(
+            'skip' => 'symbol is messed',
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'percentage' => 'undefined',
+                'stopLossPrice' => 'undefined',
+                'takeProfitPrice' => 'undefined',
+                'collateral' => 'undefined',
+                'initialMargin' => 'undefined',
+                'initialMarginPercentage' => 'undefined',
+                'hedged' => 'undefined',
+                'id' => 'undefined',
+                'notional' => 'undefined',
+            ),
+        ),
+        'fetchBalance' => array(
+            'skip' => 'tmp skip',
+        ),
+    ),
+    'gate' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed codes',
+                'fetchCurrencies' => array(
+                    'fee' => 'not provided',
+                ),
+                'limits' => 'max should be above min',
+                'contractSize' => 'broken for some markets',
+                'strike' => 'incorrect number type',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'timestamp' => 'timestamp is in decimals',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138',
+                'baseVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'bid' => 'same',
+                'ask' => 'same',
+                'quoteVolume' => 'same',
+                'baseVolume' => 'same',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skip' => 'currently returns a lot of default/non open positions',
+        ),
+        'fetchLedger' => array(
+            'skippedProperties' => array(
+                'currency' => 'undefined',
+                'status' => 'undefined',
+                'fee' => 'undefined',
+                'account' => 'undefined',
+                'referenceAccount' => 'undefined',
+                'referenceId' => 'undefined',
+            ),
+        ),
+        'fetchTradingFees' => array(
+            'skip' => 'sandbox does not have this endpoint',
+        ),
+        'fetchDeposits' => array(
+            'skip' => 'sandbox does not have this endpoint',
+        ),
+        'fetchWithdrawals' => array(
+            'skip' => 'sandbox does not have this endpoint',
+        ),
+    ),
+    'hollaex' => array(
+        'skipWs' => 'temp',
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4957',
+            ),
+        ),
+    ),
+    'htx' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'limits' => 'messed',
+                'currencyIdAndCode' => 'messed codes',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+                'precision' => 'is undefined',
+                'limits' => 'broken somewhere',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4860',
+            ),
+        ),
+    ),
+    'huobijp' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'limits' => 'messed',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'fee' => 'not defined',
+                'networks' => 'missing',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'fees' => 'missing',
+            ),
+        ),
+    ),
+    'stex' => array(
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'probit' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skip' => 'needs fixing',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'limits' => 'messed',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'idex' => array(
+        'skipWs' => 'timeouts',
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+                'networks' => 'missing',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'messed bid-ask',
+                'bid' => 'messed bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'messed bid-ask',
+                'bid' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'independentreserve' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'side is undefined',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid should be greater than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'coinfalcon' => array(
+        'fetchTickers' => array(
+            'skip' => 'negative values',
+        ),
+    ),
+    'kuna' => array(
+        'skip' => 'temporary glitches with this exchange: https://app.travis-ci.com/github/ccxt/ccxt/builds/267517440#L2304',
+        'httpsProxy' => 'http://5.75.153.75:8002',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'deposit' => 'is undefined',
+                'withdraw' => 'is undefined',
+                'active' => 'is undefined',
+                'precision' => 'somewhat strange atm https://app.travis-ci.com/github/ccxt/ccxt/builds/267515280#L2337',
+            ),
+        ),
+    ),
+    'kucoin' => array(
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'depositForNonCrypto' => 'not provided',
+                'withdrawForNonCrypto' => 'not provided',
+            ),
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+                'quoteVolume' => 'quoteVolume <= baseVolume * high https://app.travis-ci.com/github/ccxt/ccxt/builds/263304041#L2190',
+                'baseVolume' => 'same',
+            ),
+        ),
+    ),
+    'kucoinfutures' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'percentage' => 'percentage is not provided',
+            ),
+        ),
+    ),
+    'latoken' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skip' => 'negative values',
+        ),
+    ),
+    'luno' => array(
+        'skipWs' => 'temp',
+        'fetchOrderBook' => array(
+            'skip' => 'bid should be greater than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+    ),
+    'lbank' => array(
+        'loadMarkets' => array(
+            'skip' => 'settle must be defined when contract is true',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'lykke' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed codes',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'fee' => 'not provided',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid should be greater than next bid',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'same',
+        ),
+        'fetchTickers' => array(
+            'skip' => 'negative values',
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'mercado' => array(
+        'loadMarkets' => array(
+            'skip' => 'needs migration to v4, as raw info is not being used. granular can be used for skipping \'info\'',
+        ),
+        'fetchOrderBook' => array(
+            'skip' => 'bid > ask',
+        ),
+        'fetchL2OrderBook' => array(
+            'skip' => 'bid > ask',
+        ),
+        'fetchTickers' => array(
+            'skip' => 'bid > ask',
+        ),
+        'fetchTicker' => array(
+            'skip' => 'bid > ask',
+        ),
+        'fetchCurrencies' => array(
+            'skip' => 'info key is missing',
+        ),
+    ),
+    'novadax' => array(
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/266029139',
+                'bid' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/266029139',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'ndax' => array(
+        'skipWs' => 'timeouts',
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+    ),
+    'mexc' => array(
+        'skipWs' => 'temp',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'is undefined',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'side is not buy/sell',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'bid' => 'messed bid-ask',
+                'ask' => 'messed bid-ask',
+            ),
+        ),
+        'fetchAccounts' => array(
+            'skippedProperties' => array(
+                'type' => 'type is not provided',
+            ),
+        ),
+        'fetchLeverageTiers' => array(
+            'skip' => 'swap only supported',
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6610',
+            ),
+        ),
+    ),
+    'oceanex' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchOrderBooks' => array(
+            'skip' => 'fetchOrderBooks returned 0 length',
+        ),
+    ),
+    'p2b' => array(
+        'skip' => 'temp issues',
+        'httpsProxy' => 'http://51.83.140.52:11230',
+        'loadMarkets' => array(
+            'skip' => 'invalid URL',
+        ),
+        'fetchTrades' => array(
+            'skip' => 'requires order id',
+        ),
+    ),
+    'paymium' => array(
+        'skip' => 'exchange is down',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'precision' => 'not provided',
+                'active' => 'not provided',
+                'info' => 'null',
+                'taker' => 'is undefined',
+                'maker' => 'is undefined',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'phemex' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'contractSize' => 'broken for some markets',
+                'active' => 'not provided',
+                'currencyIdAndCode' => 'messed',
+                'taker' => 'null',
+                'maker' => 'null',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'messed bid-ask',
+                'bid' => 'messed bid-ask',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'ask' => 'messed bid-ask',
+                'bid' => 'messed bid-ask',
+            ),
+        ),
+    ),
+    'okcoin' => array(
+        'skipWs' => 'temp',
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'watchTicker' => array(
+            'skippedProperties' => array(
+                'symbol' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721',
+            ),
+        ),
+    ),
+    'exmo' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'info' => 'null',
+                'withdraw' => 'not provided',
+                'deposit' => 'not provided',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4807',
+            ),
+        ),
+    ),
+    'poloniex' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'some currencies does not exist in currencies',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'undefined',
+                'deposit' => 'undefined',
+                'networks' => 'networks key is missing',
+                'precision' => 'not provided',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'side is not buy/sell',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume <= baseVolume * high | https://app.travis-ci.com/github/ccxt/ccxt/builds/263884643#L2462',
+                'baseVolume' => 'same',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'same',
+                'baseVolume' => 'same',
+            ),
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6909',
+            ),
+        ),
+    ),
+    'okx' => array(
+        'loadMarkets' => array(
+            'skip' => 'linear & inverse must not be same',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'info' => 'null',
+                'currencyIdAndCode' => 'temp skip',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume <= baseVolume * high : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2132',
+                'baseVolume' => 'same',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume <= baseVolume * high <<< okx fetchTicker',
+            ),
+        ),
+        'fetchBorrowRate' => array(
+            'skip' => 'some fields that we can\'t skip missing',
+        ),
+        'fetchBorrowRates' => array(
+            'skip' => 'same',
+        ),
+        'watchOrderBook' => array(
+            'skippedProperties' => array(
+                'nonce' => 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721',
+            ),
+        ),
+    ),
+    'tidex' => array(
+        'skip' => 'exchange unavailable, probably api upgrade needed',
+    ),
+    'kraken' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267515280#L2314',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'undefined',
+                'deposit' => 'undefined',
+                'currencyIdAndCode' => 'same as in loadMarkets',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume <= baseVolume * high is failing',
+                'baseVolume' => 'quoteVolume <= baseVolume * high is failing',
+            ),
+        ),
+    ),
+    'krakenfutures' => array(
+        'skip' => 'continious timeouts https://app.travis-ci.com/github/ccxt/ccxt/builds/265225134#L2431',
+        'timeout' => 120000,
+        'loadMarkets' => array(
+            'skip' => 'skip loadMarkets',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'undefined',
+                'deposit' => 'undefined',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skip' => 'timeouts this call specifically',
+        ),
+        'fetchTicker' => array(
+            'skip' => 'timeouts this call specifically',
+        ),
+        'watchTrades' => array(
+            'skip' => 'reverse timestamps',
+        ),
+    ),
+    'upbit' => array(
+        'skipWs' => 'timeouts',
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'ripio' => array(
+        'httpsProxy' => 'http://5.75.153.75:8002',
+    ),
+    'timex' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'fee' => 'is undefined',
+                'networks' => 'key not present',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'fees' => 'missingn from structure',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skip' => 'temporary issues',
+        ),
+    ),
+    'wavesexchange' => array(
+        'loadMarkets' => array(
+            'skip' => 'missing key',
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'index 1 (open price) is undefined',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume' => 'quoteVolume >= baseVolume * low is failing',
+            ),
+        ),
+    ),
+    'whitebit' => array(
+        'skipWs' => 'timeouts',
+        'loadMarkets' => array(
+            'skip' => 'contractSize must be undefined when contract is false',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'info' => 'missing key',
+                'precision' => 'not provided',
+                'fee' => 'is undefined',
+                'networks' => 'missing',
+                'limits' => 'broken for some markets',
+            ),
+        ),
+    ),
+    'woo' => array(
+        'skipWs' => 'requires auth',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'undefined',
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'withdraw' => 'undefined',
+                'deposit' => 'undefined',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'leverage' => 'undefined',
+                'percentage' => 'undefined',
+                'hedged' => 'undefined',
+                'stopLossPrice' => 'undefined',
+                'takeProfitPrice' => 'undefined',
+                'id' => 'undefined',
+                'marginRatio' => 'undefined',
+                'collateral' => 'undefined',
+            ),
+        ),
+    ),
+    'xt' => array(
+        'loadMarkets' => array(
+            'skip' => 'expiry and expiryDatetime are defined for non future/options markets',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'precision' => 'is undefined',
+                'withdraw' => 'undefined',
+                'deposit' => 'undefined',
+                'fee' => 'undefined',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skip' => 'some outaded contracts, eg RICHARLISONGBALL2022/code:code-221219 return bid > ask',
+        ),
+        'fetchTicker' => array(
+            'skip' => 'same',
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'messed',
+            ),
+        ),
+    ),
+    'yobit' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'currencyIdAndCode' => 'messed',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skip' => 'all tickers request exceedes max url length',
+        ),
+    ),
+    'zaif' => array(
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'info' => 'key is missing',
+            ),
+        ),
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+    ),
+    'zonda' => array(
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'active' => 'is undefined',
+            ),
+        ),
+    ),
+    'bingx' => array(
+        'skipWs' => 'broken symbols returned',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'taker' => 'is undefined',
+                'maker' => 'is undefined',
+                'currencyIdAndCode' => 'not all currencies are available',
+            ),
+        ),
+        'fetchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'undefined',
+            ),
+        ),
+        'fetchTicker' => array(
+            'skip' => 'spot not supported',
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'not supported',
+            ),
+        ),
+        'fetchOHLCV' => array(
+            'skip' => 'spot not supported',
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'deposit' => 'not provided',
+                'precision' => 'not provided',
+            ),
+        ),
+        'fetchOrderBook' => array(
+            'skippedProperties' => array(
+                'ask' => 'multiple ask prices are equal in ob https://app.travis-ci.com/github/ccxt/ccxt/builds/264706670#L2228',
+                'bid' => 'multiple bid prices are equal https://app.travis-ci.com/github/ccxt/ccxt/builds/265172859#L2745',
+            ),
+        ),
+        'watchTrades' => array(
+            'skippedProperties' => array(
+                'side' => 'undefined',
+            ),
+        ),
+        'fetchPositions' => array(
+            'skippedProperties' => array(
+                'marginRatio' => 'undefined',
+                'stopLossPrice' => 'undefined',
+                'takeProfitPrice' => 'undefined',
+                'initialMarginPercentage' => 'undefined',
+                'hedged' => 'undefined',
+                'timestamp' => 'undefined',
+                'datetime' => 'undefined',
+                'lastUpdateTimestamp' => 'undefined',
+                'maintenanceMargin' => 'undefined',
+                'contractSize' => 'undefined',
+                'markPrice' => 'undefined',
+                'lastPrice' => 'undefined',
+                'percentage' => 'undefined',
+                'liquidationPrice' => 'undefined',
+            ),
+        ),
+    ),
+    'wazirx' => array(
+        'skipWs' => 'timeouts',
+    ),
+    'coinlist' => array(
+        'fetchTicker' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low  is failing',
+            ),
+        ),
+        'fetchTickers' => array(
+            'skippedProperties' => array(
+                'quoteVolume' => 'quoteVolume >= baseVolume * low  is failing',
+                'ask' => 'invalid',
+            ),
+        ),
+    ),
+    'bitteam' => array(
+        'skip' => 'tmp timeout',
+        'loadMarkets' => array(
+            'skippedProperties' => array(
+                'taker' => 'is undefined',
+                'maker' => 'is undefined',
+            ),
+        ),
+        'fetchCurrencies' => array(
+            'skippedProperties' => array(
+                'deposit' => 'not provided',
+                'withdraw' => 'not provided',
+            ),
+        ),
+    ),
+));
+}
+
+// ***** AUTO-TRANSPILER-END *****

--- a/php/test/test_async.php
+++ b/php/test/test_async.php
@@ -12,6 +12,7 @@ define('rootDir', __DIR__ . '/../../');
 define('root_dir', __DIR__ . '/../../');
 
 include_once rootDir .'/vendor/autoload.php';
+include_once 'config.php';
 use React\Async;
 use React\Promise;
 
@@ -352,23 +353,25 @@ class testMainClass extends baseMainTestClass {
             Async\await($this->import_files($exchange));
             assert(count(is_array($this->test_files) ? array_keys($this->test_files) : array()) > 0, 'Test files were not loaded'); // ensure test files are found & filled
             $this->expand_settings($exchange);
-            $symbol = $this->check_if_specific_test_is_chosen($symbol_argv);
+            $symbol = $this->check_if_specific_test_is_chosen($exchange, $symbol_argv);
             Async\await($this->start_test($exchange, $symbol));
             exit_script(0); // needed to be explicitly finished for WS tests
         }) ();
     }
 
-    public function check_if_specific_test_is_chosen($symbol_argv) {
+    public function check_if_specific_test_is_chosen($exchange, $symbol_argv) {
         if ($symbol_argv !== null) {
-            $test_file_names = is_array($this->test_files) ? array_keys($this->test_files) : array();
+            $test_config = config();
+            $tests = $exchange->deep_extend($test_config['exchange'], $test_config[$exchange->id]);
+            $test_names = is_array($tests) ? array_keys($tests) : array();
             $possible_method_names = explode(',', $symbol_argv); // i.e. `test.ts binance fetchBalance,fetchDeposits`
             if (count($possible_method_names) >= 1) {
-                for ($i = 0; $i < count($test_file_names); $i++) {
-                    $test_file_name = $test_file_names[$i];
+                for ($i = 0; $i < count($test_names); $i++) {
+                    $test_name = $test_names[$i];
                     for ($j = 0; $j < count($possible_method_names); $j++) {
                         $method_name = $possible_method_names[$j];
-                        if ($test_file_name === $method_name) {
-                            $this->only_specific_tests[] = $test_file_name;
+                        if (mb_strpos($test_name, $method_name) !== false) {
+                            $this->only_specific_tests[] = $test_name;
                         }
                     }
                 }
@@ -435,20 +438,19 @@ class testMainClass extends baseMainTestClass {
         }
         // credentials
         $this->load_credentials_from_env($exchange);
-        // skipped tests
-        $skipped_file = $this->root_dir_for_skips . 'skip-tests.json';
-        $skipped_settings = io_file_read($skipped_file);
-        $skipped_settings_for_exchange = $exchange->safe_value($skipped_settings, $exchange_id, array());
+        // exchange tests settings
+        $tests_config = config();
+        $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange_id]);
         // others
-        $timeout = $exchange->safe_value($skipped_settings_for_exchange, 'timeout');
+        $timeout = $exchange->safe_value($tests, 'timeout');
         if ($timeout !== null) {
             $exchange->timeout = $timeout;
         }
-        $exchange->http_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'httpProxy');
-        $exchange->https_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'httpsProxy');
-        $exchange->ws_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'wsProxy');
-        $exchange->wss_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'wssProxy');
-        $this->skipped_methods = $exchange->safe_value($skipped_settings_for_exchange, 'skipMethods', array());
+        $exchange->http_proxy = $exchange->safe_string($tests, 'httpProxy');
+        $exchange->https_proxy = $exchange->safe_string($tests, 'httpsProxy');
+        $exchange->ws_proxy = $exchange->safe_string($tests, 'wsProxy');
+        $exchange->wss_proxy = $exchange->safe_string($tests, 'wssProxy');
+        $this->skipped_methods = $exchange->safe_value($tests, 'skipMethods', array());
         $this->checked_public_tests = array();
     }
 
@@ -487,10 +489,15 @@ class testMainClass extends baseMainTestClass {
         return $result;
     }
 
-    public function test_method($method_name, $exchange, $args, $is_public) {
-        // todo: temporary skip for php
-        return Async\async(function () use ($method_name, $exchange, $args, $is_public) {
-            if (mb_strpos($method_name, 'OrderBook') !== false && $this->ext === 'php') {
+    public function test_method($exchange, $test_name, $test) {
+        return Async\async(function () use ($exchange, $test_name, $test) {
+            $method_name = $test['testFile'];
+            $is_public = $test['public'];
+            $args = $test['args'];
+            $skip = $exchange->safe_string($test, 'skip');
+            // todo: temporary skip for php
+            $i = array_search('OrderBook', $method_name);
+            if ($i >= 0 && ($this->ext === 'php')) {
                 return;
             }
             $is_load_markets = ($method_name === 'loadMarkets');
@@ -502,11 +509,11 @@ class testMainClass extends baseMainTestClass {
             }
             $skip_message = null;
             $supported_by_exchange = (is_array($exchange->has) && array_key_exists($method_name, $exchange->has)) && $exchange->has[$method_name];
-            if (!$is_load_markets && (count($this->only_specific_tests) > 0 && !$exchange->in_array($method_name, $this->only_specific_tests))) {
+            if (!$is_load_markets && (count($this->only_specific_tests) > 0 && !$exchange->in_array($test_name, $this->only_specific_tests))) {
                 $skip_message = '[INFO] IGNORED_TEST';
             } elseif (!$is_load_markets && !$supported_by_exchange && !$is_proxy_test) {
                 $skip_message = '[INFO] UNSUPPORTED_TEST'; // keep it aligned with the longest message
-            } elseif ((is_array($this->skipped_methods) && array_key_exists($method_name, $this->skipped_methods)) && (is_string($this->skipped_methods[$method_name]))) {
+            } elseif (is_string($skip)) {
                 $skip_message = '[INFO] SKIPPED_TEST';
             } elseif (!(is_array($this->test_files) && array_key_exists($method_name, $this->test_files))) {
                 $skip_message = '[INFO] UNIMPLEMENTED_TEST';
@@ -523,32 +530,33 @@ class testMainClass extends baseMainTestClass {
             }
             if ($this->info) {
                 $args_stringified = '(' . implode(',', $args) . ')';
-                dump($this->add_padding('[INFO] TESTING', 25), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                dump($this->add_padding('[INFO] TESTING', 25), $this->exchange_hint($exchange), $test_name, $args_stringified);
             }
-            $skipped_properties = $exchange->safe_value($this->skipped_methods, $method_name, array());
+            $skipped_properties = $exchange->safe_value($test, 'skippedProperties', array());
             Async\await(call_method($this->test_files, $method_name, $exchange, $skipped_properties, $args));
             // if it was passed successfully, add to the list of successfull tests
             if ($is_public) {
-                $this->checked_public_tests[$method_name] = true;
+                $this->checked_public_tests[$test_name] = true;
             }
         }) ();
     }
 
-    public function test_safe($method_name, $exchange, $args = [], $is_public = false) {
+    public function test_safe($exchange, $test_name, $test) {
         // `testSafe` method does not throw an exception, instead mutes it. The reason we
         // mute the thrown exceptions here is because we don't want to stop the whole
         // tests queue if any single test-method fails. Instead, they are echoed with
         // formatted message "[TEST_FAILURE] ..." and that output is then regex-matched by
         // run-tests.js, so the exceptions are still printed out to console from there.
-        return Async\async(function () use ($method_name, $exchange, $args, $is_public) {
+        return Async\async(function () use ($exchange, $test_name, $test) {
+            $is_public = $test['public'];
             $max_retries = 3;
-            $args_stringified = $exchange->json($args); // args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
+            $args_stringified = $exchange->json($test['args']); // args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
             for ($i = 0; $i < $max_retries; $i++) {
                 try {
-                    Async\await($this->test_method($method_name, $exchange, $args, $is_public));
+                    Async\await($this->test_method($exchange, $test_name, $test));
                     return true;
                 } catch(\Throwable $e) {
-                    $is_load_markets = ($method_name === 'loadMarkets');
+                    $is_load_markets = ($test['testFile'] === 'loadMarkets');
                     $is_auth_error = ($e instanceof AuthenticationError);
                     $is_not_supported = ($e instanceof NotSupported);
                     $is_operation_failed = ($e instanceof OperationFailed); // includes "DDoSProtection", "RateLimitExceeded", "RequestTimeout", "ExchangeNotAvailable", "OperationFailed", "InvalidNonce", ...
@@ -566,10 +574,10 @@ class testMainClass extends baseMainTestClass {
                             }
                             // final step
                             if ($should_fail) {
-                                dump('[TEST_FAILURE]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $method_name, $args_stringified, exception_message($e));
+                                dump('[TEST_FAILURE]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $test_name, $args_stringified, exception_message($e));
                                 return false;
                             } else {
-                                dump('[TEST_WARNING]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $method_name, $args_stringified, exception_message($e));
+                                dump('[TEST_WARNING]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $test_name, $args_stringified, exception_message($e));
                                 return true;
                             }
                         } else {
@@ -581,25 +589,25 @@ class testMainClass extends baseMainTestClass {
                     } else {
                         // if it's loadMarkets, then fail test, because it's mandatory for tests
                         if ($is_load_markets) {
-                            dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                            dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                             return false;
                         }
                         // if the specific arguments to the test method throws "NotSupported" exception
                         // then let's don't fail the test
                         if ($is_not_supported) {
                             if ($this->info) {
-                                dump('[INFO] NOT_SUPPORTED', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                                dump('[INFO] NOT_SUPPORTED', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                             }
                             return true;
                         }
                         // If public test faces authentication error, we don't break (see comments under `testSafe` method)
                         if ($is_public && $is_auth_error) {
                             if ($this->info) {
-                                dump('[INFO]', 'Authentication problem for public method', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                                dump('[INFO]', 'Authentication problem for public method', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                             }
                             return true;
                         } else {
-                            dump('[TEST_FAILURE]', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                            dump('[TEST_FAILURE]', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                             return false;
                         }
                     }
@@ -608,44 +616,27 @@ class testMainClass extends baseMainTestClass {
         }) ();
     }
 
+    public function filter_test($tests, $key, $value) {
+        $result = array();
+        $test_names = is_array($tests) ? array_keys($tests) : array();
+        for ($i = 0; $i < count($test_names); $i++) {
+            $name = $test_names[$i];
+            if ($tests[$name][$key] === $value) {
+                $result[$name] = $tests[$name];
+            }
+        }
+        return $result;
+    }
+
     public function run_public_tests($exchange, $symbol) {
         return Async\async(function () use ($exchange, $symbol) {
-            $tests = array(
-                'fetchCurrencies' => [],
-                'fetchTicker' => [$symbol],
-                'fetchTickers' => [$symbol],
-                'fetchOHLCV' => [$symbol],
-                'fetchTrades' => [$symbol],
-                'fetchOrderBook' => [$symbol],
-                'fetchL2OrderBook' => [$symbol],
-                'fetchOrderBooks' => [],
-                'fetchBidsAsks' => [],
-                'fetchStatus' => [],
-                'fetchTime' => [],
-            );
-            if ($this->ws_tests) {
-                $tests = array(
-                    'watchOHLCV' => [$symbol],
-                    'watchTicker' => [$symbol],
-                    'watchOrderBook' => [$symbol],
-                    'watchTrades' => [$symbol],
-                );
-            }
             $market = $exchange->market($symbol);
             $is_spot = $market['spot'];
-            if (!$this->ws_tests) {
-                if ($is_spot) {
-                    $tests['fetchCurrencies'] = [];
-                } else {
-                    $tests['fetchFundingRates'] = [$symbol];
-                    $tests['fetchFundingRate'] = [$symbol];
-                    $tests['fetchFundingRateHistory'] = [$symbol];
-                    $tests['fetchIndexOHLCV'] = [$symbol];
-                    $tests['fetchMarkOHLCV'] = [$symbol];
-                    $tests['fetchPremiumIndexOHLCV'] = [$symbol];
-                }
-            }
-            $this->public_tests = $tests;
+            $code = $this->get_exchange_code($exchange);
+            $tests_config = config($symbol, $code, $is_spot);
+            $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange->id]);
+            $tests = $this->filter_test($tests, 'public', true);
+            $tests = $this->filter_test($tests, 'isWs', $this->ws_tests);
             Async\await($this->run_tests($exchange, $tests, true));
         }) ();
     }
@@ -656,25 +647,25 @@ class testMainClass extends baseMainTestClass {
             $promises = [];
             for ($i = 0; $i < count($test_names); $i++) {
                 $test_name = $test_names[$i];
-                $test_args = $tests[$test_name];
-                $promises[] = $this->test_safe($test_name, $exchange, $test_args, $is_public_test);
+                $test = $tests[$test_name];
+                $promises[] = $this->test_safe($exchange, $test_name, $test);
             }
             // todo - not yet ready in other langs too
             // promises.push (testThrottle ());
             $results = Async\await(Promise\all($promises));
             // now count which test-methods retuned `false` from "testSafe" and dump that info below
-            $failed_methods = [];
+            $failed_tests = [];
             for ($i = 0; $i < count($test_names); $i++) {
                 $test_name = $test_names[$i];
                 $test_returned_value = $results[$i];
                 if (!$test_returned_value) {
-                    $failed_methods[] = $test_name;
+                    $failed_tests[] = $test_name;
                 }
             }
             $test_prefix_string = $is_public_test ? 'PUBLIC_TESTS' : 'PRIVATE_TESTS';
-            if (count($failed_methods)) {
-                $errors_string = implode(', ', $failed_methods);
-                dump('[TEST_FAILURE]', $this->exchange_hint($exchange), $test_prefix_string, 'Failed methods : ' . $errors_string);
+            if (count($failed_tests)) {
+                $errors_string = implode(', ', $failed_tests);
+                dump('[TEST_FAILURE]', $this->exchange_hint($exchange), $test_prefix_string, 'Failed tests : ' . $errors_string);
             }
             if ($this->info) {
                 dump($this->add_padding('[INFO] END ' . $test_prefix_string . ' ' . $this->exchange_hint($exchange), 25));
@@ -684,7 +675,10 @@ class testMainClass extends baseMainTestClass {
 
     public function load_exchange($exchange) {
         return Async\async(function () use ($exchange) {
-            $result = Async\await($this->test_safe('loadMarkets', $exchange, [], true));
+            $tests_config = config('', '', true);
+            $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange->id]);
+            $load_markets_test = $tests['loadMarkets'];
+            $result = Async\await($this->test_safe($exchange, 'loadMarkets', $load_markets_test));
             if (!$result) {
                 return false;
             }
@@ -868,69 +862,26 @@ class testMainClass extends baseMainTestClass {
             //     await test ('InvalidOrder', exchange, symbol);
             //     await test ('InsufficientFunds', exchange, symbol, balance); // danger zone - won't execute with non-empty balance
             // }
-            $tests = array(
-                'signIn' => [],
-                'fetchBalance' => [],
-                'fetchAccounts' => [],
-                'fetchTransactionFees' => [],
-                'fetchTradingFees' => [],
-                'fetchStatus' => [],
-                'fetchOrders' => [$symbol],
-                'fetchOpenOrders' => [$symbol],
-                'fetchClosedOrders' => [$symbol],
-                'fetchMyTrades' => [$symbol],
-                'fetchLeverageTiers' => [[$symbol]],
-                'fetchLedger' => [$code],
-                'fetchTransactions' => [$code],
-                'fetchDeposits' => [$code],
-                'fetchWithdrawals' => [$code],
-                'fetchBorrowInterest' => [$code, $symbol],
-                'cancelAllOrders' => [$symbol],
-                'fetchCanceledOrders' => [$symbol],
-                'fetchPosition' => [$symbol],
-                'fetchDeposit' => [$code],
-                'createDepositAddress' => [$code],
-                'fetchDepositAddress' => [$code],
-                'fetchDepositAddresses' => [$code],
-                'fetchDepositAddressesByNetwork' => [$code],
-                'fetchBorrowRateHistory' => [$code],
-                'fetchLedgerEntry' => [$code],
-            );
-            if ($this->ws_tests) {
-                $tests = array(
-                    'watchBalance' => [$code],
-                    'watchMyTrades' => [$symbol],
-                    'watchOrders' => [$symbol],
-                    'watchPosition' => [$symbol],
-                    'watchPositions' => [$symbol],
-                );
-            }
             $market = $exchange->market($symbol);
             $is_spot = $market['spot'];
-            if (!$this->ws_tests) {
-                if ($is_spot) {
-                    $tests['fetchCurrencies'] = [];
-                } else {
-                    // derivatives only
-                    $tests['fetchPositions'] = [$symbol]; // this test fetches all positions for 1 symbol
-                    $tests['fetchPosition'] = [$symbol];
-                    $tests['fetchPositionRisk'] = [$symbol];
-                    $tests['setPositionMode'] = [$symbol];
-                    $tests['setMarginMode'] = [$symbol];
-                    $tests['fetchOpenInterestHistory'] = [$symbol];
-                    $tests['fetchFundingRateHistory'] = [$symbol];
-                    $tests['fetchFundingHistory'] = [$symbol];
-                }
-            }
-            // const combinedTests = exchange.deepExtend (this.publicTests, privateTests);
+            $tests_config = config($symbol, $code, $is_spot);
+            $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange->id]);
+            $tests = $this->filter_test($tests, 'public', false);
+            $tests = $this->filter_test($tests, 'isWs', $this->ws_tests);
             Async\await($this->run_tests($exchange, $tests, false));
         }) ();
     }
 
-    public function test_proxies($exchange) {
+    public function method($exchange) {
         // these tests should be synchronously executed, because of conflicting nature of proxy settings
         return Async\async(function () use ($exchange) {
             $proxy_test_name = $this->proxy_test_file_name;
+            $proxy_test = array(
+                'public' => true,
+                'testFile' => $proxy_test_name,
+                'args' => [],
+                'isWs' => false,
+            );
             // todo: temporary skip for sync py
             if ($this->ext === 'py' && $this->is_synchronous) {
                 return;
@@ -940,7 +891,7 @@ class testMainClass extends baseMainTestClass {
             $exception = null;
             for ($j = 0; $j < $max_retries; $j++) {
                 try {
-                    Async\await($this->test_method($proxy_test_name, $exchange, [], true));
+                    Async\await($this->test_method($exchange, $proxy_test_name, $proxy_test));
                     break; // if successfull, then break
                 } catch(\Throwable $e) {
                     $exception = $e;
@@ -970,7 +921,7 @@ class testMainClass extends baseMainTestClass {
                 }
                 // if (exchange.id === 'binance') {
                 //     // we test proxies functionality just for one random exchange on each build, because proxy functionality is not exchange-specific, instead it's all done from base methods, so just one working sample would mean it works for all ccxt exchanges
-                //     // await this.testProxies (exchange);
+                //     // await this.method (exchange);
                 // }
                 Async\await($this->test_exchange($exchange, $symbol));
                 Async\await(close($exchange));

--- a/php/test/test_sync.php
+++ b/php/test/test_sync.php
@@ -12,6 +12,7 @@ define('rootDir', __DIR__ . '/../../');
 define('root_dir', __DIR__ . '/../../');
 
 include_once rootDir .'/vendor/autoload.php';
+include_once 'config.php';
 use React\Async;
 use React\Promise;
 
@@ -351,22 +352,24 @@ class testMainClass extends baseMainTestClass {
         $this->import_files($exchange);
         assert(count(is_array($this->test_files) ? array_keys($this->test_files) : array()) > 0, 'Test files were not loaded'); // ensure test files are found & filled
         $this->expand_settings($exchange);
-        $symbol = $this->check_if_specific_test_is_chosen($symbol_argv);
+        $symbol = $this->check_if_specific_test_is_chosen($exchange, $symbol_argv);
         $this->start_test($exchange, $symbol);
         exit_script(0); // needed to be explicitly finished for WS tests
     }
 
-    public function check_if_specific_test_is_chosen($symbol_argv) {
+    public function check_if_specific_test_is_chosen($exchange, $symbol_argv) {
         if ($symbol_argv !== null) {
-            $test_file_names = is_array($this->test_files) ? array_keys($this->test_files) : array();
+            $test_config = config();
+            $tests = $exchange->deep_extend($test_config['exchange'], $test_config[$exchange->id]);
+            $test_names = is_array($tests) ? array_keys($tests) : array();
             $possible_method_names = explode(',', $symbol_argv); // i.e. `test.ts binance fetchBalance,fetchDeposits`
             if (count($possible_method_names) >= 1) {
-                for ($i = 0; $i < count($test_file_names); $i++) {
-                    $test_file_name = $test_file_names[$i];
+                for ($i = 0; $i < count($test_names); $i++) {
+                    $test_name = $test_names[$i];
                     for ($j = 0; $j < count($possible_method_names); $j++) {
                         $method_name = $possible_method_names[$j];
-                        if ($test_file_name === $method_name) {
-                            $this->only_specific_tests[] = $test_file_name;
+                        if (mb_strpos($test_name, $method_name) !== false) {
+                            $this->only_specific_tests[] = $test_name;
                         }
                     }
                 }
@@ -431,20 +434,19 @@ class testMainClass extends baseMainTestClass {
         }
         // credentials
         $this->load_credentials_from_env($exchange);
-        // skipped tests
-        $skipped_file = $this->root_dir_for_skips . 'skip-tests.json';
-        $skipped_settings = io_file_read($skipped_file);
-        $skipped_settings_for_exchange = $exchange->safe_value($skipped_settings, $exchange_id, array());
+        // exchange tests settings
+        $tests_config = config();
+        $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange_id]);
         // others
-        $timeout = $exchange->safe_value($skipped_settings_for_exchange, 'timeout');
+        $timeout = $exchange->safe_value($tests, 'timeout');
         if ($timeout !== null) {
             $exchange->timeout = $timeout;
         }
-        $exchange->http_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'httpProxy');
-        $exchange->https_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'httpsProxy');
-        $exchange->ws_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'wsProxy');
-        $exchange->wss_proxy = $exchange->safe_string($skipped_settings_for_exchange, 'wssProxy');
-        $this->skipped_methods = $exchange->safe_value($skipped_settings_for_exchange, 'skipMethods', array());
+        $exchange->http_proxy = $exchange->safe_string($tests, 'httpProxy');
+        $exchange->https_proxy = $exchange->safe_string($tests, 'httpsProxy');
+        $exchange->ws_proxy = $exchange->safe_string($tests, 'wsProxy');
+        $exchange->wss_proxy = $exchange->safe_string($tests, 'wssProxy');
+        $this->skipped_methods = $exchange->safe_value($tests, 'skipMethods', array());
         $this->checked_public_tests = array();
     }
 
@@ -483,9 +485,14 @@ class testMainClass extends baseMainTestClass {
         return $result;
     }
 
-    public function test_method($method_name, $exchange, $args, $is_public) {
+    public function test_method($exchange, $test_name, $test) {
+        $method_name = $test['testFile'];
+        $is_public = $test['public'];
+        $args = $test['args'];
+        $skip = $exchange->safe_string($test, 'skip');
         // todo: temporary skip for php
-        if (mb_strpos($method_name, 'OrderBook') !== false && $this->ext === 'php') {
+        $i = array_search('OrderBook', $method_name);
+        if ($i >= 0 && ($this->ext === 'php')) {
             return;
         }
         $is_load_markets = ($method_name === 'loadMarkets');
@@ -497,11 +504,11 @@ class testMainClass extends baseMainTestClass {
         }
         $skip_message = null;
         $supported_by_exchange = (is_array($exchange->has) && array_key_exists($method_name, $exchange->has)) && $exchange->has[$method_name];
-        if (!$is_load_markets && (count($this->only_specific_tests) > 0 && !$exchange->in_array($method_name, $this->only_specific_tests))) {
+        if (!$is_load_markets && (count($this->only_specific_tests) > 0 && !$exchange->in_array($test_name, $this->only_specific_tests))) {
             $skip_message = '[INFO] IGNORED_TEST';
         } elseif (!$is_load_markets && !$supported_by_exchange && !$is_proxy_test) {
             $skip_message = '[INFO] UNSUPPORTED_TEST'; // keep it aligned with the longest message
-        } elseif ((is_array($this->skipped_methods) && array_key_exists($method_name, $this->skipped_methods)) && (is_string($this->skipped_methods[$method_name]))) {
+        } elseif (is_string($skip)) {
             $skip_message = '[INFO] SKIPPED_TEST';
         } elseif (!(is_array($this->test_files) && array_key_exists($method_name, $this->test_files))) {
             $skip_message = '[INFO] UNIMPLEMENTED_TEST';
@@ -518,30 +525,31 @@ class testMainClass extends baseMainTestClass {
         }
         if ($this->info) {
             $args_stringified = '(' . implode(',', $args) . ')';
-            dump($this->add_padding('[INFO] TESTING', 25), $this->exchange_hint($exchange), $method_name, $args_stringified);
+            dump($this->add_padding('[INFO] TESTING', 25), $this->exchange_hint($exchange), $test_name, $args_stringified);
         }
-        $skipped_properties = $exchange->safe_value($this->skipped_methods, $method_name, array());
+        $skipped_properties = $exchange->safe_value($test, 'skippedProperties', array());
         call_method($this->test_files, $method_name, $exchange, $skipped_properties, $args);
         // if it was passed successfully, add to the list of successfull tests
         if ($is_public) {
-            $this->checked_public_tests[$method_name] = true;
+            $this->checked_public_tests[$test_name] = true;
         }
     }
 
-    public function test_safe($method_name, $exchange, $args = [], $is_public = false) {
+    public function test_safe($exchange, $test_name, $test) {
         // `testSafe` method does not throw an exception, instead mutes it. The reason we
         // mute the thrown exceptions here is because we don't want to stop the whole
         // tests queue if any single test-method fails. Instead, they are echoed with
         // formatted message "[TEST_FAILURE] ..." and that output is then regex-matched by
         // run-tests.js, so the exceptions are still printed out to console from there.
+        $is_public = $test['public'];
         $max_retries = 3;
-        $args_stringified = $exchange->json($args); // args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
+        $args_stringified = $exchange->json($test['args']); // args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
         for ($i = 0; $i < $max_retries; $i++) {
             try {
-                $this->test_method($method_name, $exchange, $args, $is_public);
+                $this->test_method($exchange, $test_name, $test);
                 return true;
             } catch(\Throwable $e) {
-                $is_load_markets = ($method_name === 'loadMarkets');
+                $is_load_markets = ($test['testFile'] === 'loadMarkets');
                 $is_auth_error = ($e instanceof AuthenticationError);
                 $is_not_supported = ($e instanceof NotSupported);
                 $is_operation_failed = ($e instanceof OperationFailed); // includes "DDoSProtection", "RateLimitExceeded", "RequestTimeout", "ExchangeNotAvailable", "OperationFailed", "InvalidNonce", ...
@@ -559,10 +567,10 @@ class testMainClass extends baseMainTestClass {
                         }
                         // final step
                         if ($should_fail) {
-                            dump('[TEST_FAILURE]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $method_name, $args_stringified, exception_message($e));
+                            dump('[TEST_FAILURE]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $test_name, $args_stringified, exception_message($e));
                             return false;
                         } else {
-                            dump('[TEST_WARNING]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $method_name, $args_stringified, exception_message($e));
+                            dump('[TEST_WARNING]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', $this->exchange_hint($exchange), $test_name, $args_stringified, exception_message($e));
                             return true;
                         }
                     } else {
@@ -574,25 +582,25 @@ class testMainClass extends baseMainTestClass {
                 } else {
                     // if it's loadMarkets, then fail test, because it's mandatory for tests
                     if ($is_load_markets) {
-                        dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                        dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                         return false;
                     }
                     // if the specific arguments to the test method throws "NotSupported" exception
                     // then let's don't fail the test
                     if ($is_not_supported) {
                         if ($this->info) {
-                            dump('[INFO] NOT_SUPPORTED', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                            dump('[INFO] NOT_SUPPORTED', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                         }
                         return true;
                     }
                     // If public test faces authentication error, we don't break (see comments under `testSafe` method)
                     if ($is_public && $is_auth_error) {
                         if ($this->info) {
-                            dump('[INFO]', 'Authentication problem for public method', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                            dump('[INFO]', 'Authentication problem for public method', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                         }
                         return true;
                     } else {
-                        dump('[TEST_FAILURE]', exception_message($e), $this->exchange_hint($exchange), $method_name, $args_stringified);
+                        dump('[TEST_FAILURE]', exception_message($e), $this->exchange_hint($exchange), $test_name, $args_stringified);
                         return false;
                     }
                 }
@@ -600,43 +608,26 @@ class testMainClass extends baseMainTestClass {
         }
     }
 
-    public function run_public_tests($exchange, $symbol) {
-        $tests = array(
-            'fetchCurrencies' => [],
-            'fetchTicker' => [$symbol],
-            'fetchTickers' => [$symbol],
-            'fetchOHLCV' => [$symbol],
-            'fetchTrades' => [$symbol],
-            'fetchOrderBook' => [$symbol],
-            'fetchL2OrderBook' => [$symbol],
-            'fetchOrderBooks' => [],
-            'fetchBidsAsks' => [],
-            'fetchStatus' => [],
-            'fetchTime' => [],
-        );
-        if ($this->ws_tests) {
-            $tests = array(
-                'watchOHLCV' => [$symbol],
-                'watchTicker' => [$symbol],
-                'watchOrderBook' => [$symbol],
-                'watchTrades' => [$symbol],
-            );
-        }
-        $market = $exchange->market($symbol);
-        $is_spot = $market['spot'];
-        if (!$this->ws_tests) {
-            if ($is_spot) {
-                $tests['fetchCurrencies'] = [];
-            } else {
-                $tests['fetchFundingRates'] = [$symbol];
-                $tests['fetchFundingRate'] = [$symbol];
-                $tests['fetchFundingRateHistory'] = [$symbol];
-                $tests['fetchIndexOHLCV'] = [$symbol];
-                $tests['fetchMarkOHLCV'] = [$symbol];
-                $tests['fetchPremiumIndexOHLCV'] = [$symbol];
+    public function filter_test($tests, $key, $value) {
+        $result = array();
+        $test_names = is_array($tests) ? array_keys($tests) : array();
+        for ($i = 0; $i < count($test_names); $i++) {
+            $name = $test_names[$i];
+            if ($tests[$name][$key] === $value) {
+                $result[$name] = $tests[$name];
             }
         }
-        $this->public_tests = $tests;
+        return $result;
+    }
+
+    public function run_public_tests($exchange, $symbol) {
+        $market = $exchange->market($symbol);
+        $is_spot = $market['spot'];
+        $code = $this->get_exchange_code($exchange);
+        $tests_config = config($symbol, $code, $is_spot);
+        $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange->id]);
+        $tests = $this->filter_test($tests, 'public', true);
+        $tests = $this->filter_test($tests, 'isWs', $this->ws_tests);
         $this->run_tests($exchange, $tests, true);
     }
 
@@ -645,25 +636,25 @@ class testMainClass extends baseMainTestClass {
         $promises = [];
         for ($i = 0; $i < count($test_names); $i++) {
             $test_name = $test_names[$i];
-            $test_args = $tests[$test_name];
-            $promises[] = $this->test_safe($test_name, $exchange, $test_args, $is_public_test);
+            $test = $tests[$test_name];
+            $promises[] = $this->test_safe($exchange, $test_name, $test);
         }
         // todo - not yet ready in other langs too
         // promises.push (testThrottle ());
         $results = ($promises);
         // now count which test-methods retuned `false` from "testSafe" and dump that info below
-        $failed_methods = [];
+        $failed_tests = [];
         for ($i = 0; $i < count($test_names); $i++) {
             $test_name = $test_names[$i];
             $test_returned_value = $results[$i];
             if (!$test_returned_value) {
-                $failed_methods[] = $test_name;
+                $failed_tests[] = $test_name;
             }
         }
         $test_prefix_string = $is_public_test ? 'PUBLIC_TESTS' : 'PRIVATE_TESTS';
-        if (count($failed_methods)) {
-            $errors_string = implode(', ', $failed_methods);
-            dump('[TEST_FAILURE]', $this->exchange_hint($exchange), $test_prefix_string, 'Failed methods : ' . $errors_string);
+        if (count($failed_tests)) {
+            $errors_string = implode(', ', $failed_tests);
+            dump('[TEST_FAILURE]', $this->exchange_hint($exchange), $test_prefix_string, 'Failed tests : ' . $errors_string);
         }
         if ($this->info) {
             dump($this->add_padding('[INFO] END ' . $test_prefix_string . ' ' . $this->exchange_hint($exchange), 25));
@@ -671,7 +662,10 @@ class testMainClass extends baseMainTestClass {
     }
 
     public function load_exchange($exchange) {
-        $result = $this->test_safe('loadMarkets', $exchange, [], true);
+        $tests_config = config('', '', true);
+        $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange->id]);
+        $load_markets_test = $tests['loadMarkets'];
+        $result = $this->test_safe($exchange, 'loadMarkets', $load_markets_test);
         if (!$result) {
             return false;
         }
@@ -851,67 +845,24 @@ class testMainClass extends baseMainTestClass {
         //     await test ('InvalidOrder', exchange, symbol);
         //     await test ('InsufficientFunds', exchange, symbol, balance); // danger zone - won't execute with non-empty balance
         // }
-        $tests = array(
-            'signIn' => [],
-            'fetchBalance' => [],
-            'fetchAccounts' => [],
-            'fetchTransactionFees' => [],
-            'fetchTradingFees' => [],
-            'fetchStatus' => [],
-            'fetchOrders' => [$symbol],
-            'fetchOpenOrders' => [$symbol],
-            'fetchClosedOrders' => [$symbol],
-            'fetchMyTrades' => [$symbol],
-            'fetchLeverageTiers' => [[$symbol]],
-            'fetchLedger' => [$code],
-            'fetchTransactions' => [$code],
-            'fetchDeposits' => [$code],
-            'fetchWithdrawals' => [$code],
-            'fetchBorrowInterest' => [$code, $symbol],
-            'cancelAllOrders' => [$symbol],
-            'fetchCanceledOrders' => [$symbol],
-            'fetchPosition' => [$symbol],
-            'fetchDeposit' => [$code],
-            'createDepositAddress' => [$code],
-            'fetchDepositAddress' => [$code],
-            'fetchDepositAddresses' => [$code],
-            'fetchDepositAddressesByNetwork' => [$code],
-            'fetchBorrowRateHistory' => [$code],
-            'fetchLedgerEntry' => [$code],
-        );
-        if ($this->ws_tests) {
-            $tests = array(
-                'watchBalance' => [$code],
-                'watchMyTrades' => [$symbol],
-                'watchOrders' => [$symbol],
-                'watchPosition' => [$symbol],
-                'watchPositions' => [$symbol],
-            );
-        }
         $market = $exchange->market($symbol);
         $is_spot = $market['spot'];
-        if (!$this->ws_tests) {
-            if ($is_spot) {
-                $tests['fetchCurrencies'] = [];
-            } else {
-                // derivatives only
-                $tests['fetchPositions'] = [$symbol]; // this test fetches all positions for 1 symbol
-                $tests['fetchPosition'] = [$symbol];
-                $tests['fetchPositionRisk'] = [$symbol];
-                $tests['setPositionMode'] = [$symbol];
-                $tests['setMarginMode'] = [$symbol];
-                $tests['fetchOpenInterestHistory'] = [$symbol];
-                $tests['fetchFundingRateHistory'] = [$symbol];
-                $tests['fetchFundingHistory'] = [$symbol];
-            }
-        }
-        // const combinedTests = exchange.deepExtend (this.publicTests, privateTests);
+        $tests_config = config($symbol, $code, $is_spot);
+        $tests = $exchange->deep_extend($tests_config['exchange'], $tests_config[$exchange->id]);
+        $tests = $this->filter_test($tests, 'public', false);
+        $tests = $this->filter_test($tests, 'isWs', $this->ws_tests);
         $this->run_tests($exchange, $tests, false);
     }
 
-    public function test_proxies($exchange) {
+    public function method($exchange) {
         // these tests should be synchronously executed, because of conflicting nature of proxy settings
         $proxy_test_name = $this->proxy_test_file_name;
+        $proxy_test = array(
+            'public' => true,
+            'testFile' => $proxy_test_name,
+            'args' => [],
+            'isWs' => false,
+        );
         // todo: temporary skip for sync py
         if ($this->ext === 'py' && $this->is_synchronous) {
             return;
@@ -921,7 +872,7 @@ class testMainClass extends baseMainTestClass {
         $exception = null;
         for ($j = 0; $j < $max_retries; $j++) {
             try {
-                $this->test_method($proxy_test_name, $exchange, [], true);
+                $this->test_method($exchange, $proxy_test_name, $proxy_test);
                 break; // if successfull, then break
             } catch(\Throwable $e) {
                 $exception = $e;
@@ -949,7 +900,7 @@ class testMainClass extends baseMainTestClass {
             }
             // if (exchange.id === 'binance') {
             //     // we test proxies functionality just for one random exchange on each build, because proxy functionality is not exchange-specific, instead it's all done from base methods, so just one working sample would mean it works for all ccxt exchanges
-            //     // await this.testProxies (exchange);
+            //     // await this.method (exchange);
             // }
             $this->test_exchange($exchange, $symbol);
             close($exchange);

--- a/python/ccxt/test/config.py
+++ b/python/ccxt/test/config.py
@@ -1,0 +1,2676 @@
+
+
+
+
+# *********************************
+# ***** AUTO-TRANSPILER-START *****
+def config(symbol='BTC/USDT', code='USDT', is_spot=True):
+    return ({
+    'exchange': {
+        'loadMarkets': {
+            'testFile': 'loadMarkets',
+            'args': [],
+            'isWs': False,
+            'public': True,
+        },
+        'fetchTicker': {
+            'testFile': 'fetchTicker',
+            'isWs': False,
+            'public': True,
+            'args': [symbol],
+        },
+        'fetchTickers': {
+            'testFile': 'fetchTickers',
+            'isWs': False,
+            'public': True,
+            'args': [symbol],
+        },
+        'fetchOHLCV': {
+            'testFile': 'fetchOHLCV',
+            'isWs': False,
+            'public': True,
+            'args': [symbol],
+        },
+        'fetchTrades': {
+            'testFile': 'fetchTrades',
+            'isWs': False,
+            'public': True,
+            'args': [symbol],
+        },
+        'fetchOrderBook': {
+            'testFile': 'fetchOrderBook',
+            'isWs': False,
+            'public': True,
+            'args': [symbol],
+        },
+        'fetchL2OrderBook': {
+            'testFile': 'fetchL2OrderBook',
+            'isWs': False,
+            'public': True,
+            'args': [symbol],
+        },
+        'fetchOrderBooks': {
+            'testFile': 'fetchOrderBooks',
+            'isWs': False,
+            'public': True,
+            'args': [],
+        },
+        'fetchBidsAsks': {
+            'testFile': 'fetchBidsAsks',
+            'isWs': False,
+            'public': True,
+            'args': [],
+        },
+        'fetchTime': {
+            'testFile': 'fetchTime',
+            'isWs': False,
+            'public': True,
+            'args': [],
+        },
+        'fetchCurrencies - public': {
+            'testFile': 'fetchCurrencies',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': None if is_spot else 'only run for swap markets',
+        },
+        'fetchFundingRates': {
+            'testFile': 'fetchFundingRates',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchFundingRate': {
+            'testFile': 'fetchFundingRate',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchFundingRateHistory - public': {
+            'testFile': 'fetchFundingRateHistory',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchIndexOHLCV': {
+            'testFile': 'fetchIndexOHLCV',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchMarkOHLCV': {
+            'testFile': 'fetchMarkOHLCV',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchPremiumIndexOHLCV': {
+            'testFile': 'fetchPremiumIndexOHLCV',
+            'isWs': False,
+            'public': True,
+            'args': [],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'signIn': {
+            'testFile': 'signIn',
+            'isWs': False,
+            'public': False,
+            'args': [],
+        },
+        'fetchBalance': {
+            'testFile': 'fetchBalance',
+            'isWs': False,
+            'public': False,
+            'args': [],
+        },
+        'fetchAccounts': {
+            'testFile': 'fetchAccounts',
+            'isWs': False,
+            'public': False,
+            'args': [],
+        },
+        'fetchTransactionFees': {
+            'testFile': 'fetchTransactionFees',
+            'isWs': False,
+            'public': False,
+            'args': [],
+        },
+        'fetchTradingFees': {
+            'testFile': 'fetchTradingFees',
+            'isWs': False,
+            'public': False,
+            'args': [],
+        },
+        'fetchStatus': {
+            'testFile': 'fetchStatus',
+            'isWs': False,
+            'public': False,
+            'args': [],
+        },
+        'fetchOrders': {
+            'testFile': 'fetchOrders',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+        },
+        'fetchOpenOrders': {
+            'testFile': 'fetchOpenOrders',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+        },
+        'fetchClosedOrders': {
+            'testFile': 'fetchClosedOrders',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+        },
+        'fetchMyTrades': {
+            'testFile': 'fetchMyTrades',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+        },
+        'fetchLeverageTiers': {
+            'testFile': 'fetchLeverageTiers',
+            'isWs': False,
+            'public': False,
+            'args': [[symbol]],
+        },
+        'fetchLedger': {
+            'testFile': 'fetchLedger',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchTransactions': {
+            'testFile': 'fetchTransactions',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchDeposits': {
+            'testFile': 'fetchDeposits',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchWithdrawals': {
+            'testFile': 'fetchWithdrawals',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchBorrowInterest': {
+            'testFile': 'fetchBorrowInterest',
+            'isWs': False,
+            'public': False,
+            'args': [code, symbol],
+        },
+        'addMargin': {
+            'testFile': 'addMargin',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'reduceMargin': {
+            'testFile': 'reduceMargin',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'setMargin': {
+            'testFile': 'setMargin',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'setMarginMode': {
+            'testFile': 'setMarginMode',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'setLeverage': {
+            'testFile': 'setLeverage',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'cancelAllOrders': {
+            'testFile': 'cancelAllOrders',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+        },
+        'cancelOrder': {
+            'testFile': 'cancelOrder',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'cancelOrders': {
+            'testFile': 'cancelOrders',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchCanceledOrders': {
+            'testFile': 'fetchCanceledOrders',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+        },
+        'fetchClosedOrder': {
+            'testFile': 'fetchClosedOrder',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchOpenOrder': {
+            'testFile': 'fetchOpenOrder',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchOrder': {
+            'testFile': 'fetchOrder',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchOrderTrades': {
+            'testFile': 'fetchOrderTrades',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchDeposit': {
+            'testFile': 'fetchDeposit',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'createDepositAddress': {
+            'testFile': 'createDepositAddress',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchDepositAddress': {
+            'testFile': 'fetchDepositAddress',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchDepositAddresses': {
+            'testFile': 'fetchDepositAddresses',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchDepositAddressesByNetwork': {
+            'testFile': 'fetchDepositAddressesByNetwork',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'editOrder': {
+            'testFile': 'editOrder',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchBorrowRateHistory': {
+            'testFile': 'fetchBorrowRateHistory',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchLedgerEntry': {
+            'testFile': 'fetchLedgerEntry',
+            'isWs': False,
+            'public': False,
+            'args': [code],
+        },
+        'fetchWithdrawal': {
+            'testFile': 'fetchWithdrawal',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'transfer': {
+            'testFile': 'transfer',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'withdraw': {
+            'testFile': 'withdraw',
+            'isWs': False,
+            'public': False,
+            'args': [],
+            'skip': True,
+        },
+        'fetchPositions': {
+            'testFile': 'fetchPositions',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchPosition': {
+            'testFile': 'fetchPosition',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchPositionRisk': {
+            'testFile': 'fetchPositionRisk',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'setPositionMode': {
+            'testFile': 'setPositionMode',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchOpenInterestHistory': {
+            'testFile': 'fetchOpenInterestHistory',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchFundingRateHistory - private': {
+            'testFile': 'fetchFundingRateHistory',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'fetchFundingHistory': {
+            'testFile': 'fetchFundingHistory',
+            'isWs': False,
+            'public': False,
+            'args': [symbol],
+            'skip': 'only run for swap markets' if is_spot else None,
+        },
+        'watchOHLCV': {
+            'testFile': 'watchOHLCV',
+            'isWs': True,
+            'public': True,
+            'args': [symbol],
+        },
+        'watchTicker': {
+            'testFile': 'watchTicker',
+            'isWs': True,
+            'public': True,
+            'args': [symbol],
+        },
+        'watchOrderBook': {
+            'testFile': 'watchOrderBook',
+            'isWs': True,
+            'public': True,
+            'args': [symbol],
+        },
+        'watchTrades': {
+            'testFile': 'watchTrades',
+            'isWs': True,
+            'public': True,
+            'args': [symbol],
+        },
+        'watchTickers with symbol': {
+            'testFile': 'watchTickers',
+            'isWs': True,
+            'public': True,
+            'args': [symbol],
+        },
+        'watchTickers with symbol channel name': {
+            'testFile': 'watchTickers',
+            'isWs': True,
+            'public': True,
+            'args': [symbol, {
+    'name': 'ticker',
+}],
+        },
+        'watchTickers with symbol channel bookTicker': {
+            'testFile': 'watchTickers',
+            'isWs': True,
+            'public': True,
+            'args': [symbol, {
+    'name': 'bookTicker',
+}],
+        },
+        'watchBalance': {
+            'testFile': 'watchBalance',
+            'isWs': True,
+            'public': False,
+            'args': [code],
+        },
+        'watchMyTrades': {
+            'testFile': 'watchMyTrades',
+            'isWs': True,
+            'public': False,
+            'args': [symbol],
+        },
+        'watchOrders': {
+            'testFile': 'watchOrders',
+            'isWs': True,
+            'public': False,
+            'args': [symbol],
+        },
+        'watchPosition': {
+            'testFile': 'watchPosition',
+            'isWs': True,
+            'public': False,
+            'args': [symbol],
+        },
+        'watchPositions': {
+            'testFile': 'watchPositions',
+            'isWs': True,
+            'public': False,
+            'args': [symbol],
+        },
+    },
+    'ace': {
+        'skip': 'temp',
+        'skipWs': True,
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'temporary skip, because ids are numeric and we are in wip for numeric id tests',
+                'quoteId': 'numeric',
+                'quote': 'numeric',
+                'baseId': 'numeric',
+                'base': 'numeric',
+                'settleId': 'numeric',
+                'settle': 'numeric',
+                'active': 'is undefined',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'needs reversion of amount/price',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+    },
+    'alpaca': {
+        'skip': 'private endpoints',
+        'skipWs': 'private endpoints',
+    },
+    'ascendex': {
+        'skipWs': 'unknown https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2416',
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken currencies',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'low': '16 Aug - happened weird negative 24hr low',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+    },
+    'bequant': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/264802937#L2194',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'broken bid-ask',
+                'ask': 'broken bid-ask',
+            },
+        },
+    },
+    'binance': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+        'wsProxy': 'http://5.75.153.75:8002',
+        'fetchStatus': {
+            'skip': 'temporarily failing',
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'i.e. binance does not have currency code BCC',
+                'expiry': 'expiry not set for future markets',
+                'expiryDatetime': 'expiry not set for future markets',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided in public api',
+                'networks': 'not yet unified',
+            },
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            },
+        },
+    },
+    'binanceus': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'expiry': 'expiry not set for future markets',
+                'expiryDatetime': 'expiry not set for future markets',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchStatus': {
+            'skip': 'private endpoints',
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            },
+        },
+    },
+    'binancecoinm': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+        'loadMarkets': {
+            'skippedProperties': {
+                'expiry': 'expiry not set for future markets',
+                'expiryDatetime': 'expiry not set for future markets',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            },
+        },
+        'watchOrderBook': {
+            'skip': 'out of order update',
+        },
+    },
+    'binanceusdm': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchPositions': {
+            'skip': 'currently returns a lot of default/non open positions',
+        },
+        'fetchLedger': {
+            'skippedProperties': {
+                'account': 'empty',
+                'status': 'not provided',
+                'before': 'not provided',
+                'after': 'not provided',
+                'fee': 'not provided',
+                'code': 'not provided',
+                'referenceId': 'not provided',
+            },
+        },
+        'fetchBalance': {
+            'skip': 'tmp skip',
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466',
+            },
+        },
+    },
+    'bit2c': {
+        'skip': 'temporary certificate issues',
+        'until': '2023-11-25',
+        'loadMarkets': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'active': 'not provided',
+                'taker': 'not provided',
+                'maker': 'not provided',
+                'info': 'null',
+            },
+        },
+        'fetchOrderBook': {
+            'skippedProperties': {
+                'bid': 'sometimes equals to zero: https://app.travis-ci.com/github/ccxt/ccxt/builds/267809189#L2540',
+                'ask': 'same',
+            },
+        },
+    },
+    'tokocrypto': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+    },
+    'bitbank': {},
+    'bitbay': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'expiry': 'expiry not set for future markets',
+                'expiryDatetime': 'expiry not set for future markets',
+            },
+        },
+    },
+    'bitbns': {
+        'skip': 'temp',
+        'loadMarkets': {
+            'skippedProperties': {
+                'limits': 'only one market has min>max limit',
+                'active': 'not provided',
+                'currencyIdAndCode': 'broken',
+            },
+        },
+        'fetchTickers': {
+            'skip': 'unknown symbol might be returned',
+        },
+    },
+    'bitcoincom': {
+        'skipWs': True,
+    },
+    'bitfinex': {
+        'loadMarkets': {
+            'skip': 'linear and inverse values are same',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'symbol': 'something broken with symbol',
+                'ask': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/262965121#L3179',
+                'bid': 'same',
+            },
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'symbol': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L3846',
+            },
+        },
+    },
+    'bitfinex2': {
+        'skipWs': True,
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken currencies',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'multiple bids might have same value',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'fetchTickers': {
+            'skip': 'negative values',
+        },
+    },
+    'bitflyer': {
+        'loadMarkets': {
+            'skip': 'contract is true, but contractSize is undefined',
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'side key has an null value, but is expected to have a value',
+            },
+        },
+    },
+    'bitget': {
+        'skipWs': True,
+        'loadMarkets': {
+            'skippedProperties': {
+                'precision': 'broken precision',
+                'limits': 'limit max value is zero, lwer than min',
+                'contractSize': 'not defined when contract',
+                'currencyIdAndCode': 'broken currencies',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'broken bid-ask',
+                'ask': 'broken bid-ask',
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'watchTrades': {
+            'skippedProperties': {
+                'timestamp': 'ts order is reverted (descending)',
+            },
+        },
+    },
+    'bithumb': {
+        'skip': 'fetchMarkets returning undefined',
+        'until': '2023-09-05',
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'bitmart': {
+        'skipWs': True,
+        'loadMarkets': {
+            'skippedProperties': {
+                'expiry': 'expiry is expected to be > 0',
+                'settle': 'not defined when contract',
+                'settleId': 'not defined when contract',
+                'currencyIdAndCode': 'broken currencies',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'networks': 'missing',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'same',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'same',
+            },
+        },
+        'fetchL2OrderBook': {
+            'skip': 'bid==ask , https://app.travis-ci.com/github/ccxt/ccxt/builds/263304041#L2170',
+        },
+        'fetchLOrderBook': {
+            'skip': 'same',
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4256',
+                'bid': 'wrong data https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4325',
+            },
+        },
+        'watchTrades': {
+            'skippedProperties': {
+                'side': 'not set https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4312',
+            },
+        },
+    },
+    'bitmex': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skip': 'some market types are out of expected market-types',
+        },
+        'fetchOHLCV': {
+            'skip': 'open might be greater than high',
+        },
+        'fetchTickers': {
+            'skip': 'negative values',
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'stopLossPrice': 'undefined',
+                'takeProfitPrice': 'undefined',
+                'marginRatio': 'undefined',
+                'lastPrice': 'undefined',
+                'collateral': 'undefined',
+                'hedged': 'undefined',
+                'lastUpdateTimestamp': 'undefined',
+                'entryPrice': 'undefined',
+                'markPrice': 'undefined',
+                'leverage': 'undefined',
+                'initialMargin': 'undefined',
+                'maintenanceMargin': 'can be zero for default position',
+                'notional': 'can be zero for default position',
+                'contracts': 'contracts',
+                'unrealizedPnl': 'undefined',
+                'realizedPnl': 'undefined',
+                'liquidationPrice': 'can be 0',
+                'percentage': 'might be 0',
+            },
+        },
+        'fetchMyTrades': {
+            'skippedProperties': {
+                'side': 'sometimes side is not available',
+            },
+        },
+        'fetchLedger': {
+            'skippedProperties': {
+                'referenceId': 'undefined',
+                'amount': 'undefined',
+                'before': 'not provided',
+                'tag': 'undefined',
+                'tagFrom': 'undefined',
+                'tagTo': 'undefined',
+                'type': 'unmapped types',
+                'timestamp': 'default value might be invalid',
+            },
+        },
+        'fetchDepositsWithdrawals': {
+            'skippedProperties': {
+                'currency': 'undefined',
+                'currencyIdAndCode': 'messes codes',
+            },
+        },
+        'fetchTransactions': {
+            'skip': 'skip',
+        },
+    },
+    'bitopro': {
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'networks': 'missing',
+            },
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken currencies',
+            },
+        },
+        'watchTicker': {
+            'skip': 'datetime error: https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4373',
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4373',
+            },
+        },
+    },
+    'bitpanda': {
+        'skipWs': True,
+        'fetchOrderBook': {
+            'skip': 'some bid might be lower than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+    },
+    'bitrue': {
+        'skipWs': True,
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken currencies',
+                'limits': 'max is below min',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'not set',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'bid ask crossed',
+                'ask': 'bid ask crossed',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'bitso': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'not provided',
+            },
+        },
+        'fetchOHLCV': {
+            'skip': 'randomly failing with 404 not found',
+        },
+    },
+    'bitstamp': {
+        'fetchOrderBook': {
+            'skip': 'bid/ask might be 0',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'bid': 'greater than ask https://app.travis-ci.com/github/ccxt/ccxt/builds/264241638#L3027',
+                'baseVolume': 'baseVolume * low = 8.43e-6 * 3692.59081464 = 0.03112854056 < 0.0311285405674152',
+                'quoteVolume': 'quoteVolume >= baseVolume * low <<< bitstamp fetchTickers',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'same',
+                'baseVolume': 'same',
+                'quoteVolume': 'same',
+            },
+        },
+        'watchOrderBook': {
+            'skip': 'something broken https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4473 and https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4504',
+        },
+    },
+    'bitstamp1': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'info': 'null',
+                'precision': 'not provided',
+                'active': 'not provided',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bid/ask might be 0',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'bid': 'greater than ask https://app.travis-ci.com/github/ccxt/ccxt/builds/264241638#L3027',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'same',
+            },
+        },
+    },
+    'bl3p': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'active': 'not provided',
+                'info': 'null',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'side is undefined',
+            },
+        },
+    },
+    'bitvavo': {
+        'skip': 'temp',
+        'httpsProxy': 'http://51.83.140.52:11230',
+        'skipWs': 'temp',
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'networks': 'missing',
+            },
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken currencies',
+                'taker': 'is undefined',
+                'maker': 'is undefined',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'broken bid-ask',
+                'ask': 'broken bid-ask',
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing https://app.travis-ci.com/github/ccxt/ccxt/builds/266144312#L2220',
+            },
+        },
+    },
+    'blockchaincom': {
+        'skipWs': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/265225134#L2304',
+        'loadMarkets': {
+            'skippedProperties': {
+                'taker': 'not provided',
+                'maker': 'not provided',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bid should be greater than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4517 and https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4562',
+            },
+        },
+    },
+    'bkex': {
+        'fetchOrderBook': {
+            'skip': 'system busy',
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken currencies',
+                'contractSize': 'broken for some markets',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'networks': 'missing',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchOHLCV': {
+            'skip': 'open might be greater than high',
+        },
+    },
+    'btcbox': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'precision': 'is undefined',
+                'active': 'is undefined',
+                'info': 'null',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bids[0][0] (3787971.0) should be < than asks[0][0] (3787971.0) <<< btcbox ',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'bids[0][0] (3787971.0) should be < than asks[0][0] (3787971.0) <<< btcbox ',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'broken bid-ask',
+                'ask': 'broken bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'bid': 'broken bid-ask',
+                'ask': 'broken bid-ask',
+            },
+        },
+    },
+    'btcex': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+                'limits': 'sometimes \'max\' value is zero, lower than \'min\'',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'messed bid-ask : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2090',
+                'ask': 'same as above',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'bid': 'same as above',
+                'ask': 'same as above',
+            },
+        },
+    },
+    'btcalpha': {
+        'skip': True,
+        'fetchOrderBook': {
+            'skip': 'bids[0][0] is not < asks[0][0]',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'symbol': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/265171549#L2518',
+                'percentage': 'broken',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'percentage': '',
+                'symbol': '',
+                'bid': '',
+                'ask': '',
+            },
+        },
+    },
+    'btcmarkets': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bid should be greater than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+    },
+    'btctradeua': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'precision': 'is undefined',
+                'active': 'is undefined',
+                'taker': 'is undefined',
+                'maker': 'is undefined',
+                'info': 'null',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bid should be greater than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+    },
+    'btcturk': {
+        'fetchOrderBook': {
+            'skip': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/263287870#L2201',
+        },
+    },
+    'bybit': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+        'wsProxy': 'http://5.75.153.75:8002',
+        'fetchTickers': {
+            'skippedProperties': {
+                'symbol': 'returned symbol is not same as requested symbol. i.e. symbol:code vs symbol',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'symbol': 'same',
+            },
+        },
+        'fetchTrades': {
+            'skip': 'endpoint return Internal System Error',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'temp skip',
+            },
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'temp skip',
+            },
+        },
+        'fetchPositions': {
+            'skip': 'currently returns a lot of default/non open positions',
+        },
+        'fetchLedger': {
+            'skippedProperties': {
+                'account': 'account is not provided',
+                'status': 'status is not provided',
+                'fee': 'undefined',
+            },
+        },
+        'fetchOpenInterestHistory': {
+            'skippedProperties': {
+                'openInterestAmount': 'openInterestAmount is not provided',
+            },
+        },
+        'fetchBorrowRate': {
+            'skip': 'does not work with unified account',
+        },
+    },
+    'buda': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+    },
+    'bigone': {
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'broken bid-ask',
+                'ask': 'broken bid-ask',
+                'baseVolume': 'negative value',
+            },
+        },
+    },
+    'coincheck': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'info': 'not provided',
+                'precision': 'not provided',
+                'active': 'is undefined',
+                'taker': 'is undefined',
+                'maker': 'is undefined',
+            },
+        },
+    },
+    'coinbase': {
+        'skip': 'private endpoints',
+        'skipWs': 'needs auth',
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'not provided',
+            },
+        },
+        'fetchTrades': {
+            'skip': 'datetime is not same as timestamp',
+        },
+    },
+    'coinbasepro': {
+        'skipWs': 'needs auth',
+        'fetchStatus': {
+            'skip': 'request timeout',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+    },
+    'coinbaseprime': {
+        'fetchStatus': {
+            'skip': 'request timeout',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+    },
+    'coinone': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quote scale isn\'t right',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quote scale isn\'t right',
+            },
+        },
+    },
+    'coinspot': {
+        'skip': 'temp',
+        'loadMarkets': {
+            'skip': 'precision key has an null value, but is expected to have a value| taker key missing from structure (markets are created from constructor .options, so needs to fill with default values in base)',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'ask': 'broken bid-ask',
+                'bid': 'broken bid-ask',
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'coinsph': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'taker': 'messed',
+                'maker': 'messed',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'cex': {
+        'skipWs': 'timeouts',
+        'proxies': {
+            'skip': 'probably they do not permit our proxy location',
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+                'currencyIdAndCode': 'messes codes',
+            },
+        },
+        'fetchOHLCV': {
+            'skip': 'unexpected issue',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'limits': 'min is negative',
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+                'networks': 'missing',
+            },
+        },
+    },
+    'coinex': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'broken',
+                'active': 'is undefined',
+            },
+        },
+    },
+    'coinmate': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'ask should be less than next ask',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+    },
+    'cryptocom': {
+        'skipWs': 'timeout',
+        'proxies': {
+            'skip': 'probably they do not permit our proxy',
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'limits': 'max is below min',
+                'active': 'is undefined',
+                'currencyIdAndCode': 'from travis location (USA) these webapi endpoints cant be loaded',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'timestamp': 'timestamp might be of 1970-01-01T00:00:00.000Z',
+                'quoteVolume': 'can\'t be infered',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'timestamp': 'timestamp might be of 1970-01-01T00:00:00.000Z',
+                'quoteVolume': 'can\'t be infered',
+            },
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'entryPrice': 'entryPrice is not provided',
+                'markPrice': 'undefined',
+                'notional': 'undefined',
+                'leverage': 'undefined',
+                'liquidationPrice': 'undefined',
+                'marginMode': 'undefined',
+                'percentage': 'undefined',
+                'marginRatio': 'undefined',
+                'stopLossPrice': 'undefined',
+                'takeProfitPrice': 'undefined',
+                'maintenanceMargin': 'undefined',
+                'initialMarginPercentage': 'undefined',
+                'maintenanceMarginPercentage': 'undefined',
+                'hedged': 'undefined',
+                'side': 'undefined',
+                'contracts': 'undefined',
+            },
+        },
+        'fetchAccounts': {
+            'skippedProperties': {
+                'type': 'type is not provided',
+                'code': 'not provided',
+            },
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4756',
+            },
+        },
+    },
+    'currencycom': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skippedProperties': {
+                'type': 'unexpected market type',
+                'contractSize': 'not defined when contract',
+                'settle': 'not defined when contract',
+                'settleId': 'not defined when contract',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'ask': 'not above bid https://app.travis-ci.com/github/ccxt/ccxt/builds/263871244#L2163',
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'ask': 'not above bid https://app.travis-ci.com/github/ccxt/ccxt/builds/263871244#L2163',
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'delta': {
+        'loadMarkets': {
+            'skip': 'expiryDatetime must be equal to expiry in iso8601 format',
+        },
+        'fetchOrderBook': {
+            'skip': 'ask crossing bids test failing',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'failing the test',
+                'bid': 'failing the test',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'failing the test',
+                'bid': 'failing the test',
+            },
+        },
+    },
+    'deribit': {
+        'skipWs': 'timeouts',
+        'fetchCurrencies': {
+            'skip': 'deposit/withdraw not provided',
+        },
+        'loadMarkets': {
+            'skip': 'strike is set when option is not true',
+        },
+        'fetchTickers': {
+            'skip': 'something wrong',
+        },
+        'fetchBalance': {
+            'skip': 'does not add up',
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'percentage': 'undefined',
+                'hedged': 'undefined',
+                'stopLossPrice': 'undefined',
+                'takeProfitPrice': 'undefined',
+                'lastPrice': 'undefined',
+                'collateral': 'undefined',
+                'marginMode': 'undefined',
+                'marginRatio': 'undefined',
+                'contracts': 'undefined',
+                'id': 'undefined',
+            },
+        },
+        'fetchDeposits': {
+            'skippedProperties': {
+                'id': 'undefined',
+                'network': 'undefined',
+                'addressFrom': 'undefined',
+                'tag': 'undefined',
+                'tagTo': 'undefined',
+                'tagFrom': 'undefined',
+                'fee': 'undefined',
+            },
+        },
+    },
+    'flowbtc': {
+        'fetchTrades': {
+            'skip': 'timestamp is more than current utc timestamp',
+        },
+        'fetchOHLCV': {
+            'skip': 'same',
+        },
+    },
+    'fmfwio': {
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'fee': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+    },
+    'gemini': {
+        'skipWs': 'temporary',
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed codes',
+                'active': 'not provided',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4833',
+            },
+        },
+    },
+    'hitbtc': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed codes',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'fee': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+    },
+    'hitbtc3': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'limits': 'messed min max',
+                'currencyIdAndCode': 'messed codes',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'fee': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+    },
+    'digifinex': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed codes',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'messed',
+            },
+        },
+        'fetchTicker': {
+            'skip': 'unexpected symbol is being returned | safeMarket() requires a fourth argument for BTC_code to disambiguate between different markets with the same market id',
+        },
+        'fetchTickers': {
+            'skip': 'unexpected symbol is being returned | safeMarket() requires a fourth argument for BTC_code to disambiguate between different markets with the same market id',
+        },
+        'fetchLeverageTiers': {
+            'skippedProperties': {
+                'minNotional': 'undefined',
+                'currencyIdAndCode': 'messed codes',
+                'currency': 'messed',
+            },
+        },
+        'fetchBorrowRates': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed codes',
+                'currency': 'messed',
+            },
+        },
+        'fetchBorrowInterest': {
+            'skip': 'symbol is messed',
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'percentage': 'undefined',
+                'stopLossPrice': 'undefined',
+                'takeProfitPrice': 'undefined',
+                'collateral': 'undefined',
+                'initialMargin': 'undefined',
+                'initialMarginPercentage': 'undefined',
+                'hedged': 'undefined',
+                'id': 'undefined',
+                'notional': 'undefined',
+            },
+        },
+        'fetchBalance': {
+            'skip': 'tmp skip',
+        },
+    },
+    'gate': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed codes',
+                'fetchCurrencies': {
+                    'fee': 'not provided',
+                },
+                'limits': 'max should be above min',
+                'contractSize': 'broken for some markets',
+                'strike': 'incorrect number type',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'timestamp': 'timestamp is in decimals',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138',
+                'baseVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'bid': 'same',
+                'ask': 'same',
+                'quoteVolume': 'same',
+                'baseVolume': 'same',
+            },
+        },
+        'fetchPositions': {
+            'skip': 'currently returns a lot of default/non open positions',
+        },
+        'fetchLedger': {
+            'skippedProperties': {
+                'currency': 'undefined',
+                'status': 'undefined',
+                'fee': 'undefined',
+                'account': 'undefined',
+                'referenceAccount': 'undefined',
+                'referenceId': 'undefined',
+            },
+        },
+        'fetchTradingFees': {
+            'skip': 'sandbox does not have this endpoint',
+        },
+        'fetchDeposits': {
+            'skip': 'sandbox does not have this endpoint',
+        },
+        'fetchWithdrawals': {
+            'skip': 'sandbox does not have this endpoint',
+        },
+    },
+    'hollaex': {
+        'skipWs': 'temp',
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4957',
+            },
+        },
+    },
+    'htx': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'limits': 'messed',
+                'currencyIdAndCode': 'messed codes',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+                'precision': 'is undefined',
+                'limits': 'broken somewhere',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4860',
+            },
+        },
+    },
+    'huobijp': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skippedProperties': {
+                'limits': 'messed',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'fee': 'not defined',
+                'networks': 'missing',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'fees': 'missing',
+            },
+        },
+    },
+    'stex': {
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+    },
+    'probit': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skip': 'needs fixing',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'limits': 'messed',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'idex': {
+        'skipWs': 'timeouts',
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+                'networks': 'missing',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'messed bid-ask',
+                'bid': 'messed bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'messed bid-ask',
+                'bid': 'messed bid-ask',
+            },
+        },
+    },
+    'independentreserve': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'side is undefined',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bid should be greater than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+    },
+    'coinfalcon': {
+        'fetchTickers': {
+            'skip': 'negative values',
+        },
+    },
+    'kuna': {
+        'skip': 'temporary glitches with this exchange: https://app.travis-ci.com/github/ccxt/ccxt/builds/267517440#L2304',
+        'httpsProxy': 'http://5.75.153.75:8002',
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'deposit': 'is undefined',
+                'withdraw': 'is undefined',
+                'active': 'is undefined',
+                'precision': 'somewhat strange atm https://app.travis-ci.com/github/ccxt/ccxt/builds/267515280#L2337',
+            },
+        },
+    },
+    'kucoin': {
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'depositForNonCrypto': 'not provided',
+                'withdrawForNonCrypto': 'not provided',
+            },
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+                'quoteVolume': 'quoteVolume <= baseVolume * high https://app.travis-ci.com/github/ccxt/ccxt/builds/263304041#L2190',
+                'baseVolume': 'same',
+            },
+        },
+    },
+    'kucoinfutures': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'percentage': 'percentage is not provided',
+            },
+        },
+    },
+    'latoken': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skip': 'negative values',
+        },
+    },
+    'luno': {
+        'skipWs': 'temp',
+        'fetchOrderBook': {
+            'skip': 'bid should be greater than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+    },
+    'lbank': {
+        'loadMarkets': {
+            'skip': 'settle must be defined when contract is true',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'lykke': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed codes',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'fee': 'not provided',
+            },
+        },
+        'fetchOrderBook': {
+            'skip': 'bid should be greater than next bid',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'same',
+        },
+        'fetchTickers': {
+            'skip': 'negative values',
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'mercado': {
+        'loadMarkets': {
+            'skip': 'needs migration to v4, as raw info is not being used. granular can be used for skipping \'info\'',
+        },
+        'fetchOrderBook': {
+            'skip': 'bid > ask',
+        },
+        'fetchL2OrderBook': {
+            'skip': 'bid > ask',
+        },
+        'fetchTickers': {
+            'skip': 'bid > ask',
+        },
+        'fetchTicker': {
+            'skip': 'bid > ask',
+        },
+        'fetchCurrencies': {
+            'skip': 'info key is missing',
+        },
+    },
+    'novadax': {
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/266029139',
+                'bid': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/266029139',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'ndax': {
+        'skipWs': 'timeouts',
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+    },
+    'mexc': {
+        'skipWs': 'temp',
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'is undefined',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'side is not buy/sell',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'bid': 'messed bid-ask',
+                'ask': 'messed bid-ask',
+            },
+        },
+        'fetchAccounts': {
+            'skippedProperties': {
+                'type': 'type is not provided',
+            },
+        },
+        'fetchLeverageTiers': {
+            'skip': 'swap only supported',
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6610',
+            },
+        },
+    },
+    'oceanex': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchOrderBooks': {
+            'skip': 'fetchOrderBooks returned 0 length',
+        },
+    },
+    'p2b': {
+        'skip': 'temp issues',
+        'httpsProxy': 'http://51.83.140.52:11230',
+        'loadMarkets': {
+            'skip': 'invalid URL',
+        },
+        'fetchTrades': {
+            'skip': 'requires order id',
+        },
+    },
+    'paymium': {
+        'skip': 'exchange is down',
+        'loadMarkets': {
+            'skippedProperties': {
+                'precision': 'not provided',
+                'active': 'not provided',
+                'info': 'null',
+                'taker': 'is undefined',
+                'maker': 'is undefined',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'phemex': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'contractSize': 'broken for some markets',
+                'active': 'not provided',
+                'currencyIdAndCode': 'messed',
+                'taker': 'null',
+                'maker': 'null',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'messed bid-ask',
+                'bid': 'messed bid-ask',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+                'ask': 'messed bid-ask',
+                'bid': 'messed bid-ask',
+            },
+        },
+    },
+    'okcoin': {
+        'skipWs': 'temp',
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'watchTicker': {
+            'skippedProperties': {
+                'symbol': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721',
+            },
+        },
+    },
+    'exmo': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'info': 'null',
+                'withdraw': 'not provided',
+                'deposit': 'not provided',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4807',
+            },
+        },
+    },
+    'poloniex': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'some currencies does not exist in currencies',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'undefined',
+                'deposit': 'undefined',
+                'networks': 'networks key is missing',
+                'precision': 'not provided',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'side is not buy/sell',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume <= baseVolume * high | https://app.travis-ci.com/github/ccxt/ccxt/builds/263884643#L2462',
+                'baseVolume': 'same',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'same',
+                'baseVolume': 'same',
+            },
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6909',
+            },
+        },
+    },
+    'okx': {
+        'loadMarkets': {
+            'skip': 'linear & inverse must not be same',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'info': 'null',
+                'currencyIdAndCode': 'temp skip',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume <= baseVolume * high : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2132',
+                'baseVolume': 'same',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume <= baseVolume * high <<< okx fetchTicker',
+            },
+        },
+        'fetchBorrowRate': {
+            'skip': 'some fields that we can\'t skip missing',
+        },
+        'fetchBorrowRates': {
+            'skip': 'same',
+        },
+        'watchOrderBook': {
+            'skippedProperties': {
+                'nonce': 'missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721',
+            },
+        },
+    },
+    'tidex': {
+        'skip': 'exchange unavailable, probably api upgrade needed',
+    },
+    'kraken': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'https://app.travis-ci.com/github/ccxt/ccxt/builds/267515280#L2314',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'undefined',
+                'deposit': 'undefined',
+                'currencyIdAndCode': 'same as in loadMarkets',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume <= baseVolume * high is failing',
+                'baseVolume': 'quoteVolume <= baseVolume * high is failing',
+            },
+        },
+    },
+    'krakenfutures': {
+        'skip': 'continious timeouts https://app.travis-ci.com/github/ccxt/ccxt/builds/265225134#L2431',
+        'timeout': 120000,
+        'loadMarkets': {
+            'skip': 'skip loadMarkets',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'undefined',
+                'deposit': 'undefined',
+            },
+        },
+        'fetchTickers': {
+            'skip': 'timeouts this call specifically',
+        },
+        'fetchTicker': {
+            'skip': 'timeouts this call specifically',
+        },
+        'watchTrades': {
+            'skip': 'reverse timestamps',
+        },
+    },
+    'upbit': {
+        'skipWs': 'timeouts',
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'ripio': {
+        'httpsProxy': 'http://5.75.153.75:8002',
+    },
+    'timex': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'fee': 'is undefined',
+                'networks': 'key not present',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'fees': 'missingn from structure',
+            },
+        },
+        'fetchTickers': {
+            'skip': 'temporary issues',
+        },
+    },
+    'wavesexchange': {
+        'loadMarkets': {
+            'skip': 'missing key',
+        },
+        'fetchOHLCV': {
+            'skip': 'index 1 (open price) is undefined',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low is failing',
+                'baseVolume': 'quoteVolume >= baseVolume * low is failing',
+            },
+        },
+    },
+    'whitebit': {
+        'skipWs': 'timeouts',
+        'loadMarkets': {
+            'skip': 'contractSize must be undefined when contract is false',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'info': 'missing key',
+                'precision': 'not provided',
+                'fee': 'is undefined',
+                'networks': 'missing',
+                'limits': 'broken for some markets',
+            },
+        },
+    },
+    'woo': {
+        'skipWs': 'requires auth',
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'undefined',
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'withdraw': 'undefined',
+                'deposit': 'undefined',
+            },
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'leverage': 'undefined',
+                'percentage': 'undefined',
+                'hedged': 'undefined',
+                'stopLossPrice': 'undefined',
+                'takeProfitPrice': 'undefined',
+                'id': 'undefined',
+                'marginRatio': 'undefined',
+                'collateral': 'undefined',
+            },
+        },
+    },
+    'xt': {
+        'loadMarkets': {
+            'skip': 'expiry and expiryDatetime are defined for non future/options markets',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'precision': 'is undefined',
+                'withdraw': 'undefined',
+                'deposit': 'undefined',
+                'fee': 'undefined',
+            },
+        },
+        'fetchTickers': {
+            'skip': 'some outaded contracts, eg RICHARLISONGBALL2022/code:code-221219 return bid > ask',
+        },
+        'fetchTicker': {
+            'skip': 'same',
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'messed',
+            },
+        },
+    },
+    'yobit': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'currencyIdAndCode': 'messed',
+            },
+        },
+        'fetchTickers': {
+            'skip': 'all tickers request exceedes max url length',
+        },
+    },
+    'zaif': {
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'info': 'key is missing',
+            },
+        },
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+    },
+    'zonda': {
+        'loadMarkets': {
+            'skippedProperties': {
+                'active': 'is undefined',
+            },
+        },
+    },
+    'bingx': {
+        'skipWs': 'broken symbols returned',
+        'loadMarkets': {
+            'skippedProperties': {
+                'taker': 'is undefined',
+                'maker': 'is undefined',
+                'currencyIdAndCode': 'not all currencies are available',
+            },
+        },
+        'fetchTrades': {
+            'skippedProperties': {
+                'side': 'undefined',
+            },
+        },
+        'fetchTicker': {
+            'skip': 'spot not supported',
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'not supported',
+            },
+        },
+        'fetchOHLCV': {
+            'skip': 'spot not supported',
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'deposit': 'not provided',
+                'precision': 'not provided',
+            },
+        },
+        'fetchOrderBook': {
+            'skippedProperties': {
+                'ask': 'multiple ask prices are equal in ob https://app.travis-ci.com/github/ccxt/ccxt/builds/264706670#L2228',
+                'bid': 'multiple bid prices are equal https://app.travis-ci.com/github/ccxt/ccxt/builds/265172859#L2745',
+            },
+        },
+        'watchTrades': {
+            'skippedProperties': {
+                'side': 'undefined',
+            },
+        },
+        'fetchPositions': {
+            'skippedProperties': {
+                'marginRatio': 'undefined',
+                'stopLossPrice': 'undefined',
+                'takeProfitPrice': 'undefined',
+                'initialMarginPercentage': 'undefined',
+                'hedged': 'undefined',
+                'timestamp': 'undefined',
+                'datetime': 'undefined',
+                'lastUpdateTimestamp': 'undefined',
+                'maintenanceMargin': 'undefined',
+                'contractSize': 'undefined',
+                'markPrice': 'undefined',
+                'lastPrice': 'undefined',
+                'percentage': 'undefined',
+                'liquidationPrice': 'undefined',
+            },
+        },
+    },
+    'wazirx': {
+        'skipWs': 'timeouts',
+    },
+    'coinlist': {
+        'fetchTicker': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low  is failing',
+            },
+        },
+        'fetchTickers': {
+            'skippedProperties': {
+                'quoteVolume': 'quoteVolume >= baseVolume * low  is failing',
+                'ask': 'invalid',
+            },
+        },
+    },
+    'bitteam': {
+        'skip': 'tmp timeout',
+        'loadMarkets': {
+            'skippedProperties': {
+                'taker': 'is undefined',
+                'maker': 'is undefined',
+            },
+        },
+        'fetchCurrencies': {
+            'skippedProperties': {
+                'deposit': 'not provided',
+                'withdraw': 'not provided',
+            },
+        },
+    },
+})
+
+# ***** AUTO-TRANSPILER-END *****
+
+__all__ = [ config ]

--- a/python/ccxt/test/test_async.py
+++ b/python/ccxt/test/test_async.py
@@ -19,6 +19,7 @@ sys.path.append(root)
 
 import ccxt.async_support as ccxt  # noqa: E402
 import ccxt.pro as ccxtpro  # noqa: E402
+from config import config
 
 # ------------------------------------------------------------------------------
 import asyncio
@@ -298,21 +299,23 @@ class testMainClass(baseMainTestClass):
         await self.import_files(exchange)
         assert len(list(self.test_files.keys())) > 0, 'Test files were not loaded'  # ensure test files are found & filled
         self.expand_settings(exchange)
-        symbol = self.check_if_specific_test_is_chosen(symbol_argv)
+        symbol = self.check_if_specific_test_is_chosen(exchange, symbol_argv)
         await self.start_test(exchange, symbol)
         exit_script(0)  # needed to be explicitly finished for WS tests
 
-    def check_if_specific_test_is_chosen(self, symbol_argv):
+    def check_if_specific_test_is_chosen(self, exchange, symbol_argv):
         if symbol_argv is not None:
-            test_file_names = list(self.test_files.keys())
+            test_config = config()
+            tests = exchange.deep_extend(test_config['exchange'], test_config[exchange.id])
+            test_names = list(tests.keys())
             possible_method_names = symbol_argv.split(',')  # i.e. `test.ts binance fetchBalance,fetchDeposits`
             if len(possible_method_names) >= 1:
-                for i in range(0, len(test_file_names)):
-                    test_file_name = test_file_names[i]
+                for i in range(0, len(test_names)):
+                    test_name = test_names[i]
                     for j in range(0, len(possible_method_names)):
                         method_name = possible_method_names[j]
-                        if test_file_name == method_name:
-                            self.only_specific_tests.append(test_file_name)
+                        if method_name in test_name:
+                            self.only_specific_tests.append(test_name)
             # if method names were found, then remove them from symbolArgv
             if len(self.only_specific_tests) > 0:
                 return None
@@ -361,19 +364,18 @@ class testMainClass(baseMainTestClass):
                     set_exchange_prop(exchange, key, final_value)
         # credentials
         self.load_credentials_from_env(exchange)
-        # skipped tests
-        skipped_file = self.root_dir_for_skips + 'skip-tests.json'
-        skipped_settings = io_file_read(skipped_file)
-        skipped_settings_for_exchange = exchange.safe_value(skipped_settings, exchange_id, {})
+        # exchange tests settings
+        tests_config = config()
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange_id])
         # others
-        timeout = exchange.safe_value(skipped_settings_for_exchange, 'timeout')
+        timeout = exchange.safe_value(tests, 'timeout')
         if timeout is not None:
             exchange.timeout = timeout
-        exchange.http_proxy = exchange.safe_string(skipped_settings_for_exchange, 'httpProxy')
-        exchange.https_proxy = exchange.safe_string(skipped_settings_for_exchange, 'httpsProxy')
-        exchange.ws_proxy = exchange.safe_string(skipped_settings_for_exchange, 'wsProxy')
-        exchange.wss_proxy = exchange.safe_string(skipped_settings_for_exchange, 'wssProxy')
-        self.skipped_methods = exchange.safe_value(skipped_settings_for_exchange, 'skipMethods', {})
+        exchange.http_proxy = exchange.safe_string(tests, 'httpProxy')
+        exchange.https_proxy = exchange.safe_string(tests, 'httpsProxy')
+        exchange.ws_proxy = exchange.safe_string(tests, 'wsProxy')
+        exchange.wss_proxy = exchange.safe_string(tests, 'wssProxy')
+        self.skipped_methods = exchange.safe_value(tests, 'skipMethods', {})
         self.checked_public_tests = {}
 
     def add_padding(self, message, size):
@@ -404,9 +406,14 @@ class testMainClass(baseMainTestClass):
             result = result + ' [subType: ' + market_sub_type + '] '
         return result
 
-    async def test_method(self, method_name, exchange, args, is_public):
+    async def test_method(self, exchange, test_name, test):
+        method_name = test['testFile']
+        is_public = test['public']
+        args = test['args']
+        skip = exchange.safe_string(test, 'skip')
         # todo: temporary skip for php
-        if 'OrderBook' in method_name and self.ext == 'php':
+        i = method_name.find('OrderBook')
+        if i >= 0 and (self.ext == 'php'):
             return
         is_load_markets = (method_name == 'loadMarkets')
         is_fetch_currencies = (method_name == 'fetchCurrencies')
@@ -416,11 +423,11 @@ class testMainClass(baseMainTestClass):
             return
         skip_message = None
         supported_by_exchange = (method_name in exchange.has) and exchange.has[method_name]
-        if not is_load_markets and (len(self.only_specific_tests) > 0 and not exchange.in_array(method_name, self.only_specific_tests)):
+        if not is_load_markets and (len(self.only_specific_tests) > 0 and not exchange.in_array(test_name, self.only_specific_tests)):
             skip_message = '[INFO] IGNORED_TEST'
         elif not is_load_markets and not supported_by_exchange and not is_proxy_test:
             skip_message = '[INFO] UNSUPPORTED_TEST'  # keep it aligned with the longest message
-        elif (method_name in self.skipped_methods) and (isinstance(self.skipped_methods[method_name], str)):
+        elif isinstance(skip, str):
             skip_message = '[INFO] SKIPPED_TEST'
         elif not (method_name in self.test_files):
             skip_message = '[INFO] UNIMPLEMENTED_TEST'
@@ -433,27 +440,28 @@ class testMainClass(baseMainTestClass):
             return
         if self.info:
             args_stringified = '(' + ','.join(args) + ')'
-            dump(self.add_padding('[INFO] TESTING', 25), self.exchange_hint(exchange), method_name, args_stringified)
-        skipped_properties = exchange.safe_value(self.skipped_methods, method_name, {})
+            dump(self.add_padding('[INFO] TESTING', 25), self.exchange_hint(exchange), test_name, args_stringified)
+        skipped_properties = exchange.safe_value(test, 'skippedProperties', {})
         await call_method(self.test_files, method_name, exchange, skipped_properties, args)
         # if it was passed successfully, add to the list of successfull tests
         if is_public:
-            self.checked_public_tests[method_name] = True
+            self.checked_public_tests[test_name] = True
 
-    async def test_safe(self, method_name, exchange, args=[], is_public=False):
+    async def test_safe(self, exchange, test_name, test):
         # `testSafe` method does not throw an exception, instead mutes it. The reason we
         # mute the thrown exceptions here is because we don't want to stop the whole
         # tests queue if any single test-method fails. Instead, they are echoed with
         # formatted message "[TEST_FAILURE] ..." and that output is then regex-matched by
         # run-tests.js, so the exceptions are still printed out to console from there.
+        is_public = test['public']
         max_retries = 3
-        args_stringified = exchange.json(args)  # args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
+        args_stringified = exchange.json(test['args'])  # args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
         for i in range(0, max_retries):
             try:
-                await self.test_method(method_name, exchange, args, is_public)
+                await self.test_method(exchange, test_name, test)
                 return True
             except Exception as e:
-                is_load_markets = (method_name == 'loadMarkets')
+                is_load_markets = (test['testFile'] == 'loadMarkets')
                 is_auth_error = (isinstance(e, AuthenticationError))
                 is_not_supported = (isinstance(e, NotSupported))
                 is_operation_failed = (isinstance(e, OperationFailed))  # includes "DDoSProtection", "RateLimitExceeded", "RequestTimeout", "ExchangeNotAvailable", "OperationFailed", "InvalidNonce", ...
@@ -470,10 +478,10 @@ class testMainClass(baseMainTestClass):
                             should_fail = False
                         # final step
                         if should_fail:
-                            dump('[TEST_FAILURE]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), method_name, args_stringified, exception_message(e))
+                            dump('[TEST_FAILURE]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), test_name, args_stringified, exception_message(e))
                             return False
                         else:
-                            dump('[TEST_WARNING]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), method_name, args_stringified, exception_message(e))
+                            dump('[TEST_WARNING]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), test_name, args_stringified, exception_message(e))
                             return True
                     else:
                         # wait and retry again
@@ -483,57 +491,40 @@ class testMainClass(baseMainTestClass):
                 else:
                     # if it's loadMarkets, then fail test, because it's mandatory for tests
                     if is_load_markets:
-                        dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                        dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return False
                     # if the specific arguments to the test method throws "NotSupported" exception
                     # then let's don't fail the test
                     if is_not_supported:
                         if self.info:
-                            dump('[INFO] NOT_SUPPORTED', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                            dump('[INFO] NOT_SUPPORTED', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return True
                     # If public test faces authentication error, we don't break (see comments under `testSafe` method)
                     if is_public and is_auth_error:
                         if self.info:
-                            dump('[INFO]', 'Authentication problem for public method', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                            dump('[INFO]', 'Authentication problem for public method', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return True
                     else:
-                        dump('[TEST_FAILURE]', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                        dump('[TEST_FAILURE]', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return False
 
+    def filter_test(self, tests, key, value):
+        result = {}
+        test_names = list(tests.keys())
+        for i in range(0, len(test_names)):
+            name = test_names[i]
+            if tests[name][key] == value:
+                result[name] = tests[name]
+        return result
+
     async def run_public_tests(self, exchange, symbol):
-        tests = {
-            'fetchCurrencies': [],
-            'fetchTicker': [symbol],
-            'fetchTickers': [symbol],
-            'fetchOHLCV': [symbol],
-            'fetchTrades': [symbol],
-            'fetchOrderBook': [symbol],
-            'fetchL2OrderBook': [symbol],
-            'fetchOrderBooks': [],
-            'fetchBidsAsks': [],
-            'fetchStatus': [],
-            'fetchTime': [],
-        }
-        if self.ws_tests:
-            tests = {
-                'watchOHLCV': [symbol],
-                'watchTicker': [symbol],
-                'watchOrderBook': [symbol],
-                'watchTrades': [symbol],
-            }
         market = exchange.market(symbol)
         is_spot = market['spot']
-        if not self.ws_tests:
-            if is_spot:
-                tests['fetchCurrencies'] = []
-            else:
-                tests['fetchFundingRates'] = [symbol]
-                tests['fetchFundingRate'] = [symbol]
-                tests['fetchFundingRateHistory'] = [symbol]
-                tests['fetchIndexOHLCV'] = [symbol]
-                tests['fetchMarkOHLCV'] = [symbol]
-                tests['fetchPremiumIndexOHLCV'] = [symbol]
-        self.public_tests = tests
+        code = self.get_exchange_code(exchange)
+        tests_config = config(symbol, code, is_spot)
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange.id])
+        tests = self.filter_test(tests, 'public', True)
+        tests = self.filter_test(tests, 'isWs', self.ws_tests)
         await self.run_tests(exchange, tests, True)
 
     async def run_tests(self, exchange, tests, is_public_test):
@@ -541,27 +532,30 @@ class testMainClass(baseMainTestClass):
         promises = []
         for i in range(0, len(test_names)):
             test_name = test_names[i]
-            test_args = tests[test_name]
-            promises.append(self.test_safe(test_name, exchange, test_args, is_public_test))
+            test = tests[test_name]
+            promises.append(self.test_safe(exchange, test_name, test))
         # todo - not yet ready in other langs too
         # promises.push (testThrottle ());
         results = await asyncio.gather(*promises)
         # now count which test-methods retuned `false` from "testSafe" and dump that info below
-        failed_methods = []
+        failed_tests = []
         for i in range(0, len(test_names)):
             test_name = test_names[i]
             test_returned_value = results[i]
             if not test_returned_value:
-                failed_methods.append(test_name)
+                failed_tests.append(test_name)
         test_prefix_string = 'PUBLIC_TESTS' if is_public_test else 'PRIVATE_TESTS'
-        if len(failed_methods):
-            errors_string = ', '.join(failed_methods)
-            dump('[TEST_FAILURE]', self.exchange_hint(exchange), test_prefix_string, 'Failed methods : ' + errors_string)
+        if len(failed_tests):
+            errors_string = ', '.join(failed_tests)
+            dump('[TEST_FAILURE]', self.exchange_hint(exchange), test_prefix_string, 'Failed tests : ' + errors_string)
         if self.info:
             dump(self.add_padding('[INFO] END ' + test_prefix_string + ' ' + self.exchange_hint(exchange), 25))
 
     async def load_exchange(self, exchange):
-        result = await self.test_safe('loadMarkets', exchange, [], True)
+        tests_config = config('', '', True)
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange.id])
+        load_markets_test = tests['loadMarkets']
+        result = await self.test_safe(exchange, 'loadMarkets', load_markets_test)
         if not result:
             return False
         symbols = ['BTC/CNY', 'BTC/USD', 'BTC/USDT', 'BTC/EUR', 'BTC/ETH', 'ETH/BTC', 'BTC/JPY', 'ETH/EUR', 'ETH/JPY', 'ETH/CNY', 'ETH/USD', 'LTC/CNY', 'DASH/BTC', 'DOGE/BTC', 'BTC/AUD', 'BTC/PLN', 'USD/SLL', 'BTC/RUB', 'BTC/UAH', 'LTC/BTC', 'EUR/USD']
@@ -699,63 +693,23 @@ class testMainClass(baseMainTestClass):
         #     await test ('InvalidOrder', exchange, symbol);
         #     await test ('InsufficientFunds', exchange, symbol, balance); # danger zone - won't execute with non-empty balance
         # }
-        tests = {
-            'signIn': [],
-            'fetchBalance': [],
-            'fetchAccounts': [],
-            'fetchTransactionFees': [],
-            'fetchTradingFees': [],
-            'fetchStatus': [],
-            'fetchOrders': [symbol],
-            'fetchOpenOrders': [symbol],
-            'fetchClosedOrders': [symbol],
-            'fetchMyTrades': [symbol],
-            'fetchLeverageTiers': [[symbol]],
-            'fetchLedger': [code],
-            'fetchTransactions': [code],
-            'fetchDeposits': [code],
-            'fetchWithdrawals': [code],
-            'fetchBorrowInterest': [code, symbol],
-            'cancelAllOrders': [symbol],
-            'fetchCanceledOrders': [symbol],
-            'fetchPosition': [symbol],
-            'fetchDeposit': [code],
-            'createDepositAddress': [code],
-            'fetchDepositAddress': [code],
-            'fetchDepositAddresses': [code],
-            'fetchDepositAddressesByNetwork': [code],
-            'fetchBorrowRateHistory': [code],
-            'fetchLedgerEntry': [code],
-        }
-        if self.ws_tests:
-            tests = {
-                'watchBalance': [code],
-                'watchMyTrades': [symbol],
-                'watchOrders': [symbol],
-                'watchPosition': [symbol],
-                'watchPositions': [symbol],
-            }
         market = exchange.market(symbol)
         is_spot = market['spot']
-        if not self.ws_tests:
-            if is_spot:
-                tests['fetchCurrencies'] = []
-            else:
-                # derivatives only
-                tests['fetchPositions'] = [symbol]  # this test fetches all positions for 1 symbol
-                tests['fetchPosition'] = [symbol]
-                tests['fetchPositionRisk'] = [symbol]
-                tests['setPositionMode'] = [symbol]
-                tests['setMarginMode'] = [symbol]
-                tests['fetchOpenInterestHistory'] = [symbol]
-                tests['fetchFundingRateHistory'] = [symbol]
-                tests['fetchFundingHistory'] = [symbol]
-        # const combinedTests = exchange.deepExtend (this.publicTests, privateTests);
+        tests_config = config(symbol, code, is_spot)
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange.id])
+        tests = self.filter_test(tests, 'public', False)
+        tests = self.filter_test(tests, 'isWs', self.ws_tests)
         await self.run_tests(exchange, tests, False)
 
-    async def test_proxies(self, exchange):
+    async def method(self, exchange):
         # these tests should be synchronously executed, because of conflicting nature of proxy settings
         proxy_test_name = self.proxy_test_file_name
+        proxy_test = {
+            'public': True,
+            'testFile': proxy_test_name,
+            'args': [],
+            'isWs': False,
+        }
         # todo: temporary skip for sync py
         if self.ext == 'py' and self.is_synchronous:
             return
@@ -764,7 +718,7 @@ class testMainClass(baseMainTestClass):
         exception = None
         for j in range(0, max_retries):
             try:
-                await self.test_method(proxy_test_name, exchange, [], True)
+                await self.test_method(exchange, proxy_test_name, proxy_test)
                 break  # if successfull, then break
             except Exception as e:
                 exception = e
@@ -785,7 +739,7 @@ class testMainClass(baseMainTestClass):
                 return
             # if (exchange.id === 'binance') {
             #     # we test proxies functionality just for one random exchange on each build, because proxy functionality is not exchange-specific, instead it's all done from base methods, so just one working sample would mean it works for all ccxt exchanges
-            #     # await this.testProxies (exchange);
+            #     # await this.method (exchange);
             # }
             await self.test_exchange(exchange, symbol)
             await close(exchange)

--- a/python/ccxt/test/test_sync.py
+++ b/python/ccxt/test/test_sync.py
@@ -19,6 +19,7 @@ sys.path.append(root)
 
 import ccxt  # noqa: E402
 import ccxt.pro as ccxtpro  # noqa: E402
+from config import config
 
 # ------------------------------------------------------------------------------
 # from typing import Optional
@@ -297,21 +298,23 @@ class testMainClass(baseMainTestClass):
         self.import_files(exchange)
         assert len(list(self.test_files.keys())) > 0, 'Test files were not loaded'  # ensure test files are found & filled
         self.expand_settings(exchange)
-        symbol = self.check_if_specific_test_is_chosen(symbol_argv)
+        symbol = self.check_if_specific_test_is_chosen(exchange, symbol_argv)
         self.start_test(exchange, symbol)
         exit_script(0)  # needed to be explicitly finished for WS tests
 
-    def check_if_specific_test_is_chosen(self, symbol_argv):
+    def check_if_specific_test_is_chosen(self, exchange, symbol_argv):
         if symbol_argv is not None:
-            test_file_names = list(self.test_files.keys())
+            test_config = config()
+            tests = exchange.deep_extend(test_config['exchange'], test_config[exchange.id])
+            test_names = list(tests.keys())
             possible_method_names = symbol_argv.split(',')  # i.e. `test.ts binance fetchBalance,fetchDeposits`
             if len(possible_method_names) >= 1:
-                for i in range(0, len(test_file_names)):
-                    test_file_name = test_file_names[i]
+                for i in range(0, len(test_names)):
+                    test_name = test_names[i]
                     for j in range(0, len(possible_method_names)):
                         method_name = possible_method_names[j]
-                        if test_file_name == method_name:
-                            self.only_specific_tests.append(test_file_name)
+                        if method_name in test_name:
+                            self.only_specific_tests.append(test_name)
             # if method names were found, then remove them from symbolArgv
             if len(self.only_specific_tests) > 0:
                 return None
@@ -360,19 +363,18 @@ class testMainClass(baseMainTestClass):
                     set_exchange_prop(exchange, key, final_value)
         # credentials
         self.load_credentials_from_env(exchange)
-        # skipped tests
-        skipped_file = self.root_dir_for_skips + 'skip-tests.json'
-        skipped_settings = io_file_read(skipped_file)
-        skipped_settings_for_exchange = exchange.safe_value(skipped_settings, exchange_id, {})
+        # exchange tests settings
+        tests_config = config()
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange_id])
         # others
-        timeout = exchange.safe_value(skipped_settings_for_exchange, 'timeout')
+        timeout = exchange.safe_value(tests, 'timeout')
         if timeout is not None:
             exchange.timeout = timeout
-        exchange.http_proxy = exchange.safe_string(skipped_settings_for_exchange, 'httpProxy')
-        exchange.https_proxy = exchange.safe_string(skipped_settings_for_exchange, 'httpsProxy')
-        exchange.ws_proxy = exchange.safe_string(skipped_settings_for_exchange, 'wsProxy')
-        exchange.wss_proxy = exchange.safe_string(skipped_settings_for_exchange, 'wssProxy')
-        self.skipped_methods = exchange.safe_value(skipped_settings_for_exchange, 'skipMethods', {})
+        exchange.http_proxy = exchange.safe_string(tests, 'httpProxy')
+        exchange.https_proxy = exchange.safe_string(tests, 'httpsProxy')
+        exchange.ws_proxy = exchange.safe_string(tests, 'wsProxy')
+        exchange.wss_proxy = exchange.safe_string(tests, 'wssProxy')
+        self.skipped_methods = exchange.safe_value(tests, 'skipMethods', {})
         self.checked_public_tests = {}
 
     def add_padding(self, message, size):
@@ -403,9 +405,14 @@ class testMainClass(baseMainTestClass):
             result = result + ' [subType: ' + market_sub_type + '] '
         return result
 
-    def test_method(self, method_name, exchange, args, is_public):
+    def test_method(self, exchange, test_name, test):
+        method_name = test['testFile']
+        is_public = test['public']
+        args = test['args']
+        skip = exchange.safe_string(test, 'skip')
         # todo: temporary skip for php
-        if 'OrderBook' in method_name and self.ext == 'php':
+        i = method_name.find('OrderBook')
+        if i >= 0 and (self.ext == 'php'):
             return
         is_load_markets = (method_name == 'loadMarkets')
         is_fetch_currencies = (method_name == 'fetchCurrencies')
@@ -415,11 +422,11 @@ class testMainClass(baseMainTestClass):
             return
         skip_message = None
         supported_by_exchange = (method_name in exchange.has) and exchange.has[method_name]
-        if not is_load_markets and (len(self.only_specific_tests) > 0 and not exchange.in_array(method_name, self.only_specific_tests)):
+        if not is_load_markets and (len(self.only_specific_tests) > 0 and not exchange.in_array(test_name, self.only_specific_tests)):
             skip_message = '[INFO] IGNORED_TEST'
         elif not is_load_markets and not supported_by_exchange and not is_proxy_test:
             skip_message = '[INFO] UNSUPPORTED_TEST'  # keep it aligned with the longest message
-        elif (method_name in self.skipped_methods) and (isinstance(self.skipped_methods[method_name], str)):
+        elif isinstance(skip, str):
             skip_message = '[INFO] SKIPPED_TEST'
         elif not (method_name in self.test_files):
             skip_message = '[INFO] UNIMPLEMENTED_TEST'
@@ -432,27 +439,28 @@ class testMainClass(baseMainTestClass):
             return
         if self.info:
             args_stringified = '(' + ','.join(args) + ')'
-            dump(self.add_padding('[INFO] TESTING', 25), self.exchange_hint(exchange), method_name, args_stringified)
-        skipped_properties = exchange.safe_value(self.skipped_methods, method_name, {})
+            dump(self.add_padding('[INFO] TESTING', 25), self.exchange_hint(exchange), test_name, args_stringified)
+        skipped_properties = exchange.safe_value(test, 'skippedProperties', {})
         call_method(self.test_files, method_name, exchange, skipped_properties, args)
         # if it was passed successfully, add to the list of successfull tests
         if is_public:
-            self.checked_public_tests[method_name] = True
+            self.checked_public_tests[test_name] = True
 
-    def test_safe(self, method_name, exchange, args=[], is_public=False):
+    def test_safe(self, exchange, test_name, test):
         # `testSafe` method does not throw an exception, instead mutes it. The reason we
         # mute the thrown exceptions here is because we don't want to stop the whole
         # tests queue if any single test-method fails. Instead, they are echoed with
         # formatted message "[TEST_FAILURE] ..." and that output is then regex-matched by
         # run-tests.js, so the exceptions are still printed out to console from there.
+        is_public = test['public']
         max_retries = 3
-        args_stringified = exchange.json(args)  # args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
+        args_stringified = exchange.json(test['args'])  # args.join() breaks when we provide a list of symbols | "args.toString()" breaks bcz of "array to string conversion"
         for i in range(0, max_retries):
             try:
-                self.test_method(method_name, exchange, args, is_public)
+                self.test_method(exchange, test_name, test)
                 return True
             except Exception as e:
-                is_load_markets = (method_name == 'loadMarkets')
+                is_load_markets = (test['testFile'] == 'loadMarkets')
                 is_auth_error = (isinstance(e, AuthenticationError))
                 is_not_supported = (isinstance(e, NotSupported))
                 is_operation_failed = (isinstance(e, OperationFailed))  # includes "DDoSProtection", "RateLimitExceeded", "RequestTimeout", "ExchangeNotAvailable", "OperationFailed", "InvalidNonce", ...
@@ -469,10 +477,10 @@ class testMainClass(baseMainTestClass):
                             should_fail = False
                         # final step
                         if should_fail:
-                            dump('[TEST_FAILURE]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), method_name, args_stringified, exception_message(e))
+                            dump('[TEST_FAILURE]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), test_name, args_stringified, exception_message(e))
                             return False
                         else:
-                            dump('[TEST_WARNING]', 'Method could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), method_name, args_stringified, exception_message(e))
+                            dump('[TEST_WARNING]', 'Test could not be tested due to a repeated Network/Availability issues', ' | ', self.exchange_hint(exchange), test_name, args_stringified, exception_message(e))
                             return True
                     else:
                         # wait and retry again
@@ -482,57 +490,40 @@ class testMainClass(baseMainTestClass):
                 else:
                     # if it's loadMarkets, then fail test, because it's mandatory for tests
                     if is_load_markets:
-                        dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                        dump('[TEST_FAILURE]', 'Exchange can not load markets', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return False
                     # if the specific arguments to the test method throws "NotSupported" exception
                     # then let's don't fail the test
                     if is_not_supported:
                         if self.info:
-                            dump('[INFO] NOT_SUPPORTED', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                            dump('[INFO] NOT_SUPPORTED', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return True
                     # If public test faces authentication error, we don't break (see comments under `testSafe` method)
                     if is_public and is_auth_error:
                         if self.info:
-                            dump('[INFO]', 'Authentication problem for public method', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                            dump('[INFO]', 'Authentication problem for public method', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return True
                     else:
-                        dump('[TEST_FAILURE]', exception_message(e), self.exchange_hint(exchange), method_name, args_stringified)
+                        dump('[TEST_FAILURE]', exception_message(e), self.exchange_hint(exchange), test_name, args_stringified)
                         return False
 
+    def filter_test(self, tests, key, value):
+        result = {}
+        test_names = list(tests.keys())
+        for i in range(0, len(test_names)):
+            name = test_names[i]
+            if tests[name][key] == value:
+                result[name] = tests[name]
+        return result
+
     def run_public_tests(self, exchange, symbol):
-        tests = {
-            'fetchCurrencies': [],
-            'fetchTicker': [symbol],
-            'fetchTickers': [symbol],
-            'fetchOHLCV': [symbol],
-            'fetchTrades': [symbol],
-            'fetchOrderBook': [symbol],
-            'fetchL2OrderBook': [symbol],
-            'fetchOrderBooks': [],
-            'fetchBidsAsks': [],
-            'fetchStatus': [],
-            'fetchTime': [],
-        }
-        if self.ws_tests:
-            tests = {
-                'watchOHLCV': [symbol],
-                'watchTicker': [symbol],
-                'watchOrderBook': [symbol],
-                'watchTrades': [symbol],
-            }
         market = exchange.market(symbol)
         is_spot = market['spot']
-        if not self.ws_tests:
-            if is_spot:
-                tests['fetchCurrencies'] = []
-            else:
-                tests['fetchFundingRates'] = [symbol]
-                tests['fetchFundingRate'] = [symbol]
-                tests['fetchFundingRateHistory'] = [symbol]
-                tests['fetchIndexOHLCV'] = [symbol]
-                tests['fetchMarkOHLCV'] = [symbol]
-                tests['fetchPremiumIndexOHLCV'] = [symbol]
-        self.public_tests = tests
+        code = self.get_exchange_code(exchange)
+        tests_config = config(symbol, code, is_spot)
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange.id])
+        tests = self.filter_test(tests, 'public', True)
+        tests = self.filter_test(tests, 'isWs', self.ws_tests)
         self.run_tests(exchange, tests, True)
 
     def run_tests(self, exchange, tests, is_public_test):
@@ -540,27 +531,30 @@ class testMainClass(baseMainTestClass):
         promises = []
         for i in range(0, len(test_names)):
             test_name = test_names[i]
-            test_args = tests[test_name]
-            promises.append(self.test_safe(test_name, exchange, test_args, is_public_test))
+            test = tests[test_name]
+            promises.append(self.test_safe(exchange, test_name, test))
         # todo - not yet ready in other langs too
         # promises.push (testThrottle ());
         results = (promises)
         # now count which test-methods retuned `false` from "testSafe" and dump that info below
-        failed_methods = []
+        failed_tests = []
         for i in range(0, len(test_names)):
             test_name = test_names[i]
             test_returned_value = results[i]
             if not test_returned_value:
-                failed_methods.append(test_name)
+                failed_tests.append(test_name)
         test_prefix_string = 'PUBLIC_TESTS' if is_public_test else 'PRIVATE_TESTS'
-        if len(failed_methods):
-            errors_string = ', '.join(failed_methods)
-            dump('[TEST_FAILURE]', self.exchange_hint(exchange), test_prefix_string, 'Failed methods : ' + errors_string)
+        if len(failed_tests):
+            errors_string = ', '.join(failed_tests)
+            dump('[TEST_FAILURE]', self.exchange_hint(exchange), test_prefix_string, 'Failed tests : ' + errors_string)
         if self.info:
             dump(self.add_padding('[INFO] END ' + test_prefix_string + ' ' + self.exchange_hint(exchange), 25))
 
     def load_exchange(self, exchange):
-        result = self.test_safe('loadMarkets', exchange, [], True)
+        tests_config = config('', '', True)
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange.id])
+        load_markets_test = tests['loadMarkets']
+        result = self.test_safe(exchange, 'loadMarkets', load_markets_test)
         if not result:
             return False
         symbols = ['BTC/CNY', 'BTC/USD', 'BTC/USDT', 'BTC/EUR', 'BTC/ETH', 'ETH/BTC', 'BTC/JPY', 'ETH/EUR', 'ETH/JPY', 'ETH/CNY', 'ETH/USD', 'LTC/CNY', 'DASH/BTC', 'DOGE/BTC', 'BTC/AUD', 'BTC/PLN', 'USD/SLL', 'BTC/RUB', 'BTC/UAH', 'LTC/BTC', 'EUR/USD']
@@ -698,63 +692,23 @@ class testMainClass(baseMainTestClass):
         #     test ('InvalidOrder', exchange, symbol);
         #     test ('InsufficientFunds', exchange, symbol, balance); # danger zone - won't execute with non-empty balance
         # }
-        tests = {
-            'signIn': [],
-            'fetchBalance': [],
-            'fetchAccounts': [],
-            'fetchTransactionFees': [],
-            'fetchTradingFees': [],
-            'fetchStatus': [],
-            'fetchOrders': [symbol],
-            'fetchOpenOrders': [symbol],
-            'fetchClosedOrders': [symbol],
-            'fetchMyTrades': [symbol],
-            'fetchLeverageTiers': [[symbol]],
-            'fetchLedger': [code],
-            'fetchTransactions': [code],
-            'fetchDeposits': [code],
-            'fetchWithdrawals': [code],
-            'fetchBorrowInterest': [code, symbol],
-            'cancelAllOrders': [symbol],
-            'fetchCanceledOrders': [symbol],
-            'fetchPosition': [symbol],
-            'fetchDeposit': [code],
-            'createDepositAddress': [code],
-            'fetchDepositAddress': [code],
-            'fetchDepositAddresses': [code],
-            'fetchDepositAddressesByNetwork': [code],
-            'fetchBorrowRateHistory': [code],
-            'fetchLedgerEntry': [code],
-        }
-        if self.ws_tests:
-            tests = {
-                'watchBalance': [code],
-                'watchMyTrades': [symbol],
-                'watchOrders': [symbol],
-                'watchPosition': [symbol],
-                'watchPositions': [symbol],
-            }
         market = exchange.market(symbol)
         is_spot = market['spot']
-        if not self.ws_tests:
-            if is_spot:
-                tests['fetchCurrencies'] = []
-            else:
-                # derivatives only
-                tests['fetchPositions'] = [symbol]  # this test fetches all positions for 1 symbol
-                tests['fetchPosition'] = [symbol]
-                tests['fetchPositionRisk'] = [symbol]
-                tests['setPositionMode'] = [symbol]
-                tests['setMarginMode'] = [symbol]
-                tests['fetchOpenInterestHistory'] = [symbol]
-                tests['fetchFundingRateHistory'] = [symbol]
-                tests['fetchFundingHistory'] = [symbol]
-        # const combinedTests = exchange.deepExtend (this.publicTests, privateTests);
+        tests_config = config(symbol, code, is_spot)
+        tests = exchange.deep_extend(tests_config['exchange'], tests_config[exchange.id])
+        tests = self.filter_test(tests, 'public', False)
+        tests = self.filter_test(tests, 'isWs', self.ws_tests)
         self.run_tests(exchange, tests, False)
 
-    def test_proxies(self, exchange):
+    def method(self, exchange):
         # these tests should be synchronously executed, because of conflicting nature of proxy settings
         proxy_test_name = self.proxy_test_file_name
+        proxy_test = {
+            'public': True,
+            'testFile': proxy_test_name,
+            'args': [],
+            'isWs': False,
+        }
         # todo: temporary skip for sync py
         if self.ext == 'py' and self.is_synchronous:
             return
@@ -763,7 +717,7 @@ class testMainClass(baseMainTestClass):
         exception = None
         for j in range(0, max_retries):
             try:
-                self.test_method(proxy_test_name, exchange, [], True)
+                self.test_method(exchange, proxy_test_name, proxy_test)
                 break  # if successfull, then break
             except Exception as e:
                 exception = e
@@ -784,7 +738,7 @@ class testMainClass(baseMainTestClass):
                 return
             # if (exchange.id === 'binance') {
             #     # we test proxies functionality just for one random exchange on each build, because proxy functionality is not exchange-specific, instead it's all done from base methods, so just one working sample would mean it works for all ccxt exchanges
-            #     # this.testProxies (exchange);
+            #     # this.method (exchange);
             # }
             self.test_exchange(exchange, symbol)
             close(exchange)

--- a/run-tests.js
+++ b/run-tests.js
@@ -206,18 +206,12 @@ const sequentialMap = async (input, fn) => {
 
 /*  ------------------------------------------------------------------------ */
 
-const testExchange = async (exchange) => {
+const testExchange = async (exchangeId) => {
 
-    const exchangeConfig = exchange.deepExtend (testConfigp['exchange'], testConfig[exchange.id])
+    const testsConfig = config ();
+    const exchangeConfig = testsConfig[exchangeId];
 
     const percentsDone = () => ((numExchangesTested / exchanges.length) * 100).toFixed (0) + '%';
-
-    // no need to test alias classes
-    if (exchange.alias) {
-        numExchangesTested++;
-        log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, wsFlag, '[Skipped alias]'.yellow)
-        return [];
-    }
 
     if (
         exchangeConfig && 
@@ -230,19 +224,19 @@ const testExchange = async (exchange) => {
         if (!('until' in exchangeConfig)) {
             // if until not specified, skip forever
             numExchangesTested++;
-            log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, wsFlag, '[Skipped]'.yellow)
+            log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchangeId, wsFlag, '[Skipped]'.yellow)
             return [];
         }
         if (new Date(exchangeConfig.until) > new Date()) {
             numExchangesTested++;
             // if untilDate has not been yet reached, skip test for exchange
-            log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, wsFlag, '[Skipped till ' + exchangeConfig.until + ']'.yellow)
+            log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchangeId, wsFlag, '[Skipped till ' + exchangeConfig.until + ']'.yellow)
             return [];
         }
     }
 
 /*  Run tests for all/selected languages (in parallel)     */
-    let args = [exchange];
+    let args = [exchangeId];
     if (symbol !== undefined && symbol !== 'all') {
         args.push(symbol);
     }
@@ -307,7 +301,7 @@ const testExchange = async (exchange) => {
     }
 
     numExchangesTested++;
-    log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, wsFlag, logMessage)
+    log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchangeId, wsFlag, logMessage)
 
     // independenly of the success result, show infos
     // ( these infos will be shown as soon as each exchange test is finished, and will not wait 100% of all tests to be finished )
@@ -326,7 +320,7 @@ const testExchange = async (exchange) => {
 
     return {
 
-        exchange,
+        exchange: exchangeId,
         failed,
         hasWarnings,
         explain () {
@@ -336,12 +330,12 @@ const testExchange = async (exchange) => {
                     continue;
                 // if failed, then show full output (includes warnings)
                 if (failed) {
-                    log.bright ('\nFAILED'.bgBrightRed.white, exchange.red,    '(' + language + ' ' + wsFlag + '):\n')
+                    log.bright ('\nFAILED'.bgBrightRed.white, exchangeId.red,    '(' + language + ' ' + wsFlag + '):\n')
                     log.indent (1) ('\n', output)
                 }
                 // if not failed, but there are warnings, then show them
                 else if (warnings.length) {
-                    log.bright ('\nWARN'.yellow.inverse,     exchange.yellow, '(' + language + ' ' + wsFlag + '):\n')
+                    log.bright ('\nWARN'.yellow.inverse,     exchangeId.yellow, '(' + language + ' ' + wsFlag + '):\n')
                     log.indent (1) ('\n', warnings.join ('\n'))
                 }
             }

--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -155,7 +155,7 @@ function assertCurrencyCode (exchange, skippedProperties, method, entry, actualC
 }
 
 function assertValidCurrencyIdAndCode (exchange, skippedProperties, method, entry, currencyId, currencyCode) {
-    // this is exclusive exceptional key name to be used in `skip-tests.json`, to skip check for currency id and code
+    // this is exclusive exceptional key name to be used in `skippedProperties`, to skip check for currency id and code
     if ('currencyIdAndCode' in skippedProperties) {
         return;
     }

--- a/ts/src/test/config.ts
+++ b/ts/src/test/config.ts
@@ -1,0 +1,2703 @@
+
+type Test = {
+    testFile?: string;
+    isWs?: boolean;
+    public?: boolean;
+    args?: any[];
+    skippedProperties?: {}
+    skip?: string;
+}
+
+type Tests = Test & {
+    skip?: string;
+    skipWs?: string;
+    skipPhpAsync?: string;
+    until?: string;
+    httpProxy?: string;
+    httpsProxy?: string;
+    wsProxy?: string;
+    wssProxy?: string;
+    timeout?: number;
+}
+
+type TestConfig = {
+    [key: string]: Tests;
+}
+
+// *********************************
+// ***** AUTO-TRANSPILER-START *****
+function config (symbol: string = 'BTC/USDT', code: string = 'USDT', isSpot: boolean = true) {
+    return ({
+        'exchange': {
+            // public tests
+            'loadMarkets': {
+                'testFile': 'loadMarkets',
+                'args': [],
+                'isWs': false,
+                'public': true,
+            },
+            'fetchTicker': {
+                'testFile': 'fetchTicker',
+                'isWs': false,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'fetchTickers': {
+                'testFile': 'fetchTickers',
+                'isWs': false,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'fetchOHLCV': {
+                'testFile': 'fetchOHLCV',
+                'isWs': false,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'fetchTrades': {
+                'testFile': 'fetchTrades',
+                'isWs': false,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'fetchOrderBook': {
+                'testFile': 'fetchOrderBook',
+                'isWs': false,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'fetchL2OrderBook': {
+                'testFile': 'fetchL2OrderBook',
+                'isWs': false,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'fetchOrderBooks': {
+                'testFile': 'fetchOrderBooks',
+                'isWs': false,
+                'public': true,
+                'args': []
+            },
+            'fetchBidsAsks': {
+                'testFile': 'fetchBidsAsks',
+                'isWs': false,
+                'public': true,
+                'args': []
+            },
+            'fetchTime': {
+                'testFile': 'fetchTime',
+                'isWs': false,
+                'public': true,
+                'args': []
+            },
+            'fetchCurrencies - public': {
+                'testFile': 'fetchCurrencies',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? undefined : 'only run for swap markets',
+            },
+            'fetchFundingRates': {
+                'testFile': 'fetchFundingRates',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchFundingRate': {
+                'testFile': 'fetchFundingRate',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchFundingRateHistory - public': {
+                'testFile': 'fetchFundingRateHistory',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchIndexOHLCV': {
+                'testFile': 'fetchIndexOHLCV',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchMarkOHLCV': {
+                'testFile': 'fetchMarkOHLCV',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchPremiumIndexOHLCV': {
+                'testFile': 'fetchPremiumIndexOHLCV',
+                'isWs': false,
+                'public': true,
+                'args': [],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            // private tests
+            'signIn': {
+                'testFile': 'signIn',
+                'isWs': false,
+                'public': false,
+                'args': []
+            },
+            'fetchBalance': {
+                'testFile': 'fetchBalance',
+                'isWs': false,
+                'public': false,
+                'args': []
+            },
+            'fetchAccounts': {
+                'testFile': 'fetchAccounts',
+                'isWs': false,
+                'public': false,
+                'args': []
+            },
+            'fetchTransactionFees': {
+                'testFile': 'fetchTransactionFees',
+                'isWs': false,
+                'public': false,
+                'args': []
+            },
+            'fetchTradingFees': {
+                'testFile': 'fetchTradingFees',
+                'isWs': false,
+                'public': false,
+                'args': []
+            },
+            'fetchStatus': {
+                'testFile': 'fetchStatus',
+                'isWs': false,
+                'public': false,
+                'args': []
+            },
+            'fetchOrders': {
+                'testFile': 'fetchOrders',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'fetchOpenOrders': {
+                'testFile': 'fetchOpenOrders',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'fetchClosedOrders': {
+                'testFile': 'fetchClosedOrders',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'fetchMyTrades': {
+                'testFile': 'fetchMyTrades',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'fetchLeverageTiers': {
+                'testFile': 'fetchLeverageTiers',
+                'isWs': false,
+                'public': false,
+                'args': [ [ symbol ] ]
+            },
+            'fetchLedger': {
+                'testFile': 'fetchLedger',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchTransactions': {
+                'testFile': 'fetchTransactions',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchDeposits': {
+                'testFile': 'fetchDeposits',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchWithdrawals': {
+                'testFile': 'fetchWithdrawals',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchBorrowInterest': {
+                'testFile': 'fetchBorrowInterest',
+                'isWs': false,
+                'public': false,
+                'args': [ code, symbol ]
+            },
+            'addMargin': {
+                'testFile': 'addMargin',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'reduceMargin': {
+                'testFile': 'reduceMargin',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'setMargin': {
+                'testFile': 'setMargin',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'setMarginMode': {
+                'testFile': 'setMarginMode',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'setLeverage': {
+                'testFile': 'setLeverage',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'cancelAllOrders': {
+                'testFile': 'cancelAllOrders',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'cancelOrder': {
+                'testFile': 'cancelOrder',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'cancelOrders': {
+                'testFile': 'cancelOrders',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchCanceledOrders': {
+                'testFile': 'fetchCanceledOrders',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'fetchClosedOrder': {
+                'testFile': 'fetchClosedOrder',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchOpenOrder': {
+                'testFile': 'fetchOpenOrder',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchOrder': {
+                'testFile': 'fetchOrder',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchOrderTrades': {
+                'testFile': 'fetchOrderTrades',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchDeposit': {
+                'testFile': 'fetchDeposit',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'createDepositAddress': {
+                'testFile': 'createDepositAddress',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchDepositAddress': {
+                'testFile': 'fetchDepositAddress',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchDepositAddresses': {
+                'testFile': 'fetchDepositAddresses',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchDepositAddressesByNetwork': {
+                'testFile': 'fetchDepositAddressesByNetwork',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'editOrder': {
+                'testFile': 'editOrder',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchBorrowRateHistory': {
+                'testFile': 'fetchBorrowRateHistory',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchLedgerEntry': {
+                'testFile': 'fetchLedgerEntry',
+                'isWs': false,
+                'public': false,
+                'args': [ code ]
+            },
+            'fetchWithdrawal': {
+                'testFile': 'fetchWithdrawal',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'transfer': {
+                'testFile': 'transfer',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'withdraw': {
+                'testFile': 'withdraw',
+                'isWs': false,
+                'public': false,
+                'args': [],
+                'skip': true
+            },
+            'fetchPositions': {
+                'testFile': 'fetchPositions',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchPosition': {
+                'testFile': 'fetchPosition',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchPositionRisk': {
+                'testFile': 'fetchPositionRisk',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'setPositionMode': {
+                'testFile': 'setPositionMode',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchOpenInterestHistory': {
+                'testFile': 'fetchOpenInterestHistory',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            'fetchFundingRateHistory - private': {
+                'testFile': 'fetchFundingRateHistory',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+
+            },
+            'fetchFundingHistory': {
+                'testFile': 'fetchFundingHistory',
+                'isWs': false,
+                'public': false,
+                'args': [ symbol ],
+                'skip': isSpot ? 'only run for swap markets' : undefined,
+            },
+            // public ws tests
+            'watchOHLCV': {
+                'testFile': 'watchOHLCV',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'watchTicker': {
+                'testFile': 'watchTicker',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'watchOrderBook': {
+                'testFile': 'watchOrderBook',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'watchTrades': {
+                'testFile': 'watchTrades',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'watchTickers with symbol': {
+                'testFile': 'watchTickers',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol ]
+            },
+            'watchTickers with symbol channel name': {
+                'testFile': 'watchTickers',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol, { 'name': 'ticker' } ]
+            },
+            'watchTickers with symbol channel bookTicker': {
+                'testFile': 'watchTickers',
+                'isWs': true,
+                'public': true,
+                'args': [ symbol, { 'name': 'bookTicker' } ]
+            },
+            // private ws tests
+            'watchBalance': {
+                'testFile': 'watchBalance',
+                'isWs': true,
+                'public': false,
+                'args': [ code ]
+            },
+            'watchMyTrades': {
+                'testFile': 'watchMyTrades',
+                'isWs': true,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'watchOrders': {
+                'testFile': 'watchOrders',
+                'isWs': true,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'watchPosition': {
+                'testFile': 'watchPosition',
+                'isWs': true,
+                'public': false,
+                'args': [ symbol ]
+            },
+            'watchPositions': {
+                'testFile': 'watchPositions',
+                'isWs': true,
+                'public': false,
+                'args': [ symbol ]
+            },
+        },
+        "ace": {
+            "skip": "temp",
+            "skipWs": true,
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "temporary skip, because ids are numeric and we are in wip for numeric id tests",
+                    "quoteId": "numeric",
+                    "quote": "numeric",
+                    "baseId": "numeric",
+                    "base": "numeric",
+                    "settleId": "numeric",
+                    "settle": "numeric",
+                    "active": "is undefined"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "needs reversion of amount/price"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            }
+        },
+        "alpaca": {
+            "skip": "private endpoints",
+            "skipWs": "private endpoints"
+        },
+        "ascendex": {
+            "skipWs": "unknown https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2416",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken currencies"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "low": "16 Aug - happened weird negative 24hr low",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            }
+        },
+        "bequant": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "https://app.travis-ci.com/github/ccxt/ccxt/builds/264802937#L2194"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "broken bid-ask",
+                    "ask": "broken bid-ask"
+                }
+            }
+        },
+        "binance": {
+            "httpsProxy": "http://5.75.153.75:8002",
+            "wsProxy": "http://5.75.153.75:8002",
+            "fetchStatus": {
+                "skip": "temporarily failing"
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "i.e. binance does not have currency code BCC",
+                    "expiry": "expiry not set for future markets",
+                    "expiryDatetime": "expiry not set for future markets"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided in public api",
+                    "networks": "not yet unified"
+                }
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466"
+                }
+            }
+        },
+        "binanceus": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "expiry": "expiry not set for future markets",
+                    "expiryDatetime": "expiry not set for future markets"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchStatus": {
+                "skip": "private endpoints"
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466"
+                }
+            }
+        },
+        "binancecoinm": {
+            "httpsProxy": "http://5.75.153.75:8002",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "expiry": "expiry not set for future markets",
+                    "expiryDatetime": "expiry not set for future markets"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466"
+                }
+            },
+            "watchOrderBook": {
+                "skip": "out of order update"
+            }
+        },
+        "binanceusdm": {
+            "httpsProxy": "http://5.75.153.75:8002",
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchPositions": {
+                "skip": "currently returns a lot of default/non open positions"
+            },
+            "fetchLedger": {
+                "skippedProperties": {
+                    "account": "empty",
+                    "status": "not provided",
+                    "before": "not provided",
+                    "after": "not provided",
+                    "fee": "not provided",
+                    "code": "not provided",
+                    "referenceId": "not provided"
+                }
+            },
+            "fetchBalance": {
+                "skip": "tmp skip"
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L2466"
+                }
+            }
+        },
+        "bit2c": {
+            "skip": "temporary certificate issues",
+            "until": "2023-11-25",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "active": "not provided",
+                    "taker": "not provided",
+                    "maker": "not provided",
+                    "info": "null"
+                }
+            },
+            "fetchOrderBook": {
+                "skippedProperties": {
+                    "bid": "sometimes equals to zero: https://app.travis-ci.com/github/ccxt/ccxt/builds/267809189#L2540",
+                    "ask": "same"
+                }
+            }
+        },
+        "tokocrypto": {
+            "httpsProxy": "http://5.75.153.75:8002"
+        },
+        "bitbank": {},
+        "bitbay": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "expiry": "expiry not set for future markets",
+                    "expiryDatetime": "expiry not set for future markets"
+                }
+            }
+        },
+        "bitbns": {
+            "skip": "temp",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "limits": "only one market has min>max limit",
+                    "active": "not provided",
+                    "currencyIdAndCode": "broken"
+                }
+            },
+            "fetchTickers": {
+                "skip": "unknown symbol might be returned"
+            }
+        },
+        "bitcoincom": {
+            "skipWs": true
+        },
+        "bitfinex": {
+            "loadMarkets": {
+                "skip": "linear and inverse values are same"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "symbol": "something broken with symbol",
+                    "ask": "https://app.travis-ci.com/github/ccxt/ccxt/builds/262965121#L3179",
+                    "bid": "same"
+                }
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "symbol": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L3846"
+                }
+            }
+        },
+        "bitfinex2": {
+            "skipWs": true,
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken currencies"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "multiple bids might have same value"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "fetchTickers": {
+                "skip": "negative values"
+            }
+        },
+        "bitflyer": {
+            "loadMarkets": {
+                "skip": "contract is true, but contractSize is undefined"
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "side key has an null value, but is expected to have a value"
+                }
+            }
+        },
+        "bitget": {
+            "skipWs": true,
+            "loadMarkets": {
+                "skippedProperties": {
+                    "precision": "broken precision",
+                    "limits": "limit max value is zero, lwer than min",
+                    "contractSize": "not defined when contract",
+                    "currencyIdAndCode": "broken currencies"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "broken bid-ask",
+                    "ask": "broken bid-ask",
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "watchTrades": {
+                "skippedProperties": {
+                    "timestamp": "ts order is reverted (descending)"
+                }
+            }
+        },
+        "bithumb": {
+            "skip": "fetchMarkets returning undefined",
+            "until": "2023-09-05",
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "bitmart": {
+            "skipWs": true,
+            "loadMarkets": {
+                "skippedProperties": {
+                    "expiry": "expiry is expected to be > 0",
+                    "settle": "not defined when contract",
+                    "settleId": "not defined when contract",
+                    "currencyIdAndCode": "broken currencies"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "networks": "missing"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "same"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "same"
+                }
+            },
+            "fetchL2OrderBook": {
+                "skip": "bid==ask , https://app.travis-ci.com/github/ccxt/ccxt/builds/263304041#L2170"
+            },
+            "fetchLOrderBook": {
+                "skip": "same"
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4256",
+                    "bid": "wrong data https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4325"
+                }
+            },
+            "watchTrades": {
+                "skippedProperties": {
+                    "side": "not set https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4312"
+                }
+            }
+        },
+        "bitmex": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skip": "some market types are out of expected market-types"
+            },
+            "fetchOHLCV": {
+                "skip": "open might be greater than high"
+            },
+            "fetchTickers": {
+                "skip": "negative values"
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "stopLossPrice": "undefined",
+                    "takeProfitPrice": "undefined",
+                    "marginRatio": "undefined",
+                    "lastPrice": "undefined",
+                    "collateral": "undefined",
+                    "hedged": "undefined",
+                    "lastUpdateTimestamp": "undefined",
+                    "entryPrice": "undefined",
+                    "markPrice": "undefined",
+                    "leverage": "undefined",
+                    "initialMargin": "undefined",
+                    "maintenanceMargin": "can be zero for default position",
+                    "notional": "can be zero for default position",
+                    "contracts": "contracts",
+                    "unrealizedPnl": "undefined",
+                    "realizedPnl": "undefined",
+                    "liquidationPrice": "can be 0",
+                    "percentage": "might be 0"
+                }
+            },
+            "fetchMyTrades": {
+                "skippedProperties": {
+                    "side": "sometimes side is not available"
+                }
+            },
+            "fetchLedger": {
+                "skippedProperties": {
+                    "referenceId": "undefined",
+                    "amount": "undefined",
+                    "before": "not provided",
+                    "tag": "undefined",
+                    "tagFrom": "undefined",
+                    "tagTo": "undefined",
+                    "type": "unmapped types",
+                    "timestamp": "default value might be invalid"
+                }
+            },
+            "fetchDepositsWithdrawals": {
+                "skippedProperties": {
+                    "currency": "undefined",
+                    "currencyIdAndCode": "messes codes"
+                }
+            },
+            "fetchTransactions": {
+                "skip": "skip"
+            }
+        },
+        "bitopro": {
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "networks": "missing"
+                }
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken currencies"
+                }
+            },
+            "watchTicker": {
+                "skip": "datetime error: https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4373"
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4373"
+                }
+            }
+        },
+        "bitpanda": {
+            "skipWs": true,
+            "fetchOrderBook": {
+                "skip": "some bid might be lower than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            }
+        },
+        "bitrue": {
+            "skipWs": true,
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken currencies",
+                    "limits": "max is below min"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "not set"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "bid ask crossed",
+                    "ask": "bid ask crossed"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "bitso": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "not provided"
+                }
+            },
+            "fetchOHLCV": {
+                "skip": "randomly failing with 404 not found"
+            }
+        },
+        "bitstamp": {
+            "fetchOrderBook": {
+                "skip": "bid/ask might be 0"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "bid": "greater than ask https://app.travis-ci.com/github/ccxt/ccxt/builds/264241638#L3027",
+                    "baseVolume": "baseVolume * low = 8.43e-6 * 3692.59081464 = 0.03112854056 < 0.0311285405674152",
+                    "quoteVolume": "quoteVolume >= baseVolume * low <<< bitstamp fetchTickers"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "same",
+                    "baseVolume": "same",
+                    "quoteVolume": "same"
+                }
+            },
+            "watchOrderBook": {
+                "skip": "something broken https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4473 and https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4504"
+            }
+        },
+        "bitstamp1": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "info": "null",
+                    "precision": "not provided",
+                    "active": "not provided"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bid/ask might be 0"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "bid": "greater than ask https://app.travis-ci.com/github/ccxt/ccxt/builds/264241638#L3027"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "same"
+                }
+            }
+        },
+        "bl3p": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "active": "not provided",
+                    "info": "null"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "side is undefined"
+                }
+            }
+        },
+        "bitvavo": {
+            "skip": "temp",
+            "httpsProxy": "http://51.83.140.52:11230",
+            "skipWs": "temp",
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "networks": "missing"
+                }
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken currencies",
+                    "taker": "is undefined",
+                    "maker": "is undefined"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "broken bid-ask",
+                    "ask": "broken bid-ask",
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing https://app.travis-ci.com/github/ccxt/ccxt/builds/266144312#L2220"
+                }
+            }
+        },
+        "blockchaincom": {
+            "skipWs": "https://app.travis-ci.com/github/ccxt/ccxt/builds/265225134#L2304",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "taker": "not provided",
+                    "maker": "not provided"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bid should be greater than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4517 and https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4562"
+                }
+            }
+        },
+        "bkex": {
+            "fetchOrderBook": {
+                "skip": "system busy"
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken currencies",
+                    "contractSize": "broken for some markets"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "networks": "missing"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchOHLCV": {
+                "skip": "open might be greater than high"
+            }
+        },
+        "btcbox": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "precision": "is undefined",
+                    "active": "is undefined",
+                    "info": "null"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bids[0][0] (3787971.0) should be < than asks[0][0] (3787971.0) <<< btcbox "
+            },
+            "fetchL2OrderBook": {
+                "skip": "bids[0][0] (3787971.0) should be < than asks[0][0] (3787971.0) <<< btcbox "
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "broken bid-ask",
+                    "ask": "broken bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "bid": "broken bid-ask",
+                    "ask": "broken bid-ask"
+                }
+            }
+        },
+        "btcex": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined",
+                    "limits": "sometimes 'max' value is zero, lower than 'min'"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "messed bid-ask : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2090",
+                    "ask": "same as above"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "bid": "same as above",
+                    "ask": "same as above"
+                }
+            }
+        },
+        "btcalpha": {
+            "skip": true,
+            "fetchOrderBook": {
+                "skip": "bids[0][0] is not < asks[0][0]"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "symbol": "https://app.travis-ci.com/github/ccxt/ccxt/builds/265171549#L2518",
+                    "percentage": "broken",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "percentage": "",
+                    "symbol": "",
+                    "bid": "",
+                    "ask": ""
+                }
+            }
+        },
+        "btcmarkets": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bid should be greater than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            }
+        },
+        "btctradeua": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "precision": "is undefined",
+                    "active": "is undefined",
+                    "taker": "is undefined",
+                    "maker": "is undefined",
+                    "info": "null"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bid should be greater than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            }
+        },
+        "btcturk": {
+            "fetchOrderBook": {
+                "skip": "https://app.travis-ci.com/github/ccxt/ccxt/builds/263287870#L2201"
+            }
+        },
+        "bybit": {
+            "httpsProxy": "http://5.75.153.75:8002",
+            "wsProxy": "http://5.75.153.75:8002",
+            "fetchTickers": {
+                "skippedProperties": {
+                    "symbol": "returned symbol is not same as requested symbol. i.e. symbol:code vs symbol"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "symbol": "same"
+                }
+            },
+            "fetchTrades": {
+                "skip": "endpoint return Internal System Error"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "temp skip"
+                }
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "temp skip"
+                }
+            },
+            "fetchPositions": {
+                "skip": "currently returns a lot of default/non open positions"
+            },
+            "fetchLedger": {
+                "skippedProperties": {
+                    "account": "account is not provided",
+                    "status": "status is not provided",
+                    "fee": "undefined"
+                }
+            },
+            "fetchOpenInterestHistory": {
+                "skippedProperties": {
+                    "openInterestAmount": "openInterestAmount is not provided"
+                }
+            },
+            "fetchBorrowRate": {
+                "skip": "does not work with unified account"
+            }
+        },
+        "buda": {
+            "httpsProxy": "http://5.75.153.75:8002"
+        },
+        "bigone": {
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "broken bid-ask",
+                    "ask": "broken bid-ask",
+                    "baseVolume": "negative value"
+                }
+            }
+        },
+        "coincheck": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "info": "not provided",
+                    "precision": "not provided",
+                    "active": "is undefined",
+                    "taker": "is undefined",
+                    "maker": "is undefined"
+                }
+            }
+        },
+        "coinbase": {
+            "skip": "private endpoints",
+            "skipWs": "needs auth",
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "not provided"
+                }
+            },
+            "fetchTrades": {
+                "skip": "datetime is not same as timestamp"
+            }
+        },
+        "coinbasepro": {
+            "skipWs": "needs auth",
+            "fetchStatus": {
+                "skip": "request timeout"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            }
+        },
+        "coinbaseprime": {
+            "fetchStatus": {
+                "skip": "request timeout"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            }
+        },
+        "coinone": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quote scale isn't right"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quote scale isn't right"
+                }
+            }
+        },
+        "coinspot": {
+            "skip": "temp",
+            "loadMarkets": {
+                "skip": "precision key has an null value, but is expected to have a value| taker key missing from structure (markets are created from constructor .options, so needs to fill with default values in base)"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "ask": "broken bid-ask",
+                    "bid": "broken bid-ask",
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "coinsph": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "taker": "messed",
+                    "maker": "messed"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "cex": {
+            "skipWs": "timeouts",
+            "proxies": {
+                "skip": "probably they do not permit our proxy location"
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined",
+                    "currencyIdAndCode": "messes codes"
+                }
+            },
+            "fetchOHLCV": {
+                "skip": "unexpected issue"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "limits": "min is negative",
+                    "withdraw": "not provided",
+                    "deposit": "not provided",
+                    "networks": "missing"
+                }
+            }
+        },
+        "coinex": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "broken",
+                    "active": "is undefined"
+                }
+            }
+        },
+        "coinmate": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "ask should be less than next ask"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            }
+        },
+        "cryptocom": {
+            "skipWs": "timeout",
+            "proxies": {
+                "skip": "probably they do not permit our proxy"
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "limits": "max is below min",
+                    "active": "is undefined",
+                    "currencyIdAndCode": "from travis location (USA) these webapi endpoints cant be loaded"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "timestamp": "timestamp might be of 1970-01-01T00:00:00.000Z",
+                    "quoteVolume": "can't be infered"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "timestamp": "timestamp might be of 1970-01-01T00:00:00.000Z",
+                    "quoteVolume": "can't be infered"
+                }
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "entryPrice": "entryPrice is not provided",
+                    "markPrice": "undefined",
+                    "notional": "undefined",
+                    "leverage": "undefined",
+                    "liquidationPrice": "undefined",
+                    "marginMode": "undefined",
+                    "percentage": "undefined",
+                    "marginRatio": "undefined",
+                    "stopLossPrice": "undefined",
+                    "takeProfitPrice": "undefined",
+                    "maintenanceMargin": "undefined",
+                    "initialMarginPercentage": "undefined",
+                    "maintenanceMarginPercentage": "undefined",
+                    "hedged": "undefined",
+                    "side": "undefined",
+                    "contracts": "undefined"
+                }
+            },
+            "fetchAccounts": {
+                "skippedProperties": {
+                    "type": "type is not provided",
+                    "code": "not provided"
+                }
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4756"
+                }
+            }
+        },
+        "currencycom": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "type": "unexpected market type",
+                    "contractSize": "not defined when contract",
+                    "settle": "not defined when contract",
+                    "settleId": "not defined when contract"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "ask": "not above bid https://app.travis-ci.com/github/ccxt/ccxt/builds/263871244#L2163",
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "ask": "not above bid https://app.travis-ci.com/github/ccxt/ccxt/builds/263871244#L2163",
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "delta": {
+            "loadMarkets": {
+                "skip": "expiryDatetime must be equal to expiry in iso8601 format"
+            },
+            "fetchOrderBook": {
+                "skip": "ask crossing bids test failing"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "failing the test",
+                    "bid": "failing the test"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "failing the test",
+                    "bid": "failing the test"
+                }
+            }
+        },
+        "deribit": {
+            "skipWs": "timeouts",
+            "fetchCurrencies": {
+                "skip": "deposit/withdraw not provided"
+            },
+            "loadMarkets": {
+                "skip": "strike is set when option is not true"
+            },
+            "fetchTickers": {
+                "skip": "something wrong"
+            },
+            "fetchBalance": {
+                "skip": "does not add up"
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "percentage": "undefined",
+                    "hedged": "undefined",
+                    "stopLossPrice": "undefined",
+                    "takeProfitPrice": "undefined",
+                    "lastPrice": "undefined",
+                    "collateral": "undefined",
+                    "marginMode": "undefined",
+                    "marginRatio": "undefined",
+                    "contracts": "undefined",
+                    "id": "undefined"
+                }
+            },
+            "fetchDeposits": {
+                "skippedProperties": {
+                    "id": "undefined",
+                    "network": "undefined",
+                    "addressFrom": "undefined",
+                    "tag": "undefined",
+                    "tagTo": "undefined",
+                    "tagFrom": "undefined",
+                    "fee": "undefined"
+                }
+            }
+        },
+        "flowbtc": {
+            "fetchTrades": {
+                "skip": "timestamp is more than current utc timestamp"
+            },
+            "fetchOHLCV": {
+                "skip": "same"
+            }
+        },
+        "fmfwio": {
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "fee": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            }
+        },
+        "gemini": {
+            "skipWs": "temporary",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed codes",
+                    "active": "not provided"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4833"
+                }
+            }
+        },
+        "hitbtc": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed codes"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "fee": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            }
+        },
+        "hitbtc3": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "limits": "messed min max",
+                    "currencyIdAndCode": "messed codes"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "fee": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            }
+        },
+        "digifinex": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed codes"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "messed"
+                }
+            },
+            "fetchTicker": {
+                "skip": "unexpected symbol is being returned | safeMarket() requires a fourth argument for BTC_code to disambiguate between different markets with the same market id"
+            },
+            "fetchTickers": {
+                "skip": "unexpected symbol is being returned | safeMarket() requires a fourth argument for BTC_code to disambiguate between different markets with the same market id"
+            },
+            "fetchLeverageTiers": {
+                "skippedProperties": {
+                    "minNotional": "undefined",
+                    "currencyIdAndCode": "messed codes",
+                    "currency": "messed"
+                }
+            },
+            "fetchBorrowRates": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed codes",
+                    "currency": "messed"
+                }
+            },
+            "fetchBorrowInterest": {
+                "skip": "symbol is messed"
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "percentage": "undefined",
+                    "stopLossPrice": "undefined",
+                    "takeProfitPrice": "undefined",
+                    "collateral": "undefined",
+                    "initialMargin": "undefined",
+                    "initialMarginPercentage": "undefined",
+                    "hedged": "undefined",
+                    "id": "undefined",
+                    "notional": "undefined"
+                }
+            },
+            "fetchBalance": {
+                "skip": "tmp skip"
+            }
+        },
+        "gate": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed codes",
+                    "fetchCurrencies": {
+                        "fee": "not provided"
+                    },
+                    "limits": "max should be above min",
+                    "contractSize": "broken for some markets",
+                    "strike": "incorrect number type"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "timestamp": "timestamp is in decimals"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask",
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138",
+                    "baseVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "bid": "same",
+                    "ask": "same",
+                    "quoteVolume": "same",
+                    "baseVolume": "same"
+                }
+            },
+            "fetchPositions": {
+                "skip": "currently returns a lot of default/non open positions"
+            },
+            "fetchLedger": {
+                "skippedProperties": {
+                    "currency": "undefined",
+                    "status": "undefined",
+                    "fee": "undefined",
+                    "account": "undefined",
+                    "referenceAccount": "undefined",
+                    "referenceId": "undefined"
+                }
+            },
+            "fetchTradingFees": {
+                "skip": "sandbox does not have this endpoint"
+            },
+            "fetchDeposits": {
+                "skip": "sandbox does not have this endpoint"
+            },
+            "fetchWithdrawals": {
+                "skip": "sandbox does not have this endpoint"
+            }
+        },
+        "hollaex": {
+            "skipWs": "temp",
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4957"
+                }
+            }
+        },
+        "htx": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "limits": "messed",
+                    "currencyIdAndCode": "messed codes"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided",
+                    "precision": "is undefined",
+                    "limits": "broken somewhere"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4860"
+                }
+            }
+        },
+        "huobijp": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "limits": "messed"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "fee": "not defined",
+                    "networks": "missing"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "fees": "missing"
+                }
+            }
+        },
+        "stex": {
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            }
+        },
+        "probit": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skip": "needs fixing"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "limits": "messed"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "idex": {
+            "skipWs": "timeouts",
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided",
+                    "networks": "missing"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "messed bid-ask",
+                    "bid": "messed bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "messed bid-ask",
+                    "bid": "messed bid-ask"
+                }
+            }
+        },
+        "independentreserve": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "side is undefined"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bid should be greater than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            }
+        },
+        "coinfalcon": {
+            "fetchTickers": {
+                "skip": "negative values"
+            }
+        },
+        "kuna": {
+            "skip": "temporary glitches with this exchange: https://app.travis-ci.com/github/ccxt/ccxt/builds/267517440#L2304",
+            "httpsProxy": "http://5.75.153.75:8002",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "deposit": "is undefined",
+                    "withdraw": "is undefined",
+                    "active": "is undefined",
+                    "precision": "somewhat strange atm https://app.travis-ci.com/github/ccxt/ccxt/builds/267515280#L2337"
+                }
+            }
+        },
+        "kucoin": {
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "depositForNonCrypto": "not provided",
+                    "withdrawForNonCrypto": "not provided"
+                }
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask",
+                    "quoteVolume": "quoteVolume <= baseVolume * high https://app.travis-ci.com/github/ccxt/ccxt/builds/263304041#L2190",
+                    "baseVolume": "same"
+                }
+            }
+        },
+        "kucoinfutures": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "percentage": "percentage is not provided"
+                }
+            }
+        },
+        "latoken": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skip": "negative values"
+            }
+        },
+        "luno": {
+            "skipWs": "temp",
+            "fetchOrderBook": {
+                "skip": "bid should be greater than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            }
+        },
+        "lbank": {
+            "loadMarkets": {
+                "skip": "settle must be defined when contract is true"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "lykke": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed codes"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "fee": "not provided"
+                }
+            },
+            "fetchOrderBook": {
+                "skip": "bid should be greater than next bid"
+            },
+            "fetchL2OrderBook": {
+                "skip": "same"
+            },
+            "fetchTickers": {
+                "skip": "negative values"
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "mercado": {
+            "loadMarkets": {
+                "skip": "needs migration to v4, as raw info is not being used. granular can be used for skipping 'info'"
+            },
+            "fetchOrderBook": {
+                "skip": "bid > ask"
+            },
+            "fetchL2OrderBook": {
+                "skip": "bid > ask"
+            },
+            "fetchTickers": {
+                "skip": "bid > ask"
+            },
+            "fetchTicker": {
+                "skip": "bid > ask"
+            },
+            "fetchCurrencies": {
+                "skip": "info key is missing"
+            }
+        },
+        "novadax": {
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "https://app.travis-ci.com/github/ccxt/ccxt/builds/266029139",
+                    "bid": "https://app.travis-ci.com/github/ccxt/ccxt/builds/266029139"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "ndax": {
+            "skipWs": "timeouts",
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            }
+        },
+        "mexc": {
+            "skipWs": "temp",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "is undefined"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "side is not buy/sell"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "bid": "messed bid-ask",
+                    "ask": "messed bid-ask"
+                }
+            },
+            "fetchAccounts": {
+                "skippedProperties": {
+                    "type": "type is not provided"
+                }
+            },
+            "fetchLeverageTiers": {
+                "skip": "swap only supported"
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6610"
+                }
+            }
+        },
+        "oceanex": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchOrderBooks": {
+                "skip": "fetchOrderBooks returned 0 length"
+            }
+        },
+        "p2b": {
+            "skip": "temp issues",
+            "httpsProxy": "http://51.83.140.52:11230",
+            "loadMarkets": {
+                "skip": "invalid URL"
+            },
+            "fetchTrades": {
+                "skip": "requires order id"
+            }
+        },
+        "paymium": {
+            "skip": "exchange is down",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "precision": "not provided",
+                    "active": "not provided",
+                    "info": "null",
+                    "taker": "is undefined",
+                    "maker": "is undefined"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "phemex": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "contractSize": "broken for some markets",
+                    "active": "not provided",
+                    "currencyIdAndCode": "messed",
+                    "taker": "null",
+                    "maker": "null"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "messed bid-ask",
+                    "bid": "messed bid-ask"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "ask": "messed bid-ask",
+                    "bid": "messed bid-ask"
+                }
+            }
+        },
+        "okcoin": {
+            "skipWs": "temp",
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "watchTicker": {
+                "skippedProperties": {
+                    "symbol": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721"
+                }
+            }
+        },
+        "exmo": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "info": "null",
+                    "withdraw": "not provided",
+                    "deposit": "not provided"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L4807"
+                }
+            }
+        },
+        "poloniex": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "some currencies does not exist in currencies"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "undefined",
+                    "deposit": "undefined",
+                    "networks": "networks key is missing",
+                    "precision": "not provided"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "side is not buy/sell"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume <= baseVolume * high | https://app.travis-ci.com/github/ccxt/ccxt/builds/263884643#L2462",
+                    "baseVolume": "same"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "same",
+                    "baseVolume": "same"
+                }
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6909"
+                }
+            }
+        },
+        "okx": {
+            "loadMarkets": {
+                "skip": "linear & inverse must not be same"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "info": "null",
+                    "currencyIdAndCode": "temp skip"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume <= baseVolume * high : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2132",
+                    "baseVolume": "same"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume <= baseVolume * high <<< okx fetchTicker"
+                }
+            },
+            "fetchBorrowRate": {
+                "skip": "some fields that we can't skip missing"
+            },
+            "fetchBorrowRates": {
+                "skip": "same"
+            },
+            "watchOrderBook": {
+                "skippedProperties": {
+                    "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721"
+                }
+            }
+        },
+        "tidex": {
+            "skip": "exchange unavailable, probably api upgrade needed"
+        },
+        "kraken": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267515280#L2314"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "undefined",
+                    "deposit": "undefined",
+                    "currencyIdAndCode": "same as in loadMarkets"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume <= baseVolume * high is failing",
+                    "baseVolume": "quoteVolume <= baseVolume * high is failing"
+                }
+            }
+        },
+        "krakenfutures": {
+            "skip": "continious timeouts https://app.travis-ci.com/github/ccxt/ccxt/builds/265225134#L2431",
+            "timeout": 120000,
+            "loadMarkets": {
+                "skip": "skip loadMarkets"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "undefined",
+                    "deposit": "undefined"
+                }
+            },
+            "fetchTickers": {
+                "skip": "timeouts this call specifically"
+            },
+            "fetchTicker": {
+                "skip": "timeouts this call specifically"
+            },
+            "watchTrades": {
+                "skip": "reverse timestamps"
+            }
+        },
+        "upbit": {
+            "skipWs": "timeouts",
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "ripio": {
+            "httpsProxy": "http://5.75.153.75:8002"
+        },
+        "timex": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "fee": "is undefined",
+                    "networks": "key not present"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "fees": "missingn from structure"
+                }
+            },
+            "fetchTickers": {
+                "skip": "temporary issues"
+            }
+        },
+        "wavesexchange": {
+            "loadMarkets": {
+                "skip": "missing key"
+            },
+            "fetchOHLCV": {
+                "skip": "index 1 (open price) is undefined"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            },
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low is failing",
+                    "baseVolume": "quoteVolume >= baseVolume * low is failing"
+                }
+            }
+        },
+        "whitebit": {
+            "skipWs": "timeouts",
+            "loadMarkets": {
+                "skip": "contractSize must be undefined when contract is false"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "info": "missing key",
+                    "precision": "not provided",
+                    "fee": "is undefined",
+                    "networks": "missing",
+                    "limits": "broken for some markets"
+                }
+            }
+        },
+        "woo": {
+            "skipWs": "requires auth",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "undefined",
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "withdraw": "undefined",
+                    "deposit": "undefined"
+                }
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "leverage": "undefined",
+                    "percentage": "undefined",
+                    "hedged": "undefined",
+                    "stopLossPrice": "undefined",
+                    "takeProfitPrice": "undefined",
+                    "id": "undefined",
+                    "marginRatio": "undefined",
+                    "collateral": "undefined"
+                }
+            }
+        },
+        "xt": {
+            "loadMarkets": {
+                "skip": "expiry and expiryDatetime are defined for non future/options markets"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "precision": "is undefined",
+                    "withdraw": "undefined",
+                    "deposit": "undefined",
+                    "fee": "undefined"
+                }
+            },
+            "fetchTickers": {
+                "skip": "some outaded contracts, eg RICHARLISONGBALL2022/code:code-221219 return bid > ask"
+            },
+            "fetchTicker": {
+                "skip": "same"
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "messed"
+                }
+            }
+        },
+        "yobit": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "currencyIdAndCode": "messed"
+                }
+            },
+            "fetchTickers": {
+                "skip": "all tickers request exceedes max url length"
+            }
+        },
+        "zaif": {
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "info": "key is missing"
+                }
+            },
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            }
+        },
+        "zonda": {
+            "loadMarkets": {
+                "skippedProperties": {
+                    "active": "is undefined"
+                }
+            }
+        },
+        "bingx": {
+            "skipWs": "broken symbols returned",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "taker": "is undefined",
+                    "maker": "is undefined",
+                    "currencyIdAndCode": "not all currencies are available"
+                }
+            },
+            "fetchTrades": {
+                "skippedProperties": {
+                    "side": "undefined"
+                }
+            },
+            "fetchTicker": {
+                "skip": "spot not supported"
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "not supported"
+                }
+            },
+            "fetchOHLCV": {
+                "skip": "spot not supported"
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "deposit": "not provided",
+                    "precision": "not provided"
+                }
+            },
+            "fetchOrderBook": {
+                "skippedProperties": {
+                    "ask": "multiple ask prices are equal in ob https://app.travis-ci.com/github/ccxt/ccxt/builds/264706670#L2228",
+                    "bid": "multiple bid prices are equal https://app.travis-ci.com/github/ccxt/ccxt/builds/265172859#L2745"
+                }
+            },
+            "watchTrades": {
+                "skippedProperties": {
+                    "side": "undefined"
+                }
+            },
+            "fetchPositions": {
+                "skippedProperties": {
+                    "marginRatio": "undefined",
+                    "stopLossPrice": "undefined",
+                    "takeProfitPrice": "undefined",
+                    "initialMarginPercentage": "undefined",
+                    "hedged": "undefined",
+                    "timestamp": "undefined",
+                    "datetime": "undefined",
+                    "lastUpdateTimestamp": "undefined",
+                    "maintenanceMargin": "undefined",
+                    "contractSize": "undefined",
+                    "markPrice": "undefined",
+                    "lastPrice": "undefined",
+                    "percentage": "undefined",
+                    "liquidationPrice": "undefined"
+                }
+            }
+        },
+        "wazirx": {
+            "skipWs": "timeouts"
+        },
+        "coinlist": {
+            "fetchTicker": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low  is failing"
+                }
+            },
+            "fetchTickers": {
+                "skippedProperties": {
+                    "quoteVolume": "quoteVolume >= baseVolume * low  is failing",
+                    "ask": "invalid"
+                }
+            }
+        },
+        "bitteam": {
+            "skip": "tmp timeout",
+            "loadMarkets": {
+                "skippedProperties": {
+                    "taker": "is undefined",
+                    "maker": "is undefined"
+                }
+            },
+            "fetchCurrencies": {
+                "skippedProperties": {
+                    "deposit": "not provided",
+                    "withdraw": "not provided"
+                }
+            }
+        }
+
+    });
+}
+
+
+export { config, TestConfig, Test, Tests };
+
+// ***** AUTO-TRANSPILER-END *****
+// *******************************

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -500,7 +500,7 @@ export default class testMainClass extends baseMainTestClass {
         const testNames = Object.keys (tests);
         for (let i = 0; i < testNames.length; i++) {
             const name = testNames[i];
-            if (tests[name][key] === value) {
+            if (typeof tests[name] === 'object' && tests[name][key] === value) {
                 result[name] = tests[name];
             }
         }


### PR DESCRIPTION
- This PR proposes using a test configuration file to configure all tests.
- It allows running several tests on the same method with different params
- It allows to override any test for an exchange
- It used a typed config to standarize every test invocation
- It allows running custom tests for an exchange or method using existing testing files or specifing a new one.
- when calling `

### TODO
- [ ] Would like to revise the transpile logic. `indexOf` is not transpiling correctly to php with the astTranspiler
- [ ] Fully test on all exchanges