### PR TITLE
fix(alpaca): fetchTrades uses correct default type for response

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -445,7 +445,7 @@ export default class alpaca extends Exchange {
             'loc': loc,
         };
         params = this.omit (params, [ 'loc', 'method' ]);
-        let response = undefined;
+        let symbolTrades = undefined;
         if (method === 'marketPublicGetV1beta3CryptoLocTrades') {
             if (since !== undefined) {
                 request['start'] = this.iso8601 (since);
@@ -453,44 +453,45 @@ export default class alpaca extends Exchange {
             if (limit !== undefined) {
                 request['limit'] = limit;
             }
-            response = await this.marketPublicGetV1beta3CryptoLocTrades (this.extend (request, params));
+            const response = await this.marketPublicGetV1beta3CryptoLocTrades (this.extend (request, params));
+            //
+            //    {
+            //        "next_page_token": null,
+            //        "trades": {
+            //            "BTC/USD": [
+            //                {
+            //                    "i": 36440704,
+            //                    "p": 22625,
+            //                    "s": 0.0001,
+            //                    "t": "2022-07-21T11:47:31.073391Z",
+            //                    "tks": "B"
+            //                }
+            //            ]
+            //        }
+            //    }
+            //
+            const trades = this.safeDict (response, 'trades', {});
+            symbolTrades = this.safeList (trades, marketId, []);
         } else if (method === 'marketPublicGetV1beta3CryptoLocLatestTrades') {
-            response = await this.marketPublicGetV1beta3CryptoLocLatestTrades (this.extend (request, params));
+            const response = await this.marketPublicGetV1beta3CryptoLocLatestTrades (this.extend (request, params));
+            //
+            //    {
+            //       "trades": {
+            //            "BTC/USD": {
+            //                "i": 36440704,
+            //                "p": 22625,
+            //                "s": 0.0001,
+            //                "t": "2022-07-21T11:47:31.073391Z",
+            //                "tks": "B"
+            //            }
+            //        }
+            //    }
+            //
+            const trades = this.safeDict (response, 'trades', {});
+            symbolTrades = this.safeDict (trades, marketId, {});
+            symbolTrades = [ symbolTrades ];
         } else {
             throw new NotSupported (this.id + ' fetchTrades() does not support ' + method + ', marketPublicGetV1beta3CryptoLocTrades and marketPublicGetV1beta3CryptoLocLatestTrades are supported');
-        }
-        //
-        // {
-        //     "next_page_token":null,
-        //     "trades":{
-        //        "BTC/USD":[
-        //           {
-        //              "i":36440704,
-        //              "p":22625,
-        //              "s":0.0001,
-        //              "t":"2022-07-21T11:47:31.073391Z",
-        //              "tks":"B"
-        //           }
-        //        ]
-        //     }
-        // }
-        //
-        // {
-        //     "trades":{
-        //        "BTC/USD":{
-        //           "i":36440704,
-        //           "p":22625,
-        //           "s":0.0001,
-        //           "t":"2022-07-21T11:47:31.073391Z",
-        //           "tks":"B"
-        //        }
-        //     }
-        // }
-        //
-        const trades = this.safeValue (response, 'trades', {});
-        let symbolTrades = this.safeValue (trades, marketId, {});
-        if (!Array.isArray (symbolTrades)) {
-            symbolTrades = [ symbolTrades ];
         }
         return this.parseTrades (symbolTrades, market, since, limit);
     }
@@ -585,7 +586,7 @@ export default class alpaca extends Exchange {
             'loc': loc,
         };
         params = this.omit (params, [ 'loc', 'method' ]);
-        let response = undefined;
+        let ohlcvs = undefined;
         if (method === 'marketPublicGetV1beta3CryptoLocBars') {
             if (limit !== undefined) {
                 request['limit'] = limit;
@@ -594,60 +595,61 @@ export default class alpaca extends Exchange {
                 request['start'] = this.yyyymmdd (since);
             }
             request['timeframe'] = this.safeString (this.timeframes, timeframe, timeframe);
-            response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
+            const response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
+            //
+            //    {
+            //        "bars": {
+            //           "BTC/USD": [
+            //              {
+            //                 "c": 22887,
+            //                 "h": 22888,
+            //                 "l": 22873,
+            //                 "n": 11,
+            //                 "o": 22883,
+            //                 "t": "2022-07-21T05:00:00Z",
+            //                 "v": 1.1138,
+            //                 "vw": 22883.0155324116
+            //              },
+            //              {
+            //                 "c": 22895,
+            //                 "h": 22895,
+            //                 "l": 22884,
+            //                 "n": 6,
+            //                 "o": 22884,
+            //                 "t": "2022-07-21T05:01:00Z",
+            //                 "v": 0.001,
+            //                 "vw": 22889.5
+            //              }
+            //           ]
+            //        },
+            //        "next_page_token": "QlRDL1VTRHxNfDIwMjItMDctMjFUMDU6MDE6MDAuMDAwMDAwMDAwWg=="
+            //     }
+            //
+            const bars = this.safeDict (response, 'bars', {});
+            ohlcvs = this.safeList (bars, marketId, []);
         } else if (method === 'marketPublicGetV1beta3CryptoLocLatestBars') {
-            response = await this.marketPublicGetV1beta3CryptoLocLatestBars (this.extend (request, params));
+            const response = await this.marketPublicGetV1beta3CryptoLocLatestBars (this.extend (request, params));
+            //
+            //    {
+            //        "bars": {
+            //           "BTC/USD": {
+            //              "c": 22887,
+            //              "h": 22888,
+            //              "l": 22873,
+            //              "n": 11,
+            //              "o": 22883,
+            //              "t": "2022-07-21T05:00:00Z",
+            //              "v": 1.1138,
+            //              "vw": 22883.0155324116
+            //           }
+            //        }
+            //     }
+            //
+            const bars = this.safeDict (response, 'bars', {});
+            ohlcvs = this.safeDict (bars, marketId, {});
+            ohlcvs = [ ohlcvs ];
         } else {
             throw new NotSupported (this.id + ' fetchOHLCV() does not support ' + method + ', marketPublicGetV1beta3CryptoLocBars and marketPublicGetV1beta3CryptoLocLatestBars are supported');
-        }
-        //
-        //    {
-        //        "bars":{
-        //           "BTC/USD":[
-        //              {
-        //                 "c":22887,
-        //                 "h":22888,
-        //                 "l":22873,
-        //                 "n":11,
-        //                 "o":22883,
-        //                 "t":"2022-07-21T05:00:00Z",
-        //                 "v":1.1138,
-        //                 "vw":22883.0155324116
-        //              },
-        //              {
-        //                 "c":22895,
-        //                 "h":22895,
-        //                 "l":22884,
-        //                 "n":6,
-        //                 "o":22884,
-        //                 "t":"2022-07-21T05:01:00Z",
-        //                 "v":0.001,
-        //                 "vw":22889.5
-        //              }
-        //           ]
-        //        },
-        //        "next_page_token":"QlRDL1VTRHxNfDIwMjItMDctMjFUMDU6MDE6MDAuMDAwMDAwMDAwWg=="
-        //     }
-        //
-        //    {
-        //        "bars":{
-        //           "BTC/USD":{
-        //              "c":22887,
-        //              "h":22888,
-        //              "l":22873,
-        //              "n":11,
-        //              "o":22883,
-        //              "t":"2022-07-21T05:00:00Z",
-        //              "v":1.1138,
-        //              "vw":22883.0155324116
-        //           }
-        //        }
-        //     }
-        //
-        const bars = this.safeValue (response, 'bars', {});
-        let ohlcvs = this.safeValue (bars, marketId, {});
-        if (!Array.isArray (ohlcvs)) {
-            ohlcvs = [ ohlcvs ];
         }
         return this.parseOHLCVs (ohlcvs, market, timeframe, since, limit);
     }

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -85,11 +85,47 @@
         ],
         "fetchClosedOrders": [
             {
-                "description": "Spot open orders",
+                "description": "Spot closed orders",
                 "method": "fetchClosedOrders",
                 "url": "https://api.alpaca.markets/v2/orders?status=closed&symbols=LTC%2FUSDT",
                 "input": [
                     "LTC/USDT"
+                ]
+            }
+        ],
+        "fetchTrades": [
+            {
+                "description": "Fetch Trades",
+                "method": "fetchTrades",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/trades?symbols=BTC%2FUSDT",
+                "input": [
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Fetch trades with method: marketPublicGetV1beta3CryptoLocLatestTrades",
+                "method": "fetchTrades",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/latest/trades?symbols=BTC%2FUSDT",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "method": "marketPublicGetV1beta3CryptoLocLatestTrades"
+                  }
+                ]
+            },
+            {
+                "description": "Fetch trades with method: marketPublicGetV1beta3CryptoLocTrades",
+                "method": "fetchTrades",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/trades?symbols=BTC%2FUSD",
+                "input": [
+                  "BTC/USD",
+                  null,
+                  null,
+                  {
+                    "method": "marketPublicGetV1beta3CryptoLocTrades"
+                  }
                 ]
             }
         ]


