### PR TITLE
feat(kucoin): add hf support to fetchBalance and fetchLedger

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -3449,10 +3449,12 @@ export default class kucoin extends Exchange {
          * @name kucoin#fetchBalance
          * @description query for balance and get the amount of funds available for trading or funds locked in orders
          * @see https://docs.kucoin.com/#list-accounts
+         * @see https://www.kucoin.com/docs/rest/account/basic-info/get-account-list-spot-margin-trade_hf
          * @see https://docs.kucoin.com/#query-isolated-margin-account-info
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {object} [params.marginMode] 'cross' or 'isolated', margin type for fetching margin balance
          * @param {object} [params.type] extra parameters specific to the exchange API endpoint
+         * @param {object} [params.hf] *default if false* if true, the result includes the balance of the high frequency account
          * @returns {object} a [balance structure]{@link https://docs.ccxt.com/#/?id=balance-structure}
          */
         await this.loadMarkets ();
@@ -3464,8 +3466,13 @@ export default class kucoin extends Exchange {
         const defaultType = this.safeString2 (this.options, 'fetchBalance', 'defaultType', 'spot');
         const requestedType = this.safeString (params, 'type', defaultType);
         const accountsByType = this.safeValue (this.options, 'accountsByType');
-        const type = this.safeString (accountsByType, requestedType, requestedType);
+        let type = this.safeString (accountsByType, requestedType, requestedType);
         params = this.omit (params, 'type');
+        const isHf = this.safeValue (params, 'hf', false);
+        if (isHf) {
+            type = 'trade_hf';
+        }
+        params = this.omit (params, 'hf');
         const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchBalance', params);
         let response = undefined;
         const request = {};
@@ -3545,7 +3552,7 @@ export default class kucoin extends Exchange {
             'datetime': undefined,
         };
         if (isolated) {
-            const assets = this.safeValue (data, 'assets', []);
+            const assets = this.safeValue (data, 'assets', data);
             for (let i = 0; i < assets.length; i++) {
                 const entry = assets[i];
                 const marketId = this.safeString (entry, 'symbol');
@@ -3877,12 +3884,14 @@ export default class kucoin extends Exchange {
          * @method
          * @name kucoin#fetchLedger
          * @see https://docs.kucoin.com/#get-account-ledgers
+         * @see https://www.kucoin.com/docs/rest/account/basic-info/get-account-ledgers-trade_hf
+         * @see https://www.kucoin.com/docs/rest/account/basic-info/get-account-ledgers-margin_hf
          * @description fetch the history of changes, actions done by the user or operations that altered balance of the user
-         * @see https://docs.kucoin.com/#get-account-ledgers
          * @param {string} code unified currency code, default is undefined
          * @param {int} [since] timestamp in ms of the earliest ledger entry, default is undefined
          * @param {int} [limit] max number of ledger entrys to return, default is undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {boolean} [params.hf] default false, when true will fetch ledger entries for the high frequency trading account
          * @param {int} [params.until] the latest time in ms to fetch entries for
          * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {object} a [ledger structure]{@link https://docs.ccxt.com/#/?id=ledger-structure}
@@ -3891,6 +3900,8 @@ export default class kucoin extends Exchange {
         await this.loadAccounts ();
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchLedger', 'paginate');
+        const isHf = this.safeValue (params, 'hf');
+        params = this.omit (params, 'hf');
         if (paginate) {
             return await this.fetchPaginatedCallDynamic ('fetchLedger', code, since, limit, params);
         }
@@ -3911,7 +3922,18 @@ export default class kucoin extends Exchange {
             request['currency'] = currency['id'];
         }
         [ request, params ] = this.handleUntilOption ('endAt', request, params);
-        const response = await this.privateGetAccountsLedgers (this.extend (request, params));
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLedger', params);
+        let response = undefined;
+        if (isHf) {
+            if (marginMode !== undefined) {
+                response = await this.privateGetHfMarginAccountLedgers (this.extend (request, params));
+            } else {
+                response = await this.privateGetHfAccountsLedgers (this.extend (request, params));
+            }
+        } else {
+            response = await this.privateGetAccountsLedgers (this.extend (request, params));
+        }
         //
         //     {
         //         "code":"200000",
@@ -3950,7 +3972,7 @@ export default class kucoin extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data');
-        const items = this.safeValue (data, 'items');
+        const items = this.safeValue (data, 'items', data);
         return this.parseLedger (items, currency, since, limit);
     }
 

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -45,6 +45,22 @@
                   }
                 ],
                 "output": "{\"clientOid\":\"7417761e-9fa9-4030-8863-66fba6487b24\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"limit\",\"size\":\"0.1\",\"price\":\"55\",\"stopPrice\":\"60\"}"
+            },
+            {
+                "description": "Create hf order",
+                "method": "createOrder",
+                "url": "https://api.kucoin.com/api/v1/hf/orders",
+                "input": [
+                  "LTC/USDT",
+                  "market",
+                  "buy",
+                  0.1,
+                  null,
+                  {
+                    "hf": true
+                  }
+                ],
+                "output": "{\"clientOid\":\"5d7a8110-1ea6-46e7-8d8f-1ba53267f20c\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"market\",\"size\":\"0.1\",\"hf\":true}"
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -178,6 +194,16 @@
                         "type": "spot"
                     }
                 ]
+            },
+            {
+                "description": "fetch spot hf balance",
+                "method": "fetchBalance",
+                "url": "https://api.kucoin.com/api/v1/accounts?type=trade_hf",
+                "input": [
+                  {
+                    "hf": true
+                  }
+                ]
             }
         ],
         "fetchDeposits": [
@@ -208,6 +234,18 @@
                     "swap"
                 ],
                 "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"from\":\"trade\",\"to\":\"contract\",\"clientOid\":\"eac5ee3a-c116-4109-9a47-29c4b1aa6567\"}"
+            },
+            {
+                "description": "transfer from trade to hf account",
+                "method": "transfer",
+                "url": "https://api.kucoin.com/api/v2/accounts/inner-transfer",
+                "input": [
+                  "USDT",
+                  5,
+                  "trade",
+                  "trade_hf"
+                ],
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"from\":\"trade\",\"to\":\"trade_hf\",\"clientOid\":\"d0da1feb-d76c-4562-b727-ddfabec6ca45\"}"
             }
         ],
         "fetchLedger": [
@@ -217,6 +255,19 @@
                 "url": "https://api.kucoin.com/api/v1/accounts/ledgers?currency=USDT",
                 "input": [
                     "USDT"
+                ]
+            },
+            {
+                "description": "fetch hf ledger",
+                "method": "fetchLedger",
+                "url": "https://api.kucoin.com/api/v1/hf/accounts/ledgers?currency=USDT",
+                "input": [
+                  "USDT",
+                  null,
+                  null,
+                  {
+                    "hf": true
+                  }
                 ]
             }
         ]


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/20644


```
 p kucoin fetchBalance '{"hf":true}'         
Python v3.11.5
CCXT v4.2.10
kucoin.fetchBalance({'hf': True})
{'LTC': {'free': 0.1, 'total': 0.1, 'used': 0.0},
 'USDT': {'free': 14.3497564, 'total': 14.3497564, 'used': 0.0},
 'datetime': None,
 'free': {'LTC': 0.1, 'USDT': 14.3497564},
 'info': {'code': '200000',
          'data': [{'available': '14.3497564',
                    'balance': '14.3497564',
                    'currency': 'USDT',
                    'holds': '0',
                    'id': '11181564216323',
                    'type': 'trade_hf'},
                   {'available': '0.1',
                    'balance': '0.1',
                    'currency': 'LTC',
                    'holds': '0',
                    'id': '11182674802691',
                    'type': 'trade_hf'}]},
 'timestamp': None,
 'total': {'LTC': 0.1, 'USDT': 14.3497564},
 'used': {'LTC': 0.0, 'USDT': 0.0}}
```
