### PR TITLE
fix(binance) no timestamp for futures watched tickers

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -998,7 +998,7 @@ export default class binance extends binanceRest {
             timestamp = this.safeInteger (message, 'E');
         } else {
             // take the timestamp of the closing price for candlestick streams
-            timestamp = this.safeInteger (message, 'C');
+            timestamp = this.safeInteger2 (message, 'C', 'E');
         }
         const marketId = this.safeString (message, 's');
         const symbol = this.safeSymbol (marketId, undefined, undefined, marketType);


### PR DESCRIPTION
under watchTicker for futures contracts, field 'C' is not set, but 'E' is set.

        //         "C": 1579485597842,     // close time
        //         "E": 1579485598569,     // event time
