### PR TITLE
binance: createOrder, postOnly

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5609,7 +5609,7 @@ export default class binance extends Exchange {
                 request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
             }
         }
-        if (timeInForceIsRequired) {
+        if (timeInForceIsRequired && (this.safeString (params, 'timeInForce') === undefined)) {
             request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
         }
         if (!isPortfolioMargin && market['contract'] && postOnly) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5416,21 +5416,6 @@ export default class binance extends Exchange {
                 }
             }
         }
-        if (!isPortfolioMargin) {
-            const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
-            if (market['spot'] || marketType === 'margin') {
-                // only supported for spot/margin api (all margin markets are spot markets)
-                if (postOnly) {
-                    type = 'LIMIT_MAKER';
-                }
-                if (marginMode === 'isolated') {
-                    request['isIsolated'] = true;
-                }
-            }
-            if (market['contract'] && postOnly) {
-                request['timeInForce'] = 'GTX';
-            }
-        }
         const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const stopLossPrice = this.safeString (params, 'stopLossPrice', triggerPrice); // fallback to stopLoss
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
@@ -5498,6 +5483,19 @@ export default class binance extends Exchange {
             request[clientOrderIdRequest] = brokerId + this.uuid22 ();
         } else {
             request[clientOrderIdRequest] = clientOrderId;
+        }
+        let postOnly = undefined;
+        if (!isPortfolioMargin) {
+            postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
+            if (market['spot'] || marketType === 'margin') {
+                // only supported for spot/margin api (all margin markets are spot markets)
+                if (postOnly) {
+                    uppercaseType = 'LIMIT_MAKER';
+                }
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
+            }
         }
         const typeRequest = isPortfolioMarginConditional ? 'strategyType' : 'type';
         request[typeRequest] = uppercaseType;
@@ -5596,9 +5594,6 @@ export default class binance extends Exchange {
             }
             request['price'] = this.priceToPrecision (symbol, price);
         }
-        if (timeInForceIsRequired) {
-            request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
-        }
         if (stopPriceIsRequired) {
             if (market['contract']) {
                 if (stopPrice === undefined) {
@@ -5614,20 +5609,11 @@ export default class binance extends Exchange {
                 request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
             }
         }
-        if (!isPortfolioMargin) {
-            const postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
-            if (market['spot'] || marketType === 'margin') {
-                // only supported for spot/margin api (all margin markets are spot markets)
-                if (postOnly) {
-                    type = 'LIMIT_MAKER';
-                }
-                if (marginMode === 'isolated') {
-                    request['isIsolated'] = true;
-                }
-            }
-            if (market['contract'] && postOnly) {
-                request['timeInForce'] = 'GTX';
-            }
+        if (timeInForceIsRequired) {
+            request['timeInForce'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
+        }
+        if (!isPortfolioMargin && market['contract'] && postOnly) {
+            request['timeInForce'] = 'GTX';
         }
         // remove timeInForce from params because PO is only used by this.isPostOnly and it's not a valid value for Binance
         if (this.safeString (params, 'timeInForce') === 'PO') {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -50,7 +50,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "timestamp=1699380855361&symbol=LTCUSDT&side=BUY&newClientOrderId=x-R4BD3S82102a551f8c1642bba06728&newOrderRespType=RESULT&type=LIMIT_MAKER&quantity=0.2&price=50&recvWindow=10000&signature=6ae855678678e86725443f243b2f40613ed3e48e39a478ea0433c7dcbc36fce8"
+                "output": "timestamp=1707174812474&symbol=LTCUSDT&side=BUY&newOrderRespType=FULL&newClientOrderId=x-R4BD3S8281350e594e8f4383a36f19&type=LIMIT_MAKER&quantity=0.2&price=50&recvWindow=10000&signature=4e01e6b644312f26fce0be6524ed2eda08079dec6b6f1f2670a685362e39c6f1"
             },
             {
                 "description": "Swap market buy order",


### PR DESCRIPTION
Removed duplicate conditional code for spot `postOnly` orders, rearranged `timeInForce` execution ordering:

```
binance createOrder LTC/USDT limit buy 0.2 50 '{"postOnly":true}'

binance.createOrder (LTC/USDT, limit, buy, 0.2, 50, [object Object])
2024-02-05T21:24:14.979Z iteration 0 passed in 521 ms

{
  info: {
    symbol: 'LTCUSDT',
    orderId: '3604664',
    orderListId: '-1',
    clientOrderId: 'x-R4BD3S82e8cd835a73114ef6aa574f',
    transactTime: '1707168256009',
    price: '50.00000000',
    origQty: '0.20000000',
    executedQty: '0.00000000',
    cummulativeQuoteQty: '0.00000000',
    status: 'NEW',
    timeInForce: 'GTC',
    type: 'LIMIT_MAKER',
    side: 'BUY',
    workingTime: '1707168256009',
    fills: [],
    selfTradePreventionMode: 'EXPIRE_MAKER'
  },
  id: '3604664',
  clientOrderId: 'x-R4BD3S82e8cd835a73114ef6aa574f',
  timestamp: 1707168256009,
  datetime: '2024-02-05T21:24:16.009Z',
  lastUpdateTimestamp: 1707168256009,
  symbol: 'LTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: true,
  side: 'buy',
  price: 50,
  amount: 0.2,
  cost: 0,
  filled: 0,
  remaining: 0.2,
  status: 'open',
  trades: [],
  fees: []
}