### PR TITLE
binance: fetchOrder, portfolio margin

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5007,7 +5007,7 @@ export default class binance extends Exchange {
         //         "msg": "Quantity greater than max quantity."
         //     }
         //
-        // createOrder, fetchOpenOrders: portfolio margin linear swap and future
+        // createOrder, fetchOpenOrders, fetchOrder: portfolio margin linear swap and future
         //
         //     {
         //         "symbol": "BTCUSDT",
@@ -5030,7 +5030,7 @@ export default class binance extends Exchange {
         //         "status": "NEW"
         //     }
         //
-        // createOrder, fetchOpenOrders: portfolio margin inverse swap and future
+        // createOrder, fetchOpenOrders, fetchOrder: portfolio margin inverse swap and future
         //
         //     {
         //         "symbol": "ETHUSD_PERP",
@@ -5115,7 +5115,7 @@ export default class binance extends Exchange {
         //         "type": "LIMIT"
         //     }
         //
-        // fetchOpenOrders: portfolio margin spot margin
+        // fetchOpenOrders, fetchOrder: portfolio margin spot margin
         //
         //     {
         //         "symbol": "BTCUSDT",
@@ -5720,9 +5720,14 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/delivery/en/#query-order-user_data
          * @see https://binance-docs.github.io/apidocs/voptions/en/#query-single-order-trade
          * @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-order-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-um-order-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-cm-order-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-margin-account-order-user_data
+         * @param {string} id the order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to fetch an order in a portfolio margin account
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
@@ -5732,7 +5737,10 @@ export default class binance extends Exchange {
         const market = this.market (symbol);
         const defaultType = this.safeString2 (this.options, 'fetchOrder', 'defaultType', 'spot');
         const type = this.safeString (params, 'type', defaultType);
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrder', params);
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchOrder', params);
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'fetchOrder', 'papi', 'portfolioMargin', false);
         const request = {
             'symbol': market['id'],
         };
@@ -5746,21 +5754,33 @@ export default class binance extends Exchange {
         } else {
             request['orderId'] = id;
         }
-        const requestParams = this.omit (query, [ 'type', 'clientOrderId', 'origClientOrderId' ]);
+        params = this.omit (params, [ 'type', 'clientOrderId', 'origClientOrderId' ]);
         let response = undefined;
         if (market['option']) {
-            response = await this.eapiPrivateGetOrder (this.extend (request, requestParams));
+            response = await this.eapiPrivateGetOrder (this.extend (request, params));
         } else if (market['linear']) {
-            response = await this.fapiPrivateGetOrder (this.extend (request, requestParams));
-        } else if (market['inverse']) {
-            response = await this.dapiPrivateGetOrder (this.extend (request, requestParams));
-        } else if (type === 'margin' || marginMode !== undefined) {
-            if (marginMode === 'isolated') {
-                request['isIsolated'] = true;
+            if (isPortfolioMargin) {
+                response = await this.papiGetUmOrder (this.extend (request, params));
+            } else {
+                response = await this.fapiPrivateGetOrder (this.extend (request, params));
             }
-            response = await this.sapiGetMarginOrder (this.extend (request, requestParams));
+        } else if (market['inverse']) {
+            if (isPortfolioMargin) {
+                response = await this.papiGetCmOrder (this.extend (request, params));
+            } else {
+                response = await this.dapiPrivateGetOrder (this.extend (request, params));
+            }
+        } else if ((type === 'margin') || (marginMode !== undefined) || isPortfolioMargin) {
+            if (isPortfolioMargin) {
+                response = await this.papiGetMarginOrder (this.extend (request, params));
+            } else {
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
+                response = await this.sapiGetMarginOrder (this.extend (request, params));
+            }
         } else {
-            response = await this.privateGetOrder (this.extend (request, requestParams));
+            response = await this.privateGetOrder (this.extend (request, params));
         }
         return this.parseOrder (response, market);
     }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5744,7 +5744,7 @@ export default class binance extends Exchange {
         const request = {
             'symbol': market['id'],
         };
-        const clientOrderId = this.safeValue2 (params, 'origClientOrderId', 'clientOrderId');
+        const clientOrderId = this.safeString2 (params, 'origClientOrderId', 'clientOrderId');
         if (clientOrderId !== undefined) {
             if (market['option']) {
                 request['clientOrderId'] = clientOrderId;

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -827,6 +827,43 @@
                     "marginMode": "isolated"
                   }
                 ]
+            },
+            {
+                "description": "Linear swap portfolio margin fetch order",
+                "method": "fetchOrder",
+                "url": "https://papi.binance.com/papi/v1/um/order?timestamp=1707257405537&symbol=BTCUSDT&orderId=259696755816&recvWindow=10000&signature=d916df835ea5208731b4da01ebb6eaef2eca85205777d49ef71e1d791505c522",
+                "input": [
+                  259696755816,
+                  "BTC/USDT:USDT",
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap portfolio margin fetch order",
+                "method": "fetchOrder",
+                "url": "https://papi.binance.com/papi/v1/cm/order?timestamp=1707257668234&symbol=ETHUSD_PERP&orderId=71371262156&recvWindow=10000&signature=8fb58c60d328534f21486e533ffe0e7371f96050d815609a05662d640b91eba8",
+                "input": [
+                  71371262156,
+                  "ETH/USD:ETH",
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin portfolio margin fetch order",
+                "method": "fetchOrder",
+                "url": "https://papi.binance.com/papi/v1/margin/order?timestamp=1707257917946&symbol=BTCUSDT&orderId=24711539682&recvWindow=10000&signature=ecc58b10a3bb4c26814fb521facda9151b0e7caafacc65836557b89eca386e17",
+                "input": [
+                  24711539682,
+                  "BTC/USDT",
+                  {
+                    "portfolioMargin": true,
+                    "marginMode": "cross"
+                  }
+                ]
             }
         ],
         "fetchOpenOrders": [


### PR DESCRIPTION
Added portfolio margin support to fetchOrder:

```
binance fetchOrder 259696755816 BTC/USDT:USDT '{"portfolioMargin":true}'

binance.fetchOrder (259696755816, BTC/USDT:USDT, [object Object])
2024-02-06T22:10:06.402Z iteration 0 passed in 916 ms

{
  info: {
    orderId: '259696755816',
    symbol: 'BTCUSDT',
    status: 'NEW',
    clientOrderId: 'x-xcKtGhcua59242ca4aa34a91af4b29',
    price: '35000',
    avgPrice: '0.00000',
    origQty: '0.010',
    executedQty: '0',
    cumQuote: '0',
    timeInForce: 'GTC',
    type: 'LIMIT',
    reduceOnly: false,
    side: 'BUY',
    origType: 'LIMIT',
    time: '1707257372486',
    updateTime: '1707257372486',
    positionSide: 'BOTH',
    selfTradePreventionMode: 'NONE',
    goodTillDate: '0'
  },
  id: '259696755816',
  clientOrderId: 'x-xcKtGhcua59242ca4aa34a91af4b29',
  timestamp: 1707257372486,
  datetime: '2024-02-06T22:09:32.486Z',
  lastUpdateTimestamp: 1707257372486,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 35000,
  amount: 0.01,
  cost: 0,
  filled: 0,
  remaining: 0.01,
  status: 'open',
  trades: [],
  fees: []
}
```
```
binance fetchOrder 71371262156 ETH/USD:ETH '{"portfolioMargin":true}'

binance.fetchOrder (71371262156, ETH/USD:ETH, [object Object])
2024-02-06T22:14:29.397Z iteration 0 passed in 1214 ms

{
  info: {
    orderId: '71371262156',
    symbol: 'ETHUSD_PERP',
    pair: 'ETHUSD',
    status: 'NEW',
    clientOrderId: 'x-xcKtGhcu452bf21af92e474892ab37',
    price: '2000',
    avgPrice: '0.00',
    origQty: '1',
    executedQty: '0',
    cumBase: '0',
    timeInForce: 'GTC',
    type: 'LIMIT',
    reduceOnly: false,
    side: 'BUY',
    origType: 'LIMIT',
    time: '1707257639789',
    updateTime: '1707257639789',
    positionSide: 'BOTH'
  },
  id: '71371262156',
  clientOrderId: 'x-xcKtGhcu452bf21af92e474892ab37',
  timestamp: 1707257639789,
  datetime: '2024-02-06T22:13:59.789Z',
  lastUpdateTimestamp: 1707257639789,
  symbol: 'ETH/USD:ETH',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 2000,
  amount: 1,
  cost: 0,
  filled: 0,
  remaining: 1,
  status: 'open',
  trades: [],
  fees: []
}
```
```
binance fetchOrder 24711539682 BTC/USDT '{"portfolioMargin":true,"marginMode":"cross"}'

binance.fetchOrder (24711539682, BTC/USDT, [object Object])
2024-02-06T22:18:38.799Z iteration 0 passed in 854 ms

{
  info: {
    symbol: 'BTCUSDT',
    orderId: '24711539682',
    clientOrderId: 'x-R4BD3S824fcc76c9173d4bcc8c15df',
    price: '35000.00000000',
    origQty: '0.00100000',
    executedQty: '0.00000000',
    cummulativeQuoteQty: '0.00000000',
    status: 'NEW',
    timeInForce: 'GTC',
    type: 'LIMIT',
    side: 'BUY',
    stopPrice: '0.00000000',
    icebergQty: '0.00000000',
    time: '1707257882364',
    updateTime: '1707257882364',
    isWorking: true,
    accountId: '200180970',
    selfTradePreventionMode: 'EXPIRE_MAKER',
    preventedMatchId: null,
    preventedQuantity: null
  },
  id: '24711539682',
  clientOrderId: 'x-R4BD3S824fcc76c9173d4bcc8c15df',
  timestamp: 1707257882364,
  datetime: '2024-02-06T22:18:02.364Z',
  lastUpdateTimestamp: 1707257882364,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 35000,
  amount: 0.001,
  cost: 0,
  filled: 0,
  remaining: 0.001,
  status: 'open',
  trades: [],
  fees: []
}
```