### PR TITLE
fix(bitrue): fetchWithdrawals uses correct default type for response

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -2583,20 +2583,29 @@ export default class bitrue extends Exchange {
         }
         const response = await this.spotV1PrivateGetWithdrawHistory (this.extend (request, params));
         //
-        //     {
-        //         "code": 200,
-        //         "msg": "succ",
-        //         "data": {
-        //             "msg": null,
-        //             "amount": 1000,
-        //             "fee": 1,
-        //             "ctime": null,
-        //             "coin": "usdt_erc20",
-        //             "addressTo": "0x2edfae3878d7b6db70ce4abed177ab2636f60c83"
-        //         }
-        //     }
+        //    {
+        //        "code": 200,
+        //        "msg": "succ",
+        //        "data": [
+        //            {
+        //                "id": 183745,
+        //                "symbol": "usdt_erc20",
+        //                "amount": "8.4000000000000000",
+        //                "fee": "1.6000000000000000",
+        //                "payAmount": "0.0000000000000000",
+        //                "createdAt": 1595336441000,
+        //                "updatedAt": 1595336576000,
+        //                "addressFrom": "",
+        //                "addressTo": "0x2edfae3878d7b6db70ce4abed177ab2636f60c83",
+        //                "txid": "",
+        //                "confirmations": 0,
+        //                "status": 6,
+        //                "tagType": null
+        //            }
+        //        ]
+        //    }
         //
-        const data = this.safeValue (response, 'data', {});
+        const data = this.safeList (response, 'data', []);
         return this.parseTransactions (data, currency);
     }
 
@@ -2946,7 +2955,7 @@ export default class bitrue extends Exchange {
         //         }]
         //     }
         //
-        const data = this.safeValue (response, 'data', {});
+        const data = this.safeList (response, 'data', []);
         return this.parseTransfers (data, currency, since, limit);
     }
 

--- a/ts/src/test/static/request/bitrue.json
+++ b/ts/src/test/static/request/bitrue.json
@@ -240,7 +240,7 @@
                 ]
             },
             {
-                "description": "Cancel spot order",
+                "description": "Cancel swap order",
                 "method": "cancelOrder",
                 "url": "https://fapi.bitrue.com/fapi/v2/cancel",
                 "input": [
@@ -249,6 +249,16 @@
                 ],
                 "output": "{\"recvWindow\":5000,\"orderId\":\"1941111689217512895\",\"contractName\":\"E-LTC-USDT\"}"
             }
+        ],
+        "fetchWithdrawals": [
+          {
+            "description": "Fetch Withdrawals",
+            "method": "fetchWithdrawals",
+            "url": "https://www.bitrue.com/api/v1/withdraw/history?timestamp=1709351446237&recvWindow=5000&coin=usdc&status=5&signature=5f27a957b7e087e9eb4ade590ae3969695b19d9f3d6de68713d75a0376fbce0d",
+            "input": [
+              "USDC"
+            ]
+          }
         ]
     }
 }


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.57
bitrue.fetchWithdrawals(USDC)
[{'address': '4KYD8YLkApnK2nxyUM32o1YWCPi1w59AwsFAo9BZnpk1',
  'addressFrom': None,
  'addressTo': '4KYD8YLkApnK2nxyUM32o1YWCPi1w59AwsFAo9BZnpk1',
  'amount': 12.939977,
  'comment': None,
  'currency': 'USDC',
  'datetime': '2023-10-19T22:35:14.000Z',
  'fee': {'cost': 1.0, 'currency': 'USDC'},
  'id': '4635516',
  'info': {'addressFrom': '',
           'addressTo': '4KYD8YLkApnK2nxyUM32o1YWCPi1w59AwsFAo9BZnpk1',
           'amount': '12.9399770000000000',
           'confirmations': '1',
           'createdAt': '1697754914000',
           'fee': '1.0000000000000000',
           'id': '4635516',
           'payAmount': '12.9399770000000000',
           'realAddress': '4KYD8YLkApnK2nxyUM32o1YWCPi1w59AwsFAo9BZnpk1',
           'status': '5',
           'symbol': 'usdc_sol',
           'tag': '',
           'tagType': None,
           'txid': '2sJ6UKYMCUHSsnnT8jGWhyfSWp6Rfjy6uF3Hp4v3r86YAyd5Tc1kcHca9pJsvm7E7HWCPiopFuAu6P13sZp7NTQa',
           'updatedAt': '1697755697000'},
  'internal': False,
  'network': 'SOL',
  'status': 'ok',
  'tag': None,
  'tagFrom': None,
  'tagTo': None,
  'timestamp': 1697754914000,
  'txid': '2sJ6UKYMCUHSsnnT8jGWhyfSWp6Rfjy6uF3Hp4v3r86YAyd5Tc1kcHca9pJsvm7E7HWCPiopFuAu6P13sZp7NTQa',
  'type': 'withdrawal',
  'updated': 1697755697000}]
```