### PR TITLE
feat(bl3p): createDepositAddress

### DIFF
--- a/ts/src/bl3p.ts
+++ b/ts/src/bl3p.ts
@@ -45,7 +45,7 @@ export default class bl3p extends Exchange {
                 'fetchBorrowRateHistory': false,
                 'fetchCrossBorrowRate': false,
                 'fetchCrossBorrowRates': false,
-                'fetchDepositAddress': true,
+                'fetchDepositAddress': false,
                 'fetchDepositAddresses': false,
                 'fetchDepositAddressesByNetwork': false,
                 'fetchFundingHistory': false,
@@ -467,34 +467,6 @@ export default class bl3p extends Exchange {
         //
         const data = this.safeDict (response, 'data');
         return this.parseDepositAddress (data, currency);
-    }
-
-    async fetchDepositAddress (code: string, params = {}) {
-        /**
-         * @method
-         * @name bl3p#fetchDepositAddress
-         * @description fetch the deposit address for a currency associated with this account
-         * @see https://github.com/BitonicNL/bl3p-api/blob/master/docs/authenticated_api/http.md#33---get-the-last-deposit-address
-         * @param {string} code unified currency code
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
-         */
-        await this.loadMarkets ();
-        const currency = this.currency (code);
-        const request = {
-            'currency': currency['id'],
-        };
-        const response = await this.privatePostGENMKTMoneyDepositAddress (this.extend (request, params));
-        //
-        //    {
-        //        "result": "success",
-        //        "data": {
-        //            "address": "36Udu9zi1uYicpXcJpoKfv3bewZeok5tpk"
-        //        }
-        //    }
-        //
-        const data = this.safeValue (response, 'data');
-        return this.parseDepositAddress (data);
     }
 
     parseDepositAddress (depositAddress, currency: Currency = undefined) {

--- a/ts/src/bl3p.ts
+++ b/ts/src/bl3p.ts
@@ -5,7 +5,7 @@ import Exchange from './abstract/bl3p.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
-import type { Balances, Int, Market, OrderBook, OrderSide, OrderType, Str, Ticker, Trade, IndexType } from './base/types.js';
+import type { Balances, Int, Market, OrderBook, OrderSide, OrderType, Str, Ticker, Trade, IndexType, Currency } from './base/types.js';
 
 // ---------------------------------------------------------------------------
 
@@ -34,6 +34,7 @@ export default class bl3p extends Exchange {
                 'cancelOrder': true,
                 'closeAllPositions': false,
                 'closePosition': false,
+                'createDepositAddress': true,
                 'createOrder': true,
                 'createReduceOnlyOrder': false,
                 'createStopLimitOrder': false,
@@ -44,6 +45,9 @@ export default class bl3p extends Exchange {
                 'fetchBorrowRateHistory': false,
                 'fetchCrossBorrowRate': false,
                 'fetchCrossBorrowRates': false,
+                'fetchDepositAddress': true,
+                'fetchDepositAddresses': false,
+                'fetchDepositAddressesByNetwork': false,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
                 'fetchFundingRateHistory': false,
@@ -435,6 +439,79 @@ export default class bl3p extends Exchange {
             'order_id': id,
         };
         return await this.privatePostMarketMoneyOrderCancel (this.extend (request, params));
+    }
+
+    async createDepositAddress (code: string, params = {}) {
+        /**
+         * @method
+         * @name bl3p#createDepositAddress
+         * @description create a currency deposit address
+         * @see https://github.com/BitonicNL/bl3p-api/blob/master/docs/authenticated_api/http.md#32---create-a-new-deposit-address
+         * @param {string} code unified currency code of the currency for the deposit address
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'currency': currency['id'],
+        };
+        const response = await this.privatePostGENMKTMoneyNewDepositAddress (this.extend (request, params));
+        //
+        //    {
+        //        "result": "success",
+        //        "data": {
+        //            "address": "36Udu9zi1uYicpXcJpoKfv3bewZeok5tpk"
+        //        }
+        //    }
+        //
+        const data = this.safeDict (response, 'data');
+        return this.parseDepositAddress (data, currency);
+    }
+
+    async fetchDepositAddress (code: string, params = {}) {
+        /**
+         * @method
+         * @name bl3p#fetchDepositAddress
+         * @description fetch the deposit address for a currency associated with this account
+         * @see https://github.com/BitonicNL/bl3p-api/blob/master/docs/authenticated_api/http.md#33---get-the-last-deposit-address
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request = {
+            'currency': currency['id'],
+        };
+        const response = await this.privatePostGENMKTMoneyDepositAddress (this.extend (request, params));
+        //
+        //    {
+        //        "result": "success",
+        //        "data": {
+        //            "address": "36Udu9zi1uYicpXcJpoKfv3bewZeok5tpk"
+        //        }
+        //    }
+        //
+        const data = this.safeValue (response, 'data');
+        return this.parseDepositAddress (data);
+    }
+
+    parseDepositAddress (depositAddress, currency: Currency = undefined) {
+        //
+        //    {
+        //        "address": "36Udu9zi1uYicpXcJpoKfv3bewZeok5tpk"
+        //    }
+        //
+        const address = this.safeString (depositAddress, 'address');
+        this.checkAddress (address);
+        return {
+            'info': depositAddress,
+            'currency': this.safeString (currency, 'code'),
+            'address': address,
+            'tag': undefined,
+            'network': undefined,
+        };
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/test/static/currencies/bl3p.json
+++ b/ts/src/test/static/currencies/bl3p.json
@@ -1,0 +1,52 @@
+{
+    "BTC": {
+        "info": false,
+        "id": "BTC",
+        "numericId": false,
+        "code": "BTC",
+        "precision": 1e-8,
+        "type": false,
+        "name": false,
+        "active": false,
+        "deposit": false,
+        "withdraw": false,
+        "fee": false,
+        "fees": {},
+        "networks": {},
+        "limits": {
+            "deposit": {
+                "min": false,
+                "max": false
+            },
+            "withdraw": {
+                "min": false,
+                "max": false
+            }
+        }
+    },
+    "EUR": {
+        "info": false,
+        "id": "EUR",
+        "numericId": false,
+        "code": "EUR",
+        "precision": 1e-8,
+        "type": false,
+        "name": false,
+        "active": false,
+        "deposit": false,
+        "withdraw": false,
+        "fee": false,
+        "fees": {},
+        "networks": {},
+        "limits": {
+            "deposit": {
+                "min": false,
+                "max": false
+            },
+            "withdraw": {
+                "min": false,
+                "max": false
+            }
+        }
+    }
+}

--- a/ts/src/test/static/markets/bl3p.json
+++ b/ts/src/test/static/markets/bl3p.json
@@ -1,0 +1,49 @@
+{
+    "BTC/EUR": {
+        "id": "BTCEUR",
+        "lowercaseId": false,
+        "symbol": "BTC/EUR",
+        "base": "BTC",
+        "quote": "EUR",
+        "settle": false,
+        "baseId": "BTC",
+        "quoteId": "EUR",
+        "settleId": false,
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "index": false,
+        "active": false,
+        "contract": false,
+        "linear": false,
+        "inverse": false,
+        "subType": false,
+        "taker": 0.0025,
+        "maker": 0.0025,
+        "contractSize": false,
+        "expiry": false,
+        "expiryDatetime": false,
+        "strike": false,
+        "optionType": false,
+        "precision": {
+          "amount": false,
+          "price": false,
+          "cost": false,
+          "base": false,
+          "quote": false
+        },
+        "limits": {
+          "leverage": { "min": false, "max": false },
+          "amount": { "min": false, "max": false },
+          "price": { "min": false, "max": false },
+          "cost": { "min": false, "max": false }
+        },
+        "created": false,
+        "info": false,
+        "tierBased": false,
+        "percentage": false
+    }
+}

--- a/ts/src/test/static/request/bl3p.json
+++ b/ts/src/test/static/request/bl3p.json
@@ -2,9 +2,10 @@
     "exchange": "bl3p",
     "skipKeys": [
         "time",
-        "account-group"
+        "account-group",
+        "nonce"
     ],
-    "outputType": "json",
+    "outputType": "both",
     "methods": {
         "createDepositAddress": [
             {

--- a/ts/src/test/static/request/bl3p.json
+++ b/ts/src/test/static/request/bl3p.json
@@ -1,0 +1,21 @@
+{
+    "exchange": "bl3p",
+    "skipKeys": [
+        "time",
+        "account-group"
+    ],
+    "outputType": "json",
+    "methods": {
+        "createDepositAddress": [
+            {
+                "description": "Create Deposit Address",
+                "method": "createDepositAddress",
+                "url": "https://api.bl3p.eu/1/GENMKT/money/new_deposit_address",
+                "input": [
+                    "BTC"
+                ],
+                "output": "nonce=1708429815&currency=BTC"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- fetchDepositAddress is in the api docs, but the endpoint doesn't return anything, so I removed it

# Testing

```
% py bl3p createDepositAddress BTC
Python v3.9.6
CCXT v4.2.45
bl3p.createDepositAddress(BTC)
{'address': '38WHdCMSbxQrC191r4RnnaJiBUD34uEb3E',
 'currency': 'BTC',
 'info': {'address': '38WHdCMSbxQrC191r4RnnaJiBUD34uEb3E'},
 'network': None,
 'tag': None}
 ```