### PR TITLE
feat(gemini) - watchTradesForSymbols

### DIFF
--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -98,7 +98,7 @@ export default class gemini extends geminiRest {
             marketIds.push (market['id']);
         }
         const queryStr = marketIds.join (',');
-        const url = this.urls['api']['ws'] + '/v1/multimarketdata?trades=true&bids=false&offers=false&symbols=' + queryStr;
+        const url = this.urls['api']['ws'] + '/v1/multimarketdata?trades=true&bids=false&offers=false&heartbeat=true&symbols=' + queryStr;
         const trades = await this.watchMultiple (url, messageHashes, undefined);
         if (this.newUpdates) {
             const first = this.safeList (trades, 0);

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -109,7 +109,7 @@ export default class gemini extends geminiRest {
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }
 
-    parseWsTrade (trade, market = undefined) {
+    parseWsTrade (trade, market = undefined): Trade {
         //
         // regular v2 trade
         //

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -17,6 +17,7 @@ export default class gemini extends geminiRest {
                 'watchTicker': false,
                 'watchTickers': false,
                 'watchTrades': true,
+                'watchTradesForSymbols': true,
                 'watchMyTrades': false,
                 'watchOrders': true,
                 'watchOrderBook': true,

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -2,7 +2,7 @@
 
 import geminiRest from '../gemini.js';
 import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
-import { ExchangeError } from '../base/errors.js';
+import { ExchangeError, NotSupported } from '../base/errors.js';
 import { sha384 } from '../static_dependencies/noble-hashes/sha512.js';
 import type { Int, Str, OrderBook, Order, Trade, OHLCV } from '../base/types.js';
 import Client from '../base/ws/Client.js';
@@ -86,7 +86,7 @@ export default class gemini extends geminiRest {
         symbols = this.marketSymbols (symbols, undefined, false, true, true);
         const firstMarket = this.market (symbols[0]);
         if (!firstMarket['spot'] && !firstMarket['linear']) {
-            throw new ExchangeError (this.id + ' watchTradesForSymbols supports only spot or linear-swap symbols');
+            throw new NotSupported (this.id + ' watchTradesForSymbols() supports only spot or linear-swap symbols');
         }
         const messageHashes = [];
         const marketIds = [];

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -110,6 +110,8 @@ export default class gemini extends geminiRest {
 
     parseWsTrade (trade, market = undefined) {
         //
+        // regular v2 trade
+        //
         //     {
         //         "type": "trade",
         //         "symbol": "BTCUSD",
@@ -120,11 +122,25 @@ export default class gemini extends geminiRest {
         //         "side": "buy"
         //     }
         //
-        const timestamp = this.safeInteger (trade, 'timestamp');
+        // multi data trade
+        //
+        //    {
+        //        "type": "trade",
+        //        "symbol": "ETHUSD",
+        //        "tid": "1683002242170204", // this does not seem trade/event id, but ts
+        //        "price": "2299.24",
+        //        "amount": "0.002662",
+        //        "makerSide": "bid"
+        //    }
+        //
+        let timestamp = this.safeInteger (trade, 'timestamp');
+        if (timestamp === undefined) {
+            timestamp = this.safeIntegerProduct (trade, 'tid', 0.001);
+        }
         const id = this.safeString (trade, 'event_id');
         const priceString = this.safeString (trade, 'price');
-        const amountString = this.safeString (trade, 'quantity');
-        const side = this.safeStringLower (trade, 'side');
+        const amountString = this.safeString (trade, 'quantity', 'amount');
+        const side = this.safeStringLower (trade, 'side', 'makerSide');
         const marketId = this.safeStringLower (trade, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
         return this.safeTrade ({

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -92,7 +92,7 @@ export default class gemini extends geminiRest {
         const marketIds = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
-            const messageHash = 'trades' + ':' + symbol;
+            const messageHash = 'trades:' + symbol;
             messageHashes.push (messageHash);
             const market = this.market (symbol);
             marketIds.push (market['id']);
@@ -227,13 +227,13 @@ export default class gemini extends geminiRest {
         }
     }
 
-    handleTradesForMulti (client: Client, trades) {
+    handleTradesForMultidata (client: Client, trades) {
         if (trades !== undefined) {
             const tradesLimit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const storesForSymbols = {};
             for (let i = 0; i < trades.length; i++) {
                 const marketId = trades[i]['symbol'];
-                const market = this.safeMarket (marketId);
+                const market = this.safeMarket (marketId.toLowerCase ());
                 const symbol = market['symbol'];
                 const trade = this.parseWsTrade (trades[i], market);
                 let stored = this.safeValue (this.trades, symbol);
@@ -704,7 +704,7 @@ export default class gemini extends geminiRest {
             }
             const length = collectedEventsOfTrades.length;
             if (length > 0) {
-                this.handleTradesForMulti (client, collectedEventsOfTrades);
+                this.handleTradesForMultidata (client, collectedEventsOfTrades);
             }
         }
     }

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -85,8 +85,8 @@ export default class gemini extends geminiRest {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true, true);
         const firstMarket = this.market (symbols[0]);
-        if (firstMarket['type'] !== 'spot') {
-            throw new ExchangeError (this.id + ' watchTradesForSymbols supports only spot symbols');
+        if (!firstMarket['spot'] && !firstMarket['linear']) {
+            throw new ExchangeError (this.id + ' watchTradesForSymbols supports only spot or linear-swap symbols');
         }
         const messageHashes = [];
         const marketIds = [];

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -508,6 +508,7 @@ export default class gemini extends geminiRest {
         //         "socket_sequence": 7
         //     }
         //
+        client.lastPong = this.milliseconds ();
         return message;
     }
 


### PR DESCRIPTION
as shown, there are "multi data" streams: https://docs.gemini.com/websocket-api/#multi-market-data

```
2024-02-03T22:29:53.785Z connecting to wss://api.gemini.com/v1/multimarketdata?trades=true&bids=false&offers=false&symbols=ethusd,btcusd
2024-02-03T22:29:54.508Z onUpgrade
2024-02-03T22:29:54.509Z onOpen
2024-02-03T22:29:54.561Z onMessage { eventId: 0, events: [], socket_sequence: 0, type: 'update' }
2024-02-03T22:29:58.320Z onMessage { eventId: 0, events: [], socket_sequence: 1, type: 'update' }
2024-02-03T22:30:03.516Z onMessage {
  eventId: '1683002242320429',
  events: [
    {
      amount: '0.001592',
      makerSide: 'ask',
      price: '2298.76',
      symbol: 'ETHUSD',
      tid: '1683002242320429',
      type: 'trade'
    }
  ],
  socket_sequence: 2,
  timestamp: 1706999404,
  timestampms: 1706999404159,
  type: 'update'
}
2024-02-03T22:30:24.520Z sending undefined
2024-02-03T22:30:26.233Z onMessage {
  eventId: '1683002242324296',
  events: [
    {
      amount: '0.002662',
      makerSide: 'bid',
      price: '2298.62',
      symbol: 'ETHUSD',
      tid: '1683002242324296',
      type: 'trade'
    }
  ],
  socket_sequence: 3,
  timestamp: 1706999426,
  timestampms: 1706999426825,
  type: 'update'
}
```