### PR TITLE
fix(gate) - tickers default TZ

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2627,7 +2627,7 @@ export default class gate extends Exchange {
             request['underlying'] = this.safeString (optionParts, 0);
             response = await this.publicOptionsGetTickers (this.extend (request, requestParams));
         } else {
-            throw new NotSupported (this.id + ' fetchTickers() not support this market type');
+            throw new NotSupported (this.id + ' fetchTickers() not support this market type, provide symbols or set params["defaultType"] to one from spot/margin/swap/future/option');
         }
         return this.parseTickers (response, symbols);
     }

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2613,6 +2613,7 @@ export default class gate extends Exchange {
         const [ type, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         const [ request, requestParams ] = this.prepareRequest (undefined, type, query);
         let response = undefined;
+        request['timezone'] = 'utc0'; // default to utc
         if (type === 'spot' || type === 'margin') {
             response = await this.publicSpotGetTickers (this.extend (request, requestParams));
         } else if (type === 'swap') {


### PR DESCRIPTION
as API docs say there are different values: https://www.gate.io/docs/developers/apiv4/en/#enumerated-values-12

we need to align to utc.

```
e.fetchTickers();

....
{
  'ETC/ETH': {
    symbol: 'ETC/ETH',
    high: 0.010822,
    low: 0.010445,
    bid: 0.010722,
    ask: 0.010752,
    vwap: 0.010671157314751923,
    close: 0.01074,
    last: 0.01074,
    percentage: 2.85,
    baseVolume: 641.3246292393,
    quoteVolume: 6.843676008437521,
    info: {
      currency_pair: 'ETC_ETH',
      last: '0.01074',
      lowest_ask: '0.010752',
      highest_bid: '0.010722',
      change_percentage: '2.85',
      change_utc0: '1.46',
      change_utc8: '1.22',
      base_volume: '641.3246292393',
      quote_volume: '6.8436760084375215',
      high_24h: '0.010822',
      low_24h: '0.010445'
    }
  }
  ....
}
```
_(cli was trimmed and couldnt post the raw part)_