### PR TITLE
binance: fetchOpenOrders, portfolio margin support

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -829,6 +829,74 @@
                         "marginMode": "isolated"
                     }
                 ]
+            },
+            {
+                "description": "Linear swap portfolio margin open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://papi.binance.com/papi/v1/um/openOrders?timestamp=1707197626953&symbol=BTCUSDT&recvWindow=10000&signature=4df8c7c7f3715ffd41cf6dcffafff6f58f56e37e3f924feab36ee77595b63f72",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap portfolio margin open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/openOrders?timestamp=1707197862310&symbol=ETHUSD_PERP&recvWindow=10000&signature=e2f92aad2f3fb7fe80b0c081494ca36a4bb32fa79194b2072bd8781731ce25c0",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Linear swap conditional portfolio margin open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://papi.binance.com/papi/v1/um/conditional/openOrders?timestamp=1707198871950&symbol=BTCUSDT&recvWindow=10000&signature=df05759f3ce7eedef0fc3fca72635deb0379a289365808755f1086c5dd59c980",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap conditional portfolio margin open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/conditional/openOrders?timestamp=1707199082780&symbol=ETHUSD_PERP&recvWindow=10000&signature=b8b647ada017a613b32424302351b6a9794b8a7a81a34b5a91b39f3e5ea5ec08",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin portfolio margin open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://papi.binance.com/papi/v1/margin/openOrders?timestamp=1707199469255&symbol=BTCUSDT&recvWindow=10000&signature=5602662ad2b21486608f4e061cdf4812203b345743b752f0f4c6e5fa090ff70c",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "marginMode": "cross"
+                  }
+                ]
             }
         ],
         "fetchCanceledOrders": [

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -172,6 +172,92 @@
             "stopLossPrice": null
           }
         ]
