### PR TITLE
fix(whitebit) - has fetchstatus true

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -68,6 +68,7 @@ export default class whitebit extends Exchange {
                 'fetchOrderTrades': true,
                 'fetchPositionMode': false,
                 'fetchPremiumIndexOHLCV': false,
+                'fetchStatus': true,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,


### PR DESCRIPTION
this was the only exchange that had `fetchStatus` implemented, but missing from `has`