### PR TITLE
Okx: fix fetchStatus

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1220,9 +1220,16 @@ export default class okx extends Exchange {
         for (let i = 0; i < data.length; i++) {
             const event = data[i];
             const state = this.safeString (event, 'state');
+            update['eta'] = this.safeInteger (event, 'end');
+            update['url'] = this.safeString (event, 'href');
             if (state === 'ongoing') {
-                update['eta'] = this.safeInteger (event, 'end');
                 update['status'] = 'maintenance';
+            } else if (state === 'scheduled') {
+                update['status'] = 'ok';
+            } else if (state === 'completed') {
+                update['status'] = 'ok';
+            } else if (state === 'canceled') {
+                update['status'] = 'ok';
             }
         }
         return update;


### PR DESCRIPTION
- Edited the `status` handling in fetchStatus
- Added the `url` value for populated responses

fixes: #20750

```
okx.fetchStatus ()
2024-01-10T05:33:34.556Z iteration 0 passed in 353 ms

{ status: 'ok', info: { code: '0', data: [], msg: '' } }
```