### PR TITLE
bitfinex2: add the remaining swap support

### DIFF
--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1363,11 +1363,11 @@ export default class bitfinex2 extends Exchange {
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
-         * @param {int} [limit] the maximum amount of candles to fetch
+         * @param {int} [limit] the maximum amount of candles to fetch, default 100 max 10000
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          * @param {int} [params.until] timestamp in ms of the latest candle to fetch
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          */
         await this.loadMarkets ();
         let paginate = false;
@@ -1377,7 +1377,7 @@ export default class bitfinex2 extends Exchange {
         }
         const market = this.market (symbol);
         if (limit === undefined) {
-            limit = 10000; // default 100, max 5000
+            limit = 10000;
         }
         let request = {
             'symbol': market['id'],

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -3513,4 +3513,70 @@ export default class bitfinex2 extends Exchange {
             'status': marginStatus,
         };
     }
+
+    async fetchOrder (id: string, symbol: string = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitfinex2#fetchOrder
+         * @description fetches information on an order made by the user
+         * @see https://docs.bitfinex.com/reference/rest-auth-retrieve-orders
+         * @see https://docs.bitfinex.com/reference/rest-auth-retrieve-orders-by-symbol
+         * @param {string} id the order id
+         * @param {string} [symbol] unified symbol of the market the order was made in
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const request = {
+            'id': [ this.parseToNumeric (id) ],
+        };
+        let market = undefined;
+        let response = undefined;
+        if (symbol === undefined) {
+            response = await this.privatePostAuthROrders (this.extend (request, params));
+        } else {
+            market = this.market (symbol);
+            request['symbol'] = market['id'];
+            response = await this.privatePostAuthROrdersSymbol (this.extend (request, params));
+        }
+        //
+        //     [
+        //         [
+        //             139658969116,
+        //             null,
+        //             1706843908637,
+        //             "tBTCUST",
+        //             1706843908637,
+        //             1706843908638,
+        //             0.0001,
+        //             0.0001,
+        //             "EXCHANGE LIMIT",
+        //             null,
+        //             null,
+        //             null,
+        //             0,
+        //             "ACTIVE",
+        //             null,
+        //             null,
+        //             35000,
+        //             0,
+        //             0,
+        //             0,
+        //             null,
+        //             null,
+        //             null,
+        //             0,
+        //             0,
+        //             null,
+        //             null,
+        //             null,
+        //             "API>BFX",
+        //             null,
+        //             null,
+        //             {}
+        //         ]
+        //     ]
+        //
+        return this.parseOrder (response[0], market);
+    }
 }

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -3241,7 +3241,8 @@ export default class bitfinex2 extends Exchange {
         //         ]
         //     ]
         //
-        return this.parseOpenInterest (response[0], market);
+        const oi = this.safeList (response, 0);
+        return this.parseOpenInterest (oi, market);
     }
 
     async fetchOpenInterestHistory (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -3582,7 +3583,8 @@ export default class bitfinex2 extends Exchange {
         //         ]
         //     ]
         //
-        return this.parseOrder (response[0], market);
+        const order = this.safeList (response, 0);
+        return this.parseOrder (order, market);
     }
 
     async editOrder (id: string, symbol, type, side, amount = undefined, price = undefined, params = {}) {

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1313,9 +1313,9 @@ export default class bitfinex2 extends Exchange {
          * @see https://docs.bitfinex.com/reference/rest-public-trades
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int} [since] timestamp in ms of the earliest trade to fetch
-         * @param {int} [limit] the maximum amount of trades to fetch
+         * @param {int} [limit] the maximum amount of trades to fetch, default 120, max 10000
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @param {int} [params.until] the latest time in ms to fetch entries for
          * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
          */

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -354,6 +354,7 @@ export default class bitfinex2 extends Exchange {
                     'margin': 'margin',
                     'derivatives': 'margin',
                     'future': 'margin',
+                    'swap': 'margin',
                 },
                 'withdraw': {
                     'includeFee': false,

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -2953,7 +2953,7 @@ export default class bitfinex2 extends Exchange {
     async fetchFundingRate (symbol: string, params = {}) {
         /**
          * @method
-         * @name bitfine#fetchFundingRate
+         * @name bitfinex2#fetchFundingRate
          * @description fetch the current funding rate
          * @see https://docs.bitfinex.com/reference/rest-public-derivatives-status
          * @param {string} symbol unified market symbol
@@ -2966,7 +2966,7 @@ export default class bitfinex2 extends Exchange {
     async fetchFundingRates (symbols: Strings = undefined, params = {}) {
         /**
          * @method
-         * @name bitfine#fetchFundingRate
+         * @name bitfinex2#fetchFundingRate
          * @description fetch the current funding rate
          * @see https://docs.bitfinex.com/reference/rest-public-derivatives-status
          * @param {string[]} symbols list of unified market symbols
@@ -3018,13 +3018,15 @@ export default class bitfinex2 extends Exchange {
     async fetchFundingRateHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         /**
          * @method
-         * @name bitfine#fetchFundingRateHistory
+         * @name bitfinex2#fetchFundingRateHistory
          * @description fetches historical funding rate prices
          * @see https://docs.bitfinex.com/reference/rest-public-derivatives-status-history
          * @param {string} symbol unified market symbol
+         * @param {int} [since] timestamp in ms of the earliest funding rate entry
+         * @param {int} [limit] max number of funding rate entrys to return
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {int} [params.until] timestamp in ms of the latest funding rate
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
          */
         if (symbol === undefined) {

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -3080,7 +3080,13 @@ export default class bitfinex2 extends Exchange {
             const rate = this.parseFundingRateHistory (fr, market);
             rates.push (rate);
         }
-        return this.filterBySymbolSinceLimit (rates, symbol, since, limit) as FundingRateHistory[];
+        const reversedArray = [];
+        const rawRates = this.filterBySymbolSinceLimit (rates, symbol, since, limit);
+        for (let i = rawRates.length - 1; i >= 0; i--) {
+            const valueAtIndex = rawRates[i];
+            reversedArray.push (valueAtIndex);
+        }
+        return reversedArray as FundingRateHistory[];
     }
 
     parseFundingRate (contract, market: Market = undefined) {

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -26,9 +26,10 @@ export default class bitfinex2 extends Exchange {
                 'CORS': undefined,
                 'spot': true,
                 'margin': undefined, // has but unimplemented
-                'swap': undefined, // has but unimplemented
+                'swap': true,
                 'future': undefined,
                 'option': undefined,
+                'addMargin': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
                 'cancelOrders': true,
@@ -50,13 +51,17 @@ export default class bitfinex2 extends Exchange {
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
                 'fetchDepositsWithdrawals': true,
+                'fetchFundingHistory': false,
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
                 'fetchFundingRates': true,
                 'fetchIndexOHLCV': false,
                 'fetchLedger': true,
+                'fetchLeverage': false,
+                'fetchLeverageTiers': false,
                 'fetchLiquidations': true,
                 'fetchMarginMode': false,
+                'fetchMarketLeverageTiers': false,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
@@ -66,7 +71,10 @@ export default class bitfinex2 extends Exchange {
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderTrades': true,
+                'fetchPosition': false,
                 'fetchPositionMode': false,
+                'fetchPositions': true,
+                'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
                 'fetchTickers': true,
                 'fetchTime': false,
@@ -74,7 +82,11 @@ export default class bitfinex2 extends Exchange {
                 'fetchTradingFees': true,
                 'fetchTransactionFees': undefined,
                 'fetchTransactions': 'emulated',
+                'reduceMargin': false,
+                'setLeverage': false,
                 'setMargin': true,
+                'setMarginMode': false,
+                'setPositionMode': false,
                 'withdraw': true,
             },
             'timeframes': {
@@ -2893,7 +2905,6 @@ export default class bitfinex2 extends Exchange {
          * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {object} a [ledger structure]{@link https://docs.ccxt.com/#/?id=ledger-structure}
          */
-        await this.loadMarkets ();
         await this.loadMarkets ();
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchLedger', 'paginate');

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -2903,10 +2903,10 @@ export default class bitfinex2 extends Exchange {
          * @see https://docs.bitfinex.com/reference/rest-auth-ledgers
          * @param {string} code unified currency code, default is undefined
          * @param {int} [since] timestamp in ms of the earliest ledger entry, default is undefined
-         * @param {int} [limit] max number of ledger entrys to return, default is undefined
+         * @param {int} [limit] max number of ledger entrys to return, default is undefined max is 2500
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {int} [params.until] timestamp in ms of the latest ledger entry
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {object} a [ledger structure]{@link https://docs.ccxt.com/#/?id=ledger-structure}
          */
         await this.loadMarkets ();
@@ -2921,7 +2921,7 @@ export default class bitfinex2 extends Exchange {
             request['start'] = since;
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // max 2500
+            request['limit'] = limit;
         }
         [ request, params ] = this.handleUntilOption ('end', request, params);
         let response = undefined;

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -3080,7 +3080,15 @@ export default class bitfinex2 extends Exchange {
             const rate = this.parseFundingRateHistory (fr, market);
             rates.push (rate);
         }
-        return this.filterBySymbolSinceLimit (rates, symbol, since, limit).reverse () as FundingRateHistory[];
+        const reversedArray = [];
+        const rawRates = this.filterBySymbolSinceLimit (rates, symbol, since, limit);
+        const rawRatesLength = rawRates.length;
+        const ratesLength = Math.max (rawRatesLength - 1, 0);
+        for (let i = ratesLength; i >= 0; i--) {
+            const valueAtIndex = rawRates[i];
+            reversedArray.push (valueAtIndex);
+        }
+        return reversedArray as FundingRateHistory[];
     }
 
     parseFundingRate (contract, market: Market = undefined) {

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -3602,7 +3602,7 @@ export default class bitfinex2 extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
-            'id': id,
+            'id': this.parseToNumeric (id),
         };
         if (amount !== undefined) {
             let amountString = this.amountToPrecision (symbol, amount);

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -3080,13 +3080,7 @@ export default class bitfinex2 extends Exchange {
             const rate = this.parseFundingRateHistory (fr, market);
             rates.push (rate);
         }
-        const reversedArray = [];
-        const rawRates = this.filterBySymbolSinceLimit (rates, symbol, since, limit);
-        for (let i = rawRates.length - 1; i >= 0; i--) {
-            const valueAtIndex = rawRates[i];
-            reversedArray.push (valueAtIndex);
-        }
-        return reversedArray as FundingRateHistory[];
+        return this.filterBySymbolSinceLimit (rates, symbol, since, limit).reverse () as FundingRateHistory[];
     }
 
     parseFundingRate (contract, market: Market = undefined) {

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1034,9 +1034,6 @@ export default class bitfinex2 extends Exchange {
             'symbol': market['id'],
             'precision': precision,
         };
-        if ((limit !== 1) && (limit !== 25) && (limit !== 100)) {
-            throw new BadRequest (this.id + ' fetchOrderBook() requires the limit argument to be either 1, 25 or 100');
-        }
         if (limit !== undefined) {
             request['len'] = limit;
         }

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -1023,7 +1023,7 @@ export default class bitfinex2 extends Exchange {
          * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
          * @see https://docs.bitfinex.com/reference/rest-public-book
          * @param {string} symbol unified symbol of the market to fetch the order book for
-         * @param {int} [limit] the maximum amount of order book entries to return
+         * @param {int} [limit] the maximum amount of order book entries to return, bitfinex only allows 1, 25, or 100
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
          */
@@ -1034,8 +1034,11 @@ export default class bitfinex2 extends Exchange {
             'symbol': market['id'],
             'precision': precision,
         };
+        if ((limit !== 1) && (limit !== 25) && (limit !== 100)) {
+            throw new BadRequest (this.id + ' fetchOrderBook() requires the limit argument to be either 1, 25 or 100');
+        }
         if (limit !== undefined) {
-            request['len'] = limit; // 25 or 100
+            request['len'] = limit;
         }
         const fullRequest = this.extend (request, params);
         const orderbook = await this.publicGetBookSymbolPrecision (fullRequest);

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -642,6 +642,17 @@
               ],
               "output": "{\"ops\":[[\"on\",{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"price\":\"35000\",\"type\":\"EXCHANGE LIMIT\"}],[\"on\",{\"symbol\":\"tLTCUST\",\"amount\":\"0.25\",\"price\":\"50\",\"type\":\"EXCHANGE LIMIT\"}]]}"
           }
-      ]
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "Fetch a BTC deposit address",
+                "method": "fetchDepositAddress",
+                "url": "https://api.bitfinex.com/v2/auth/w/deposit/address",
+                "input": [
+                  "BTC"
+                ],
+                "output": "{\"method\":\"bitcoin\",\"wallet\":\"exchange\",\"op_renew\":0}"
+            }
+        ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -666,6 +666,19 @@
                 ],
                 "output": "{\"start\":1670849733000,\"limit\":2}"
             }
+        ],
+        "fetchPositions": [
+            {
+                "description": "Fetch swap positions",
+                "method": "fetchPositions",
+                "url": "https://api.bitfinex.com/v2/auth/r/positions",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ]
+                ],
+                "output": "{}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -151,6 +151,29 @@
                 "output": "{\"end\":1699458293539,\"start\":1699457638000,\"limit\":5}"
             }
         ],
+        "fetchOHLCV": [
+            {
+                "description": "Spot fetch OHLCV with timeframe and since arguments",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCUST/hist?sort=1&start=1552298700000&limit=100",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1552298700000
+                ]
+            },
+            {
+                "description": "Swap fetch OHLCV with timeframe and limit arguments",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCF0:USTF0/hist?sort=1&limit=150",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1m",
+                  null,
+                  150
+                ]
+            }
+        ],
         "fetchOpenOrders": [
             {
                 "description": "Spot open orders",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -58,6 +58,36 @@
                 ]
             }
         ],
+        "fetchTickers": [
+            {
+                "description": "Fetch all tickers",
+                "method": "fetchTickers",
+                "url": "https://api-pub.bitfinex.com/v2/tickers?symbols=ALL",
+                "input": []
+            },
+            {
+                "description": "Spot fetch tickers",
+                "method": "fetchTickers",
+                "url": "https://api-pub.bitfinex.com/v2/tickers?symbols=tBTCUST%2CtLTCUST",
+                "input": [
+                  [
+                    "BTC/USDT",
+                    "LTC/USDT"
+                  ]
+                ]
+            },
+            {
+                "description": "Swap fetch tickers",
+                "method": "fetchTickers",
+                "url": "https://api-pub.bitfinex.com/v2/tickers?symbols=tBTCF0%3AUSTF0%2CtLTCF0%3AUSTF0",
+                "input": [
+                  [
+                    "BTC/USDT:USDT",
+                    "LTC/USDT:USDT"
+                  ]
+                ]
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -715,6 +715,16 @@
                   ]
                 ]
             }
+        ],
+        "fetchFundingRateHistory": [
+            {
+                "description": "Swap fetch funding rate history",
+                "method": "fetchFundingRateHistory",
+                "url": "https://api-pub.bitfinex.com/v2/status/deriv/tBTCF0:USTF0/hist",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -679,6 +679,19 @@
                 ],
                 "output": "{}"
             }
+        ],
+        "fetchLedger": [
+            {
+                "description": "Fetch ledger with code since and limit arguments",
+                "method": "fetchLedger",
+                "url": "https://api.bitfinex.com/v2/auth/r/ledgers/UST/hist",
+                "input": [
+                  "USDT",
+                  1699460471000,
+                  3
+                ],
+                "output": "{\"start\":1699460471000,\"limit\":3}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -5,6 +5,14 @@
     ],
     "outputType": "json",
     "methods": {
+        "fetchStatus": [
+            {
+                "description": "Fetch the API status",
+                "method": "fetchStatus",
+                "url": "https://api-pub.bitfinex.com/v2/platform/status",
+                "input": []
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -88,6 +88,24 @@
                 ]
             }
         ],
+        "fetchTicker": [
+            {
+                "description": "Spot fetch ticker",
+                "method": "fetchTicker",
+                "url": "https://api-pub.bitfinex.com/v2/ticker/tBTCUST",
+                "input": [
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Swap fetch ticker",
+                "method": "fetchTicker",
+                "url": "https://api-pub.bitfinex.com/v2/ticker/tBTCF0:USTF0",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -653,6 +653,19 @@
                 ],
                 "output": "{\"method\":\"bitcoin\",\"wallet\":\"exchange\",\"op_renew\":0}"
             }
+        ],
+        "fetchDepositsWithdrawals": [
+            {
+                "description": "Fetch deposits and withdrawals with code since and limit arguments",
+                "method": "fetchDepositsWithdrawals",
+                "url": "https://api.bitfinex.com/v2/auth/r/movements/UST/hist",
+                "input": [
+                  "USDT",
+                  1670849733000,
+                  2
+                ],
+                "output": "{\"start\":1670849733000,\"limit\":2}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -13,6 +13,32 @@
                 "input": []
             }
         ],
+        "transfer": [
+            {
+                "description": "Transfer from spot to swap",
+                "method": "transfer",
+                "url": "https://api.bitfinex.com/v2/auth/w/transfer",
+                "input": [
+                  "USDT",
+                  5,
+                  "spot",
+                  "swap"
+                ],
+                "output": "{\"amount\":\"5\",\"currency\":\"UST\",\"currency_to\":\"UST\",\"from\":\"exchange\",\"to\":\"margin\"}"
+            },
+            {
+                "description": "Transfer from margin to spot",
+                "method": "transfer",
+                "url": "https://api.bitfinex.com/v2/auth/w/transfer",
+                "input": [
+                  "USDT",
+                  5,
+                  "margin",
+                  "spot"
+                ],
+                "output": "{\"amount\":\"5\",\"currency\":\"UST\",\"currency_to\":\"UST\",\"from\":\"margin\",\"to\":\"exchange\"}"
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -163,13 +163,13 @@
                 ]
             },
             {
-                "description": "Swap fetch OHLCV with timeframe and limit arguments",
+                "description": "Swap fetch OHLCV with timeframe since and limit arguments",
                 "method": "fetchOHLCV",
-                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCF0:USTF0/hist?sort=1&limit=150",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCF0:USTF0/hist?sort=1&start=1552298700000&limit=150",
                 "input": [
                   "BTC/USDT:USDT",
                   "1m",
-                  null,
+                  1552298700000,
                   150
                 ]
             }
@@ -691,16 +691,6 @@
                   3
                 ],
                 "output": "{\"start\":1699460471000,\"limit\":3}"
