### PR TITLE
fix(whitebit): handleMessage uses safeString for result instead of safeMessage

### DIFF
--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -887,12 +887,10 @@ export default class whitebit extends whitebitRest {
         if (!this.handleErrorMessage (client, message)) {
             return;
         }
-        const result = this.safeValue (message, 'result', {});
-        if (result !== undefined) {
-            if (result === 'pong') {
-                this.handlePong (client, message);
-                return;
-            }
+        const result = this.safeString (message, 'result');
+        if (result === 'pong') {
+            this.handlePong (client, message);
+            return;
         }
         const id = this.safeInteger (message, 'id');
         if (id !== undefined) {


### PR DESCRIPTION
```
% whitebit watchTrades BTC/USDT --verbose > temp.txt

2024-03-02T03:16:10.489Z
Node.js: v18.12.0
CCXT v4.2.57
whitebit.watchTrades (BTC/USDT)
...
    timestamp |                 datetime |   symbol |         id | order | type | takerOrMaker | side |    price |   amount |             cost | fee | fees[39m
-----------------------------------------------------------------------------------------------------------------------------------------------------------
1709349427342 | 2024-03-02T03:17:07.342Z | BTC/USDT | 3634495161 |       |      |              |  buy | 62031.25 | 0.075935 | 0.00471034296875 |     |   []
1 objects
2024-03-02T03:17:12.093Z sending { id: 0, method: 'ping', params: [] }
2024-03-02T03:17:12.224Z onMessage { error: null, result: 'pong', id: 0 }
2024-03-02T03:17:12.609Z onMessage {
  method: 'trades_update',
  params: [ 'BTC_USDT', [ [Object], [Object] ] ],
  id: null
}
```