### PR TITLE
feat(bingx): add fetchMyTrades in spot market

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -121,6 +121,7 @@ export default class bingx extends Exchange {
                                 'trade/query': 3,
                                 'trade/openOrders': 3,
                                 'trade/historyOrders': 3,
+                                'trade/myTrades': 3,
                                 'user/commissionRate': 3,
                                 'account/balance': 3,
                             },
@@ -180,6 +181,7 @@ export default class bingx extends Exchange {
                                 'user/positions': 3,
                                 'user/income': 3,
                                 'trade/openOrders': 3,
+                                'trade/openOrder': 3,
                                 'trade/order': 3,
                                 'trade/marginType': 3,
                                 'trade/leverage': 3,
@@ -856,6 +858,22 @@ export default class bingx extends Exchange {
         //        "buyerMaker": false
         //    }
         //
+        // spot
+        // fetchMyTrades
+        //     {
+        //         "symbol": "LTC-USDT",
+        //         "id": 36237072,
+        //         "orderId": 1674069326895775744,
+        //         "price": "85.891",
+        //         "qty": "0.0582",
+        //         "quoteQty": "4.9988562000000005",
+        //         "commission": -0.00005820000000000001,
+        //         "commissionAsset": "LTC",
+        //         "time": 1687964205000,
+        //         "isBuyer": true,
+        //         "isMaker": false
+        //     }
+        //
         // swap
         // fetchTrades
         //
@@ -918,7 +936,7 @@ export default class bingx extends Exchange {
         }
         const cost = this.safeString (trade, 'quoteQty');
         const type = (cost === undefined) ? 'spot' : 'swap';
-        const currencyId = this.safeString2 (trade, 'currency', 'N');
+        const currencyId = this.safeStringN (trade, [ 'currency', 'N', 'commissionAsset' ]);
         const currencyCode = this.safeCurrencyCode (currencyId);
         const m = this.safeValue (trade, 'm');
         const marketId = this.safeString (trade, 's');
@@ -933,6 +951,14 @@ export default class bingx extends Exchange {
                 side = (isBuyerMaker || m) ? 'sell' : 'buy';
                 takeOrMaker = 'taker';
             }
+        }
+        const isBuyer = this.safeValue (trade, 'isBuyer');
+        if (isBuyer !== undefined) {
+            side = isBuyer ? 'buy' : 'sell';
+        }
+        const isMaker = this.safeValue (trade, 'isMaker');
+        if (isMaker !== undefined) {
+            takeOrMaker = isMaker ? 'maker' : 'taker';
         }
         return this.safeTrade ({
             'id': this.safeStringN (trade, [ 'id', 't' ]),
@@ -3277,57 +3303,97 @@ export default class bingx extends Exchange {
          * @method
          * @name bingx#fetchMyTrades
          * @description fetch all trades made by the user
+         * @see https://bingx-api.github.io/docs/#/en-us/spot/trade-api.html#Query%20Order%20History
          * @see https://bingx-api.github.io/docs/#/swapV2/trade-api.html#Query%20historical%20transaction%20orders
          * @param {string} [symbol] unified market symbol
          * @param {int} [since] the earliest time in ms to fetch trades for
          * @param {int} [limit] the maximum number of trades structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {int} [params.until] timestamp in ms for the ending date filter, default is undefined
          * @param {string} params.trandingUnit COIN (directly represent assets such as BTC and ETH) or CONT (represents the number of contract sheets)
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
          */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol argument');
         }
-        if (since === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a since argument');
-        }
-        const tradingUnit = this.safeStringUpper (params, 'tradingUnit', 'CONT');
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (market['spot']) {
-            throw new BadSymbol (this.id + ' fetchMyTrades() supports swap contracts only');
-        }
+        let response = undefined;
         const request = {
             'symbol': market['id'],
-            'tradingUnit': tradingUnit,
-            'startTs': since,
-            'endTs': this.nonce (),
         };
-        const query = this.omit (params, 'tradingUnit');
-        const response = await this.swapV2PrivateGetTradeAllFillOrders (this.extend (request, query));
-        //
-        //    {
-        //       "code": "0",
-        //       "msg": '',
-        //       "data": { fill_orders: [
-        //          {
-        //              "volume": "0.1",
-        //              "price": "106.75",
-        //              "amount": "10.6750",
-        //              "commission": "-0.0053",
-        //              "currency": "USDT",
-        //              "orderId": "1676213270274379776",
-        //              "liquidatedPrice": "0.00",
-        //              "liquidatedMarginRatio": "0.00",
-        //              "filledTime": "2023-07-04T20:56:01.000+0800"
-        //          }
-        //        ]
-        //      }
-        //    }
-        //
-        const data = this.safeValue (response, 'data', []);
-        const fillOrders = this.safeValue (data, 'fill_orders', []);
-        return this.parseTrades (fillOrders, market, since, limit, query);
+        if (since !== undefined) {
+            const startTimeReq = market['spot'] ? 'startTime' : 'startTs';
+            request[startTimeReq] = since;
+        } else if (market['swap']) {
+            throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a since argument in swap market type');
+        }
+        const until = this.safeInteger (params, 'until');
+        params = this.omit (params, 'until');
+        if (until !== undefined) {
+            const endTimeReq = market['spot'] ? 'endTime' : 'endTs';
+            request[endTimeReq] = until;
+        } else if (market['swap']) {
+            request['endTs'] = this.nonce ();
+        }
+        let fills = undefined;
+        if (market['spot']) {
+            response = await this.spotV1PrivateGetTradeMyTrades (this.extend (request, params));
+            const data = this.safeValue (response, 'data', []);
+            fills = this.safeValue (data, 'fills', []);
+            //
+            //     {
+            //         "code": 0,
+            //         "msg": "",
+            //         "debugMsg": "",
+            //         "data": {
+            //             "fills": [
+            //                 {
+            //                     "symbol": "LTC-USDT",
+            //                     "id": 36237072,
+            //                     "orderId": 1674069326895775744,
+            //                     "price": "85.891",
+            //                     "qty": "0.0582",
+            //                     "quoteQty": "4.9988562000000005",
+            //                     "commission": -0.00005820000000000001,
+            //                     "commissionAsset": "LTC",
+            //                     "time": 1687964205000,
+            //                     "isBuyer": true,
+            //                     "isMaker": false
+            //                 }
+            //             ]
+            //         }
+            //     }
+            //
+        } else {
+            const tradingUnit = this.safeStringUpper (params, 'tradingUnit', 'CONT');
+            params = this.omit (params, 'tradingUnit');
+            request['tradingUnit'] = tradingUnit;
+            response = await this.swapV2PrivateGetTradeAllFillOrders (this.extend (request, params));
+            const data = this.safeValue (response, 'data', []);
+            fills = this.safeValue (data, 'fill_orders', []);
+            //
+            //    {
+            //       "code": "0",
+            //       "msg": '',
+            //       "data": { fill_orders: [
+            //          {
+            //              "volume": "0.1",
+            //              "price": "106.75",
+            //              "amount": "10.6750",
+            //              "commission": "-0.0053",
+            //              "currency": "USDT",
+            //              "orderId": "1676213270274379776",
+            //              "liquidatedPrice": "0.00",
+            //              "liquidatedMarginRatio": "0.00",
+            //              "filledTime": "2023-07-04T20:56:01.000+0800"
+            //          }
+            //        ]
+            //      }
+            //    }
+            //
+        }
+        return this.parseTrades (fills, market, since, limit, params);
     }
 
     parseDepositWithdrawFee (fee, currency: Currency = undefined) {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3318,6 +3318,7 @@ export default class bingx extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const now = this.milliseconds ();
         let response = undefined;
         const request = {
             'symbol': market['id'],
@@ -3326,7 +3327,7 @@ export default class bingx extends Exchange {
             const startTimeReq = market['spot'] ? 'startTime' : 'startTs';
             request[startTimeReq] = since;
         } else if (market['swap']) {
-            throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a since argument in swap market type');
+            request['startTs'] = now - 7776000000; // 90 days
         }
         const until = this.safeInteger (params, 'until');
         params = this.omit (params, 'until');
@@ -3334,7 +3335,7 @@ export default class bingx extends Exchange {
             const endTimeReq = market['spot'] ? 'endTime' : 'endTs';
             request[endTimeReq] = until;
         } else if (market['swap']) {
-            request['endTs'] = this.nonce ();
+            request['endTs'] = now;
         }
         let fills = undefined;
         if (market['spot']) {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -2,7 +2,9 @@
     "exchange": "bingx",
     "skipKeys": [
         "timestamp",
-        "signature"
+        "signature",
+        "startTs",
+        "endTs"
     ],
     "outputType": "urlencoded",
     "methods": {
@@ -680,6 +682,25 @@
                 "url": "https://open-api.bingx.com/openApi/swap/v1/positionSide/dual?dualSidePosition=true&timestamp=1698777135343&signature=d55a7e4f7f9dbe56c4004c9f3ab340869d3cb004e2f0b5b861e5fbd1762fd9a0",
                 "input": [
                     true
+                ]
+            }
+        ],
+        "fetchMyTrades": [
+            {
+                "description": "fetch my trades - spot",
+                "method": "fetchMyTrades",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/trade/myTrades?symbol=LTC-USDT&timestamp=1699460638640&signature=e5942598ddd9d11cceec8f7e2acb3269c8c2dfe237642314eca3b5d8a5c308e0",
+                "input": [
+                    "LTC/USDT"
+                ]
+            },
+            {
+                "description": "fetch my trades - swap",
+                "method": "fetchMyTrades",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/allFillOrders?endTs=1705040628035&startTs=1687964205000&symbol=LTC-USDT&tradingUnit=CONT&timestamp=1699460638640&signature=e5942598ddd9d11cceec8f7e2acb3269c8c2dfe237642314eca3b5d8a5c308e0",
+                "input": [
+                    "LTC/USDT:USDT",
+                    1687964205000
                 ]
             }
         ]

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -742,6 +742,153 @@
           }
         }
       }
+    ],
+    "fetchMyTrades": [
+      {
+        "description": "Swap trade",
+        "method": "fetchMyTrades",
+        "input": [
+          "LTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "data": {
+            "fill_orders": [
+              {
+                "filledTm": "2024-01-06T21:19:45Z",
+                "volume": "10",
+                "price": "65.2965",
+                "amount": "65.2965",
+                "commission": "-0.0326",
+                "currency": "USDT",
+                "orderId": "1743623387810590720",
+                "liquidatedPrice": "",
+                "liquidatedMarginRatio": "",
+                "filledTime": "2024-01-06T21:19:45.000+0800",
+                "clientOrderID": "",
+                "symbol": "LTC-USDT",
+                "onlyOnePosition": false
+              }
+            ]
+          }
+        },
+        "parsedResponse": [
+          {
+            "id": null,
+            "info": {
+              "filledTm": "2024-01-06T21:19:45Z",
+              "volume": "10",
+              "price": "65.2965",
+              "amount": "65.2965",
+              "commission": "-0.0326",
+              "currency": "USDT",
+              "orderId": "1743623387810590720",
+              "liquidatedPrice": "",
+              "liquidatedMarginRatio": "",
+              "filledTime": "2024-01-06T21:19:45.000+0800",
+              "clientOrderID": "",
+              "symbol": "LTC-USDT",
+              "onlyOnePosition": false
+            },
+            "timestamp": 1704575985000,
+            "datetime": "2024-01-06T21:19:45.000Z",
+            "symbol": "LTC/USDT:USDT",
+            "order": "1743623387810590720",
+            "type": null,
+            "side": null,
+            "takerOrMaker": null,
+            "price": 65.2965,
+            "amount": 10,
+            "cost": 65.2965,
+            "fee": {
+              "cost": 0.0326,
+              "currency": "USDT",
+              "rate": null
+            },
+            "fees": [
+              {
+                "cost": 0.0326,
+                "currency": "USDT",
+                "rate": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Spot trade",
+        "method": "fetchMyTrades",
+        "input": [
+          "LTC/USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "code": "0",
+          "msg": "",
+          "debugMsg": "",
+          "data": {
+            "fills": [
+              {
+                "symbol": "LTC-USDT",
+                "id": "49884117",
+                "orderId": "1740029773184237568",
+                "price": "75.562",
+                "qty": "0.1",
+                "quoteQty": "7.5562000000000005",
+                "commission": "-0.0001",
+                "commissionAsset": "LTC",
+                "time": "1703690401000",
+                "isBuyer": true,
+                "isMaker": false
+              }
+            ]
+          }
+        },
+        "parsedResponse": [
+          {
+            "id": "49884117",
+            "info": {
+              "symbol": "LTC-USDT",
+              "id": "49884117",
+              "orderId": "1740029773184237568",
+              "price": "75.562",
+              "qty": "0.1",
+              "quoteQty": "7.5562000000000005",
+              "commission": "-0.0001",
+              "commissionAsset": "LTC",
+              "time": "1703690401000",
+              "isBuyer": true,
+              "isMaker": false
+            },
+            "timestamp": 1703690401000,
+            "datetime": "2023-12-27T15:20:01.000Z",
+            "symbol": "LTC/USDT",
+            "order": "1740029773184237568",
+            "type": null,
+            "side": "buy",
+            "takerOrMaker": "taker",
+            "price": 75.562,
+            "amount": 0.1,
+            "cost": 7.5562000000000005,
+            "fee": {
+              "cost": 0.0001,
+              "currency": "LTC",
+              "rate": null
+            },
+            "fees": [
+              {
+                "cost": 0.0001,
+                "currency": "LTC",
+                "rate": null
+              }
+            ]
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
```BASH
$ p bingx fetchMyTrades LTC/USDT 1703690338000 1
Python v3.11.3
CCXT v4.2.12
bingx.fetchMyTrades(LTC/USDT,1703690338000,1)
[{'amount': 0.1,
  'cost': 7.5562000000000005,
  'datetime': '2023-12-27T15:20:01.000Z',
  'fee': {'cost': 0.0001, 'currency': 'LTC', 'rate': None},
  'fees': [{'cost': 0.0001, 'currency': 'LTC', 'rate': None}],
  'id': '49884117',
  'info': {'commission': '-0.0001',
           'commissionAsset': 'LTC',
           'id': '49884117',
           'isBuyer': True,
           'isMaker': False,
           'orderId': '1740029773184237568',
           'price': '75.562',
           'qty': '0.1',
           'quoteQty': '7.5562000000000005',
           'symbol': 'LTC-USDT',
           'time': '1703690401000'},
  'order': '1740029773184237568',
  'price': 75.562,
  'side': 'buy',
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1703690401000,
  'type': None}]
```