### PR TITLE
fix(bitmart) watchTicker

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1164,7 +1164,7 @@ export default class bitmart extends Exchange {
         //          "base_volume_24h":"117387.58", // NOT base, but quote currency!!!
         //          "s_t": 1610936002
         //      }
-        // 
+        //
         // swap
         //
         //      {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1134,7 +1134,7 @@ export default class bitmart extends Exchange {
 
     parseTicker (ticker, market: Market = undefined): Ticker {
         //
-        // spot
+        // spot (REST)
         //
         //      {
         //          "symbol": "SOLAR_USDT",
@@ -1154,6 +1154,17 @@ export default class bitmart extends Exchange {
         //          "timestamp": 1667403439367
         //      }
         //
+        // spot (WS)
+        //      {
+        //          "symbol":"BTC_USDT",
+        //          "last_price":"146.24",
+        //          "open_24h":"147.17",
+        //          "high_24h":"147.48",
+        //          "low_24h":"143.88",
+        //          "base_volume_24h":"117387.58", // NOT base, but quote currency!!!
+        //          "s_t": 1610936002
+        //      }
+        // 
         // swap
         //
         //      {
@@ -1169,7 +1180,11 @@ export default class bitmart extends Exchange {
         //          "legal_coin_price":"0.1302699"
         //      }
         //
-        const timestamp = this.safeInteger (ticker, 'timestamp');
+        let timestamp = this.safeInteger (ticker, 'timestamp');
+        if (timestamp === undefined) {
+            // ticker from WS has a different field (in seconds)
+            timestamp = this.safeIntegerProduct (ticker, 's_t', 1000);
+        }
         const marketId = this.safeString2 (ticker, 'symbol', 'contract_symbol');
         market = this.safeMarket (marketId, market);
         const symbol = market['symbol'];
@@ -1184,9 +1199,19 @@ export default class bitmart extends Exchange {
                 percentage = '0';
             }
         }
-        const baseVolume = this.safeString (ticker, 'base_volume_24h');
+        let baseVolume = this.safeString (ticker, 'base_volume_24h');
         let quoteVolume = this.safeString (ticker, 'quote_volume_24h');
-        quoteVolume = this.safeString (ticker, 'volume_24h', quoteVolume);
+        if (quoteVolume === undefined) {
+            if (baseVolume === undefined) {
+                // this is swap
+                quoteVolume = this.safeString (ticker, 'volume_24h', quoteVolume);
+            } else {
+                // this is a ticker from websockets
+                // contrary to name and documentation, base_volume_24h is actually the quote volume
+                quoteVolume = baseVolume;
+                baseVolume = undefined;
+            }
+        }
         const average = this.safeString2 (ticker, 'avg_price', 'index_price');
         const high = this.safeString2 (ticker, 'high_24h', 'high_price');
         const low = this.safeString2 (ticker, 'low_24h', 'low_price');


### PR DESCRIPTION
## symptoms
tickers received through websockets are 
1. missing timestamp 
2. report wrong volume

## cause
- through WS, timestamp is sent as s_t (in seconds)
- bitmart sends a field called base_volume_24h. Although the name suggests (and the documentation says) it's the volume in base currency, it is actually the volume in quote currency. You can see this by comparing info from WS-ticker and REST-ticker.

## fixes
- timestamp taken from s_t field
- quoteVolume taken from base_volume_24h field
- baseVolume set to undefined