### PR TITLE
Bitfinex2: fetchOpenInterestHistory

### DIFF
--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -137,6 +137,16 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchOpenInterestHistory": [
+            {
+                "description": "Fetch the open interest history of a swap trading pair",
+                "method": "fetchOpenInterestHistory",
+                "url": "https://api-pub.bitfinex.com/v2/status/deriv/tBTCF0:USTF0/hist",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchOpenInterestHistory to bitfinex2:
```
bitfinex2.fetchOpenInterestHistory (BTC/USDT:USDT, , , 3)
2024-01-26T19:37:25.100Z iteration 0 passed in 837 ms

       symbol | openInterestAmount
----------------------------------
BTC/USDT:USDT |      5803.98697087
BTC/USDT:USDT |      5803.98697087
BTC/USDT:USDT |      5804.00031179
3 objects
```