### PR TITLE
fix(wavesexchange) - fix trades limit (QUICK)

### DIFF
--- a/ts/src/wavesexchange.ts
+++ b/ts/src/wavesexchange.ts
@@ -2114,7 +2114,7 @@ export default class wavesexchange extends Exchange {
             'priceAsset': market['quoteId'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 100);
         }
         if (since !== undefined) {
             request['timeStart'] = since;


### PR DESCRIPTION
100 is max limit, beyond API triggers excetpion