### PR TITLE
feat(idex): fetchDepositAddress

### DIFF
--- a/ts/src/test/static/request/idex.json
+++ b/ts/src/test/static/request/idex.json
@@ -24,6 +24,12 @@
                     "USDT"
                 ]
             }
-        ]
+        ],
+        "fetchDepositAddress": {
+            "description": "Fetch Deposit Address",
+            "method": "fetchDepositAddress",
+            "url": "https://api-matic.idex.io/v1/wallets?nonce=1ab69e90cbbc11ee9696ffffffffffff",
+            "input": []
+          }
     }
 }

--- a/ts/src/test/static/request/idex.json
+++ b/ts/src/test/static/request/idex.json
@@ -25,11 +25,13 @@
                 ]
             }
         ],
-        "fetchDepositAddress": {
-            "description": "Fetch Deposit Address",
-            "method": "fetchDepositAddress",
-            "url": "https://api-matic.idex.io/v1/wallets?nonce=1ab69e90cbbc11ee9696ffffffffffff",
-            "input": []
-          }
+        "fetchDepositAddress": [
+            {
+                "description": "Fetch Deposit Address",
+                "method": "fetchDepositAddress",
+                "url": "https://api-matic.idex.io/v1/wallets?nonce=1ab69e90cbbc11ee9696ffffffffffff",
+                "input": []
+            }
+        ]
     }
 }


### PR DESCRIPTION
Idex can only fetch these 2 depositAddresses, I don't know where the first one comes from, but the second is the one that is linked to my metamask and is the address that shows up everywhere on idex

# Testing
```
% py idex fetchDepositAddress BTC
Python v3.9.6
CCXT v4.2.45
idex.fetchDepositAddress(BTC)
{'address': '0x0Ef3456E616552238B0c562d409507Ed6051A7b3',
 'currency': None,
 'info': [{'address': '0x37A1827CA64C94A26028bDCb43FBDCB0bf6DAf5B',
           'time': '1678342148086',
           'totalPortfolioValueUsd': '0.00'},
          {'address': '0x0Ef3456E616552238B0c562d409507Ed6051A7b3',
           'time': '1691697811659',
           'totalPortfolioValueUsd': '15.83'}],
 'network': 'MATIC',
 'tag': None}
```