### PR TITLE
Bitfinex2: fetchLiquidations

### DIFF
--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -147,6 +147,16 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchLiquidations": [
+            {
+                "description": "Swap fetch public liquidations",
+                "method": "fetchLiquidations",
+                "url": "https://api-pub.bitfinex.com/v2/liquidations/hist",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchLiquidations to bitfinex2:

```
bitfinex2.fetchLiquidations (BTC/USDT:USDT)
2024-01-28T09:27:32.663Z iteration 0 passed in 1086 ms

       symbol |  contracts |  baseValue |     timestamp |                 datetime | price |    quoteValue
----------------------------------------------------------------------------------------------------------
BTC/USDT:USDT |     0.0392 |     0.0392 | 1706417848752 | 2024-01-28T04:57:28.752Z |       | 
BTC/USDT:USDT |     0.0392 |     0.0392 | 1706417848753 | 2024-01-28T04:57:28.753Z | 42735 |      1675.212
BTC/USDT:USDT | 0.03908247 | 0.03908247 | 1706417848757 | 2024-01-28T04:57:28.757Z | 42735 | 1670.18935545
BTC/USDT:USDT |      0.002 |      0.002 | 1706418029074 | 2024-01-28T05:00:29.074Z |       | 
BTC/USDT:USDT |      0.002 |      0.002 | 1706418029079 | 2024-01-28T05:00:29.079Z | 42815 |         85.63
5 objects
```