### PR TITLE
feat(bitmex) - watchTickers

### DIFF
--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -341,16 +341,16 @@ export default class bitmex extends bitmexRest {
         //     }
         //
         const table = this.safeString (message, 'table');
-        const data = this.safeValue (message, 'data', []);
+        const data = this.safeList (message, 'data', []);
         const tickers = {};
         for (let i = 0; i < data.length; i++) {
             const update = data[i];
-            const marketId = this.safeValue (update, 'symbol');
+            const marketId = this.safeString (update, 'symbol');
             const market = this.safeMarket (marketId);
             const symbol = market['symbol'];
             const messageHash = table + ':' + marketId;
-            let ticker = this.safeValue (this.tickers, symbol, {});
-            const info = this.safeValue (ticker, 'info', {});
+            let ticker = this.safeDict (this.tickers, symbol, {});
+            const info = this.safeDict (ticker, 'info', {});
             ticker = this.parseTicker (this.extend (info, update), market);
             tickers[symbol] = ticker;
             this.tickers[symbol] = ticker;

--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -5,7 +5,7 @@ import bitmexRest from '../bitmex.js';
 import { AuthenticationError, ExchangeError, RateLimitExceeded } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
-import type { Int, Str, Strings, OrderBook, Order, Trade, Ticker, OHLCV, Position, Balances } from '../base/types.js';
+import type { Int, Str, Strings, OrderBook, Order, Trade, Ticker, Tickers, OHLCV, Position, Balances } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 
 //  ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ export default class bitmex extends bitmexRest {
                 'watchOrders': true,
                 'watchPostions': true,
                 'watchTicker': true,
-                'watchTickers': false,
+                'watchTickers': true,
                 'watchTrades': true,
                 'watchTradesForSymbols': true,
             },
@@ -76,6 +76,41 @@ export default class bitmex extends bitmexRest {
             ],
         };
         return await this.watch (url, messageHash, this.extend (request, params), messageHash);
