### PR TITLE
bitopro: add watchMyTrades

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -338,6 +338,7 @@
         }
     },
     "bitopro": {
+        "skipWs": true,
         "skipMethods": {
             "fetchCurrencies": {
                 "precision": "not provided",

--- a/ts/src/pro/bitopro.ts
+++ b/ts/src/pro/bitopro.ts
@@ -5,7 +5,7 @@ import bitoproRest from '../bitopro.js';
 import { ExchangeError } from '../base/errors.js';
 import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import { sha384 } from '../static_dependencies/noble-hashes/sha512.js';
-import type { Int, OrderBook, Trade, Ticker, Balances, Market } from '../base/types.js';
+import type { Int, OrderBook, Trade, Ticker, Balances, Market, Str } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 
 // ----------------------------------------------------------------------------
@@ -16,7 +16,7 @@ export default class bitopro extends bitoproRest {
             'has': {
                 'ws': true,
                 'watchBalance': true,
-                'watchMyTrades': false,
+                'watchMyTrades': true,
                 'watchOHLCV': false,
                 'watchOrderBook': true,
                 'watchOrders': false,
@@ -182,7 +182,7 @@ export default class bitopro extends bitoproRest {
         client.resolve (tradesCache, messageHash);
     }
 
-    async watchMyTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+    async watchMyTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         /**
          * @method
          * @name bitopro#watchMyTrades

--- a/ts/src/pro/bitopro.ts
+++ b/ts/src/pro/bitopro.ts
@@ -3,9 +3,9 @@
 
 import bitoproRest from '../bitopro.js';
 import { ExchangeError } from '../base/errors.js';
-import { ArrayCache } from '../base/ws/Cache.js';
+import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import { sha384 } from '../static_dependencies/noble-hashes/sha512.js';
-import type { Int, OrderBook, Trade, Ticker, Balances } from '../base/types.js';
+import type { Int, OrderBook, Trade, Ticker, Balances, Market } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 
 // ----------------------------------------------------------------------------
@@ -182,6 +182,151 @@ export default class bitopro extends bitoproRest {
         client.resolve (tradesCache, messageHash);
     }
 
+    async watchMyTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        /**
+         * @method
+         * @name bitopro#watchMyTrades
+         * @description watches information on multiple trades made by the user
+         * @see https://github.com/bitoex/bitopro-offical-api-docs/blob/master/ws/private/matches_stream.md
+         * @param {string} symbol unified market symbol of the market trades were made in
+         * @param {int} [since] the earliest time in ms to fetch trades for
+         * @param {int} [limit] the maximum number of trade structures to retrieve
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure
+         */
+        this.checkRequiredCredentials ();
+        await this.loadMarkets ();
+        let messageHash = 'USER_TRADE';
+        if (symbol !== undefined) {
+            const market = this.market (symbol);
+            messageHash = messageHash + ':' + market['symbol'];
+        }
+        const url = this.urls['ws']['private'] + '/' + 'user-trades';
+        this.authenticate (url);
+        const trades = await this.watch (url, messageHash, undefined, messageHash);
+        if (this.newUpdates) {
+            limit = trades.getLimit (symbol, limit);
+        }
+        return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
+    }
+
+    handleMyTrade (client: Client, message) {
+        //
+        //     {
+        //         "event": "USER_TRADE",
+        //         "timestamp": 1694667358782,
+        //         "datetime": "2023-09-14T12:55:58.782Z",
+        //         "data": {
+        //             "base": "usdt",
+        //             "quote": "twd",
+        //             "side": "ask",
+        //             "price": "32.039",
+        //             "volume": "1",
+        //             "fee": "6407800",
+        //             "feeCurrency": "twd",
+        //             "transactionTimestamp": 1694667358,
+        //             "eventTimestamp": 1694667358,
+        //             "orderID": 390733918,
+        //             "orderType": "LIMIT",
+        //             "matchID": "bd07673a-94b1-419e-b5ee-d7b723261a5d",
+        //             "isMarket": false,
+        //             "isMaker": false
+        //         }
+        //     }
+        //
+        const data = this.safeValue (message, 'data', {});
+        const baseId = this.safeString (data, 'base');
+        const quoteId = this.safeString (data, 'quote');
+        const base = this.safeCurrencyCode (baseId);
+        const quote = this.safeCurrencyCode (quoteId);
+        const symbol = this.symbol (base + '/' + quote);
+        const messageHash = this.safeString (message, 'event');
+        if (this.myTrades === undefined) {
+            const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
+            this.myTrades = new ArrayCacheBySymbolById (limit);
+        }
+        const trades = this.myTrades;
+        const parsed = this.parseWsTrade (data);
+        trades.append (parsed);
+        client.resolve (trades, messageHash);
+        client.resolve (trades, messageHash + ':' + symbol);
+    }
+
+    parseWsTrade (trade, market: Market = undefined): Trade {
+        //
+        //     {
+        //         "base": "usdt",
+        //         "quote": "twd",
+        //         "side": "ask",
+        //         "price": "32.039",
+        //         "volume": "1",
+        //         "fee": "6407800",
+        //         "feeCurrency": "twd",
+        //         "transactionTimestamp": 1694667358,
+        //         "eventTimestamp": 1694667358,
+        //         "orderID": 390733918,
+        //         "orderType": "LIMIT",
+        //         "matchID": "bd07673a-94b1-419e-b5ee-d7b723261a5d",
+        //         "isMarket": false,
+        //         "isMaker": false
+        //     }
+        //
+        const id = this.safeString (trade, 'matchID');
+        const orderId = this.safeString (trade, 'orderID');
+        const timestamp = this.safeTimestamp (trade, 'transactionTimestamp');
+        const baseId = this.safeString (trade, 'base');
+        const quoteId = this.safeString (trade, 'quote');
+        const base = this.safeCurrencyCode (baseId);
+        const quote = this.safeCurrencyCode (quoteId);
+        const symbol = this.symbol (base + '/' + quote);
+        market = this.safeMarket (symbol, market);
+        const price = this.safeString (trade, 'price');
+        const type = this.safeStringLower (trade, 'orderType');
+        let side = this.safeString (trade, 'side');
+        if (side !== undefined) {
+            if (side === 'ask') {
+                side = 'sell';
+            } else if (side === 'bid') {
+                side = 'buy';
+            }
+        }
+        const amount = this.safeString (trade, 'volume');
+        let fee = undefined;
+        const feeAmount = this.safeString (trade, 'fee');
+        const feeSymbol = this.safeCurrencyCode (this.safeString (trade, 'feeCurrency'));
+        if (feeAmount !== undefined) {
+            fee = {
+                'cost': feeAmount,
+                'currency': feeSymbol,
+                'rate': undefined,
+            };
+        }
+        const isMaker = this.safeValue (trade, 'isMaker');
+        let takerOrMaker = undefined;
+        if (isMaker !== undefined) {
+            if (isMaker) {
+                takerOrMaker = 'maker';
+            } else {
+                takerOrMaker = 'taker';
+            }
+        }
+        return this.safeTrade ({
+            'id': id,
+            'info': trade,
+            'order': orderId,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'symbol': symbol,
+            'takerOrMaker': takerOrMaker,
+            'type': type,
+            'side': side,
+            'price': price,
+            'amount': amount,
+            'cost': undefined,
+            'fee': fee,
+        }, market);
+    }
+
     async watchTicker (symbol: string, params = {}): Promise<Ticker> {
         /**
          * @method
@@ -329,6 +474,7 @@ export default class bitopro extends bitoproRest {
             'TICKER': this.handleTicker,
             'ORDER_BOOK': this.handleOrderBook,
             'ACCOUNT_BALANCE': this.handleBalance,
+            'USER_TRADE': this.handleMyTrade,
         };
         const event = this.safeString (message, 'event');
         const method = this.safeValue (methods, event);


### PR DESCRIPTION
```BASH
$ p bitopro watchMyTrades ETH/TWD
Python v3.11.3
CCXT v4.2.21
bitopro.watchMyTrades(ETH/TWD)
[{'amount': 0.00091972,
  'cost': 64.99937156,
  'datetime': '2024-01-24T02:19:44.000Z',
  'fee': {'cost': 184.0, 'currency': 'BITO', 'rate': None},
  'fees': [{'cost': 184.0, 'currency': 'BITO', 'rate': None}],
  'id': None,
  'info': {'base': 'eth',
           'eventTimestamp': 1706062784,
           'fee': '184',
           'feeCurrency': 'BITO',
           'isMaker': False,
           'isMarket': True,
           'matchID': '',
           'orderID': '4869968086',
           'orderType': 'MARKET',
           'price': '70673',
           'quote': 'twd',
           'side': 'bid',
           'transactionTimestamp': 1706062784,
           'volume': '0.00091972'},
  'order': '4869968086',
  'price': 70673.0,
  'side': 'buy',
  'symbol': 'ETH/TWD',
  'takerOrMaker': 'taker',
  'timestamp': 1706062784000,
  'type': 'market'}]
```