### PR TITLE
bingx: fetchMarginMode

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -831,6 +831,27 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "setMarginMode": [
+            {
+                "description": "Swap set the margin mode",
+                "method": "setMarginMode",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/marginType?marginType=ISOLATED&symbol=BTC-USDT&timestamp=1709612405970&signature=ad4ff86204ba2cb9963a64e13a858215a2a1e31d2f10616ce5b0bbf64558800d",
+                "input": [
+                  "isolated",
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchMarginMode": [
+            {
+                "description": "Swap fetch the margin mode",
+                "method": "fetchMarginMode",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/marginType?symbol=BTC-USDT&timestamp=1709612311793&signature=a327894546ea7337cc55fa527bc183bba415213c48f0b9dafdc27bb6c38d8df9",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchMarginMode` to bingx:
```
bingx.fetchMarginMode (BTC/USDT:USDT)
2024-03-05T04:18:32.101Z iteration 0 passed in 3308 ms

{
  info: { marginType: 'CROSSED' },
  symbol: 'BTC/USDT:USDT',
  marginMode: 'cross'
}
```
```
bingx.fetchMarginMode (BTC/USDT:USDT)
2024-03-05T04:21:48.472Z iteration 0 passed in 4001 ms

{
  info: { marginType: 'ISOLATED' },
  symbol: 'BTC/USDT:USDT',
  marginMode: 'isolated'
}
```