+    }
+
+    async watchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        /**
+         * @method
+         * @name bitmex#watchTickers
+         * @description watches a price ticker, a statistical calculation with the information calculated over the past 24 hours for all markets of a specific list
+         * @param {string[]} symbols unified symbol of the market to fetch the ticker for
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols, undefined, true);
+        const name = 'instrument';
+        const url = this.urls['api']['ws'];
+        const messageHashes = [];
+        if (symbols !== undefined) {
+            for (let i = 0; i < symbols.length; i++) {
+                const symbol = symbols[i];
+                const market = this.market (symbol);
+                const hash = name + ':' + market['id'];
+                messageHashes.push (hash);
+            }
+        } else {
+            messageHashes.push (name);
+        }
+        const request = {
+            'op': 'subscribe',
+            'args': messageHashes,
+        };
+        const tickers = await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
+        if (this.newUpdates) {
+            return tickers;
+        }
+        return this.filterByArray (this.tickers, 'symbol', symbols);
     }
 
     handleTicker (client: Client, message) {
@@ -307,6 +342,7 @@ export default class bitmex extends bitmexRest {
         //
         const table = this.safeString (message, 'table');
         const data = this.safeValue (message, 'data', []);
+        const tickers = {};
         for (let i = 0; i < data.length; i++) {
             const update = data[i];
             const marketId = this.safeValue (update, 'symbol');
@@ -316,9 +352,11 @@ export default class bitmex extends bitmexRest {
             let ticker = this.safeValue (this.tickers, symbol, {});
             const info = this.safeValue (ticker, 'info', {});
             ticker = this.parseTicker (this.extend (info, update), market);
+            tickers[symbol] = ticker;
             this.tickers[symbol] = ticker;
             client.resolve (ticker, messageHash);
         }
+        client.resolve (tickers, 'instrument');
         return message;
     }
 

--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -106,9 +106,14 @@ export default class bitmex extends bitmexRest {
             'op': 'subscribe',
             'args': messageHashes,
         };
-        const tickers = await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
+        const ticker = await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
         if (this.newUpdates) {
-            return tickers;
+            if (symbols === undefined) {
+                return ticker;
+            }
+            const result = {};
+            result[ticker['symbol']] = ticker;
+            return result;
         }
         return this.filterByArray (this.tickers, 'symbol', symbols);
     }


### PR DESCRIPTION
```
const res = await e.watchTickers();

2024-01-31T12:26:43.295Z connecting to wss://ws.bitmex.com/realtime
2024-01-31T12:26:43.743Z onUpgrade
2024-01-31T12:26:43.745Z onOpen
2024-01-31T12:26:43.746Z sending { op: 'subscribe', args: [ 'instrument' ] }
2024-01-31T12:26:43.748Z onMessage {
  info: 'Welcome to the BitMEX Realtime API.',
  version: '2.0.0',
  timestamp: '2024-01-31T12:26:43.840Z',
  docs: 'https://www.bitmex.com/app/wsAPI',
  heartbeatEnabled: false,
  limit: { remaining: 179 }
}
2024-01-31T12:26:43.841Z onMessage {
  success: true,
  subscribe: 'instrument',
  request: { op: 'subscribe', args: [ 'instrument' ] }
}
....
```

res:
```
{
  "SNT/USDT:USDT": {
    symbol: "SNT/USDT:USDT",
    timestamp: 1706704003061,
    datetime: "2024-01-31T12:26:43.061Z",
    high: undefined,
    low: undefined,
    bid: 0.03828,
    bidVolume: undefined,
    ask: 0.03844,
    askVolume: undefined,
    vwap: undefined,
    open: 0.03996,
    close: 0.03996,
    last: 0.03996,
    previousClose: undefined,
    change: 0,
    percentage: 0,
    average: 0.03996,
    baseVolume: 0,
    quoteVolume: 0,
    info: {
      symbol: "SNTUSDT",
      rootSymbol: "SNT",
      state: "Open",
      typ: "FFWCSX",
      listing: "2023-11-08T04:00:00.000Z",
      front: "2023-11-08T04:00:00.000Z",
      positionCurrency: "SNT",
      underlying: "SNT",
      quoteCurrency: "USDT",
      underlyingSymbol: "SNTT=",
      reference: "BMEX",
      referenceSymbol: ".BSNTT",
      maxOrderQty: 1000000000,
      maxPrice: 1000,
      lotSize: 100,
      tickSize: 0.00001,
      multiplier: 1000000,
      settlCurrency: "USDt",
      underlyingToPositionMultiplier: 1,
      quoteToSettleMultiplier: 1000000,
      isQuanto: false,
      isInverse: false,
      initMargin: 0.1,
      maintMargin: 0.05,
      riskLimit: 20000000000,
      riskStep: 20000000000,
      taxed: true,
      deleverage: true,
      makerFee: -0.00015,
      takerFee: 0.00075,
      settlementFee: 0,
      fundingBaseSymbol: ".SNTBON8H",
      fundingQuoteSymbol: ".USDTBON8H",
      fundingPremiumSymbol: ".SNTUSDTPI8H",
      fundingTimestamp: "2024-01-31T20:00:00.000Z",
      fundingInterval: "2000-01-01T08:00:00.000Z",
      fundingRate: 0.0001,
      indicativeFundingRate: 0.0001,
      prevClosePrice: 0.03837,
      prevTotalVolume: 2492200,
      totalVolume: 2492200,
      volume: 0,
      volume24h: 0,
      prevTotalTurnover: 107378725000,
      totalTurnover: 107378725000,
      turnover: 0,
      turnover24h: 0,
      homeNotional24h: 0,
      foreignNotional24h: 0,
      prevPrice24h: 0.03996,
      lastPrice: 0.03996,
      lastPriceProtected: 0.03996,
      lastTickDirection: "PlusTick",
      lastChangePcnt: 0.0278,
      bidPrice: 0.03828,
      midPrice: 0.03836,
      askPrice: 0.03844,
      hasLiquidity: false,
      openInterest: 2600,
      openValue: 99736000,
      fairMethod: "FundingRate",
      fairBasisRate: 0.1095,
      fairBasis: 0,
      fairPrice: 0.03836,
      markMethod: "FairPrice",
      markPrice: 0.03836,
      indicativeSettlePrice: 0.03836,
      instantPnl: false,
      minTick: 0.00001,
      timestamp: "2024-01-31T12:26:43.061Z",
    },
  },

..........

```