### PR TITLE
feat(krakenfutures): add fetchClosedOrders and fetchCanceledOrders

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1622,7 +1622,8 @@ export default class krakenfutures extends Exchange {
         let remaining = this.safeString (details, 'unfilledSize');
         let average = undefined;
         let filled2 = '0.0';
-        if (trades.length) {
+        const tradesLength = trades.length;
+        if (tradesLength > 0) {
             let vwapSum = '0.0';
             for (let i = 0; i < trades.length; i++) {
                 const trade = trades[i];

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1215,7 +1215,7 @@ export default class krakenfutures extends Exchange {
         if (since !== undefined) {
             request['from'] = since;
         }
-        const response = await this.historyGetOrders (params);
+        const response = await this.historyGetOrders (this.extend (request, params));
         const allOrders = this.safeList (response, 'elements', []);
         const closedOrders = [];
         for (let i = 0; i < allOrders.length; i++) {
@@ -1258,7 +1258,7 @@ export default class krakenfutures extends Exchange {
         if (since !== undefined) {
             request['from'] = since;
         }
-        const response = await this.historyGetOrders (params);
+        const response = await this.historyGetOrders (this.extend (request, params));
         const allOrders = this.safeList (response, 'elements', []);
         const canceledAndRejected = [];
         for (let i = 0; i < allOrders.length; i++) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -147,7 +147,6 @@ export default class krakenfutures extends Exchange {
                         'accountlogcsv',
                         'market/{symbol}/orders',
                         'market/{symbol}/executions',
-                        'orders',
                     ],
                 },
             },

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -41,6 +41,7 @@ export default class krakenfutures extends Exchange {
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
                 'fetchClosedOrders': true, // https://support.kraken.com/hc/en-us/articles/360058243651-Historical-orders
+                'fetchCanceledOrders': true,
                 'fetchCrossBorrowRate': false,
                 'fetchCrossBorrowRates': false,
                 'fetchDepositAddress': false,

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -6,7 +6,7 @@ import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable
 import { Precise } from './base/Precise.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
-import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Trade, FundingRateHistory, OrderRequest, Order, Balances, Str, Ticker, OrderBook, Tickers, Strings, Market, Currency, Dict } from './base/types.js';
+import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Trade, FundingRateHistory, OrderRequest, Order, Balances, Str, Ticker, OrderBook, Tickers, Strings, Market, Currency } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -40,8 +40,8 @@ export default class krakenfutures extends Exchange {
                 'fetchBalance': true,
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
-                'fetchClosedOrders': true, // https://support.kraken.com/hc/en-us/articles/360058243651-Historical-orders
                 'fetchCanceledOrders': true,
+                'fetchClosedOrders': true, // https://support.kraken.com/hc/en-us/articles/360058243651-Historical-orders
                 'fetchCrossBorrowRate': false,
                 'fetchCrossBorrowRates': false,
                 'fetchDepositAddress': false,
@@ -1217,7 +1217,7 @@ export default class krakenfutures extends Exchange {
         }
         const response = await this.historyGetOrders (params);
         const allOrders = this.safeList (response, 'elements', []);
-        const closedOrders: Dict[] = [];
+        const closedOrders: any[] = [];
         for (let i = 0; i < allOrders.length; i++) {
             const order = allOrders[i];
             const event = this.safeDict (order, 'event', {});
@@ -1260,7 +1260,7 @@ export default class krakenfutures extends Exchange {
         }
         const response = await this.historyGetOrders (params);
         const allOrders = this.safeList (response, 'elements', []);
-        const canceledAndRejected: Dict[] = [];
+        const canceledAndRejected: any[] = [];
         for (let i = 0; i < allOrders.length; i++) {
             const order = allOrders[i];
             const event = this.safeDict (order, 'event', {});

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1217,7 +1217,7 @@ export default class krakenfutures extends Exchange {
         }
         const response = await this.historyGetOrders (params);
         const allOrders = this.safeList (response, 'elements', []);
-        const closedOrders: any[] = [];
+        const closedOrders = [];
         for (let i = 0; i < allOrders.length; i++) {
             const order = allOrders[i];
             const event = this.safeDict (order, 'event', {});
@@ -1260,7 +1260,7 @@ export default class krakenfutures extends Exchange {
         }
         const response = await this.historyGetOrders (params);
         const allOrders = this.safeList (response, 'elements', []);
-        const canceledAndRejected: any[] = [];
+        const canceledAndRejected = [];
         for (let i = 0; i < allOrders.length; i++) {
             const order = allOrders[i];
             const event = this.safeDict (order, 'event', {});

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -71,6 +71,20 @@
                     "takeProfitPrice": 49000
                   }
                 ]
+            },
+            {
+                "method": "order with clientOrderId",
+                "url": "https://futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_LTCUSD&side=buy&size=0.1&cliOrdId=myid1&orderType=lmt&limitPrice=50",
+                "input": [
+                  "LTC/USD:USD",
+                  "limit",
+                  "buy",
+                  0.1,
+                  50,
+                  {
+                    "clientOrderId": "myid1"
+                  }
+                ]
             }
         ],
         "transfer": [
@@ -95,6 +109,71 @@
                     "main",
                     "funding"
                 ]
+            }
+        ],
+        "cancelOrder": [
+            {
+                "description": "cancel order",
+                "method": "cancelOrder",
+                "url": "https://futures.kraken.com/derivatives/api/v3/cancelorder?order_id=6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+                "input": [
+                  "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+                  "LTC/USD:USD"
+                ]
+            }
+        ],
+        "fetchMyTrades": [
+            {
+                "description": "fetch my trades",
+                "method": "fetchMyTrades",
+                "url": "https://futures.kraken.com/derivatives/api/v3/fills",
+                "input": [
+                  "LTC/USD:USD",
+                  null,
+                  1
+                ]
+            }
+        ],
+        "fetchOpenOrders": [
+            {
+                "description": "fetch open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://futures.kraken.com/derivatives/api/v3/openorders",
+                "input": []
+            }
+        ],
+        "fetchClosedOrders": [
+            {
+                "description": "fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://futures.kraken.com/api/history/v2/orders?count=1",
+                "input": [
+                  "LTC/USD:USD",
+                  null,
+                  1
+                ]
+            }
+        ],
+        "fetchBalance": [
+            {
+                "description": "fetch balance",
+                "method": "fetchBalance",
+                "url": "https://futures.kraken.com/derivatives/api/v3/accounts",
+                "input": []
+            }
+        ],
+        "cancelOrders": [
+            {
+                "description": "cancel orders",
+                "method": "cancelOrders",
+                "url": "https://futures.kraken.com/derivatives/api/v3/batchorder",
+                "input": [
+                  [
+                    "3d080c9b-6a50-45c1-8365-11c00295f011"
+                  ],
+                  "LTC/USD:USD"
+                ],
+                "output": "json={\"batchOrder\":[{\"order\":\"cancel\",\"order_id\":\"3d080c9b-6a50-45c1-8365-11c00295f011\"}]}"
             }
         ]
     }

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -92,6 +92,253 @@
           }
         ]
       }
