### PR TITLE
fix(coinsph) - fetchtrades

### DIFF
--- a/ts/src/coinsph.ts
+++ b/ts/src/coinsph.ts
@@ -998,10 +998,10 @@ export default class coinsph extends Exchange {
                 'currency': this.safeCurrencyCode (feeCurrencyId),
             };
         }
-        const isBuyer = this.safeString2 (trade, 'isBuyer', 'isBuyerMaker', undefined);
+        const isBuyer = this.safeValue2 (trade, 'isBuyer', 'isBuyerMaker', undefined);
         let side = undefined;
         if (isBuyer !== undefined) {
-            side = (isBuyer === 'true') ? 'buy' : 'sell';
+            side = (isBuyer === true) ? 'buy' : 'sell';
         }
         const isMaker = this.safeString2 (trade, 'isMaker', undefined);
         let takerOrMaker = undefined;


### PR DESCRIPTION
was broken implementation, parsing only ended up with "sell" assignations.
now fixed:
```

> ccxt@4.2.16 cli.js
> node ./examples/js/cli.js coinsph fetchTrades BTC/USDT

2024-01-17T07:20:57.125Z
Node.js: v20.10.0
CCXT v4.2.16
coinsph.fetchTrades (BTC/USDT)
2024-01-17T07:20:59.296Z iteration 0 passed in 853 ms

                 id |     timestamp |                 datetime |   symbol | side |    price |    amount |          
 cost | fees
-------------------------------------------------------------------------------------------------------------------------------
1598511086847418369 | 1705293371002 | 2024-01-15T04:36:11.002Z | BTC/USDT | sell |  42455.1 | 0.0004268 |    18.11983668 |   []
1598531283486531586 | 1705295778629 | 2024-01-15T05:16:18.629Z | BTC/USDT |  buy | 42609.41 | 0.0007405 |   31.552268105 |   []
...
500 objects
2024-01-17T07:20:59.296Z iteration 1 passed in 853 ms
```
