### PR TITLE
Deribit: fix fetchFundingRateHistory since

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -2913,7 +2913,7 @@ export default class deribit extends Exchange {
         }
         const request = {
             'instrument_name': market['id'],
-            'start_timestamp': since,
+            'start_timestamp': since - 1,
             'end_timestamp': time,
         };
         const response = await this.publicGetGetFundingRateHistory (this.extend (request, params));

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -605,6 +605,17 @@
                   "BTC/USD:BTC-240126-39000-C"
                 ]
             }
+        ],
+        "fetchFundingRateHistory": [
+            {
+                "description": "Fetch funding rate history with a since argument",
+                "method": "fetchFundingRateHistory",
+                "url": "https://test.deribit.com/api/v2/public/get_funding_rate_history?instrument_name=BTC_USDT-PERPETUAL&start_timestamp=1705622399999&end_timestamp=1705631426030",
+                "input": [
+                  "BTC/USDT:USDT",
+                  1705622400000
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Fixed an error with fetchFundingRateHistory `start_timestamp` parameter, needed to use `since - 1` to retrieve the correct data:

```
deribit.fetchFundingRateHistory (BTC/USDT:USDT, 1705622400000)
2024-01-19T02:30:26.342Z iteration 0 passed in 313 ms

       symbol | indexPrice |     timestamp |                 datetime |           fundingRate
---------------------------------------------------------------------------------------------
BTC/USDT:USDT | 41317.2222 | 1705622400000 | 2024-01-19T00:00:00.000Z | -0.004864664070384957
BTC/USDT:USDT |   41295.04 | 1705626000000 | 2024-01-19T01:00:00.000Z | -0.004926675066692415
BTC/USDT:USDT |   41271.62 | 1705629600000 | 2024-01-19T02:00:00.000Z | -0.004932759630270609
3 objects
```