+    ],
+    "fetchClosedOrders": [
+      {
+        "description": "fetch closed orders",
+        "method": "fetchClosedOrders",
+        "input": [
+          "LTC/USD:USD",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "elements": [
+            {
+              "uid": "43067af0-41e2-4c9b-b35e-fe238d6fba72",
+              "timestamp": "1707331402406",
+              "event": {
+                "OrderPlaced": {
+                  "order": {
+                    "uid": "7e10f528-17e3-4b15-a9f2-1a327d509cd6",
+                    "accountUid": "406142dd-7c5c-4a8b-acbc-5f16eca30009",
+                    "tradeable": "PF_LTCUSD",
+                    "direction": "Buy",
+                    "quantity": "0",
+                    "filled": "0.1",
+                    "timestamp": "1707331402406",
+                    "limitPrice": "68.9600",
+                    "orderType": "IoC",
+                    "clientId": "",
+                    "reduceOnly": false,
+                    "lastUpdateTimestamp": "1707331402406",
+                    "status": "closed"
+                  },
+                  "reason": "new_user_order",
+                  "reducedQuantity": "",
+                  "algoId": ""
+                }
+              }
+            }
+          ],
+          "accountUid": "406142dd-7c5c-4a8b-acbc-5f16eca30009",
+          "len": "1",
+          "continuationToken": "MTcwNzMzMDk5NTA5Mi8xMzQ0NTIxMDM0MzA="
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "uid": "7e10f528-17e3-4b15-a9f2-1a327d509cd6",
+              "accountUid": "406142dd-7c5c-4a8b-acbc-5f16eca30009",
+              "tradeable": "PF_LTCUSD",
+              "direction": "Buy",
+              "quantity": "0",
+              "filled": "0.1",
+              "timestamp": "1707331402406",
+              "limitPrice": "68.9600",
+              "orderType": "IoC",
+              "clientId": "",
+              "reduceOnly": false,
+              "lastUpdateTimestamp": "1707331402406",
+              "status": "closed"
+            },
+            "id": "7e10f528-17e3-4b15-a9f2-1a327d509cd6",
+            "clientOrderId": null,
+            "timestamp": null,
+            "datetime": null,
+            "lastTradeTimestamp": null,
+            "lastUpdateTimestamp": null,
+            "symbol": "LTC/USD:USD",
+            "type": "market",
+            "timeInForce": "ioc",
+            "postOnly": false,
+            "reduceOnly": false,
+            "side": null,
+            "price": 68.96,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "amount": 0.1,
+            "cost": 6.896,
+            "average": 68.96,
+            "filled": 0.1,
+            "remaining": 0,
+            "status": "closed",
+            "fee": null,
+            "fees": [],
+            "trades": [],
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      }
+    ],
+    "fetchOpenOrders": [
+      {
+        "description": "fetch open orders",
+        "method": "fetchOpenOrders",
+        "input": [],
+        "httpResponse": {
+          "result": "success",
+          "openOrders": [
+            {
+              "order_id": "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+              "symbol": "PF_LTCUSD",
+              "side": "buy",
+              "orderType": "lmt",
+              "limitPrice": "50",
+              "unfilledSize": "0.1",
+              "receivedTime": "2024-02-08T12:44:12.892Z",
+              "status": "untouched",
+              "filledSize": "0",
+              "reduceOnly": false,
+              "lastUpdateTime": "2024-02-08T12:44:12.892Z"
+            }
+          ],
+          "serverTime": "2024-02-08T12:44:24.316Z"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "order_id": "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+              "symbol": "PF_LTCUSD",
+              "side": "buy",
+              "orderType": "lmt",
+              "limitPrice": "50",
+              "unfilledSize": "0.1",
+              "receivedTime": "2024-02-08T12:44:12.892Z",
+              "status": "untouched",
+              "filledSize": "0",
+              "reduceOnly": false,
+              "lastUpdateTime": "2024-02-08T12:44:12.892Z"
+            },
+            "id": "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+            "clientOrderId": null,
+            "timestamp": 1707396252892,
+            "datetime": "2024-02-08T12:44:12.892Z",
+            "lastTradeTimestamp": null,
+            "lastUpdateTimestamp": 1707396252892,
+            "symbol": "LTC/USD:USD",
+            "type": "limit",
+            "timeInForce": "gtc",
+            "postOnly": false,
+            "reduceOnly": false,
+            "side": "buy",
+            "price": 50,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "amount": 0.1,
+            "cost": 0,
+            "average": null,
+            "filled": 0,
+            "remaining": 0.1,
+            "status": "open",
+            "fee": null,
+            "fees": [],
+            "trades": [],
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      }
+    ],
+    "fetchCanceledOrders": [
+      {
+        "description": "fetch canceled orders",
+        "method": "fetchCanceledOrders",
+        "input": [
+          "LTC/USD:USD",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "elements": [
+            {
+              "uid": "e48699ed-d629-4898-9be8-0075fcc4bf25",
+              "timestamp": "1707396252892",
+              "event": {
+                "OrderPlaced": {
+                  "order": {
+                    "uid": "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+                    "accountUid": "406142dd-7c5c-4a8b-acbc-5f16eca30009",
+                    "tradeable": "PF_LTCUSD",
+                    "direction": "Buy",
+                    "quantity": "0.1",
+                    "filled": "0",
+                    "timestamp": "1707396252892",
+                    "limitPrice": "50",
+                    "orderType": "Limit",
+                    "clientId": "",
+                    "reduceOnly": false,
+                    "lastUpdateTimestamp": "1707396252892",
+                    "status": "canceled"
+                  },
+                  "reason": "new_user_order",
+                  "reducedQuantity": "",
+                  "algoId": ""
+                }
+              }
+            }
+          ],
+          "accountUid": "406142dd-7c5c-4a8b-acbc-5f16eca30009",
+          "len": "1",
+          "continuationToken": "MTcwNzMzMTQwMjQwNi8xMzQ0NTI5MjU4Mzg="
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "uid": "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+              "accountUid": "406142dd-7c5c-4a8b-acbc-5f16eca30009",
+              "tradeable": "PF_LTCUSD",
+              "direction": "Buy",
+              "quantity": "0.1",
+              "filled": "0",
+              "timestamp": "1707396252892",
+              "limitPrice": "50",
+              "orderType": "Limit",
+              "clientId": "",
+              "reduceOnly": false,
+              "lastUpdateTimestamp": "1707396252892",
+              "status": "canceled"
+            },
+            "id": "6e88d923-630d-40aa-af4f-64e5e2b3ad03",
+            "clientOrderId": null,
+            "timestamp": null,
+            "datetime": null,
+            "lastTradeTimestamp": null,
+            "lastUpdateTimestamp": null,
+            "symbol": "LTC/USD:USD",
+            "type": "limit",
+            "timeInForce": "gtc",
+            "postOnly": false,
+            "reduceOnly": false,
+            "side": null,
+            "price": 50,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "amount": 0.1,
+            "cost": 0,
+            "average": null,
+            "filled": 0,
+            "remaining": 0.1,
+            "status": "canceled",
+            "fee": null,
+            "fees": [],
+            "trades": [],
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
- [x]  missing static tests
- [x] check issue with symbol returned being different