### PR TITLE
exchange: createTrailingAmountOrder, createTrailingPercentOrder

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4183,7 +4183,7 @@ export default class Exchange {
         throw new NotSupported (this.id + ' createOrder() is not supported yet');
     }
 
-    async createTrailingAmountOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingAmount, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
+    async createTrailingAmountOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingAmount = undefined, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name createTrailingAmountOrder
@@ -4198,6 +4198,9 @@ export default class Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        if (trailingAmount === undefined) {
+            throw new ArgumentsRequired (this.id + ' createTrailingAmountOrder() requires a trailingAmount argument');
+        }
         params['trailingAmount'] = trailingAmount;
         if (trailingTriggerPrice !== undefined) {
             params['trailingTriggerPrice'] = trailingTriggerPrice;
@@ -4208,7 +4211,7 @@ export default class Exchange {
         throw new NotSupported (this.id + ' createTrailingAmountOrder() is not supported yet');
     }
 
-    async createTrailingPercentOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingPercent, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
+    async createTrailingPercentOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingPercent = undefined, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name createTrailingPercentOrder
@@ -4223,6 +4226,9 @@ export default class Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        if (trailingPercent === undefined) {
+            throw new ArgumentsRequired (this.id + ' createTrailingPercentOrder() requires a trailingPercent argument');
+        }
         params['trailingPercent'] = trailingPercent;
         if (trailingTriggerPrice !== undefined) {
             params['trailingTriggerPrice'] = trailingTriggerPrice;

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -483,6 +483,8 @@ export default class Exchange {
                 'createStopOrder': undefined,
                 'createStopLimitOrder': undefined,
                 'createStopMarketOrder': undefined,
+                'createTrailingAmountOrder': undefined,
+                'createTrailingPercentOrder': undefined,
                 'createOrderWs': undefined,
                 'editOrderWs': undefined,
                 'fetchOpenOrdersWs': undefined,
@@ -4179,6 +4181,56 @@ export default class Exchange {
 
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, params = {}): Promise<Order> {
         throw new NotSupported (this.id + ' createOrder() is not supported yet');
+    }
+
+    async createTrailingAmountOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingAmount, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
+        /**
+         * @method
+         * @name createTrailingAmountOrder
+         * @description create a trailing order by providing the symbol, type, side, amount, price and trailingAmount
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much you want to trade in units of the base currency, or number of contracts
+         * @param {float} [price] the price for the order to be filled at, in units of the quote currency, ignored in market orders
+         * @param {float} trailingAmount the quote amount to trail away from the current market price
+         * @param {float} [trailingTriggerPrice] the price to activate a trailing order, default uses the price argument
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        params['trailingAmount'] = trailingAmount;
+        if (trailingTriggerPrice !== undefined) {
+            params['trailingTriggerPrice'] = trailingTriggerPrice;
+        }
+        if (this.has['createTrailingAmountOrder']) {
+            return await this.createOrder (symbol, type, side, amount, price, params);
+        }
+        throw new NotSupported (this.id + ' createTrailingAmountOrder() is not supported yet');
+    }
+
+    async createTrailingPercentOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingPercent, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
+        /**
+         * @method
+         * @name createTrailingPercentOrder
+         * @description create a trailing order by providing the symbol, type, side, amount, price and trailingPercent
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much you want to trade in units of the base currency, or number of contracts
+         * @param {float} [price] the price for the order to be filled at, in units of the quote currency, ignored in market orders
+         * @param {float} trailingPercent the percent to trail away from the current market price
+         * @param {float} [trailingTriggerPrice] the price to activate a trailing order, default uses the price argument
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        params['trailingPercent'] = trailingPercent;
+        if (trailingTriggerPrice !== undefined) {
+            params['trailingTriggerPrice'] = trailingTriggerPrice;
+        }
+        if (this.has['createTrailingPercentOrder']) {
+            return await this.createOrder (symbol, type, side, amount, price, params);
+        }
+        throw new NotSupported (this.id + ' createTrailingPercentOrder() is not supported yet');
     }
 
     async createMarketOrderWithCost (symbol: string, side: OrderSide, cost, params = {}) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -46,6 +46,7 @@ export default class binance extends Exchange {
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrderWithCost': true,
                 'createMarketSellOrderWithCost': true,
+                'createTrailingPercentOrder': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -38,6 +38,8 @@ export default class bingx extends Exchange {
                 'createMarketSellOrderWithCost': true,
                 'createOrder': true,
                 'createOrders': true,
+                'createTrailingAmountOrder': true,
+                'createTrailingPercentOrder': true,
                 'fetchBalance': true,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': true,

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -42,6 +42,7 @@ export default class bitget extends Exchange {
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
+                'createTrailingPercentOrder': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createReduceOnlyOrder': false,

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -41,6 +41,7 @@ export default class bitmart extends Exchange {
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
+                'createTrailingPercentOrder': true,
                 'createOrder': true,
                 'createPostOnlyOrder': true,
                 'createStopLimitOrder': false,

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -44,6 +44,7 @@ export default class bitmex extends Exchange {
                 'closePosition': true,
                 'createOrder': true,
                 'createReduceOnlyOrder': true,
+                'createTrailingAmountOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
                 'fetchClosedOrders': true,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -41,6 +41,7 @@ export default class bybit extends Exchange {
                 'closePosition': false,
                 'createMarketBuyOrderWithCost': true,
                 'createMarketSellOrderWithCost': false,
+                'createTrailingAmountOrder': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -38,6 +38,7 @@ export default class deribit extends Exchange {
                 'cancelOrder': true,
                 'cancelOrders': false,
                 'createDepositAddress': true,
+                'createTrailingAmountOrder': true,
                 'createOrder': true,
                 'createStopLimitOrder': true,
                 'createStopMarketOrder': true,

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -43,6 +43,7 @@ export default class htx extends Exchange {
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
+                'createTrailingPercentOrder': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createReduceOnlyOrder': false,

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -40,6 +40,7 @@ export default class kraken extends Exchange {
                 'createOrder': true,
                 'createStopLimitOrder': true,
                 'createStopMarketOrder': true,
+                'createTrailingAmountOrder': true,
                 'createStopOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -40,6 +40,7 @@ export default class okx extends Exchange {
                 'createDepositAddress': false,
                 'createMarketBuyOrderWithCost': true,
                 'createMarketSellOrderWithCost': true,
+                'createTrailingPercentOrder': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -376,6 +376,46 @@
                 ]
             }
         ],
+        "createTrailingAmountOrder": [
+            {
+                "description": "Swap create a trailing amount order",
+                "method": "createTrailingAmountOrder",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=1000&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1704859549691&type=TRAILING_STOP_MARKET&signature=f026f00618ba73fdc6f07d69601e8d6d66f861cfaa0d46d08b6bb7eaaa5eb194",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  1000,
+                  null,
+                  {
+                    "reduceOnly": true,
+                    "trailingAmount": 1000
+                  }
+                ]
+            }
+        ],
+        "createTrailingPercentOrder": [
+            {
+                "description": "Swap create a trailing percent order",
+                "method": "createTrailingPercentOrder",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&priceRate=0.05&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1704859767615&type=TRAILING_STOP_MARKET&signature=682c1e28fea424756445d9c41f4ff1c864293ca1f77b3eec31ca847402afa426",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "market",
+                  "sell",
+                  0.0001,
+                  null,
+                  5,
+                  null,
+                  {
+                    "reduceOnly": true,
+                    "trailingPercent": 5
+                  }
+                ]
+            }
+        ],
         "cancelOrder": [
             {
                 "description": "Spot cancel order",

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -43,6 +43,8 @@ export default class woo extends Exchange {
                 'createMarketOrder': false,
                 'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
+                'createTrailingAmountOrder': true,
+                'createTrailingPercentOrder': true,
                 'createOrder': true,
                 'createReduceOnlyOrder': true,
                 'createStopLimitOrder': false,


### PR DESCRIPTION
Added new functions `createTrailingAmountOrder` and `createTrailingPercentOrder` to the base exchange class and added support to bingx:

```
bingx createTrailingAmountOrder BTC/USDT:USDT market sell 0.0001 undefined 1000 undefined '{"reduceOnly":true}'

bingx.createTrailingAmountOrder (BTC/USDT:USDT, market, sell, 0.0001, , 1000, , [object Object])
2024-01-10T04:05:50.004Z iteration 0 passed in 1315 ms

{
  info: {
    orderId: '0',
    symbol: 'BTC-USDT',
    positionSide: 'LONG',
    side: 'SELL',
    type: 'TRAILING_STOP_MARKET',
    price: '1000',
    quantity: '0.0001',
    stopPrice: '0',
    workingType: 'MARK_PRICE',
    clientOrderID: '',
    timeInForce: 'GTC',
    priceRate: '0',
    stopLoss: '',
    takeProfit: '',
    reduceOnly: false
  },
  id: '0',
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop_market',
  side: 'sell',
  price: 1000,
  stopPrice: 0,
  triggerPrice: 0,
  fee: { currency: 'USDT' },
  trades: [],
  fees: [ { currency: 'USDT' } ]
}
```
```
bingx createTrailingPercentOrder BTC/USDT:USDT market sell 0.0001 undefined 5 undefined '{"reduceOnly":true}'

bingx.createTrailingPercentOrder (BTC/USDT:USDT, market, sell, 0.0001, , 5, , [object Object])
2024-01-10T04:09:27.942Z iteration 0 passed in 1329 ms

{
  info: {
    orderId: '0',
    symbol: 'BTC-USDT',
    positionSide: 'LONG',
    side: 'SELL',
    type: 'TRAILING_STOP_MARKET',
    price: '0',
    quantity: '0.0001',
    stopPrice: '0',
    workingType: 'MARK_PRICE',
    clientOrderID: '',
    timeInForce: 'GTC',
    priceRate: '0.05',
    stopLoss: '',
    takeProfit: '',
    reduceOnly: false
  },
  id: '0',
  symbol: 'BTC/USDT:USDT',
  type: 'trailing_stop_market',
  side: 'sell',
  stopPrice: 0,
  triggerPrice: 0,
  fee: { currency: 'USDT' },
  trades: [],
  fees: [ { currency: 'USDT' } ]
}
```