### PR TITLE
fix(krakenfutures): parseMyTrades returns symbol with response

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -803,36 +803,29 @@ export default class krakenfutures extends Exchange {
             id = this.safeString (trade, 'executionId');
         }
         let order = this.safeString (trade, 'order_id');
-        let symbolId = this.safeString (trade, 'symbol');
+        let marketId = this.safeString (trade, 'symbol');
         let side = this.safeString (trade, 'side');
         let type = undefined;
         const priorEdit = this.safeValue (trade, 'orderPriorEdit');
         const priorExecution = this.safeValue (trade, 'orderPriorExecution');
         if (priorExecution !== undefined) {
             order = this.safeString (priorExecution, 'orderId');
-            symbolId = this.safeString (priorExecution, 'symbol');
+            marketId = this.safeString (priorExecution, 'symbol');
             side = this.safeString (priorExecution, 'side');
             type = this.safeString (priorExecution, 'type');
         } else if (priorEdit !== undefined) {
             order = this.safeString (priorEdit, 'orderId');
-            symbolId = this.safeString (priorEdit, 'symbol');
+            marketId = this.safeString (priorEdit, 'symbol');
             side = this.safeString (priorEdit, 'type');
             type = this.safeString (priorEdit, 'type');
         }
         if (type !== undefined) {
             type = this.parseOrderType (type);
         }
-        let symbol = undefined;
-        if (symbolId !== undefined) {
-            market = this.safeValue (this.markets_by_id, symbolId);
-            if (market === undefined) {
-                symbol = symbolId;
-            }
-        }
-        symbol = this.safeString (market, 'symbol', symbol);
+        market = this.safeMarket (marketId, market);
         let cost = undefined;
