### PR TITLE
feat(coincheck): add pro

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -634,6 +634,7 @@
         }
     },
     "coincheck": {
+        "skipWs": true,
         "skipMethods": {
             "loadMarkets":{
                 "info":"not provided",

--- a/ts/src/coincheck.ts
+++ b/ts/src/coincheck.ts
@@ -67,6 +67,7 @@ export default class coincheck extends Exchange {
                 'setLeverage': false,
                 'setMarginMode': false,
                 'setPositionMode': false,
+                'ws': true,
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87182088-1d6d6380-c2ec-11ea-9c64-8ab9f9b289f5.jpg',

--- a/ts/src/pro/coincheck.ts
+++ b/ts/src/pro/coincheck.ts
@@ -145,11 +145,8 @@ export default class coincheck extends coincheckRest {
         //         ]
         //     ]
         //
-        let symbol = undefined;
-        if (message.length > 0) {
-            const first = this.safeValue (message, 0, []);
-            symbol = this.symbol (this.safeString (first, 2));
-        }
+        const first = this.safeValue (message, 0, []);
+        const symbol = this.symbol (this.safeString (first, 2));
         let stored = this.safeValue (this.trades, symbol);
         if (stored === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);

--- a/ts/src/pro/coincheck.ts
+++ b/ts/src/pro/coincheck.ts
@@ -1,0 +1,114 @@
+
+//  ---------------------------------------------------------------------------
+
+import coincheckRest from '../coincheck.js';
+import { AuthenticationError } from '../base/errors.js';
+import type { Int, OrderBook } from '../base/types.js';
+import Client from '../base/ws/Client.js';
+
+//  ---------------------------------------------------------------------------
+
+export default class coincheck extends coincheckRest {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'has': {
+                'ws': true,
+                'watchOrderBook': false,
+                'watchOrders': false,
+                'watchTrades': false,
+                'watchOHLCV': false,
+                'watchTicker': false,
+                'watchTickers': false,
+            },
+            'urls': {
+                'api': {
+                    'ws': 'wss://ws-api.coincheck.com/',
+                },
+            },
+            'options': {
+                'expiresIn': '',
+                'userId': '',
+                'wsSessionToken': '',
+                'watchOrderBook': {
+                    'snapshotDelay': 6,
+                    'snapshotMaxRetries': 3,
+                },
+                'tradesLimit': 1000,
+                'OHLCVLimit': 1000,
+            },
+            'exceptions': {
+                'exact': {
+                    '4009': AuthenticationError,
+                },
+            },
+        });
+    }
+
+    async watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
+        /**
+         * @method
+         * @name coincheck#watchOrderBook
+         * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
+         * @see https://coincheck.com/documents/exchange/api#websocket-order-book
+         * @param {string} symbol unified symbol of the market to fetch the order book for
+         * @param {int} [limit] the maximum amount of order book entries to return
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const messageHash = 'orderbook:' + symbol;
+        const url = this.urls['api']['ws'];
+        const request = {
+            'type': 'subscribe',
+            'channel': market['id'] + '-orderbook',
+        };
+        const message = this.extend (request, params);
+        const orderbook = await this.watch (url, messageHash, message, messageHash);
+        return orderbook.limit ();
+    }
+
+    handleOrderBook (client, message) {
+        //
+        //     [
+        //         "btc_jpy",
+        //         {
+        //             "bids": [
+        //                 [
+        //                     "6288279.0",
+        //                     "0"
+        //                 ]
+        //             ],
+        //             "asks": [
+        //                 [
+        //                     "6290314.0",
+        //                     "0"
+        //                 ]
+        //             ],
+        //             "last_update_at": "1705396097"
+        //         }
+        //     ]
+        //
+        const symbol = this.symbol (this.safeString (message, 0));
+        const data = this.safeValue (message, 1, {});
+        const timestamp = this.safeTimestamp (data, 'last_update_at');
+        const snapshot = this.parseOrderBook (data, symbol, timestamp);
+        let orderbook = this.safeValue (this.orderbooks, symbol);
+        if (orderbook === undefined) {
+            orderbook = this.orderBook (snapshot);
+            this.orderbooks[symbol] = orderbook;
+        } else {
+            orderbook = this.orderbooks[symbol];
+            orderbook.reset (snapshot);
+        }
+        const messageHash = 'orderbook:' + symbol;
+        client.resolve (orderbook, messageHash);
+    }
+
+    handleMessage (client: Client, message) {
+        const data = this.safeValue (message, 0);
+        if (!Array.isArray (data)) {
+            this.handleOrderBook.call (this, client, message);
+        }
+    }
+}


### PR DESCRIPTION
```BASH
$ p coincheck watchOrderBook BTC/JPY
Python v3.11.3
CCXT v4.2.15
coincheck.watchOrderBook(BTC/JPY)
{'asks': [[6344401.0, 0.034], [6351833.0, 0.01007838]],
 'bids': [[6339962.0, 0.017], [6332415.0, 0.00913328], [6332396.0, 0.01153465]],
 'datetime': '2024-01-17T06:08:41.000Z',
 'nonce': None,
 'symbol': 'BTC/JPY',
 'timestamp': 1705471721000}

$ p coincheck watchTrades BTC/JPY
Python v3.11.3
CCXT v4.2.15
coincheck.watchTrades(BTC/JPY)
[{'id': '256138840', 'info': ['1705471741', '256138840', 'btc_jpy', '6342579.0', '0.01', 'sell', '6083140394', '6083140388'], 'timestamp': 1705471741000, 'datetime': '2024-01-17T06:09:01.000Z', 'order': None, 'symbol': 'BTC/JPY', 'type': None, 'side': 'sell', 'takerOrMaker': None, 'price': 6342579.0, 'amount': 0.01, 'cost': 63425.79, 'fee': None, 'fees': []}]
```