### PR TITLE
feat(Exchange.py): handle wait_for calls

### DIFF
--- a/python/ccxt/async_support/base/ws/future.py
+++ b/python/ccxt/async_support/base/ws/future.py
@@ -45,7 +45,13 @@ class Future(asyncio.Future):
                     if are_all_canceled and future._state == 'PENDING':
                         future.set_exception(ExchangeClosedByUser('Connection closed by the user'))
                         return
+
+                    # handle wait_for scenario
+                    if are_all_canceled and future._state == 'CANCELLED':
+                        return
+
                     first = futures_list[0]
+
                     first_result = first.result()
                     future.set_result(first_result)
             else:


### PR DESCRIPTION
How to test:

```Python
async def wait_trades():
    while True:
        trades = await exchange.watch_trades_for_symbols(["BTC/USDT", "ETH/USDT"])
```
And then

```Python
    await asyncio.wait_for(wait_trades(), timeout=5)
```