### PR TITLE
binance: fetchPositonsRisk, add portfolio margin support

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1810,6 +1810,34 @@
                         "subType": "inverse"
                     }
                 ]
+            },
+            {
+                "description": "Inverse portfolio margin fetch positions risk",
+                "method": "fetchPositionsRisk",
+                "url": "https://papi.binance.com/papi/v1/cm/positionRisk?timestamp=1707443702916&recvWindow=10000&signature=88c195bc372626397818eb714cae53388fdfb9baa32f997d0611075dde07bd4f",
+                "input": [
+                  [
+                    "ETH/USD:ETH"
+                  ],
+                  {
+                    "portfolioMargin": true,
+                    "subType": "inverse"
+                  }
+                ]
+            },
+            {
+                "description": "Linear portfolio margin fetch positions risk",
+                "method": "fetchPositionsRisk",
+                "url": "https://papi.binance.com/papi/v1/um/positionRisk?timestamp=1707444182528&recvWindow=10000&signature=c51d48deff54a226859b6fe4ce62a5982c1b3eec82255d211c6e67d6b3bd4f0f",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ],
+                  {
+                    "portfolioMargin": true,
+                    "subType": "linear"
+                  }
+                ]
             }
         ],
         "fetchAccountPositions": [


### PR DESCRIPTION
Added portfolio margin support to fetchPositionsRisk:

```
binance fetchPositionsRisk '["ETH/USD:ETH"]' '{"portfolioMargin":true,"subType":"inverse"}'

binance.fetchPositionsRisk (ETH/USD:ETH, [object Object])
2024-02-09T01:55:03.113Z iteration 0 passed in 1189 ms

     symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral |   notional | markPrice |     entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage |                 datetime | side | hedged
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USD:ETH |         1 |           10 |    0.00000438 |      100 |     289.96236795 |          0 | 0.00412376 |   2424.97 | 2422.400000007 | 1707371941861 |    0.00004123 |                    0.01 |      0.0000206188 |                       0.005 | 2024-02-08T05:59:01.861Z | long |   true
1 objects
```
```
binance fetchPositionsRisk '["BTC/USDT:USDT"]' '{"portfolioMargin":true,"subType":"linear"}'

binance.fetchPositionsRisk (BTC/USDT:USDT, [object Object])
2024-02-09T02:03:02.741Z iteration 0 passed in 1186 ms

       symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral | notional | markPrice | entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage |                 datetime | side | hedged
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT |      0.01 |            1 |         9.199 |      100 |   38007.34331755 |          0 |  454.449 |   45444.9 |      44525 | 1707371879042 |       4.54449 |                    0.01 |          1.817796 |                       0.004 | 2024-02-08T05:57:59.042Z | long |   true
1 objects
```