### PR TITLE
fix(tests) - symbols order [QUICK]

### DIFF
--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -589,9 +589,9 @@ export default class testMainClass extends baseMainTestClass {
             return false;
         }
         const symbols = [
-            'BTC/CNY',
             'BTC/USDT',
             'BTC/USDC',
+            'BTC/CNY',
             'BTC/USD',
             'BTC/EUR',
             'BTC/ETH',

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -590,8 +590,9 @@ export default class testMainClass extends baseMainTestClass {
         }
         const symbols = [
             'BTC/CNY',
-            'BTC/USD',
             'BTC/USDT',
+            'BTC/USDC',
+            'BTC/USD',
             'BTC/EUR',
             'BTC/ETH',
             'ETH/BTC',
@@ -713,8 +714,9 @@ export default class testMainClass extends baseMainTestClass {
             'ZRX',
         ];
         const spotSymbols = [
-            'BTC/USD',
             'BTC/USDT',
+            'BTC/USDC',
+            'BTC/USD',
             'BTC/CNY',
             'BTC/EUR',
             'BTC/ETH',
@@ -728,6 +730,7 @@ export default class testMainClass extends baseMainTestClass {
         ];
         const swapSymbols = [
             'BTC/USDT:USDT',
+            'BTC/USDC:USDC',
             'BTC/USD:USD',
             'ETH/USDT:USDT',
             'ETH/USD:USD',


### PR DESCRIPTION
crypto pairs are most prominent for exchanges, and when testing, `btc/usdt` pairs are more updated in WS streams typically, so better to have this order