### PR TITLE
fix(bigone): fetchMarkets uses /symbols endpoint

### DIFF
--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -525,7 +525,10 @@ export default class bigone extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} an array of objects representing market data
          */
-        const response = await this.publicGetAssetPairs (params);
+        const promises = [ this.publicGetAssetPairs (params), this.contractPublicGetSymbols (params) ];
+        const promisesResult = await Promise.all (promises);
+        const response = promisesResult[0];
+        const contractResponse = promisesResult[1];
         //
         //     {
         //         "code":0,
@@ -551,7 +554,6 @@ export default class bigone extends Exchange {
         //         ]
         //     }
         //
-        const contractResponse = await this.contractPublicGetSymbols (params);
         //
         //    [
         //        {

--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -647,7 +647,7 @@ export default class bigone extends Exchange {
             const baseId = this.safeString (market, 'baseCurrency');
             const quoteId = this.safeString (market, 'quoteCurrency');
             const settleId = this.safeString (market, 'settleCurrency');
-            const marketId = this.safeString (market, 'BTCUSD');
+            const marketId = this.safeString (market, 'symbol');
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const settle = this.safeCurrencyCode (settleId);

--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -671,7 +671,7 @@ export default class bigone extends Exchange {
                 'contract': true,
                 'linear': !inverse,
                 'inverse': inverse,
-                'contractSize': this.safeString (market, 'multiplier'),
+                'contractSize': this.safeNumber (market, 'multiplier'),
                 'expiry': undefined,
                 'expiryDatetime': undefined,
                 'strike': undefined,
@@ -694,7 +694,7 @@ export default class bigone extends Exchange {
                         'max': this.safeNumber (market, 'priceMax'),
                     },
                     'cost': {
-                        'min': this.safeString (market, 'initialMargin'),
+                        'min': this.safeNumber (market, 'initialMargin'),
                         'max': undefined,
                     },
                 },

--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -677,8 +677,8 @@ export default class bigone extends Exchange {
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {
-                    'amount': this.safeNumber (market, 'valuePrecision'),
-                    'price': this.safeNumber (market, 'pricePrecision'),
+                    'amount': this.parseNumber (this.parsePrecision (this.safeString (market, 'valuePrecision'))),
+                    'price': this.parseNumber (this.parsePrecision (this.safeString (market, 'pricePrecision'))),
                 },
                 'limits': {
                     'leverage': {

--- a/ts/src/test/static/markets/bigone.json
+++ b/ts/src/test/static/markets/bigone.json
@@ -269,33 +269,43 @@
         "linear": true,
         "inverse": false,
         "subType": "linear",
-        "contractSize": 1,
-        "precision": {},
+        "contractSize": 0.001,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.1
+        },
         "limits": {
             "leverage": {},
             "amount": {},
-            "price": {},
-            "cost": {}
+            "price": {
+                "min": 0.5,
+                "max": 1000000
+            },
+            "cost": {
+                "min": 0.01
+            }
         },
         "info": {
-            "usdtPrice": "1.00059444",
+            "baseCurrency": "BTC",
+            "multiplier": "0.001",
+            "enable": true,
+            "priceStep": "0.5",
+            "maxRiskLimit": "1E+7",
+            "pricePrecision": "1",
+            "maintenanceMargin": "0.005000000",
             "symbol": "BTCUSDT",
-            "btcPrice": "46373.36",
-            "ethPrice": "2439.46",
-            "nextFundingRate": "0.00010",
-            "fundingRate": "0.00010",
-            "latestPrice": "46366.5",
-            "last24hPriceChange": "-0.0084",
-            "indexPrice": "46345.81",
-            "volume24h": "105253093",
-            "turnover24h": "4621735825.696",
-            "nextFundingTime": "1704909600000",
-            "markPrice": "46345.83919786",
-            "last24hMaxPrice": "48008.0",
-            "volume24hInUsd": "4624483170.340227",
-            "openValue": "950450.829789635",
-            "last24hMinPrice": "44336.5",
-            "openInterest": "24046.0"
+            "valuePrecision": "4",
+            "minRiskLimit": "1E+6",
+            "riskLimit": "1E+6",
+            "isInverse": false,
+            "riskStep": "1E+4",
+            "settleCurrency": "USDT",
+            "baseName": "Bitcoin",
+            "feePrecision": "8",
+            "priceMin": "0.5",
+            "priceMax": "1E+6",
+            "initialMargin": "0.010000000",
+            "quoteCurrency": "USDT"
         }
     },
     "XRP/USDT:USDT": {
@@ -318,33 +328,43 @@
         "linear": true,
         "inverse": false,
         "subType": "linear",
-        "contractSize": 1,
-        "precision": {},
+        "contractSize": 100,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.0001
+        },
         "limits": {
             "leverage": {},
             "amount": {},
-            "price": {},
-            "cost": {}
+            "price": {
+                "min": 0.0001,
+                "max": 100000000
+            },
+            "cost": {
+                "min": 0.02
+            }
         },
         "info": {
-            "usdtPrice": "1.00059444",
+            "baseCurrency": "XRP",
+            "multiplier": "1E+2",
+            "enable": true,
+            "priceStep": "0.0001",
+            "maxRiskLimit": "2.1E+6",
+            "pricePrecision": "4",
+            "maintenanceMargin": "0.010000000",
             "symbol": "XRPUSDT",
-            "btcPrice": "46373.36",
-            "ethPrice": "2439.46",
-            "nextFundingRate": "0.00010",
-            "fundingRate": "0.00010",
-            "latestPrice": "0.5695",
-            "last24hPriceChange": "0.0161",
-            "indexPrice": "0.56942",
-            "volume24h": "11391206",
-            "turnover24h": "689659238.97",
-            "nextFundingTime": "1704909600000",
-            "markPrice": "0.56942036",
-            "last24hMaxPrice": "0.5784",
-            "volume24hInUsd": "690069200.0080134",
-            "openValue": "0.0",
-            "last24hMinPrice": "0.5499",
-            "openInterest": "0.0"
+            "valuePrecision": "4",
+            "minRiskLimit": "3E+5",
+            "riskLimit": "3E+5",
+            "isInverse": false,
+            "riskStep": "500",
+            "settleCurrency": "USDT",
+            "baseName": "XRP",
+            "feePrecision": "8",
+            "priceMin": "0.0001",
+            "priceMax": "1E+8",
+            "initialMargin": "0.020000000",
+            "quoteCurrency": "USDT"
         }
     }
 }


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.12
bigone.fetchMarkets()
[{'active': True,
  'base': 'MOB',
  'baseId': 'MOB',
  'contract': False,
  'contractSize': None,
  'created': None,
  'expiry': None,
  'expiryDatetime': None,
  'future': False,
  'id': 'MOB-BTC',
  'index': False,
  'info': {'base_asset': {'id': '3327b9e8-8a25-4e51-bd41-8e6d1b007280',
                          'name': 'Mobilecoin',
                          'symbol': 'MOB'},
           'base_scale': '2',
           'id': '007b24e6-1e27-4a2f-b4a0-247b4b1f39ee',
           'max_quote_value': '35',
           'min_quote_value': '0.0001',
           'name': 'MOB-BTC',
           'quote_asset': {'id': '0df9c3c3-255a-46d7-ab82-dedae169fba9',
                           'name': 'Bitcoin',
                           'symbol': 'BTC'},
           'quote_scale': '6'},
  'inverse': None,
  'limits': {'amount': {'max': None, 'min': None},
             'cost': {'max': 35.0, 'min': 0.0001},
             'leverage': {'max': None, 'min': None},
             'price': {'max': None, 'min': None}},
  'linear': None,
  'lowercaseId': None,
  'maker': None,
  'margin': False,
  'option': False,
  'optionType': None,
  'precision': {'amount': 0.01, 'price': 1e-06},
  'quote': 'BTC',
  'quoteId': 'BTC',
  'settle': None,
  'settleId': None,
  'spot': True,
  'strike': None,
  'subType': None,
  'swap': False,
  'symbol': 'MOB/BTC',
  'taker': None,
  'type': 'spot',
  'uuid': '007b24e6-1e27-4a2f-b4a0-247b4b1f39ee'},
...
 {'active': True,
  'base': 'LTC',
  'baseId': 'LTC',
  'contract': True,
  'contractSize': 1.0,
  'created': None,
  'expiry': None,
  'expiryDatetime': None,
  'future': False,
  'id': 'LTCUSDT',
  'index': None,
  'info': {'baseCurrency': 'LTC',
           'baseName': 'Litecoin',
           'enable': True,
           'feePrecision': '8',
           'initialMargin': '0.020000000',
           'isInverse': False,
           'maintenanceMargin': '0.010000000',
           'maxRiskLimit': '2.1E+6',
           'minRiskLimit': '3E+5',
           'multiplier': '1',
           'priceMax': '1E+8',
           'priceMin': '0.01',
           'pricePrecision': '2',
           'priceStep': '0.01',
           'quoteCurrency': 'USDT',
           'riskLimit': '3E+5',
           'riskStep': '500',
           'settleCurrency': 'USDT',
           'symbol': 'LTCUSDT',
           'valuePrecision': '4'},
  'inverse': False,
  'limits': {'amount': {'max': None, 'min': None},
             'cost': {'max': None, 'min': 0.02},
             'leverage': {'max': None, 'min': None},
             'price': {'max': 100000000.0, 'min': 0.01}},
  'linear': True,
  'lowercaseId': None,
  'maker': None,
  'margin': False,
  'option': False,
  'optionType': None,
  'precision': {'amount': 0.0001, 'price': 0.01},
  'quote': 'USDT',
  'quoteId': 'USDT',
  'settle': 'USDT',
  'settleId': 'USDT',
  'spot': False,
  'strike': None,
  'subType': None,
  'swap': True,
  'symbol': 'LTC/USDT:USDT',
  'taker': None,
  'type': 'swap',
  'uuid': None}
]
```