### PR TITLE
feat(coinbase) - fetchBidsAsks - multi symbol arguments support

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3231,7 +3231,12 @@ export default class coinbase extends Exchange {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
         // the 'product_ids' param isn't working properly and returns {"pricebooks":[]} when defined
-        const response = await this.v3PrivateGetBrokerageBestBidAsk (params);
+        const request = {};
+        if (symbols !== undefined) {
+            const marketIds = this.marketIds (symbols);
+            request['product_ids'] = marketIds.join (',');
+        }
+        const response = await this.v3PrivateGetBrokerageBestBidAsk (this.extend (request, params));
         //
         //     {
         //         "pricebooks": [

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3233,8 +3233,7 @@ export default class coinbase extends Exchange {
         // the 'product_ids' param isn't working properly and returns {"pricebooks":[]} when defined
         const request = {};
         if (symbols !== undefined) {
-            const marketIds = this.marketIds (symbols);
-            request['product_ids'] = marketIds;
+            request['product_ids'] = this.marketIds (symbols);
         }
         const response = await this.v3PrivateGetBrokerageBestBidAsk (this.extend (request, params));
         //

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3234,7 +3234,7 @@ export default class coinbase extends Exchange {
         const request = {};
         if (symbols !== undefined) {
             const marketIds = this.marketIds (symbols);
-            request['product_ids'] = marketIds.join (',');
+            request['product_ids'] = marketIds;
         }
         const response = await this.v3PrivateGetBrokerageBestBidAsk (this.extend (request, params));
         //
@@ -3367,7 +3367,7 @@ export default class coinbase extends Exchange {
         const savedPath = fullPath;
         if (method === 'GET') {
             if (Object.keys (query).length) {
-                fullPath += '?' + this.urlencode (query);
+                fullPath += '?' + this.urlencodeWithArrayRepeat (query);
             }
         }
         const url = this.urls['api']['rest'] + fullPath;

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3230,7 +3230,6 @@ export default class coinbase extends Exchange {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        // the 'product_ids' param isn't working properly and returns {"pricebooks":[]} when defined
         const request = {};
         if (symbols !== undefined) {
             request['product_ids'] = this.marketIds (symbols);

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -266,6 +266,19 @@
                 ],
                 "output": "{\"type\":\"send\",\"to\":\"0x93536de4c50a8a90874162504f26978fa946c23a\",\"amount\":10,\"currency\":\"USDC\"}"
             }
+        ],
+        "fetchBidsAsks": [
+            {
+                "description": "fetchBidsAsks with symbols",
+                "method": "fetchBidsAsks",
+                "url": "https://api.coinbase.com/api/v3/brokerage/best_bid_ask?product_ids=BTC-USDT&product_ids=ETH-USDT",
+                "input": [
+                  [
+                    "BTC/USDT",
+                    "ETH/USDT"
+                  ]
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
added support for multi symbols (with `product_ids` request argument , as per https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getbestbidask )

also amended the query encoding part, because with simple `urlencode` it generates such link:
`/best_bid_ask?product_ids%5B0%5D=ADA-USDT&product_ids%5B1%5D=BTC-USDT`

while with `urlencodeWithArrayRepeat` it generates correct link:
`/best_bid_ask?product_ids=ADA-USDT&product_ids=BTC-USDT'`

which is accepted by coinbase.

```
await e.fetchBidsAsks(['ADA/USDT', 'BTC/USDT']);



fetch Request:
 coinbase GET https://api.coinbase.com/api/v3/brokerage/best_bid_ask?product_ids=ADA-USDT&product_ids=BTC-USDT
RequestHeaders: {...}
RequestBody: undefined

handleRestResponse:
 coinbase GET https://api.coinbase.com/api/v3/brokerage/best_bid_ask?product_ids=ADA-USDT&product_ids=BTC-USDT 200 OK      
ResponseHeaders: { ...}
ResponseBody:
{
    "pricebooks": [{
            "product_id": "ADA-USDT",
            "bids": [{  "price": "0.519", "size": "17327.47" } ],
            "asks": [{  "price": "0.52",  "size": "21815.54"    } ],
            "time": "2024-01-30T20:20:11.207786Z"
        }, {
            "product_id": "BTC-USDT",
            "bids": [{ "price": "43583.04", "size": "0.0573614"  }  ],
            "asks": [{"price": "43584.91",   "size": "0.00022027"  }  ],
            "time": "2024-01-30T20:20:15.268973Z"
        }
    ]
}



```