### PR TITLE
fix(alpaca): handleCryptoMessage uses safeString instead of safeValue

### DIFF
--- a/ts/src/pro/alpaca.ts
+++ b/ts/src/pro/alpaca.ts
@@ -634,7 +634,7 @@ export default class alpaca extends alpacaRest {
         for (let i = 0; i < message.length; i++) {
             const data = message[i];
             const T = this.safeString (data, 'T');
-            const msg = this.safeValue (data, 'msg', {});
+            const msg = this.safeString (data, 'msg');
             if (T === 'subscription') {
                 this.handleSubscription (client, data);
                 return;


### PR DESCRIPTION
I keep getting 404, but it doesn't make sense for this to be a safeValue instead of a safeString

```
% alpaca watchTrades BTC/USDT --verbose
(node:25367) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
2024-03-02T03:26:16.869Z
Node.js: v18.12.0
CCXT v4.2.57
alpaca.watchTrades (BTC/USDT)
2024-03-02T03:26:17.525Z connecting to wss://stream.data.alpaca.markets/v1beta2/crypto
2024-03-02T03:26:17.899Z onError Unexpected server response: 404
2024-03-02T03:26:17.899Z onClose CloseEvent {
```