### PR TITLE
fix(hitbtc) - watchTickers & watchTicker

### DIFF
--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -317,7 +317,8 @@ export default class hitbtc extends hitbtcRest {
                 'symbols': [ market['id'] ],
             },
         };
-        return await this.subscribePublic (name, [ symbol ], this.deepExtend (request, params));
+        const result = await this.subscribePublic (name, [ symbol ], this.deepExtend (request, params));
+        return this.safeValue (result, symbol);
     }
 
     async watchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
@@ -401,16 +402,16 @@ export default class hitbtc extends hitbtcRest {
         const data = this.safeValue (message, 'data', {});
         const marketIds = Object.keys (data);
         const channel = this.safeString (message, 'ch');
-        const newTickers = [];
+        const newTickers = {};
         for (let i = 0; i < marketIds.length; i++) {
             const marketId = marketIds[i];
             const market = this.safeMarket (marketId);
             const symbol = market['symbol'];
             const ticker = this.parseWsTicker (data[marketId], market);
             this.tickers[symbol] = ticker;
-            newTickers.push (ticker);
+            newTickers[symbol] = ticker;
             const messageHash = channel + '::' + symbol;
-            client.resolve (this.tickers[symbol], messageHash);
+            client.resolve (newTickers, messageHash);
         }
         const messageHashes = this.findMessageHashes (client, channel + '::');
         for (let i = 0; i < messageHashes.length; i++) {


### PR DESCRIPTION
currently, while running: ```
let r1 = await e.watchTicker ('ETH/USDT');
let r2 = await e.watchTickers (['ETH/USDT']);
let r3 = await e.watchTickers ();
```
watchTickers with single item array has a bug, specifically, it coincides with single ticker messagehash, causing the return type to be a single ticker object.
This PR fixes so it returns dict from `watchTickers` in all cases, and single ticker from `watchTicker`.