### PR TITLE
feat(binance): add websocket limit to binance watchMultiple

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -207,7 +207,15 @@ export default class binance extends binanceRest {
             type = firstMarket['linear'] ? 'future' : 'delivery';
         }
         const name = 'depth';
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, 'multipleOrderbook');
+        let streamHash = 'multipleOrderbook';
+        if (symbols !== undefined) {
+            const symbolsLength = symbols.length;
+            if (symbolsLength > 200) {
+                throw new BadRequest (this.id + ' watchOrderBookForSymbols() accepts 200 symbols at most. To watch more symbols call watchOrderBookForSymbols() multiple times');
+            }
+            streamHash += '::' + symbols.join (',');
+        }
+        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash);
         const requestId = this.requestId (url);
         const watchOrderBookRate = this.safeString (this.options, 'watchOrderBookRate', '100');
         const subParams = [];
@@ -463,6 +471,14 @@ export default class binance extends binanceRest {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true, true);
+        let streamHash = 'multipleTrades';
+        if (symbols !== undefined) {
+            const symbolsLength = symbols.length;
+            if (symbolsLength > 200) {
+                throw new BadRequest (this.id + ' watchTradesForSymbols() accepts 200 symbols at most. To watch more symbols call watchTradesForSymbols() multiple times');
+            }
+            streamHash += '::' + symbols.join (',');
+        }
         const options = this.safeValue (this.options, 'watchTradesForSymbols', {});
         const name = this.safeString (options, 'name', 'trade');
         const firstMarket = this.market (symbols[0]);
@@ -478,7 +494,7 @@ export default class binance extends binanceRest {
             subParams.push (currentMessageHash);
         }
         const query = this.omit (params, 'type');
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, 'multipleTrades');
+        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash);
         const requestId = this.requestId (url);
         const request = {
             'method': 'SUBSCRIBE',


### PR DESCRIPTION
This PR solves two isuees and adds an extra check

## Issue 1 - streams limit
In binance each connection accepts up to 200 streams.
- This adds an error to tell the user. The user can subscribe to many more symbols but must do it calling watchOrderBookForSymbols more than once for every 200 symbols to create several streams.

## Issue 2 - Ratelimit error
- This also solves a throttling issue, where if the user is calling watchOrderBook several times, it was in turn calling watchOrderBookForSymbols which was always using the same stream, and therefore throwing a 1008 error in binance. By using stream hashes this is solved. It also explains why this issue came up #20667

## Subscriptions per stream check
- Adds a check when creating a stream that no more than 200 subscriptions are made per stream.

## TODO: in a future PR:
 - Add tests for rate limits and stream limits for different markets in binance. Will add once test PR is through