### PR TITLE
gemini - watchBidsAsks

### DIFF
--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -427,6 +427,19 @@ export default class gemini extends geminiRest {
         return orderbook.limit ();
     }
 
+    async watchBidsAsks (symbols: string[], limit: Int = undefined, params = {}): Promise<Tickers> {
+        /**
+         * @method
+         * @name gemini#watchBidsAsks
+         * @description watches best bid & ask for symbols
+         * @see https://docs.gemini.com/websocket-api/#multi-market-data
+         * @param {string[]} symbols unified symbol of the market to fetch the ticker for
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
+         */
+        return await this.helperForWatchMultipleConstruct ('bidsasks', symbols, params);
+    }
+
     async helperForWatchMultipleConstruct (itemHashName:string, symbols: string[], params = {}) {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true, true);

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -472,9 +472,8 @@ export default class gemini extends geminiRest {
         const market = this.safeMarket (marketId.toLowerCase ());
         const symbol = market['symbol'];
         if (!(symbol in this.bidsasks)) {
-            this.bidsasks[symbol] = this.parseTicker ({
-                'symbol': symbol,
-            });
+            this.bidsasks[symbol] = this.parseTicker ({});
+            this.bidsasks[symbol]['symbol'] = symbol;
         }
         const currentBidAsk = this.bidsasks[symbol];
         const messageHash = 'bidsasks:' + symbol;
@@ -497,6 +496,7 @@ export default class gemini extends geminiRest {
         }
         currentBidAsk['timestamp'] = timestamp;
         currentBidAsk['datetime'] = this.iso8601 (timestamp);
+        currentBidAsk['info'] = rawBidAskChanges;
         this.bidsasks[symbol] = currentBidAsk;
         client.resolve (currentBidAsk, messageHash);
     }


### PR DESCRIPTION
in previous week I had done all other multi-endpoints and just for the sake of completeness, this one was remaining and i've finished gemini.


```
npm run cli.js -- gemini watchBidsAsks "['BTC/USDT','ETH/USDT']"                           

> ccxt@4.2.49 cli.js
> node ./examples/js/cli.js gemini watchBidsAsks ['BTC/USDT','ETH/USDT']

2024-02-23T08:34:16.282Z
Node.js: v20.10.0
CCXT v4.2.49
gemini.watchBidsAsks (BTC/USDT,ETH/USDT)
{
  symbol: 'BTC/USDT',
  timestamp: 1708677259376,
  datetime: '2024-02-23T08:34:19.376Z',
  bid: 50847.69,
  bidVolume: 0.00163622,
  ask: 51001.82,
  askVolume: 0.1177,
  info: [
    {
      delta: '0.00163622',
      price: '50847.69',
      reason: 'initial',
      remaining: '0.00163622',
      side: 'bid',
      symbol: 'BTCUSDT',
      type: 'change'
    },
    {
      delta: '0.1177',
      price: '51001.82',
      reason: 'initial',
      remaining: '0.1177',
      side: 'ask',
      symbol: 'BTCUSDT',
      type: 'change'
    }
  ]
}
```