### PR TITLE
feat(ascendex): fetchBalance - can pass params["marginMode"]

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -819,12 +819,14 @@ export default class ascendex extends Exchange {
          */
         await this.loadMarkets ();
         await this.loadAccounts ();
-        let query = undefined;
         let marketType = undefined;
-        [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        let marginMode = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBalance', params);
         const isMargin = this.safeValue (params, 'margin', false);
-        marketType = isMargin ? 'margin' : marketType;
-        query = this.omit (query, 'margin');
+        const isCross = marginMode === 'cross';
+        marketType = (isMargin || isCross) ? 'margin' : marketType;
+        params = this.omit (params, 'margin');
         const accountsByType = this.safeValue (this.options, 'accountsByType', {});
         const accountCategory = this.safeString (accountsByType, marketType, 'cash');
         const account = this.safeValue (this.accounts, 0, {});
@@ -832,14 +834,17 @@ export default class ascendex extends Exchange {
         const request = {
             'account-group': accountGroup,
         };
+        if ((marginMode === 'isolated') && (marketType !== 'swap')) {
+            throw new BadRequest (this.id + ' does not supported isolated margin trading');
+        }
         if ((accountCategory === 'cash') || (accountCategory === 'margin')) {
             request['account-category'] = accountCategory;
         }
         let response = undefined;
         if ((marketType === 'spot') || (marketType === 'margin')) {
-            response = await this.v1PrivateAccountCategoryGetBalance (this.extend (request, query));
+            response = await this.v1PrivateAccountCategoryGetBalance (this.extend (request, params));
         } else if (marketType === 'swap') {
-            response = await this.v2PrivateAccountGroupGetFuturesPosition (this.extend (request, query));
+            response = await this.v2PrivateAccountGroupGetFuturesPosition (this.extend (request, params));
         } else {
             throw new NotSupported (this.id + ' fetchBalance() is not currently supported for ' + marketType + ' markets');
         }


### PR DESCRIPTION
```
% ascendex fetchBalance '{"marginMode": "cross"}'
2024-01-16T07:13:11.557Z
Node.js: v18.12.0
CCXT v4.2.15
ascendex.fetchBalance ([object Object])
2024-01-16T07:13:29.025Z iteration 0 passed in 5500 ms

{
  info: {
    code: '0',
    data: [
      {
        asset: 'USDT',
        totalBalance: '0.000090577',
        availableBalance: '0.000090577',
        borrowed: '0',
        interest: '0'
      }
    ]
  },
  timestamp: 1705389209022,
  datetime: '2024-01-16T07:13:29.022Z',
  USDT: { free: 0.000090577, used: 0, total: 0.000090577, debt: 0 },
  free: { USDT: 0.000090577 },
  used: { USDT: 0 },
  total: { USDT: 0.000090577 },
  debt: { USDT: 0 }
}
2024-01-16T07:13:29.025Z iteration 1 passed in 5500 ms
```
```
% ascendex fetchBalance                          
2024-01-16T07:13:46.986Z
Node.js: v18.12.0
CCXT v4.2.15
ascendex.fetchBalance ()
2024-01-16T07:13:53.417Z iteration 0 passed in 1438 ms

{
  info: {
    code: '0',
    data: [
      {
        asset: 'SOL',
        totalBalance: '0.040107562',
        availableBalance: '0.040107562'
      },
      {
        asset: 'TRX',
        totalBalance: '0.000028',
        availableBalance: '0.000028'
      }
    ]
  },
  timestamp: 1705389233415,
  datetime: '2024-01-16T07:13:53.415Z',
  SOL: { free: 0.040107562, used: 0, total: 0.040107562 },
  TRX: { free: 0.000028, used: 0, total: 0.000028 },
  free: { SOL: 0.040107562, TRX: 0.000028 },
  used: { SOL: 0, TRX: 0 },
  total: { SOL: 0.040107562, TRX: 0.000028 }
}
2024-01-16T07:13:53.417Z iteration 1 passed in 1438 ms
```