### PR TITLE
Binance: update endpoints for borrow margin methods

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -228,6 +228,7 @@ export default class binance extends Exchange {
                         'asset/convert-transfer/queryByPage': 0.033335,
                         'asset/wallet/balance': 6, // Weight(IP): 60 => cost = 0.1 * 60 = 6
                         'asset/custody/transfer-history': 6, // Weight(IP): 60 => cost = 0.1 * 60 = 6
+                        'margin/borrow-repay': 1,
                         'margin/loan': 1,
                         'margin/repay': 1,
                         'margin/account': 1,
@@ -479,6 +480,7 @@ export default class binance extends Exchange {
                         'capital/withdraw/apply': 4.0002, // Weight(UID): 600 => cost = 0.006667 * 600 = 4.0002
                         'capital/contract/convertible-coins': 4.0002,
                         'capital/deposit/credit-apply': 0.1, // Weight(IP): 1 => cost = 0.1 * 1 = 0.1
+                        'margin/borrow-repay': 20.001,
                         'margin/transfer': 4.0002,
                         'margin/loan': 20.001, // Weight(UID): 3000 => cost = 0.006667 * 3000 = 20.001
                         'margin/repay': 20.001,
@@ -9036,7 +9038,7 @@ export default class binance extends Exchange {
          * @method
          * @name binance#repayCrossMargin
          * @description repay borrowed margin and interest
-         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-repay-margin
+         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-repay-margin
          * @param {string} code unified currency code of the currency to repay
          * @param {float} amount the amount to repay
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -9048,8 +9050,9 @@ export default class binance extends Exchange {
             'asset': currency['id'],
             'amount': this.currencyToPrecision (code, amount),
             'isIsolated': 'FALSE',
+            'type': 'REPAY',
         };
-        const response = await this.sapiPostMarginRepay (this.extend (request, params));
+        const response = await this.sapiPostMarginBorrowRepay (this.extend (request, params));
         //
         //     {
         //         "tranId": 108988250265,
@@ -9064,7 +9067,7 @@ export default class binance extends Exchange {
          * @method
          * @name binance#repayIsolatedMargin
          * @description repay borrowed margin and interest
-         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-repay-margin
+         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-repay-margin
          * @param {string} symbol unified market symbol, required for isolated margin
          * @param {string} code unified currency code of the currency to repay
          * @param {float} amount the amount to repay
@@ -9079,8 +9082,9 @@ export default class binance extends Exchange {
             'amount': this.currencyToPrecision (code, amount),
             'symbol': market['id'],
             'isIsolated': 'TRUE',
+            'type': 'REPAY',
         };
-        const response = await this.sapiPostMarginRepay (this.extend (request, params));
+        const response = await this.sapiPostMarginBorrowRepay (this.extend (request, params));
         //
         //     {
         //         "tranId": 108988250265,
@@ -9095,7 +9099,7 @@ export default class binance extends Exchange {
          * @method
          * @name binance#borrowCrossMargin
          * @description create a loan to borrow margin
-         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-margin
+         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-repay-margin
          * @param {string} code unified currency code of the currency to borrow
          * @param {float} amount the amount to borrow
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -9107,8 +9111,9 @@ export default class binance extends Exchange {
             'asset': currency['id'],
             'amount': this.currencyToPrecision (code, amount),
             'isIsolated': 'FALSE',
+            'type': 'BORROW',
         };
-        const response = await this.sapiPostMarginLoan (this.extend (request, params));
+        const response = await this.sapiPostMarginBorrowRepay (this.extend (request, params));
         //
         //     {
         //         "tranId": 108988250265,
@@ -9123,7 +9128,7 @@ export default class binance extends Exchange {
          * @method
          * @name binance#borrowIsolatedMargin
          * @description create a loan to borrow margin
-         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-margin
+         * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-repay-margin
          * @param {string} symbol unified market symbol, required for isolated margin
          * @param {string} code unified currency code of the currency to borrow
          * @param {float} amount the amount to borrow
@@ -9138,8 +9143,9 @@ export default class binance extends Exchange {
             'amount': this.currencyToPrecision (code, amount),
             'symbol': market['id'],
             'isIsolated': 'TRUE',
+            'type': 'BORROW',
         };
-        const response = await this.sapiPostMarginLoan (this.extend (request, params));
+        const response = await this.sapiPostMarginBorrowRepay (this.extend (request, params));
         //
         //     {
         //         "tranId": 108988250265,

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1316,6 +1316,56 @@
                   ]
                 ]
             }
+        ],
+        "borrowIsolatedMargin":[
+            {
+                "description": "Borrow isolated margin",
+                "method": "borrowIsolatedMargin",
+                "url": "https://api.binance.com/sapi/v1/margin/borrow-repay",
+                "input": [
+                  "LTC/USDT",
+                  "USDT",
+                  1
+                ],
+                "output": "timestamp=1704884479247&asset=USDT&amount=1&symbol=LTCUSDT&isIsolated=TRUE&type=BORROW&recvWindow=10000&signature=f173dc9490b5b255ac77fbf3bd0a53586cc768d2364cd0c439d51084ea1c4f98"
+            }
+        ],
+        "repayIsolatedMargin": [
+            {
+                "description": "Repay isolated margin",
+                "method": "repayIsolatedMargin",
+                "url": "https://api.binance.com/sapi/v1/margin/borrow-repay",
+                "input": [
+                  "LTC/USDT",
+                  "USDT",
+                  1
+                ],
+                "output": "timestamp=1704884544319&asset=USDT&amount=1&symbol=LTCUSDT&isIsolated=TRUE&type=REPAY&recvWindow=10000&signature=aa81a97855a7512780aebf078a1a149360dcbee2111ab8e416881ff0e8c933a8"
+            }
+        ],
+        "borrowCrossMargin": [
+            {
+                "description": "borrow cross margin",
+                "method": "borrowCrossMargin",
+                "url": "https://api.binance.com/sapi/v1/margin/borrow-repay",
+                "input": [
+                  "USDT",
+                  1
+                ],
+                "output": "timestamp=1704884619619&asset=USDT&amount=1&isIsolated=FALSE&type=BORROW&recvWindow=10000&signature=7decbb81d0e7d0b0d553496893c7a36438ddcba418c9437eaa384a541325843b"
+            }
+        ],
+        "repayCrossMargin": [
+            {
+                "description": "repay cross margin",
+                "method": "repayCrossMargin",
+                "url": "https://api.binance.com/sapi/v1/margin/borrow-repay",
+                "input": [
+                  "USDT",
+                  1
+                ],
+                "output": "timestamp=1704884654418&asset=USDT&amount=1&isIsolated=FALSE&type=REPAY&recvWindow=10000&signature=22d5b8db751dc8cc40771a7e6999e863c5630b9108c15dca22c7bebd6b07ca17"
+            }
         ]
     }
 }


### PR DESCRIPTION
Updated the endpoints for the methods `borrowIsolatedMargin`, `borrowCrossMargin`, `repayIsolatedMargin`, and `repayCrossMargin` because the previously used endpoints are being phased out.

I was unable to test these changes because I only have testnet API keys at the moment and I'm receiving this error:

`[NotSupported] binance does not have a testnet/sandbox URL for sapi endpoints`