### PR TITLE
binance: edit fetchBalance, portfolio margin

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3153,25 +3153,35 @@ export default class binance extends Exchange {
         return account;
     }
 
-    parseBalanceCustom (response, type = undefined, marginMode = undefined): Balances {
+    parseBalanceCustom (response, type = undefined, marginMode = undefined, isPortfolioMargin = false): Balances {
         const result = {
             'info': response,
         };
         let timestamp = undefined;
         const isolated = marginMode === 'isolated';
         const cross = (type === 'margin') || (marginMode === 'cross');
-        if (type === 'papi') {
+        if (isPortfolioMargin) {
             for (let i = 0; i < response.length; i++) {
                 const entry = response[i];
                 const account = this.account ();
                 const currencyId = this.safeString (entry, 'asset');
                 const code = this.safeCurrencyCode (currencyId);
-                const borrowed = this.safeString (entry, 'crossMarginBorrowed');
-                const interest = this.safeString (entry, 'crossMarginInterest');
-                account['free'] = this.safeString (entry, 'crossMarginFree');
-                account['used'] = this.safeString (entry, 'crossMarginLocked');
-                account['total'] = this.safeString (entry, 'crossMarginAsset');
-                account['debt'] = Precise.stringAdd (borrowed, interest);
+                if (type === 'linear') {
+                    account['free'] = this.safeString (entry, 'umWalletBalance');
+                    account['used'] = this.safeString (entry, 'umUnrealizedPNL');
+                } else if (type === 'inverse') {
+                    account['free'] = this.safeString (entry, 'cmWalletBalance');
+                    account['used'] = this.safeString (entry, 'cmUnrealizedPNL');
+                } else if (cross) {
+                    const borrowed = this.safeString (entry, 'crossMarginBorrowed');
+                    const interest = this.safeString (entry, 'crossMarginInterest');
+                    account['debt'] = Precise.stringAdd (borrowed, interest);
+                    account['free'] = this.safeString (entry, 'crossMarginFree');
+                    account['used'] = this.safeString (entry, 'crossMarginLocked');
+                    account['total'] = this.safeString (entry, 'crossMarginAsset');
+                } else {
+                    account['total'] = this.safeString (entry, 'totalWalletBalance');
+                }
                 result[code] = account;
             }
         } else if (!isolated && ((type === 'spot') || cross)) {
@@ -3287,7 +3297,11 @@ export default class binance extends Exchange {
         let response = undefined;
         const request = {};
         if (isPortfolioMargin || (type === 'papi')) {
-            type = 'papi';
+            if (this.isLinear (type, subType)) {
+                type = 'linear';
+            } else if (this.isInverse (type, subType)) {
+                type = 'inverse';
+            }
             response = await this.papiGetBalance (this.extend (request, query));
         } else if (this.isLinear (type, subType)) {
             type = 'linear';
@@ -3527,7 +3541,7 @@ export default class binance extends Exchange {
         //         },
         //     ]
         //
-        return this.parseBalanceCustom (response, type, marginMode);
+        return this.parseBalanceCustom (response, type, marginMode, isPortfolioMargin);
     }
 
     async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3302,6 +3302,7 @@ export default class binance extends Exchange {
             } else if (this.isInverse (type, subType)) {
                 type = 'inverse';
             }
+            isPortfolioMargin = true;
             response = await this.papiGetBalance (this.extend (request, query));
         } else if (this.isLinear (type, subType)) {
             type = 'linear';

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -994,18 +994,33 @@
         ],
         "httpResponse": [
           {
-            "asset": "USDT",
-            "totalWalletBalance": "66.9923261",
-            "crossMarginAsset": "35.9697141",
+            "asset": "ETH",
+            "totalWalletBalance": "0.00057786",
+            "crossMarginAsset": "0.0",
             "crossMarginBorrowed": "0.0",
-            "crossMarginFree": "35.9697141",
+            "crossMarginFree": "0.0",
             "crossMarginInterest": "0.0",
             "crossMarginLocked": "0.0",
-            "umWalletBalance": "31.022612",
+            "umWalletBalance": "0.0",
+            "umUnrealizedPNL": "0.0",
+            "cmWalletBalance": "0.00057786",
+            "cmUnrealizedPNL": "0.0",
+            "updateTime": "1708067615305",
+            "negativeBalance": "0.0"
+          },
+          {
+            "asset": "USDT",
+            "totalWalletBalance": "136.03451668",
+            "crossMarginAsset": "30.6003261",
+            "crossMarginBorrowed": "0.00011146",
+            "crossMarginFree": "30.6003261",
+            "crossMarginInterest": "0.00000197",
+            "crossMarginLocked": "0.0",
+            "umWalletBalance": "105.43419058",
             "umUnrealizedPNL": "0.0",
             "cmWalletBalance": "0.0",
             "cmUnrealizedPNL": "0.0",
-            "updateTime": "0",
+            "updateTime": "1708064880778",
             "negativeBalance": "0.0"
           },
           {
@@ -1020,40 +1035,55 @@
             "umUnrealizedPNL": "0.0",
             "cmWalletBalance": "0.0",
             "cmUnrealizedPNL": "0.0",
-            "updateTime": "0",
+            "updateTime": "1707550484595",
             "negativeBalance": "0.0"
           },
           {
             "asset": "ADA",
-            "totalWalletBalance": "0.0525",
-            "crossMarginAsset": "0.0525",
+            "totalWalletBalance": "10.0325",
+            "crossMarginAsset": "10.0325",
             "crossMarginBorrowed": "0.0",
-            "crossMarginFree": "0.0525",
+            "crossMarginFree": "10.0325",
             "crossMarginInterest": "0.0",
             "crossMarginLocked": "0.0",
             "umWalletBalance": "0.0",
             "umUnrealizedPNL": "0.0",
             "cmWalletBalance": "0.0",
             "cmUnrealizedPNL": "0.0",
-            "updateTime": "0",
+            "updateTime": "1707550484595",
             "negativeBalance": "0.0"
           }
         ],
         "parsedResponse": {
           "info": [
             {
-              "asset": "USDT",
-              "totalWalletBalance": "66.9923261",
-              "crossMarginAsset": "35.9697141",
+              "asset": "ETH",
+              "totalWalletBalance": "0.00057786",
+              "crossMarginAsset": "0.0",
               "crossMarginBorrowed": "0.0",
-              "crossMarginFree": "35.9697141",
+              "crossMarginFree": "0.0",
               "crossMarginInterest": "0.0",
               "crossMarginLocked": "0.0",
-              "umWalletBalance": "31.022612",
+              "umWalletBalance": "0.0",
+              "umUnrealizedPNL": "0.0",
+              "cmWalletBalance": "0.00057786",
+              "cmUnrealizedPNL": "0.0",
+              "updateTime": "1708067615305",
+              "negativeBalance": "0.0"
+            },
+            {
+              "asset": "USDT",
+              "totalWalletBalance": "136.03451668",
+              "crossMarginAsset": "30.6003261",
+              "crossMarginBorrowed": "0.00011146",
+              "crossMarginFree": "30.6003261",
+              "crossMarginInterest": "0.00000197",
+              "crossMarginLocked": "0.0",
+              "umWalletBalance": "105.43419058",
               "umUnrealizedPNL": "0.0",
               "cmWalletBalance": "0.0",
               "cmUnrealizedPNL": "0.0",
-              "updateTime": "0",
+              "updateTime": "1708064880778",
               "negativeBalance": "0.0"
             },
             {
@@ -1068,62 +1098,238 @@
               "umUnrealizedPNL": "0.0",
               "cmWalletBalance": "0.0",
               "cmUnrealizedPNL": "0.0",
-              "updateTime": "0",
+              "updateTime": "1707550484595",
               "negativeBalance": "0.0"
             },
             {
               "asset": "ADA",
-              "totalWalletBalance": "0.0525",
-              "crossMarginAsset": "0.0525",
+              "totalWalletBalance": "10.0325",
+              "crossMarginAsset": "10.0325",
               "crossMarginBorrowed": "0.0",
-              "crossMarginFree": "0.0525",
+              "crossMarginFree": "10.0325",
               "crossMarginInterest": "0.0",
               "crossMarginLocked": "0.0",
               "umWalletBalance": "0.0",
               "umUnrealizedPNL": "0.0",
               "cmWalletBalance": "0.0",
               "cmUnrealizedPNL": "0.0",
-              "updateTime": "0",
+              "updateTime": "1707550484595",
               "negativeBalance": "0.0"
             }
           ],
+          "ETH": {
+            "free": null,
+            "used": null,
+            "total": 0.00057786
+          },
           "USDT": {
-            "free": 35.9697141,
-            "used": 0,
-            "total": 35.9697141,
-            "debt": 0
+            "free": null,
+            "used": null,
+            "total": 136.03451668
           },
           "LTC": {
-            "free": 0.000636,
-            "used": 0,
-            "total": 0.000636,
-            "debt": 0
+            "free": null,
+            "used": null,
+            "total": 0.000636
           },
           "ADA": {
-            "free": 0.0525,
-            "used": 0,
-            "total": 0.0525,
-            "debt": 0
+            "free": null,
+            "used": null,
+            "total": 10.0325
           },
           "timestamp": null,
           "datetime": null,
           "free": {
-            "USDT": 35.9697141,
-            "LTC": 0.000636,
-            "ADA": 0.0525
+            "ETH": null,
+            "USDT": null,
+            "LTC": null,
+            "ADA": null
           },
           "used": {
+            "ETH": null,
+            "USDT": null,
+            "LTC": null,
+            "ADA": null
+          },
+          "total": {
+            "ETH": 0.00057786,
+            "USDT": 136.03451668,
+            "LTC": 0.000636,
+            "ADA": 10.0325
+          }
+        }
+      },
+      {
+        "description": "fetch linear papi balance",
+        "method": "fetchBalance",
+        "input": [
+          {
+            "type": "papi",
+            "subType": "linear"
+          }
+        ],
+        "httpResponse": [
+          {
+            "asset": "ETH",
+            "totalWalletBalance": "0.00057786",
+            "crossMarginAsset": "0.0",
+            "crossMarginBorrowed": "0.0",
+            "crossMarginFree": "0.0",
+            "crossMarginInterest": "0.0",
+            "crossMarginLocked": "0.0",
+            "umWalletBalance": "0.0",
+            "umUnrealizedPNL": "0.0",
+            "cmWalletBalance": "0.00057786",
+            "cmUnrealizedPNL": "0.0",
+            "updateTime": "1708067615305",
+            "negativeBalance": "0.0"
+          },
+          {
+            "asset": "USDT",
+            "totalWalletBalance": "136.03451668",
+            "crossMarginAsset": "30.6003261",
+            "crossMarginBorrowed": "0.00011146",
+            "crossMarginFree": "30.6003261",
+            "crossMarginInterest": "0.00000197",
+            "crossMarginLocked": "0.0",
+            "umWalletBalance": "105.43419058",
+            "umUnrealizedPNL": "0.0",
+            "cmWalletBalance": "0.0",
+            "cmUnrealizedPNL": "0.0",
+            "updateTime": "1708064880778",
+            "negativeBalance": "0.0"
+          },
+          {
+            "asset": "LTC",
+            "totalWalletBalance": "0.000636",
+            "crossMarginAsset": "0.000636",
+            "crossMarginBorrowed": "0.0",
+            "crossMarginFree": "0.000636",
+            "crossMarginInterest": "0.0",
+            "crossMarginLocked": "0.0",
+            "umWalletBalance": "0.0",
+            "umUnrealizedPNL": "0.0",
+            "cmWalletBalance": "0.0",
+            "cmUnrealizedPNL": "0.0",
+            "updateTime": "1707550484595",
+            "negativeBalance": "0.0"
+          },
+          {
+            "asset": "ADA",
+            "totalWalletBalance": "10.0325",
+            "crossMarginAsset": "10.0325",
+            "crossMarginBorrowed": "0.0",
+            "crossMarginFree": "10.0325",
+            "crossMarginInterest": "0.0",
+            "crossMarginLocked": "0.0",
+            "umWalletBalance": "0.0",
+            "umUnrealizedPNL": "0.0",
+            "cmWalletBalance": "0.0",
+            "cmUnrealizedPNL": "0.0",
+            "updateTime": "1707550484595",
+            "negativeBalance": "0.0"
+          }
+        ],
+        "parsedResponse": {
+          "info": [
+            {
+              "asset": "ETH",
+              "totalWalletBalance": "0.00057786",
+              "crossMarginAsset": "0.0",
+              "crossMarginBorrowed": "0.0",
+              "crossMarginFree": "0.0",
+              "crossMarginInterest": "0.0",
+              "crossMarginLocked": "0.0",
+              "umWalletBalance": "0.0",
+              "umUnrealizedPNL": "0.0",
+              "cmWalletBalance": "0.00057786",
+              "cmUnrealizedPNL": "0.0",
+              "updateTime": "1708067615305",
+              "negativeBalance": "0.0"
+            },
+            {
+              "asset": "USDT",
+              "totalWalletBalance": "136.03451668",
+              "crossMarginAsset": "30.6003261",
+              "crossMarginBorrowed": "0.00011146",
+              "crossMarginFree": "30.6003261",
+              "crossMarginInterest": "0.00000197",
+              "crossMarginLocked": "0.0",
+              "umWalletBalance": "105.43419058",
+              "umUnrealizedPNL": "0.0",
+              "cmWalletBalance": "0.0",
+              "cmUnrealizedPNL": "0.0",
+              "updateTime": "1708064880778",
+              "negativeBalance": "0.0"
+            },
+            {
+              "asset": "LTC",
+              "totalWalletBalance": "0.000636",
+              "crossMarginAsset": "0.000636",
+              "crossMarginBorrowed": "0.0",
+              "crossMarginFree": "0.000636",
+              "crossMarginInterest": "0.0",
+              "crossMarginLocked": "0.0",
+              "umWalletBalance": "0.0",
+              "umUnrealizedPNL": "0.0",
+              "cmWalletBalance": "0.0",
+              "cmUnrealizedPNL": "0.0",
+              "updateTime": "1707550484595",
+              "negativeBalance": "0.0"
+            },
+            {
+              "asset": "ADA",
+              "totalWalletBalance": "10.0325",
+              "crossMarginAsset": "10.0325",
+              "crossMarginBorrowed": "0.0",
+              "crossMarginFree": "10.0325",
+              "crossMarginInterest": "0.0",
+              "crossMarginLocked": "0.0",
+              "umWalletBalance": "0.0",
+              "umUnrealizedPNL": "0.0",
+              "cmWalletBalance": "0.0",
+              "cmUnrealizedPNL": "0.0",
+              "updateTime": "1707550484595",
+              "negativeBalance": "0.0"
+            }
+          ],
+          "ETH": {
+            "free": 0,
+            "used": 0,
+            "total": 0
+          },
+          "USDT": {
+            "free": 105.43419058,
+            "used": 0,
+            "total": 105.43419058
+          },
+          "LTC": {
+            "free": 0,
+            "used": 0,
+            "total": 0
+          },
+          "ADA": {
+            "free": 0,
+            "used": 0,
+            "total": 0
+          },
+          "timestamp": null,
+          "datetime": null,
+          "free": {
+            "ETH": 0,
+            "USDT": 105.43419058,
+            "LTC": 0,
+            "ADA": 0
+          },
+          "used": {
+            "ETH": 0,
             "USDT": 0,
             "LTC": 0,
             "ADA": 0
           },
           "total": {
-            "USDT": 35.9697141,
-            "LTC": 0.000636,
-            "ADA": 0.0525
-          },
-          "debt": {
-            "USDT": 0,
+            "ETH": 0,
+            "USDT": 105.43419058,
             "LTC": 0,
             "ADA": 0
           }


### PR DESCRIPTION
Edited fetchBalance for portfolio margin so that linear, inverse, margin or total combined balances can be fetched:

```
binance fetchBalance '{"portfolioMargin":true}'

binance.fetchBalance ([object Object])
2024-02-16T07:02:24.563Z iteration 0 passed in 860 ms

{
  info: [
    {
      asset: 'ETH',
      totalWalletBalance: '0.00011066',
      crossMarginAsset: '0.0',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.0',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.00011066',
      cmUnrealizedPNL: '0.00047332',
      updateTime: '1708041600090',
      negativeBalance: '0.0'
    },
    {
      asset: 'USDT',
      totalWalletBalance: '136.03451668',
      crossMarginAsset: '30.6003261',
      crossMarginBorrowed: '0.00011146',
      crossMarginFree: '30.6003261',
      crossMarginInterest: '0.00000193',
      crossMarginLocked: '0.0',
      umWalletBalance: '105.43419058',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1708064880778',
      negativeBalance: '0.0'
    },
    {
      asset: 'LTC',
      totalWalletBalance: '0.000636',
      crossMarginAsset: '0.000636',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.000636',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    },
    {
      asset: 'ADA',
      totalWalletBalance: '10.0325',
      crossMarginAsset: '10.0325',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '10.0325',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    }
  ],
  ETH: { total: 0.00011066 },
  USDT: { total: 136.03451668 },
  LTC: { total: 0.000636 },
  ADA: { total: 10.0325 },
  free: {},
  used: {},
  total: { ETH: 0.00011066, USDT: 136.03451668, LTC: 0.000636, ADA: 10.0325 }
}
```
```
binance fetchBalance '{"portfolioMargin":true,"type":"margin"}'

binance.fetchBalance ([object Object])
2024-02-16T07:03:02.791Z iteration 0 passed in 943 ms

{
  info: [
    {
      asset: 'ETH',
      totalWalletBalance: '0.00011066',
      crossMarginAsset: '0.0',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.0',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.00011066',
      cmUnrealizedPNL: '0.00047',
      updateTime: '1708041600090',
      negativeBalance: '0.0'
    },
    {
      asset: 'USDT',
      totalWalletBalance: '136.03451668',
      crossMarginAsset: '30.6003261',
      crossMarginBorrowed: '0.00011146',
      crossMarginFree: '30.6003261',
      crossMarginInterest: '0.00000193',
      crossMarginLocked: '0.0',
      umWalletBalance: '105.43419058',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1708064880778',
      negativeBalance: '0.0'
    },
    {
      asset: 'LTC',
      totalWalletBalance: '0.000636',
      crossMarginAsset: '0.000636',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.000636',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    },
    {
      asset: 'ADA',
      totalWalletBalance: '10.0325',
      crossMarginAsset: '10.0325',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '10.0325',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    }
  ],
  ETH: { free: 0, used: 0, total: 0, debt: 0 },
  USDT: { free: 30.6003261, used: 0, total: 30.6003261, debt: 0.00011339 },
  LTC: { free: 0.000636, used: 0, total: 0.000636, debt: 0 },
  ADA: { free: 10.0325, used: 0, total: 10.0325, debt: 0 },
  free: { ETH: 0, USDT: 30.6003261, LTC: 0.000636, ADA: 10.0325 },
  used: { ETH: 0, USDT: 0, LTC: 0, ADA: 0 },
  total: { ETH: 0, USDT: 30.6003261, LTC: 0.000636, ADA: 10.0325 },
  debt: { ETH: 0, USDT: 0.00011339, LTC: 0, ADA: 0 }
}
```
```
binance fetchBalance '{"portfolioMargin":true,"subType":"linear"}'

binance.fetchBalance ([object Object])
2024-02-16T07:03:28.840Z iteration 0 passed in 968 ms

{
  info: [
    {
      asset: 'ETH',
      totalWalletBalance: '0.00011066',
      crossMarginAsset: '0.0',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.0',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.00011066',
      cmUnrealizedPNL: '0.00046982',
      updateTime: '1708041600090',
      negativeBalance: '0.0'
    },
    {
      asset: 'USDT',
      totalWalletBalance: '136.03451668',
      crossMarginAsset: '30.6003261',
      crossMarginBorrowed: '0.00011146',
      crossMarginFree: '30.6003261',
      crossMarginInterest: '0.00000193',
      crossMarginLocked: '0.0',
      umWalletBalance: '105.43419058',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1708064880778',
      negativeBalance: '0.0'
    },
    {
      asset: 'LTC',
      totalWalletBalance: '0.000636',
      crossMarginAsset: '0.000636',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.000636',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    },
    {
      asset: 'ADA',
      totalWalletBalance: '10.0325',
      crossMarginAsset: '10.0325',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '10.0325',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    }
  ],
  ETH: { free: 0, used: 0, total: 0 },
  USDT: { free: 105.43419058, used: 0, total: 105.43419058 },
  LTC: { free: 0, used: 0, total: 0 },
  ADA: { free: 0, used: 0, total: 0 },
  free: { ETH: 0, USDT: 105.43419058, LTC: 0, ADA: 0 },
  used: { ETH: 0, USDT: 0, LTC: 0, ADA: 0 },
  total: { ETH: 0, USDT: 105.43419058, LTC: 0, ADA: 0 }
}
```
```
binance fetchBalance '{"portfolioMargin":true,"subType":"inverse"}'

binance.fetchBalance ([object Object])
2024-02-16T07:03:55.712Z iteration 0 passed in 934 ms

{
  info: [
    {
      asset: 'ETH',
      totalWalletBalance: '0.00011066',
      crossMarginAsset: '0.0',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.0',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.00011066',
      cmUnrealizedPNL: '0.00046852',
      updateTime: '1708041600090',
      negativeBalance: '0.0'
    },
    {
      asset: 'USDT',
      totalWalletBalance: '136.03451668',
      crossMarginAsset: '30.6003261',
      crossMarginBorrowed: '0.00011146',
      crossMarginFree: '30.6003261',
      crossMarginInterest: '0.00000193',
      crossMarginLocked: '0.0',
      umWalletBalance: '105.43419058',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1708064880778',
      negativeBalance: '0.0'
    },
    {
      asset: 'LTC',
      totalWalletBalance: '0.000636',
      crossMarginAsset: '0.000636',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '0.000636',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    },
    {
      asset: 'ADA',
      totalWalletBalance: '10.0325',
      crossMarginAsset: '10.0325',
      crossMarginBorrowed: '0.0',
      crossMarginFree: '10.0325',
      crossMarginInterest: '0.0',
      crossMarginLocked: '0.0',
      umWalletBalance: '0.0',
      umUnrealizedPNL: '0.0',
      cmWalletBalance: '0.0',
      cmUnrealizedPNL: '0.0',
      updateTime: '1707550484595',
      negativeBalance: '0.0'
    }
  ],
  ETH: { free: 0.00011066, used: 0.00046852, total: 0.00057918 },
  USDT: { free: 0, used: 0, total: 0 },
  LTC: { free: 0, used: 0, total: 0 },
  ADA: { free: 0, used: 0, total: 0 },
  free: { ETH: 0.00011066, USDT: 0, LTC: 0, ADA: 0 },
  used: { ETH: 0.00046852, USDT: 0, LTC: 0, ADA: 0 },
  total: { ETH: 0.00057918, USDT: 0, LTC: 0, ADA: 0 }
}
```

### Open position:
```
umWalletBalance: '56.76086098',
umUnrealizedPNL: '48.984',
```
### Closed position:
```
umWalletBalance: '105.43419058',
umUnrealizedPNL: '0.0',
```