### PR TITLE
fix(coinbase): add params to the body when using Authorization as header

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3594,6 +3594,11 @@ export default class coinbase extends Exchange {
                     'Authorization': authorization,
                     'Content-Type': 'application/json',
                 };
+                if (method !== 'GET') {
+                    if (Object.keys (query).length) {
+                        body = this.json (query);
+                    }
+                }
             } else if (this.token && !this.checkRequiredCredentials (false)) {
                 headers = {
                     'Authorization': 'Bearer ' + this.token,


### PR DESCRIPTION
Fixed a bug when using the Authorization header like below
`exchange["headers"]["Authorization"]`

It was already incompletely fixed #20997 