### PR TITLE
fix(bitmart): parse network ids

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -514,6 +514,7 @@ export default class bitmart extends Exchange {
                 },
                 'networks': {
                     'ERC20': 'ERC20',
+                    'SOL': 'SOL',
                     'BTC': 'BTC',
                     'TRC20': 'TRC20',
                     // todo: should be TRX after unification
@@ -536,7 +537,6 @@ export default class bitmart extends Exchange {
                     'FIO': 'FIO',
                     'SCRT': 'SCRT',
                     'IOTX': 'IOTX',
-                    'SOL': 'SOL',
                     'ALGO': 'ALGO',
                     'ATOM': 'ATOM',
                     'DOT': 'DOT',
@@ -3073,6 +3073,7 @@ export default class bitmart extends Exchange {
          * @method
          * @name bitmart#fetchDepositAddress
          * @description fetch the deposit address for a currency associated with this account
+         * @see https://developer-pro.bitmart.com/en/spot/#deposit-address-keyed
          * @param {string} code unified currency code
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
@@ -3095,41 +3096,59 @@ export default class bitmart extends Exchange {
         }
         const response = await this.privateGetAccountV1DepositAddress (this.extend (request, params));
         //
-        //     {
-        //         "message":"OK",
-        //         "code":1000,
-        //         "trace":"0e6edd79-f77f-4251-abe5-83ba75d06c1a",
-        //         "data":{
-        //             "currency":"USDT-TRC20",
-        //             "chain":"USDT-TRC20",
-        //             "address":"TGR3ghy2b5VLbyAYrmiE15jasR6aPHTvC5",
-        //             "address_memo":""
-        //         }
-        //     }
+        //    {
+        //        "message": "OK",
+        //        "code": 1000,
+        //        "trace": "0e6edd79-f77f-4251-abe5-83ba75d06c1a",
+        //        "data": {
+        //            currency: 'ETH',
+        //            chain: 'Ethereum',
+        //            address: '0x99B5EEc2C520f86F0F62F05820d28D05D36EccCf',
+        //            address_memo: ''
+        //        }
+        //    }
         //
         const data = this.safeValue (response, 'data', {});
-        const address = this.safeString (data, 'address');
-        const tag = this.safeString (data, 'address_memo');
-        const chain = this.safeString (data, 'chain');
+        return this.parseDepositAddress (data, currency);
+    }
+
+    parseDepositAddress (depositAddress, currency = undefined) {
+        //
+        //    {
+        //        currency: 'ETH',
+        //        chain: 'Ethereum',
+        //        address: '0x99B5EEc2C520f86F0F62F05820d28D05D36EccCf',
+        //        address_memo: ''
+        //    }
+        //
+        const currencyId = this.safeString (depositAddress, 'currency');
+        const address = this.safeString (depositAddress, 'address');
+        const chain = this.safeString (depositAddress, 'chain');
         let network = undefined;
+        currency = this.safeCurrency (currencyId, currency);
         if (chain !== undefined) {
             const parts = chain.split ('-');
-            const networkId = this.safeString (parts, 1);
-            network = this.safeNetwork (networkId);
+            const partsLength = parts.length;
+            const networkId = this.safeString (parts, partsLength - 1);
+            network = this.safeNetworkCode (networkId, currency);
         }
         this.checkAddress (address);
         return {
-            'currency': code,
+            'info': depositAddress,
+            'currency': this.safeString (currency, 'code'),
             'address': address,
-            'tag': tag,
+            'tag': this.safeString (depositAddress, 'address_memo'),
             'network': network,
-            'info': response,
         };
     }
 
-    safeNetwork (networkId) {
-        // TODO: parse
-        return networkId;
+    safeNetworkCode (networkId, currency = undefined) {
+        const name = this.safeString (currency, 'name');
+        if (networkId === name) {
+            const code = this.safeString (currency, 'code');
+            return code;
+        }
+        return this.networkIdToCode (networkId);
     }
 
     async withdraw (code: string, amount: number, address, tag = undefined, params = {}) {


### PR DESCRIPTION
- networkId is parsed
- previously safeString was grabbing the wrong index for some networks
- separates parser

------------------------

```
% bitmart fetchDepositAddress ETH 
2024-03-04T20:56:38.066Z
Node.js: v18.12.0
CCXT v4.2.59
bitmart.fetchDepositAddress (ETH)
2024-03-04T20:56:41.698Z iteration 0 passed in 515 ms

{
  info: {
    currency: 'ETH',
    chain: 'Ethereum',
    address: '0x99B5EEc2C520f86F0F62F05820d28D05D36EccCf',
    address_memo: ''
  },
  currency: 'ETH',
  address: '0x99B5EEc2C520f86F0F62F05820d28D05D36EccCf',
  tag: undefined,
  network: 'ETH'
}
2024-03-04T20:56:41.698Z iteration 1 passed in 515 ms
```
```
% bitmart fetchDepositAddress USDC
2024-03-04T20:56:56.920Z
Node.js: v18.12.0
CCXT v4.2.59
bitmart.fetchDepositAddress (USDC)
2024-03-04T20:57:00.764Z iteration 0 passed in 515 ms

{
  info: {
    currency: 'USDC',
    chain: 'Ethereum',
    address: '0x99B5EEc2C520f86F0F62F05820d28D05D36EccCf',
    address_memo: ''
  },
  currency: 'USDC',
  address: '0x99B5EEc2C520f86F0F62F05820d28D05D36EccCf',
  tag: undefined,
  network: 'ERC20'
}
2024-03-04T20:57:00.764Z iteration 1 passed in 515 ms
```