### PR TITLE
feat(binance): update test ws endpoint

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -47,7 +47,7 @@ export default class binance extends binanceRest {
                     'ws': {
                         'spot': 'wss://testnet.binance.vision/ws',
                         'margin': 'wss://testnet.binance.vision/ws',
-                        'future': 'wss://stream.binancefuture.com/ws',
+                        'future': 'wss://fstream.binancefuture.com/ws',
                         'delivery': 'wss://dstream.binancefuture.com/ws',
                         'ws': 'wss://testnet.binance.vision/ws-api/v3',
                     },


### PR DESCRIPTION
![image](https://github.com/ccxt/ccxt/assets/43336371/454a5d71-aee9-4534-9b2d-3468607d623e)


DEMO

```
n binanceusdm watchTicker "BTC/USDT:USDT" --verbose --sandbox
2024-01-24T17:12:49.419Z
Node.js: v20.7.0
CCXT v4.2.21
binanceusdm.watchTicker (BTC/USDT:USDT)
2024-01-24T17:12:50.678Z connecting to wss://fstream.binancefuture.com/ws/0
2024-01-24T17:12:52.281Z onUpgrade
2024-01-24T17:12:52.282Z onOpen
2024-01-24T17:12:52.284Z sending { method: 'SUBSCRIBE', params: [ 'btcusdt@ticker' ], id: 1 }
2024-01-24T17:12:52.600Z onMessage { result: null, id: 1 }
2024-01-24T17:12:56.036Z onMessage {
  e: '24hrTicker',
  E: 1706116375946,
  s: 'BTCUSDT',
  p: '834.10',
  P: '2.113',
  w: '40257.35',
  c: '40299.90',
  Q: '6.369',
  o: '39465.80',
  h: '41400.00',
  l: '39400.00',
  v: '125188.711',
  q: '5039766300.69',
  O: 1706029920000,
  C: 1706116375935,
  F: 278926563,
  L: 278989564,
  n: 62944
}
```
