### PR TITLE
binance: fetchMyTrades, add portfolio margin support

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -768,6 +768,45 @@
                     "marginMode": "isolated"
                   }
                 ]
+            },
+            {
+                "description": "Linear swap portfolio margin fetch my trades",
+                "method": "fetchMyTrades",
+                "url": "https://papi.binance.com/papi/v1/um/userTrades?timestamp=1707530080933&symbol=BTCUSDT&recvWindow=10000&signature=60b731019a84caf5034fb81e6ace6c4ccf66f02dc2b75713f1965a659d28c856",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap portfolio margin fetch my trades",
+                "method": "fetchMyTrades",
+                "url": "https://papi.binance.com/papi/v1/cm/userTrades?timestamp=1707530344032&symbol=ETHUSD_PERP&recvWindow=10000&signature=d689f5f2a52c7fef837beb49c2493ccc15de55c0706d9878a6890a972a943fc8",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin portfolio margin fetch my trades",
+                "method": "fetchMyTrades",
+                "url": "https://papi.binance.com/papi/v1/margin/myTrades?timestamp=1707549805183&symbol=ADAUSDT&recvWindow=10000&signature=5592c16d537fb2fd7c109ad2a7d779f28f24cb4a11175b33a1f458df35f611c0",
+                "input": [
+                  "ADA/USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
             }
         ],
         "fetchOrders": [

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -598,6 +598,73 @@
             ]
           }
         ]
+      },
+      {
+        "description": "spot porfolioMargin private trade",
+        "method": "fetchMyTrades",
+        "input": [
+          "LTC/USDT",
+          null,
+          1,
+          {
+            "portfolioMargin": true
+          }
+        ],
+        "httpResponse": [
+          {
+            "symbol": "LTCUSDT",
+            "id": "320530367",
+            "orderId": "3949667670",
+            "price": "69.39000000",
+            "qty": "0.17300000",
+            "quoteQty": "12.00447000",
+            "commission": "0.01200447",
+            "commissionAsset": "USDT",
+            "time": "1706694267729",
+            "isBuyer": false,
+            "isMaker": false,
+            "isBestMatch": true
+          }
+        ],
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "LTCUSDT",
+              "id": "320530367",
+              "orderId": "3949667670",
+              "price": "69.39000000",
+              "qty": "0.17300000",
+              "quoteQty": "12.00447000",
+              "commission": "0.01200447",
+              "commissionAsset": "USDT",
+              "time": "1706694267729",
+              "isBuyer": false,
+              "isMaker": false,
+              "isBestMatch": true
+            },
+            "timestamp": 1706694267729,
+            "datetime": "2024-01-31T09:44:27.729Z",
+            "symbol": "LTC/USDT",
+            "id": "320530367",
+            "order": "3949667670",
+            "type": null,
+            "side": "sell",
+            "takerOrMaker": "taker",
+            "price": 69.39,
+            "amount": 0.173,
+            "cost": 12.00447,
+            "fee": {
+              "cost": 0.01200447,
+              "currency": "USDT"
+            },
+            "fees": [
+              {
+                "cost": 0.01200447,
+                "currency": "USDT"
+              }
+            ]
+          }
+        ]
       }
     ],
     "fetchBalance": [


### PR DESCRIPTION
Added portfolio margin support to fetchMyTrades:

```
binance fetchMyTrades BTC/USDT:USDT undefined undefined '{"portfolioMargin":true}'

binance.fetchMyTrades (BTC/USDT:USDT, , , [object Object])
2024-02-10T07:26:17.045Z iteration 0 passed in 907 ms

    timestamp |                 datetime |        symbol |         id |        order | side | takerOrMaker |   price | amount |   cost |                                  fee |                                   fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1707530039409 | 2024-02-10T01:53:59.409Z | BTC/USDT:USDT | 4575108247 | 261942655610 | sell |        taker | 47263.4 |   0.01 | 472.63 | {"cost":0.1890536,"currency":"USDT"} | [{"cost":0.1890536,"currency":"USDT"}]
1 objects
```
```
binance fetchMyTrades ETH/USD:ETH undefined undefined '{"portfolioMargin":true}'

binance.fetchMyTrades (ETH/USD:ETH, , , [object Object])
2024-02-10T07:26:56.512Z iteration 0 passed in 808 ms

    timestamp |                 datetime |      symbol |        id |       order | side | takerOrMaker |   price | amount |       cost |                                 fee |                                  fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1707530317519 | 2024-02-10T01:58:37.519Z | ETH/USD:ETH | 701907838 | 71548909034 | sell |        taker | 2498.15 |      1 | 0.00400296 | {"cost":0.0000016,"currency":"ETH"} | [{"cost":0.0000016,"currency":"ETH"}]
1 objects
```
```
binance fetchMyTrades ADA/USDT undefined undefined '{"portfolioMargin":true}'

binance.fetchMyTrades (ADA/USDT, , , [object Object])
2024-02-10T07:27:29.861Z iteration 0 passed in 1026 ms

    timestamp |                 datetime |   symbol |        id |      order | side | takerOrMaker |  price | amount |     cost |                                  fee |                                   fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1658325303132 | 2022-07-20T13:55:03.132Z | ADA/USDT | 397339429 | 3503118990 |  buy |        taker | 0.5253 |   47.5 | 24.95175 |     {"cost":0.0475,"currency":"ADA"} |     [{"cost":0.0475,"currency":"ADA"}]
1658325328904 | 2022-07-20T13:55:28.904Z | ADA/USDT | 397339687 | 3503121376 | sell |        taker |  0.526 |   47.4 |  24.9324 | {"cost":0.0249324,"currency":"USDT"} | [{"cost":0.0249324,"currency":"USDT"}]
1707545754658 | 2024-02-10T06:15:54.658Z | ADA/USDT | 470227525 | 4421170808 |  buy |        taker | 0.5389 |     10 |    5.389 |       {"cost":0.01,"currency":"ADA"} |       [{"cost":0.01,"currency":"ADA"}]
1707545780522 | 2024-02-10T06:16:20.522Z | ADA/USDT | 470227543 | 4421170947 | sell |        taker | 0.5388 |     10 |    5.388 |  {"cost":0.005388,"currency":"USDT"} |  [{"cost":0.005388,"currency":"USDT"}]
4 objects
```