### PR TITLE
feat(run-tests) - warning & timeouts upgrade

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -66,6 +66,9 @@ for (const arg of args) {
 
 const wsFlag = exchangeSpecificFlags['--ws'] ? 'WS': '';
 
+const timeoutSeconds = wsFlag ? 60 : 250; // 250 seconds for REST exchange test, for WS smaller is enough
+
+
 /*  --------------------------------------------------------------------------- */
 
 const exchangeOptions = []
@@ -94,7 +97,9 @@ if (!exchanges.length) {
 /*  --------------------------------------------------------------------------- */
 
 const sleep = s => new Promise (resolve => setTimeout (resolve, s*1000))
-const timeout = (s, promise) => Promise.race ([ promise, sleep (s).then (() => { throw new Error ('timed out') }) ])
+const timeout = (s, promise) => Promise.race ([ promise, sleep (s).then (() => {
+    throw new Error ('RUNTEST_TIMED_OUT');
+}) ])
 
 /*  --------------------------------------------------------------------------- */
 
@@ -104,21 +109,14 @@ const exec = (bin, ...args) => {
     stderr,  not separating them into distinct buffers — so that we can show
     the same output as if it were running in a terminal.                        */
 
-    return timeout (250, new Promise (return_ => {
+    let output = ''
+    let stderr = ''
 
-        const psSpawn = ps.spawn (bin, args)
-
-        let output = ''
-        let stderr = ''
-
-        psSpawn.stdout.on ('data', data => { output += data.toString () })
-        psSpawn.stderr.on ('data', data => { output += data.toString (); stderr += data.toString (); })
-
-        psSpawn.on ('exit', code => {
+    const generateResultFromOutput = (output, stderr, code) => {
             // keep this commented code for a while (just in case), as the below avoids vscode false positive warnings from output: https://github.com/nodejs/node/issues/34799 during debugging
-            // const removeDebuger = (str) => str.replace ('Debugger attached.\r\n','').replace('Waiting for the debugger to disconnect...\r\n', '').replace(/\(node:\d+\) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\)\n/, '');
-            // stderr = removeDebuger(stderr);
-            // output = removeDebuger(output);
+            const removeDebuger = (str) => str.replace ('Debugger attached.\r\n','').replace('Waiting for the debugger to disconnect...\r\n', '').replace(/\(node:\d+\) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\)\n/, '');
+            stderr = removeDebuger(stderr);
+            output = removeDebuger(output);
 
             output = ansi.strip (output.trim ())
 
@@ -162,22 +160,36 @@ const exec = (bin, ...args) => {
                 warnings.push (stderr)
             }
 
-            return_ ({
+            return {
                 failed: hasFailed || code !== 0,
                 output,
                 warnings,
                 infos,
-            })
-        })
+            }
+    }
 
-    })).catch (e => ({
+    return timeout (timeoutSeconds, new Promise (return_ => {
 
-        failed: true,
-        output: e.message,
-        warnings: [],
-        infos: [],
+        const psSpawn = ps.spawn (bin, args)
 
-    }));
+        psSpawn.stdout.on ('data', data => { output += data.toString () })
+        psSpawn.stderr.on ('data', data => { output += data.toString (); stderr += data.toString (); })
+
+        psSpawn.on ('exit', code => return_ (generateResultFromOutput (output, stderr, code)) )
+
+    })).catch (e => {
+        const isTimeout = e.message === 'RUNTEST_TIMED_OUT';
+        if (isTimeout && wsFlag) {
+            stderr += '\n' + 'RUNTEST_TIMED_OUT: ';
+            return generateResultFromOutput (output, stderr, 0);
+        }
+        return {
+            failed: true,
+            output: e.message,
+            warnings: [],
+            infos: [],
+        }
+    } );
 };
 
 /*  ------------------------------------------------------------------------ */
@@ -310,7 +322,7 @@ const testExchange = async (exchange) => {
 
     // independenly of the success result, show infos
     // ( these infos will be shown as soon as each exchange test is finished, and will not wait 100% of all tests to be finished )
-    const displayInfos = false; // temporarily disable from run-tests, because they are still outputed in console from individual langs
+    const displayInfos = true; // temporarily disable from run-tests, because they are still outputed in console from individual langs
     if (displayInfos) {
         if (debugKeys['--info'] && infos.length) {
             // show info if enabled

--- a/run-tests.js
+++ b/run-tests.js
@@ -179,7 +179,7 @@ const exec = (bin, ...args) => {
 
     })).catch (e => {
         const isTimeout = e.message === 'RUNTEST_TIMED_OUT';
-        if (isTimeout && wsFlag) {
+        if (isTimeout) {
             stderr += '\n' + 'RUNTEST_TIMED_OUT: ';
             return generateResultFromOutput (output, stderr, 0);
         }

--- a/run-tests.js
+++ b/run-tests.js
@@ -114,9 +114,9 @@ const exec = (bin, ...args) => {
 
     const generateResultFromOutput = (output, stderr, code) => {
             // keep this commented code for a while (just in case), as the below avoids vscode false positive warnings from output: https://github.com/nodejs/node/issues/34799 during debugging
-            const removeDebuger = (str) => str.replace ('Debugger attached.\r\n','').replace('Waiting for the debugger to disconnect...\r\n', '').replace(/\(node:\d+\) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\)\n/, '');
-            stderr = removeDebuger(stderr);
-            output = removeDebuger(output);
+            // const removeDebuger = (str) => str.replace ('Debugger attached.\r\n','').replace('Waiting for the debugger to disconnect...\r\n', '').replace(/\(node:\d+\) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\)\n/, '');
+            // stderr = removeDebuger(stderr);
+            // output = removeDebuger(output);
 
             output = ansi.strip (output.trim ())
 


### PR DESCRIPTION
- dissected the part directly into a function `generateResultFromOutput`  (without flow changes, just move into method)
- even if it timeouts, the already generated output is retained and can be viewed if `--info` provided. till date, timeout just killed process without any info.
- timeout will no longer FAIL build, instead it will warn.