### PR TITLE
feat(kucoin): watchOrderBook add level2Depth5 & level2Depth50 method

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -569,19 +569,19 @@ export default class kucoin extends kucoinRest {
         const marketId = this.safeString (data, 'symbol', topicSymbol);
         const symbol = this.safeSymbol (marketId, undefined, '-');
         const messageHash = 'orderbook:' + symbol;
-        let storedOrderBook = this.orderbooks[symbol];
+        let orderbook = this.orderbooks[symbol];
         if (subject === 'level2') {
-            if (storedOrderBook === undefined) {
-                storedOrderBook = this.orderBook ();
+            if (orderbook === undefined) {
+                orderbook = this.orderBook ();
             } else {
-                storedOrderBook.reset ();
+                orderbook.reset ();
             }
-            storedOrderBook['symbol'] = symbol;
+            orderbook['symbol'] = symbol;
         } else {
-            const nonce = this.safeInteger (storedOrderBook, 'nonce');
+            const nonce = this.safeInteger (orderbook, 'nonce');
             const deltaEnd = this.safeInteger2 (data, 'sequenceEnd', 'timestamp');
             if (nonce === undefined) {
-                const cacheLength = storedOrderBook.cache.length;
+                const cacheLength = orderbook.cache.length;
                 const subscriptions = Object.keys (client.subscriptions);
                 let subscription = undefined;
                 for (let i = 0; i < subscriptions.length; i++) {
@@ -596,14 +596,14 @@ export default class kucoin extends kucoinRest {
                 if (cacheLength === snapshotDelay) {
                     this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, {});
                 }
-                storedOrderBook.cache.push (data);
+                orderbook.cache.push (data);
                 return;
             } else if (nonce >= deltaEnd) {
                 return;
             }
         }
-        this.handleDelta (storedOrderBook, data);
-        client.resolve (storedOrderBook, messageHash);
+        this.handleDelta (orderbook, data);
+        client.resolve (orderbook, messageHash);
     }
 
     getCacheIndex (orderbook, cache) {

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -586,7 +586,7 @@ export default class kucoin extends kucoinRest {
         const marketId = this.safeString (data, 'symbol', topicSymbol);
         const symbol = this.safeSymbol (marketId, undefined, '-');
         const messageHash = 'orderbook:' + symbol;
-        let orderbook = this.orderbooks[symbol];
+        let orderbook = this.safeDict (this.orderbooks, symbol);
         if (subject === 'level2') {
             if (orderbook === undefined) {
                 orderbook = this.orderBook ();


### PR DESCRIPTION
see: ccxt/ccxt#21104

```BASH
$ p kucoin watchOrderBook BTC/USDT None '{"method": "/spotMarket/level2Depth5"}'
Python v3.11.3
CCXT v4.2.36
kucoin.watchOrderBook(BTC/USDT,None,{'method': '/spotMarket/level2Depth5'})
{'asks': [[43052.1, 1.20980665], [43052.2, 0.07784757], [43053.9, 0.276647], [43054.0, 0.2211], [43054.6, 0.13589565]],
 'bids': [[43052.0, 1.02840429], [43050.1, 0.03588013], [43050.0, 0.2211], [43048.0, 0.2211], [43047.7, 0.22530693]],
 'datetime': '2024-02-06T08:45:22.084Z',
 'nonce': 1707209122084,
 'symbol': 'BTC/USDT',
 'timestamp': 1707209122084}

$ p kucoin watchOrderBook BTC/USDT None '{"method": "/spotMarket/level2Depth50"}'
Python v3.11.3
CCXT v4.2.36
kucoin.watchOrderBook(BTC/USDT,None,{'method': '/spotMarket/level2Depth50'})
{'asks': [[43050.2, 1.02306227], [43051.7, 0.276647], [43051.9, 0.31980789], [43052.0, 0.22669634], [43052.1, 0.85333054], [43052.4, 0.13596881], [43054.0, 0.2211], [43055.2, 0.00464519], [43055.3, 0.02798182], [43056.0, 0.2211], [43056.2, 0.00692784], [43056.3, 0.22500004], [43056.4, 0.19368709], [43056.5, 0.375], [43057.5, 0.08], [43057.8, 0.37180172], [43058.0, 0.32095355], [43059.0, 0.232277], [43059.7, 0.14002624], [43059.8, 0.05], [43059.9, 0.02757545], [43060.0, 0.2211], [43060.5, 0.233377], [43061.1, 0.0076], [43061.5, 0.0015], [43061.6, 0.11556997], [43061.7, 0.20664774], [43061.8, 0.01161394], [43061.9, 0.375], [43062.0, 0.2211], [43063.1, 0.00030405], [43063.7, 0.1395486], [43064.0, 0.22852774], [43064.3, 0.00015561], [43064.5, 0.18008833], [43064.6, 0.0650179], [43064.7, 0.0351963], [43064.8, 0.00030788], [43064.9, 0.696885], [43065.3, 0.0305], [43065.7, 0.27911093], [43065.8, 0.01868435], [43066.0, 0.22470856], [43066.2, 0.00012318], [43066.3, 0.00021258], [43066.4, 5.096e-05], [43066.8, 0.27904433], [43067.0, 0.00799488], [43067.4, 0.07020856], [43067.6, 7.874e-05]],
 'bids': [[43050.1, 0.91357295], [43050.0, 0.2211], [43048.2, 0.15419194], [43048.1, 0.03588656], [43048.0, 0.2211], [43047.1, 0.01892611], [43046.0, 0.2211], [43045.9, 0.02838902], [43044.8, 0.00706167], [43044.5, 0.00015556], [43044.1, 0.27202622], [43044.0, 0.453377], [43043.8, 0.13956976], [43043.3, 0.00372], [43042.4, 0.01174841], [43042.3, 0.31842751], [43042.2, 0.28856598], [43042.1, 0.19426341], [43042.0, 0.5302072], [43040.5, 0.0003064], [43040.4, 0.01161394], [43040.1, 0.232581], [43040.0, 0.2211], [43039.7, 0.00116896], [43039.5, 0.00336], [43037.6, 1.1611398], [43037.5, 0.03457451], [43037.4, 0.20938581], [43037.0, 2.87356], [43036.9, 0.00786228], [43036.1, 0.375], [43035.8, 0.01868435], [43035.0, 0.27919659], [43033.8, 0.232277], [43031.7, 0.375], [43031.3, 0.00091334], [43029.9, 0.0009192], [43029.7, 0.37226627], [43029.6, 0.03484182], [43028.9, 0.00045941], [43028.6, 0.13417457], [43028.5, 0.22362424], [43026.3, 0.41810289], [43026.2, 0.375], [43025.8, 0.02420059], [43025.6, 0.12783], [43025.5, 0.696838], [43025.1, 0.02423789], [43024.4, 0.00404161], [43023.3, 0.1393207]],
 'datetime': '2024-02-06T08:45:41.207Z',
 'nonce': 1707209141207,
 'symbol': 'BTC/USDT',
 'timestamp': 1707209141207}
```