### PR TITLE
fix(binanceus) incorrect has-values in pro implementation

### DIFF
--- a/ts/src/pro/binanceus.ts
+++ b/ts/src/pro/binanceus.ts
@@ -11,7 +11,7 @@ export default class binanceus extends binance {
         // eslint-disable-next-line new-cap
         const restInstance = new binanceusRest ();
         const restDescribe = restInstance.describe ();
-        const extended = this.deepExtend (super.describe (), restDescribe);
+        const extended = this.deepExtend (restDescribe, super.describe ());
         return this.deepExtend (extended, {
             'id': 'binanceus',
             'name': 'Binance US',


### PR DESCRIPTION
## symptoms
The binanceus.has structure had a value of _false_ for all websocket functions despite the fact that binanceus _does_ offer websockets. 

## example
binanceus.has.watchOHLCV showed _false_, but should have shown _true_.

## cause
The root of the issue lies in the inheritance tree of the websocket class for binanceus. 
The websocket class of binanceus extends the websocket class of binance, which in turn extends exchange.
This tree misses the description of the rest class for binanceus, thus holding incorrect rest url's. 
The provided solution copied this missing information _over_ the base class description.
The base class description had just set (for instance) watchOHLC to _true_, this action set it to _false_.

## fix
Insert the info instead of overwrite it: The information from the sockets class of binance should overwrite the rest class of binanceus before overwriting the values with socket information for binanceus.
