### PR TITLE
Bybit: adjust stop handling for fetchMyTrades, fetchOrders and fetchOpenOrders

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4625,7 +4625,7 @@ export default class bybit extends Exchange {
          * @param {int} [since] the earliest time in ms to fetch open orders for
          * @param {int} [limit] the maximum number of open orders structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {boolean} [params.stop] true if stop order
+         * @param {boolean} [params.stop] set to true for fetching open stop orders
          * @param {string} [params.type] market type, ['swap', 'option', 'spot']
          * @param {string} [params.subType] market subType, ['linear', 'inverse']
          * @param {string} [params.baseCoin] Base coin. Supports linear, inverse & option
@@ -4662,11 +4662,7 @@ export default class bybit extends Exchange {
         const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
         params = this.omit (params, [ 'stop', 'trigger' ]);
         if (isStop) {
-            if (type === 'spot') {
-                request['orderFilter'] = 'tpslOrder';
-            } else {
-                request['orderFilter'] = 'StopOrder';
-            }
+            request['orderFilter'] = 'StopOrder';
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4462,11 +4462,7 @@ export default class bybit extends Exchange {
         const isStop = this.safeValueN (params, [ 'trigger', 'stop' ], false);
         params = this.omit (params, [ 'trigger', 'stop' ]);
         if (isStop) {
-            if (type === 'spot') {
-                request['orderFilter'] = 'tpslOrder';
-            } else {
-                request['orderFilter'] = 'StopOrder';
-            }
+            request['orderFilter'] = 'StopOrder';
         }
         if (limit !== undefined) {
             request['limit'] = limit;

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -445,6 +445,21 @@
                 ]
             }
         ],
+        "fetchOrders": [
+            {
+                "description": "Spot fetch trigger orders",
+                "method": "fetchOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/history?symbol=BTCUSDT&category=spot&orderFilter=StopOrder",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "stop": true
+                  }
+                ]
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot fetchMyTrades",

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -407,6 +407,19 @@
                         "type": "swap"
                     }
                 ]
+            },
+            {
+                "description": "Spot fetch open trigger orders",
+                "method": "fetchOpenOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/realtime?symbol=BTCUSDT&category=spot&orderFilter=StopOrder",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "stop": true
+                  }
+                ]
             }
         ],
         "fetchClosedOrders": [


### PR DESCRIPTION
Removed `orderFilter` from `fetchMyTrades` because it's not actually supported for the endpoint we're using. Edited the spot trigger handling for `fetchOrders` and `fetchOpenOrders`, so that `orderFilter` uses `StopOrder`:

Added static request tests for `fetchOrders` and `fetchOpenOrders` spot trigger orders.

```
bybit fetchOrders BTC/USDT undefined undefined '{"stop":true}'

bybit.fetchOrders (BTC/USDT, , , [object Object])
2024-01-18T02:27:49.669Z iteration 0 passed in 786 ms

                 id |       clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | reduceOnly | side | price | stopPrice | triggerPrice | amount | cost | filled | remaining |   status |                            fee | trades |                           fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1599897800789984000 | 1599897800789984001 | 1705458680187 | 2024-01-17T02:31:20.187Z |      1705458711542 |       1705458711542 | BTC/USDT | limit |         GTC |    false |      false |  buy | 35000 |     35500 |        35500 |  0.001 |    0 |      0 |     0.001 | canceled | {"cost":"0","currency":"USDT"} |     [] | [{"cost":0,"currency":"USDT"}]
1599966007471112960 | 1599966007471112961 | 1705466811056 | 2024-01-17T04:46:51.056Z |      1705466854241 |       1705466854241 | BTC/USDT | limit |         GTC |    false |      false |  buy | 35000 |     35500 |        35500 |  0.001 |    0 |      0 |     0.001 | canceled | {"cost":"0","currency":"USDT"} |     [] | [{"cost":0,"currency":"USDT"}]
1599966662050972416 | 1599966662050972417 | 1705466889088 | 2024-01-17T04:48:09.088Z |      1705466935754 |       1705466935754 | BTC/USDT | limit |         GTC |    false |      false |  buy | 35000 |     35500 |        35500 |  0.001 |    0 |      0 |     0.001 | canceled | {"cost":"0","currency":"USDT"} |     [] | [{"cost":0,"currency":"USDT"}]
3 objects
```
```
bybit fetchOpenOrders BTC/USDT undefined undefined '{"stop":true}'

bybit.fetchOpenOrders (BTC/USDT, , , [object Object])
2024-01-18T02:35:59.978Z iteration 0 passed in 1591 ms

                 id |       clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | reduceOnly | side | price | stopPrice | triggerPrice | amount | cost | filled | remaining | status |                            fee | trades |                           fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1600623510408135424 | 1600623510408135425 | 1705545191515 | 2024-01-18T02:33:11.515Z |      1705545191515 |       1705545191515 | BTC/USDT | limit |         GTC |    false |      false |  buy | 35000 |     35700 |        35700 |  0.001 |    0 |      0 |     0.001 |   open | {"cost":"0","currency":"USDT"} |     [] | [{"cost":0,"currency":"USDT"}]
1 objects
```