### PR TITLE
coinbase: increase limit for fetchBalance

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1779,6 +1779,7 @@ export default class coinbase extends Exchange {
             request['limit'] = 250;
             response = await this.v3PrivateGetBrokerageAccounts (this.extend (request, params));
         } else {
+            request['limit'] = 100;
             response = await this.v2PrivateGetAccounts (this.extend (request, params));
         }
         //
@@ -3612,6 +3613,10 @@ export default class coinbase extends Exchange {
                     if (Object.keys (query).length) {
                         body = this.json (query);
                         payload = body;
+                    }
+                } else {
+                    if (Object.keys (query).length) {
+                        payload += '?' + this.urlencode (query);
                     }
                 }
                 const auth = nonce + method + savedPath + payload;

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -148,7 +148,7 @@
             {
                 "description": "Fetch spot Balance",
                 "method": "fetchBalance",
-                "url": "https://api.coinbase.com/v2/accounts",
+                "url": "https://api.coinbase.com/v2/accounts?limit=100",
                 "input": [
                     {
                         "type": "spot"
@@ -168,7 +168,7 @@
             {
                 "description": "Fetch swap Balance",
                 "method": "fetchBalance",
-                "url": "https://api.coinbase.com/v2/accounts",
+                "url": "https://api.coinbase.com/v2/accounts?limit=100",
                 "input": [
                     {
                         "type": "swap"


### PR DESCRIPTION
Related issue: ccxt/ccxt#21399

```BASH
$ n coinbase fetchBalance --verbose
2024-02-27T03:07:23.617Z
Node.js: v20.11.1
CCXT v4.2.52
coinbase.fetchBalance ()
fetch Request:
 coinbase GET https://api.coinbase.com/v2/accounts?limit=100
RequestHeaders:
 {
...
}
RequestBody:
 undefined

handleRestResponse:
 coinbase GET https://api.coinbase.com/v2/accounts?limit=100 200 OK
ResponseHeaders:
 {
...
}
ResponseBody:
...
```