### PR TITLE
mexc: fetchLeverage

### DIFF
--- a/ts/src/test/static/request/mexc.json
+++ b/ts/src/test/static/request/mexc.json
@@ -451,6 +451,16 @@
                 ],
                 "output": "[\"129402018493145088\"]"
             }
+        ],
+        "fetchLeverage": [
+            {
+                "description": "Swap fetch leverage",
+                "method": "fetchLeverage",
+                "url": "https://contract.mexc.com/api/v1/private/position/leverage?symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchLeverage` support to mexc:

```
mexc.fetchLeverage (BTC/USDT:USDT)
2024-03-01T07:53:13.674Z iteration 0 passed in 5401 ms

{
  info: {
    level: '1',
    maxVol: '463300',
    mmr: '0.004',
    imr: '0.005',
    positionType: '1',
    openType: '1',
    leverage: '20',
    limitBySys: false,
    currentMmr: '0.004'
  },
  symbol: 'BTC/USDT:USDT',
  leverage: 20
}
```