### PR TITLE
fix(ascendex): remove made up timestamp data

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -762,11 +762,10 @@ export default class ascendex extends Exchange {
     }
 
     parseBalance (response): Balances {
-        const timestamp = this.milliseconds ();
         const result = {
             'info': response,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
         };
         const balances = this.safeValue (response, 'data', []);
         for (let i = 0; i < balances.length; i++) {
@@ -781,11 +780,10 @@ export default class ascendex extends Exchange {
     }
 
     parseMarginBalance (response) {
-        const timestamp = this.milliseconds ();
         const result = {
             'info': response,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
         };
         const balances = this.safeValue (response, 'data', []);
         for (let i = 0; i < balances.length; i++) {
@@ -803,11 +801,10 @@ export default class ascendex extends Exchange {
     }
 
     parseSwapBalance (response) {
-        const timestamp = this.milliseconds ();
         const result = {
             'info': response,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
         };
         const data = this.safeValue (response, 'data', {});
         const collaterals = this.safeValue (data, 'collaterals', []);
@@ -830,6 +827,8 @@ export default class ascendex extends Exchange {
          * @see https://ascendex.github.io/ascendex-pro-api/#margin-account-balance
          * @see https://ascendex.github.io/ascendex-futures-pro-api-v2/#position
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.type] wallet type, 'spot', 'margin', or 'swap'
+         * @param {string} [params.marginMode] 'cross' or undefined, for spot margin trading, value of 'isolated' is invalid
          * @returns {object} a [balance structure]{@link https://docs.ccxt.com/#/?id=balance-structure}
          */
         await this.loadMarkets ();
@@ -3209,12 +3208,11 @@ export default class ascendex extends Exchange {
         //
         const status = this.safeInteger (transfer, 'code');
         const currencyCode = this.safeCurrencyCode (undefined, currency);
-        const timestamp = this.milliseconds ();
         return {
             'info': transfer,
             'id': undefined,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'timestamp': undefined,
+            'datetime': undefined,
             'currency': currencyCode,
             'amount': undefined,
             'fromAccount': undefined,


### PR DESCRIPTION
```
% py ascendex fetchBalance
Python v3.9.6
CCXT v4.2.59
ascendex.fetchBalance()
{'SOL': {'free': 0.040107562, 'total': 0.040107562, 'used': 0.0},
 'TRX': {'free': 2.8e-05, 'total': 2.8e-05, 'used': 0.0},
 'datetime': None,
 'free': {'SOL': 0.040107562, 'TRX': 2.8e-05},
 'info': {'code': '0',
          'data': [{'asset': 'SOL',
                    'availableBalance': '0.040107562',
                    'totalBalance': '0.040107562'},
                   {'asset': 'TRX',
                    'availableBalance': '0.000028',
                    'totalBalance': '0.000028'}]},
 'timestamp': None,
 'total': {'SOL': 0.040107562, 'TRX': 2.8e-05},
 'used': {'SOL': 0.0, 'TRX': 0.0}}
 ```

 ```
 % py ascendex fetchBalance '{"type": "margin"}'
Python v3.9.6
CCXT v4.2.59
ascendex.fetchBalance({'type': 'margin'})
{'USDT': {'debt': 0.0, 'free': 9.0577e-05, 'total': 9.0577e-05, 'used': 0.0},
 'datetime': None,
 'debt': {'USDT': 0.0},
 'free': {'USDT': 9.0577e-05},
 'info': {'code': '0',
          'data': [{'asset': 'USDT',
                    'availableBalance': '0.000090577',
                    'borrowed': '0',
                    'interest': '0',
                    'totalBalance': '0.000090577'}]},
 'timestamp': None,
 'total': {'USDT': 9.0577e-05},
 'used': {'USDT': 0.0}}
 ```

 ```
 Python v3.9.6
CCXT v4.2.59
ascendex.fetchBalance({'type': 'swap'})
{'datetime': None,
 'free': {},
 'info': {'code': '0',
          'data': {'ac': 'FUTURES',
                   'accountId': 'futV7spM19RCPgezgG4rg2rj3dWuhlv7',
                   'collaterals': [],
                   'contracts': [{'avgOpenPrice': '0',
                                  'buyOpenOrderNotional': '0',
                                  'indexPrice': '0.04955',
                                  'isolatedMargin': '0',
                                  'leverage': '50',
                                  'marginType': 'crossed',
                                  'markPrice': '0.049576769',
                                  'posStopMode': 'Full',
                                  'position': '0',
                                  'realizedPnl': '0',
                                  'referenceCost': '0',
                                  'sellOpenOrderNotional': '0',
                                  'side': 'LONG',
                                  'stopLossPrice': '0',
                                  'stopLossTrigger': 'market',
                                  'symbol': 'VET-PERP',
                                  'takeProfitPrice': '0',
                                  'takeProfitTrigger': 'market',
                                  'unrealizedPnl': '0'},
                                  ...
                   ],
 'timestamp': None,
 'total': {},
 'used': {}}
 ```
