### PR TITLE
fix(gate): transfer - remove made up timestamp data

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -5110,11 +5110,19 @@ export default class gate extends Exchange {
     }
 
     parseTransfer (transfer, currency: Currency = undefined) {
-        const timestamp = this.milliseconds ();
+        //
+        //    {
+        //        "currency": "BTC",
+        //        "from": "spot",
+        //        "to": "margin",
+        //        "amount": "1",
+        //        "currency_pair": "BTC_USDT"
+        //    }
+        //
         return {
             'id': this.safeString (transfer, 'tx_id'),
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'currency': this.safeCurrencyCode (undefined, currency),
             'amount': undefined,
             'fromAccount': undefined,


### PR DESCRIPTION
```
% gate transfer USDT 1 spot future
2024-01-10T02:42:28.592Z
Node.js: v18.12.0
CCXT v4.2.11
gate.transfer (USDT, 1, spot, future)
2024-01-10T02:42:35.295Z iteration 0 passed in 484 ms

{
  id: '1704854555119',
  timestamp: undefined,
  datetime: undefined,
  currency: 'USDT',
  amount: undefined,
  fromAccount: undefined,
  toAccount: undefined,
  status: undefined,
  info: { tx_id: '1704854555119' }
}
2024-01-10T02:42:35.295Z iteration 1 passed in 484 ms
```

```
% py gate transfer USDT 1 spot future
Python v3.9.6
CCXT v4.2.11
gate.transfer(USDT,1,spot,future)
{'amount': None,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': None,
 'id': '1704854855409',
 'info': {'tx_id': '1704854855409'},
 'status': None,
 'timestamp': None,
 'toAccount': None}
 ```