### PR TITLE
binance: cancelAllOrders, portfolio margin support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5096,7 +5096,7 @@ export default class binance extends Exchange {
         //         "priceProtect": false
         //     }
         //
-        // createOrder: portfolio margin spot margin
+        // createOrder, cancelAllOrders: portfolio margin spot margin
         //
         //     {
         //         "clientOrderId": "x-R4BD3S82e9ef29d8346440f0b28b86",
@@ -5122,7 +5122,8 @@ export default class binance extends Exchange {
         }
         const status = this.parseOrderStatus (this.safeString2 (order, 'status', 'strategyStatus'));
         const marketId = this.safeString (order, 'symbol');
-        const marketType = ('closePosition' in order) ? 'contract' : 'spot';
+        const isContract = ('positionSide' in order) || ('cumQuote' in order);
+        const marketType = isContract ? 'contract' : 'spot';
         const symbol = this.safeSymbol (marketId, market, undefined, marketType);
         const filled = this.safeString (order, 'executedQty', '0');
         const timestamp = this.safeIntegerN (order, [ 'time', 'createTime', 'workingTime', 'transactTime', 'updateTime' ]); // order of the keys matters here
@@ -6075,42 +6076,73 @@ export default class binance extends Exchange {
         /**
          * @method
          * @name binance#cancelAllOrders
+         * @description cancel all open orders in a market
          * @see https://binance-docs.github.io/apidocs/spot/en/#cancel-all-open-orders-on-a-symbol-trade
          * @see https://binance-docs.github.io/apidocs/futures/en/#cancel-all-open-orders-trade
          * @see https://binance-docs.github.io/apidocs/delivery/en/#cancel-all-open-orders-trade
          * @see https://binance-docs.github.io/apidocs/voptions/en/#cancel-all-option-orders-on-specific-symbol-trade
          * @see https://binance-docs.github.io/apidocs/spot/en/#margin-account-cancel-order-trade
-         * @description cancel all open orders in a market
+         * @see https://binance-docs.github.io/apidocs/pm/en/#cancel-all-um-open-orders-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#cancel-all-cm-open-orders-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#cancel-all-um-open-conditional-orders-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#cancel-all-cm-open-conditional-orders-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#cancel-margin-account-all-open-orders-on-a-symbol-trade
          * @param {string} symbol unified market symbol of the market to cancel orders in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to cancel orders in a portfolio margin account
+         * @param {boolean} [params.stop] set to true if you would like to cancel portfolio margin account conditional orders
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument');
+            throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol argument');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request = {
             'symbol': market['id'],
         };
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'cancelAllOrders', 'papi', 'portfolioMargin', false);
+        const isConditional = this.safeBool2 (params, 'stop', 'conditional');
         const type = this.safeString (params, 'type', market['type']);
-        params = this.omit (params, [ 'type' ]);
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('cancelAllOrders', params);
+        params = this.omit (params, [ 'type', 'stop', 'conditional' ]);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('cancelAllOrders', params);
         let response = undefined;
         if (market['option']) {
-            response = await this.eapiPrivateDeleteAllOpenOrders (this.extend (request, query));
+            response = await this.eapiPrivateDeleteAllOpenOrders (this.extend (request, params));
         } else if (market['linear']) {
-            response = await this.fapiPrivateDeleteAllOpenOrders (this.extend (request, query));
-        } else if (market['inverse']) {
-            response = await this.dapiPrivateDeleteAllOpenOrders (this.extend (request, query));
-        } else if ((type === 'margin') || (marginMode !== undefined)) {
-            if (marginMode === 'isolated') {
-                request['isIsolated'] = true;
+            if (isPortfolioMargin) {
+                if (isConditional) {
+                    response = await this.papiDeleteUmConditionalAllOpenOrders (this.extend (request, params));
+                } else {
+                    response = await this.papiDeleteUmAllOpenOrders (this.extend (request, params));
+                }
+            } else {
+                response = await this.fapiPrivateDeleteAllOpenOrders (this.extend (request, params));
             }
-            response = await this.sapiDeleteMarginOpenOrders (this.extend (request, query));
+        } else if (market['inverse']) {
+            if (isPortfolioMargin) {
+                if (isConditional) {
+                    response = await this.papiDeleteCmConditionalAllOpenOrders (this.extend (request, params));
+                } else {
+                    response = await this.papiDeleteCmAllOpenOrders (this.extend (request, params));
+                }
+            } else {
+                response = await this.dapiPrivateDeleteAllOpenOrders (this.extend (request, params));
+            }
+        } else if ((type === 'margin') || (marginMode !== undefined)) {
+            if (isPortfolioMargin) {
+                response = await this.papiDeleteMarginAllOpenOrders (this.extend (request, params));
+            } else {
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
+                response = await this.sapiDeleteMarginOpenOrders (this.extend (request, params));
+            }
         } else {
-            response = await this.privateDeleteOpenOrders (this.extend (request, query));
+            response = await this.privateDeleteOpenOrders (this.extend (request, params));
         }
         if (Array.isArray (response)) {
             return this.parseOrders (response, market);

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -507,6 +507,64 @@
                 "input": [
                     "ETH/USDT:USDT-231229-800-C"
                 ]
+            },
+            {
+                "description": "Spot margin portfolio margin cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://papi.binance.com/papi/v1/margin/allOpenOrders?timestamp=1707200410926&symbol=BTCUSDT&recvWindow=10000&signature=df707ee6f73851d1e718c1dac653ef25728c1cd886a430f50f1f50aa29521923",
+                "input": [
+                  "BTC/USDT",
+                  {
+                    "portfolioMargin": true,
+                    "marginMode": "cross"
+                  }
+                ]
+            },
+            {
+                "description": "Linear swap portfolio margin cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://papi.binance.com/papi/v1/um/allOpenOrders?timestamp=1707200607284&symbol=BTCUSDT&recvWindow=10000&signature=288414f1b0973e263c547484ce798dcf5940c8fbf65491610cb196d2f42900fc",
+                "input": [
+                  "BTC/USDT:USDT",
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap portfolio margin cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/allOpenOrders?timestamp=1707200728688&symbol=ETHUSD_PERP&recvWindow=10000&signature=032e5ca4f8726847411668a8d3790721a6c284989259aad341eadf45c07c3a8f",
+                "input": [
+                  "ETH/USD:ETH",
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Linear swap conditional portfolio margin cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://papi.binance.com/papi/v1/um/conditional/allOpenOrders?timestamp=1707200837231&symbol=BTCUSDT&recvWindow=10000&signature=a2d5b52b27de004012e2505eabd7008521b2755832a94e9c20e6c8b37bd8f44f",
+                "input": [
+                  "BTC/USDT:USDT",
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap conditional portfolio margin cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/conditional/allOpenOrders?timestamp=1707200939553&symbol=ETHUSD_PERP&recvWindow=10000&signature=a2cd0a7bcdbf763ed40e90f84660de730e43d0e278755090fc96874911e0fb9f",
+                "input": [
+                  "ETH/USD:ETH",
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
             }
         ],
         "fetchBalance": [


### PR DESCRIPTION
Added portfolio margin support to cancelAllOrders:

```
binance cancelAllOrders BTC/USDT '{"portfolioMargin":true,"marginMode":"cross"}'

binance.cancelAllOrders (BTC/USDT, [object Object])
2024-02-06T06:20:11.739Z iteration 0 passed in 864 ms

         id |          clientOrderId |   symbol |  type | timeInForce | postOnly | side | price | amount | cost | filled | remaining |   status | trades | fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------
24700891701 | vLpapHLK55eZN7zIKjs7PL | BTC/USDT | limit |         GTC |    false |  buy | 35000 |  0.001 |    0 |      0 |     0.001 | canceled |     [] |   []
1 objects
```
```
binance cancelAllOrders BTC/USDT:USDT '{"portfolioMargin":true}'

binance.cancelAllOrders (BTC/USDT:USDT, [object Object])
2024-02-06T06:23:28.164Z iteration 0 passed in 931 ms

{ code: '200', msg: 'The operation of cancel all open order is done.' }
```
```
binance cancelAllOrders ETH/USD:ETH '{"portfolioMargin":true}'

binance.cancelAllOrders (ETH/USD:ETH, [object Object])
2024-02-06T06:25:29.568Z iteration 0 passed in 885 ms

{ code: '200', msg: 'The operation of cancel all open order is done.' }
```
```
binance cancelAllOrders BTC/USDT:USDT '{"portfolioMargin":true,"stop":true}'

binance.cancelAllOrders (BTC/USDT:USDT, [object Object])
2024-02-06T06:27:18.151Z iteration 0 passed in 971 ms

{
  code: 200,
  msg: 'The operation of cancel all conditional open order is done.'
}
```
```
binance cancelAllOrders ETH/USD:ETH '{"portfolioMargin":true,"stop":true}'

binance.cancelAllOrders (ETH/USD:ETH, [object Object])
2024-02-06T06:29:00.437Z iteration 0 passed in 936 ms

{
  code: 200,
  msg: 'The operation of cancel all conditional open order is done.'
}
```