### PR TITLE
fix(ascendex): fetchDepositAddress - accepts params["network"]

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -276,7 +276,7 @@ export default class ascendex extends Exchange {
                     'fillResponseFromRequest': true,
                 },
                 'networks': {
-                    'BSC': 'BEP20 (BSC)',
+                    'BSC': 'BEP20 ' + '(BSC)',
                     'ARB': 'arbitrum',
                     'SOL': 'Solana',
                     'AVAX': 'avalanche C chain',

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2417,12 +2417,13 @@ export default class ascendex extends Exchange {
          * @description fetch the deposit address for a currency associated with this account
          * @param {string} code unified currency code
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.network] unified network code for deposit chain
          * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
-        const chainName = this.safeString (params, 'chainName');
-        params = this.omit (params, 'chainName');
+        const chainName = this.safeString2 (params, 'network', 'chainName');
+        params = this.omit (params, [ 'network', 'chainName' ]);
         const request = {
             'asset': currency['id'],
         };

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -157,7 +157,7 @@ export default class ascendex extends Exchange {
                         'get': {
                             'info': 1,
                             'wallet/transactions': 1,
-                            'wallet/deposit/address': 1, // not documented
+                            'wallet/deposit/address': 1,
                             'data/balance/snapshot': 1,
                             'data/balance/history': 1,
                         },
@@ -281,6 +281,9 @@ export default class ascendex extends Exchange {
                     'SOL': 'Solana',
                     'AVAX': 'avalanche C chain',
                     'OMNI': 'Omni',
+                    'TRC': 'TRC20',
+                    'TRX': 'TRC20',
+                    'ERC': 'ERC20',
                 },
                 'networksById': {
                     'BEP20 (BSC)': 'BSC',
@@ -288,6 +291,16 @@ export default class ascendex extends Exchange {
                     'Solana': 'SOL',
                     'avalanche C chain': 'AVAX',
                     'Omni': 'OMNI',
+                    'TRC20': 'TRC20',
+                    'ERC20': 'ERC20',
+                    'GO20': 'GO20',
+                    'BEP2': 'BEP2',
+                    'Bitcoin': 'BTC',
+                    'Bitcoin ABC': 'BCH',
+                    'Litecoin': 'LTC',
+                    'Matic Network': 'MATIC',
+                    'xDai': 'STAKE',
+                    'Akash': 'AKT',
                 },
             },
             'exceptions': {
@@ -2381,7 +2394,7 @@ export default class ascendex extends Exchange {
         const tag = this.safeString (depositAddress, tagId);
         this.checkAddress (address);
         const code = (currency === undefined) ? undefined : currency['code'];
-        const chainName = this.safeString (depositAddress, 'chainName');
+        const chainName = this.safeString (depositAddress, 'blockchain');
         const network = this.safeNetwork (chainName);
         return {
             'currency': code,
@@ -2393,20 +2406,7 @@ export default class ascendex extends Exchange {
     }
 
     safeNetwork (networkId) {
-        const networksById = {
-            'TRC20': 'TRC20',
-            'ERC20': 'ERC20',
-            'GO20': 'GO20',
-            'BEP2': 'BEP2',
-            'BEP20 (BSC)': 'BEP20',
-            'Bitcoin': 'BTC',
-            'Bitcoin ABC': 'BCH',
-            'Litecoin': 'LTC',
-            'Matic Network': 'MATIC',
-            'Solana': 'SOL',
-            'xDai': 'STAKE',
-            'Akash': 'AKT',
-        };
+        const networksById = this.safeDict (this.options, 'networksById');
         return this.safeString (networksById, networkId, networkId);
     }
 
@@ -2415,6 +2415,7 @@ export default class ascendex extends Exchange {
          * @method
          * @name ascendex#fetchDepositAddress
          * @description fetch the deposit address for a currency associated with this account
+         * @see https://ascendex.github.io/ascendex-pro-api/#query-deposit-addresses
          * @param {string} code unified currency code
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.network] unified network code for deposit chain
@@ -2422,10 +2423,12 @@ export default class ascendex extends Exchange {
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
-        const chainName = this.safeString2 (params, 'network', 'chainName');
+        const networkCode = this.safeString2 (params, 'network', 'chainName');
+        const networkId = this.networkCodeToId (networkCode);
         params = this.omit (params, [ 'network', 'chainName' ]);
         const request = {
             'asset': currency['id'],
+            'blockchain': networkId,
         };
         const response = await this.v1PrivateGetWalletDepositAddress (this.extend (request, params));
         //
@@ -2467,12 +2470,12 @@ export default class ascendex extends Exchange {
         let address = undefined;
         if (numAddresses > 1) {
             const addressesByChainName = this.indexBy (addresses, 'chainName');
-            if (chainName === undefined) {
+            if (networkId === undefined) {
                 const chainNames = Object.keys (addressesByChainName);
                 const chains = chainNames.join (', ');
                 throw new ArgumentsRequired (this.id + ' fetchDepositAddress() returned more than one address, a chainName parameter is required, one of ' + chains);
             }
-            address = this.safeValue (addressesByChainName, chainName, {});
+            address = this.safeValue (addressesByChainName, networkId, {});
         } else {
             // first address
             address = this.safeValue (addresses, 0, {});

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2425,7 +2425,7 @@ export default class ascendex extends Exchange {
         const currency = this.currency (code);
         const networkCode = this.safeString2 (params, 'network', 'chainName');
         const networkId = this.networkCodeToId (networkCode);
-        params = this.omit (params, [ 'network', 'chainName' ]);
+        params = this.omit (params, [ 'chainName' ]);
         const request = {
             'asset': currency['id'],
             'blockchain': networkId,

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2395,7 +2395,7 @@ export default class ascendex extends Exchange {
         this.checkAddress (address);
         const code = (currency === undefined) ? undefined : currency['code'];
         const chainName = this.safeString (depositAddress, 'blockchain');
-        const network = this.safeNetwork (chainName);
+        const network = this.networkIdToCode (chainName, code);
         return {
             'currency': code,
             'address': address,
@@ -2464,8 +2464,8 @@ export default class ascendex extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'data', {});
-        const addresses = this.safeValue (data, 'address', []);
+        const data = this.safeDict (response, 'data', {});
+        const addresses = this.safeList (data, 'address', []);
         const numAddresses = addresses.length;
         let address = undefined;
         if (numAddresses > 1) {
@@ -2475,10 +2475,10 @@ export default class ascendex extends Exchange {
                 const chains = chainNames.join (', ');
                 throw new ArgumentsRequired (this.id + ' fetchDepositAddress() returned more than one address, a chainName parameter is required, one of ' + chains);
             }
-            address = this.safeValue (addressesByChainName, networkId, {});
+            address = this.safeDict (addressesByChainName, networkId, {});
         } else {
             // first address
-            address = this.safeValue (addresses, 0, {});
+            address = this.safeDict (addresses, 0, {});
         }
         const result = this.parseDepositAddress (address, currency);
         return this.extend (result, {

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -334,6 +334,20 @@
                   }
                 ]
             }
+        ],
+        "transfer": [
+            {
+                "description": "transfer from spot to futures",
+                "method": "transfer",
+                "url": "https://ascendex.com/3/api/pro/v1/transfer",
+                "input": [
+                  "USDT",
+                  1,
+                  "cash",
+                  "futures"
+                ],
+                "output": "{\"amount\":\"1\",\"asset\":\"USDT\",\"fromAccount\":\"cash\",\"toAccount\":\"futures\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -339,6 +339,7 @@
             {
                 "description": "transfer from spot to futures",
                 "method": "transfer",
+                "disabled": true,
                 "url": "https://ascendex.com/3/api/pro/v1/transfer",
                 "input": [
                   "USDT",

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -321,6 +321,19 @@
                 ],
                 "output":"{\"symbol\":\"BTC-PERP\",\"time\":1701161145825}"
             }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "fetch deposit address",
+                "method": "fetchDepositAddress",
+                "url": "https://ascendex.com/api/pro/v1/wallet/deposit/address?asset=USDT&blockchain=TRC20&network=TRC20",
+                "input": [
+                  "USDT",
+                  {
+                    "network": "TRC20"
+                  }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/ascendex.json
+++ b/ts/src/test/static/response/ascendex.json
@@ -49,6 +49,181 @@
           }
         }
       }
+    ],
+    "fetchClosedOrders": [
+      {
+        "description": "fetch spot closed orders",
+        "method": "fetchClosedOrders",
+        "input": [],
+        "httpResponse": {
+          "code": "0",
+          "data": [
+            {
+              "accountId": "cshF5SlR9ukAXoDOuXbND4dVpBMw9gzH",
+              "seqNum": "38621007619",
+              "orderId": "a18d8972df3cU7223046196BGzSSwzfj",
+              "createTime": "1707408023997",
+              "lastExecTime": "1707408024011",
+              "side": "Sell",
+              "symbol": "LTC/USDT",
+              "orderQty": "0.1",
+              "orderType": "Market",
+              "price": "65.68",
+              "status": "Filled",
+              "stopPrice": "0",
+              "fillQty": "0.1",
+              "avgFillPrice": "69.14",
+              "fee": "0.006914",
+              "feeAsset": "USDT",
+              "positionMode": "NULL_VAL"
+            }
+          ]
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "accountId": "cshF5SlR9ukAXoDOuXbND4dVpBMw9gzH",
+              "seqNum": "38621007619",
+              "orderId": "a18d8972df3cU7223046196BGzSSwzfj",
+              "createTime": "1707408023997",
+              "lastExecTime": "1707408024011",
+              "side": "Sell",
+              "symbol": "LTC/USDT",
+              "orderQty": "0.1",
+              "orderType": "Market",
+              "price": "65.68",
+              "status": "Filled",
+              "stopPrice": "0",
+              "fillQty": "0.1",
+              "avgFillPrice": "69.14",
+              "fee": "0.006914",
+              "feeAsset": "USDT",
+              "positionMode": "NULL_VAL"
+            },
+            "id": "a18d8972df3cU7223046196BGzSSwzfj",
+            "clientOrderId": null,
+            "timestamp": 1707408024011,
+            "datetime": "2024-02-08T16:00:24.011Z",
+            "lastTradeTimestamp": 1707408024011,
+            "symbol": "LTC/USDT",
+            "type": "market",
+            "timeInForce": "IOC",
+            "postOnly": null,
+            "reduceOnly": null,
+            "side": "sell",
+            "price": 65.68,
+            "stopPrice": 0,
+            "triggerPrice": 0,
+            "amount": 0.1,
+            "cost": 6.568,
+            "average": null,
+            "filled": 0.1,
+            "remaining": 0,
+            "status": "closed",
+            "fee": {
+              "cost": 0.006914,
+              "currency": "USDT"
+            },
+            "trades": [],
+            "fees": [
+              {
+                "cost": 0.006914,
+                "currency": "USDT"
+              }
+            ],
+            "lastUpdateTimestamp": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      }
+    ],
+    "fetchOrder": [
+      {
+        "description": "fetch spot order",
+        "method": "fetchOrder",
+        "input": [
+          "a18d8972df3cU7223046196BGzSSwzfj",
+          "LTC/USDT"
+        ],
+        "httpResponse": {
+          "code": "0",
+          "accountId": "cshF5SlR9ukAXoDOuXbND4dVpBMw9gzH",
+          "ac": "CASH",
+          "data": {
+            "seqNum": "38621007619",
+            "orderId": "a18d8972df3cU7223046196BGzSSwzfj",
+            "symbol": "LTC/USDT",
+            "orderType": "Market",
+            "lastExecTime": "1707408024011",
+            "price": "65.68",
+            "orderQty": "0.1",
+            "side": "Sell",
+            "status": "Filled",
+            "avgPx": "69.14",
+            "cumFilledQty": "0.1",
+            "stopPrice": "",
+            "errorCode": "",
+            "cumFee": "0.006914",
+            "feeAsset": "USDT",
+            "execInst": "NULL_VAL"
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "seqNum": "38621007619",
+            "orderId": "a18d8972df3cU7223046196BGzSSwzfj",
+            "symbol": "LTC/USDT",
+            "orderType": "Market",
+            "lastExecTime": "1707408024011",
+            "price": "65.68",
+            "orderQty": "0.1",
+            "side": "Sell",
+            "status": "Filled",
+            "avgPx": "69.14",
+            "cumFilledQty": "0.1",
+            "stopPrice": "",
+            "errorCode": "",
+            "cumFee": "0.006914",
+            "feeAsset": "USDT",
+            "execInst": "NULL_VAL"
+          },
+          "id": "a18d8972df3cU7223046196BGzSSwzfj",
+          "clientOrderId": null,
+          "timestamp": 1707408024011,
+          "datetime": "2024-02-08T16:00:24.011Z",
+          "lastTradeTimestamp": 1707408024011,
+          "symbol": "LTC/USDT",
+          "type": "market",
+          "timeInForce": "IOC",
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": "sell",
+          "price": 65.68,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "amount": 0.1,
+          "cost": 6.914,
+          "average": 69.14,
+          "filled": 0.1,
+          "remaining": 0,
+          "status": "closed",
+          "fee": {
+            "cost": 0.006914,
+            "currency": "USDT"
+          },
+          "trades": [],
+          "fees": [
+            {
+              "cost": 0.006914,
+              "currency": "USDT"
+            }
+          ],
+          "lastUpdateTimestamp": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null
+        }
+      }
     ]
   }
 }

--- a/ts/src/test/static/response/ascendex.json
+++ b/ts/src/test/static/response/ascendex.json
@@ -1,0 +1,54 @@
+{
+  "exchange": "ascendex",
+  "skipKeys": [],
+  "options": {
+  },
+  "methods": {
+    "fetchDepositAddress": [
+      {
+        "description": "fetch usdt deposit address",
+        "method": "fetchDepositAddress",
+        "input": [
+          "USDT",
+          {
+            "network": "TRC20"
+          }
+        ],
+        "httpResponse": {
+          "code": "0",
+          "data": {
+            "asset": "USDT",
+            "assetName": "Tether",
+            "address": [
+              {
+                "address": "ZXXfdfd",
+                "destTag": "",
+                "blockchain": "TRC20"
+              }
+            ]
+          }
+        },
+        "parsedResponse": {
+          "currency": "USDT",
+          "address": "ZXXfdfd",
+          "tag": null,
+          "network": "TRC20",
+          "info": {
+            "code": "0",
+            "data": {
+              "asset": "USDT",
+              "assetName": "Tether",
+              "address": [
+                {
+                  "address": "ZXXfdfd",
+                  "destTag": "",
+                  "blockchain": "TRC20"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Typescript works, but python currently fails because `BEP20 (BSC)` is being transpile to `BEP20(BSC)` without a space

```
% ascendex fetchDepositAddress USDT '{"network": "BSC"}' 
2024-01-31T19:49:25.734Z
Node.js: v18.12.0
CCXT v4.2.29
ascendex.fetchDepositAddress (USDT, [object Object])
2024-01-31T19:49:30.768Z iteration 0 passed in 660 ms

{
  currency: 'USDT',
  address: '0xbaf5d3e0ef4a5f60ab6b1c47b02627403da0bebf',
  tag: undefined,
  network: 'BSC',
  info: {
    code: '0',
    data: {
      asset: 'USDT',
      assetName: 'Tether',
      address: [
        {
          address: '0xbaf5d3e0ef4a5f60ab6b1c47b02627403da0bebf',
          destTag: '',
          blockchain: 'BEP20 (BSC)'
        }
      ]
    }
  }
}
2024-01-31T19:49:30.768Z iteration 1 passed in 660 ms
```

```
% py ascendex fetchDepositAddress USDT '{"network": "BSC"}'
Python v3.9.6
CCXT v4.2.36
ascendex.fetchDepositAddress(USDT,{'network': 'BSC'})
{'address': '0xbaf5d3e0ef4a5f60ab6b1c47b02627403da0bebf',
 'currency': 'USDT',
 'info': {'code': '0',
          'data': {'address': [{'address': '0xbaf5d3e0ef4a5f60ab6b1c47b02627403da0bebf',
                                'blockchain': 'BEP20 (BSC)',
                                'destTag': ''}],
                   'asset': 'USDT',
                   'assetName': 'Tether'}},
 'network': 'BSC',
 'tag': None}
```