### PR TITLE
fix(phemex): editOrder & static-tests

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2761,7 +2761,7 @@ export default class phemex extends Exchange {
             request['baseQtyEV'] = finalQty;
         } else if (amount !== undefined) {
             if (isUSDTSettled) {
-                request['baseQtyEV'] = this.amountToPrecision (market['symbol'], amount);
+                request['orderQtyRq'] = this.amountToPrecision (market['symbol'], amount);
             } else {
                 request['baseQtyEV'] = this.toEv (amount, market);
             }

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -88,7 +88,7 @@
             {
                 "description": "Edit swap order",
                 "method": "editOrder",
-                "url": "https://testnet-api.phemex.com/g-orders/replace?symbol=LTCUSDT&orderID=f19a1108-8dc0-4afb-b281-0cd2c8ca65d9&priceRp=50&baseQtyEV=0.14&posSide=Merged",
+                "url": "https://testnet-api.phemex.com/g-orders/replace?symbol=LTCUSDT&orderID=f19a1108-8dc0-4afb-b281-0cd2c8ca65d9&priceRp=50&orderQtyRq=0.14&posSide=Merged",
                 "input": [
                   "f19a1108-8dc0-4afb-b281-0cd2c8ca65d9",
                   "LTC/USDT:USDT",


### PR DESCRIPTION
fix: ccxt/ccxt#20910

```BASH
$ p phemex editOrder '"145871c1-1d95-4b89-ab39-c22e4adf3170"' BTC/USDT:USDT limit sell 0.2 45000 --test
Python v3.11.3
CCXT v4.2.20
phemex.editOrder(145871c1-1d95-4b89-ab39-c22e4adf3170,BTC/USDT:USDT,limit,sell,0.2,45000)
{'amount': 0.2,
 'average': None,
 'clientOrderId': 'CCXT123456d679d426d478bc4d',
 'cost': 0.0,
 'datetime': '2024-01-23T02:52:07.211Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '145871c1-1d95-4b89-ab39-c22e4adf3170',
 'info': {'actionTimeNs': '1705978327211484302',
          'bizError': '0',
          'clOrdID': 'CCXT123456d679d426d478bc4d',
          'closedPnlRv': '0',
          'closedSizeRq': '0',
          'cumQtyRq': '0',
          'cumValueRv': '0',
          'displayQtyRq': '0.2',
          'execInst': 'None',
          'execStatus': 'PendingReplace',
          'leavesQtyRq': '0.2',
          'leavesValueRv': '9000',
          'ordStatus': 'New',
          'orderID': '145871c1-1d95-4b89-ab39-c22e4adf3170',
          'orderQtyRq': '0.2',
          'orderType': 'Limit',
          'pegOffsetProportionRr': '0',
          'pegOffsetValueRp': '0',
          'pegPriceType': 'UNSPECIFIED',
          'priceRp': '45000',
          'side': 'Sell',
          'slPxRp': '0',
          'stopDirection': 'UNSPECIFIED',
          'stopLossRp': '0',
          'stopPxRp': '0',
          'symbol': 'BTCUSDT',
          'takeProfitRp': '0',
          'timeInForce': 'GoodTillCancel',
          'tpPxRp': '0',
          'transactTimeNs': '1705978327211484302',
          'trigger': 'UNSPECIFIED'},
 'lastTradeTimestamp': 1705978327211,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 45000.0,
 'reduceOnly': None,
 'remaining': 0.2,
 'side': 'sell',
 'status': 'open',
 'stopLossPrice': 0.0,
 'stopPrice': None,
 'symbol': 'BTC/USDT:USDT',
 'takeProfitPrice': 0.0,
 'timeInForce': 'GTC',
 'timestamp': 1705978327211,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
```