### PR TITLE
mexc: invalid content type error

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -5438,7 +5438,7 @@ export default class mexc extends Exchange {
                     'source': this.safeString (this.options, 'broker', 'CCXT'),
                 };
             }
-            if (method === 'POST') {
+            if ((method === 'POST') || (method === 'PUT')) {
                 headers['Content-Type'] = 'application/json';
             }
         } else if (section === 'contract' || section === 'spot2') {


### PR DESCRIPTION
Fixed a bug with calling websocket methods on mexc after this update: https://www.mexc.com/support/articles/17827791513387

fixes: #21345

The error was triggered through the `keepAliveListenKey` method calling the `spotPrivatePutUserDataStream` endpoint. Which occurs about every 20 minutes when a websocket connection is made. The bug is fixed by setting `headers['Content-Type'] = 'application/json'` for PUT endpoints.