### PR TITLE
coinbase: add preview in createOrder

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -219,6 +219,7 @@ export default class coinbase extends Exchange {
                             'brokerage/orders/batch_cancel',
                             'brokerage/orders/edit',
                             'brokerage/orders/edit_preview',
+                            'brokerage/orders/preview',
                             'brokerage/portfolios',
                             'brokerage/portfolios/move_funds',
                             'brokerage/convert/quote',

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -2243,11 +2243,12 @@ export default class coinbase extends Exchange {
          * @param {string} [params.stop_direction] 'UNKNOWN_STOP_DIRECTION', 'STOP_DIRECTION_STOP_UP', 'STOP_DIRECTION_STOP_DOWN' the direction the stopPrice is triggered from
          * @param {string} [params.end_time] '2023-05-25T17:01:05.092Z' for 'GTD' orders
          * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
+         * @param {boolean} [params.preview] default to false, wether to use the test/preview endpoint or not
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const request = {
+        let request = {
             'client_order_id': this.uuid (),
             'product_id': market['id'],
             'side': side.toUpperCase (),
@@ -2372,7 +2373,15 @@ export default class coinbase extends Exchange {
             }
         }
         params = this.omit (params, [ 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'stopPrice', 'stop_price', 'stopDirection', 'stop_direction', 'clientOrderId', 'postOnly', 'post_only', 'end_time' ]);
-        const response = await this.v3PrivatePostBrokerageOrders (this.extend (request, params));
+        const preview = this.safeValue2 (params, 'preview', 'test', false);
+        let response = undefined;
+        if (preview) {
+            params = this.omit (params, [ 'preview', 'test' ]);
+            request = this.omit (request, 'client_order_id');
+            response = await this.v3PrivatePostBrokerageOrdersPreview (this.extend (request, params));
+        } else {
+            response = await this.v3PrivatePostBrokerageOrders (this.extend (request, params));
+        }
         //
         // successful order
         //

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -114,6 +114,22 @@
                   }
                 ],
                 "output": "{\"client_order_id\":\"c6449e15-78c0-4ff8-a603-2047c131faa3\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+            },
+            {
+                "description": "create preview/test order",
+                "method": "createOrder",
+                "url": "https://api.coinbase.com/api/v3/brokerage/orders/preview",
+                "input": [
+                  "DOGE/USDT",
+                  "limit",
+                  "buy",
+                  10,
+                  0.05,
+                  {
+                    "preview": true
+                  }
+                ],
+                "output": "{\"product_id\":\"DOGE-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_gtc\":{\"base_size\":\"10\",\"limit_price\":\"0.05\",\"post_only\":false}}}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
```BASH
$ p coinbase createOrder DOGE/USDT limit buy 10 0.05 '{"preview": true}'
Python v3.11.3
CCXT v4.2.38
coinbase.createOrder(DOGE/USDT,limit,buy,10,0.05,{'preview': True})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': None,
 'info': {},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'DOGE/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```