### PR TITLE
fix(hitbtc): transfer - remove made up timestamp data

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -2614,11 +2614,10 @@ export default class hitbtc extends Exchange {
         //         "2db6ebab-fb26-4537-9ef8-1a689472d236"
         //     ]
         //
-        const timestamp = this.milliseconds ();
         return {
             'id': this.safeString (transfer, 0),
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'currency': this.safeCurrencyCode (undefined, currency),
             'amount': undefined,
             'fromAccount': undefined,


### PR DESCRIPTION
```
%  py hitbtc transfer USDT 1 spot future
Python v3.9.6
CCXT v4.2.11
hitbtc.transfer(USDT,1,spot,future)
{'amount': None,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': None,
 'id': '207414b3-1d96-42e2-a5ca-e399fcca5a03',
 'info': ['207414b3-1d96-42e2-a5ca-e399fcca5a03',
          '2d2a47d1-822a-4766-b06a-a310176e339f'],
 'status': None,
 'timestamp': None,
 'toAccount': None}
```