### PR TITLE
binance: fetchOrders, add portfolio margin support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5323,7 +5323,7 @@ export default class binance extends Exchange {
         }
         return this.safeOrder ({
             'info': order,
-            'id': this.safeString2 (order, 'orderId', 'strategyId'),
+            'id': this.safeString2 (order, 'strategyId', 'orderId'),
             'clientOrderId': this.safeString2 (order, 'clientOrderId', 'newClientStrategyId'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6295,13 +6295,23 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/delivery/en/#all-orders-user_data
          * @see https://binance-docs.github.io/apidocs/voptions/en/#query-option-order-history-trade
          * @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-all-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-um-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-cm-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-um-conditional-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-cm-conditional-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-margin-account-orders-user_data
          * @param {string} symbol unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to fetch orders in a portfolio margin account
+         * @param {boolean} [params.stop] set to true if you would like to fetch portfolio margin account stop or conditional orders
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchClosedOrders() requires a symbol argument');
+        }
         const orders = await this.fetchOrders (symbol, since, undefined, params);
         const filteredOrders = this.filterBy (orders, 'status', 'closed');
         return this.filterBySinceLimit (filteredOrders, since, limit);
@@ -6315,22 +6325,23 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/spot/en/#all-orders-user_data
          * @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-all-orders-user_data
          * @see https://binance-docs.github.io/apidocs/voptions/en/#query-option-order-history-trade
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-um-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-cm-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-um-conditional-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-cm-conditional-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-margin-account-orders-user_data
          * @param {string} symbol unified market symbol of the market the orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to fetch orders in a portfolio margin account
+         * @param {boolean} [params.stop] set to true if you would like to fetch portfolio margin account stop or conditional orders
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchCanceledOrders() requires a symbol argument');
         }
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        if (market['swap'] || market['future']) {
-            throw new NotSupported (this.id + ' fetchCanceledOrders() supports spot, margin and option markets only');
-        }
-        params = this.omit (params, 'type');
         const orders = await this.fetchOrders (symbol, since, undefined, params);
         const filteredOrders = this.filterBy (orders, 'status', 'canceled');
         return this.filterBySinceLimit (filteredOrders, since, limit);

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5082,7 +5082,7 @@ export default class binance extends Exchange {
         //         "msg": "Quantity greater than max quantity."
         //     }
         //
-        // createOrder, fetchOpenOrders, fetchOrder, cancelOrder: portfolio margin linear swap and future
+        // createOrder, fetchOpenOrders, fetchOrder, cancelOrder, fetchOrders: portfolio margin linear swap and future
         //
         //     {
         //         "symbol": "BTCUSDT",
@@ -5105,7 +5105,7 @@ export default class binance extends Exchange {
         //         "status": "NEW"
         //     }
         //
-        // createOrder, fetchOpenOrders, fetchOrder, cancelOrder: portfolio margin inverse swap and future
+        // createOrder, fetchOpenOrders, fetchOrder, cancelOrder, fetchOrders: portfolio margin inverse swap and future
         //
         //     {
         //         "symbol": "ETHUSD_PERP",
@@ -5190,7 +5190,7 @@ export default class binance extends Exchange {
         //         "type": "LIMIT"
         //     }
         //
-        // fetchOpenOrders, fetchOrder: portfolio margin spot margin
+        // fetchOpenOrders, fetchOrder, fetchOrders: portfolio margin spot margin
         //
         //     {
         //         "symbol": "BTCUSDT",
@@ -5234,6 +5234,32 @@ export default class binance extends Exchange {
         //         "priceRate": null,      // only return with trailing orders
         //         "bookTime": 1707270098774,
         //         "updateTime": 1707270119261,
+        //         "workingType": "CONTRACT_PRICE",
+        //         "priceProtect": false,
+        //         "goodTillDate": 0,
+        //         "selfTradePreventionMode": "NONE"
+        //     }
+        //
+        // fetchOrders: portfolio margin linear and inverse swap conditional
+        //
+        //     {
+        //         "newClientStrategyId": "x-xcKtGhcuaf166172ed504cd1bc0396",
+        //         "strategyId": 3733211,
+        //         "strategyStatus": "CANCELLED",
+        //         "strategyType": "STOP",
+        //         "origQty": "0.010",
+        //         "price": "35000",
+        //         "orderId": 0,
+        //         "reduceOnly": false,
+        //         "side": "BUY",
+        //         "positionSide": "BOTH",
+        //         "stopPrice": "50000",
+        //         "symbol": "BTCUSDT",
+        //         "type": "LIMIT",
+        //         "bookTime": 1707270098774,
+        //         "updateTime": 1707270119261,
+        //         "timeInForce": "GTC",
+        //         "triggerTime": 0,
         //         "workingType": "CONTRACT_PRICE",
         //         "priceProtect": false,
         //         "goodTillDate": 0,
@@ -5895,13 +5921,20 @@ export default class binance extends Exchange {
          * @see https://binance-docs.github.io/apidocs/delivery/en/#all-orders-user_data
          * @see https://binance-docs.github.io/apidocs/voptions/en/#query-option-order-history-trade
          * @see https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-all-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-um-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-cm-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-um-conditional-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-cm-conditional-orders-user_data
+         * @see https://binance-docs.github.io/apidocs/pm/en/#query-all-margin-account-orders-user_data
          * @param {string} symbol unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
          * @param {int} [params.until] the latest time in ms to fetch orders for
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.portfolioMargin] set to true if you would like to fetch orders in a portfolio margin account
+         * @param {boolean} [params.stop] set to true if you would like to fetch portfolio margin account stop or conditional orders
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
@@ -5914,17 +5947,18 @@ export default class binance extends Exchange {
             return await this.fetchPaginatedCallDynamic ('fetchOrders', symbol, since, limit, params) as Order[];
         }
         const market = this.market (symbol);
-        const defaultType = this.safeString2 (this.options, 'fetchOrders', 'defaultType', 'spot');
+        const defaultType = this.safeString2 (this.options, 'fetchOrders', 'defaultType', market['type']);
         const type = this.safeString (params, 'type', defaultType);
-        const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchOrders', params);
-        const request = {
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchOrders', params);
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'fetchOrders', 'papi', 'portfolioMargin', false);
+        const isConditional = this.safeBool2 (params, 'stop', 'conditional');
+        params = this.omit (params, [ 'stop', 'conditional', 'type' ]);
+        let request = {
             'symbol': market['id'],
         };
-        const until = this.safeInteger (params, 'until');
-        if (until !== undefined) {
-            params = this.omit (params, 'until');
-            request['endTime'] = until;
-        }
+        [ request, params ] = this.handleUntilOption ('endTime', request, params);
         if (since !== undefined) {
             request['startTime'] = since;
         }
@@ -5933,18 +5967,38 @@ export default class binance extends Exchange {
         }
         let response = undefined;
         if (market['option']) {
-            response = await this.eapiPrivateGetHistoryOrders (this.extend (request, query));
+            response = await this.eapiPrivateGetHistoryOrders (this.extend (request, params));
         } else if (market['linear']) {
-            response = await this.fapiPrivateGetAllOrders (this.extend (request, query));
-        } else if (market['inverse']) {
-            response = await this.dapiPrivateGetAllOrders (this.extend (request, query));
-        } else if (type === 'margin' || marginMode !== undefined) {
-            if (marginMode === 'isolated') {
-                request['isIsolated'] = true;
+            if (isPortfolioMargin) {
+                if (isConditional) {
+                    response = await this.papiGetUmConditionalAllOrders (this.extend (request, params));
+                } else {
+                    response = await this.papiGetUmAllOrders (this.extend (request, params));
+                }
+            } else {
+                response = await this.fapiPrivateGetAllOrders (this.extend (request, params));
             }
-            response = await this.sapiGetMarginAllOrders (this.extend (request, query));
+        } else if (market['inverse']) {
+            if (isPortfolioMargin) {
+                if (isConditional) {
+                    response = await this.papiGetCmConditionalAllOrders (this.extend (request, params));
+                } else {
+                    response = await this.papiGetCmAllOrders (this.extend (request, params));
+                }
+            } else {
+                response = await this.dapiPrivateGetAllOrders (this.extend (request, params));
+            }
         } else {
-            response = await this.privateGetAllOrders (this.extend (request, query));
+            if (isPortfolioMargin) {
+                response = await this.papiGetMarginAllOrders (this.extend (request, params));
+            } else if (type === 'margin' || marginMode !== undefined) {
+                if (marginMode === 'isolated') {
+                    request['isIsolated'] = true;
+                }
+                response = await this.sapiGetMarginAllOrders (this.extend (request, params));
+            } else {
+                response = await this.privateGetAllOrders (this.extend (request, params));
+            }
         }
         //
         //  spot
@@ -6018,6 +6072,112 @@ export default class binance extends Exchange {
         //             "lastTrade": {"id":"69","time":"1676084430567","price":"24.9","qty":"1.00"},
         //             "mmp": false
         //         }
+        //     ]
+        //
+        // inverse portfolio margin
+        //
+        //     [
+        //         {
+        //             "orderId": 71328442983,
+        //             "symbol": "ETHUSD_PERP",
+        //             "pair": "ETHUSD",
+        //             "status": "CANCELED",
+        //             "clientOrderId": "x-xcKtGhcu4b3e3d8515dd4dc5ba9ccc",
+        //             "price": "2000",
+        //             "avgPrice": "0.00",
+        //             "origQty": "1",
+        //             "executedQty": "0",
+        //             "cumBase": "0",
+        //             "timeInForce": "GTC",
+        //             "type": "LIMIT",
+        //             "reduceOnly": false,
+        //             "side": "BUY",
+        //             "origType": "LIMIT",
+        //             "time": 1707197843046,
+        //             "updateTime": 1707197941373,
+        //             "positionSide": "BOTH"
+        //         },
+        //     ]
+        //
+        // linear portfolio margin
+        //
+        //     [
+        //         {
+        //             "orderId": 259235347005,
+        //             "symbol": "BTCUSDT",
+        //             "status": "CANCELED",
+        //             "clientOrderId": "x-xcKtGhcu402881c9103f42bdb4183b",
+        //             "price": "35000",
+        //             "avgPrice": "0.00000",
+        //             "origQty": "0.010",
+        //             "executedQty": "0",
+        //             "cumQuote": "0",
+        //             "timeInForce": "GTC",
+        //             "type": "LIMIT",
+        //             "reduceOnly": false,
+        //             "side": "BUY",
+        //             "origType": "LIMIT",
+        //             "time": 1707194702167,
+        //             "updateTime": 1707197804748,
+        //             "positionSide": "BOTH",
+        //             "selfTradePreventionMode": "NONE",
+        //             "goodTillDate": 0
+        //         },
+        //     ]
+        //
+        // conditional portfolio margin
+        //
+        //     [
+        //         {
+        //             "newClientStrategyId": "x-xcKtGhcuaf166172ed504cd1bc0396",
+        //             "strategyId": 3733211,
+        //             "strategyStatus": "CANCELLED",
+        //             "strategyType": "STOP",
+        //             "origQty": "0.010",
+        //             "price": "35000",
+        //             "orderId": 0,
+        //             "reduceOnly": false,
+        //             "side": "BUY",
+        //             "positionSide": "BOTH",
+        //             "stopPrice": "50000",
+        //             "symbol": "BTCUSDT",
+        //             "type": "LIMIT",
+        //             "bookTime": 1707270098774,
+        //             "updateTime": 1707270119261,
+        //             "timeInForce": "GTC",
+        //             "triggerTime": 0,
+        //             "workingType": "CONTRACT_PRICE",
+        //             "priceProtect": false,
+        //             "goodTillDate": 0,
+        //             "selfTradePreventionMode": "NONE"
+        //         },
+        //     ]
+        //
+        // spot margin portfolio margin
+        //
+        //     [
+        //         {
+        //             "symbol": "BTCUSDT",
+        //             "orderId": 24684460474,
+        //             "clientOrderId": "x-R4BD3S82e9ef29d8346440f0b28b86",
+        //             "price": "35000.00000000",
+        //             "origQty": "0.00100000",
+        //             "executedQty": "0.00000000",
+        //             "cummulativeQuoteQty": "0.00000000",
+        //             "status": "CANCELED",
+        //             "timeInForce": "GTC",
+        //             "type": "LIMIT",
+        //             "side": "BUY",
+        //             "stopPrice": "0.00000000",
+        //             "icebergQty": "0.00000000",
+        //             "time": 1707113538870,
+        //             "updateTime": 1707113797688,
+        //             "isWorking": true,
+        //             "accountId": 200180970,
+        //             "selfTradePreventionMode": "EXPIRE_MAKER",
+        //             "preventedMatchId": null,
+        //             "preventedQuantity": null
+        //         },
         //     ]
         //
         return this.parseOrders (response, market, since, limit);

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -867,6 +867,73 @@
                         "marginMode": "isolated"
                     }
                 ]
+            },
+            {
+                "description": "Linear swap portfolio margin fetch orders",
+                "method": "fetchOrders",
+                "url": "https://papi.binance.com/papi/v1/um/allOrders?timestamp=1707792652974&symbol=BTCUSDT&recvWindow=10000&signature=73fea37c53ceb88f88dd00ff5b7963bd76a05c3ee51ff978820b5db43d85e6e0",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap portfolio margin fetch orders",
+                "method": "fetchOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/allOrders?timestamp=1707792759881&symbol=ETHUSD_PERP&recvWindow=10000&signature=d55ede981e4d2dcfc2436a15dbe088eb41440285d8fb2e7dd20bf96eaaff8776",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Linear swap conditional portfolio margin fetch orders",
+                "method": "fetchOrders",
+                "url": "https://papi.binance.com/papi/v1/um/conditional/allOrders?timestamp=1707792805020&symbol=BTCUSDT&recvWindow=10000&signature=fa5930b499e5a683591142f732b96939815fb42fb1d4c9c1caec2e87368bf5a7",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap conditional portfolio margin fetch orders",
+                "method": "fetchOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/conditional/allOrders?timestamp=1707792703391&symbol=ETHUSD_PERP&recvWindow=10000&signature=b8a90970cff0ef5402e2eddb88efef01316b83d1827a7015bdc6e3735ccb711e",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin portfolio margin fetch orders",
+                "method": "fetchOrders",
+                "url": "https://papi.binance.com/papi/v1/margin/allOrders?timestamp=1707792860318&symbol=BTCUSDT&recvWindow=10000&signature=b8c3ab4decfe00027b3811b0d64cc7dfc5c6c73648ce095078ff805d1b78a1b0",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
             }
         ],
         "fetchOrder": [

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1173,6 +1173,73 @@
                     null,
                     1
                 ]
+            },
+            {
+                "description": "Spot margin portfolio margin fetch canceled orders",
+                "method": "fetchCanceledOrders",
+                "url": "https://papi.binance.com/papi/v1/margin/allOrders?timestamp=1707794017912&symbol=BTCUSDT&recvWindow=10000&signature=2d3478743a749fe36639cac676194b6926ffd82132fce7dca901caf3b08abcd4",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Linear portfolio margin fetch canceled orders",
+                "method": "fetchCanceledOrders",
+                "url": "https://papi.binance.com/papi/v1/um/allOrders?timestamp=1707798719391&symbol=BTCUSDT&recvWindow=10000&signature=3ea34eedd573746fe9bad66ea1b8eef8863a273653d408c246b94cc6029fd7bb",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse portfolio margin fetch canceled orders",
+                "method": "fetchCanceledOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/allOrders?timestamp=1707798826314&symbol=ETHUSD_PERP&recvWindow=10000&signature=8fff8802c032c9b55965aa1c2d949cabb5fbb9a6b23316bb03a3631d79af6851",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Linear conditional portfolio margin fetch canceled orders",
+                "method": "fetchCanceledOrders",
+                "url": "https://papi.binance.com/papi/v1/um/conditional/allOrders?timestamp=1707798862888&symbol=BTCUSDT&recvWindow=10000&signature=6492a3f7739ac309e269451258f34bbd16f7c6b247b4fc7ac074cccf1acedcdf",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse conditional portfolio margin fetch canceled orders",
+                "method": "fetchCanceledOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/conditional/allOrders?timestamp=1707798908668&symbol=ETHUSD_PERP&recvWindow=10000&signature=cab4eee248582eb3f6ea432c5b2891afae57c723f8aabeaf047126c95c4fd95e",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
             }
         ],
         "fetchClosedOrders": [

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1185,6 +1185,73 @@
                   null,
                   10
                 ]
+            },
+            {
+                "description": "Linear portfolio margin fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://papi.binance.com/papi/v1/um/allOrders?timestamp=1707793443640&symbol=BTCUSDT&recvWindow=10000&signature=5a0b8c56d3b612d0ea09042e8c664fea9c8e94d3ea3d18e5369c4ca0a73f03e4",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse portfolio margin fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/allOrders?timestamp=1707793564312&symbol=ETHUSD_PERP&recvWindow=10000&signature=93a4fc25b85e718978fe065176fb43098a33f994aa03c05278051ed9c392d10c",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
+            },
+            {
+                "description": "Linear conditional portfolio margin fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://papi.binance.com/papi/v1/um/conditional/allOrders?timestamp=1707793503573&symbol=BTCUSDT&recvWindow=10000&signature=3a62b27a95127273f2841ff3800aedc91741b1e9a06913317ec7a09328cf2260",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Inverse conditional portfolio margin fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://papi.binance.com/papi/v1/cm/conditional/allOrders?timestamp=1707793604304&symbol=ETHUSD_PERP&recvWindow=10000&signature=8a515858c3a0cacc9f6170829688a426044733c29a9fb8563d5c94bfa8b443b0",
+                "input": [
+                  "ETH/USD:ETH",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true,
+                    "stop": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin portfolio margin fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://papi.binance.com/papi/v1/margin/allOrders?timestamp=1707793643759&symbol=BTCUSDT&recvWindow=10000&signature=3a0df656e278682cc86f523c35eb04243e21cd1f2cfcf3fa6bc5cc5981821182",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "portfolioMargin": true
+                  }
+                ]
             }
         ],
         "fetchOrderTrades": [

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -1386,6 +1386,179 @@
           }
         ]
       }
