### PR TITLE
binance: fix parseMarket, strike price

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3015,7 +3015,7 @@ export default class binance extends Exchange {
         let fees = this.fees;
         let linear = undefined;
         let inverse = undefined;
-        const strike = this.safeInteger (market, 'strikePrice');
+        const strike = this.safeString (market, 'strikePrice');
         let symbol = base + '/' + quote;
         if (contract) {
             if (swap) {
@@ -3023,7 +3023,7 @@ export default class binance extends Exchange {
             } else if (future) {
                 symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
             } else if (option) {
-                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + this.numberToString (strike) + '-' + this.safeString (optionParts, 3);
+                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + strike + '-' + this.safeString (optionParts, 3);
             }
             contractSize = this.safeNumber2 (market, 'contractSize', 'unit', this.parseNumber ('1'));
             linear = settle === quote;
@@ -3053,6 +3053,10 @@ export default class binance extends Exchange {
             unifiedType = 'option';
             active = undefined;
         }
+        let parsedStrike = undefined;
+        if (strike !== undefined) {
+            parsedStrike = this.parseToNumeric (strike);
+        }
         const entry = {
             'id': id,
             'lowercaseId': lowercaseId,
@@ -3078,7 +3082,7 @@ export default class binance extends Exchange {
             'contractSize': contractSize,
             'expiry': expiry,
             'expiryDatetime': this.iso8601 (expiry),
-            'strike': strike,
+            'strike': parsedStrike,
             'optionType': this.safeStringLower (market, 'side'),
             'precision': {
                 'amount': this.safeInteger2 (market, 'quantityPrecision', 'quantityScale'),


### PR DESCRIPTION
Fixed the strike price because some option trading pairs have decimal places in their strike price: `doge-240223-0.091-c`
fixes: #21288