### PR TITLE
fix(probit) - max fetchtrades limit (QUICK)

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -797,6 +797,8 @@ export default class probit extends Exchange {
         }
         if (limit !== undefined) {
             request['limit'] = Math.min (limit, 1000);
+        } else {
+            request['limit'] = 1000; // required to set any value
         }
         const response = await this.publicGetTrade (this.extend (request, params));
         //

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -789,7 +789,6 @@ export default class probit extends Exchange {
         const market = this.market (symbol);
         const request = {
             'market_id': market['id'],
-            'limit': 100,
             'start_time': '1970-01-01T00:00:00.000Z',
             'end_time': this.iso8601 (this.milliseconds ()),
         };
@@ -797,7 +796,7 @@ export default class probit extends Exchange {
             request['start_time'] = this.iso8601 (since);
         }
         if (limit !== undefined) {
-            request['limit'] = Math.min (limit, 10000);
+            request['limit'] = Math.min (limit, 1000);
         }
         const response = await this.publicGetTrade (this.extend (request, params));
         //


### PR DESCRIPTION
max limit is 1000 now: https://docs-en.probit.com/reference/trade-1
otherwise throws ` {"errorCode":"INVALID_ARGUMENT","message":"","details":{"limit":"invalid"}}`

though, the crappy engine, independently providing the limit argument, the response back still contains 2000 items :) but you can't put limit yourself above 1000.