### PR TITLE
fix(build) jsdoc2md.js script throws exception for woo and htx exchanges

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -4895,7 +4895,7 @@ export default class htx extends Exchange {
     async createTrailingPercentOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingPercent = undefined, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
         /**
          * @method
-         * @name createTrailingPercentOrder
+         * @name htx#createTrailingPercentOrder
          * @description create a trailing order by providing the symbol, type, side, amount, price and trailingPercent
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -776,7 +776,7 @@ export default class woo extends Exchange {
     async createTrailingAmountOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingAmount = undefined, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
         /**
          * @method
-         * @name createTrailingAmountOrder
+         * @name woo#createTrailingAmountOrder
          * @description create a trailing order by providing the symbol, type, side, amount, price and trailingAmount
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
@@ -802,7 +802,7 @@ export default class woo extends Exchange {
     async createTrailingPercentOrder (symbol: string, type: OrderType, side: OrderSide, amount, price = undefined, trailingPercent = undefined, trailingTriggerPrice = undefined, params = {}): Promise<Order> {
         /**
          * @method
-         * @name createTrailingPercentOrder
+         * @name woo#createTrailingPercentOrder
          * @description create a trailing order by providing the symbol, type, side, amount, price and trailingPercent
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'


### PR DESCRIPTION
got an exception during npm run build-docs

```
RangeError: Maximum call stack size exceeded
    at Object.eval [as main] (eval at createFunctionContext (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:262:23), <anonymous>:9:163)
    at main (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/runtime.js:208:32)
    at ret (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/runtime.js:212:12)
    at ret (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/compiler/compiler.js:519:21)
    at Object.invokePartial (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/runtime.js:334:12)
    at Object.invokePartialWrapper [as invokePartial] (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/runtime.js:84:39)
    at eval (eval at createFunctionContext (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:262:23), <anonymous>:10:31)
    at prog (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/runtime.js:268:12)
    at Object.indexChildren (/Users/user1/dev/currinex/github/ccxt/node_modules/dmd/helpers/ddata.js:174:17)
    at Object.wrapper (/Users/user1/dev/currinex/github/ccxt/node_modules/handlebars/dist/cjs/handlebars/internal/wrapHelper.js:15:19)


```