### PR TITLE
binance: setPositionMode, portfolio margin support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -9171,9 +9171,12 @@ export default class binance extends Exchange {
          * @description set hedged to true or false for a market
          * @see https://binance-docs.github.io/apidocs/futures/en/#change-position-mode-trade
          * @see https://binance-docs.github.io/apidocs/delivery/en/#change-position-mode-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#change-um-position-mode-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#change-cm-position-mode-trade
          * @param {bool} hedged set to true to use dualSidePosition
          * @param {string} symbol not used by binance setPositionMode ()
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to set the position mode for a portfolio margin account
          * @returns {object} response from the exchange
          */
         const defaultType = this.safeString (this.options, 'defaultType', 'future');
@@ -9181,6 +9184,8 @@ export default class binance extends Exchange {
         params = this.omit (params, [ 'type' ]);
         let subType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('setPositionMode', undefined, params);
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'setPositionMode', 'papi', 'portfolioMargin', false);
         let dualSidePosition = undefined;
         if (hedged) {
             dualSidePosition = 'true';
@@ -9192,10 +9197,17 @@ export default class binance extends Exchange {
         };
         let response = undefined;
         if (this.isInverse (type, subType)) {
-            response = await this.dapiPrivatePostPositionSideDual (this.extend (request, params));
+            if (isPortfolioMargin) {
+                response = await this.papiPostCmPositionSideDual (this.extend (request, params));
+            } else {
+                response = await this.dapiPrivatePostPositionSideDual (this.extend (request, params));
+            }
         } else {
-            // default to future
-            response = await this.fapiPrivatePostPositionSideDual (this.extend (request, params));
+            if (isPortfolioMargin) {
+                response = await this.papiPostUmPositionSideDual (this.extend (request, params));
+            } else {
+                response = await this.fapiPrivatePostPositionSideDual (this.extend (request, params));
+            }
         }
         //
         //     {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1785,6 +1785,34 @@
                     }
                 ],
                 "output": "timestamp=1699441011001&dualSidePosition=true&recvWindow=10000&signature=f932a4e8dd21ce1dcea84d8ab2fd9451c31b77c710d1adb9c51f54adc520cd90"
+            },
+            {
+                "description": "Swap linear portfolio margin set position mode",
+                "method": "setPositionMode",
+                "url": "https://papi.binance.com/papi/v1/um/positionSide/dual",
+                "input": [
+                  true,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "subType": "linear"
+                  }
+                ],
+                "output": "timestamp=1707282494111&dualSidePosition=true&recvWindow=10000&signature=5895dd7f3c7bf056635cc297f9d6c92a4aa907e61d8f6e900b99d4b25407eab5"
+            },
+            {
+                "description": "Swap inverse portfolio margin set position mode",
+                "method": "setPositionMode",
+                "url": "https://papi.binance.com/papi/v1/cm/positionSide/dual",
+                "input": [
+                  true,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "subType": "inverse"
+                  }
+                ],
+                "output": "timestamp=1707282567514&dualSidePosition=true&recvWindow=10000&signature=12b2fe3fb47a0ae0ef4ec810b754aba2223e7e20e1145c89ef7aa5c1dc6a4485"
             }
         ],
         "fetchBidsAsks": [


### PR DESCRIPTION
Added portfolio margin support to setPositionMode:

```
binance setPositionMode true undefined '{"portfolioMargin":true,"subType":"linear"}'

binance.setPositionMode (true, , [object Object])
2024-02-07T05:08:14.934Z iteration 0 passed in 873 ms

{ code: '200', msg: 'success' }
```
```
binance setPositionMode true undefined '{"portfolioMargin":true,"subType":"inverse"}'

binance.setPositionMode (true, , [object Object])
2024-02-07T05:09:28.505Z iteration 0 passed in 1041 ms

{ code: '200', msg: 'success' }
```