### PR TITLE
Bybit: edit cancelAllOrders orderFilter param

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4172,7 +4172,7 @@ export default class bybit extends Exchange {
             // only works for spot market
             const isStop = this.safeValue (params, 'stop', false);
             params = this.omit (params, [ 'stop' ]);
-            request['orderFilter'] = isStop ? 'tpslOrder' : 'Order';
+            request['orderFilter'] = isStop ? 'StopOrder' : 'Order';
         }
         if (id !== undefined) { // The user can also use argument params["orderLinkId"]
             request['orderId'] = id;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3930,7 +3930,7 @@ export default class bybit extends Exchange {
         if (market['option']) {
             response = await this.privatePostOptionUsdcOpenapiPrivateV1ReplaceOrder (this.extend (request, params));
         } else {
-            const isStop = this.safeValue (params, 'stop', false);
+            const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
             const triggerPrice = this.safeValue2 (params, 'stopPrice', 'triggerPrice');
             const stopLossPrice = this.safeValue (params, 'stopLossPrice');
             const isStopLossOrder = stopLossPrice !== undefined;
@@ -4108,8 +4108,8 @@ export default class bybit extends Exchange {
             // 'orderLinkId': 'string', // one of order_id, stop_order_id or order_link_id is required
             // 'orderId': id,
         };
-        const isStop = this.safeValue (params, 'stop', false);
-        params = this.omit (params, [ 'stop' ]);
+        const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
+        params = this.omit (params, [ 'stop', 'trigger' ]);
         if (id !== undefined) { // The user can also use argument params["order_link_id"]
             request['orderId'] = id;
         }
@@ -4170,8 +4170,8 @@ export default class bybit extends Exchange {
         };
         if (market['spot']) {
             // only works for spot market
-            const isStop = this.safeValue (params, 'stop', false);
-            params = this.omit (params, [ 'stop' ]);
+            const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
+            params = this.omit (params, [ 'stop', 'trigger' ]);
             request['orderFilter'] = isStop ? 'StopOrder' : 'Order';
         }
         if (id !== undefined) { // The user can also use argument params["orderLinkId"]
@@ -4216,13 +4216,13 @@ export default class bybit extends Exchange {
         if (market['option']) {
             response = await this.privatePostOptionUsdcOpenapiPrivateV1CancelAll (this.extend (request, params));
         } else {
-            const isStop = this.safeValue (params, 'stop', false);
+            const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
             if (isStop) {
                 request['orderFilter'] = 'StopOrder';
             } else {
                 request['orderFilter'] = 'Order';
             }
-            params = this.omit (params, [ 'stop' ]);
+            params = this.omit (params, [ 'stop', 'trigger' ]);
             response = await this.privatePostPerpetualUsdcOpenapiPrivateV1CancelAll (this.extend (request, params));
         }
         //
@@ -4290,8 +4290,8 @@ export default class bybit extends Exchange {
                 request['settleCoin'] = this.safeString (params, 'settleCoin', defaultSettle);
             }
         }
-        const isStop = this.safeValue (params, 'stop', false);
-        params = this.omit (params, [ 'stop' ]);
+        const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
+        params = this.omit (params, [ 'stop', 'trigger' ]);
         if (isStop) {
             request['orderFilter'] = 'StopOrder';
         }
@@ -4358,15 +4358,15 @@ export default class bybit extends Exchange {
         } else {
             request['category'] = 'OPTION';
         }
-        const isStop = this.safeValue (params, 'stop', false);
-        params = this.omit (params, [ 'stop' ]);
+        const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
+        params = this.omit (params, [ 'stop', 'trigger' ]);
         if (isStop) {
             request['orderFilter'] = 'StopOrder';
         }
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await (this as any).privatePostOptionUsdcOpenapiPrivateV1QueryOrderHistory (this.extend (request, params));
+        const response = await this.privatePostOptionUsdcOpenapiPrivateV1QueryOrderHistory (this.extend (request, params));
         //
         //     {
         //         "result": {
@@ -4663,8 +4663,8 @@ export default class bybit extends Exchange {
             return await this.fetchUsdcOpenOrders (symbol, since, limit, params);
         }
         request['category'] = type;
-        const isStop = this.safeValue (params, 'stop', false);
-        params = this.omit (params, [ 'stop' ]);
+        const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
+        params = this.omit (params, [ 'stop', 'trigger' ]);
         if (isStop) {
             if (type === 'spot') {
                 request['orderFilter'] = 'tpslOrder';
@@ -4803,7 +4803,7 @@ export default class bybit extends Exchange {
          * @method
          * @name bybit#fetchMyTrades
          * @description fetch all trades made by the user
-         * @see https://bybit-exchange.github.io/docs/v5/position/execution
+         * @see https://bybit-exchange.github.io/docs/api-explorer/v5/position/execution
          * @param {string} symbol unified market symbol
          * @param {int} [since] the earliest time in ms to fetch trades for
          * @param {int} [limit] the maximum number of trades structures to retrieve
@@ -4836,8 +4836,8 @@ export default class bybit extends Exchange {
             return await this.fetchMyUsdcTrades (symbol, since, limit, params);
         }
         request['category'] = type;
-        const isStop = this.safeValue (params, 'stop', false);
-        params = this.omit (params, [ 'stop', 'type' ]);
+        const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
+        params = this.omit (params, [ 'stop', 'type', 'trigger' ]);
         if (isStop) {
             if (type === 'spot') {
                 request['orderFilter'] = 'tpslOrder';

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4293,7 +4293,7 @@ export default class bybit extends Exchange {
         const isStop = this.safeValue (params, 'stop', false);
         params = this.omit (params, [ 'stop' ]);
         if (isStop) {
-            request['orderFilter'] = 'tpslOrder';
+            request['orderFilter'] = 'StopOrder';
         }
         const response = await this.privatePostV5OrderCancelAll (this.extend (request, params));
         //

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -306,6 +306,19 @@
                     "LTC/USDT"
                 ],
                 "output": "{\"symbol\":\"LTCUSDT\",\"orderFilter\":\"Order\",\"orderId\":\"1513125485218108928\",\"category\":\"spot\"}"
+            },
+            {
+                "description": "Spot cancel a stop order",
+                "method": "cancelOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel",
+                "input": [
+                  "1599966662050972416",
+                  "BTC/USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"orderFilter\":\"StopOrder\",\"orderId\":\"1599966662050972416\",\"category\":\"spot\"}"
             }
         ],
         "cancelAllOrders": [

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -246,6 +246,34 @@
                   }
                 ],
                 "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"0.001\",\"trailingStop\":\"1000\"}"
+            },
+            {
+                "description": "Swap inverse market buy order",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/create",
+                "input": [
+                  "BTC/USD:BTC",
+                  "market",
+                  "buy",
+                  1
+                ],
+                "output": "{\"symbol\":\"BTCUSD\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"inverse\",\"qty\":\"1\"}"
+            },
+            {
+                "description": "Swap inverse market sell order",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/create",
+                "input": [
+                  "BTC/USD:BTC",
+                  "market",
+                  "sell",
+                  1,
+                  null,
+                  {
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSD\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"inverse\",\"qty\":\"1\",\"reduceOnly\":true}"
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -441,6 +469,16 @@
                 "method": "fetchPositions",
                 "url": "https://api-testnet.bybit.com/v5/position/list?settleCoin=USDT&category=linear",
                 "input": []
+            }
+        ],
+        "fetchPosition": [
+            {
+                "description": "Swap fetch an inverse swap position",
+                "method": "fetchPosition",
+                "url": "https://api-testnet.bybit.com/v5/position/list?symbol=BTCUSD&category=inverse",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
             }
         ],
         "fetchBalance": [

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -317,6 +317,30 @@
                   "BTC/USDT:USDT"
                 ],
                 "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"linear\"}"
+            },
+            {
+                "description": "Swap cancel all open stop orders",
+                "method": "cancelAllOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel-all",
+                "input": [
+                  "BTC/USDT:USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"linear\",\"orderFilter\":\"StopOrder\"}"
+            },
+            {
+                "description": "Spot cancel all open stop orders",
+                "method": "cancelAllOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel-all",
+                "input": [
+                  "BTC/USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"spot\",\"orderFilter\":\"StopOrder\"}"
             }
         ],
         "fetchOpenOrders": [


### PR DESCRIPTION
I checked the bybit changelog to see if any updates needed to be made:
https://bybit-exchange.github.io/docs/changelog/v5#2024-01-15

It doesn't look like any updates are required for our current implementations but `cancelAllOrders` and `cancelOrder` was using the wrong `orderFilter` for stop orders which I updated.

Also added static request tests for `cancelOrder`, `cancelAllOrders`, inverse market `createOrder` and `fetchPosition`

```
bybit cancelAllOrders BTC/USDT:USDT '{"stop":true}'

bybit.cancelAllOrders (BTC/USDT:USDT, [object Object])
2024-01-17T02:27:18.854Z iteration 0 passed in 791 ms

                                  id |        symbol | trades | fees
--------------------------------------------------------------------
a61d80ca-e4e0-4106-89d8-12395fcf6ed7 | BTC/USDT:USDT |     [] |   []
1 objects
```
```
bybit cancelOrder "'1599966662050972416'" BTC/USDT '{"stop":true}'

{
  info: {
    orderId: '1599966662050972416',
    orderLinkId: '1599966662050972417'
  },
  id: '1599966662050972416',
  clientOrderId: '1599966662050972417',
  symbol: 'BTC/USDT',
  trades: [],
  fees: []
}
```