### PR TITLE
feat(bitmart) - watchtickers for spot and update for swap

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3564,23 +3564,6 @@ export default class Exchange {
         ];
     }
 
-    resolveMessageHashesForSymbol (client, symbol, result, prexif) {
-        const prefixSeparator = '::';
-        const symbolsSeparator = ',';
-        const messageHashes = this.findMessageHashes (client, prexif);
-        for (let i = 0; i < messageHashes.length; i++) {
-            const messageHash = messageHashes[i];
-            const parts = messageHash.split (prefixSeparator);
-            const symbolsString = parts[1];
-            const symbols = symbolsString.split (symbolsSeparator);
-            if (this.inArray (symbol, symbols)) {
-                const response = {};
-                response[symbol] = result;
-                client.resolve (response, messageHash);
-            }
-        }
-    }
-
     filterByArray (objects, key: IndexType, values = undefined, indexed = true) {
         objects = this.toArray (objects);
         // return all of them if no values were passed

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3564,6 +3564,23 @@ export default class Exchange {
         ];
     }
 
+    resolveMessageHashesForSymbol (client, symbol, result, prexif) {
+        const prefixSeparator = '::';
+        const symbolsSeparator = ',';
+        const messageHashes = this.findMessageHashes (client, prexif);
+        for (let i = 0; i < messageHashes.length; i++) {
+            const messageHash = messageHashes[i];
+            const parts = messageHash.split (prefixSeparator);
+            const symbolsString = parts[1];
+            const symbols = symbolsString.split (symbolsSeparator);
+            if (this.inArray (symbol, symbols)) {
+                const response = {};
+                response[symbol] = result;
+                client.resolve (response, messageHash);
+            }
+        }
+    }
+
     filterByArray (objects, key: IndexType, values = undefined, indexed = true) {
         objects = this.toArray (objects);
         // return all of them if no values were passed

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -930,8 +930,8 @@ export default class bitmart extends bitmartRest {
             const ticker = this.parseWsSwapTicker (data);
             const symbol = this.safeString (ticker, 'symbol');
             this.tickers[symbol] = ticker;
+            client.resolve (ticker, 'tickers::swap');
             this.resolveMessageHashesForSymbol (client, symbol, ticker, 'tickers::');
-            // client.resolve (ticker, 'tickers::swap');
         }
         return message;
     }


### PR DESCRIPTION
- added spot watchTickers support
- handleTickers upgrade

works as expected for all variations, like:
```
//
ex.options.defaultType = 'spot';
await e.watchTickers();
//
await e.watchTickers(['ETH/USDT', 'ADA/USDT']);
//
ex.options.defaultType = 'swap';
await e.watchTickers();
//
await e.watchTickers(['ETH/USDT:USDT', 'ADA/USDT:USDT']);
```
