### PR TITLE
Digifinex: fetchTickers, safeMarket fourth argument error

### DIFF
--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -1160,9 +1160,11 @@ export default class digifinex extends Exchange {
         //         "timestamp": 1663221614998
         //     }
         //
+        const indexPrice = this.safeNumber (ticker, 'index_price');
+        const marketType = (indexPrice !== undefined) ? 'contract' : 'spot';
         const marketId = this.safeStringUpper2 (ticker, 'symbol', 'instrument_id');
-        const symbol = this.safeSymbol (marketId, market);
-        market = this.safeMarket (marketId);
+        const symbol = this.safeSymbol (marketId, market, undefined, marketType);
+        market = this.safeMarket (marketId, market, undefined, marketType);
         let timestamp = this.safeTimestamp (ticker, 'date');
         if (market['swap']) {
             timestamp = this.safeInteger (ticker, 'timestamp');

--- a/ts/src/test/static/request/digifinex.json
+++ b/ts/src/test/static/request/digifinex.json
@@ -485,6 +485,26 @@
                         "type": "swap"
                     }
                 ]
+            },
+            {
+                "description": "Spot market fetch tickers",
+                "method": "fetchTickers",
+                "url": "https://openapi.digifinex.com/v3/ticker",
+                "input": [
+                  [
+                    "BTC/USDT"
+                  ]
+                ]
+            },
+            {
+                "description": "Swap market fetch tickers",
+                "method": "fetchTickers",
+                "url": "https://openapi.digifinex.com/swap/v2/public/tickers",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ]
+                ]
             }
         ],
         "fetchTicker": [


### PR DESCRIPTION
Added a `marketType` argument to `safeMarket` and `safeSymbol` in parseTicker to prevent an error that a user was receiving
fixes: #21045