### PR TITLE
bitmart - subscribe multiple + watchOrderBookForSymbols

### DIFF
--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -1300,7 +1300,7 @@ export default class bitmart extends bitmartRest {
             }
         }
         if (isSpot) {
-            let channel = table.replace ('spot/', '');
+            const channel = table.replace ('spot/', '');
             for (let i = 0; i < data.length; i++) {
                 const update = data[i];
                 const marketId = this.safeString (update, 'symbol');
@@ -1373,7 +1373,7 @@ export default class bitmart extends bitmartRest {
          * @method
          * @name bitmart#watchOrderBookForSymbols
          * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
-         * @see 
+         * @see https://developer-pro.bitmart.com/en/spot/#public-depth-increase-channel
          * @param {string[]} symbols unified array of symbols
          * @param {int} [limit] the maximum amount of order book entries to return
          * @param {object} [params] extra parameters specific to the exchange API endpoint

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -54,11 +54,15 @@ export default class bitmart extends bitmartRest {
                     'fetchBalanceSnapshot': true, // or false
                     'awaitBalanceSnapshot': false, // whether to wait for the balance snapshot before providing updates
                 },
+                //
+                // orderbook channels can have:
+                //  -  'depth5', 'depth20', 'depth50' // these endpoints emit full Orderbooks once in every 500ms
+                //  -  'depth/increase100' // this endpoint is preferred, because it emits once in 100ms. however, when this value is chosen, it only affects spot-market, but contracts markets automatically `depth50` will be being used  
                 'watchOrderBook': {
-                    'depth': 'depth/increase100', // depth/increase100, depth5, depth20, depth50
+                    'depth': 'depth/increase100',
                 },
                 'watchOrderBookForSymbols': {
-                    'depth': 'depth/increase100', // depth/increase100, depth5, depth20, depth50
+                    'depth': 'depth/increase100',
                 },
                 'ws': {
                     'inflate': true,

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -1381,6 +1381,7 @@ export default class bitmart extends bitmartRest {
          * @param {string[]} symbols unified array of symbols
          * @param {int} [limit] the maximum amount of order book entries to return
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.depth] the type of order book to subscribe to, default is 'depth/increase100', also accepts 'depth5' or 'depth20' or depth50
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
          */
         await this.loadMarkets ();

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -1372,6 +1372,9 @@ export default class bitmart extends bitmartRest {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true);
+        if (symbols.length > 20) {
+            throw new NotSupported (this.id + ' watchOrderBookForSymbols() accepts a maximum of 20 symbols in one request');
+        }
         const market = this.market (symbols[0]);
         let channel = undefined;
         [ channel, params ] = this.handleOptionAndParams (params, 'watchOrderBookForSymbols', 'depth', 'depth/increase100');

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -110,7 +110,7 @@ export default class bitmart extends bitmartRest {
         return await this.watch (url, messageHash, this.deepExtend (request, params), messageHash);
     }
 
-    async subscribeMultiple (channel, type, symbols, params = {}) {
+    async subscribeMultiple (channel: string, type: string, symbols: string[], params = {}) {
         const url = this.implodeHostname (this.urls['api']['ws'][type]['public']);
         const channelType = (type === 'spot') ? 'spot' : 'futures';
         const actionType = (type === 'spot') ? 'op' : 'action';

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -57,7 +57,7 @@ export default class bitmart extends bitmartRest {
                 //
                 // orderbook channels can have:
                 //  -  'depth5', 'depth20', 'depth50' // these endpoints emit full Orderbooks once in every 500ms
-                //  -  'depth/increase100' // this endpoint is preferred, because it emits once in 100ms. however, when this value is chosen, it only affects spot-market, but contracts markets automatically `depth50` will be being used  
+                //  -  'depth/increase100' // this endpoint is preferred, because it emits once in 100ms. however, when this value is chosen, it only affects spot-market, but contracts markets automatically `depth50` will be being used
                 'watchOrderBook': {
                     'depth': 'depth/increase100',
                 },


### PR DESCRIPTION
```
 await e.watchOrderBookForSymbols(['SHIB/USDT', 'LINK/USDT']);


2024-02-06T20:02:30.072Z connecting to wss://ws-manager-compress.bitmart.com/api?protocol=1.1
2024-02-06T20:02:31.023Z onUpgrade
2024-02-06T20:02:31.024Z onOpen
2024-02-06T20:02:31.031Z sending {
  args: [
    'spot/depth/increase100:SHIB_USDT',
    'spot/depth/increase100:LINK_USDT'
  ],
  op: 'subscribe'
}
2024-02-06T20:02:31.406Z onMessage {
  data: [
    {
      asks: [Array],
      bids: [Array],
      ms_t: 1707249751090,
      symbol: 'SHIB_USDT',
      type: 'snapshot',
      version: 328040
    }
  ],
  table: 'spot/depth/increase100'
}
2024-02-06T20:02:31.420Z onMessage {
  data: [
    {
      asks: [Array],
      bids: [Array],
      ms_t: 1707249751095,
      symbol: 'LINK_USDT',
      type: 'snapshot',
      version: 11752913
    }
  ],
  table: 'spot/depth/increase100'
}
2024-02-06T20:02:31.423Z onMessage {
  data: [
    {
      asks: [],
      bids: [Array],
      ms_t: 1707249751129,
      symbol: 'SHIB_USDT',
      type: 'update',
      version: 328041
    }
  ],
  table: 'spot/depth/increase100'
}
```

parsed
```
{
  bids: [
    [
      0.000008865,
      25153017,
    ],
...
  ],
  asks: [
    [
      0.000008928,
      10338701,
    ],,
    ...
  ],
  timestamp: 1707249751129,
  datetime: "2024-02-06T20:02:31.129Z",
  nonce: undefined,
  symbol: "SHIB/USDT",
}

```