### PR TITLE
bitmex: fetchLeverage, fetchLeverages

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -555,6 +555,7 @@ export default class Exchange {
                 'fetchLedger': undefined,
                 'fetchLedgerEntry': undefined,
                 'fetchLeverage': undefined,
+                'fetchLeverages': undefined,
                 'fetchLeverageTiers': undefined,
                 'fetchLiquidations': undefined,
                 'fetchMarginMode': undefined,
@@ -2326,6 +2327,10 @@ export default class Exchange {
 
     async fetchLeverage (symbol: string, params = {}): Promise<{}> {
         throw new NotSupported (this.id + ' fetchLeverage() is not supported yet');
+    }
+
+    async fetchLeverages (symbols: string[] = undefined, params = {}): Promise<{}> {
+        throw new NotSupported (this.id + ' fetchLeverages() is not supported yet');
     }
 
     async setPositionMode (hedged: boolean, symbol: Str = undefined, params = {}): Promise<{}> {

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -61,7 +61,7 @@ export default class bitmex extends Exchange {
                 'fetchFundingRates': true,
                 'fetchIndexOHLCV': false,
                 'fetchLedger': true,
-                'fetchLeverage': false,
+                'fetchLeverage': true,
                 'fetchLeverages': true,
                 'fetchLeverageTiers': false,
                 'fetchLiquidations': true,
@@ -2156,6 +2156,21 @@ export default class bitmex extends Exchange {
             });
         }
         return result;
+    }
+
+    async fetchLeverage (symbol: string, params = {}) {
+        /**
+         * @method
+         * @name bitmex#fetchLeverage
+         * @description fetch the set leverage for a market
+         * @see https://www.bitmex.com/api/explorer/#!/Position/Position_get
+         * @param {string} symbol unified market symbol
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        await this.loadMarkets ();
+        const leverage = await this.fetchLeverages ([ symbol ], params);
+        return leverage;
     }
 
     async fetchPositions (symbols: Strings = undefined, params = {}) {

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -616,6 +616,14 @@
           ]
         ]
       }
+    ],
+    "fetchLeverages": [
+      {
+        "description": "Fetch leverages",
+        "method": "fetchLeverages",
+        "url": "https://testnet.bitmex.com/api/v1/position",
+        "input": []
+      }
     ]
   }
 }

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -624,6 +624,16 @@
         "url": "https://testnet.bitmex.com/api/v1/position",
         "input": []
       }
+    ],
+    "fetchLeverage": [
+      {
+        "description": "Swap fetch leverage",
+        "method": "fetchLeverage",
+        "url": "https://testnet.bitmex.com/api/v1/position",
+        "input": [
+          "BTC/USDT:USDT"
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Added `fetchLeverage` and `fetchLeverages` support to bitmex:

```
bitmex.fetchLeverages ()
2024-03-01T03:45:17.324Z iteration 0 passed in 705 ms

       symbol | marginMode | leverage
-------------------------------------
     ETH/USDT |      cross |
     TRX/USDT |      cross |
SOL/USDT:USDT |      cross |       33
BTC/USDT:USDT |      cross |      100
  BTC/USD:BTC |      cross |      100
5 objects
```
```
bitmex.fetchLeverage (BTC/USDT:USDT)
2024-03-01T03:55:14.271Z iteration 0 passed in 684 ms

       symbol | leverage | marginMode
-------------------------------------
BTC/USDT:USDT |      100 |      cross
1 objects
```