### PR TITLE
fix(krakenfutures) - watchTickers multi symbols

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -186,9 +186,12 @@ export default class krakenfutures extends krakenfuturesRest {
         params = this.omit (params, [ 'watchTickerMethod', 'method' ]);
         symbols = this.marketSymbols (symbols, undefined, false);
         const ticker = await this.subscribePublic (name, symbols, params);
-        const tickers = {};
-        tickers[ticker['symbol']] = ticker;
-        return tickers;
+        if (this.newUpdates) {
+            const tickers = {};
+            tickers[ticker['symbol']] = ticker;
+            return tickers;
+        }
+        return this.filterByArray (this.tickers, 'symbol', symbols);
     }
 
     async watchTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -185,7 +185,10 @@ export default class krakenfutures extends krakenfuturesRest {
         const name = this.safeString2 (params, 'method', 'watchTickerMethod', method);
         params = this.omit (params, [ 'watchTickerMethod', 'method' ]);
         symbols = this.marketSymbols (symbols, undefined, false);
-        return await this.subscribePublic (name, symbols, params);
+        const ticker = await this.subscribePublic (name, symbols, params);
+        const tickers = {};
+        tickers[ticker['symbol']] = ticker;
+        return tickers;
     }
 
     async watchTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {


### PR DESCRIPTION
was returning the single symbol. now returns object
```
2024-01-16T09:26:01.307Z connecting to wss://futures.kraken.com/ws/v1
2024-01-16T09:26:01.601Z onUpgrade
2024-01-16T09:26:01.602Z onOpen
2024-01-16T09:26:01.604Z onMessage { event: 'info', version: 1 }
2024-01-16T09:26:01.605Z sending { event: 'subscribe', feed: 'ticker', product_ids: [ 'PF_XBTUSD' ] }
2024-01-16T09:26:01.701Z onMessage { event: 'subscribed', feed: 'ticker', product_ids: [ 'PF_XBTUSD' ] }
2024-01-16T09:26:01.702Z onMessage {
  time: 1705397160978,
  product_id: 'PF_XBTUSD',
  funding_rate: 1.05155668823625,
  funding_rate_prediction: 1.3525169528334215,
  relative_funding_rate: 0.000024472125,
  relative_funding_rate_prediction: 0.000031404351388889,
  next_funding_rate_time: 1705399200000,
  feed: 'ticker',
  bid: 43068,
  ask: 43073,
  bid_size: 0.4,
  ask_size: 0.8,
  volume: 4164.8214,
  dtm: 0,
  leverage: '50x',
  index: 43049.47,
  premium: 0,
  last: 43071,
  change: 0.92,
  suspended: false,
  tag: 'perpetual',
  pair: 'XBT:USD',
  openInterest: 1831.129,
  markPrice: 43074.06138501308,
  maturityTime: 0,
  post_only: false,
  volumeQuote: 177950143.5551
}


--------------------------------------------
{
  "BTC/USD:USD": {
    info: {
      time: 1705397160978,
      product_id: "PF_XBTUSD",
      funding_rate: 1.05155668823625,
      funding_rate_prediction: 1.3525169528334215,
      relative_funding_rate: 0.000024472125,
      relative_funding_rate_prediction: 0.000031404351388889,
      next_funding_rate_time: 1705399200000,
      feed: "ticker",
      bid: 43068,
      ask: 43073,
      bid_size: 0.4,
      ask_size: 0.8,
      volume: 4164.8214,
      dtm: 0,
      leverage: "50x",
      index: 43049.47,
      premium: 0,
      last: 43071,
      change: 0.92,
      suspended: false,
      tag: "perpetual",
      pair: "XBT:USD",
      openInterest: 1831.129,
      markPrice: 43074.06138501308,
      maturityTime: 0,
      post_only: false,
      volumeQuote: 177950143.5551,
    },
    symbol: "BTC/USD:USD",
    timestamp: undefined,
    datetime: undefined,
    high: undefined,
    low: undefined,
    bid: 43068,
    bidVolume: 0.4,
    ask: 43073,
    askVolume: 0.8,
    vwap: 42726.95668416898,
    open: 43070.08,
    close: 43071,
    last: 43071,
    previousClose: undefined,
    change: 0.92,
    percentage: undefined,
    average: undefined,
    baseVolume: 4164.8214,
    quoteVolume: 177950143.5551,
  },
}
```

