### PR TITLE
binance: createOrder, portfolio margin support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5404,21 +5404,6 @@ export default class binance extends Exchange {
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'createOrder', 'papi', 'portfolioMargin', false);
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
-        if (!isPortfolioMargin) {
-            const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
-            if (market['spot'] || marketType === 'margin') {
-                // only supported for spot/margin api (all margin markets are spot markets)
-                if (postOnly) {
-                    type = 'LIMIT_MAKER';
-                }
-                if (marginMode === 'isolated') {
-                    request['isIsolated'] = true;
-                }
-            }
-            if (market['contract'] && postOnly) {
-                request['timeInForce'] = 'GTX';
-            }
-        }
         if ((marketType === 'margin') || (marginMode !== undefined) || market['option']) {
             // for swap and future reduceOnly is a string that cant be sent with close position set to true or in hedge mode
             const reduceOnly = this.safeBool (params, 'reduceOnly', false);
@@ -5612,6 +5597,21 @@ export default class binance extends Exchange {
             }
             if (stopPrice !== undefined) {
                 request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
+            }
+        }
+        if (!isPortfolioMargin) {
+            const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
+            if (market['spot'] || marketType === 'margin') {
+                // only supported for spot/margin api (all margin markets are spot markets)
+                if (postOnly) {
+                    type = 'LIMIT_MAKER';
+                }
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
+            }
+            if (market['contract'] && postOnly) {
+                request['timeInForce'] = 'GTX';
             }
         }
         // remove timeInForce from params because PO is only used by this.isPostOnly and it's not a valid value for Binance

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4999,18 +4999,128 @@ export default class binance extends Exchange {
         //         "lastTrade": {"id":"69","time":"1676084430567","price":"24.9","qty":"1.00"},
         //         "mmp": false
         //     }
-        //     {
+        //
         // cancelOrders/createOrders
-        //          "code": -4005,
-        //          "msg": "Quantity greater than max quantity."
-        //       },
+        //
+        //     {
+        //         "code": -4005,
+        //         "msg": "Quantity greater than max quantity."
+        //     }
+        //
+        // createOrder: portfolio margin linear swap and future
+        //
+        //     {
+        //         "symbol": "BTCUSDT",
+        //         "side": "BUY",
+        //         "executedQty": "0.000",
+        //         "orderId": 258649539704,
+        //         "goodTillDate": 0,
+        //         "avgPrice": "0",
+        //         "origQty": "0.010",
+        //         "clientOrderId": "x-xcKtGhcu02573c6f15e544e990057b",
+        //         "positionSide": "BOTH",
+        //         "cumQty": "0.000",
+        //         "updateTime": 1707110415436,
+        //         "type": "LIMIT",
+        //         "reduceOnly": false,
+        //         "price": "35000.00",
+        //         "cumQuote": "0.00000",
+        //         "selfTradePreventionMode": "NONE",
+        //         "timeInForce": "GTC",
+        //         "status": "NEW"
+        //     }
+        //
+        // createOrder: portfolio margin inverse swap and future
+        //
+        //     {
+        //         "symbol": "ETHUSD_PERP",
+        //         "side": "BUY",
+        //         "cumBase": "0",
+        //         "executedQty": "0",
+        //         "orderId": 71275227732,
+        //         "avgPrice": "0.00",
+        //         "origQty": "1",
+        //         "clientOrderId": "x-xcKtGhcuca5af3acfb5044198c5398",
+        //         "positionSide": "BOTH",
+        //         "cumQty": "0",
+        //         "updateTime": 1707110994334,
+        //         "type": "LIMIT",
+        //         "pair": "ETHUSD",
+        //         "reduceOnly": false,
+        //         "price": "2000",
+        //         "timeInForce": "GTC",
+        //         "status": "NEW"
+        //     }
+        //
+        // createOrder: portfolio margin linear swap and future conditional
+        //
+        //     {
+        //         "newClientStrategyId": "x-xcKtGhcu27f109953d6e4dc0974006",
+        //         "strategyId": 3645916,
+        //         "strategyStatus": "NEW",
+        //         "strategyType": "STOP",
+        //         "origQty": "0.010",
+        //         "price": "35000.00",
+        //         "reduceOnly": false,
+        //         "side": "BUY",
+        //         "positionSide": "BOTH",
+        //         "stopPrice": "45000.00",
+        //         "symbol": "BTCUSDT",
+        //         "timeInForce": "GTC",
+        //         "bookTime": 1707112625879,
+        //         "updateTime": 1707112625879,
+        //         "workingType": "CONTRACT_PRICE",
+        //         "priceProtect": false,
+        //         "goodTillDate": 0,
+        //         "selfTradePreventionMode": "NONE"
+        //     }
+        //
+        // createOrder: portfolio margin inverse swap and future conditional
+        //
+        //     {
+        //         "newClientStrategyId": "x-xcKtGhcuc6b86f053bb34933850739",
+        //         "strategyId": 1423462,
+        //         "strategyStatus": "NEW",
+        //         "strategyType": "STOP",
+        //         "origQty": "1",
+        //         "price": "2000",
+        //         "reduceOnly": false,
+        //         "side": "BUY",
+        //         "positionSide": "BOTH",
+        //         "stopPrice": "3000",
+        //         "symbol": "ETHUSD_PERP",
+        //         "timeInForce": "GTC",
+        //         "bookTime": 1707113098840,
+        //         "updateTime": 1707113098840,
+        //         "workingType": "CONTRACT_PRICE",
+        //         "priceProtect": false
+        //     }
+        //
+        // createOrder: portfolio margin spot margin
+        //
+        //     {
+        //         "clientOrderId": "x-R4BD3S82e9ef29d8346440f0b28b86",
+        //         "cummulativeQuoteQty": "0.00000000",
+        //         "executedQty": "0.00000000",
+        //         "fills": [],
+        //         "orderId": 24684460474,
+        //         "origQty": "0.00100000",
+        //         "price": "35000.00000000",
+        //         "selfTradePreventionMode": "EXPIRE_MAKER",
+        //         "side": "BUY",
+        //         "status": "NEW",
+        //         "symbol": "BTCUSDT",
+        //         "timeInForce": "GTC",
+        //         "transactTime": 1707113538870,
+        //         "type": "LIMIT"
+        //     }
         //
         const code = this.safeString (order, 'code');
         if (code !== undefined) {
             // cancelOrders/createOrders might have a partial success
             return this.safeOrder ({ 'info': order, 'status': 'rejected' }, market);
         }
-        const status = this.parseOrderStatus (this.safeString (order, 'status'));
+        const status = this.parseOrderStatus (this.safeString2 (order, 'status', 'strategyStatus'));
         const marketId = this.safeString (order, 'symbol');
         const marketType = ('closePosition' in order) ? 'contract' : 'spot';
         const symbol = this.safeSymbol (marketId, market, undefined, marketType);
@@ -5036,11 +5146,9 @@ export default class binance extends Exchange {
         //   Note this is not the actual cost, since Binance futures uses leverage to calculate margins.
         let cost = this.safeString2 (order, 'cummulativeQuoteQty', 'cumQuote');
         cost = this.safeString (order, 'cumBase', cost);
-        const id = this.safeString (order, 'orderId');
         let type = this.safeStringLower (order, 'type');
         const side = this.safeStringLower (order, 'side');
         const fills = this.safeValue (order, 'fills', []);
-        const clientOrderId = this.safeString (order, 'clientOrderId');
         let timeInForce = this.safeString (order, 'timeInForce');
         if (timeInForce === 'GTX') {
             // GTX means "Good Till Crossing" and is an equivalent way of saying Post Only
@@ -5063,8 +5171,8 @@ export default class binance extends Exchange {
         }
         return this.safeOrder ({
             'info': order,
-            'id': id,
-            'clientOrderId': clientOrderId,
+            'id': this.safeString2 (order, 'orderId', 'strategyId'),
+            'clientOrderId': this.safeString2 (order, 'clientOrderId', 'newClientStrategyId'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,
@@ -5178,47 +5286,93 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/voptions/en/#new-order-trade
          * @see https://binance-docs.github.io/apidocs/spot/en/#new-order-using-sor-trade
          * @see https://binance-docs.github.io/apidocs/spot/en/#test-new-order-using-sor-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#new-um-order-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#new-cm-order-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#new-margin-order-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#new-um-conditional-order-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#new-cm-conditional-order-trade
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit' or 'STOP_LOSS' or 'STOP_LOSS_LIMIT' or 'TAKE_PROFIT' or 'TAKE_PROFIT_LIMIT' or 'STOP'
          * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
-         * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {float} amount how much of you want to trade in units of the base currency
+         * @param {float} [price] the price that the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.reduceOnly] for swap and future reduceOnly is a string 'true' or 'false' that cant be sent with close position set to true or in hedge mode. For spot margin and option reduceOnly is a boolean.
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
          * @param {boolean} [params.sor] *spot only* whether to use SOR (Smart Order Routing) or not, default is false
          * @param {boolean} [params.test] *spot only* whether to use the test endpoint or not, default is false
          * @param {float} [params.trailingPercent] the percent to trail away from the current market price
          * @param {float} [params.trailingTriggerPrice] the price to trigger a trailing order, default uses the price argument
+         * @param {float} [params.triggerPrice] the price that a trigger order is triggered at
+         * @param {float} [params.stopLossPrice] the price that a stop loss order is triggered at
+         * @param {float} [params.takeProfitPrice] the price that a take profit order is triggered at
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to create an order in a portfolio margin account
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
         const marketType = this.safeString (params, 'type', market['type']);
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
-        const sor = this.safeValue2 (params, 'sor', 'SOR', false);
-        params = this.omit (params, 'sor', 'SOR');
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'createOrder', 'papi', 'portfolioMargin', false);
+        const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
+        const stopLossPrice = this.safeString (params, 'stopLossPrice');
+        const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
+        const trailingPercent = this.safeString2 (params, 'trailingPercent', 'callbackRate');
+        const isTrailingPercentOrder = trailingPercent !== undefined;
+        const isStopLoss = stopLossPrice !== undefined;
+        const isTakeProfit = takeProfitPrice !== undefined;
+        const isConditional = (triggerPrice !== undefined) || isTrailingPercentOrder || isStopLoss || isTakeProfit;
+        const sor = this.safeBool2 (params, 'sor', 'SOR', false);
+        const test = this.safeBool (params, 'test', false);
+        params = this.omit (params, [ 'sor', 'SOR', 'test' ]);
+        if (isPortfolioMargin) {
+            params['portfolioMargin'] = isPortfolioMargin;
+        }
         const request = this.createOrderRequest (symbol, type, side, amount, price, params);
-        let method = 'privatePostOrder';
-        if (sor) {
-            method = 'privatePostSorOrder';
-        } else if (market['linear']) {
-            method = 'fapiPrivatePostOrder';
-        } else if (market['inverse']) {
-            method = 'dapiPrivatePostOrder';
-        } else if (marketType === 'margin' || marginMode !== undefined) {
-            method = 'sapiPostMarginOrder';
-        }
+        let response = undefined;
         if (market['option']) {
-            method = 'eapiPrivatePostOrder';
-        }
-        // support for testing orders
-        if (market['spot'] || marketType === 'margin') {
-            const test = this.safeBool (query, 'test', false);
+            response = await this.eapiPrivatePostOrder (request);
+        } else if (sor) {
             if (test) {
-                method += 'Test';
+                response = await this.privatePostSorOrderTest (request);
+            } else {
+                response = await this.privatePostSorOrder (request);
+            }
+        } else if (market['linear']) {
+            if (isPortfolioMargin) {
+                if (isConditional) {
+                    response = await this.papiPostUmConditionalOrder (request);
+                } else {
+                    response = await this.papiPostUmOrder (request);
+                }
+            } else {
+                response = await this.fapiPrivatePostOrder (request);
+            }
+        } else if (market['inverse']) {
+            if (isPortfolioMargin) {
+                if (isConditional) {
+                    response = await this.papiPostCmConditionalOrder (request);
+                } else {
+                    response = await this.papiPostCmOrder (request);
+                }
+            } else {
+                response = await this.dapiPrivatePostOrder (request);
+            }
+        } else if (marketType === 'margin' || marginMode !== undefined) {
+            if (isPortfolioMargin) {
+                response = await this.papiPostMarginOrder (request);
+            } else {
+                response = await this.sapiPostMarginOrder (request);
+            }
+        } else {
+            if (test) {
+                response = await this.privatePostOrderTest (request);
+            } else {
+                response = await this.privatePostOrder (request);
             }
         }
-        const response = await this[method] (request);
         return this.parseOrder (response, market);
     }
 
@@ -5227,16 +5381,13 @@ export default class binance extends Exchange {
          * @method
          * @ignore
          * @name binance#createOrderRequest
-         * @description helper function to build request
+         * @description helper function to build the request
          * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type 'market' or 'limit' or 'STOP_LOSS' or 'STOP_LOSS_LIMIT' or 'TAKE_PROFIT' or 'TAKE_PROFIT_LIMIT' or 'STOP'
+         * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
-         * @param {float} amount how much of currency you want to trade in units of base currency
-         * @param {float|undefined} price the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
-         * @param {object} params extra parameters specific to the exchange API endpoint
-         * @param {string|undefined} params.marginMode 'cross' or 'isolated', for spot margin trading
-         * @param {float} [params.trailingPercent] the percent to trail away from the current market price
-         * @param {float} [params.trailingTriggerPrice] the price to trigger a trailing order, default uses the price argument
+         * @param {float} amount how much you want to trade in units of the base currency
+         * @param {float} [price] the price that the order is to be fullfilled, in units of the quote currency, ignored in market orders
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} request to be sent to the exchange
          */
         const market = this.market (symbol);
@@ -5245,35 +5396,53 @@ export default class binance extends Exchange {
         const initialUppercaseType = type.toUpperCase ();
         const isMarketOrder = initialUppercaseType === 'MARKET';
         const isLimitOrder = initialUppercaseType === 'LIMIT';
-        const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
-        const triggerPrice = this.safeValue2 (params, 'triggerPrice', 'stopPrice');
-        const stopLossPrice = this.safeValue (params, 'stopLossPrice', triggerPrice);  // fallback to stopLoss
-        const takeProfitPrice = this.safeValue (params, 'takeProfitPrice');
-        const trailingDelta = this.safeValue (params, 'trailingDelta');
+        const request = {
+            'symbol': market['id'],
+            'side': side.toUpperCase (),
+        };
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'createOrder', 'papi', 'portfolioMargin', false);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
+        if (!isPortfolioMargin) {
+            const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
+            if (market['spot'] || marketType === 'margin') {
+                // only supported for spot/margin api (all margin markets are spot markets)
+                if (postOnly) {
+                    type = 'LIMIT_MAKER';
+                }
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
+            }
+            if (market['contract'] && postOnly) {
+                request['timeInForce'] = 'GTX';
+            }
+        }
+        if ((marketType === 'margin') || (marginMode !== undefined) || market['option']) {
+            // for swap and future reduceOnly is a string that cant be sent with close position set to true or in hedge mode
+            const reduceOnly = this.safeBool (params, 'reduceOnly', false);
+            params = this.omit (params, 'reduceOnly');
+            if (market['option']) {
+                request['reduceOnly'] = reduceOnly;
+            } else {
+                if (reduceOnly) {
+                    request['sideEffectType'] = 'AUTO_REPAY';
+                }
+            }
+        }
+        const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
+        const stopLossPrice = this.safeString (params, 'stopLossPrice', triggerPrice); // fallback to stopLoss
+        const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
+        const trailingDelta = this.safeString (params, 'trailingDelta');
         const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activationPrice', this.numberToString (price));
         const trailingPercent = this.safeString2 (params, 'trailingPercent', 'callbackRate');
         const isTrailingPercentOrder = trailingPercent !== undefined;
         const isStopLoss = stopLossPrice !== undefined || trailingDelta !== undefined;
         const isTakeProfit = takeProfitPrice !== undefined;
-        params = this.omit (params, [ 'type', 'newClientOrderId', 'clientOrderId', 'postOnly', 'stopLossPrice', 'takeProfitPrice', 'stopPrice', 'triggerPrice', 'trailingTriggerPrice', 'trailingPercent' ]);
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
-        const request = {
-            'symbol': market['id'],
-            'side': side.toUpperCase (),
-        };
-        if (market['spot'] || marketType === 'margin') {
-            // only supported for spot/margin api (all margin markets are spot markets)
-            if (postOnly) {
-                type = 'LIMIT_MAKER';
-            }
-        }
-        if (marketType === 'margin' || marginMode !== undefined) {
-            const reduceOnly = this.safeValue (params, 'reduceOnly');
-            if (reduceOnly) {
-                request['sideEffectType'] = 'AUTO_REPAY';
-                params = this.omit (params, 'reduceOnly');
-            }
-        }
+        const isTriggerOrder = triggerPrice !== undefined;
+        const isConditional = isTriggerOrder || isTrailingPercentOrder || isStopLoss || isTakeProfit;
+        const isPortfolioMarginConditional = (isPortfolioMargin && isConditional);
         let uppercaseType = type.toUpperCase ();
         let stopPrice = undefined;
         if (isTrailingPercentOrder) {
@@ -5299,29 +5468,20 @@ export default class binance extends Exchange {
                 uppercaseType = market['contract'] ? 'TAKE_PROFIT' : 'TAKE_PROFIT_LIMIT';
             }
         }
-        if (marginMode === 'isolated') {
-            request['isIsolated'] = true;
-        }
-        if (clientOrderId === undefined) {
-            const broker = this.safeValue (this.options, 'broker', {});
-            const defaultId = (market['contract']) ? 'x-xcKtGhcu' : 'x-R4BD3S82';
-            const brokerId = this.safeString (broker, marketType, defaultId);
-            request['newClientOrderId'] = brokerId + this.uuid22 ();
-        } else {
-            request['newClientOrderId'] = clientOrderId;
-        }
         if ((marketType === 'spot') || (marketType === 'margin')) {
-            request['newOrderRespType'] = this.safeValue (this.options['newOrderRespType'], type, 'RESULT'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
+            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'RESULT'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
         } else {
             // swap, futures and options
-            request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
+            if (!isPortfolioMargin) {
+                request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
+            }
         }
         if (market['option']) {
             if (type === 'market') {
                 throw new InvalidOrder (this.id + ' ' + type + ' is not a valid order type for the ' + symbol + ' market');
             }
         } else {
-            const validOrderTypes = this.safeValue (market['info'], 'orderTypes');
+            const validOrderTypes = this.safeList (market['info'], 'orderTypes');
             if (!this.inArray (uppercaseType, validOrderTypes)) {
                 if (initialUppercaseType !== uppercaseType) {
                     throw new InvalidOrder (this.id + ' stopPrice parameter is not allowed for ' + symbol + ' ' + type + ' orders');
@@ -5330,7 +5490,17 @@ export default class binance extends Exchange {
                 }
             }
         }
-        request['type'] = uppercaseType;
+        const clientOrderIdRequest = isPortfolioMarginConditional ? 'newClientStrategyId' : 'newClientOrderId';
+        if (clientOrderId === undefined) {
+            const broker = this.safeDict (this.options, 'broker', {});
+            const defaultId = (market['contract']) ? 'x-xcKtGhcu' : 'x-R4BD3S82';
+            const brokerId = this.safeString (broker, marketType, defaultId);
+            request[clientOrderIdRequest] = brokerId + this.uuid22 ();
+        } else {
+            request[clientOrderIdRequest] = clientOrderId;
+        }
+        const typeRequest = isPortfolioMarginConditional ? 'strategyType' : 'type';
+        request[typeRequest] = uppercaseType;
         // additional required fields depending on the order type
         let timeInForceIsRequired = false;
         let priceIsRequired = false;
@@ -5358,9 +5528,9 @@ export default class binance extends Exchange {
         //
         if (uppercaseType === 'MARKET') {
             if (market['spot']) {
-                const quoteOrderQty = this.safeValue (this.options, 'quoteOrderQty', true);
+                const quoteOrderQty = this.safeBool (this.options, 'quoteOrderQty', true);
                 if (quoteOrderQty) {
-                    const quoteOrderQtyNew = this.safeValue2 (query, 'quoteOrderQty', 'cost');
+                    const quoteOrderQtyNew = this.safeString2 (params, 'quoteOrderQty', 'cost');
                     const precision = market['precision']['price'];
                     if (quoteOrderQtyNew !== undefined) {
                         request['quoteOrderQty'] = this.decimalToPrecision (quoteOrderQtyNew, TRUNCATE, precision, this.precisionMode);
@@ -5401,7 +5571,7 @@ export default class binance extends Exchange {
             stopPriceIsRequired = true;
             priceIsRequired = true;
         } else if ((uppercaseType === 'STOP_MARKET') || (uppercaseType === 'TAKE_PROFIT_MARKET')) {
-            const closePosition = this.safeValue (query, 'closePosition');
+            const closePosition = this.safeBool (params, 'closePosition');
             if (closePosition === undefined) {
                 quantityIsRequired = true;
             }
@@ -5413,7 +5583,12 @@ export default class binance extends Exchange {
             }
         }
         if (quantityIsRequired) {
-            request['quantity'] = this.amountToPrecision (symbol, amount);
+            // portfolio margin has a different amount precision
+            if (isPortfolioMargin) {
+                request['quantity'] = this.parseToNumeric (amount);
+            } else {
+                request['quantity'] = this.amountToPrecision (symbol, amount);
+            }
         }
         if (priceIsRequired) {
             if (price === undefined) {
@@ -5423,9 +5598,6 @@ export default class binance extends Exchange {
         }
         if (timeInForceIsRequired) {
             request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
-        }
-        if (market['contract'] && postOnly) {
-            request['timeInForce'] = 'GTX';
         }
         if (stopPriceIsRequired) {
             if (market['contract']) {
@@ -5444,9 +5616,9 @@ export default class binance extends Exchange {
         }
         // remove timeInForce from params because PO is only used by this.isPostOnly and it's not a valid value for Binance
         if (this.safeString (params, 'timeInForce') === 'PO') {
-            params = this.omit (params, [ 'timeInForce' ]);
+            params = this.omit (params, 'timeInForce');
         }
-        const requestParams = this.omit (params, [ 'quoteOrderQty', 'cost', 'stopPrice', 'test', 'type', 'newClientOrderId', 'clientOrderId', 'postOnly' ]);
+        const requestParams = this.omit (params, [ 'type', 'newClientOrderId', 'clientOrderId', 'postOnly', 'stopLossPrice', 'takeProfitPrice', 'stopPrice', 'triggerPrice', 'trailingTriggerPrice', 'trailingPercent', 'quoteOrderQty', 'cost', 'test' ]);
         return this.extend (request, requestParams);
     }
 

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -4,7 +4,8 @@
         "signature",
         "timestamp",
         "recvWindow",
-        "newClientOrderId"
+        "newClientOrderId",
+        "newClientStrategyId"
     ],
     "outputType": "urlencoded",
     "methods": {
@@ -138,7 +139,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "timestamp=1699113838137&symbol=LTCUSDT&side=BUY&newClientOrderId=x-R4BD3S8277d937b569914d1bb5f784&newOrderRespType=FULL&type=LIMIT&quantity=0.2&price=50&timeInForce=GTC&marginMode=cross&recvWindow=10000&signature=0e12b57b83c758aceb6d88c4950c1259f41cc0b86d7e6259fcdb3202cd3d3c32"
+                "output": "timestamp=1699113838137&symbol=LTCUSDT&side=BUY&newClientOrderId=x-R4BD3S8277d937b569914d1bb5f784&newOrderRespType=FULL&type=LIMIT&quantity=0.2&price=50&timeInForce=GTC&recvWindow=10000&signature=0e12b57b83c758aceb6d88c4950c1259f41cc0b86d7e6259fcdb3202cd3d3c32"
             },
             {
                 "description": "Swap limit sell",

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -233,6 +233,89 @@
                   }
                 ],
                 "output": "timestamp=1704512493514&symbol=BTCUSDT&side=SELL&callbackRate=5&newClientOrderId=x-xcKtGhcufdcb378c830d451392c9a2&newOrderRespType=RESULT&type=TRAILING_STOP_MARKET&quantity=0.1&reduceOnly=true&recvWindow=10000&signature=381024e31ce5868d69dd3e12668b9b47514c1211e7d0021a7939cb26d07f679a"
+            },
+            {
+                "description": "Linear swap portfolio margin limit buy order",
+                "method": "createOrder",
+                "url": "https://papi.binance.com/papi/v1/um/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.01,
+                  35000,
+                  {
+                    "portfolioMargin": true
+                  }
+                ],
+                "output": "timestamp=1707112464420&symbol=BTCUSDT&side=BUY&newClientOrderId=x-xcKtGhcu0b020e257d4943d49c0ffe&type=LIMIT&quantity=0.01&price=35000&timeInForce=GTC&recvWindow=10000&signature=6d8b1ae407634704c7d7d26cbb62f0f438a09e9863b81a8a89a24461c4997808"
+            },
+            {
+                "description": "Inverse swap portfolio margin limit buy order",
+                "method": "createOrder",
+                "url": "https://papi.binance.com/papi/v1/cm/order",
+                "input": [
+                  "ETH/USD:ETH",
+                  "limit",
+                  "buy",
+                  1,
+                  2000,
+                  {
+                    "portfolioMargin": true
+                  }
+                ],
+                "output": "timestamp=1707112388003&symbol=ETHUSD_PERP&side=BUY&newClientOrderId=x-xcKtGhcu69273341d6114bd8b800aa&type=LIMIT&quantity=1&price=2000&timeInForce=GTC&recvWindow=10000&signature=4e4f549a6358aa1731060e825069022389780706305a60eaa58fbbf0c4a7d03f"
+            },
+            {
+                "description": "Linear swap portfolio margin conditional limit buy order",
+                "method": "createOrder",
+                "url": "https://papi.binance.com/papi/v1/um/conditional/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.01,
+                  35000,
+                  {
+                    "portfolioMargin": true,
+                    "triggerPrice": 45000
+                  }
+                ],
+                "output": "timestamp=1707112624772&symbol=BTCUSDT&side=BUY&newClientStrategyId=x-xcKtGhcu27f109953d6e4dc0974006&strategyType=STOP&quantity=0.01&price=35000&stopPrice=45000&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
+            },
+            {
+                "description": "Inverse swap portfolio margin conditional limit buy order",
+                "method": "createOrder",
+                "url": "https://papi.binance.com/papi/v1/cm/conditional/order",
+                "input": [
+                  "ETH/USD:ETH",
+                  "limit",
+                  "buy",
+                  1,
+                  2000,
+                  {
+                    "portfolioMargin": true,
+                    "triggerPrice": 3000
+                  }
+                ],
+                "output": "timestamp=1707113097689&symbol=ETHUSD_PERP&side=BUY&newClientStrategyId=x-xcKtGhcuc6b86f054bb34933850739&strategyType=STOP&quantity=1&price=2000&stopPrice=3000&recvWindow=10000&signature=aa5ec5fa5eb51372fa68597242bc2ddc31a32e9be5c084f00c2f6999b31cad2b"
+            },
+            {
+                "description": "Spot margin portfolio margin limit buy order",
+                "method": "createOrder",
+                "url": "https://papi.binance.com/papi/v1/margin/order",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.001,
+                  35000,
+                  {
+                    "portfolioMargin": true,
+                    "marginMode": "cross"
+                  }
+                ],
+                "output": "timestamp=1707113537828&symbol=BTCUSDT&side=BUY&newOrderRespType=FULL&newClientOrderId=x-R4BD3S82e9ef29d8346440f0b28b86&type=LIMIT&quantity=0.001&price=35000&timeInForce=GTC&recvWindow=10000&signature=08d71bf9a60d5184cc256964f1175179c813d11e038718c0d64d5cc5b982f2f5"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Added support for `linear`, `inverse`, `linear conditional`, `inverse conditional` and `spot margin` orders on binance using the portfolio margin account:

```
binance createOrder BTC/USDT:USDT limit buy 0.01 35000 '{"portfolioMargin":true}'

binance.createOrder (BTC/USDT:USDT, limit, buy, 0.01, 35000, [object Object])
2024-02-05T05:27:14.684Z iteration 0 passed in 909 ms

{
  info: {
    symbol: 'BTCUSDT',
    side: 'BUY',
    executedQty: '0.000',
    orderId: '258651795452',
    goodTillDate: '0',
    avgPrice: '0',
    origQty: '0.010',
    clientOrderId: 'x-xcKtGhcub8581ea69c0e46f3a04615',
    positionSide: 'BOTH',
    cumQty: '0.000',
    updateTime: '1707110834882',
    type: 'LIMIT',
    reduceOnly: false,
    price: '35000.00',
    cumQuote: '0.00000',
    selfTradePreventionMode: 'NONE',
    timeInForce: 'GTC',
    status: 'NEW'
  },
  id: '258651795452',
  clientOrderId: 'x-xcKtGhcub8581ea69c0e46f3a04615',
  timestamp: 1707110834882,
  datetime: '2024-02-05T05:27:14.882Z',
  lastUpdateTimestamp: 1707110834882,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 35000,
  amount: 0.01,
  cost: 0,
  filled: 0,
  remaining: 0.01,
  status: 'open',
  trades: [],
  fees: []
}
```
```
binance createOrder ETH/USD:ETH limit buy 1 2000 '{"portfolioMargin":true}'

binance.createOrder (ETH/USD:ETH, limit, buy, 1, 2000, [object Object])
2024-02-05T05:33:43.514Z iteration 0 passed in 882 ms

{
  info: {
    symbol: 'ETHUSD_PERP',
    side: 'BUY',
    cumBase: '0',
    executedQty: '0',
    orderId: '71275337455',
    avgPrice: '0.00',
    origQty: '1',
    clientOrderId: 'x-xcKtGhcu1134062e7782422c815943',
    positionSide: 'BOTH',
    cumQty: '0',
    updateTime: '1707111223728',
    type: 'LIMIT',
    pair: 'ETHUSD',
    reduceOnly: false,
    price: '2000',
    timeInForce: 'GTC',
    status: 'NEW'
  },
  id: '71275337455',
  clientOrderId: 'x-xcKtGhcu1134062e7782422c815943',
  timestamp: 1707111223728,
  datetime: '2024-02-05T05:33:43.728Z',
  lastUpdateTimestamp: 1707111223728,
  symbol: 'ETH/USD:ETH',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 2000,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  status: 'open',
  trades: [],
  fees: []
}
```
```
binance createOrder BTC/USDT:USDT limit buy 0.01 35000 '{"portfolioMargin":true,"triggerPrice":45000}'

binance.createOrder (BTC/USDT:USDT, limit, buy, 0.01, 35000, [object Object])
2024-02-05T06:03:47.153Z iteration 0 passed in 1331 ms

{
  info: {
    newClientStrategyId: 'x-xcKtGhcube0b6239d5334b3586a37f',
    strategyId: '3646097',
    strategyStatus: 'NEW',
    strategyType: 'STOP',
    origQty: '0.010',
    price: '35000.00',
    reduceOnly: false,
    side: 'BUY',
    positionSide: 'BOTH',
    stopPrice: '45000.00',
    symbol: 'BTCUSDT',
    timeInForce: 'GTC',
    bookTime: '1707113027280',
    updateTime: '1707113027280',
    workingType: 'CONTRACT_PRICE',
    priceProtect: false,
    goodTillDate: '0',
    selfTradePreventionMode: 'NONE'
  },
  id: '3646097',
  clientOrderId: 'x-xcKtGhcube0b6239d5334b3586a37f',
  timestamp: 1707113027280,
  datetime: '2024-02-05T06:03:47.280Z',
  lastUpdateTimestamp: 1707113027280,
  symbol: 'BTC/USDT',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 35000,
  triggerPrice: 45000,
  amount: 0.01,
  cost: 0,
  filled: 0,
  remaining: 0.01,
  trades: [],
  fees: [],
  stopPrice: 45000
}
```
```
binance createOrder ETH/USD:ETH limit buy 1 2000 '{"portfolioMargin":true,"triggerPrice":3000}'

binance.createOrder (ETH/USD:ETH, limit, buy, 1, 2000, [object Object])
2024-02-05T06:09:44.147Z iteration 0 passed in 977 ms

{
  info: {
    newClientStrategyId: 'x-xcKtGhcu39a833eb994a48009471e7',
    strategyId: '1423463',
    strategyStatus: 'NEW',
    strategyType: 'STOP',
    origQty: '1',
    price: '2000',
    reduceOnly: false,
    side: 'BUY',
    positionSide: 'BOTH',
    stopPrice: '3000',
    symbol: 'ETHUSD_PERP',
    timeInForce: 'GTC',
    bookTime: '1707113384326',
    updateTime: '1707113384326',
    workingType: 'CONTRACT_PRICE',
    priceProtect: false
  },
  id: '1423463',
  clientOrderId: 'x-xcKtGhcu39a833eb994a48009471e7',
  timestamp: 1707113384326,
  datetime: '2024-02-05T06:09:44.326Z',
  lastUpdateTimestamp: 1707113384326,
  symbol: 'ETH/USD:ETH',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 2000,
  triggerPrice: 3000,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  status: 'open',
  trades: [],
  fees: [],
  stopPrice: 3000
}
```
```
binance createOrder BTC/USDT limit buy 0.001 35000 '{"portfolioMargin":true,"marginMode":"cross"}'

binance.createOrder (BTC/USDT, limit, buy, 0.001, 35000, [object Object])
2024-02-05T06:17:01.559Z iteration 0 passed in 902 ms

{
  info: {
    clientOrderId: 'x-R4BD3S828419c93ec5d94bc380c998',
    cummulativeQuoteQty: '0.00000000',
    executedQty: '0.00000000',
    fills: [],
    orderId: '24684493711',
    origQty: '0.00100000',
    price: '35000.00000000',
    selfTradePreventionMode: 'EXPIRE_MAKER',
    side: 'BUY',
    status: 'NEW',
    symbol: 'BTCUSDT',
    timeInForce: 'GTC',
    transactTime: '1707113821795',
    type: 'LIMIT'
  },
  id: '24684493711',
  clientOrderId: 'x-R4BD3S828419c93ec5d94bc380c998',
  timestamp: 1707113821795,
  datetime: '2024-02-05T06:17:01.795Z',
  lastUpdateTimestamp: 1707113821795,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 35000,
  amount: 0.001,
  cost: 0,
  filled: 0,
  remaining: 0.001,
  status: 'open',
  trades: [],
  fees: []
}
```