+      },
+      {
+        "description": "open portfolio margin orders",
+        "method": "fetchOpenOrders",
+        "input": [
+          "LTC/USDT:USDT",
+          null,
+          1,
+          {
+            "portfolioMargin": true
+          }
+        ],
+        "httpResponse": [
+          {
+            "orderId": "29067571132",
+            "symbol": "LTCUSDT",
+            "status": "NEW",
+            "clientOrderId": "x-xcKtGhcud28547066cdd46a7b96e40",
+            "price": "50",
+            "avgPrice": "0",
+            "origQty": "0.410",
+            "executedQty": "0",
+            "cumQuote": "0",
+            "timeInForce": "GTC",
+            "type": "LIMIT",
+            "reduceOnly": false,
+            "side": "BUY",
+            "positionSide": "BOTH",
+            "origType": "LIMIT",
+            "time": "1707212775174",
+            "updateTime": "1707212775174",
+            "goodTillDate": "0",
+            "selfTradePreventionMode": "NONE"
+          }
+        ],
+        "parsedResponse": [
+          {
+            "info": {
+              "orderId": "29067571132",
+              "symbol": "LTCUSDT",
+              "status": "NEW",
+              "clientOrderId": "x-xcKtGhcud28547066cdd46a7b96e40",
+              "price": "50",
+              "avgPrice": "0",
+              "origQty": "0.410",
+              "executedQty": "0",
+              "cumQuote": "0",
+              "timeInForce": "GTC",
+              "type": "LIMIT",
+              "reduceOnly": false,
+              "side": "BUY",
+              "positionSide": "BOTH",
+              "origType": "LIMIT",
+              "time": "1707212775174",
+              "updateTime": "1707212775174",
+              "goodTillDate": "0",
+              "selfTradePreventionMode": "NONE"
+            },
+            "id": "29067571132",
+            "clientOrderId": "x-xcKtGhcud28547066cdd46a7b96e40",
+            "timestamp": 1707212775174,
+            "datetime": "2024-02-06T09:46:15.174Z",
+            "lastTradeTimestamp": null,
+            "lastUpdateTimestamp": 1707212775174,
+            "symbol": "LTC/USDT:USDT",
+            "type": "limit",
+            "timeInForce": "GTC",
+            "postOnly": false,
+            "reduceOnly": false,
+            "side": "buy",
+            "price": 50,
+            "triggerPrice": null,
+            "amount": 0.41,
+            "cost": 0,
+            "average": null,
+            "filled": 0,
+            "remaining": 0.41,
+            "status": "open",
+            "fee": null,
+            "trades": [],
+            "fees": [],
+            "stopPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
       }
     ],
     "fetchPositions": [


### PR DESCRIPTION
Added portfolio margin support to fetchOpenOrders:

```
binance fetchOpenOrders BTC/USDT:USDT undefined undefined '{"portfolioMargin":true}'

binance.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2024-02-06T05:33:47.929Z iteration 0 passed in 1028 ms

          id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |        symbol |  type | timeInForce | postOnly | reduceOnly | side | price | amount | cost | filled | remaining | status | trades | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
259235347005 | x-xcKtGhcu402881c9103f42bdb4183b | 1707194702167 | 2024-02-06T04:45:02.167Z |       1707194702167 | BTC/USDT:USDT | limit |         GTC |    false |      false |  buy | 35000 |   0.01 |    0 |      0 |      0.01 |   open |     [] |   []
1 objects
```
```
binance fetchOpenOrders ETH/USD:ETH undefined undefined '{"portfolioMargin":true}'

binance.fetchOpenOrders (ETH/USD:ETH, , , [object Object])
2024-02-06T05:37:43.143Z iteration 0 passed in 885 ms

         id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |      symbol |  type | timeInForce | postOnly | reduceOnly | side | price | amount | cost | filled | remaining | status | trades | fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
71328442983 | x-xcKtGhcu4b3e3d8515dd4dc5ba9ccc | 1707197843046 | 2024-02-06T05:37:23.046Z |       1707197843046 | ETH/USD:ETH | limit |         GTC |    false |      false |  buy |  2000 |      1 |    0 |      0 |         1 |   open |     [] |   []
1 objects
```
```
binance fetchOpenOrders BTC/USDT:USDT undefined undefined '{"portfolioMargin":true,"stop":true}'

binance.fetchOpenOrders (BTC/USDT:USDT, , , [object Object])
2024-02-06T05:54:32.768Z iteration 0 passed in 869 ms

     id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |        symbol | timeInForce | postOnly | reduceOnly | side | price | triggerPrice | amount | cost | filled | remaining |  status | trades | fees | stopPrice
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3692718 | x-xcKtGhcu750c732b9b0444189ff9a1 | 1707198509789 | 2024-02-06T05:48:29.789Z |       1707198509789 | BTC/USDT:USDT |         GTC |    false |      false |  buy | 35000 |        50000 |   0.01 |    0 |      0 |      0.01 |    open |     [] |   [] |     50000
1 objects
```
```
binance fetchOpenOrders ETH/USD:ETH undefined undefined '{"portfolioMargin":true,"stop":true}'

binance.fetchOpenOrders (ETH/USD:ETH, , , [object Object])
2024-02-06T05:58:03.628Z iteration 0 passed in 899 ms

     id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |      symbol | timeInForce | postOnly | reduceOnly | side | price | triggerPrice | amount | cost | filled | remaining | status | trades | fees | stopPrice
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1423464 | x-xcKtGhcubd66e2d41e994ac88eea0b | 1707199014725 | 2024-02-06T05:56:54.725Z |       1707199014725 | ETH/USD:ETH |         GTC |    false |      false |  buy |  2000 |         4000 |      1 |    0 |      0 |         1 |   open |     [] |   [] |      4000
1 objects
```
```
binance fetchOpenOrders BTC/USDT undefined undefined '{"portfolioMargin":true,"marginMode":"cross"}'

binance.fetchOpenOrders (BTC/USDT, , , [object Object])
2024-02-06T06:04:30.079Z iteration 0 passed in 875 ms

         id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | side | price | amount | cost | filled | remaining | status | trades | fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
24700763749 | x-R4BD3S826f724c2a4af6425f98c7b6 | 1707199187679 | 2024-02-06T05:59:47.679Z |       1707199187679 | BTC/USDT | limit |         GTC |    false |  buy | 35000 |  0.001 |    0 |      0 |     0.001 |   open |     [] |   []
1 objects
```