### PR TITLE
fix(kraken) - trades max limit (QUICK)

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1280,12 +1280,8 @@ export default class kraken extends Exchange {
             request['since'] = since * 1e6;
             request['since'] = since.toString () + '000000'; // expected to be in nanoseconds
         }
-        // https://github.com/ccxt/ccxt/issues/5698
-        if (limit !== undefined && limit !== 1000) {
-            const fetchTradesWarning = this.safeValue (this.options, 'fetchTradesWarning', true);
-            if (fetchTradesWarning) {
-                throw new ExchangeError (this.id + ' fetchTrades() cannot serve ' + limit.toString () + " trades without breaking the pagination, see https://github.com/ccxt/ccxt/issues/5698 for more details. Set exchange.options['fetchTradesWarning'] to acknowledge this warning and silence it.");
-            }
+        if (limit !== undefined) {
+            request['count'] = limit;
         }
         const response = await this.publicGetTrades (this.extend (request, params));
         //


### PR DESCRIPTION
fix old fTrades implementation of kaken.  that commented issue seems it was 4 years ago (when api didn't have limit support), but now limit (`count`) param is supported:

https://docs.kraken.com/rest/#tag/Market-Data/operation/getRecentTrades

so i have not rerpoduced that old mentioned issue anylonger, so it seems to work now well.

(fix #5698)