### PR TITLE
Deribit: fix fetchPositions linear currency

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -2435,6 +2435,7 @@ export default class deribit extends Exchange {
          * @method
          * @name deribit#fetchPosition
          * @description fetch data on a single open contract trade position
+         * @see https://docs.deribit.com/#private-get_position
          * @param {string} symbol unified market symbol of the market the position is held in, default is undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [position structure]{@link https://docs.ccxt.com/#/?id=position-structure}
@@ -2480,6 +2481,7 @@ export default class deribit extends Exchange {
          * @method
          * @name deribit#fetchPositions
          * @description fetch all open positions
+         * @see https://docs.deribit.com/#private-get_positions
          * @param {string[]|undefined} symbols list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.kind] market type filter for positions 'future', 'option', 'spot', 'future_combo' or 'option_combo'

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -588,6 +588,28 @@
                 ]
             }
         ],
+        "fetchPositions": [
+            {
+                "description": "Swap fetch positions",
+                "method": "fetchPositions",
+                "url": "https://test.deribit.com/api/v2/private/get_positions?currency=USDT&kind=future",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ]
+                ]
+            },
+            {
+                "description": "Option fetch positions",
+                "method": "fetchPositions",
+                "url": "https://test.deribit.com/api/v2/private/get_positions?currency=BTC&kind=option",
+                "input": [
+                  [
+                    "BTC/USD:BTC-240126-39000-C"
+                  ]
+                ]
+            }
+        ],
         "fetchPosition": [
             {
                 "description": "Swap fetch position",


### PR DESCRIPTION
For fetchPositions contract positions the currency parameter should be settle instead of base, it was returning an empty array for linear positions before these changes:

```
deribit.fetchPositions (BTC/USDT:USDT)
2024-01-19T03:23:31.809Z iteration 0 passed in 199 ms

       symbol |     timestamp |                 datetime | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice | notional | leverage | unrealizedPnl | contractSize |  markPrice | side
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT | 1705634611808 | 2024-01-19T03:23:31.808Z |   2.449441373 |       81648.04576666666 |       1.224729872 |          40824.329066666665 |      38420 |    0.003 |       50 |    -1.3004711 |        0.001 | 40823.7167 | long
1 objects
```
```
deribit.fetchPositions (BTC/USD:BTC-240126-39000-C)
2024-01-19T04:08:57.046Z iteration 0 passed in 198 ms

                    symbol |     timestamp |                 datetime | initialMargin | maintenanceMargin | entryPrice | unrealizedPnl | contractSize |  markPrice | side
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USD:BTC-240126-39000-C | 1705637337046 | 2024-01-19T04:08:57.046Z |             0 |                 0 |     0.1775 |  -0.105376079 |            1 | 0.07212392 | long
1 objects
```