### PR TITLE
bybit: add fetchOpenOrder, fetchClosedOrder, remove fetchOrder, fetchOrders

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4439,11 +4439,11 @@ export default class bybit extends Exchange {
     }
 
     async fetchOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
-        throw new NotSupported (this.id + ' fetchOrder() is not supported on bybit, please use fetchOpenOrder or fetchClosedOrder');
+        throw new NotSupported (this.id + ' fetchOrder() is not supported after the 5/02 update, please use fetchOpenOrder or fetchClosedOrder');
     }
 
     async fetchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
-        throw new NotSupported (this.id + ' fetchOrders() is not supported on bybit, please use fetchOpenOrders, fetchClosedOrders or fetchCanceledOrders');
+        throw new NotSupported (this.id + ' fetchOrders() is not supported after the 5/02 update, please use fetchOpenOrders, fetchClosedOrders or fetchCanceledOrders');
     }
 
     async fetchClosedOrder (id: string, symbol: Str = undefined, params = {}) {

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -58,7 +58,9 @@ export default class bybit extends Exchange {
                 'fetchBorrowInterest': false, // temporarily disabled, as it doesn't work
                 'fetchBorrowRateHistories': false,
                 'fetchBorrowRateHistory': false,
+                'fetchCanceledAndClosedOrders': true,
                 'fetchCanceledOrders': true,
+                'fetchClosedOrder': true,
                 'fetchClosedOrders': true,
                 'fetchCrossBorrowRate': true,
                 'fetchCrossBorrowRates': false,
@@ -86,10 +88,11 @@ export default class bybit extends Exchange {
                 'fetchOHLCV': true,
                 'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': true,
+                'fetchOpenOrder': true,
                 'fetchOpenOrders': true,
-                'fetchOrder': true,
+                'fetchOrder': false,
                 'fetchOrderBook': true,
-                'fetchOrders': true,
+                'fetchOrders': false,
                 'fetchOrderTrades': true,
                 'fetchPosition': true,
                 'fetchPositions': true,
@@ -3424,36 +3427,6 @@ export default class bybit extends Exchange {
         }, market);
     }
 
-    async fetchOrder (id: string, symbol: Str = undefined, params = {}) {
-        /**
-         * @method
-         * @name bybit#fetchOrder
-         * @description fetches information on an order made by the user
-         * @see https://bybit-exchange.github.io/docs/v5/order/order-list
-         * @param {string} symbol unified symbol of the market the order was made in
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
-         */
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
-        }
-        await this.loadMarkets ();
-        const request = {
-            'orderId': id,
-        };
-        const result = await this.fetchOrders (symbol, undefined, undefined, this.extend (request, params));
-        const length = result.length;
-        if (length === 0) {
-            const isTrigger = this.safeBoolN (params, [ 'trigger', 'stop' ], false);
-            const extra = isTrigger ? '' : 'If you are trying to fetch SL/TP conditional order, you might try setting params["trigger"] = true';
-            throw new OrderNotFound ('Order ' + id.toString () + ' was not found.' + extra);
-        }
-        if (length > 1) {
-            throw new InvalidOrder (this.id + ' returned more than one order');
-        }
-        return this.safeValue (result, 0) as Order;
-    }
-
     async createMarketBuyOrderWithCost (symbol: string, cost: number, params = {}) {
         /**
          * @method
@@ -4465,29 +4438,103 @@ export default class bybit extends Exchange {
         return this.parseOrders (data, market, since, limit);
     }
 
+    async fetchOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
+        throw new NotSupported (this.id + ' fetchOrder() is not supported on bybit, please use fetchOpenOrder or fetchClosedOrder');
+    }
+
     async fetchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
+        throw new NotSupported (this.id + ' fetchOrders() is not supported on bybit, please use fetchOpenOrders, fetchClosedOrders or fetchCanceledOrders');
+    }
+
+    async fetchClosedOrder (id: string, symbol: Str = undefined, params = {}) {
         /**
          * @method
-         * @name bybit#fetchOrders
-         * @description fetches information on multiple orders made by the user
+         * @name bybit#fetchClosedOrder
+         * @description fetches information on a closed order made by the user
          * @see https://bybit-exchange.github.io/docs/v5/order/order-list
-         * @param {string} symbol unified market symbol of the market orders were made in
+         * @param {string} id order id
+         * @param {string} [symbol] unified symbol of the market the order was made in
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {boolean} [params.stop] set to true for fetching a closed stop order
+         * @param {string} [params.type] market type, ['swap', 'option', 'spot']
+         * @param {string} [params.subType] market subType, ['linear', 'inverse']
+         * @param {string} [params.orderFilter] 'Order' or 'StopOrder' or 'tpslOrder'
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const request = {
+            'orderId': id,
+        };
+        const result = await this.fetchClosedOrders (symbol, undefined, undefined, this.extend (request, params));
+        const length = result.length;
+        if (length === 0) {
+            const isTrigger = this.safeBoolN (params, [ 'trigger', 'stop' ], false);
+            const extra = isTrigger ? '' : 'If you are trying to fetch SL/TP conditional order, you might try setting params["trigger"] = true';
+            throw new OrderNotFound ('Order ' + id.toString () + ' was not found.' + extra);
+        }
+        if (length > 1) {
+            throw new InvalidOrder (this.id + ' returned more than one order');
+        }
+        return this.safeValue (result, 0) as Order;
+    }
+
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+        /**
+         * @method
+         * @name bybit#fetchOpenOrder
+         * @description fetches information on an open order made by the user
+         * @see https://bybit-exchange.github.io/docs/v5/order/open-order
+         * @param {string} id order id
+         * @param {string} [symbol] unified symbol of the market the order was made in
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {boolean} [params.stop] set to true for fetching an open stop order
+         * @param {string} [params.type] market type, ['swap', 'option', 'spot']
+         * @param {string} [params.subType] market subType, ['linear', 'inverse']
+         * @param {string} [params.baseCoin] Base coin. Supports linear, inverse & option
+         * @param {string} [params.settleCoin] Settle coin. Supports linear, inverse & option
+         * @param {string} [params.orderFilter] 'Order' or 'StopOrder' or 'tpslOrder'
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const request = {
+            'orderId': id,
+        };
+        const result = await this.fetchOpenOrders (symbol, undefined, undefined, this.extend (request, params));
+        const length = result.length;
+        if (length === 0) {
+            const isTrigger = this.safeBoolN (params, [ 'trigger', 'stop' ], false);
+            const extra = isTrigger ? '' : 'If you are trying to fetch SL/TP conditional order, you might try setting params["trigger"] = true';
+            throw new OrderNotFound ('Order ' + id.toString () + ' was not found.' + extra);
+        }
+        if (length > 1) {
+            throw new InvalidOrder (this.id + ' returned more than one order');
+        }
+        return this.safeValue (result, 0) as Order;
+    }
+
+    async fetchCanceledAndClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
+        /**
+         * @method
+         * @name bybit#fetchCanceledAndClosedOrders
+         * @description fetches information on multiple canceled and closed orders made by the user
+         * @see https://bybit-exchange.github.io/docs/v5/order/order-list
+         * @param {string} [symbol] unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {boolean} [params.stop] true if stop order
+         * @param {boolean} [params.stop] set to true for fetching stop orders
          * @param {string} [params.type] market type, ['swap', 'option', 'spot']
          * @param {string} [params.subType] market subType, ['linear', 'inverse']
          * @param {string} [params.orderFilter] 'Order' or 'StopOrder' or 'tpslOrder'
          * @param {int} [params.until] the latest time in ms to fetch entries for
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         let paginate = false;
-        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchOrders', 'paginate');
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchCanceledAndClosedOrders', 'paginate');
         if (paginate) {
-            return await this.fetchPaginatedCallCursor ('fetchOrders', symbol, since, limit, params, 'nextPageCursor', 'nextPageCursor', undefined, 50) as Order[];
+            return await this.fetchPaginatedCallCursor ('fetchCanceledAndClosedOrders', symbol, since, limit, params, 'nextPageCursor', 'nextPageCursor', undefined, 50) as Order[];
         }
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         const isUnifiedAccount = (enableUnifiedMargin || enableUnifiedAccount);
@@ -4500,7 +4547,7 @@ export default class bybit extends Exchange {
             request['symbol'] = market['id'];
         }
         let type = undefined;
-        [ type, params ] = this.getBybitType ('fetchOrders', market, params);
+        [ type, params ] = this.getBybitType ('fetchCanceledAndClosedOrders', market, params);
         if (((type === 'option') || isUsdcSettled) && !isUnifiedAccount) {
             return await this.fetchUsdcOrders (symbol, since, limit, params);
         }
@@ -4583,17 +4630,23 @@ export default class bybit extends Exchange {
          * @name bybit#fetchClosedOrders
          * @description fetches information on multiple closed orders made by the user
          * @see https://bybit-exchange.github.io/docs/v5/order/order-list
-         * @param {string} symbol unified market symbol of the market orders were made in
+         * @param {string} [symbol] unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {boolean} [params.stop] set to true for fetching closed stop orders
+         * @param {string} [params.type] market type, ['swap', 'option', 'spot']
+         * @param {string} [params.subType] market subType, ['linear', 'inverse']
+         * @param {string} [params.orderFilter] 'Order' or 'StopOrder' or 'tpslOrder'
+         * @param {int} [params.until] the latest time in ms to fetch entries for
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         const request = {
             'orderStatus': 'Filled',
         };
-        return await this.fetchOrders (symbol, since, limit, this.extend (request, params));
+        return await this.fetchCanceledAndClosedOrders (symbol, since, limit, this.extend (request, params));
     }
 
     async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -4602,20 +4655,23 @@ export default class bybit extends Exchange {
          * @name bybit#fetchCanceledOrders
          * @description fetches information on multiple canceled orders made by the user
          * @see https://bybit-exchange.github.io/docs/v5/order/order-list
-         * @param {string} symbol unified market symbol of the market orders were made in
+         * @param {string} [symbol] unified market symbol of the market orders were made in
          * @param {int} [since] timestamp in ms of the earliest order, default is undefined
          * @param {int} [limit] max number of orders to return, default is undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {boolean} [params.stop] true if stop order
          * @param {string} [params.type] market type, ['swap', 'option', 'spot']
          * @param {string} [params.subType] market subType, ['linear', 'inverse']
+         * @param {string} [params.orderFilter] 'Order' or 'StopOrder' or 'tpslOrder'
+         * @param {int} [params.until] the latest time in ms to fetch entries for
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         const request = {
             'orderStatus': 'Cancelled',
         };
-        return await this.fetchOrders (symbol, since, limit, this.extend (request, params));
+        return await this.fetchCanceledAndClosedOrders (symbol, since, limit, this.extend (request, params));
     }
 
     async fetchUsdcOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -745,6 +745,15 @@
                   "90e3a7b9-20dc-4d04-9259-a565135dbf69",
                   "BTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "spot open order with symbol",
+                "method": "fetchOpenOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/realtime?symbol=LTCUSDT&category=spot&orderId=1620421817225451008",
+                "input": [
+                  "1620421817225451008",
+                  "LTC/USDT"
+                ]
             }
         ],
         "fetchClosedOrder": [
@@ -764,6 +773,15 @@
                 "input": [
                   "1e471313-dd08-4335-a66a-398937d92a51",
                   "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "fetch closed order spot with symbol",
+                "method": "fetchClosedOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/history?symbol=LTCUSDT&category=spot&orderStatus=Filled&orderId=1620421267343808000",
+                "input": [
+                  "1620421267343808000",
+                  "LTC/USDT"
                 ]
             }
         ]

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -517,41 +517,6 @@
                 "input": []
             }
         ],
-        "fetchOrder": [
-            {
-                "description": "Spot fetchOrder",
-                "method": "fetchOrder",
-                "url": "https://api-testnet.bybit.com/v5/order/history?symbol=LTCUSDT&category=spot&orderId=1513125485218108928",
-                "input": [
-                    "1513125485218108928",
-                    "LTC/USDT"
-                ]
-            },
-            {
-                "description": "Swap fetchOrder",
-                "method": "fetchOrder",
-                "url": "https://api-testnet.bybit.com/v5/order/history?symbol=LTCUSDT&category=linear&orderId=8caeea8c-cf80-4b06-83e8-bb7df45fc122",
-                "input": [
-                    "8caeea8c-cf80-4b06-83e8-bb7df45fc122",
-                    "LTC/USDT:USDT"
-                ]
-            }
-        ],
-        "fetchOrders": [
-            {
-                "description": "Spot fetch trigger orders",
-                "method": "fetchOrders",
-                "url": "https://api-testnet.bybit.com/v5/order/history?symbol=BTCUSDT&category=spot&orderFilter=StopOrder",
-                "input": [
-                  "BTC/USDT",
-                  null,
-                  null,
-                  {
-                    "stop": true
-                  }
-                ]
-            }
-        ],
         "fetchMyTrades": [
             {
                 "description": "Spot fetchMyTrades",
@@ -761,6 +726,44 @@
                   }
                 ]
               }
+        ],
+        "fetchOpenOrder": [
+            {
+                "description": "Spot fetch open order",
+                "method": "fetchOpenOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/realtime?category=spot&orderId=1620279018815488768",
+                "input": [
+                  "1620279018815488768"
+                ]
+            },
+            {
+                "description": "Swap fetch open order",
+                "method": "fetchOpenOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/realtime?symbol=BTCUSDT&category=linear&orderId=90e3a7b9-20dc-4d04-9259-a565135dbf69",
+                "input": [
+                  "90e3a7b9-20dc-4d04-9259-a565135dbf69",
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchClosedOrder": [
+            {
+                "description": "Spot fetch closed order",
+                "method": "fetchClosedOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/history?category=spot&orderStatus=Filled&orderId=1620280083321455360",
+                "input": [
+                  "1620280083321455360"
+                ]
+            },
+            {
+                "description": "Swap fetch closed order",
+                "method": "fetchClosedOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/history?symbol=BTCUSDT&category=linear&orderStatus=Filled&orderId=1e471313-dd08-4335-a66a-398937d92a51",
+                "input": [
+                  "1e471313-dd08-4335-a66a-398937d92a51",
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     },
     "disabled": []

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -730,6 +730,7 @@
         "fetchOpenOrder": [
             {
                 "description": "Spot fetch open order",
+                "options": {"defaultType": "spot"},
                 "method": "fetchOpenOrder",
                 "url": "https://api-testnet.bybit.com/v5/order/realtime?category=spot&orderId=1620279018815488768",
                 "input": [
@@ -749,6 +750,7 @@
         "fetchClosedOrder": [
             {
                 "description": "Spot fetch closed order",
+                "options": {"defaultType": "spot"},
                 "method": "fetchClosedOrder",
                 "url": "https://api-testnet.bybit.com/v5/order/history?category=spot&orderStatus=Filled&orderId=1620280083321455360",
                 "input": [

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -61,6 +61,7 @@
     "fetchOrder": [
       {
         "description": "fetch spot buy closed order",
+        "disabled": true,
         "method": "fetchOrder",
         "input": [
           "1609602210852247040",
@@ -206,6 +207,7 @@
       {
         "description": "Spot sell closed order",
         "method": "fetchOrder",
+        "disabled": true,
         "input": [
           "1609604284784580096",
           "XRP/USDT"
@@ -342,6 +344,300 @@
           "fees": [
             {
               "cost": 0.0658173,
+              "currency": "USDT"
+            }
+          ]
+        }
+      }
+    ],
+    "fetchOpenOrder": [
+      {
+        "description": "spot open order",
+        "method": "fetchOpenOrder",
+        "input": [
+          "1620421817225451008",
+          "LTC/USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "1620421817225451008%3A1707905333604%2C1620421817225451008%3A1707905333604",
+            "category": "spot",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "Limit",
+                "orderLinkId": "1620421817225451009",
+                "slLimitPrice": "0",
+                "orderId": "1620421817225451008",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "0.000",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "",
+                "orderStatus": "New",
+                "takeProfit": "0",
+                "cumExecValue": "0.0000000",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "isLeverage": "0",
+                "rejectReason": "EC_NoError",
+                "price": "50.000",
+                "orderIv": "",
+                "createdTime": "1707905333604",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "GTC",
+                "leavesValue": "15.0000000",
+                "updatedTime": "1707905333608",
+                "side": "Buy",
+                "smpGroup": "0",
+                "triggerPrice": "0.000",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0",
+                "leavesQty": "0.30000",
+                "slTriggerBy": "",
+                "closeOnTrigger": false,
+                "placeType": "",
+                "cumExecQty": "0.00000",
+                "reduceOnly": false,
+                "qty": "0.30000",
+                "stopLoss": "0",
+                "marketUnit": "",
+                "smpOrderId": "",
+                "triggerBy": "",
+                "nextPageCursor": "1620421817225451008%3A1707905333604%2C1620421817225451008%3A1707905333604"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905721940"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "LTCUSDT",
+            "orderType": "Limit",
+            "orderLinkId": "1620421817225451009",
+            "slLimitPrice": "0",
+            "orderId": "1620421817225451008",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "0.000",
+            "stopOrderType": "",
+            "lastPriceOnCreated": "",
+            "orderStatus": "New",
+            "takeProfit": "0",
+            "cumExecValue": "0.0000000",
+            "smpType": "None",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "isLeverage": "0",
+            "rejectReason": "EC_NoError",
+            "price": "50.000",
+            "orderIv": "",
+            "createdTime": "1707905333604",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "GTC",
+            "leavesValue": "15.0000000",
+            "updatedTime": "1707905333608",
+            "side": "Buy",
+            "smpGroup": "0",
+            "triggerPrice": "0.000",
+            "tpLimitPrice": "0",
+            "cumExecFee": "0",
+            "leavesQty": "0.30000",
+            "slTriggerBy": "",
+            "closeOnTrigger": false,
+            "placeType": "",
+            "cumExecQty": "0.00000",
+            "reduceOnly": false,
+            "qty": "0.30000",
+            "stopLoss": "0",
+            "marketUnit": "",
+            "smpOrderId": "",
+            "triggerBy": "",
+            "nextPageCursor": "1620421817225451008%3A1707905333604%2C1620421817225451008%3A1707905333604"
+          },
+          "id": "1620421817225451008",
+          "clientOrderId": "1620421817225451009",
+          "timestamp": 1707905333604,
+          "datetime": "2024-02-14T10:08:53.604Z",
+          "lastTradeTimestamp": 1707905333608,
+          "lastUpdateTimestamp": 1707905333608,
+          "symbol": "LTC/USDT",
+          "type": "limit",
+          "timeInForce": "GTC",
+          "postOnly": false,
+          "reduceOnly": false,
+          "side": "buy",
+          "price": 50,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": 0.3,
+          "cost": 0,
+          "average": null,
+          "filled": 0,
+          "remaining": 0.3,
+          "status": "open",
+          "fee": {
+            "cost": "0",
+            "currency": "USDT"
+          },
+          "trades": [],
+          "fees": [
+            {
+              "cost": 0,
+              "currency": "USDT"
+            }
+          ]
+        }
+      }
+    ],
+    "fetchClosedOrder": [
+      {
+        "description": "swap closed order",
+        "method": "fetchClosedOrder",
+        "input": [
+          "01462c4c-5765-4b21-a137-316bb404401d",
+          "LTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "01462c4c-5765-4b21-a137-316bb404401d%3A1707905807328%2C01462c4c-5765-4b21-a137-316bb404401d%3A1707905807328",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "Market",
+                "orderLinkId": "",
+                "slLimitPrice": "0",
+                "orderId": "01462c4c-5765-4b21-a137-316bb404401d",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "70.17",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "70.14",
+                "orderStatus": "Filled",
+                "createType": "CreateByUser",
+                "takeProfit": "",
+                "cumExecValue": "7.017",
+                "tpslMode": "",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "rejectReason": "EC_NoError",
+                "isLeverage": "",
+                "price": "73.64",
+                "orderIv": "",
+                "createdTime": "1707905807328",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0",
+                "updatedTime": "1707905807330",
+                "side": "Buy",
+                "smpGroup": "0",
+                "triggerPrice": "",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0.00385935",
+                "slTriggerBy": "",
+                "leavesQty": "0",
+                "closeOnTrigger": false,
+                "placeType": "",
+                "cumExecQty": "0.1",
+                "reduceOnly": false,
+                "qty": "0.1",
+                "stopLoss": "",
+                "smpOrderId": "",
+                "triggerBy": "",
+                "nextPageCursor": "01462c4c-5765-4b21-a137-316bb404401d%3A1707905807328%2C01462c4c-5765-4b21-a137-316bb404401d%3A1707905807328"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905849583"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "LTCUSDT",
+            "orderType": "Market",
+            "orderLinkId": "",
+            "slLimitPrice": "0",
+            "orderId": "01462c4c-5765-4b21-a137-316bb404401d",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "70.17",
+            "stopOrderType": "",
+            "lastPriceOnCreated": "70.14",
+            "orderStatus": "Filled",
+            "createType": "CreateByUser",
+            "takeProfit": "",
+            "cumExecValue": "7.017",
+            "tpslMode": "",
+            "smpType": "None",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "rejectReason": "EC_NoError",
+            "isLeverage": "",
+            "price": "73.64",
+            "orderIv": "",
+            "createdTime": "1707905807328",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "IOC",
+            "leavesValue": "0",
+            "updatedTime": "1707905807330",
+            "side": "Buy",
+            "smpGroup": "0",
+            "triggerPrice": "",
+            "tpLimitPrice": "0",
+            "cumExecFee": "0.00385935",
+            "slTriggerBy": "",
+            "leavesQty": "0",
+            "closeOnTrigger": false,
+            "placeType": "",
+            "cumExecQty": "0.1",
+            "reduceOnly": false,
+            "qty": "0.1",
+            "stopLoss": "",
+            "smpOrderId": "",
+            "triggerBy": "",
+            "nextPageCursor": "01462c4c-5765-4b21-a137-316bb404401d%3A1707905807328%2C01462c4c-5765-4b21-a137-316bb404401d%3A1707905807328"
+          },
+          "id": "01462c4c-5765-4b21-a137-316bb404401d",
+          "clientOrderId": null,
+          "timestamp": 1707905807328,
+          "datetime": "2024-02-14T10:16:47.328Z",
+          "lastTradeTimestamp": 1707905807330,
+          "lastUpdateTimestamp": 1707905807330,
+          "symbol": "LTC/USDT:USDT",
+          "type": "market",
+          "timeInForce": "IOC",
+          "postOnly": false,
+          "reduceOnly": false,
+          "side": "buy",
+          "price": 73.64,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": 0.1,
+          "cost": 7.017,
+          "average": 70.17,
+          "filled": 0.1,
+          "remaining": 0,
+          "status": "closed",
+          "fee": {
+            "cost": "0.00385935",
+            "currency": "USDT"
+          },
+          "trades": [],
+          "fees": [
+            {
+              "cost": 0.00385935,
               "currency": "USDT"
             }
           ]
@@ -1209,6 +1505,244 @@
           "datetime": "2024-02-01T16:13:09.954Z",
           "nonce": null
         }
+      }
+    ],
+    "fetchTrades": [
+      {
+        "description": "swap public trade",
+        "method": "fetchTrades",
+        "input": [
+          "BTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "execId": "9afd1288-b444-53f8-8e40-c2f99368ad22",
+                "symbol": "BTCUSDT",
+                "price": "51444.40",
+                "size": "0.972",
+                "side": "Buy",
+                "time": "1707905515968",
+                "isBlockTrade": false
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905516443"
+        },
+        "parsedResponse": [
+          {
+            "id": "9afd1288-b444-53f8-8e40-c2f99368ad22",
+            "info": {
+              "execId": "9afd1288-b444-53f8-8e40-c2f99368ad22",
+              "symbol": "BTCUSDT",
+              "price": "51444.40",
+              "size": "0.972",
+              "side": "Buy",
+              "time": "1707905515968",
+              "isBlockTrade": false
+            },
+            "timestamp": 1707905515968,
+            "datetime": "2024-02-14T10:11:55.968Z",
+            "symbol": "BTC/USDT:USDT",
+            "order": null,
+            "type": null,
+            "side": "buy",
+            "takerOrMaker": null,
+            "price": 51444.4,
+            "amount": 0.972,
+            "cost": 50003.9568,
+            "fee": null,
+            "fees": []
+          }
+        ]
+      }
+    ],
+    "fetchTicker": [
+      {
+        "description": "swap ticker",
+        "method": "fetchTicker",
+        "input": [
+          "BTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "lastPrice": "51444.40",
+                "indexPrice": "51469.95",
+                "markPrice": "51444.40",
+                "prevPrice24h": "50147.50",
+                "price24hPcnt": "0.025861",
+                "highPrice24h": "51444.40",
+                "lowPrice24h": "48381.60",
+                "prevPrice1h": "50999.90",
+                "openInterest": "225766.793",
+                "openInterestValue": "11614437205.81",
+                "turnover24h": "2352063794.0035",
+                "volume24h": "47293.8870",
+                "fundingRate": "-0.00046295",
+                "nextFundingTime": "1707926400000",
+                "predictedDeliveryPrice": "",
+                "basisRate": "",
+                "deliveryFeeRate": "",
+                "deliveryTime": "0",
+                "ask1Size": "491.691",
+                "bid1Price": "51444.30",
+                "ask1Price": "51444.40",
+                "bid1Size": "55.841",
+                "basis": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905549267"
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT:USDT",
+          "timestamp": null,
+          "datetime": null,
+          "high": 51444.4,
+          "low": 48381.6,
+          "bid": 51444.3,
+          "bidVolume": 55.841,
+          "ask": 51444.4,
+          "askVolume": 491.691,
+          "vwap": 49732.93470260755,
+          "open": 50147.5,
+          "close": 51444.4,
+          "last": 51444.4,
+          "previousClose": null,
+          "change": 1296.9,
+          "percentage": 2.5861,
+          "average": 50795.95,
+          "baseVolume": 47293.887,
+          "quoteVolume": 2352063794.0035,
+          "info": {
+            "symbol": "BTCUSDT",
+            "lastPrice": "51444.40",
+            "indexPrice": "51469.95",
+            "markPrice": "51444.40",
+            "prevPrice24h": "50147.50",
+            "price24hPcnt": "0.025861",
+            "highPrice24h": "51444.40",
+            "lowPrice24h": "48381.60",
+            "prevPrice1h": "50999.90",
+            "openInterest": "225766.793",
+            "openInterestValue": "11614437205.81",
+            "turnover24h": "2352063794.0035",
+            "volume24h": "47293.8870",
+            "fundingRate": "-0.00046295",
+            "nextFundingTime": "1707926400000",
+            "predictedDeliveryPrice": "",
+            "basisRate": "",
+            "deliveryFeeRate": "",
+            "deliveryTime": "0",
+            "ask1Size": "491.691",
+            "bid1Price": "51444.30",
+            "ask1Price": "51444.40",
+            "bid1Size": "55.841",
+            "basis": ""
+          }
+        }
+      }
+    ],
+    "fetchLedger": [
+      {
+        "description": "fetch ledger",
+        "method": "fetchLedger",
+        "input": [
+          "USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "5579768%3A0%2C5579768%3A0",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "side": "Buy",
+                "funding": "-0.0006935",
+                "orderLinkId": "",
+                "orderId": "4211a103-d410-4168-b788-0a09bbb1edcc",
+                "fee": "0",
+                "change": "-0.0006935",
+                "cashFlow": "0",
+                "transactionTime": "1707897600000",
+                "type": "SETTLEMENT",
+                "feeRate": "0.0001",
+                "bonusChange": "0",
+                "size": "0.1",
+                "qty": "0.1",
+                "cashBalance": "94.05070437",
+                "currency": "USDT",
+                "id": "452265_LTCUSDT_157751525050",
+                "category": "linear",
+                "tradePrice": "69.35",
+                "tradeId": "25cf3f0b-230e-4c30-82f1-24d060592d89",
+                "nextPageCursor": "5579768%3A0%2C5579768%3A0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905594088"
+        },
+        "parsedResponse": [
+          {
+            "id": "452265_LTCUSDT_157751525050",
+            "currency": "USDT",
+            "account": null,
+            "referenceAccount": null,
+            "referenceId": null,
+            "status": null,
+            "amount": 0.0006935,
+            "before": 94.05001087,
+            "after": 94.05070437,
+            "fee": 0,
+            "direction": "out",
+            "timestamp": 1707897600000,
+            "datetime": "2024-02-14T08:00:00.000Z",
+            "type": "trade",
+            "info": {
+              "symbol": "LTCUSDT",
+              "side": "Buy",
+              "funding": "-0.0006935",
+              "orderLinkId": "",
+              "orderId": "4211a103-d410-4168-b788-0a09bbb1edcc",
+              "fee": "0",
+              "change": "-0.0006935",
+              "cashFlow": "0",
+              "transactionTime": "1707897600000",
+              "type": "SETTLEMENT",
+              "feeRate": "0.0001",
+              "bonusChange": "0",
+              "size": "0.1",
+              "qty": "0.1",
+              "cashBalance": "94.05070437",
+              "currency": "USDT",
+              "id": "452265_LTCUSDT_157751525050",
+              "category": "linear",
+              "tradePrice": "69.35",
+              "tradeId": "25cf3f0b-230e-4c30-82f1-24d060592d89",
+              "nextPageCursor": "5579768%3A0%2C5579768%3A0"
+            }
+          }
+        ]
       }
     ]
   }

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -1569,9 +1569,7 @@
         "description": "swap ticker",
         "method": "fetchTicker",
         "input": [
-          "BTC/USDT:USDT",
-          null,
-          1
+          "BTC/USDT:USDT"
         ],
         "httpResponse": {
           "retCode": "0",


### PR DESCRIPTION
Added support for `fetchOpenOrder` and `fetchClosedOrder`
Removed support for `fetchOrder` and `fetchOrders`
Throw an error if the user calls fetchOrder or fetchOrders and suggest using fetchOpenOrder(s)/fetchClosedOrder(s).

```
bybit.fetchOpenOrder (90e3a7b9-20dc-4d04-9259-a565135dbf69, BTC/USDT:USDT)
2024-02-14T05:22:01.084Z iteration 0 passed in 1119 ms

{
  info: {
    symbol: 'BTCUSDT',
    orderType: 'Limit',
    orderLinkId: '',
    slLimitPrice: '0',
    orderId: '90e3a7b9-20dc-4d04-9259-a565135dbf69',
    cancelType: 'UNKNOWN',
    avgPrice: '',
    stopOrderType: '',
    lastPriceOnCreated: '49601.3',
    orderStatus: 'New',
    createType: 'CreateByUser',
    takeProfit: '',
    cumExecValue: '0',
    tpslMode: '',
    smpType: 'None',
    triggerDirection: '0',
    blockTradeId: '',
    isLeverage: '',
    rejectReason: 'EC_NoError',
    price: '35000',
    orderIv: '',
    createdTime: '1707881064490',
    tpTriggerBy: '',
    positionIdx: '0',
    timeInForce: 'GTC',
    leavesValue: '35',
    updatedTime: '1707881064493',
    side: 'Buy',
    smpGroup: '0',
    triggerPrice: '',
    tpLimitPrice: '0',
    cumExecFee: '0',
    leavesQty: '0.001',
    slTriggerBy: '',
    closeOnTrigger: false,
    placeType: '',
    cumExecQty: '0',
    reduceOnly: false,
    qty: '0.001',
    stopLoss: '',
    marketUnit: '',
    smpOrderId: '',
    triggerBy: '',
    nextPageCursor: '90e3a7b9-20dc-4d04-9259-a565135dbf69%3A1707881064490%2C90e3a7b9-20dc-4d04-9259-a565135dbf69%3A1707881064490'
  },
  id: '90e3a7b9-20dc-4d04-9259-a565135dbf69',
  timestamp: 1707881064490,
  datetime: '2024-02-14T03:24:24.490Z',
  lastTradeTimestamp: 1707881064493,
  lastUpdateTimestamp: 1707881064493,
  symbol: 'BTC/USDT:USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 35000,
  amount: 0.001,
  cost: 0,
  filled: 0,
  remaining: 0.001,
  status: 'open',
  fee: { cost: '0', currency: 'USDT' },
  trades: [],
  fees: [ { cost: 0, currency: 'USDT' } ]
}
```
```
bybit.fetchOpenOrder (1620279018815488768)
2024-02-14T05:25:38.397Z iteration 0 passed in 718 ms

{
  info: {
    symbol: 'BTCUSDT',
    orderType: 'Limit',
    orderLinkId: '1620279018815488769',
    slLimitPrice: '0',
    orderId: '1620279018815488768',
    cancelType: 'UNKNOWN',
    avgPrice: '0.00',
    stopOrderType: '',
    lastPriceOnCreated: '',
    orderStatus: 'New',
    takeProfit: '0',
    cumExecValue: '0.00000000',
    smpType: 'None',
    triggerDirection: '0',
    blockTradeId: '',
    isLeverage: '0',
    rejectReason: 'EC_NoError',
    price: '30000.00',
    orderIv: '',
    createdTime: '1707888310706',
    tpTriggerBy: '',
    positionIdx: '0',
    timeInForce: 'GTC',
    leavesValue: '45.00000000',
    updatedTime: '1707888310709',
    side: 'Buy',
    smpGroup: '0',
    triggerPrice: '0.00',
    tpLimitPrice: '0',
    cumExecFee: '0',
    leavesQty: '0.001500',
    slTriggerBy: '',
    closeOnTrigger: false,
    placeType: '',
    cumExecQty: '0.000000',
    reduceOnly: false,
    qty: '0.001500',
    stopLoss: '0',
    marketUnit: '',
    smpOrderId: '',
    triggerBy: '',
    nextPageCursor: '1620279018815488768%3A1707888310706%2C1620279018815488768%3A1707888310706'
  },
  id: '1620279018815488768',
  clientOrderId: '1620279018815488769',
  timestamp: 1707888310706,
  datetime: '2024-02-14T05:25:10.706Z',
  lastTradeTimestamp: 1707888310709,
  lastUpdateTimestamp: 1707888310709,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 30000,
  amount: 0.0015,
  cost: 0,
  filled: 0,
  remaining: 0.0015,
  status: 'open',
  fee: { cost: '0', currency: 'USDT' },
  trades: [],
  fees: [ { cost: 0, currency: 'USDT' } ]
}
```
```
bybit.fetchClosedOrder (1620280083321455360)
2024-02-14T05:27:45.753Z iteration 0 passed in 1108 ms

{
  info: {
    symbol: 'BTCUSDT',
    orderType: 'Market',
    orderLinkId: '1620280083321455361',
    slLimitPrice: '0',
    orderId: '1620280083321455360',
    cancelType: 'UNKNOWN',
    avgPrice: '33674.45',
    stopOrderType: '',
    lastPriceOnCreated: '',
    orderStatus: 'Filled',
    takeProfit: '0',
    cumExecValue: '50.51168952',
    smpType: 'None',
    triggerDirection: '0',
    blockTradeId: '',
    rejectReason: 'EC_NoError',
    isLeverage: '0',
    price: '0',
    orderIv: '',
    createdTime: '1707888437606',
    tpTriggerBy: '',
    positionIdx: '0',
    timeInForce: 'IOC',
    leavesValue: '2.30257548',
    updatedTime: '1707888437609',
    side: 'Buy',
    smpGroup: '0',
    triggerPrice: '0.00',
    tpLimitPrice: '0',
    cumExecFee: '0.0000015',
    slTriggerBy: '',
    leavesQty: '0.000000',
    closeOnTrigger: false,
    placeType: '',
    cumExecQty: '0.001500',
    reduceOnly: false,
    qty: '0.001500',
    stopLoss: '0',
    marketUnit: 'baseCoin',
    smpOrderId: '',
    triggerBy: '',
    nextPageCursor: '1620280083321455360%3A1707888437606%2C1620280083321455360%3A1707888437606'
  },
  id: '1620280083321455360',
  clientOrderId: '1620280083321455361',
  timestamp: 1707888437606,
  datetime: '2024-02-14T05:27:17.606Z',
  lastTradeTimestamp: 1707888437609,
  lastUpdateTimestamp: 1707888437609,
  symbol: 'BTC/USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 33674.45,
  amount: 0.0015,
  cost: 50.51168952,
  average: 33674.45,
  filled: 0.0015,
  remaining: 0,
  status: 'closed',
  fee: { cost: '0.0000015', currency: 'BTC' },
  trades: [],
  fees: [ { cost: 0.0000015, currency: 'BTC' } ]
}
```
```
bybit.fetchClosedOrder (1e471313-dd08-4335-a66a-398937d92a51, BTC/USDT:USDT)
2024-02-14T05:30:01.582Z iteration 0 passed in 716 ms

{
  info: {
    symbol: 'BTCUSDT',
    orderType: 'Market',
    orderLinkId: '',
    slLimitPrice: '0',
    orderId: '1e471313-dd08-4335-a66a-398937d92a51',
    cancelType: 'UNKNOWN',
    avgPrice: '49504.1',
    stopOrderType: '',
    lastPriceOnCreated: '49501.6',
    orderStatus: 'Filled',
    createType: 'CreateByUser',
    takeProfit: '',
    cumExecValue: '49.5041',
    tpslMode: '',
    smpType: 'None',
    triggerDirection: '0',
    blockTradeId: '',
    rejectReason: 'EC_NoError',
    isLeverage: '',
    price: '51976.6',
    orderIv: '',
    createdTime: '1707888575193',
    tpTriggerBy: '',
    positionIdx: '0',
    timeInForce: 'IOC',
    leavesValue: '0',
    updatedTime: '1707888575196',
    side: 'Buy',
    smpGroup: '0',
    triggerPrice: '',
    tpLimitPrice: '0',
    cumExecFee: '0.02722726',
    slTriggerBy: '',
    leavesQty: '0',
    closeOnTrigger: false,
    placeType: '',
    cumExecQty: '0.001',
    reduceOnly: false,
    qty: '0.001',
    stopLoss: '',
    smpOrderId: '',
    triggerBy: '',
    nextPageCursor: '1e471313-dd08-4335-a66a-398937d92a51%3A1707888575193%2C1e471313-dd08-4335-a66a-398937d92a51%3A1707888575193'
  },
  id: '1e471313-dd08-4335-a66a-398937d92a51',
  timestamp: 1707888575193,
  datetime: '2024-02-14T05:29:35.193Z',
  lastTradeTimestamp: 1707888575196,
  lastUpdateTimestamp: 1707888575196,
  symbol: 'BTC/USDT:USDT',
  type: 'market',
  timeInForce: 'IOC',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 51976.6,
  amount: 0.001,
  cost: 49.5041,
  average: 49504.1,
  filled: 0.001,
  remaining: 0,
  status: 'closed',
  fee: { cost: '0.02722726', currency: 'USDT' },
  trades: [],
  fees: [ { cost: 0.02722726, currency: 'USDT' } ]
}
```