### PR TITLE
fetchOHLCV: switch between current and history candles

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2146,17 +2146,14 @@ export default class okx extends Exchange {
         let defaultType = 'Candles';
         if (since !== undefined) {
             const now = this.milliseconds ();
-            const difference = now - since;
             const durationInMilliseconds = duration * 1000;
-            // if the since timestamp is more than limit candles back in the past
-            // additional one bar for max offset to round the current day to UTC
-            const calc = (1440 - limit - 1) * durationInMilliseconds;
-            if (difference > calc) {
+            // switch to history candles if since is past the cutoff for current candles
+            const historyBorder = now - (1440 * durationInMilliseconds);
+            if (since <= historyBorder) {
                 defaultType = 'HistoryCandles';
             }
-            const startTime = Math.max (since - 1, 0);
-            request['before'] = startTime;
-            request['after'] = this.sum (startTime, durationInMilliseconds * limit);
+            request['before'] = since;
+            request['after'] = this.sum (since, durationInMilliseconds * limit);
         }
         const until = this.safeInteger (params, 'until');
         if (until !== undefined) {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2148,8 +2148,8 @@ export default class okx extends Exchange {
             const now = this.milliseconds ();
             const durationInMilliseconds = duration * 1000;
             // switch to history candles if since is past the cutoff for current candles
-            const historyBorder = now - (1440 * durationInMilliseconds);
-            if (since <= historyBorder) {
+            const historyBorder = now - ((1440 - 1) * durationInMilliseconds);
+            if (since < historyBorder) {
                 defaultType = 'HistoryCandles';
             }
             request['before'] = since;

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -902,6 +902,30 @@
               }
             ]
           }
+        ],
+        "fetchOHLCV": [
+          {
+            "description": "fetchOHLCV using a timestamp that is 1439 candles in the past so that the history endpoint is used",
+            "method": "fetchOHLCV",
+            "url": "https://www.okx.com/api/v5/market/history-candles?instId=BTC-USDT&bar=1H&limit=300&before=1699931781033&after=1701011781033",
+            "input": [
+              "BTC/USDT",
+              "1h",
+              1699931781033,
+              300
+            ]
+          },
+          {
+            "description": "fetchOHLCV using a timestamp that is 1438 candles in the past so that the current endpoint is used",
+            "method": "fetchOHLCV",
+            "url": "https://www.okx.com/api/v5/market/candles?instId=BTC-USDT&bar=1H&limit=300&before=1699935566969&after=1701015566969",
+            "input": [
+              "BTC/USDT",
+              "1h",
+              1699935566969,
+              300
+            ]
+          }
         ]
     }
 }


### PR DESCRIPTION
Edited how fetchOHLCV switches between history and current candles in the since handling
fixes: #20756
### Test 1 (history candles):
```
const hourInMs = 3600 * 1000;
since = this.milliseconds() - 1439 * hourInMs;
```
```
okx.fetchOHLCV (BTC/USDT, 1h, 1699862134346, 300)

okx GET https://www.okx.com/api/v5/market/history-candles?instId=BTC-USDT&bar=1H&limit=300&before=1699862134346&after=1700942134346

1700582400000 | 36974.8 | 37260.1 |   36750 | 37190.8 | 14441.17524511
1700586000000 | 37191.5 | 37509.7 | 36612.4 |   36900 | 90031.81273416
1700589600000 | 36903.9 | 36964.6 | 35779.1 | 35853.3 |    120.9956569
...
1700931600000 |   37744 | 37799.3 |   37700 |   37770 |   674.07239716
1700935200000 |   37770 | 37820.2 | 37755.4 | 37818.3 |   746.98028882
1700938800000 |   37819 |   37840 | 37790.2 | 37818.3 |   684.92567018
100 objects
```
### Test 2 (current candles):
```
const hourInMs = 3600 * 1000;
since = this.milliseconds() - 1438 * hourInMs;
```
```
okx.fetchOHLCV (BTC/USDT, 1h,1699865851198 , 300)

okx GET https://www.okx.com/api/v5/market/candles?instId=BTC-USDT&bar=1H&limit=300&before=1699865851198&after=1700945851198

1699866000000 | 37027.4 | 37040.1 | 36947.3 |   36982 |   1507.79655319
1699869600000 |   36984 | 37009.1 | 36914.9 | 36973.7 |   2561.28039174
1699873200000 | 36972.8 | 36973.7 | 36700.8 | 36817.3 |   5842.25295832
...
1700935200000 |   37770 | 37820.2 | 37755.4 | 37818.3 |    746.98028882
1700938800000 |   37819 |   37840 | 37790.2 | 37818.3 |    684.92567018
1700942400000 | 37818.3 | 37886.9 | 37766.6 | 37800.1 |    1017.9527583
300 objects
```