### PR TITLE
fix(kraken): watchOHLCV interval must be passed as integer

### DIFF
--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -560,7 +560,7 @@ export default class kraken extends krakenRest {
             ],
             'subscription': {
                 'name': name,
-                'interval': this.safeString (this.timeframes, timeframe, timeframe),
+                'interval': this.safeValue (this.timeframes, timeframe, timeframe),
             },
         };
         const request = this.deepExtend (subscribe, params);


### PR DESCRIPTION
The interval parameter to the ohlc subscription _must be_ an integer value (was converted to string by safeString).
