### PR TITLE
Bitfinex2: setMargin

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -69,6 +69,7 @@ export default class bitfinex2 extends Exchange {
                 'fetchTradingFees': true,
                 'fetchTransactionFees': undefined,
                 'fetchTransactions': 'emulated',
+                'setMargin': true,
                 'withdraw': true,
             },
             'timeframes': {
@@ -3295,5 +3296,50 @@ export default class bitfinex2 extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
         });
+    }
+
+    async setMargin (symbol: string, amount, params = {}) {
+        /**
+         * @method
+         * @name bitfinex2#setMargin
+         * @description either adds or reduces margin in a swap position in order to set the margin to a specific value
+         * @see https://docs.bitfinex.com/reference/rest-auth-deriv-pos-collateral-set
+         * @param {string} symbol unified market symbol of the market to set margin in
+         * @param {float} amount the amount to set the margin to
+         * @param {object} [params] parameters specific to the exchange API endpoint
+         * @returns {object} A [margin structure]{@link https://github.com/ccxt/ccxt/wiki/Manual#add-margin-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new NotSupported (this.id + ' setMargin() only support swap markets');
+        }
+        const request = {
+            'symbol': market['id'],
+            'collateral': this.parseToNumeric (amount),
+        };
+        const response = await this.privatePostAuthWDerivCollateralSet (this.extend (request, params));
+        //
+        //     [
+        //         [
+        //             1
+        //         ]
+        //     ]
+        //
+        const data = this.safeValue (response, 0);
+        return this.parseMarginModification (data, market);
+    }
+
+    parseMarginModification (data, market = undefined) {
+        const marginStatusRaw = data[0];
+        const marginStatus = (marginStatusRaw === 1) ? 'ok' : 'failed';
+        return {
+            'info': data,
+            'type': undefined,
+            'amount': undefined,
+            'code': undefined,
+            'symbol': market['symbol'],
+            'status': marginStatus,
+        };
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -157,6 +157,18 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "setMargin": [
+            {
+                "description": "Set the margin collateral for a swap position",
+                "method": "setMargin",
+                "url": "https://api.bitfinex.com/v2/auth/w/deriv/collateral/set",
+                "input": [
+                  "BTC/USDT:USDT",
+                  0.5
+                ],
+                "output": "{\"symbol\":\"tBTCF0:USTF0\",\"collateral\":0.5}"
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `setMargin` to bitfinex2:
```
bitfinex2.setMargin (BTC/USDT:USDT, 0.75)
2024-01-30T03:53:46.952Z iteration 0 passed in 1346 ms

{ info: [ 1 ], symbol: 'BTC/USDT:USDT', status: 'ok' }
```