### PR TITLE
bitfinex2: cancelOrders

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -31,6 +31,7 @@ export default class bitfinex2 extends Exchange {
                 'option': undefined,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
+                'cancelOrders': true,
                 'createDepositAddress': true,
                 'createLimitOrder': true,
                 'createMarketOrder': true,
@@ -1673,6 +1674,7 @@ export default class bitfinex2 extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        await this.loadMarkets ();
         const request = {
             'all': 1,
         };
@@ -1692,6 +1694,7 @@ export default class bitfinex2 extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        await this.loadMarkets ();
         const cid = this.safeValue2 (params, 'cid', 'clientOrderId'); // client order id
         let request = undefined;
         if (cid !== undefined) {
@@ -1712,6 +1715,83 @@ export default class bitfinex2 extends Exchange {
         const response = await this.privatePostAuthWOrderCancel (this.extend (request, params));
         const order = this.safeValue (response, 4);
         return this.parseOrder (order);
+    }
+
+    async cancelOrders (ids, symbol: Str = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitfinex2#cancelOrders
+         * @description cancel multiple orders at the same time
+         * @see https://docs.bitfinex.com/reference/rest-auth-cancel-orders-multiple
+         * @param {string[]} ids order ids
+         * @param {string} symbol unified market symbol, default is undefined
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an array of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        for (let i = 0; i < ids.length; i++) {
+            ids[i] = this.parseToNumeric (ids[i]);
+        }
+        const request = {
+            'id': ids,
+        };
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const response = await this.privatePostAuthWOrderCancelMulti (this.extend (request, params));
+        //
+        //     [
+        //         1706740198811,
+        //         "oc_multi-req",
+        //         null,
+        //         null,
+        //         [
+        //             [
+        //                 139530205057,
+        //                 null,
+        //                 1706740132275,
+        //                 "tBTCF0:USTF0",
+        //                 1706740132276,
+        //                 1706740132276,
+        //                 0.0001,
+        //                 0.0001,
+        //                 "LIMIT",
+        //                 null,
+        //                 null,
+        //                 null,
+        //                 0,
+        //                 "ACTIVE",
+        //                 null,
+        //                 null,
+        //                 39000,
+        //                 0,
+        //                 0,
+        //                 0,
+        //                 null,
+        //                 null,
+        //                 null,
+        //                 0,
+        //                 0,
+        //                 null,
+        //                 null,
+        //                 null,
+        //                 "API>BFX",
+        //                 null,
+        //                 null,
+        //                 {
+        //                     "lev": 10,
+        //                     "$F33": 10
+        //                 }
+        //             ],
+        //         ],
+        //         null,
+        //         "SUCCESS",
+        //         "Submitting 2 order cancellations."
+        //     ]
+        //
+        const orders = this.safeList (response, 4, []);
+        return this.parseOrders (orders, market);
     }
 
     async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -457,6 +457,20 @@
                 ],
                 "output": "{\"id\":139449164689}"
             }
+        ],
+        "cancelOrders": [
+            {
+                "description": "Cancel multiple orders at the same time",
+                "method": "cancelOrders",
+                "url": "https://api.bitfinex.com/v2/auth/w/order/cancel/multi",
+                "input": [
+                  [
+                    139535430656,
+                    139533608984
+                  ]
+                ],
+                "output": "{\"id\":[139535430656,139533608984]}"
+            }
         ]
     }
 }


### PR DESCRIPTION
Added support for `cancelOrders` to bitfinex2:
```
bitfinex2.cancelOrders (139535430656,139533608984)
2024-01-31T22:27:00.917Z iteration 0 passed in 1050 ms

          id | clientOrderId |     timestamp |                 datetime |        symbol | timeInForce | postOnly | side | price | amount | cost | filled | remaining | status | trades | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
139535430656 | 1706739366905 | 1706739366907 | 2024-01-31T22:16:06.907Z | BTC/USDT:USDT |         GTC |    false |  buy | 39000 | 0.0001 |    0 |      0 |    0.0001 |   open |     [] |   []
139533608984 | 1706739393597 | 1706739393599 | 2024-01-31T22:16:33.599Z | LTC/USDT:USDT |         GTC |    false |  buy |    50 |   0.25 |    0 |      0 |      0.25 |   open |     [] |   []
2 objects
```