### PR TITLE
Bitget: createOrder, one way mode orders

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3995,6 +3995,7 @@ export default class bitget extends Exchange {
          * @param {string} [params.trailingPercent] *swap and future only* the percent to trail away from the current market price, rate can not be greater than 10
          * @param {string} [params.trailingTriggerPrice] *swap and future only* the price to trigger a trailing stop order, default uses the price argument
          * @param {string} [params.triggerType] *swap and future only* 'fill_price', 'mark_price' or 'index_price'
+         * @param {boolean} [params.oneWayMode] *swap and future only* required to set this to true in one_way_mode and you can leave this as undefined in hedge_mode, can adjust the mode using the setPositionMode() method
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -4175,14 +4176,21 @@ export default class bitget extends Exchange {
                 }
                 const marginModeRequest = (marginMode === 'cross') ? 'crossed' : 'isolated';
                 request['marginMode'] = marginModeRequest;
+                const oneWayMode = this.safeValue (params, 'oneWayMode', false);
+                params = this.omit (params, 'oneWayMode');
                 let requestSide = side;
                 if (reduceOnly) {
-                    request['reduceOnly'] = 'YES';
-                    request['tradeSide'] = 'Close';
-                    // on bitget if the position is long the side is always buy, and if the position is short the side is always sell
-                    requestSide = (side === 'buy') ? 'sell' : 'buy';
+                    if (oneWayMode) {
+                        request['reduceOnly'] = 'YES';
+                    } else {
+                        // on bitget hedge mode if the position is long the side is always buy, and if the position is short the side is always sell
+                        requestSide = (side === 'buy') ? 'sell' : 'buy';
+                        request['tradeSide'] = 'Close';
+                    }
                 } else {
-                    request['tradeSide'] = 'Open';
+                    if (!oneWayMode) {
+                        request['tradeSide'] = 'Open';
+                    }
                 }
                 request['side'] = requestSide;
             }

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -127,7 +127,7 @@
                     "marginMode": "cross"
                   }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"38000\",\"force\":\"post_only\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"side\":\"buy\",\"reduceOnly\":\"YES\",\"tradeSide\":\"Close\"}"
+                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"38000\",\"force\":\"post_only\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"side\":\"buy\",\"tradeSide\":\"Close\"}"
             },
             {
                 "description": "Cross margin limit buy order",
@@ -193,7 +193,42 @@
                   "reduceOnly": true
                 }
               ],
-              "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.002\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"planType\":\"track_plan\",\"triggerPrice\":\"45000\",\"callbackRatio\":\"10\",\"marginMode\":\"crossed\",\"reduceOnly\":\"YES\",\"tradeSide\":\"Close\",\"side\":\"buy\"}"
+              "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.002\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"planType\":\"track_plan\",\"triggerPrice\":\"45000\",\"callbackRatio\":\"10\",\"marginMode\":\"crossed\",\"tradeSide\":\"Close\",\"side\":\"buy\"}"
+            },
+            {
+              "description": "Swap oneWayMode market sell order with reduceOnly",
+              "method": "createOrder",
+              "url": "https://api.bitget.com/api/v2/mix/order/place-order",
+              "input": [
+                "BTC/USDT:USDT",
+                "market",
+                "sell",
+                0.001,
+                null,
+                {
+                  "marginMode": "isolated",
+                  "reduceOnly": true,
+                  "oneWayMode": true
+                }
+              ],
+              "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"isolated\",\"reduceOnly\":\"YES\",\"side\":\"sell\"}"    
+            },
+            {
+              "description": "Swap oneWayMode limit buy order",
+              "method": "createOrder",
+              "url": "https://api.bitget.com/api/v2/mix/order/place-order",
+              "input": [
+                "BTC/USDT:USDT",
+                "limit",
+                "buy",
+                0.001,
+                40000,
+                {
+                  "marginMode": "isolated",
+                  "oneWayMode": true
+                }
+              ],
+              "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"40000\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"isolated\",\"side\":\"buy\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Added a new parameter called `oneWayMode` to separate some order parameters depending on if the order is one-way or hedge mode, default is hedge mode.

One way mode doesn't work if the `tradeSide` parameter is filled which is required for hedge mode

fixes: #20729
fixes: #19140

```
bitget createOrder BTC/USDT:USDT limit buy 0.001 40000 '{"marginMode":"isolated","oneWayMode":true}'

bitget.createOrder (BTC/USDT:USDT, limit, buy, 0.001, 40000, [object Object])
2024-01-09T05:29:09.332Z iteration 0 passed in 961 ms

{
  info: { clientOid: '1128486843994226688', orderId: '1128486843981643783' },
  id: '1128486843981643783',
  clientOrderId: '1128486843994226688',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fees: []
}
```