### PR TITLE
fix(mexc): watchOrderBook assigns timestamp for contract markets

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -483,7 +483,7 @@ export default class mexc extends mexcRest {
         }
         try {
             this.handleDelta (storedOrderBook, data);
-            const timestamp = this.safeInteger (message, 't');
+            const timestamp = this.safeInteger2 (message, 't', 'ts');
             storedOrderBook['timestamp'] = timestamp;
             storedOrderBook['datetime'] = this.iso8601 (timestamp);
         } catch (e) {


### PR DESCRIPTION
```
2024-02-06T21:40:57.696Z
Node.js: v18.12.0
CCXT v4.2.36
mexc.watchOrderBook (BTC/USDT:USDT)
CountedOrderBook {
  bids: CountedBids(4493) [
    [ 43197, 105624, 1 ],   [ 43196.9, 132897, 1 ],  [ 43196.8, 144757, 2 ],
    ...
    [ 0.2, 2339433, 13 ],   [ 0.1, 28014806, 79 ]
  ],
  asks: CountedAsks(2561) [
    [ 43197.1, 102407, 1 ],  [ 43197.2, 100334, 1 ],  [ 43197.3, 167243, 2 ],
    ...
    [ 525050, 25, 1 ],       [ 7000000, 5, 1 ]
  ],
  timestamp: 1707255670707,
  datetime: '2024-02-06T21:41:10.707Z',
  nonce: 14111480533,
  symbol: 'BTC/USDT:USDT'
}
...
```