### PR TITLE
fix(gate) - max trades limit (QUICK)

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3122,7 +3122,7 @@ export default class gate extends Exchange {
             request['to'] = this.parseToInt (until / 1000);
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // default 100, max 1000
+            request['limit'] = Math.min (limit, 1000); // default 100, max 1000
         }
         if (since !== undefined && (market['contract'])) {
             request['from'] = this.parseToInt (since / 1000);


### PR DESCRIPTION
there is limit 1000, above that exception is thrown   https://www.gate.io/docs/developers/apiv4/en/#retrieve-market-trades:~:text=list.%20Default%3A%20100%2C%20Minimum%3A%201%2C%20Maximum%3A%201000

(swap & futures does not have a note in api docs by manual testing, seems 1000 is the limit for them too) 