### PR TITLE
fix(bingx)!: fetchBalance - undefined marketType fetches spot balance

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1443,14 +1443,20 @@ export default class bingx extends Exchange {
         await this.loadMarkets ();
         let response = undefined;
         let standard = undefined;
+        let marketType = undefined;
+        let marginMode = undefined;
         [ standard, params ] = this.handleOptionAndParams (params, 'fetchBalance', 'standard', false);
-        const [ marketType, marketTypeQuery ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBalance', params);
         if (standard) {
-            response = await this.contractV1PrivateGetBalance (marketTypeQuery);
-        } else if (marketType === 'spot') {
-            response = await this.spotV1PrivateGetAccountBalance (marketTypeQuery);
+            response = await this.contractV1PrivateGetBalance (params);
+        } else if ((marketType === 'spot') || (marketType === undefined)) {
+            if (marginMode !== undefined) {
+                throw new BadRequest (this.id + ' does not support spot margin trading');
+            }
+            response = await this.spotV1PrivateGetAccountBalance (params);
         } else {
-            response = await this.swapV2PrivateGetUserBalance (marketTypeQuery);
+            response = await this.swapV2PrivateGetUserBalance (params);
         }
         //
         // spot

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1444,16 +1444,11 @@ export default class bingx extends Exchange {
         let response = undefined;
         let standard = undefined;
         let marketType = undefined;
-        let marginMode = undefined;
         [ standard, params ] = this.handleOptionAndParams (params, 'fetchBalance', 'standard', false);
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
-        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBalance', params);
         if (standard) {
             response = await this.contractV1PrivateGetBalance (params);
         } else if ((marketType === 'spot') || (marketType === undefined)) {
-            if (marginMode !== undefined) {
-                throw new BadRequest (this.id + ' does not support spot margin trading');
-            }
             response = await this.spotV1PrivateGetAccountBalance (params);
         } else {
             response = await this.swapV2PrivateGetUserBalance (params);


### PR DESCRIPTION
passing a marginMode for spot fetchBalance throws an error	

```
% py bingx fetchBalance
Python v3.9.6
CCXT v4.2.15
bingx.fetchBalance()
{'USDT': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'VST': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'free': {'USDT': 0.0, 'VST': 0.0},
 'info': {'code': '0',
          'data': {'balances': [{'asset': 'USDT', 'free': '0', 'locked': '0'},
                                {'asset': 'VST', 'free': '0', 'locked': '0'}]},
          'debugMsg': '',
          'msg': ''},
 'total': {'USDT': 0.0, 'VST': 0.0},
 'used': {'USDT': 0.0, 'VST': 0.0}}
 ```
 
 ```
 % py bingx fetchBalance '{"defaultType": "swap"}'
Python v3.9.6
CCXT v4.2.15
bingx.fetchBalance({'defaultType': 'swap'})
{'USDT': {'free': 0.3645, 'total': 0.3565, 'used': -0.008},
 'free': {'USDT': 0.3645},
 'info': {'code': '0',
          'data': {'balance': {'asset': 'USDT',
                               'availableMargin': '0.3645',
                               'balance': '0.3565',
                               'equity': '0.9016',
                               'freezedMargin': '0.0000',
                               'realisedProfit': '-0.0878',
                               'unrealizedProfit': '0.5451',
                               'usedMargin': '-0.0080',
                               'userId': '1245247939641409536'}},
          'msg': ''},
 'total': {'USDT': 0.3565},
 'used': {'USDT': -0.008}}
 ```