### PR TITLE
binance: fetchFundingHistory, add portfolio margin support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -7160,20 +7160,16 @@ export default class binance extends Exchange {
         //     }
         //
         const marketId = this.safeString (income, 'symbol');
-        const symbol = this.safeSymbol (marketId, market, undefined, 'swap');
-        const amount = this.safeNumber (income, 'income');
         const currencyId = this.safeString (income, 'asset');
-        const code = this.safeCurrencyCode (currencyId);
-        const id = this.safeString (income, 'tranId');
         const timestamp = this.safeInteger (income, 'time');
         return {
             'info': income,
-            'symbol': symbol,
-            'code': code,
+            'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
+            'code': this.safeCurrencyCode (currencyId),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'id': id,
-            'amount': amount,
+            'id': this.safeString (income, 'tranId'),
+            'amount': this.safeNumber (income, 'income'),
         };
     }
 
@@ -9108,15 +9104,19 @@ export default class binance extends Exchange {
          * @description fetch the history of funding payments paid and received on this account
          * @see https://binance-docs.github.io/apidocs/futures/en/#get-income-history-user_data
          * @see https://binance-docs.github.io/apidocs/delivery/en/#get-income-history-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#get-um-income-history-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#get-cm-income-history-user_data
          * @param {string} symbol unified market symbol
          * @param {int} [since] the earliest time in ms to fetch funding history for
          * @param {int} [limit] the maximum number of funding history structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {int} [params.until] timestamp in ms of the latest funding history entry
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to fetch the funding history for a portfolio margin account
          * @returns {object} a [funding history structure]{@link https://docs.ccxt.com/#/?id=funding-history-structure}
          */
         await this.loadMarkets ();
         let market = undefined;
-        const request = {
+        let request = {
             'incomeType': 'FUNDING_FEE', // "TRANSFER"，"WELCOME_BONUS", "REALIZED_PNL"，"FUNDING_FEE", "COMMISSION" and "INSURANCE_CLEAR"
         };
         if (symbol !== undefined) {
@@ -9128,6 +9128,9 @@ export default class binance extends Exchange {
         }
         let subType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchFundingHistory', market, params, 'linear');
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'fetchFundingHistory', 'papi', 'portfolioMargin', false);
+        [ request, params ] = this.handleUntilOption ('endTime', request, params);
         if (since !== undefined) {
             request['startTime'] = since;
         }
@@ -9139,9 +9142,17 @@ export default class binance extends Exchange {
         params = this.omit (params, 'type');
         let response = undefined;
         if (this.isLinear (type, subType)) {
-            response = await this.fapiPrivateGetIncome (this.extend (request, params));
+            if (isPortfolioMargin) {
+                response = await this.papiGetUmIncome (this.extend (request, params));
+            } else {
+                response = await this.fapiPrivateGetIncome (this.extend (request, params));
+            }
         } else if (this.isInverse (type, subType)) {
-            response = await this.dapiPrivateGetIncome (this.extend (request, params));
+            if (isPortfolioMargin) {
+                response = await this.papiGetCmIncome (this.extend (request, params));
+            } else {
+                response = await this.dapiPrivateGetIncome (this.extend (request, params));
+            }
         } else {
             throw new NotSupported (this.id + ' fetchFundingHistory() supports linear and inverse contracts only');
         }

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1744,6 +1744,32 @@
                 "input": [
                     "BTC/USD:BTC"
                 ]
+            },
+            {
+                "description": "Linear swap portfolio margin fetch funding history",
+                "method": "fetchFundingHistory",
+                "url": "https://papi.binance.com/papi/v1/um/income?timestamp=1707450596925&incomeType=FUNDING_FEE&symbol=BTCUSDT&recvWindow=10000&signature=2b76b4aedcc0b567260c087b446b50146f6db538a00d4cb692b0aeb0f939b9d3",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap portfolio margin fetch funding history",
+                "method": "fetchFundingHistory",
+                "url": "https://papi.binance.com/papi/v1/cm/income?timestamp=1707450694387&incomeType=FUNDING_FEE&symbol=ETHUSD_PERP&recvWindow=10000&signature=26f345820e4a993c6a6be8b6acc0b7fdcc98cdf2ed33ddf0c3f78cef382ea4e2",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
             }
         ],
         "fetchTrades": [

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -1220,6 +1220,52 @@
           "nonce": 35263532345
         }
       }
+    ],
+    "fetchFundingHistory": [
+      {
+        "description": "fetch portfolio margin funding history",
+        "method": "fetchFundingHistory",
+        "input": [
+          "BTC/USDT:USDT",
+          null,
+          1,
+          {
+            "portfolioMargin": true
+          }
+        ],
+        "httpResponse": [
+          {
+            "symbol": "BTCUSDT",
+            "incomeType": "FUNDING_FEE",
+            "income": "-0.04618913",
+            "asset": "USDT",
+            "time": "1707465600000",
+            "info": "FUNDING_FEE",
+            "tranId": "8082457372019390060",
+            "tradeId": ""
+          }
+        ],
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "BTCUSDT",
+              "incomeType": "FUNDING_FEE",
+              "income": "-0.04618913",
+              "asset": "USDT",
+              "time": "1707465600000",
+              "info": "FUNDING_FEE",
+              "tranId": "8082457372019390060",
+              "tradeId": ""
+            },
+            "symbol": "BTC/USDT:USDT",
+            "code": "USDT",
+            "timestamp": 1707465600000,
+            "datetime": "2024-02-09T08:00:00.000Z",
+            "id": "8082457372019390060",
+            "amount": -0.04618913
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Added portfolio margin support to fetchFundingHistory:

```
binance fetchFundingHistory BTC/USDT:USDT undefined undefined '{"portfolioMargin":true}'

binance.fetchFundingHistory (BTC/USDT:USDT, , , [object Object])
2024-02-09T03:49:57.783Z iteration 0 passed in 909 ms

       symbol | code |     timestamp |                 datetime |                  id |      amount
---------------------------------------------------------------------------------------------------
BTC/USDT:USDT | USDT | 1707379200000 | 2024-02-08T08:00:00.000Z | 8078833491895382710 | -0.02908058
BTC/USDT:USDT | USDT | 1707408000000 | 2024-02-08T16:00:00.000Z | 8080041451447377960 | -0.01176148
BTC/USDT:USDT | USDT | 1707436800000 | 2024-02-09T00:00:00.000Z | 8081249411628529080 | -0.01430506
3 objects
```
```
binance fetchFundingHistory ETH/USD:ETH undefined undefined '{"portfolioMargin":true}'

binance.fetchFundingHistory (ETH/USD:ETH, , , [object Object])
2024-02-09T03:51:35.218Z iteration 0 passed in 882 ms

     symbol | code |     timestamp |                 datetime |                  id |  amount
---------------------------------------------------------------------------------------------
ETH/USD:ETH |  ETH | 1707379200000 | 2024-02-08T08:00:00.000Z | 8078833502183673940 | -4.1e-7
ETH/USD:ETH |  ETH | 1707408000000 | 2024-02-08T16:00:00.000Z | 8080041445587601090 |   -4e-7
ETH/USD:ETH |  ETH | 1707436800000 | 2024-02-09T00:00:00.000Z | 8081249405307373400 | -4.1e-7
3 objects
```