### PR TITLE
exchange.handleNetworkParameter

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5987,7 +5987,7 @@ export default class Exchange {
         const defaultNetworks = this.safeDict (this.options, 'defaultNetworks');
         const defaultNetwork = this.safeString (defaultNetworks, code);
         const network = this.safeStringN (params, [ 'network', 'defaultNetwork', 'networkCode' ], defaultNetwork);
-        params = this.omit (params, 'network');
+        params = this.omit (params, [ 'network', 'defaultNetwork', 'networkCode' ]);
         return [ network, params ];
     }
 }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5982,6 +5982,14 @@ export default class Exchange {
     parseGreeks (greeks, market: Market = undefined): Greeks {
         throw new NotSupported (this.id + ' parseGreeks () is not supported yet');
     }
+
+    handleNetworkParameter (code: string, params = {}) {
+        const defaultNetworks = this.safeDict (this.options, 'defaultNetworks');
+        const defaultNetwork = this.safeString (defaultNetworks, code);
+        const network = this.safeString2 (params, 'network', 'defaultNetwork', defaultNetwork);
+        params = this.omit (params, 'network');
+        return [ network, params ];
+    }
 }
 
 export {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5986,7 +5986,7 @@ export default class Exchange {
     handleNetworkParameter (code: string, params = {}) {
         const defaultNetworks = this.safeDict (this.options, 'defaultNetworks');
         const defaultNetwork = this.safeString (defaultNetworks, code);
-        const network = this.safeString2 (params, 'network', 'defaultNetwork', defaultNetwork);
+        const network = this.safeStringN (params, [ 'network', 'defaultNetwork', 'networkCode' ], defaultNetwork);
         params = this.omit (params, 'network');
         return [ network, params ];
     }


### PR DESCRIPTION
I know that there's already `handleNetworkCodeAndParams`, but it doesn't handle default networks, so I think this is a better solution. I would have updated `handleNetworkCodeAndParams` instead of writing a new method, but this method requires a `code` argument, so that would interfere with the exchanges that are calling `handleNetworkCodeAndParams` already

## TS

2024-02-09T03:04:25.653Z
Node.js: v18.12.0
CCXT v4.2.39

```
% mexc handleNetworkParameter USDT                        
mexc.handleNetworkParameter (USDT)
2024-02-09T03:04:29.117Z iteration 0 passed in 1 ms

[ 'TRC20', {} ]
2 objects
2024-02-09T03:04:29.117Z iteration 1 passed in 1 ms
```
```
% mexc handleNetworkParameter USDT '{"network": "ERC20"}'
mexc.handleNetworkParameter (USDT, [object Object])
2024-02-09T03:04:55.390Z iteration 0 passed in 0 ms

[ 'ERC20', {} ]
2 objects
2024-02-09T03:04:55.390Z iteration 1 passed in 0 ms
```
```
% mexc handleNetworkParameter LTC                        
mexc.handleNetworkParameter (LTC)
2024-02-09T03:05:09.938Z iteration 0 passed in 0 ms

[ undefined, {} ]
2 objects
2024-02-09T03:05:09.938Z iteration 1 passed in 0 ms
```

## Python

Python v3.9.6
CCXT v4.2.39

```
% py mexc handleNetworkParameter USDT   
mexc.handleNetworkParameter(USDT)
['TRC20', {}]
```
```
% py mexc handleNetworkParameter USDT '{"network": "ERC20"}'
mexc.handleNetworkParameter(USDT,{'network': 'ERC20'})
['ERC20', {}]
```
```
% py mexc handleNetworkParameter LTC                        
mexc.handleNetworkParameter(LTC)
[None, {}]
```