### PR TITLE
Okx: watchOrders, unify spot margin support

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1037,17 +1037,20 @@ export default class okx extends okxRest {
         /**
          * @method
          * @name okx#watchOrders
-         * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-order-channel
          * @description watches information on multiple orders made by the user
-         * @param {string} [symbol] unified market symbol of the market orders were made in
+         * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-order-channel
+         * @param {string} [symbol] unified market symbol of the market the orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {bool} [params.stop] true if fetching trigger or conditional orders
+         * @param {string} [params.type] 'spot', 'swap', 'future', 'option', 'ANY', 'SPOT', 'MARGIN', 'SWAP', 'FUTURES' or 'OPTION'
+         * @param {string} [params.marginMode] 'cross' or 'isolated', for automatically setting the type to spot margin
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         let type = undefined;
         // By default, receive order updates from any instrument type
+        [ type, params ] = this.handleOptionAndParams (params, 'watchOrders', 'defaultType');
         [ type, params ] = this.handleOptionAndParams (params, 'watchOrders', 'type', 'ANY');
         const isStop = this.safeValue2 (params, 'stop', 'trigger', false);
         params = this.omit (params, [ 'stop', 'trigger' ]);
@@ -1062,7 +1065,14 @@ export default class okx extends okxRest {
         if (type === 'future') {
             type = 'futures';
         }
-        const uppercaseType = type.toUpperCase ();
+        let uppercaseType = type.toUpperCase ();
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('watchOrders', params);
+        if (uppercaseType === 'SPOT') {
+            if (marginMode !== undefined) {
+                uppercaseType = 'MARGIN';
+            }
+        }
         const request = {
             'instType': uppercaseType,
         };


### PR DESCRIPTION
Edited `watchOrders` so that you can set the marginMode to isolated or cross, and set the type param to spot (or just use the unified spot symbol), and it will automatically use the `MARGIN` order type:

```
okx watchOrders BTC/USDT undefined undefined '{"marginMode":"cross"}'

2024-01-23T04:39:27.690Z sending {
  op: 'subscribe',
  args: [ { channel: 'orders', instId: 'BTC-USDT', instType: 'MARGIN' } ]
}
2024-01-23T04:39:27.942Z onMessage {
  event: 'subscribe',
  arg: { channel: 'orders', instType: 'MARGIN', instId: 'BTC-USDT' },
  connId: '2ee4db9d'
}
```