### PR TITLE
binance: fetchAccountPositions, add portfolio margin support

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1834,6 +1834,30 @@
                         "subType": "inverse"
                     }
                 ]
+            },
+            {
+                "description": "Linear portfolio margin fetch account positions",
+                "method": "fetchAccountPositions",
+                "url": "https://papi.binance.com/papi/v1/um/account?timestamp=1707464139103&recvWindow=10000&signature=2d245f910f1fe4d4a5481bdfe529e9e1815cea7085e6dc4e1d7640e4e9d5bb12",
+                "input": [
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "subType": "linear"
+                  }
+                ]
+            },
+            {
+                "description": "Inverse portfolio margin fetch account positions",
+                "method": "fetchAccountPositions",
+                "url": "https://papi.binance.com/papi/v1/cm/account?timestamp=1707464453893&recvWindow=10000&signature=515b93a4c7fdcbcd02bae0a798484b0e064f871375dad2fff72e7e4c8a2da16c",
+                "input": [
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "subType": "inverse"
+                  }
+                ]
             }
         ],
         "fetchOpenInterest": [


### PR DESCRIPTION
Added portfolio margin support to fetchAccountPositions:

```
binance fetchAccountPositions undefined '{"portfolioMargin":true,"subType":"linear"}'

binance.fetchAccountPositions (, [object Object])
2024-02-09T07:35:39.336Z iteration 0 passed in 1298 ms

       symbol |     timestamp |                 datetime | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice |    notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | liquidationPrice |  collateral | marginMode | side | hedged | percentage
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT | 1707371879042 | 2024-02-08T05:57:59.042Z |    4.63154856 |                    0.01 |        1.85261942 |                       0.004 |      44525 | 463.1548567 |      100 |    17.9048567 |      0.01 |            1 |       0.038 |          41612.5 | 48.69422158 |      cross | long |   true |     386.58
1 objects
```
```
binance fetchAccountPositions undefined '{"portfolioMargin":true,"subType":"inverse"}'

binance.fetchAccountPositions (, [object Object])
2024-02-09T07:40:54.102Z iteration 0 passed in 1108 ms

     symbol |     timestamp |                 datetime | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | entryPrice |  notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | liquidationPrice | collateral | marginMode | side | hedged | percentage
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USD:ETH | 1707371941861 | 2024-02-08T05:59:01.861Z |    0.00004063 |                    0.01 |        0.00002031 |                       0.005 |     2422.4 | 0.0040639 |      100 |    0.00006423 |         1 |           10 |       0.331 |          2436.21 | 0.00006136 |      cross | long |   true |     158.08
1 objects
```