### PR TITLE
fix(hitbtc) watchTicker never receives ticker

### DIFF
--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -323,7 +323,7 @@ export default class hitbtc extends hitbtcRest {
                 'symbols': [ market['id'] ],
             },
         };
-        const result = await this.subscribePublic (name, 'ticker', [ symbol ], this.deepExtend (request, params));
+        const result = await this.subscribePublic (name, 'tickers', [ symbol ], this.deepExtend (request, params));
         return this.safeValue (result, symbol);
     }
 

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -407,7 +407,6 @@ export default class hitbtc extends hitbtcRest {
         //
         const data = this.safeValue (message, 'data', {});
         const marketIds = Object.keys (data);
-        const channel = this.safeString (message, 'ch');
         const newTickers = {};
         for (let i = 0; i < marketIds.length; i++) {
             const marketId = marketIds[i];
@@ -416,8 +415,6 @@ export default class hitbtc extends hitbtcRest {
             const ticker = this.parseWsTicker (data[marketId], market);
             this.tickers[symbol] = ticker;
             newTickers[symbol] = ticker;
-            const messageHash = 'tickers::' + symbol;
-            client.resolve (newTickers, messageHash);
         }
         client.resolve (newTickers, 'tickers');
         const messageHashes = this.findMessageHashes (client, 'tickers::');
@@ -433,7 +430,6 @@ export default class hitbtc extends hitbtcRest {
                 client.resolve (tickers, messageHash);
             }
         }
-        client.resolve (this.tickers, channel);
         return message;
     }
 

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -226,7 +226,7 @@ export default class hitbtc extends hitbtcRest {
                 'symbols': [ market['id'] ],
             },
         };
-        const orderbook = await this.subscribePublic (name, name, [ symbol ], this.deepExtend (request, params));
+        const orderbook = await this.subscribePublic (name, 'orderbooks', [ symbol ], this.deepExtend (request, params));
         return orderbook.limit ();
     }
 
@@ -262,7 +262,7 @@ export default class hitbtc extends hitbtcRest {
             const market = this.safeMarket (marketId);
             const symbol = market['symbol'];
             const item = data[marketId];
-            const messageHash = channel + '::' + symbol;
+            const messageHash = 'orderbooks::' + symbol;
             if (!(symbol in this.orderbooks)) {
                 const subscription = this.safeValue (client.subscriptions, messageHash, {});
                 const limit = this.safeInteger (subscription, 'limit');
@@ -416,7 +416,7 @@ export default class hitbtc extends hitbtcRest {
             const ticker = this.parseWsTicker (data[marketId], market);
             this.tickers[symbol] = ticker;
             newTickers[symbol] = ticker;
-            const messageHash = channel + '::' + symbol;
+            const messageHash = 'tickers::' + symbol;
             client.resolve (newTickers, messageHash);
         }
         client.resolve (newTickers, 'tickers');
@@ -516,7 +516,7 @@ export default class hitbtc extends hitbtcRest {
             request['limit'] = limit;
         }
         const name = 'trades';
-        const trades = await this.subscribePublic (name, name, [ symbol ], this.deepExtend (request, params));
+        const trades = await this.subscribePublic (name, 'trades', [ symbol ], this.deepExtend (request, params));
         if (this.newUpdates) {
             limit = trades.getLimit (symbol, limit);
         }
@@ -649,7 +649,7 @@ export default class hitbtc extends hitbtcRest {
         if (limit !== undefined) {
             request['params']['limit'] = limit;
         }
-        const ohlcv = await this.subscribePublic (name, name, [ symbol ], this.deepExtend (request, params));
+        const ohlcv = await this.subscribePublic (name, 'candles', [ symbol ], this.deepExtend (request, params));
         if (this.newUpdates) {
             limit = ohlcv.getLimit (symbol, limit);
         }
@@ -711,7 +711,7 @@ export default class hitbtc extends hitbtcRest {
             for (let j = 0; j < ohlcvs.length; j++) {
                 stored.append (ohlcvs[j]);
             }
-            const messageHash = channel + '::' + symbol;
+            const messageHash = 'candles::' + symbol;
             client.resolve (stored, messageHash);
         }
         return message;


### PR DESCRIPTION
All subscription hashes for all public watch functions have been unified. This...
- fixes watchTicker issue, where no ticker was ever received
- avoids confusion with (and dependency on) channel names on the exchange
- never uses any parameter (like the period for candles) because ccxt caching mechanism doesn't support that

Removed invalid client.resolve statement, where subscriptions could have received tickers for symbols they did not describe to.

Removed superfluous client.resolve statement for a hash that was never used.

