### PR TITLE
fix(bitget): watchOrders - remove invalid amount for buy orders

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1265,7 +1265,7 @@ export default class bitget extends bitgetRest {
             'price': this.safeString (order, 'price'),
             'stopPrice': triggerPrice,
             'triggerPrice': triggerPrice,
-            'amount': this.safeString2 (order, 'size', 'baseSize'),
+            'amount': this.safeString (order, 'baseVolume'),
             'cost': this.safeStringN (order, [ 'notional', 'notionalUsd', 'quoteSize' ]),
             'average': this.omitZero (this.safeString2 (order, 'priceAvg', 'fillPrice')),
             'filled': this.safeString2 (order, 'accBaseVolume', 'baseVolume'),


### PR DESCRIPTION
It looks like only the cost is provided for buy orders

------------------------

fixes: #20868

```
% bitget watchOrders DOGE/USDT          
2024-01-25T07:04:46.540Z
Node.js: v18.12.0
CCXT v4.2.21
bitget.watchOrders (DOGE/USDT)
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134309265877946368 | 22fa1270-05a6-45d4-ae5c-dac96940b20e | 1706166324109 | 2024-01-25T07:05:24.109Z |      1706166324109 | market |         GTC |    false | sell |       |           |              |        |      |         |      0 |           |   open |     |     [] |   [] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side |    price | stopPrice | triggerPrice | amount |     cost |  average | filled | remaining | status |                                       fee | trades |                                      fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134309265877946368 | 22fa1270-05a6-45d4-ae5c-dac96940b20e | 1706166324109 | 2024-01-25T07:05:24.109Z |      1706166324261 | market |         GTC |    false | sell | 0.077971 |           |              |     69 | 5.379999 | 0.077971 |     69 |         0 | closed | {"cost":"0.0026899995","currency":"USDT"} |     [] | [{"cost":0.0026899995,"currency":"USDT"}] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134309361327722497 | d0ec02e0-56b8-4c97-9414-0ea6796b4eb0 | 1706166346866 | 2024-01-25T07:05:46.866Z |      1706166346866 | market |         GTC |    false |  buy |       |           |              |        | 5.25 |         |      0 |           |   open |     |     [] |   [] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side |    price | stopPrice | triggerPrice |  amount | cost |  average |  filled | remaining | status |                                    fee | trades |                                   fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134309361327722497 | d0ec02e0-56b8-4c97-9414-0ea6796b4eb0 | 1706166346866 | 2024-01-25T07:05:46.866Z |      1706166347009 | market |         GTC |    false |  buy | 0.077974 |           |              | 67.3301 | 5.25 | 0.077974 | 67.3301 |         0 | closed | {"cost":"0.0673301","currency":"DOGE"} |     [] | [{"cost":0.0673301,"currency":"DOGE"}] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134309466709610496 | b6f24823-01a1-402a-862c-819248026213 | 1706166371991 | 2024-01-25T07:06:11.991Z |      1706166371991 | market |         GTC |    false | sell |       |           |              |        |      |         |      0 |           |   open |     |     [] |   [] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side |    price | stopPrice | triggerPrice | amount |     cost |  average | filled | remaining | status |                                          fee | trades |                                         fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134309466709610496 | b6f24823-01a1-402a-862c-819248026213 | 1706166371991 | 2024-01-25T07:06:11.991Z |      1706166372121 | market |         GTC |    false | sell | 0.077921 |           |              |     69 | 5.376549 | 0.077921 |     69 |         0 | closed | {"cost":"0.0026883082521","currency":"USDT"} |     [] | [{"cost":0.0026883082521,"currency":"USDT"}] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134311426644955142 | 6c20a790-56bd-4364-8885-43cc354b1903 | 1706166839276 | 2024-01-25T07:13:59.276Z |      1706166839276 | limit |         GTC |    false |  buy | 0.077 |           |              |        | 5.39 |         |      0 |           |   open |     |     [] |   [] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining |   status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134311426644955142 | 6c20a790-56bd-4364-8885-43cc354b1903 | 1706166839276 | 2024-01-25T07:13:59.276Z |      1706166893899 | limit |         GTC |    false |  buy | 0.077 |           |              |        | 5.39 |         |      0 |           | canceled |     |     [] |   [] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134311729628893190 | eb9d5b5b-560e-4a92-824a-b843995dfb97 | 1706166911513 | 2024-01-25T07:15:11.513Z |      1706166911513 | market |         GTC |    false |  buy |       |           |              |        | 5.39 |         |      0 |           |   open |     |     [] |   [] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |   type | timeInForce | postOnly | side |    price | stopPrice | triggerPrice | amount | cost |  average | filled | remaining | status |                                   fee | trades |                                  fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134311729628893190 | eb9d5b5b-560e-4a92-824a-b843995dfb97 | 1706166911513 | 2024-01-25T07:15:11.513Z |      1706166911669 | market |         GTC |    false |  buy | 0.077889 |           |              | 69.201 | 5.39 | 0.077889 | 69.201 |         0 | closed | {"cost":"0.069201","currency":"DOGE"} |     [] | [{"cost":0.069201,"currency":"DOGE"}] |                     |            |                 |              
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | amount | cost | average | filled | remaining | status | fee | trades | fees | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1134312044407214083 | 94e45607-cc25-4d01-9ce1-ea907830b701 | 1706166986562 | 2024-01-25T07:16:26.562Z |      1706166986562 | limit |         GTC |    false | sell |  0.08 |           |              |        |    0 |         |      0 |           |   open |     |     [] |   [] |                     |            |                 |              
1 objects
```