### PR TITLE
feat(binance): fetchLedgerEntry (options only)

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -89,6 +89,7 @@ export default class binance extends Exchange {
                 'fetchL3OrderBook': false,
                 'fetchLastPrices': true,
                 'fetchLedger': true,
+                'fetchLedgerEntry': true,
                 'fetchLeverage': false,
                 'fetchLeverageTiers': true,
                 'fetchLiquidations': false,
@@ -10356,6 +10357,20 @@ export default class binance extends Exchange {
             result.push (this.parseSettlement (settlements[i], market));
         }
         return result;
+    }
+
+    async fetchLedgerEntry (id: string, code: Str = undefined, params = {}) {
+        await this.loadMarkets ();
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchLedgerEntry', undefined, params);
+        const query = {
+            'recordId': id,
+            'type': type,
+        };
+        if (type !== 'option') {
+            throw new BadRequest (this.id + ' fetchLedgerEntry () can only be used for type option');
+        }
+        return await this.fetchLedger (code, undefined, undefined, this.extend (query, params));
     }
 
     async fetchLedger (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2666,20 +2666,6 @@
                   }
                 ]
             }
-        ],
-        "fetchLedgerEntry": [
-            {
-                "description": "Option Fetch Ledger Entry",
-                "method": "fetchLedgerEntry",
-                "url": "https://eapi.binance.com/eapi/v1/income?timestamp=1708733694590&recordId=8110240447708406010&recvWindow=10000&signature=aa41468ca3dd5454d0f81cc757876157a67521dea70da448630044c512919b54",
-                "input": [
-                  "8110240447708406010",
-                  null,
-                  {
-                    "type": "option"
-                  }
-                ]
-            }
         ]
     }
 }

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2666,6 +2666,20 @@
                   }
                 ]
             }
+        ],
+        "fetchLedgerEntry": [
+            {
+                "description": "Option Fetch Ledger Entry",
+                "method": "fetchLedgerEntry",
+                "url": "https://eapi.binance.com/eapi/v1/income?timestamp=1708733694590&recordId=8110240447708406010&recvWindow=10000&signature=aa41468ca3dd5454d0f81cc757876157a67521dea70da448630044c512919b54",
+                "input": [
+                  "8110240447708406010",
+                  null,
+                  {
+                    "type": "option"
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
I can't properly test this out using only a testnet api key

```
2024-02-24T00:20:37.831Z
Node.js: v18.12.0
CCXT v4.2.49
binance.fetchLedger (USDT, , , [object Object])
NotSupported binance does not have a testnet/sandbox URL for eapiPrivate endpoints
---------------------------------------------------
[NotSupported] binance does not have a testnet/sandbox URL for eapiPrivate endpoints

    at sign         Users/samgermain/Documents/CCXT/ccxt/ts/src/binance.ts:10557  
    at fetch2       …samgermain/Documents/CCXT/ccxt/ts/src/base/Exchange.ts:3886  
    at request      Users/samgermain/Documents/CCXT/ccxt/ts/src/binance.ts:10798  
    at fetchLedger  Users/samgermain/Documents/CCXT/ccxt/ts/src/binance.ts:10427  
    at async run    Users/samgermain/Documents/CCXT/ccxt/examples/ts/cli.ts:338   

binance does not have a testnet/sandbox URL for eapiPrivate endpoints
```