### PR TITLE
Bitget: fetchOHLCV alternative spot endpoint, add since support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3283,9 +3283,17 @@ export default class bitget extends Exchange {
             if (method === 'publicSpotGetV2SpotMarketCandles') {
                 response = await this.publicSpotGetV2SpotMarketCandles (this.extend (request, params));
             } else if (method === 'publicSpotGetV2SpotMarketHistoryCandles') {
-                const until = this.safeInteger2 (params, 'until', 'till');
+                const until = this.safeIntegerN (params, [ 'until', 'till', 'endTime' ]);
                 params = this.omit (params, [ 'until', 'till' ]);
-                if (until === undefined) {
+                if (since !== undefined) {
+                    if (limit === undefined) {
+                        limit = 100; // exchange default
+                    }
+                    const duration = this.parseTimeframe (timeframe) * 1000;
+                    request['endTime'] = this.sum (since, duration * limit);
+                } else if (until !== undefined) {
+                    request['endTime'] = until;
+                } else {
                     request['endTime'] = this.milliseconds ();
                 }
                 response = await this.publicSpotGetV2SpotMarketHistoryCandles (this.extend (request, params));

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3267,23 +3267,25 @@ export default class bitget extends Exchange {
             'granularity': selectedTimeframe,
         };
         [ request, params ] = this.handleUntilOption ('endTime', request, params);
-        if (since !== undefined) {
-            request['startTime'] = limit;
-        }
         if (limit !== undefined) {
             request['limit'] = limit;
         }
         const options = this.safeValue (this.options, 'fetchOHLCV', {});
+        const spotOptions = this.safeValue (options, 'spot', {});
+        const defaultSpotMethod = this.safeString (spotOptions, 'method', 'publicSpotGetV2SpotMarketCandles');
+        const method = this.safeString (params, 'method', defaultSpotMethod);
+        params = this.omit (params, 'method');
+        if (method !== 'publicSpotGetV2SpotMarketHistoryCandles') {
+            if (since !== undefined) {
+                request['startTime'] = since;
+            }
+        }
         let response = undefined;
         if (market['spot']) {
-            const spotOptions = this.safeValue (options, 'spot', {});
-            const defaultSpotMethod = this.safeString (spotOptions, 'method', 'publicSpotGetV2SpotMarketCandles');
-            const method = this.safeString (params, 'method', defaultSpotMethod);
-            params = this.omit (params, 'method');
             if (method === 'publicSpotGetV2SpotMarketCandles') {
                 response = await this.publicSpotGetV2SpotMarketCandles (this.extend (request, params));
             } else if (method === 'publicSpotGetV2SpotMarketHistoryCandles') {
-                const until = this.safeIntegerN (params, [ 'until', 'till', 'endTime' ]);
+                const until = this.safeInteger2 (params, 'until', 'till');
                 params = this.omit (params, [ 'until', 'till' ]);
                 if (since !== undefined) {
                     if (limit === undefined) {


### PR DESCRIPTION
Added `since` support for using `publicSpotGetV2SpotMarketHistoryCandles` an alternative endpoint for fetchOHLCV:
fixes: #20722
fixes: #20591

```
bitget fetchOHLCV BTC/USDT 1m 1704765480000 undefined '{"method":"publicSpotGetV2SpotMarketHistoryCandles"}'

bitget.fetchOHLCV (BTC/USDT, 1m, 1704765480000, , [object Object])
2024-01-09T03:50:49.326Z iteration 0 passed in 349 ms

1704765480000 | 46472.04 | 46499.47 | 46472.03 | 46485.85 |  1.6141
1704765540000 | 46485.85 | 46558.55 | 46485.85 | 46558.17 |  4.2582
1704765600000 | 46558.17 | 46649.98 | 46558.17 | 46623.46 |  6.3014
...
704771300000 | 46879.97 | 46879.97 | 46853.09 | 46876.87 |  1.8265
1704771360000 | 46876.87 | 46920.04 | 46876.81 |  46916.7 |  1.6201
1704771420000 |  46916.7 | 46920.04 | 46882.94 | 46883.74 |  1.5166
100 objects
```