### PR TITLE
fix(coinbase): v2 methods signature

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3422,12 +3422,7 @@ export default class coinbase extends Exchange {
                         payload = body;
                     }
                 }
-                let auth = undefined;
-                if (version === 'v3') {
-                    auth = nonce + method + savedPath + payload;
-                } else {
-                    auth = nonce + method + fullPath + payload;
-                }
+                const auth = nonce + method + savedPath + payload;
                 const signature = this.hmac (this.encode (auth), this.encode (this.secret), sha256);
                 headers = {
                     'CB-ACCESS-KEY': this.apiKey,


### PR DESCRIPTION
```
2024-02-13T06:54:57.295Z
Node.js: v18.12.0
CCXT v4.2.43
coinbase.v2PrivateGetAccountsAccountIdAddresses ([object Object])
2024-02-13T06:55:00.395Z iteration 0 passed in 975 ms

{
  pagination: {
    ending_before: null,
    starting_after: null,
    previous_ending_before: null,
    next_starting_after: null,
    limit: '25',
    order: 'desc',
    previous_uri: null,
    next_uri: null
  },
  data: [
    {
      id: 'bc72f521-9f4f-5eb0-aedd-58689dbd8ab5',
      address: '3NLx6iG1vF7JdKY1fua8qWz1TYu9US3dcB',
      address_info: { address: '3NLx6iG1vF7JdKY1fua8qWz1TYu9US3dcB' },
      name: null,
      created_at: '2024-02-12T13:17:29Z',
      updated_at: '2024-02-12T13:17:29Z',
      network: 'bitcoin',
      uri_scheme: 'bitcoin',
      resource: 'address',
      resource_path: '/v2/accounts/1068a33e-0558-500d-a311-d73fef66aabe/addresses/bc72f521-9f4f-5eb0-aedd-58689dbd8ab5',
      warnings: [
        {
          type: 'correct_address_warning',
          title: 'Only send Bitcoin (BTC) to this address',
          details: 'Sending any other asset, including Bitcoin Cash (BCH), will result in permanent loss.',
          image_url: 'https://www.coinbase.com/assets/addresses/global-receive-warning-a3d91807e61c717e5a38d270965003dcc025ca8a3cea40ec3d7835b7c86087fa.png',
          options: [ { text: 'I understand', style: 'primary', id: 'dismiss' } ]
        }
      ],
```