### PR TITLE
binance: setLeverage, portfolio margin support

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1291,28 +1291,6 @@
                     "BTC/USD:BTC"
                 ],
                 "output": "timestamp=1699441011001&symbol=BTCUSD_PERP&leverage=5&recvWindow=10000&signature=f932a4e8dd21ce1dcea84d8ab2fd9451c31b77c710d1adb9c51f54adc520cd90"
-            }
-        ],
-        "setMarginMode": [
-            {
-                "description": "Set margin mode to cross",
-                "method": "setMarginMode",
-                "url": "https://testnet.binancefuture.com/fapi/v1/marginType",
-                "input": [
-                    "CROSS",
-                    "BTC/USDT:USDT"
-                ],
-                "output": "timestamp=1699441787982&symbol=BTCUSDT&marginType=CROSSED&recvWindow=10000&signature=16f612e91d2ff4494239137194470ea53d7a20eff2d1b02c0783327bd40da955"
-            },
-            {
-                "description": "Set margin mode to isolated with inverse market",
-                "method": "setMarginMode",
-                "url": "https://dapi.binance.com/dapi/v1/marginType",
-                "input": [
-                    "isolated",
-                    "BTC/USD:BTC"
-                ],
-                "output": "timestamp=1699441887107&symbol=BTCUSD_PERP&marginType=ISOLATED&recvWindow=10000&signature=23faa49ca6c2c26c2ed637bda09e850587c8cf9dd884d495b44bddf6744dff09"
             },
             {
                 "description": "Linear swap portfolio margin set leverage",
@@ -1339,6 +1317,28 @@
                   }
                 ],
                 "output": "timestamp=1707285921923&symbol=ETHUSD_PERP&leverage=100&recvWindow=10000&signature=383f5a990cdfbe2c6f26212483b7967ab613039e11e6ea3be4ef3ab2cf5640c9"
+            }
+        ],
+        "setMarginMode": [
+            {
+                "description": "Set margin mode to cross",
+                "method": "setMarginMode",
+                "url": "https://testnet.binancefuture.com/fapi/v1/marginType",
+                "input": [
+                    "CROSS",
+                    "BTC/USDT:USDT"
+                ],
+                "output": "timestamp=1699441787982&symbol=BTCUSDT&marginType=CROSSED&recvWindow=10000&signature=16f612e91d2ff4494239137194470ea53d7a20eff2d1b02c0783327bd40da955"
+            },
+            {
+                "description": "Set margin mode to isolated with inverse market",
+                "method": "setMarginMode",
+                "url": "https://dapi.binance.com/dapi/v1/marginType",
+                "input": [
+                    "isolated",
+                    "BTC/USD:BTC"
+                ],
+                "output": "timestamp=1699441887107&symbol=BTCUSD_PERP&marginType=ISOLATED&recvWindow=10000&signature=23faa49ca6c2c26c2ed637bda09e850587c8cf9dd884d495b44bddf6744dff09"
             }
         ],
         "fetchCrossBorrowRate": [

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1250,6 +1250,32 @@
                     "BTC/USD:BTC"
                 ],
                 "output": "timestamp=1699441887107&symbol=BTCUSD_PERP&marginType=ISOLATED&recvWindow=10000&signature=23faa49ca6c2c26c2ed637bda09e850587c8cf9dd884d495b44bddf6744dff09"
+            },
+            {
+                "description": "Linear swap portfolio margin set leverage",
+                "method": "setLeverage",
+                "url": "https://papi.binance.com/papi/v1/um/leverage",
+                "input": [
+                  100,
+                  "BTC/USDT:USDT",
+                  {
+                    "portfolioMargin": true
+                  }
+                ],
+                "output": "timestamp=1707286038777&symbol=BTCUSDT&leverage=100&recvWindow=10000&signature=7dc3dd7f2a447bec4ef5ef2eed9629e8228b238e90a380df9a10e0bf21e9b42f"
+            },
+            {
+                "description": "Inverse swap portfolio margin set leverage",
+                "method": "setLeverage",
+                "url": "https://papi.binance.com/papi/v1/cm/leverage",
+                "input": [
+                  100,
+                  "ETH/USD:ETH",
+                  {
+                    "portfolioMargin": true
+                  }
+                ],
+                "output": "timestamp=1707285921923&symbol=ETHUSD_PERP&leverage=100&recvWindow=10000&signature=383f5a990cdfbe2c6f26212483b7967ab613039e11e6ea3be4ef3ab2cf5640c9"
             }
         ],
         "fetchCrossBorrowRate": [


### PR DESCRIPTION
Added portfolio margin support to setLeverage:

```
binance setLeverage 100 ETH/USD:ETH '{"portfolioMargin":true}'

binance.setLeverage (100, ETH/USD:ETH, [object Object])
2024-02-07T06:05:22.793Z iteration 0 passed in 921 ms

{ leverage: '100', maxQty: '15', symbol: 'ETHUSD_PERP' }
```
```
binance setLeverage 100 BTC/USDT:USDT '{"portfolioMargin":true}'

binance.setLeverage (100, BTC/USDT:USDT, [object Object])
2024-02-07T06:07:19.754Z iteration 0 passed in 978 ms

{ leverage: '100', maxNotionalValue: '500000', symbol: 'BTCUSDT' }
```