### PR TITLE
feat(bingx): add fetchFundingRates

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -52,6 +52,7 @@ export default class bingx extends Exchange {
                 'fetchDepositWithdrawFee': 'emulated',
                 'fetchDepositWithdrawFees': true,
                 'fetchFundingRate': true,
+                'fetchFundingRates': true,
                 'fetchFundingRateHistory': true,
                 'fetchLeverage': true,
                 'fetchLiquidations': false,
@@ -1121,6 +1122,32 @@ export default class bingx extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         return this.parseFundingRate (data, market);
+    }
+
+    async fetchFundingRates (symbols: Strings = undefined, params = {}) {
+        /**
+         * @method
+         * @name bingx#fetchFundingRate
+         * @description fetch the current funding rate
+         * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#Current%20Funding%20Rate
+         * @param {string[]} [symbols] list of unified market symbols
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols, 'swap', true);
+        const response = await this.swapV2PublicGetQuotePremiumIndex (this.extend (params));
+        const data = this.safeValue (response, 'data', []);
+        const filteredResponse = [];
+        for (let i = 0; i < data.length; i++) {
+            const item = data[i];
+            const marketId = this.safeString (item, 'symbol');
+            const market = this.safeMarket (marketId, undefined, undefined, 'swap');
+            if ((symbols === undefined) || this.inArray (market['symbol'], symbols)) {
+                filteredResponse.push (this.parseFundingRate (item, market));
+            }
+        }
+        return filteredResponse;
     }
 
     parseFundingRate (contract, market: Market = undefined) {


### PR DESCRIPTION
Demo

```
p bingx fetchFundingRates '["BTC/USDT:USDT", "LTC/USDT:USDT"]'
Python v3.11.5
CCXT v4.2.17
bingx.fetchFundingRates(['BTC/USDT:USDT', 'LTC/USDT:USDT'])
[{'datetime': None,
  'estimatedSettlePrice': None,
  'fundingDatetime': None,
  'fundingRate': 0.00013,
  'fundingTimestamp': None,
  'indexPrice': 42725.5,
  'info': {'indexPrice': '42725.5',
           'lastFundingRate': '0.00013000',
           'markPrice': '42709.1',
           'nextFundingTime': '1705593600000',
           'symbol': 'BTC-USDT'},
  'interestRate': None,
  'markPrice': 42709.1,
  'nextFundingDatetime': '2024-01-18T16:00:00.000Z',
  'nextFundingRate': None,
  'nextFundingTimestamp': 1705593600000,
  'previousFundingDatetime': None,
  'previousFundingRate': None,
  'previousFundingTimestamp': None,
  'symbol': 'BTC/USDT:USDT',
  'timestamp': None},
 {'datetime': None,
  'estimatedSettlePrice': None,
  'fundingDatetime': None,
  'fundingRate': 0.000262,
  'fundingTimestamp': None,
  'indexPrice': 69.69,
  'info': {'indexPrice': '69.69',
           'lastFundingRate': '0.00026200',
           'markPrice': '69.63',
           'nextFundingTime': '1705593600000',
           'symbol': 'LTC-USDT'},
  'interestRate': None,
  'markPrice': 69.63,
  'nextFundingDatetime': '2024-01-18T16:00:00.000Z',
  'nextFundingRate': None,
  'nextFundingTimestamp': 1705593600000,
  'previousFundingDatetime': None,
  'previousFundingRate': None,
  'previousFundingTimestamp': None,
  'symbol': 'LTC/USDT:USDT',
  'timestamp': None}]
```
