### PR TITLE
fix(mexc): php urlencode

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -937,7 +937,7 @@ class Exchange {
                 $array[$key] = var_export($value, true);
             }
         }
-        return http_build_query($array, '', $this->urlencode_glue);
+        return http_build_query($array, '', $this->urlencode_glue, PHP_QUERY_RFC3986);
     }
 
     public function urlencode_nested($array) {


### PR DESCRIPTION
fix: ccxt/ccxt#21337

The default encode type for http_build_query is PHP_QUERY_RFC1738, which implies that spaces are encoded as plus (+) signs.

The behavior is different compared to other languages (encoded to %20). In this PR, I change to PHP_QUERY_RFC3986, which means spaces will be percent encoded (%20).

See doc: https://www.php.net/manual/en/function.http-build-query

```BASH
$ ph mexc withdraw USDT 9.67 '0x99985Cb68Bc8620B646BaF22C49C0D75418236CE' null '{"network": "BEP20"}'
PHP v8.2.9
CCXT version :4.2.49
mexc->withdraw(USDT, 9.67, 0x99985Cb68Bc8620B646BaF22C49C0D75418236CE, , Array)
ccxt\InsufficientFunds: mexc {"code":10101,"msg":"Insufficient balance","timestamp":1708669994516}

# it was the wrong signature error before.
```