### PR TITLE
binance: fetchPositionsRisk, remove empty positions

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -9692,12 +9692,12 @@ export default class binance extends Exchange {
         /**
          * @method
          * @name binance#fetchPositions
+         * @description fetch all open positions
          * @see https://binance-docs.github.io/apidocs/futures/en/#position-information-v2-user_data
          * @see https://binance-docs.github.io/apidocs/delivery/en/#position-information-user_data
          * @see https://binance-docs.github.io/apidocs/futures/en/#account-information-v2-user_data
          * @see https://binance-docs.github.io/apidocs/delivery/en/#account-information-user_data
          * @see https://binance-docs.github.io/apidocs/voptions/en/#option-position-information-user_data
-         * @description fetch all open positions
          * @param {string[]} [symbols] list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [method] method name to call, "positionRisk", "account" or "option", default is "positionRisk"
@@ -9912,7 +9912,10 @@ export default class binance extends Exchange {
         const result = [];
         for (let i = 0; i < response.length; i++) {
             const parsed = this.parsePositionRisk (response[i]);
-            result.push (parsed);
+            const entryPrice = this.safeString (parsed, 'entryPrice');
+            if ((entryPrice !== '0') && (entryPrice !== '0.0') && (entryPrice !== '0.00000000')) {
+                result.push (parsed);
+            }
         }
         symbols = this.marketSymbols (symbols);
         return this.filterByArrayPositions (result, 'symbol', symbols, false);


### PR DESCRIPTION
Edited fetchPositionsRisk so that empty positions aren't returned:

```
binanceusdm.fetchPositions ()
2024-02-16T05:28:28.307Z iteration 0 passed in 1393 ms

       symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice |    collateral |   notional |   markPrice |     entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin |  maintenanceMarginPercentage | marginRatio |                 datetime | marginMode | marginType |  side | hedged | percentage
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
LTC/USDT:USDT |      0.09 |            1 |   -0.48961808 |        5 |   51285.51835039 | 4639.84852977 | 6.33976808 | 70.44186756 | 65.00166666667 | 1704897291072 |    1.26795361 |                     0.2 |     0.04120849252 |                       0.0065 |           0 | 2024-01-10T14:34:51.072Z |      cross |      cross | short |  false |     -38.61
ADA/USDT:USDT |       200 |            1 |      62.11822 |       20 |                  |        58.742 |  120.86022 |   0.6043011 |        0.29371 | 1698749102911 |      6.043011 |                    0.05 |        0.78559143 |                       0.0065 |      0.0134 | 2023-10-31T10:45:02.911Z |      cross |      cross |  long |  false |    1027.93
BTC/USDT:USDT |     0.022 |            1 |  207.76915409 |        3 |                  |   940.4394459 |  1148.2086 |     52191.3 | 42747.24754098 | 1704739307325 |  382.73619617 |              0.33333333 |         4.5928344 |                        0.004 |      0.0049 | 2024-01-08T18:41:47.325Z |      cross |      cross |  long |  false |      54.28
3 objects
```
```
binancecoinm.fetchPositions ()
2024-02-16T05:29:15.456Z iteration 0 passed in 1082 ms

     symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral |   notional |      markPrice |     entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage | marginRatio |                 datetime | marginMode | marginType | side | hedged | percentage
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USD:BTC |         1 |          100 |    0.00280774 |       20 |      10.04505871 | 9.99024053 | 0.00191569 | 52200.33023486 | 21170.99999979 | 1673947276562 |    0.00009578 |                    0.05 |     0.00000766276 |                       0.004 |           0 | 2023-01-17T09:21:16.562Z |      cross |      cross | long |  false |    2931.44
1 objects
```
```
binance.fetchPositions (, [object Object])
2024-02-16T05:30:21.300Z iteration 0 passed in 1623 ms

     symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral |  notional | markPrice |     entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage |                 datetime | side | hedged
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USD:ETH |         1 |           10 |    0.00048221 |      100 |     188.45617828 |          0 | 0.0035152 |   2844.79 | 2501.620000018 | 1707550448601 |    0.00003515 |                    0.01 |       0.000017576 |                       0.005 | 2024-02-10T07:34:08.601Z | long |   true
1 objects
```
```
binance.fetchPositions (, [object Object])
2024-02-16T05:30:40.895Z iteration 0 passed in 1398 ms

       symbol | contracts | contractSize | unrealizedPnl | leverage | liquidationPrice | collateral |     notional |      markPrice | entryPrice |     timestamp | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage |                 datetime | side | hedged
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USDT:USDT |      0.01 |            1 |   49.27083305 |      100 |   37998.90272252 |          0 | 522.06483305 | 52206.48330496 |    47279.4 | 1707550415587 |    5.22064833 |                    0.01 |      2.0882593322 |                       0.004 | 2024-02-10T07:33:35.587Z | long |   true
1 objects
```