### PR TITLE
fix(coinlist): fetchBalance - remove made up timestamp data

### DIFF
--- a/ts/src/coinlist.ts
+++ b/ts/src/coinlist.ts
@@ -1123,11 +1123,10 @@ export default class coinlist extends Exchange {
         //         "net_liquidation_value_usd": "string"
         //     }
         //
-        const timestamp = this.milliseconds ();
         const result = {
             'info': response,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
         };
         const totalBalances = this.safeValue (response, 'asset_balances', {});
         const usedBalances = this.safeValue (response, 'asset_holds', {});


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.11
coinlist.fetchBalance()
{'AAVE': {'free': 0.0, 'total': 0.0, 'used': 0.0},
...
 'XTZ': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'datetime': None,
 'free': {'AAVE': 0.0,
          ...
          'XTZ': 0.0},
 'info': {'asset_balances': {'AAVE': '0.000000000000000000',
                             'ALGO': '0.000000',
                             ...
                             'WCFG': '0.000000000000000000',
                             'XTZ': '0.000000'},
          'asset_holds': {},
          'net_liquidation_value_usd': '0.000000000000000000'},
 'timestamp': None,
 'total': {'AAVE': 0.0,
           'ALGO': 0.0,
           ...
           'WCFG': 0.0,
           'XTZ': 0.0},
 'used': {'AAVE': 0.0,
          'ALGO': 0.0,
          ...
          'WCFG': 0.0,
          'XTZ': 0.0}}
```