+        const linear = this.safeBool (market, 'linear');
         if ((amount !== undefined) && (price !== undefined) && (market !== undefined)) {
-            const linear = this.safeValue (market, 'linear');
             if (linear) {
                 cost = Precise.stringMul (amount, price); // in quote
             } else {
@@ -853,15 +846,15 @@ export default class krakenfutures extends Exchange {
         return this.safeTrade ({
             'info': trade,
             'id': id,
+            'symbol': this.safeString (market, 'symbol'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'symbol': symbol,
             'order': order,
             'type': type,
             'side': side,
             'takerOrMaker': takerOrMaker,
             'price': price,
-            'amount': amount,
+            'amount': linear ? amount : undefined,
             'cost': cost,
             'fee': undefined,
         });

--- a/ts/src/test/static/markets/krakenfutures.json
+++ b/ts/src/test/static/markets/krakenfutures.json
@@ -453,5 +453,173 @@
         "maker": -0.0002,
         "index": false,
         "created": 1647959965000
+    },
+    "FTM/USD:USD": {
+        "id": "PF_FTMUSD",
+        "symbol": "FTM/USD:USD",
+        "base": "FTM",
+        "quote": "USD",
+        "settle": "USD",
+        "baseId": "FTM",
+        "quoteId": "usd",
+        "settleId": "usd",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "index": false,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
+        "taker": 0.0005,
+        "maker": 0.0002,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1,
+            "price": 0.00001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {}
+        },
+        "created": 1655729853000,
+        "info": {
+            "symbol": "PF_FTMUSD",
+            "type": "flexible_futures",
+            "tickSize": "0.00001",
+            "contractSize": "1",
+            "tradeable": true,
+            "impactMidSize": "600.00",
+            "maxPositionSize": "25000000.00000000000",
+            "openingDate": "2022-06-20T12:57:33.000Z",
+            "marginLevels": [
+                {
+                    "numNonContractUnits": "0E-20",
+                    "initialMargin": "0.04",
+                    "maintenanceMargin": "0.02"
+                },
+                {
+                    "numNonContractUnits": "250000.00000000000000000000",
+                    "initialMargin": "0.1",
+                    "maintenanceMargin": "0.05"
+                },
+                {
+                    "numNonContractUnits": "1000000.00000000000000000000",
+                    "initialMargin": "0.2",
+                    "maintenanceMargin": "0.1"
+                },
+                {
+                    "numNonContractUnits": "2000000.00000000000000000000",
+                    "initialMargin": "0.5",
+                    "maintenanceMargin": "0.25"
+                }
+            ],
+            "fundingRateCoefficient": "24",
+            "maxRelativeFundingRate": "0.0025",
+            "contractValueTradePrecision": "0",
+            "postOnly": false,
+            "feeScheduleUid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+            "retailMarginLevels": [
+                {
+                    "numNonContractUnits": "0E-20",
+                    "initialMargin": "0.04",
+                    "maintenanceMargin": "0.02"
+                },
+                {
+                    "numNonContractUnits": "250000.00000000000000000000",
+                    "initialMargin": "0.1",
+                    "maintenanceMargin": "0.05"
+                },
+                {
+                    "numNonContractUnits": "1000000.00000000000000000000",
+                    "initialMargin": "0.2",
+                    "maintenanceMargin": "0.1"
+                },
+                {
+                    "numNonContractUnits": "2000000.00000000000000000000",
+                    "initialMargin": "0.5",
+                    "maintenanceMargin": "0.25"
+                }
+            ],
+            "category": "Layer 1",
+            "tags": []
+        },
+        "tierBased": true,
+        "percentage": true,
+        "tiers": {
+            "taker": [
+                [
+                    0,
+                    0.0005
+                ],
+                [
+                    100000,
+                    0.0004
+                ],
+                [
+                    1000000,
+                    0.0003
+                ],
+                [
+                    5000000,
+                    0.00025
+                ],
+                [
+                    10000000,
+                    0.0002
+                ],
+                [
+                    20000000,
+                    0.00015
+                ],
+                [
+                    50000000,
+                    0.000125
+                ],
+                [
+                    100000000,
+                    0.0001
+                ]
+            ],
+            "maker": [
+                [
+                    0,
+                    0.0002
+                ],
+                [
+                    100000,
+                    0.0015
+                ],
+                [
+                    1000000,
+                    0.000125
+                ],
+                [
+                    5000000,
+                    0.0001
+                ],
+                [
+                    10000000,
+                    0.000075
+                ],
+                [
+                    20000000,
+                    0.00005
+                ],
+                [
+                    50000000,
+                    0.000025
+                ],
+                [
+                    100000000,
+                    0
+                ]
+            ]
+        }
     }
 }

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -1,0 +1,97 @@
+{
+  "exchange": "krakenfutures",
+  "skipKeys": [],
+  "options": {
+  },
+  "methods": {
+    "fetchMyTrades": [
+      {
+        "description": "user trades",
+        "method": "fetchMyTrades",
+        "input": [
+          null,
+          null,
+          2
+        ],
+        "httpResponse": {
+          "result": "success",
+          "fills": [
+            {
+              "fill_id": "da062bc0-5901-48a5-9bb3-34c6be3ef7a5",
+              "symbol": "PF_LTCUSD",
+              "side": "buy",
+              "order_id": "85805e01-9eed-4395-8360-ed1a228237c9",
+              "size": "0.1",
+              "price": "68.54",
+              "fillTime": "2024-02-06T22:24:34.849Z",
+              "fillType": "taker"
+            },
+            {
+              "fill_id": "7066466a-9c46-48d6-9c43-3585d48f21a4",
+              "symbol": "PF_FTMUSD",
+              "side": "sell",
+              "order_id": "56e84113-055e-44fd-950b-547113dffa3c",
+              "size": "1",
+              "price": "0.50008",
+              "fillTime": "2023-02-22T12:28:46.816Z",
+              "fillType": "taker"
+            }
+          ],
+          "serverTime": "2024-02-06T22:25:22.290Z"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "fill_id": "7066466a-9c46-48d6-9c43-3585d48f21a4",
+              "symbol": "PF_FTMUSD",
+              "side": "sell",
+              "order_id": "56e84113-055e-44fd-950b-547113dffa3c",
+              "size": "1",
+              "price": "0.50008",
+              "fillTime": "2023-02-22T12:28:46.816Z",
+              "fillType": "taker"
+            },
+            "id": "7066466a-9c46-48d6-9c43-3585d48f21a4",
+            "symbol": "FTM/USD:USD",
+            "timestamp": 1677068926816,
+            "datetime": "2023-02-22T12:28:46.816Z",
+            "order": "56e84113-055e-44fd-950b-547113dffa3c",
+            "type": null,
+            "side": "sell",
+            "takerOrMaker": "taker",
+            "price": 0.50008,
+            "amount": 1,
+            "cost": 0.50008,
+            "fee": null,
+            "fees": []
+          },
+          {
+            "info": {
+              "fill_id": "da062bc0-5901-48a5-9bb3-34c6be3ef7a5",
+              "symbol": "PF_LTCUSD",
+              "side": "buy",
+              "order_id": "85805e01-9eed-4395-8360-ed1a228237c9",
+              "size": "0.1",
+              "price": "68.54",
+              "fillTime": "2024-02-06T22:24:34.849Z",
+              "fillType": "taker"
+            },
+            "id": "da062bc0-5901-48a5-9bb3-34c6be3ef7a5",
+            "symbol": "LTC/USD:USD",
+            "timestamp": 1707258274849,
+            "datetime": "2024-02-06T22:24:34.849Z",
+            "order": "85805e01-9eed-4395-8360-ed1a228237c9",
+            "type": null,
+            "side": "buy",
+            "takerOrMaker": "taker",
+            "price": 68.54,
+            "amount": 0.1,
+            "cost": 6.854,
+            "fee": null,
+            "fees": []
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.36
krakenfutures.fetchMyTrades()
[{'amount': 1.0,
  'cost': 0.49515,
  'datetime': '2023-02-22T11:20:47.559Z',
  'fee': None,
  'fees': [],
  'id': '2691e5c8-d2f7-441e-b06d-94eeb2973279',
  'info': {'fillTime': '2023-02-22T11:20:47.559Z',
           'fillType': 'taker',
           'fill_id': '2691e5c8-d2f7-441e-b06d-94eeb2973279',
           'order_id': '6419e063-db8c-41fb-ada7-6fc20b4e17b3',
           'price': '0.49515',
           'side': 'buy',
           'size': '1',
           'symbol': 'PF_FTMUSD'},
  'order': '6419e063-db8c-41fb-ada7-6fc20b4e17b3',
  'price': 0.49515,
  'side': 'buy',
  'symbol': 'FTM/USD:USD',
  'takerOrMaker': 'taker',
  'timestamp': 1677064847559,
  'type': None},
...
```