### PR TITLE
fix(exchange): compare None as Int in get_object_value_from_key_list

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -884,7 +884,7 @@ class Exchange(object):
             if isinstance(key, str):
                 if key in dictionary_or_list and dictionary_or_list[key] is not None and dictionary_or_list[key] != '':
                     return dictionary_or_list[key]
-            else:
+            elif key is not None:
                 if (key < len(dictionary_or_list)) and (dictionary_or_list[key] is not None) and (dictionary_or_list[key] != ''):
                     return dictionary_or_list[key]
         return None


### PR DESCRIPTION
fix: ccxt/ccxt#21318

The root cause of issue is we comparing the None key as Int. We can set the default value of type to empty string, but I think the issue may happen again. In thi PR, I check whether the key is None.

```BASH
$ python3 examples/py/cli.py binance withdraw USDT 1 0x000000
Python v3.8.10
CCXT v4.2.48
binance.withdraw(USDT,1,0x000000)
{'address': None,
 'addressFrom': None,
 'addressTo': None,
 'amount': None,
 'comment': None,
 'currency': 'USDT',
 'datetime': None,
 'fee': None,
 'id': None,
 'info': {<built-in function id>: '9a67628b16ba4988ae20d329333f16bc'},
 'internal': None,
 'network': None,
 'status': None,
 'tag': None,
 'tagFrom': None,
 'tagTo': None,
 'timestamp': None,
 'txid': None,
 'type': None,
 'updated': None}
```