### PR TITLE
upbit: static request, createOrder timeInForce param

### DIFF
--- a/ts/src/test/static/markets/upbit.json
+++ b/ts/src/test/static/markets/upbit.json
@@ -162,5 +162,69 @@
             "market": "USDT-BTC",
             "english_name": "Bitcoin"
         }
+    },
+    "XRP/SGD": {
+        "id": "SGD-XRP",
+        "symbol": "XRP/SGD",
+        "base": "XRP",
+        "quote": "SGD",
+        "baseId": "XRP",
+        "quoteId": "SGD",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0025,
+        "maker": 0.0025,
+        "precision": {
+            "price": 1e-8,
+            "amount": 1e-8
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {}
+        },
+        "info": {
+            "market": "SGD-XRP",
+            "english_name": "Ripple"
+        }
+    },
+    "XRP/BTC": {
+        "id": "BTC-XRP",
+        "symbol": "XRP/BTC",
+        "base": "XRP",
+        "quote": "BTC",
+        "baseId": "XRP",
+        "quoteId": "BTC",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0025,
+        "maker": 0.0025,
+        "precision": {
+            "price": 1e-8,
+            "amount": 1e-8
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {}
+        },
+        "info": {
+            "market": "BTC-XRP",
+            "english_name": "Ripple"
+        }
     }
 }

--- a/ts/src/test/static/request/upbit.json
+++ b/ts/src/test/static/request/upbit.json
@@ -126,6 +126,38 @@
                   null
                 ],
                 "output": "{\"market\":\"USDT-BTC\",\"side\":\"ask\",\"ord_type\":\"market\",\"volume\":\"0.00015\"}"
+            },
+            {
+              "description": "Spot IOC limit sell order",
+              "method": "createOrder",
+              "url": "https://sg-api.upbit.com/v1/orders",
+              "input": [
+                "XRP/SGD",
+                "limit",
+                "sell",
+                10,
+                1.5,
+                {
+                  "timeInForce": "IOC"
+                }
+              ],
+              "output": "{\"market\":\"SGD-XRP\",\"side\":\"ask\",\"price\":\"1.5\",\"ord_type\":\"limit\",\"volume\":\"10\",\"time_in_force\":\"ioc\"}"
+            },
+            {
+              "description": "Spot FOK limit sell order",
+              "method": "createOrder",
+              "url": "https://sg-api.upbit.com/v1/orders",
+              "input": [
+                "XRP/SGD",
+                "limit",
+                "sell",
+                10,
+                1.5,
+                {
+                  "timeInForce": "FOK"
+                }
+              ],
+              "output": "{\"market\":\"SGD-XRP\",\"side\":\"ask\",\"price\":\"1.5\",\"ord_type\":\"limit\",\"volume\":\"10\",\"time_in_force\":\"fok\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Added static request tests for the newly implemented timeInForce support on upbit:

```
upbit createOrder XRP/SGD limit sell 10 1.5 '{"timeInForce":"IOC"}'

upbit.createOrder (XRP/SGD, limit, sell, 10, 1.5, [object Object])
2024-02-22T09:20:50.705Z iteration 0 passed in 1398 ms

{
  info: {
    uuid: 'ca0f087b-444c-4291-8564-c3223748ae49',
    side: 'ask',
    ord_type: 'limit',
    price: '1.5',
    state: 'wait',
    market: 'SGD-XRP',
    created_at: '2024-02-22T09:20:50Z',
    volume: '10',
    remaining_volume: '10',
    reserved_fee: '0',
    remaining_fee: '0',
    paid_fee: '0',
    locked: '10',
    executed_volume: '0',
    trades_count: '0',
    time_in_force: 'ioc'
  },
  id: 'ca0f087b-444c-4291-8564-c3223748ae49',
  timestamp: 1708593650000,
  datetime: '2024-02-22T09:20:50.000Z',
  symbol: 'XRP/SGD',
  type: 'limit',
  side: 'sell',
  price: 1.5,
  cost: 0,
  amount: 10,
  filled: 0,
  remaining: 10,
  status: 'open',
  fee: { currency: 'SGD', cost: '0' },
  trades: [],
  fees: [ { currency: 'SGD', cost: 0 } ]
}
```
```
upbit createOrder XRP/SGD limit sell 10 1.5 '{"timeInForce":"FOK"}'

upbit.createOrder (XRP/SGD, limit, sell, 10, 1.5, [object Object])
2024-02-22T09:22:10.848Z iteration 0 passed in 1450 ms

{
  info: {
    uuid: 'd8636353-ffd1-4c2c-b8e0-96f2f7014cfb',
    side: 'ask',
    ord_type: 'limit',
    price: '1.5',
    state: 'wait',
    market: 'SGD-XRP',
    created_at: '2024-02-22T09:22:10Z',
    volume: '10',
    remaining_volume: '10',
    reserved_fee: '0',
    remaining_fee: '0',
    paid_fee: '0',
    locked: '10',
    executed_volume: '0',
    trades_count: '0',
    time_in_force: 'fok'
  },
  id: 'd8636353-ffd1-4c2c-b8e0-96f2f7014cfb',
  timestamp: 1708593730000,
  datetime: '2024-02-22T09:22:10.000Z',
  symbol: 'XRP/SGD',
  type: 'limit',
  side: 'sell',
  price: 1.5,
  cost: 0,
  amount: 10,
  filled: 0,
  remaining: 10,
  status: 'open',
  fee: { currency: 'SGD', cost: '0' },
  trades: [],
  fees: [ { currency: 'SGD', cost: 0 } ]
}
```