### PR TITLE
timex: fetchDepositAddress, implodeParams used in sign

### DIFF
--- a/ts/src/test/static/request/timex.json
+++ b/ts/src/test/static/request/timex.json
@@ -56,6 +56,16 @@
                     }
                 ]
             }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "Basic call",
+                "method": "fetchDepositAddress",
+                "url": "https://plasma-relay-backend.timex.io/currencies/s/BTC?symbol=BTC",
+                "input": [
+                    "BTC"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/timex.json
+++ b/ts/src/test/static/request/timex.json
@@ -61,7 +61,7 @@
             {
                 "description": "Basic call",
                 "method": "fetchDepositAddress",
-                "url": "https://plasma-relay-backend.timex.io/currencies/s/BTC?symbol=BTC",
+                "url": "https://plasma-relay-backend.timex.io/currencies/s/BTC",
                 "input": [
                     "BTC"
                 ]

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -40,6 +40,9 @@ export default class timex extends Exchange {
                 'fetchCrossBorrowRates': false,
                 'fetchCurrencies': true,
                 'fetchDeposit': false,
+                'fetchDepositAddress': true,
+                'fetchDepositAddresses': false,
+                'fetchDepositAddressesByNetwork': false,
                 'fetchDeposits': true,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
@@ -1541,6 +1544,67 @@ export default class timex extends Exchange {
             'fee': undefined,
             'trades': rawTrades,
         }, market);
+    }
+
+    async fetchDepositAddress (code: string, params = {}) {
+        /**
+         * @method
+         * @name bitget#fetchDepositAddress
+         * @description fetch the deposit address for a currency associated with this account, does not accept params["network"]
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'symbol': currency['code'],
+        };
+        const response = await this.currenciesGetSSymbol (this.extend (request, params));
+        //
+        //    {
+        //        id: '1',
+        //        currency: {
+        //            symbol: 'BTC',
+        //            name: 'Bitcoin',
+        //            address: '0x8370fbc6ddec1e18b4e41e72ed943e238458487c',
+        //            decimals: '8',
+        //            tradeDecimals: '20',
+        //            fiatSymbol: 'BTC',
+        //            depositEnabled: true,
+        //            withdrawalEnabled: true,
+        //            transferEnabled: true,
+        //            active: true
+        //        }
+        //    }
+        //
+        const data = this.safeValue (response, 'currency', {});
+        return this.parseDepositAddress (data, currency);
+    }
+
+    parseDepositAddress (depositAddress, currency: Currency = undefined) {
+        //
+        //    {
+        //        symbol: 'BTC',
+        //        name: 'Bitcoin',
+        //        address: '0x8370fbc6ddec1e18b4e41e72ed943e238458487c',
+        //        decimals: '8',
+        //        tradeDecimals: '20',
+        //        fiatSymbol: 'BTC',
+        //        depositEnabled: true,
+        //        withdrawalEnabled: true,
+        //        transferEnabled: true,
+        //        active: true
+        //    }
+        //
+        const currencyId = this.safeString (depositAddress, 'symbol');
+        return {
+            'info': depositAddress,
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'address': this.safeString (depositAddress, 'address'),
+            'tag': undefined,
+            'network': undefined,
+        };
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -1549,7 +1549,7 @@ export default class timex extends Exchange {
     async fetchDepositAddress (code: string, params = {}) {
         /**
          * @method
-         * @name bitget#fetchDepositAddress
+         * @name timex#fetchDepositAddress
          * @description fetch the deposit address for a currency associated with this account, does not accept params["network"]
          * @param {string} code unified currency code
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1578,7 +1578,7 @@ export default class timex extends Exchange {
         //        }
         //    }
         //
-        const data = this.safeValue (response, 'currency', {});
+        const data = this.safeDict (response, 'currency', {});
         return this.parseDepositAddress (data, currency);
     }
 
@@ -1608,8 +1608,9 @@ export default class timex extends Exchange {
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+        const paramsToExtract = this.extractParams (path);
         path = this.implodeParams (path, params);
-        params = this.omit (params, this.extractParams (path));
+        params = this.omit (params, paramsToExtract);
         let url = this.urls['api']['rest'] + '/' + api + '/' + path;
         if (Object.keys (params).length) {
             url += '?' + this.urlencodeWithArrayRepeat (params);

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -1544,6 +1544,8 @@ export default class timex extends Exchange {
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
+        path = this.implodeParams (path, params);
+        params = this.omit (params, this.extractParams (path));
         let url = this.urls['api']['rest'] + '/' + api + '/' + path;
         if (Object.keys (params).length) {
             url += '?' + this.urlencodeWithArrayRepeat (params);


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.45
timex.fetchDepositAddress(BTC)
{'address': '0x8370fbc6ddec1e18b4e41e72ed943e238458487c',
 'currency': 'BTC',
 'info': {'active': True,
          'address': '0x8370fbc6ddec1e18b4e41e72ed943e238458487c',
          'decimals': '8',
          'depositEnabled': True,
          'fiatSymbol': 'BTC',
          'name': 'Bitcoin',
          'symbol': 'BTC',
          'tradeDecimals': '20',
          'transferEnabled': True,
          'withdrawalEnabled': True},
 'network': None,
 'tag': None}
 ```