-            }
-        ],
-        "fetchFundingRate": [
-            {
-                "description": "Swap fetch funding rate",
-                "method": "fetchFundingRate",
-                "url": "https://api-pub.bitfinex.com/v2/status/deriv?keys=tBTCF0%3AUSTF0",
-                "input": [
-                  "BTC/USDT:USDT"
-                ]
             }
         ],
         "fetchFundingRates": [

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -725,6 +725,27 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchOrder": [
+            {
+                "description": "Spot fetch an order using an id argument",
+                "method": "fetchOrder",
+                "url": "https://api.bitfinex.com/v2/auth/r/orders",
+                "input": [
+                  139658969116
+                ],
+                "output": "{\"id\":[139658969116]}"
+            },
+            {
+                "description": "Swap fetch an order using id and symbol arguments",
+                "method": "fetchOrder",
+                "url": "https://api.bitfinex.com/v2/auth/r/orders/tLTCF0:USTF0",
+                "input": [
+                  139663481232,
+                  "LTC/USDT:USDT"
+                ],
+                "output": "{\"id\":[139663481232]}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -746,6 +746,36 @@
                 ],
                 "output": "{\"id\":[139663481232]}"
             }
+        ],
+        "editOrder": [
+            {
+                "description": "Spot edit an order",
+                "method": "editOrder",
+                "url": "https://api.bitfinex.com/v2/auth/w/order/update",
+                "input": [
+                  139658969116,
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  35000
+                ],
+                "output": "{\"id\":139658969116,\"amount\":\"0.0001\",\"price\":\"35000\"}"
+            },
+            {
+                "description": "Swap edit an order",
+                "method": "editOrder",
+                "url": "https://api.bitfinex.com/v2/auth/w/order/update",
+                "input": [
+                  139663481232,
+                  "LTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.27,
+                  51
+                ],
+                "output": "{\"id\":139663481232,\"amount\":\"0.27\",\"price\":\"51\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -106,6 +106,27 @@
                 ]
             }
         ],
