### PR TITLE
Manual, Bitmex, Bybit: Change the trigger direction

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1895,7 +1895,7 @@ export default class bitmex extends Exchange {
         const isTrailingAmountOrder = trailingAmount !== undefined;
         if (isTriggerOrder || isTrailingAmountOrder) {
             const triggerDirection = this.safeString (params, 'triggerDirection');
-            const isAscending = (triggerDirection === 'above') || (triggerDirection === 'rising');
+            const isAscending = (triggerDirection === 'rising');
             if ((type === 'limit') || (type === 'market')) {
                 this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'rising', 'falling' ]);
             }
@@ -1949,7 +1949,7 @@ export default class bitmex extends Exchange {
         const isTrailingAmountOrder = trailingAmount !== undefined;
         if (isTrailingAmountOrder) {
             const triggerDirection = this.safeString (params, 'triggerDirection');
-            const isAscending = (triggerDirection === 'above') || (triggerDirection === 'rising');
+            const isAscending = (triggerDirection === 'rising');
             if ((type === 'limit') || (type === 'market')) {
                 this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'rising', 'falling' ]);
             }

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1866,7 +1866,7 @@ export default class bitmex extends Exchange {
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {object} [params.triggerPrice] the price at which a trigger order is triggered at
-         * @param {object} [params.triggerDirection] the direction whenever the trigger happens with relation to price - 'above' or 'below'
+         * @param {object} [params.triggerDirection] the direction that the price will be going when the triggerPrice is reached and activated, 'rising' or 'falling'
          * @param {float} [params.trailingAmount] the quote amount to trail away from the current market price
          * @returns {object} an [order structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#order-structure}
          */
@@ -1895,21 +1895,21 @@ export default class bitmex extends Exchange {
         const isTrailingAmountOrder = trailingAmount !== undefined;
         if (isTriggerOrder || isTrailingAmountOrder) {
             const triggerDirection = this.safeString (params, 'triggerDirection');
-            const triggerAbove = (triggerDirection === 'above');
+            const isAscending = (triggerDirection === 'above') || (triggerDirection === 'rising');
             if ((type === 'limit') || (type === 'market')) {
-                this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'above', 'below' ]);
+                this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'rising', 'falling' ]);
             }
             if (type === 'limit') {
                 if (side === 'buy') {
-                    orderType = triggerAbove ? 'StopLimit' : 'LimitIfTouched';
+                    orderType = isAscending ? 'StopLimit' : 'LimitIfTouched';
                 } else {
-                    orderType = triggerAbove ? 'LimitIfTouched' : 'StopLimit';
+                    orderType = isAscending ? 'LimitIfTouched' : 'StopLimit';
                 }
             } else if (type === 'market') {
                 if (side === 'buy') {
-                    orderType = triggerAbove ? 'Stop' : 'MarketIfTouched';
+                    orderType = isAscending ? 'Stop' : 'MarketIfTouched';
                 } else {
-                    orderType = triggerAbove ? 'MarketIfTouched' : 'Stop';
+                    orderType = isAscending ? 'MarketIfTouched' : 'Stop';
                 }
             }
             if (isTrailingAmountOrder) {
@@ -1949,22 +1949,22 @@ export default class bitmex extends Exchange {
         const isTrailingAmountOrder = trailingAmount !== undefined;
         if (isTrailingAmountOrder) {
             const triggerDirection = this.safeString (params, 'triggerDirection');
-            const triggerAbove = (triggerDirection === 'above');
+            const isAscending = (triggerDirection === 'above') || (triggerDirection === 'rising');
             if ((type === 'limit') || (type === 'market')) {
-                this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'above', 'below' ]);
+                this.checkRequiredArgument ('createOrder', triggerDirection, 'triggerDirection', [ 'rising', 'falling' ]);
             }
             let orderType = undefined;
             if (type === 'limit') {
                 if (side === 'buy') {
-                    orderType = triggerAbove ? 'StopLimit' : 'LimitIfTouched';
+                    orderType = isAscending ? 'StopLimit' : 'LimitIfTouched';
                 } else {
-                    orderType = triggerAbove ? 'LimitIfTouched' : 'StopLimit';
+                    orderType = isAscending ? 'LimitIfTouched' : 'StopLimit';
                 }
             } else if (type === 'market') {
                 if (side === 'buy') {
-                    orderType = triggerAbove ? 'Stop' : 'MarketIfTouched';
+                    orderType = isAscending ? 'Stop' : 'MarketIfTouched';
                 } else {
-                    orderType = triggerAbove ? 'MarketIfTouched' : 'Stop';
+                    orderType = isAscending ? 'MarketIfTouched' : 'Stop';
                 }
             }
             const isStopSellOrder = (side === 'sell') && ((orderType === 'Stop') || (orderType === 'StopLimit'));

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3633,8 +3633,8 @@ export default class bybit extends Exchange {
                 if (triggerDirection === undefined) {
                     throw new ArgumentsRequired (this.id + ' stop/trigger orders require a triggerDirection parameter, either "rising" or "falling" to determine the direction of the trigger.');
                 }
-                const isAsending = ((triggerDirection === 'above') || (triggerDirection === '1') || (triggerDirection === 'rising'));
-                request['triggerDirection'] = isAsending ? 1 : 2;
+                const isAscending = ((triggerDirection === '1') || (triggerDirection === 'rising'));
+                request['triggerDirection'] = isAscending ? 1 : 2;
             }
             request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
         } else if (isStopLossTriggerOrder || isTakeProfitTriggerOrder) {

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3479,7 +3479,7 @@ export default class bybit extends Exchange {
          * @param {boolean} [params.isLeverage] *unified spot only* false then spot trading true then margin trading
          * @param {string} [params.tpslMode] *contract only* 'full' or 'partial'
          * @param {string} [params.mmp] *option only* market maker protection
-         * @param {string} [params.triggerDirection] *contract only* the direction for trigger orders, 'above' or 'below'
+         * @param {string} [params.triggerDirection] *contract only* the direction for trigger orders, 'rising' or 'falling'
          * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
          * @param {float} [params.stopLossPrice] The price at which a stop loss order is triggered at
          * @param {float} [params.takeProfitPrice] The price at which a take profit order is triggered at
@@ -3631,9 +3631,9 @@ export default class bybit extends Exchange {
                 }
             } else {
                 if (triggerDirection === undefined) {
-                    throw new ArgumentsRequired (this.id + ' stop/trigger orders require a triggerDirection parameter, either "above" or "below" to determine the direction of the trigger.');
+                    throw new ArgumentsRequired (this.id + ' stop/trigger orders require a triggerDirection parameter, either "rising" or "falling" to determine the direction of the trigger.');
                 }
-                const isAsending = ((triggerDirection === 'above') || (triggerDirection === '1'));
+                const isAsending = ((triggerDirection === 'above') || (triggerDirection === '1') || (triggerDirection === 'rising'));
                 request['triggerDirection'] = isAsending ? 1 : 2;
             }
             request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -125,7 +125,7 @@
         "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"Limit\",\"text\":\"CCXT\",\"price\":36000,\"postOnly\":true,\"timeInForce\":\"GTC\"}"
       },
       {
-        "description": "spot market buy with triggerPrice and triggerDirection below",
+        "description": "spot market buy with triggerPrice and triggerDirection falling",
         "method": "createOrder",
         "url": "https://www.bitmex.com/api/v1/order",
         "input": [
@@ -136,13 +136,13 @@
           null,
           {
             "triggerPrice": 35,
-            "triggerDirection": "below"
+            "triggerDirection": "falling"
           }
         ],
         "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000000,\"ordType\":\"MarketIfTouched\",\"text\":\"CCXT\",\"stopPx\":35}"
       },
       {
-        "description": "spot market buy with triggerPrice and triggerDirection above",
+        "description": "spot market buy with triggerPrice and triggerDirection rising",
         "method": "createOrder",
         "url": "https://www.bitmex.com/api/v1/order",
         "input": [
@@ -153,7 +153,7 @@
           null,
           {
             "triggerPrice": 37000,
-            "triggerDirection": "above"
+            "triggerDirection": "rising"
           }
         ],
         "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000000,\"ordType\":\"Stop\",\"text\":\"CCXT\",\"stopPx\":37000}"
@@ -202,7 +202,7 @@
           null,
           {
             "trailingAmount": 100,
-            "triggerDirection": "above"
+            "triggerDirection": "rising"
           }
         ],
         "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"MarketIfTouched\",\"text\":\"CCXT\",\"pegOffsetValue\":100,\"pegPriceType\":\"TrailingStopPeg\"}"
