### PR TITLE
fix(cryptocom) switch fetchDepositWithdrawFees from spot to unified api

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -2312,13 +2312,13 @@ export default class cryptocom extends Exchange {
          * @method
          * @name cryptocom#fetchDepositWithdrawFees
          * @description fetch deposit and withdraw fees
-         * @see https://exchange-docs.crypto.com/spot/index.html#private-get-currency-networks
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#private-get-currency-networks
          * @param {string[]|undefined} codes list of unified currency codes
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a list of [fee structures]{@link https://docs.ccxt.com/#/?id=fee-structure}
          */
         await this.loadMarkets ();
-        const response = await this.v2PrivatePostPrivateGetCurrencyNetworks (params);
+        const response = await this.v1PrivatePostPrivateGetCurrencyNetworks (params);
         const data = this.safeValue (response, 'result');
         const currencyMap = this.safeValue (data, 'currency_map');
         return this.parseDepositWithdrawFees (currencyMap, codes, 'full_name');

--- a/ts/src/test/static/request/cryptocom.json
+++ b/ts/src/test/static/request/cryptocom.json
@@ -193,6 +193,20 @@
                 "input": [],
                 "output": "{\"id\":\"1700840923278\",\"method\":\"private/get-positions\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"c8406ac9040f04fbbc337b956a50c3bf030f24b4249717e03eac6f905ea3c4a5\",\"nonce\":\"1700840923278\"}"
             }
+        ],
+        "fetchDepositWithdrawFees": [
+            {
+                "description": "Fetch deposit and withdraw fees",
+                "method": "fetchDepositWithdrawFees",
+                "url": "https://api.crypto.com/exchange/v1/private/get-currency-networks",
+                "input": [
+                  [
+                    "USDT",
+                    "BTC"
+                  ]
+                ],
+                "output": "{\"id\":\"1708079230296\",\"method\":\"private/get-currency-networks\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"2b1eac4ba696b41ce2726139c63a145368f2c66ca97e090cf3361ab60b7637da\",\"nonce\":\"1708079230296\"}"
+            }
         ]
     }
 }


### PR DESCRIPTION
This function now uses the unified api.
It's a no risk change because for both endpoints, request and response are identical.