### PR TITLE
bitmart: fetchLeverage, fetchLeverages

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -555,6 +555,7 @@ export default class Exchange {
                 'fetchLedger': undefined,
                 'fetchLedgerEntry': undefined,
                 'fetchLeverage': undefined,
+                'fetchLeverages': undefined,
                 'fetchLeverageTiers': undefined,
                 'fetchLiquidations': undefined,
                 'fetchMarginMode': undefined,
@@ -2326,6 +2327,10 @@ export default class Exchange {
 
     async fetchLeverage (symbol: string, params = {}): Promise<{}> {
         throw new NotSupported (this.id + ' fetchLeverage() is not supported yet');
+    }
+
+    async fetchLeverages (symbols: string[] = undefined, params = {}): Promise<{}> {
+        throw new NotSupported (this.id + ' fetchLeverages() is not supported yet');
     }
 
     async setPositionMode (hedged: boolean, symbol: Str = undefined, params = {}): Promise<{}> {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -70,6 +70,7 @@ export default class bitmart extends Exchange {
                 'fetchIsolatedBorrowRate': true,
                 'fetchIsolatedBorrowRates': true,
                 'fetchLeverage': true,
+                'fetchLeverages': true,
                 'fetchLiquidations': false,
                 'fetchMarginMode': false,
                 'fetchMarkets': true,
@@ -4160,6 +4161,32 @@ export default class bitmart extends Exchange {
             'leverage': this.safeInteger (position, 'leverage'),
             'marginMode': this.safeNumber (position, 'marginMode'),
         };
+    }
+
+    async fetchLeverages (symbols: string[] = undefined, params = {}) {
+        /**
+         * @method
+         * @name bitmart#fetchLeverages
+         * @description fetch the set leverage for all contract markets
+         * @see https://developer-pro.bitmart.com/en/futures/#get-current-position-keyed
+         * @param {string[]} [symbols] a list of unified market symbols
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a list of [leverage structures]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        await this.loadMarkets ();
+        const positions = await this.fetchPositions (symbols, params);
+        const result = [];
+        for (let i = 0; i < positions.length; i++) {
+            const entry = positions[i];
+            const marketId = this.safeString (entry, 'symbol');
+            result.push ({
+                'info': entry,
+                'symbol': this.safeMarket (marketId, undefined, undefined, 'contract'),
+                'leverage': this.safeInteger (entry, 'leverage'),
+                'marginMode': this.safeNumber (entry, 'marginMode'),
+            });
+        }
+        return result;
     }
 
     async fetchPosition (symbol: string, params = {}) {

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -69,6 +69,7 @@ export default class bitmart extends Exchange {
                 'fetchFundingRates': false,
                 'fetchIsolatedBorrowRate': true,
                 'fetchIsolatedBorrowRates': true,
+                'fetchLeverage': true,
                 'fetchLiquidations': false,
                 'fetchMarginMode': false,
                 'fetchMarkets': true,
@@ -4139,6 +4140,25 @@ export default class bitmart extends Exchange {
             'previousFundingRate': this.safeNumber (contract, 'rate_value'),
             'previousFundingTimestamp': undefined,
             'previousFundingDatetime': undefined,
+        };
+    }
+
+    async fetchLeverage (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name bitmart#fetchLeverage
+         * @description fetch the set leverage for a market
+         * @see https://developer-pro.bitmart.com/en/futures/#get-current-position-keyed
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        await this.loadMarkets ();
+        const position = await this.fetchPosition (symbol, params);
+        return {
+            'info': position,
+            'leverage': this.safeInteger (position, 'leverage'),
+            'marginMode': this.safeNumber (position, 'marginMode'),
         };
     }
 

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -4156,10 +4156,12 @@ export default class bitmart extends Exchange {
          */
         await this.loadMarkets ();
         const position = await this.fetchPosition (symbol, params);
+        const marketId = this.safeString (position, 'symbol');
+        const market = this.safeMarket (marketId, undefined, undefined, 'contract');
         return {
             'info': position,
+            'symbol': market['symbol'],
             'leverage': this.safeInteger (position, 'leverage'),
-            'marginMode': this.safeNumber (position, 'marginMode'),
         };
     }
 
@@ -4179,11 +4181,11 @@ export default class bitmart extends Exchange {
         for (let i = 0; i < positions.length; i++) {
             const entry = positions[i];
             const marketId = this.safeString (entry, 'symbol');
+            const market = this.safeMarket (marketId, undefined, undefined, 'contract');
             result.push ({
                 'info': entry,
-                'symbol': this.safeMarket (marketId, undefined, undefined, 'contract'),
+                'symbol': market['symbol'],
                 'leverage': this.safeInteger (entry, 'leverage'),
-                'marginMode': this.safeNumber (entry, 'marginMode'),
             });
         }
         return result;

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -483,6 +483,16 @@
                     "USDT"
                 ]
             }
+        ],
+        "fetchLeverage": [
+            {
+                "description": "Swap fetch leverage",
+                "method": "fetchLeverage",
+                "url": "https://api-cloud.bitmart.com/contract/private/position?symbol=BTCUSDT",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -493,6 +493,18 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchLeverages": [
+            {
+                "description": "Swap fetch leverages",
+                "method": "fetchLeverages",
+                "url": "https://api-cloud.bitmart.com/contract/private/position?symbol=BTCUSDT",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ]
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchLeverage and fetchLeverages to bitmart:

```
bitmart.fetchLeverage (BTC/USDT:USDT)
2024-02-29T08:52:26.298Z iteration 0 passed in 518 ms

{
  info: {
    info: {
      symbol: 'BTCUSDT',
      leverage: '100',
      timestamp: '1709196746316',
      current_fee: '0.0483551045',
      open_timestamp: '1709192817449',
      current_value: '62.8805',
      mark_price: '62.8722',
      position_value: '62.6203',
      position_cross: '0.614729516343077975',
      maintenance_margin: '0.3131015',
      close_vol: '0',
      close_avg_price: '0',
      open_avg_price: '62620.3',
      entry_price: '62620.3',
      current_amount: '1',
      unrealized_value: '0.2602',
      realized_value: '-0.086617843656922025',
      position_type: '1'
    },
    symbol: 'BTC/USDT:USDT',
    timestamp: 1709196746316,
    datetime: '2024-02-29T08:52:26.316Z',
    side: 'long',
    contracts: 1,
    contractSize: 0.001,
    entryPrice: 62620.3,
    markPrice: 62.8722,
    notional: 62.8805,
    leverage: 100,
    collateral: 0.6147295163430779,
    maintenanceMargin: 0.3131015,
    maintenanceMarginPercentage: 0.004979309960957689,
    unrealizedPnl: 0.2602,
    realizedPnl: -0.08661784365692203,
    marginRatio: 0.5093321398695607
  },
  symbol: 'BTC/USDT:USDT',
  leverage: 100
}
```
```
bitmart.fetchLeverages (BTC/USDT:USDT)
2024-02-29T08:52:49.037Z iteration 0 passed in 496 ms

       symbol | leverage
------------------------
BTC/USDT:USDT |      100
1 objects
```