### PR TITLE
Bitget: fetchPositions, enable calling with no symbols argument

### DIFF
--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -725,6 +725,12 @@
                     "BTC/USDT:USDT"
                   ]
                 ]
+            },
+            {
+              "description": "Fetch linear positions without symbol",
+              "method": "fetchPositions",
+              "url": "https://api.bitget.com/api/v2/mix/position/all-position?marginCoin=USDT&productType=USDT-FUTURES",
+              "input": []
             }
         ],
         "setLeverage": [


### PR DESCRIPTION
Edited the `fetchPositions` implementation so that it can be called without a symbols argument. The default is `'productType':'USDT-FUTURES'` and `'marginCoin':'USDT'`.

The marginCoin is automatically selected for USDT-FUTURES, USDC-FUTURES, SUSDT-FUTURES and SUSDC-FUTURES productTypes, but for inverse productTypes like COIN-FUTURES and SCOIN-FUTURES the marginCoin parameter is required.

```
bitget.fetchPositions ()
2024-01-20T07:51:54.552Z iteration 0 passed in 372 ms

       symbol | notional | marginMode |  liquidationPrice | entryPrice | unrealizedPnl | percentage | contracts | contractSize | markPrice | side | hedged |     timestamp |                 datetime | maintenanceMargin | maintenanceMarginPercentage | collateral | initialMargin | initialMarginPercentage | leverage |   marginRatio
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT |  41.6651 |   isolated | 39769.53486035765 |    41670.1 |        -0.005 |      -0.23 |     0.001 |            1 |   41665.1 | long |   true | 1705737102996 | 2024-01-20T07:51:42.996Z |        0.19165946 |                       0.004 |   2.078505 |      2.083505 |    0.050006000225608485 |       20 | 0.09221024727
1 objects
```