### PR TITLE
fix(bitmart): borrowIsolatedMargin/repayIsolatedMargin - remove made up timestamp data

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -3510,14 +3510,13 @@ export default class bitmart extends Exchange {
         //         "repay_id": "2afcc16d99bd4707818c5a355dc89bed",
         //     }
         //
-        const timestamp = this.milliseconds ();
         return {
             'id': this.safeString2 (info, 'borrow_id', 'repay_id'),
             'currency': this.safeCurrencyCode (undefined, currency),
             'amount': undefined,
             'symbol': undefined,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'info': info,
         };
     }


### PR DESCRIPTION

```
2024-01-10T02:06:49.508Z
Node.js: v18.12.0
CCXT v4.2.11
bitmart.borrowIsolatedMargin (USDC/USDT, USDT, 1)
2024-01-10T02:06:55.201Z iteration 0 passed in 883 ms

{
  id: 'b6ac6237afdb4a67bc6b2fd4e26e27ab',
  currency: 'USDT',
  amount: 1,
  symbol: 'USDC/USDT',
  timestamp: undefined,
  datetime: undefined,
  info: { borrow_id: 'b6ac6237afdb4a67bc6b2fd4e26e27ab' }
}
2024-01-10T02:06:55.201Z iteration 1 passed in 883 ms
```

```
% bitmart repayIsolatedMargin USDC/USDT USDT 1 
2024-01-10T02:08:45.881Z
Node.js: v18.12.0
CCXT v4.2.11
bitmart.repayIsolatedMargin (USDC/USDT, USDT, 1)
2024-01-10T02:08:49.853Z iteration 0 passed in 713 ms

{
  id: '352cdd7e8b2444d4a9aa35542c64c4b9',
  currency: 'USDT',
  amount: 1,
  symbol: 'USDC/USDT',
  timestamp: undefined,
  datetime: undefined,
  info: { repay_id: '352cdd7e8b2444d4a9aa35542c64c4b9' }
}
2024-01-10T02:08:49.853Z iteration 1 passed in 713 ms
```