### PR TITLE
feat(bitforex): cancelAllOrders

### DIFF
--- a/ts/src/bitforex.ts
+++ b/ts/src/bitforex.ts
@@ -29,6 +29,7 @@ export default class bitforex extends Exchange {
                 'future': false,
                 'option': false,
                 'addMargin': false,
+                'cancelAllOrders': true,
                 'cancelOrder': true,
                 'createOrder': true,
                 'createReduceOnlyOrder': false,
@@ -693,6 +694,35 @@ export default class bitforex extends Exchange {
             'fee': fee,
             'trades': undefined,
         }, market);
+    }
+
+    async cancelAllOrders (symbol: Str = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitforex#cancelAllOrders
+         * @see https://github.com/githubdev2020/API_Doc_en/wiki/Cancle-all-orders
+         * @description cancel all open orders in a market
+         * @param {string} symbol unified market symbol of the market to cancel orders in
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' cancelAllOrders () requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request = {
+            'symbol': market['id'],
+        };
+        const response = await this.privatePostApiV1TradeCancelAllOrder (this.extend (request, params));
+        //
+        //    {
+        //        'data': True,
+        //        'success': True,
+        //        'time': '1706542995252'
+        //    }
+        //
+        return response;
     }
 
     async fetchOrder (id: string, symbol: Str = undefined, params = {}) {

--- a/ts/src/test/static/request/bitforex.json
+++ b/ts/src/test/static/request/bitforex.json
@@ -1,6 +1,29 @@
 {
     "exchange": "bitforex",
-    "skipKeys": [],
-    "outputType": "json",
-    "methods": {}
+    "skipKeys": ["accessKey", "nonce", "signData"],
+    "outputType": "both",
+    "methods": {
+        "cancelAllOrders": [
+            {
+                "description": "cancel all spot LTC/USDT orders",
+                "method": "cancelAllOrders",
+                "url": "https://api.bitforex.com/api/v1/trade/cancelAllOrder",
+                "input": [
+                  "LTC/USDT"
+                ],
+                "output": "accessKey=d9078f222b77f1394797cae7e663a6f8&nonce=1706544103540&symbol=coin-usdt-ltc&signData=ea3b6150870f066a8bdeb0d21ecf8ab9ccab47357408ab640dd82d6f2385121b"
+              }
+        ],
+        "fetchMyTrades": [
+            {
+                "description": "fetch my spot LTC/USDT trades",
+                "method": "fetchMyTrades",
+                "url": "https://api.bitforex.com/api/v1/trade/myTrades",
+                "input": [
+                  "LTC/USDT"
+                ],
+                "output": "accessKey=d9078f222b77f1394797cae7e663a6f8&nonce=1706544216488&symbol=coin-usdt-ltc&signData=ea89d8d7fcfb8405e5783f27a4e42d25bb8970a9cf4116195ea8bfe45f20a53d"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
```
% py bitforex cancelAllOrders BTC/USDT
Python v3.9.6
CCXT v4.2.23
bitforex.cancelAllOrders(BTC/USDT)
{'data': True, 'success': True, 'time': '1706542995252'}
```