### PR TITLE
fix(oceanex) - trades max limit (QUICK)

### DIFF
--- a/ts/src/oceanex.ts
+++ b/ts/src/oceanex.ts
@@ -482,7 +482,7 @@ export default class oceanex extends Exchange {
             'market': market['id'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         const response = await this.publicGetTrades (this.extend (request, params));
         //


### PR DESCRIPTION
api docs does not say: https://api.oceanex.pro/doc/v1/#trades-post:~:text=Limit%20the%20number%20of%20returned%20trades.%20Default%20to%2050. 
but manually reproduced the maximum, beyond it exception happens.