### PR TITLE
binance: fetchBorrowInterest, add portfolio margin support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -10459,7 +10459,7 @@ export default class binance extends Exchange {
 
     parseBorrowInterest (info, market: Market = undefined) {
         const symbol = this.safeString (info, 'isolatedSymbol');
-        const timestamp = this.safeNumber (info, 'interestAccuredTime');
+        const timestamp = this.safeInteger (info, 'interestAccuredTime');
         const marginMode = (symbol === undefined) ? 'cross' : 'isolated';
         return {
             'account': (symbol === undefined) ? 'cross' : symbol,

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2226,6 +2226,39 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchBorrowInterest": [
+            {
+                "description": "Cross fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "url": "https://api.binance.com/sapi/v1/margin/interestHistory?timestamp=1707551014113&asset=USDT&recvWindow=10000&signature=dff73a2270259eeac6da202942c96aa6880a346b5c6c3d09280fe766de203fa0",
+                "input": [
+                  "USDT"
+                ]
+            },
+            {
+                "description": "Isolated fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "url": "https://api.binance.com/sapi/v1/margin/interestHistory?timestamp=1707551070428&asset=USDT&isolatedSymbol=BTCUSDT&recvWindow=10000&signature=5cf6a6b08309f58688b75986e55266363093030d30632b4d3840ecdaf906dfc8",    
+                "input": [
+                  "USDT",
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Portfolio margin fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "url": "https://papi.binance.com/papi/v1/margin/marginInterestHistory?timestamp=1707550913636&asset=USDT&recvWindow=10000&signature=67a8ccc93c868c13044e059a799ab7929d10000f40def3a9be7ec87719e22a25",
+                "input": [
+                  "USDT",
+                  null,
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -1266,6 +1266,59 @@
           }
         ]
       }
+    ],
+    "fetchBorrowInterest": [
+      {
+        "description": "borrow interest porftolio margin",
+        "method": "fetchBorrowInterest",
+        "input": [
+          "USDT",
+          null,
+          null,
+          1,
+          {
+            "portfolioMargin": true
+          }
+        ],
+        "httpResponse": {
+          "total": "55",
+          "rows": [
+            {
+              "txId": "1656373250307228092",
+              "interestAccuredTime": "1707562800000",
+              "asset": "USDT",
+              "rawAsset": "USDT",
+              "principal": "0.00011146",
+              "interest": "0.000000010",
+              "interestRate": "0.00089489",
+              "type": "PERIODIC"
+            }
+          ]
+        },
+        "parsedResponse": [
+          {
+            "account": "cross",
+            "symbol": null,
+            "marginMode": "cross",
+            "currency": "USDT",
+            "interest": 1e-8,
+            "interestRate": 0.00089489,
+            "amountBorrowed": 0.00011146,
+            "timestamp": 1707562800000,
+            "datetime": "2024-02-10T11:00:00.000Z",
+            "info": {
+              "txId": "1656373250307228092",
+              "interestAccuredTime": "1707562800000",
+              "asset": "USDT",
+              "rawAsset": "USDT",
+              "principal": "0.00011146",
+              "interest": "0.000000010",
+              "interestRate": "0.00089489",
+              "type": "PERIODIC"
+            }
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Added portfolio margin support to fetchBorrowInterest:

```
binance fetchBorrowInterest USDT undefined undefined undefined '{"portfolioMargin":true}'

binance.fetchBorrowInterest (USDT, , , , [object Object])
2024-02-10T07:41:54.585Z iteration 0 passed in 1000 ms

account | marginMode | currency | interest | interestRate | amountBorrowed |     timestamp |                 datetime
---------------------------------------------------------------------------------------------------------------------
  cross |      cross |     USDT |     1e-8 |   0.00089489 |     0.00011146 | 1707548400000 | 2024-02-10T07:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00089489 |     0.00011146 | 1707544800000 | 2024-02-10T06:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00089489 |     0.00011146 | 1707541200000 | 2024-02-10T05:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00090474 |     0.00011146 | 1707537600000 | 2024-02-10T04:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00090474 |     0.00011146 | 1707534000000 | 2024-02-10T03:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00093076 |     0.00011146 | 1707530400000 | 2024-02-10T02:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00090295 |     0.00011146 | 1707526800000 | 2024-02-10T01:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00086412 |     0.00011146 | 1707523200000 | 2024-02-10T00:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00088385 |     0.00011146 | 1707519600000 | 2024-02-09T23:00:00.000Z
  cross |      cross |     USDT |     1e-8 |   0.00089933 |     0.00011146 | 1707516000000 | 2024-02-09T22:00:00.000Z
10 objects
```