### PR TITLE
blofin: fetchLeverages

### DIFF
--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -6,7 +6,7 @@ import { ExchangeError, ExchangeNotAvailable, ArgumentsRequired, BadRequest, Inv
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, FundingRateHistory, OrderRequest, Str, Transaction, Ticker, OrderBook, Balances, Tickers, Market, Strings, Currency, Position, TransferEntry, Leverage } from './base/types.js';
+import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, FundingRateHistory, OrderRequest, Str, Transaction, Ticker, OrderBook, Balances, Tickers, Market, Strings, Currency, Position, TransferEntry, Leverage, Leverages } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -82,6 +82,7 @@ export default class blofin extends Exchange {
                 'fetchLedger': true,
                 'fetchLedgerEntry': undefined,
                 'fetchLeverage': true,
+                'fetchLeverages': true,
                 'fetchLeverageTiers': false,
                 'fetchMarketLeverageTiers': false,
                 'fetchMarkets': true,
@@ -186,6 +187,7 @@ export default class blofin extends Exchange {
                         'account/balance': 1,
                         'account/positions': 1,
                         'account/leverage-info': 1,
+                        'account/batch-leverage-info': 1,
                         'trade/orders-tpsl-pending': 1,
                         'trade/orders-history': 1,
                         'trade/orders-tpsl-history': 1,
@@ -1908,6 +1910,62 @@ export default class blofin extends Exchange {
             'stopLossPrice': undefined,
             'takeProfitPrice': undefined,
         });
+    }
+
+    async fetchLeverages (symbols: string[] = undefined, params = {}): Promise<Leverages> {
+        /**
+         * @method
+         * @name blofin#fetchLeverages
+         * @description fetch the set leverage for all contract markets
+         * @see https://docs.blofin.com/index.html#get-multiple-leverage
+         * @param {string[]} symbols a list of unified market symbols, required on blofin
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.marginMode] 'cross' or 'isolated'
+         * @returns {object} a list of [leverage structures]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        await this.loadMarkets ();
+        if (symbols === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchLeverages() requires a symbols argument');
+        }
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLeverages', params);
+        if (marginMode === undefined) {
+            marginMode = this.safeString (params, 'marginMode', 'cross'); // cross as default marginMode
+        }
+        if ((marginMode !== 'cross') && (marginMode !== 'isolated')) {
+            throw new BadRequest (this.id + ' fetchLeverages() requires a marginMode parameter that must be either cross or isolated');
+        }
+        symbols = this.marketSymbols (symbols);
+        let instIds = '';
+        for (let i = 0; i < symbols.length; i++) {
+            const entry = symbols[i];
+            const entryMarket = this.market (entry);
+            if (i > 0) {
+                instIds = instIds + ',' + entryMarket['id'];
+            } else {
+                instIds = instIds + entryMarket['id'];
+            }
+        }
+        const request = {
+            'instId': instIds,
+            'marginMode': marginMode,
+        };
+        const response = await this.privateGetAccountBatchLeverageInfo (this.extend (request, params));
+        //
+        //     {
+        //         "code": "0",
+        //         "msg": "success",
+        //         "data": [
+        //             {
+        //                 "leverage": "3",
+        //                 "marginMode": "cross",
+        //                 "instId": "BTC-USDT"
+        //             },
+        //         ]
+        //     }
+        //
+        const leverages = this.safeList (response, 'data', []);
+        return this.parseLeverages (leverages, symbols, 'instId');
     }
 
     async fetchLeverage (symbol: string, params = {}): Promise<Leverage> {

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -1915,7 +1915,7 @@ export default class blofin extends Exchange {
          * @method
          * @name blofin#fetchLeverage
          * @description fetch the set leverage for a market
-         * @see https://blofin.com/docs#set-leverage
+         * @see https://docs.blofin.com/index.html#get-leverage
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.marginMode] 'cross' or 'isolated'

--- a/ts/src/test/static/markets/blofin.json
+++ b/ts/src/test/static/markets/blofin.json
@@ -169,5 +169,62 @@
             "maxMarketSize": "4500",
             "state": "live"
         }
+    },
+    "ETH/USDT:USDT": {
+        "id": "ETH-USDT",
+        "symbol": "ETH/USDT:USDT",
+        "base": "ETH",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "ETH",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
+        "taker": 0.0006,
+        "maker": 0.0002,
+        "contractSize": 0.01,
+        "precision": {
+            "amount": 1,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {
+                "min": 1,
+                "max": 150
+            },
+            "amount": {
+                "min": 1
+            },
+            "price": {},
+            "cost": {}
+        },
+        "created": 1669869031395,
+        "info": {
+            "instId": "ETH-USDT",
+            "baseCurrency": "ETH",
+            "quoteCurrency": "USDT",
+            "contractValue": "0.01",
+            "listTime": "1669869031395",
+            "expireTime": "1890748800000",
+            "maxLeverage": "150",
+            "minSize": "1",
+            "lotSize": "1",
+            "tickSize": "0.01",
+            "instType": "SWAP",
+            "contractType": "linear",
+            "maxLimitSize": "100000000",
+            "maxMarketSize": "150000",
+            "state": "live"
+        }
     }
 }

--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -168,6 +168,19 @@
                 ]
             }
         ],
+        "fetchLeverages": [
+          {
+            "description": "fetch multiple leverages at once",
+            "method": "fetchLeverages",
+            "url": "https://openapi.blofin.com/api/v1/account/batch-leverage-info?instId=BTC-USDT%2CETH-USDT&marginMode=cross",
+            "input": [
+              [
+                "BTC/USDT:USDT",
+                "ETH/USDT:USDT"
+              ]
+            ]
+          }
+        ],
         "closePosition": [
             {
                 "description": "close short position",


### PR DESCRIPTION
Added `fetchLeverages` to blofin:
```
blofin.fetchLeverages (BTC/USDT:USDT,ETH/USDT:USDT)
2024-03-05T08:13:53.384Z iteration 0 passed in 354 ms

{
  'BTC/USDT:USDT': {
    info: { leverage: '3', marginMode: 'cross', instId: 'BTC-USDT' },
    symbol: 'BTC/USDT:USDT',
    marginMode: 'cross',
    longLeverage: 3,
    shortLeverage: 3
  },
  'ETH/USDT:USDT': {
    info: { leverage: '3', marginMode: 'cross', instId: 'ETH-USDT' },
    symbol: 'ETH/USDT:USDT',
    marginMode: 'cross',
    longLeverage: 3,
    shortLeverage: 3
  }
}
```