@@ -219,7 +219,7 @@
           45000,
           {
             "trailingAmount": 100,
-            "triggerDirection": "above"
+            "triggerDirection": "rising"
           }
         ],
         "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"pegOffsetValue\":100,\"pegPriceType\":\"TrailingStopPeg\",\"price\":45000}"
@@ -285,7 +285,7 @@
           null,
           {
             "trailingAmount": 11000,
-            "triggerDirection": "above"
+            "triggerDirection": "rising"
           }
         ],
         "output": "{\"pegOffsetValue\":11000,\"orderID\":\"f21aa11e-3857-4e39-9230-53cb15a04c3f\",\"orderQty\":1000,\"text\":\"CCXT\"}"

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -78,7 +78,7 @@
                 "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"10\"}"
             },
             {
-                "description": "swap limit buy with triggerPrice and triggerDirection above",
+                "description": "swap limit buy with triggerPrice and triggerDirection rising",
                 "method": "createOrder",
                 "url": "https://api.bybit.com/v5/order/create",
                 "input": [
@@ -89,13 +89,13 @@
                   37000,
                   {
                     "triggerPrice": 37000,
-                    "triggerDirection": "above"
+                    "triggerDirection": "rising"
                   }
                 ],
                 "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.001\",\"price\":\"37000\",\"triggerDirection\":1,\"triggerPrice\":\"37000\"}"
             },
             {
-                "description": "swap limit buy with triggerPrice and triggerDirection below",
+                "description": "swap limit buy with triggerPrice and triggerDirection falling",
                 "method": "createOrder",
                 "url": "https://api.bybit.com/v5/order/create",
                 "input": [
@@ -106,7 +106,7 @@
                   35000,
                   {
                     "triggerPrice": 35000,
-                    "triggerDirection": "below"
+                    "triggerDirection": "falling"
                   }
                 ],
                 "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.001\",\"price\":\"35000\",\"triggerDirection\":2,\"triggerPrice\":\"35000\"}"
@@ -209,7 +209,7 @@
                   41000,
                   {
                     "triggerPrice": "40000",
-                    "triggerDirection": "above",
+                    "triggerDirection": "rising",
                     "stopLoss": "39500"
                   }
                 ],

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4255,7 +4255,7 @@ We have different classification of trigger orders:
 
 Traditional "stop" order (which you might see across exchanges' websites) is now called "trigger" order across CCXT library. Implemented by adding a `triggerPrice` parameter. They are independent basic trigger orders that can open or close a position.
 
-* Typically, it is activated when price of the underlying asset/contract crosses the `triggerPrice` from **any direction**. However, some exchanges' API require to set `triggerDirection` too, which triggers order depending whether price is above or below `triggerPrice`. For example, if you want to trigger  limit order (buy 0.1 `ETH` at limit price `1500`) once pair price crosses `1700`:
+* Typically, it is activated when the price of the underlying asset/contract touches the `triggerPrice` from **any direction**. However, some exchange API's require that you set `triggerDirection` too, which triggers the order depending on whether the price is rising or falling to the `triggerPrice`. For example, if you want to trigger a limit order (buy 0.1 `ETH` at limit price `1500`) once the price reaches `1700`:
 
 <!-- tabs:start -->
 #### **Javascript**
@@ -4280,12 +4280,12 @@ $params = {
 $order = $exchange->create_order ('ETH/USDT', 'market', 'buy', 0.1, 1500, $params)
 ```
 <!-- tabs:end -->
-However, if some exchanges require that you provided `triggerDirection`, with either `above` or `below` values:
+However, some exchanges require that you provide the `triggerDirection`, with either a `rising` or `falling` value:
 
 ```
 params = {
     'triggerPrice': 1700,
-    'triggerDirection': 'above', // order will be triggered when price is above 1700
+    'triggerDirection': 'rising', // the order will be triggered when the price rises and reaches 1700
 }
 ```
 


### PR DESCRIPTION
Changed the unified `triggerDirection` from `above/below` to `rising/falling` to make the implied direction more clear.

There has been some questions raised from users confused about when to use triggerDirection = above, or triggerDirection = below.

With the old `above/below` values it isn't immediately clear if we mean the triggerPrice is reached from above (falling) or if the current price goes above the triggerPrice (rising).

So if you say the triggerPrice is reached from above, that actually means the triggerDirection should be set to below (falling), which is a confusing contradiction.

Changing to `rising/falling` prevents this confusion because the direction is implied from the value names without leaving any room for error or misunderstanding.

From the bybit createOrder documentation for triggerDirection:
```
Used to identify the expected direction of the conditional order.
1: triggered when market price rises to the triggerPrice
2: triggered when market price falls to the triggerPrice
```