### PR TITLE
fix(bitget): update request test

### DIFF
--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1163,12 +1163,8 @@
           {
             "description": "spot trading fees",
             "method": "fetchTradingFees",
-            "url": "https://api.bitget.com/api/v2/spot/public/symbols?symbol=BTCUSDT",
-            "input": [
-              {
-                "symbol": "BTCUSDT"
-              }
-            ]
+            "url": "https://api.bitget.com/api/v2/spot/public/symbols",
+            "input": []
           }
         ],
         "fetchLedger": [

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1163,11 +1163,11 @@
           {
             "description": "spot trading fees",
             "method": "fetchTradingFees",
-            "url": "https://api.bitget.com/api/v2/spot/public/symbols?0=BTC%2FUSDT",
+            "url": "https://api.bitget.com/api/v2/spot/public/symbols?symbol=BTCUSDT",
             "input": [
-              [
-                "BTC/USDT"
-              ]
+              {
+                "symbol": "BTCUSDT"
+              }
             ]
           }
         ],


### PR DESCRIPTION
When I run static test on bitget, I found the query payload to fetchTradingFees in spot should be `symbol="BTCUSDT"`, doc: https://www.bitget.com/api-doc/spot/market/Get-Symbols.

I also found an `'list' object has no attribute 'keys'` error when send public request with array params on bitget. The reason is the params was array (list in python) instead of tuple. @carlosmiei should we use self.extend to transform all params into tuple?

![image](https://github.com/ccxt/ccxt/assets/10494397/9490059d-7eef-429b-ac2d-c7123b1a7a99)

```BASH
$ p bitget publicSpotGetV2SpotPublicSymbols '{"symbol":"BTCUSDT"}'
Python v3.11.4
CCXT v4.2.30
bitget.publicSpotGetV2SpotPublicSymbols({'symbol': 'BTCUSDT'})
{'code': '00000',
 'data': [{'areaSymbol': 'no',
           'baseCoin': 'BTC',
           'buyLimitPriceRatio': '0.05',
           'makerFeeRate': '0.002',
           'maxTradeAmount': '10000000000',
           'minTradeAmount': '0',
           'minTradeUSDT': '5',
           'pricePrecision': '2',
           'quantityPrecision': '4',
           'quoteCoin': 'USDT',
           'quotePrecision': '6',
           'sellLimitPriceRatio': '0.05',
           'status': 'online',
           'symbol': 'BTCUSDT',
           'takerFeeRate': '0.002'}],
 'msg': 'success'}
```
