### PR TITLE
fix(gate): handleTickerAndBidAsk parsing

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -396,7 +396,7 @@ export default class gate extends gateRest {
         const rawMarketType = this.safeString (parts, 0);
         const marketType = (rawMarketType === 'futures') ? 'contract' : 'spot';
         let results = [];
-        if (marketType === 'contract') {
+        if (Array.isArray (this.safeValue (message, 'result'))) {
             results = this.safeList (message, 'result', []);
         } else {
             const rawTicker = this.safeDict (message, 'result', {});


### PR DESCRIPTION
Parsing of future / contract tickers fails for `watchBidsAsks`
The message coming when watching `book_ticker` channel is a dict and not a list