### PR TITLE
binance: fetchTradingFee, add portfolio margin support

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2270,11 +2270,41 @@
                 ]
             },
             {
-                "description": "swap trading fee",
+                "description": "Linear swap fetch trading fee",
                 "method": "fetchTradingFee",
-                "url": "https://api.binance.com/sapi/v1/asset/tradeFee?timestamp=1706095328067&symbol=BTCUSDT&recvWindow=10000&signature=b24637ac06270ce8d90d3d0835e9bc6a6c56ff389364fec2bce09ee74ef8aef8",
+                "url": "https://testnet.binancefuture.com/fapi/v1/commissionRate?timestamp=1707777580650&symbol=BTCUSDT&recvWindow=10000&signature=c54b25d565695b045323ba483f32e6f07829bc0c19e07c0cb78e54ff415978ee",
                 "input": [
                   "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "Inverse swap fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://testnet.binancefuture.com/dapi/v1/commissionRate?timestamp=1707777670336&symbol=ETHUSD_PERP&recvWindow=10000&signature=8c0727960b0de153cb7dbc166fe3e6dfe3d473508909a4a6bfeda06f97dcacbf",
+                "input": [
+                  "ETH/USD:ETH"
+                ]
+            },
+            {
+                "description": "Linear portfolio margin fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://papi.binance.com/papi/v1/um/commissionRate?timestamp=1707777345377&symbol=BTCUSDT&recvWindow=10000&signature=73a49e69c333a1ae5435c90f54eb4a07321c4a33cb7088696dbb4745aeb64db8",
+                "input": [
+                  "BTC/USDT:USDT",
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse portfolio margin fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://papi.binance.com/papi/v1/cm/commissionRate?timestamp=1707777389698&symbol=ETHUSD_PERP&recvWindow=10000&signature=cb22b12993cd61b5ce6db703964ae74e375a100da50d21f81f8c8951370eb639",
+                "input": [
+                  "ETH/USD:ETH",
+                  {
+                    "portfolioMargin": true
+                  }
                 ]
             }
         ],


### PR DESCRIPTION
Added portfolio margin support to fetchTradingFee:

```
binance fetchTradingFee BTC/USDT:USDT '{"portfolioMargin":true}'

binance.fetchTradingFee (BTC/USDT:USDT, [object Object])
2024-02-12T22:35:46.337Z iteration 0 passed in 1007 ms

{
  info: {
    symbol: 'BTCUSDT',
    makerCommissionRate: '0.000160',
    takerCommissionRate: '0.000400'
  },
  symbol: 'BTC/USDT',
  maker: 0.00016,
  taker: 0.0004
}
```
```
binance fetchTradingFee ETH/USD:ETH '{"portfolioMargin":true}'

binance.fetchTradingFee (ETH/USD:ETH, [object Object])
2024-02-12T22:36:30.608Z iteration 0 passed in 961 ms

{
  info: {
    symbol: 'ETHUSD_PERP',
    makerCommissionRate: '0.000160',
    takerCommissionRate: '0.000400'
  },
  symbol: 'ETH/USD:ETH',
  maker: 0.00016,
  taker: 0.0004
}
```