### PR TITLE
feat(bybit): fetchOHLCV - add params["until"]

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2215,6 +2215,7 @@ export default class bybit extends Exchange {
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
          * @param {int} [limit] the maximum amount of candles to fetch
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {int} [params.until] the latest time in ms to fetch orders for
          * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
@@ -2228,7 +2229,7 @@ export default class bybit extends Exchange {
             return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, 1000) as OHLCV[];
         }
         const market = this.market (symbol);
-        const request = {
+        let request = {
             'symbol': market['id'],
         };
         if (limit === undefined) {
@@ -2240,6 +2241,7 @@ export default class bybit extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // max 1000, default 1000
         }
+        [ request, params ] = this.handleUntilOption ('end', request, params);
         request['interval'] = this.safeString (this.timeframes, timeframe, timeframe);
         let response = undefined;
         if (market['spot']) {

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -726,6 +726,41 @@
                   ]
                 ]
             }
+        ],
+        "fetchOHLCV": [
+            {
+                "description": "basic call",
+                "method": "fetchOHLCV",
+                "url": "https://api.bybit.com/v5/market/kline?symbol=BTCUSDT&limit=200&interval=1&category=spot",
+                "input": [
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "limit and interval set",
+                "method": "fetchOHLCV",
+                "url": "https://api.bybit.com/v5/market/kline?symbol=BTCUSDT&limit=5&interval=60&category=spot",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  5
+                ]
+            },
+            {
+                "description": "since and until set",
+                "method": "fetchOHLCV",
+                "url": "https://api.bybit.com/v5/market/kline?symbol=BTCUSDT&start=1704067200000&limit=200&end=1704067800000&interval=1&category=spot",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000,
+                  null,
+                  {
+                    "until": 1704067800000
+                  }
+                ]
+              }
         ]
     },
     "disabled": []


### PR DESCRIPTION
```
% bybit fetchOHLCV BTC/USDT 1m 1704067200000 undefined '{"until": 1704067800000}' --testnet
2024-02-09T03:40:15.294Z
Node.js: v18.12.0
CCXT v4.2.39
bybit.fetchOHLCV (BTC/USDT, 1m, 1704067200000, , [object Object])
2024-02-09T03:40:20.773Z iteration 0 passed in 1024 ms

1704067200000 | 28560.44 | 28567.45 | 28560.37 | 28567.45 | 0.311803
1704067260000 | 28567.45 | 28574.09 | 28567.41 | 28574.09 | 0.254429
...
1704067740000 | 28652.25 | 28653.41 |    28642 | 28653.41 | 0.153838
1704067800000 | 28653.41 | 28656.56 |    28637 | 28656.53 | 0.182126
11 objects
2024-02-09T03:40:20.773Z iteration 1 passed in 1024 ms
```

```
Python v3.9.6
CCXT v4.2.39
bybit.fetchOHLCV(BTC/USDT,1m,1704067200000,None,{'until': 1704067800000})
[[1704067200000, 28560.44, 28567.45, 28560.37, 28567.45, 0.311803],
 [1704067260000, 28567.45, 28574.09, 28567.41, 28574.09, 0.254429],
...
 [1704067740000, 28652.25, 28653.41, 28642.0, 28653.41, 0.153838],
 [1704067800000, 28653.41, 28656.56, 28637.0, 28656.53, 0.182126]]
 ```