### PR TITLE
fix(hitbtc) watchTickers never receives updates

### DIFF
--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -419,6 +419,7 @@ export default class hitbtc extends hitbtcRest {
             const messageHash = channel + '::' + symbol;
             client.resolve (newTickers, messageHash);
         }
+        client.resolve (newTickers, 'tickers');
         const messageHashes = this.findMessageHashes (client, 'tickers::');
         for (let i = 0; i < messageHashes.length; i++) {
             const messageHash = messageHashes[i];


### PR DESCRIPTION
## symptoms
When calling watchTickers without arguments, not a single ticker is received

## cause
The watchTickers function subscribes to the correct channel using messageHash 'tickers'.
The pro.hitbtc.handleTicker function however, never resolves a future for the hash.

## fix
handleTicker must resolve a future for messageHash 'tickers' too.

## please note
I took the liberty only to expose new (i.e. changed) tickers instead of _all_ tickers, since this is already available in the tickers property of the exchange instance.