### PR TITLE
fix(gemini) - max trades limit

### DIFF
--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -968,7 +968,7 @@ export default class gemini extends Exchange {
             'symbol': market['id'],
         };
         if (limit !== undefined) {
-            request['limit_trades'] = limit;
+            request['limit_trades'] = Math.min (limit, 500);
         }
         if (since !== undefined) {
             request['timestamp'] = since;


### PR DESCRIPTION
api docs does not mention it:
https://docs.gemini.com/rest-api/#trade-history
but after testing manually it turns out to be 500, after it exception is thrown