+        "fetchTrades": [
+            {
+                "description": "Spot fetch trades with a since argument",
+                "method": "fetchTrades",
+                "url": "https://api-pub.bitfinex.com/v2/trades/tBTCUST/hist?start=1706837940723&sort=1",
+                "input": [
+                  "BTC/USDT",
+                  1706837940723
+                ]
+            },
+            {
+                "description": "Swap fetch trades with a limit argument",
+                "method": "fetchTrades",
+                "url": "https://api-pub.bitfinex.com/v2/trades/tBTCF0:USTF0/hist?limit=3&sort=-1",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  3
+                ]
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -692,6 +692,16 @@
                 ],
                 "output": "{\"start\":1699460471000,\"limit\":3}"
             }
+        ],
+        "fetchFundingRate": [
+            {
+                "description": "Swap fetch funding rate",
+                "method": "fetchFundingRate",
+                "url": "https://api-pub.bitfinex.com/v2/status/deriv?keys=tBTCF0%3AUSTF0",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -39,6 +39,25 @@
                 "output": "{\"amount\":\"5\",\"currency\":\"UST\",\"currency_to\":\"UST\",\"from\":\"margin\",\"to\":\"exchange\"}"
             }
         ],
+        "fetchOrderBook": [
+            {
+                "description": "Spot fetch order book",
+                "method": "fetchOrderBook",
+                "url": "https://api-pub.bitfinex.com/v2/book/tBTCUST/R0",
+                "input": [
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Swap fetch order book with a limit argument",
+                "method": "fetchOrderBook",
+                "url": "https://api-pub.bitfinex.com/v2/book/tBTCF0:USTF0/R0?len=25",
+                "input": [
+                  "BTC/USDT:USDT",
+                  25
+                ]
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",

--- a/ts/src/test/static/request/bitfinex2.json
+++ b/ts/src/test/static/request/bitfinex2.json
@@ -702,6 +702,19 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchFundingRates": [
+            {
+                "description": "Swap fetch multiple funding rates at once",
+                "method": "fetchFundingRates",
+                "url": "https://api-pub.bitfinex.com/v2/status/deriv?keys=tBTCF0%3AUSTF0%2CtLTCF0%3AUSTF0",
+                "input": [
+                  [
+                    "BTC/USDT:USDT",
+                    "LTC/USDT:USDT"
+                  ]
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added support for `fetchOrder` and `editOrder`
Set the remaining swap related methods that don't have a corresponding endpoint available to false.
Added static request tests for all swap related methods.

```
bitfinex2.transfer (USDT, 5, spot, swap)
2024-02-02T00:19:45.378Z iteration 0 passed in 1145 ms

{
  timestamp: 1706833186129,
  datetime: '2024-02-02T00:19:46.129Z',
  status: 'ok',
  amount: 5,
  currency: 'USDT',
  fromAccount: 'exchange',
  toAccount: 'margin',
  info: [
    1706833186129,
    'acc_tf',
    null,
    null,
    [
      1706833186129,
      'exchange',
      'margin',
      null,
      'UST',
      'UST',
      null,
      5
    ],
    null,
    'SUCCESS',
    '5.0 Tether USDt transfered from Exchange to Margin'
  ]
}
```
```
bitfinex2.fetchOrder (139658969116)
2024-02-02T03:25:42.118Z iteration 0 passed in 1074 ms

{
  info: [
    139658969116, null,          1706843908637,
    'tBTCUST',    1706843908637, 1706843908638,
    0.0001,       0.0001,        'EXCHANGE LIMIT',
    null,         null,          null,
    0,            'ACTIVE',      null,
    null,         35000,         0,
    0,            0,             null,
    null,         null,          0,
    0,            null,          null,
    null,         'API>BFX',     null,
    null,         {}
  ],
  id: '139658969116',
  clientOrderId: '1706843908637',
  timestamp: 1706843908638,
  datetime: '2024-02-02T03:18:28.638Z',
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 35000,
  amount: 0.0001,
  cost: 0,
  filled: 0,
  remaining: 0.0001,
  status: 'open',
  trades: [],
  fees: []
}
```
```
bitfinex2.editOrder (139663481232, LTC/USDT:USDT, limit, buy, 0.27, 51)
2024-02-02T03:51:40.143Z iteration 0 passed in 1046 ms

{
  info: [
    139663481232,   null,          1706843867801,
    'tLTCF0:USTF0', 1706843867802, 1706843867803,
    0.27,           0.27,          'LIMIT',
    null,           null,          null,
    0,              'ACTIVE',      null,
    null,           51,            0,
    0,              0,             null,
    null,           null,          0,
    0,              null,          null,
    null,           'API>BFX',     null,
    null,           {}
  ],
  id: '139663481232',
  clientOrderId: '1706843867801',
  timestamp: 1706843867803,
  datetime: '2024-02-02T03:17:47.803Z',
  symbol: 'LTC/USDT:USDT',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 51,
  amount: 0.27,
  cost: 0,
  filled: 0,
  remaining: 0.27,
  status: 'open',
  trades: [],
  fees: []
}
```