### PR TITLE
bitget: allow books1 channel in watchOrderBookForSymbols

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -458,7 +458,7 @@ export default class bitget extends bitgetRest {
         symbols = this.marketSymbols (symbols);
         let channel = 'books';
         let incrementalFeed = true;
-        if ((limit === 5) || (limit === 15)) {
+        if ((limit === 1) || (limit === 5) || (limit === 15)) {
             channel += limit.toString ();
             incrementalFeed = false;
         }


### PR DESCRIPTION
Same as this one: https://github.com/ccxt/ccxt/pull/19746 since I forgot to add it to the new watchOrderBookForSymbols function
