### PR TITLE
feat(binance): fetchPositionsForSymbol

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -130,6 +130,7 @@ export default class binance extends Exchange {
                 'fetchPositionHistory': false,
                 'fetchPositionMode': true,
                 'fetchPositions': true,
+                'fetchPositionsForSymbol': 'emulated',
                 'fetchPositionsHistory': false,
                 'fetchPositionsRisk': true,
                 'fetchPremiumIndexOHLCV': true,
@@ -10094,6 +10095,10 @@ export default class binance extends Exchange {
         } else {
             throw new NotSupported (this.id + '.options["fetchPositions"]/params["method"] = "' + defaultMethod + '" is invalid, please choose between "account", "positionRisk" and "option"');
         }
+    }
+
+    async fetchPositionsForSymbol (symbol: string, params = {}) {
+        return await this.fetchPositions ([ symbol ], params);
     }
 
     async fetchAccountPositions (symbols: Strings = undefined, params = {}) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -53,7 +53,7 @@ export default class binance extends Exchange {
                 'createMarketSellOrderWithCost': true,
                 'createOrder': true,
                 'createOrders': true,
-                'createOrderWithTakeProfitAndStopLoss': true,
+                'createOrderWithTakeProfitAndStopLoss': false,
                 'createPostOnlyOrder': true,
                 'createReduceOnlyOrder': true,
                 'createStopLimitOrder': true,

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -1580,6 +1580,16 @@
                 ]
             }
         ],
+        "fetchPositionsForSymbol": [
+            {
+                "description": "Fetch Positions For Symbol",
+                "method": "fetchPositionsForSymbol",
+                "url": "https://testnet.binancefuture.com/fapi/v2/positionRisk?timestamp=1708520302938&recvWindow=10000&signature=3254a777d7a7196c8387c1c6a277c3e242e28ca379dfe0d9f0f0567e19dadfab",
+                "input": [
+                    "XRP/USDT:USDT"
+                ]
+            }
+        ],
         "transfer": [
             {
                 "description": "Transfer from cross to spot",


### PR DESCRIPTION
```
% py binanceusdm fetchPositionsForSymbol XRP/USDT:USDT --testnet     
Python v3.9.6
CCXT v4.2.48
binanceusdm.fetchPositionsForSymbol(XRP/USDT:USDT)
[{'collateral': 8.154,
  'contractSize': 1.0,
  'contracts': 15.0,
  'datetime': '2024-02-21T12:55:53.863Z',
  'entryPrice': 0.5436,
  'hedged': False,
  'id': None,
  'info': {'adlQuantile': '1',
           'breakEvenPrice': '0.54381744',
           'entryPrice': '0.5436',
           'isAutoAddMargin': 'false',
           'isolated': False,
           'isolatedMargin': '0.00000000',
           'isolatedWallet': '0',
           'leverage': '20',
           'liquidationPrice': '0',
           'marginType': 'cross',
           'markPrice': '0.54300000',
           'maxNotionalValue': '500000',
           'notional': '8.14500000',
           'positionAmt': '15.0',
           'positionSide': 'BOTH',
           'symbol': 'XRPUSDT',
           'unRealizedProfit': '-0.00900000',
           'updateTime': '1708520153863'},
  'initialMargin': 0.40725,
  'initialMarginPercentage': 0.05,
  'leverage': 20.0,
  'liquidationPrice': None,
  'maintenanceMargin': 0.040725,
  'maintenanceMarginPercentage': 0.005,
  'marginMode': 'cross',
  'marginRatio': 0.005,
  'marginType': 'cross',
  'markPrice': 0.543,
  'notional': 8.145,
  'percentage': -2.2,
  'side': 'long',
  'stopLossPrice': None,
  'symbol': 'XRP/USDT:USDT',
  'takeProfitPrice': None,
  'timestamp': 1708520153863,
  'unrealizedPnl': -0.009}]
```