### PR DESCRIPTION
```
% py alpaca fetchTrades BTC/USDT None None '{"method": "marketPublicGetV1beta3CryptoLocLatestTrades"}'    
Python v3.9.6
CCXT v4.2.57
alpaca.fetchTrades(BTC/USDT,None,None,{'method': 'marketPublicGetV1beta3CryptoLocLatestTrades'})
[{'amount': 0.001687033,
  'cost': 102.04079833688,
  'datetime': '2024-02-28T17:43:12.561Z',
  'fee': None,
  'fees': [],
  'id': '5279491075350809465',
  'info': {'i': '5279491075350809465',
           'p': '60485.36',
           's': '0.001687033',
           't': '2024-02-28T17:43:12.561000516Z',
           'tks': 'S'},
  'order': None,
  'price': 60485.36,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1709142192561,
  'type': None}]
```

```
Python v3.9.6
CCXT v4.2.57
alpaca.fetchTrades(BTC/USD,None,None,{'method': 'marketPublicGetV1beta3CryptoLocTrades'})
[{'amount': 0.002601122,
  'cost': 160.55142022702,
  'datetime': '2024-03-01T06:25:43.297Z',
  'fee': None,
  'fees': [],
  'id': '4902749691943471012',
  'info': {'i': '4902749691943471012',
           'p': '61723.91',
           's': '0.002601122',
           't': '2024-03-01T06:25:43.297645317Z',
           'tks': 'B'},
  'order': None,
  'price': 61723.91,
  'side': 'buy',
  'symbol': 'BTC/USD',
  'takerOrMaker': 'taker',
  'timestamp': 1709274343297,
  'type': None},
 ...
 ]
```