### PR TITLE
feat(woo): can now use since parameter on fetchOHLCV

### DIFF
--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -320,6 +320,40 @@
                   "USDT"
                 ]
             }
+        ],
+        "fetchOHLCV": [
+            {
+                "description": "fetchOHLCV with since and limit",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.woo.org/v1/hist/kline?start_time=1704067200000&symbol=SPOT_BTC_USDT&type=1m",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000,
+                  200
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.woo.org/v1/hist/kline?start_time=1704067200000&symbol=SPOT_BTC_USDT&type=1m",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit and without since",
+                "method": "fetchOHLCV",
+                "url": "https://api.woo.org/v1/public/kline?limit=200&symbol=SPOT_BTC_USDT&type=1m",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  200
+                ]
+              }
         ]
     }
 }

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -1542,11 +1542,12 @@ export default class woo extends Exchange {
          * @method
          * @name woo#fetchOHLCV
          * @see https://docs.woo.org/#kline-public
+         * @see https://docs.woo.org/#kline-historical-data-public
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
-         * @param {int} [limit] the maximum amount of candles to fetch
+         * @param {int} [limit] max=1000, max=100 when since is defined and is less than (now - (999 * (timeframe in ms)))
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
@@ -1556,42 +1557,68 @@ export default class woo extends Exchange {
             'symbol': market['id'],
             'type': this.safeString (this.timeframes, timeframe, timeframe),
         };
-        if (limit !== undefined) {
+        let useHistEndpoint = since !== undefined;
+        if ((limit !== undefined) && (since !== undefined)) {
+            const oneThousandCandles = this.parseTimeframe (timeframe) * 1000 * 999;  // 999 because there will be delay between this and the request, causing the latest candle to be excluded sometimes
+            const startWithLimit = this.milliseconds () - oneThousandCandles;
+            useHistEndpoint = since < startWithLimit;
+        }
+        if (useHistEndpoint) {
+            request['start_time'] = since;
+        } else if (limit !== undefined) {  // the hist endpoint does not accept limit
             request['limit'] = Math.min (limit, 1000);
         }
-        const response = await this.v1PublicGetKline (this.extend (request, params));
-        // {
-        //     "success": true,
-        //     "rows": [
-        //       {
-        //         "open": "0.94238",
-        //         "close": "0.94271",
-        //         "low": "0.94238",
-        //         "high": "0.94296",
-        //         "volume": "73.55",
-        //         "amount": "69.32040520",
-        //         "symbol": "SPOT_WOO_USDT",
-        //         "type": "1m",
-        //         "start_timestamp": "1641584700000",
-        //         "end_timestamp": "1641584760000"
-        //       },
-        //       {
-        //         "open": "0.94186",
-        //         "close": "0.94186",
-        //         "low": "0.94186",
-        //         "high": "0.94186",
-        //         "volume": "64.00",
-        //         "amount": "60.27904000",
-        //         "symbol": "SPOT_WOO_USDT",
-        //         "type": "1m",
-        //         "start_timestamp": "1641584640000",
-        //         "end_timestamp": "1641584700000"
-        //       },
-        //       ...
-        //     ]
-        // }
-        const data = this.safeValue (response, 'rows', []);
-        return this.parseOHLCVs (data, market, timeframe, since, limit);
+        let response = undefined;
+        if (!useHistEndpoint) {
+            response = await this.v1PublicGetKline (this.extend (request, params));
+            //
+            //    {
+            //        "success": true,
+            //        "rows": [
+            //            {
+            //                "open": "0.94238",
+            //                "close": "0.94271",
+            //                "low": "0.94238",
+            //                "high": "0.94296",
+            //                "volume": "73.55",
+            //                "amount": "69.32040520",
+            //                "symbol": "SPOT_WOO_USDT",
+            //                "type": "1m",
+            //                "start_timestamp": "1641584700000",
+            //                "end_timestamp": "1641584760000"
+            //            },
+            //            ...
+            //        ]
+            //    }
+            //
+        } else {
+            response = await this.v1PubGetHistKline (this.extend (request, params));
+            response = this.safeDict (response, 'data');
+            //
+            //    {
+            //        "success": true,
+            //        "data": {
+            //            "rows": [
+            //                {
+            //                    "symbol": "SPOT_BTC_USDT",
+            //                    "open": 44181.40000000,
+            //                    "close": 44174.29000000,
+            //                    "high": 44193.44000000,
+            //                    "low": 44148.34000000,
+            //                    "volume": 110.11930100,
+            //                    "amount": 4863796.24318878,
+            //                    "type": "1m",
+            //                    "start_timestamp": 1704153600000,
+            //                    "end_timestamp": 1704153660000
+            //                },
+            //                ...
+            //            ]
+            //        }
+            //    }
+            //
+        }
+        const rows = this.safeValue (response, 'rows', []);
+        return this.parseOHLCVs (rows, market, timeframe, since, limit);
     }
 
     parseOHLCV (ohlcv, market: Market = undefined): OHLCV {


### PR DESCRIPTION
fixes: #20179

--------------------

Python v3.9.6
CCXT v4.2.30

```
% py woo fetchOHLCV BTC/USDT 1m None 200
woo.fetchOHLCV(BTC/USDT,1m,None,200)
[[1706902020000, 42994.15, 42998.85, 42987.4, 42997.51, 8.118945],
 ...
 [1706913960000, 43131.61, 43133.09, 43128.72, 43133.09, 4.016183]]
```
```
% py woo fetchOHLCV BTC/USDT 1m 1704067200000 200        
Python v3.9.6
CCXT v4.2.30
woo.fetchOHLCV(BTC/USDT,1m,1704067200000,200)
[[1704067200000, 42283.58, 42300.46, 42259.78, 42298.61, 33.068111],
...
 [1704073140000, 42766.06, 42766.07, 42710.7, 42721.5, 22.375538]]
```
```
% py woo fetchOHLCV BTC/USDT 1m 1706902020000 200
Python v3.9.6
CCXT v4.2.30
woo.fetchOHLCV(BTC/USDT,1m,1706902020000,200)
[[1706902200000, 43008.19, 43017.83, 42999.59, 43013.73, 9.109107],
 ...
 [1706914140000, 43114.96, 43116.0, 43110.41, 43110.41, 0.504886]]
```