### PR TITLE
feat(exchange): fetchDepositAddress uses fetchDepositAddressesByNetwork if fetchDepositAddress is not implemented

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4876,6 +4876,17 @@ export default class Exchange {
             } else {
                 return depositAddress;
             }
+        } else if (this.has['fetchDepositAddressesByNetwork']) {
+            const network = this.safeString (params, 'network');
+            params = this.omit (params, 'network');
+            const addressStructures = await this.fetchDepositAddressesByNetwork (code, params);
+            if (network !== undefined) {
+                return this.safeDict (addressStructures, network);
+            } else {
+                const keys = Object.keys (addressStructures);
+                const key = this.safeString (keys, 0);
+                return this.safeDict (addressStructures, key);
+            }
         } else {
             throw new NotSupported (this.id + ' fetchDepositAddress() is not supported yet');
         }


### PR DESCRIPTION
I tested by removing `fetchDepositAddress` from HTX and then calling it

```
% py htx fetchDepositAddress BTC
Python v3.9.6
CCXT v4.2.44
htx.fetchDepositAddress(BTC)
{'address': 'TFqAnCgT6aHJNUUWGMMpdj5jAnqCgHPeNr',
 'currency': 'BTC',
 'info': {'address': 'TFqAnCgT6aHJNUUWGMMpdj5jAnqCgHPeNr',
          'addressTag': '',
          'chain': 'trc20btc',
          'currency': 'btc',
          'userId': '35930539'},
 'network': 'TRC20',
 'note': None,
 'tag': None}
 ```