+    ],
+    "fetchOrders": [
+      {
+        "description": "fetch portfolio margin orders",
+        "method": "fetchOrders",
+        "input": [
+          "BTC/USDT:USDT",
+          null,
+          1,
+          {
+            "portfolioMargin": true
+          }
+        ],
+        "httpResponse": [
+          {
+            "orderId": "262065925771",
+            "symbol": "BTCUSDT",
+            "status": "FILLED",
+            "clientOrderId": "x-xcKtGhcud2deca88ac9f4ccb9485a9",
+            "price": "0",
+            "avgPrice": "47279.40000",
+            "origQty": "0.010",
+            "executedQty": "0.010",
+            "cumQuote": "472.79400",
+            "timeInForce": "GTC",
+            "type": "MARKET",
+            "reduceOnly": false,
+            "side": "BUY",
+            "origType": "MARKET",
+            "time": "1707550415587",
+            "updateTime": "1707550415587",
+            "positionSide": "LONG",
+            "selfTradePreventionMode": "NONE",
+            "goodTillDate": "0"
+          }
+        ],
+        "parsedResponse": [
+          {
+            "info": {
+              "orderId": "262065925771",
+              "symbol": "BTCUSDT",
+              "status": "FILLED",
+              "clientOrderId": "x-xcKtGhcud2deca88ac9f4ccb9485a9",
+              "price": "0",
+              "avgPrice": "47279.40000",
+              "origQty": "0.010",
+              "executedQty": "0.010",
+              "cumQuote": "472.79400",
+              "timeInForce": "GTC",
+              "type": "MARKET",
+              "reduceOnly": false,
+              "side": "BUY",
+              "origType": "MARKET",
+              "time": "1707550415587",
+              "updateTime": "1707550415587",
+              "positionSide": "LONG",
+              "selfTradePreventionMode": "NONE",
+              "goodTillDate": "0"
+            },
+            "id": "262065925771",
+            "clientOrderId": "x-xcKtGhcud2deca88ac9f4ccb9485a9",
+            "timestamp": 1707550415587,
+            "datetime": "2024-02-10T07:33:35.587Z",
+            "lastTradeTimestamp": 1707550415587,
+            "lastUpdateTimestamp": 1707550415587,
+            "symbol": "BTC/USDT:USDT",
+            "type": "market",
+            "timeInForce": "GTC",
+            "postOnly": false,
+            "reduceOnly": false,
+            "side": "buy",
+            "price": 47279.4,
+            "triggerPrice": null,
+            "amount": 0.01,
+            "cost": 472.794,
+            "average": 47279.4,
+            "filled": 0.01,
+            "remaining": 0,
+            "status": "closed",
+            "fee": null,
+            "trades": [],
+            "fees": [],
+            "stopPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      },
+      {
+        "description": "fetch spot orders",
+        "method": "fetchOrders",
+        "input": [
+          "LTC/USDT",
+          null,
+          1
+        ],
+        "httpResponse": [
+          {
+            "symbol": "LTCUSDT",
+            "orderId": "3854801792",
+            "orderListId": "-1",
+            "clientOrderId": "x-R4BD3S82d1481ae59ba59326d82c8a",
+            "price": "50.00000000",
+            "origQty": "0.10000000",
+            "executedQty": "0.00000000",
+            "cummulativeQuoteQty": "0.00000000",
+            "status": "CANCELED",
+            "timeInForce": "GTC",
+            "type": "LIMIT",
+            "side": "BUY",
+            "stopPrice": "0.00000000",
+            "icebergQty": "0.00000000",
+            "time": "1701856395927",
+            "updateTime": "1706883268013",
+            "isWorking": true,
+            "workingTime": "1701856395927",
+            "origQuoteOrderQty": "0.00000000",
+            "selfTradePreventionMode": "EXPIRE_MAKER"
+          }
+        ],
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "LTCUSDT",
+              "orderId": "3854801792",
+              "orderListId": "-1",
+              "clientOrderId": "x-R4BD3S82d1481ae59ba59326d82c8a",
+              "price": "50.00000000",
+              "origQty": "0.10000000",
+              "executedQty": "0.00000000",
+              "cummulativeQuoteQty": "0.00000000",
+              "status": "CANCELED",
+              "timeInForce": "GTC",
+              "type": "LIMIT",
+              "side": "BUY",
+              "stopPrice": "0.00000000",
+              "icebergQty": "0.00000000",
+              "time": "1701856395927",
+              "updateTime": "1706883268013",
+              "isWorking": true,
+              "workingTime": "1701856395927",
+              "origQuoteOrderQty": "0.00000000",
+              "selfTradePreventionMode": "EXPIRE_MAKER"
+            },
+            "id": "3854801792",
+            "clientOrderId": "x-R4BD3S82d1481ae59ba59326d82c8a",
+            "timestamp": 1701856395927,
+            "datetime": "2023-12-06T09:53:15.927Z",
+            "lastTradeTimestamp": null,
+            "lastUpdateTimestamp": 1706883268013,
+            "symbol": "LTC/USDT",
+            "type": "limit",
+            "timeInForce": "GTC",
+            "postOnly": false,
+            "reduceOnly": null,
+            "side": "buy",
+            "price": 50,
+            "triggerPrice": null,
+            "amount": 0.1,
+            "cost": 0,
+            "average": null,
+            "filled": 0,
+            "remaining": 0.1,
+            "status": "canceled",
+            "fee": null,
+            "trades": [],
+            "fees": [],
+            "stopPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Added portfolio margin support to fetchOrders, fetchCanceledOrders and fetchClosedOrders:

```
binance fetchOrders BTC/USDT:USDT undefined 3 '{"portfolioMargin":true}'

binance.fetchOrders (BTC/USDT:USDT, , 3, [object Object])
2024-02-13T02:59:08.637Z iteration 0 passed in 841 ms

          id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |        symbol |   type | timeInForce | postOnly | reduceOnly | side |   price | amount |    cost | average | filled | remaining | status | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
260533873488 | x-xcKtGhcu6cdf0014baf4411ebb067e | 1707371879042 | 2024-02-08T05:57:59.042Z |      1707371879042 |       1707371879042 | BTC/USDT:USDT | market |         GTC |    false |      false |  buy |   44525 |   0.01 |  445.25 |   44525 |   0.01 |         0 | closed |     [] |   []
261942655610 | x-xcKtGhcu2d7e9567b4ea4ee9b52754 | 1707530039409 | 2024-02-10T01:53:59.409Z |      1707530039409 |       1707530039409 | BTC/USDT:USDT | market |         GTC |    false |       true | sell | 47263.4 |   0.01 | 472.634 | 47263.4 |   0.01 |         0 | closed |     [] |   []
262065925771 | x-xcKtGhcud2deca88ac9f4ccb9485a9 | 1707550415587 | 2024-02-10T07:33:35.587Z |      1707550415587 |       1707550415587 | BTC/USDT:USDT | market |         GTC |    false |      false |  buy | 47279.4 |   0.01 | 472.794 | 47279.4 |   0.01 |         0 | closed |     [] |   []
3 objects
```
```
binance fetchOrders ETH/USD:ETH undefined 3 '{"portfolioMargin":true}'

binance.fetchOrders (ETH/USD:ETH, , 3, [object Object])
2024-02-13T02:59:46.663Z iteration 0 passed in 1058 ms

         id |                    clientOrderId |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |      symbol |   type | timeInForce | postOnly | reduceOnly | side |   price | amount |       cost | average | filled | remaining | status | trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
71442275818 | x-xcKtGhcu41b65d74fb544f93a6d80a | 1707371941861 | 2024-02-08T05:59:01.861Z |      1707371941861 |       1707371941861 | ETH/USD:ETH | market |         GTC |    false |      false |  buy |  2422.4 |      1 | 0.00412813 |  2422.4 |      1 |         0 | closed |     [] |   []
71548909034 | x-xcKtGhcu7209d903c603490f81bcbe | 1707530317519 | 2024-02-10T01:58:37.519Z |      1707530317519 |       1707530317519 | ETH/USD:ETH | market |         GTC |    false |       true | sell | 2498.15 |      1 | 0.00400296 | 2498.15 |      1 |         0 | closed |     [] |   []
71558488698 | x-xcKtGhcu38308f482cad4f17998444 | 1707550448601 | 2024-02-10T07:34:08.601Z |      1707550448601 |       1707550448601 | ETH/USD:ETH | market |         GTC |    false |      false |  buy | 2501.63 |      1 |  0.0039974 | 2501.63 |      1 |         0 | closed |     [] |   []
3 objects
```
```
binance fetchOrders BTC/USDT:USDT undefined 3 '{"portfolioMargin":true,"stop":true}'

binance.fetchOrders (BTC/USDT:USDT, , 3, [object Object])
2024-02-13T03:00:35.720Z iteration 0 passed in 868 ms

id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |        symbol |  type | timeInForce | postOnly | reduceOnly | side | price | triggerPrice | amount | cost | filled | remaining |   status | trades | fees | stopPrice
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 0 | x-xcKtGhcu090536fae0d541b3975b6c | 1707200838107 | 2024-02-06T06:27:18.107Z |       1707200838107 | BTC/USDT:USDT | limit |         GTC |    false |      false |  buy | 35000 |        50000 |   0.01 |    0 |      0 |      0.01 | canceled |     [] |   [] |     50000
 0 | x-xcKtGhcu589121c53f1748d99440df | 1707269946859 | 2024-02-07T01:39:06.859Z |       1707269946859 | BTC/USDT:USDT | limit |         GTC |    false |      false |  buy | 35000 |        50000 |   0.01 |    0 |      0 |      0.01 | canceled |     [] |   [] |     50000
 0 | x-xcKtGhcuaf166172ed504cd1bc0396 | 1707270119261 | 2024-02-07T01:41:59.261Z |       1707270119261 | BTC/USDT:USDT | limit |         GTC |    false |      false |  buy | 35000 |        50000 |   0.01 |    0 |      0 |      0.01 | canceled |     [] |   [] |     50000
3 objects
```
```
binance fetchOrders ETH/USD:ETH undefined 3 '{"portfolioMargin":true,"stop":true}'

binance.fetchOrders (ETH/USD:ETH, , 3, [object Object])
2024-02-13T03:01:18.133Z iteration 0 passed in 943 ms

id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |      symbol |  type | timeInForce | postOnly | reduceOnly | side | price | triggerPrice | amount | cost | filled | remaining |   status | trades | fees | stopPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 0 | x-xcKtGhcubd66e2d41e994ac88eea0b | 1707199165550 | 2024-02-06T05:59:25.550Z |       1707199165550 | ETH/USD:ETH | limit |         GTC |    false |      false |  buy |  2000 |         4000 |      1 |    0 |      0 |         1 | canceled |     [] |   [] |      4000
 0 | x-xcKtGhcu9f72cd9538304fd798f225 | 1707200940367 | 2024-02-06T06:29:00.367Z |       1707200940367 | ETH/USD:ETH | limit |         GTC |    false |      false |  buy |  2000 |         3500 |      1 |    0 |      0 |         1 | canceled |     [] |   [] |      3500
 0 | x-xcKtGhcu5fb43fc8ec45453ebb68b1 | 1707270384288 | 2024-02-07T01:46:24.288Z |       1707270384288 | ETH/USD:ETH | limit |         GTC |    false |      false |  buy |  2000 |         4000 |      1 |    0 |      0 |         1 | canceled |     [] |   [] |      4000
3 objects
```
```
binance fetchOrders BTC/USDT undefined 3 '{"portfolioMargin":true}'

binance.fetchOrders (BTC/USDT, , 3, [object Object])
2024-02-13T03:01:49.125Z iteration 0 passed in 895 ms

         id |                    clientOrderId |     timestamp |                 datetime | lastUpdateTimestamp |   symbol |  type | timeInForce | postOnly | side | price | amount | cost | filled | remaining |   status |  trades | fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
24700891701 | x-R4BD3S821d922eee127b44d4a459fb | 1707200403674 | 2024-02-06T06:20:03.674Z |       1707200411712 | BTC/USDT | limit |         GTC |    false |  buy | 35000 |  0.001 |    0 |      0 |     0.001 | canceled |      [] |   []
24711539682 | x-R4BD3S824fcc76c9173d4bcc8c15df | 1707257882364 | 2024-02-06T22:18:02.364Z |       1707259955723 | BTC/USDT | limit |         GTC |    false |  buy | 35000 |  0.001 |    0 |      0 |     0.001 | canceled |      [] |   []
24784905839 | x-R4BD3S82132ba81ab14a4661bcd824 | 1707545623253 | 2024-02-10T06:13:43.253Z |       1707545655759 | BTC/USDT | limit |         GTC |    false |  buy | 35000 |  0.001 |    0 |      0 |     0.001 | canceled |      [] |   []
3 objects
```