### PR TITLE
fix(ws): freezing eror

### DIFF
--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -319,9 +319,17 @@ class Client {
                 $this->on_error(new RequestTimeout('Connection to ' . $this->url . ' timed out due to a ping-pong keepalive missing on time'));
             } else {
                 if ($this->ping) {
-                    $this->send(call_user_func($this->ping, $this));
+                    try {
+                        $this->send(call_user_func($this->ping, $this));
+                    } catch (Exception $e) {
+                        $this->on_error($e);
+                    }
                 } else {
-                    $this->connection->send(new Frame('', true, Frame::OP_PING));
+                    try {
+                        $this->connection->send(new Frame('', true, Frame::OP_PING));
+                    } catch (Exception $e) {
+                        $this->on_error($e);
+                    }
                 }
             }
         }

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -129,20 +129,14 @@ trait ClientTrait {
                                 try {
                                     Async\await($client->send($message));
                                 } catch (Exception $error) {
-                                    $future->reject($error);
-                                    foreach ($subscribe_hashes as $subscribe_hash) {
-                                        unset($client->subscriptions[$subscribe_hash]);
-                                    }
+                                    $client->on_error($error);
                                 }
                             });
                         } else {
                             try {
                                 Async\await($client->send($message));
                             } catch (Exception $error) {
-                                $future->reject($error);
-                                foreach ($subscribe_hashes as $subscribe_hash) {
-                                    unset($client->subscriptions[$subscribe_hash]);
-                                }
+                                $client->on_error($error);
                             }
                         }
                     }
@@ -188,16 +182,14 @@ trait ClientTrait {
                                 try {
                                     Async\await($client->send($message));
                                 } catch (Exception $error) {
-                                    $client->reject($error, $message_hash);
-                                    unset($client->subscriptions[$subscribe_hash]);
+                                    $client->on_error($error);
                                 }
                             });
                         } else {
                             try {
                                 Async\await($client->send($message));
                             } catch (Exception $error) {
-                                $client->reject($error, $message_hash);
-                                unset($client->subscriptions[$subscribe_hash]);
+                                $client->on_error($error);
                             }
                         }
                     }

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -430,9 +430,9 @@ class Exchange(BaseExchange):
                     try:
                         await client.send(message)
                     except ConnectionError as e:
-                        for subscribe_hash in missing_subscriptions:
-                            del client.subscriptions[subscribe_hash]
-                        future.reject(e)
+                        client.on_error (e)
+                    except Exception as e:
+                        client.on_error (e)
                 asyncio.ensure_future(send_message())
 
         if missing_subscriptions:
@@ -468,8 +468,9 @@ class Exchange(BaseExchange):
                     try:
                         await client.send(message)
                     except ConnectionError as e:
-                        del client.subscriptions[subscribe_hash]
-                        future.reject(e)
+                        client.on_error (e)
+                    except Exception as e:
+                        client.on_error (e)
                 asyncio.ensure_future(send_message())
 
         if not subscribed:

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -430,9 +430,9 @@ class Exchange(BaseExchange):
                     try:
                         await client.send(message)
                     except ConnectionError as e:
-                        client.on_error (e)
+                        client.on_error(e)
                     except Exception as e:
-                        client.on_error (e)
+                        client.on_error(e)
                 asyncio.ensure_future(send_message())
 
         if missing_subscriptions:
@@ -468,9 +468,9 @@ class Exchange(BaseExchange):
                     try:
                         await client.send(message)
                     except ConnectionError as e:
-                        client.on_error (e)
+                        client.on_error(e)
                     except Exception as e:
-                        client.on_error (e)
+                        client.on_error(e)
                 asyncio.ensure_future(send_message())
 
         if not subscribed:

--- a/python/ccxt/async_support/base/ws/aiohttp_client.py
+++ b/python/ccxt/async_support/base/ws/aiohttp_client.py
@@ -115,7 +115,10 @@ class AiohttpClient(Client):
             # therefore we need this clause anyway
             else:
                 if self.ping:
-                    await self.send(self.ping(self))
+                    try:
+                        await self.send(self.ping(self))
+                    except Exception as e:
+                        self.on_error(e)
                 else:
                     await self.connection.ping()
             await sleep(self.keepAlive / 1000)

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1519,14 +1519,12 @@ export default class Exchange {
                         client.throttle (cost).then (() => {
                             client.send (message);
                         }).catch ((e) => {
-                            delete client.subscriptions[subscribeHash];
-                            future.reject (e);
+                            client.onError (e);
                         });
                     } else {
                         client.send (message)
                         .catch ((e) => {
-                            delete client.subscriptions[subscribeHash];
-                            future.reject (e);
+                            client.onError (e);
                         });
                     }
                 }

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -206,6 +206,9 @@ export default class Client {
             } else {
                 if (this.ping) {
                     this.send (this.ping (this))
+                        .catch ((error) => {
+                            this.onError (error);
+                        })
                 } else if (isNode) {
                     // can't do this inside browser
                     // https://stackoverflow.com/questions/10585355/sending-websocket-ping-pong-frame-from-browser


### PR DESCRIPTION
This PR aims to sovle the reports of websockets freezing.
Two different cases were found:
 1. the connection is closed before a message is sent,  (can be caught by client.send throwing an error when watch is called).
 2. the connection is closed after the initial watch is called, and can be caught in the ping send throws an error)
 
 Both cases are solved by sorround the send mesages to a try catch and resetting the client when an exception is thrown
 
Issues affected
- fix #20957
- fix #20946
- fix #20935
- fix #20911