### PR TITLE
fix(watch) regression after c# intervention; watch for binance is broken

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1339,9 +1339,9 @@ export default class Exchange {
 
     // ping (client) {} // stub to override
 
-    ping (client) {
-        return undefined;
-    }
+    // ping (client) {
+    //     return undefined;
+    // }
 
     client (url): WsClient {
         this.clients = this.clients || {};


### PR DESCRIPTION
Hi guy,

after merging C# branch into master watching of binance is broken, which follows the WebSocket connection on a regular basis is stopped and ccxt every time has to reconnect to the server.

I understand, it could be a some issue with C# inheritance hierarchy, but please, don't break current code in production

Please look at the commit 15a5df7ece855000fd1bb052447c0554fecbec2b, where the empty ping() {} function commented out.