### PR TITLE
fix(woo): fetchTrades uses correct default type for response

### DIFF
--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -374,6 +374,16 @@
                 ],
                 "output": "position_mode=ONE_WAY"
             }
+        ],
+        "fetchTrades": [
+            {
+                "description": "Fetch Trades",
+                "method": "fetchTrades",
+                "url": "https://api.woo.org/v1/public/market_trades?symbol=SPOT_BTC_USDT",
+                "input": [
+                    "BTC/USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -494,7 +494,7 @@ export default class woo extends Exchange {
         //      ]
         // }
         //
-        const resultResponse = this.safeValue (response, 'rows', {});
+        const resultResponse = this.safeList (response, 'rows', []);
         return this.parseTrades (resultResponse, market, since, limit);
     }
 


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.57
woo.fetchTrades(BTC/USDT)
[{'amount': 0.000254,
  'cost': 15.75203606,
  'datetime': '2024-03-02T02:51:15.367Z',
  'fee': None,
  'fees': [],
  'id': None,
  'info': {'executed_price': '62015.89',
           'executed_quantity': '0.000254',
           'executed_timestamp': '1709347875.367',
           'side': 'BUY',
           'source': '1',
           'symbol': 'SPOT_BTC_USDT'},
  'order': None,
  'price': 62015.89,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1709347875367,
  'type': None},
```