### PR TITLE
binance: patch parseWsPosition

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2617,14 +2617,14 @@ export default class binance extends binanceRest {
         //     }
         //
         const marketId = this.safeString (position, 's');
-        const contracts = this.safeNumber (position, 'pa');
+        const contracts = this.safeString (position, 'pa');
         const contractsAbs = Precise.stringAbs (this.safeString (position, 'pa'));
         let positionSide = this.safeStringLower (position, 'ps');
         let hedged = true;
         if (positionSide === 'both') {
             hedged = false;
-            if (contracts !== 0) {
-                if (contracts < 0) {
+            if (!Precise.stringEq (contracts, '0')) {
+                if (Precise.stringLt (contracts, '0')) {
                     positionSide = 'short';
                 } else {
                     positionSide = 'long';

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2617,8 +2617,20 @@ export default class binance extends binanceRest {
         //     }
         //
         const marketId = this.safeString (position, 's');
-        const positionSide = this.safeStringLower (position, 'ps');
-        const hedged = positionSide !== 'both';
+        const contracts = this.safeNumber (position, 'pa');
+        const contractsAbs = Precise.stringAbs (this.safeString (position, 'pa'));
+        let positionSide = this.safeStringLower (position, 'ps');
+        let hedged = true;
+        if (positionSide === 'both') {
+            hedged = false;
+            if (contracts !== 0) {
+                if (contracts < 0) {
+                    positionSide = 'short';
+                } else {
+                    positionSide = 'long';
+                }
+            }
+        }
         return this.safePosition ({
             'info': position,
             'id': undefined,
@@ -2629,7 +2641,7 @@ export default class binance extends binanceRest {
             'entryPrice': this.safeNumber (position, 'ep'),
             'unrealizedPnl': this.safeNumber (position, 'up'),
             'percentage': undefined,
-            'contracts': this.safeNumber (position, 'pa'),
+            'contracts': this.parseNumber (contractsAbs),
             'contractSize': undefined,
             'markPrice': undefined,
             'side': positionSide,


### PR DESCRIPTION
fix: ccxt/ccxt#21526
> the side would be both if the position is liquidated

```BASH
p binance watchPositions '["TOKEN/USDT:USDT"]'
Python v3.11.4
CCXT v4.2.59
binance.watchPositions(['TOKEN/USDT:USDT'])
// test short position
[{'collateral': 100.07407203,
  'contractSize': 1.0,
  'contracts': 100.0,
  'datetime': '2024-03-05T13:35:23.472Z',
  'entryPrice': 0.08468,
  'hedged': False,
  'id': None,
  'info': {'adlQuantile': '0',
           'breakEvenPrice': '0.08463766',
           'entryPrice': '0.08468',
           'isAutoAddMargin': 'false',
           'isolated': False,
           'isolatedMargin': '0.00000000',
           'isolatedWallet': '0',
           'leverage': '20',
           'liquidationPrice': '1.06938002',
           'marginType': 'cross',
           'markPrice': '0.08465000',
           'maxNotionalValue': '25000',
           'notional': '-8.46500000',
           'positionAmt': '-100',
           'positionSide': 'BOTH',
           'symbol': 'TOKENUSDT',
           'unRealizedProfit': '0.00300000',
           'updateTime': '1709645723472'},
  'initialMargin': 0.42325,
  'initialMarginPercentage': 0.05,
  'leverage': 20.0,
  'liquidationPrice': 1.06938002,
  'maintenanceMargin': 0.126975,
  'maintenanceMarginPercentage': 0.015,
  'marginMode': 'cross',
  'marginRatio': 0.0013,
  'marginType': 'cross',
  'markPrice': 0.08465,
  'notional': 8.465,
  'percentage': 0.7,
  'side': 'short',
  'stopLossPrice': None,
  'symbol': 'TOKEN/USDT:USDT',
  'takeProfitPrice': None,
  'timestamp': 1709645723472,
  'unrealizedPnl': 0.003}]
  [{'collateral': None,
  'contractSize': 1.0,
  'contracts': 0.0,
  'datetime': '2024-03-05T13:36:17.434Z',
  'entryPrice': 0.0,
  'hedged': False,
  'id': None,
  'info': {'bep': '0',
           'cr': '0.11900000',
           'ep': '0',
           'iw': '0',
           'ma': 'USDT',
           'mt': 'cross',
           'pa': '0',
           'ps': 'BOTH',
           's': 'TOKENUSDT',
           'up': '0'},
  'initialMargin': None,
  'initialMarginPercentage': None,
  'leverage': None,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'side': 'both',
  'symbol': 'TOKEN/USDT:USDT',
  'timestamp': 1709645777434,
  'unrealizedPnl': 0.0}]

// test long position
  [{'collateral': None,
  'contractSize': 1.0,
  'contracts': 100.0,
  'datetime': '2024-03-05T13:36:43.603Z',
  'entryPrice': 0.08466,
  'hedged': False,
  'id': None,
  'info': {'bep': '0.08470233',
           'cr': '0.11900000',
           'ep': '0.08466',
           'iw': '0',
           'ma': 'USDT',
           'mt': 'cross',
           'pa': '100',
           'ps': 'BOTH',
           's': 'TOKENUSDT',
           'up': '0.00400000'},
  'initialMargin': None,
  'initialMarginPercentage': None,
  'leverage': None,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'side': 'long',
  'symbol': 'TOKEN/USDT:USDT',
  'timestamp': 1709645803603,
  'unrealizedPnl': 0.004}]
[{'collateral': None,
  'contractSize': 1.0,
  'contracts': 32.0,
  'datetime': '2024-03-05T13:37:07.627Z',
  'entryPrice': 0.08466,
  'hedged': False,
  'id': None,
  'info': {'bep': '0.08462736',
           'cr': '0.12716000',
           'ep': '0.08466',
           'iw': '0',
           'ma': 'USDT',
           'mt': 'cross',
           'pa': '32',
           'ps': 'BOTH',
           's': 'TOKENUSDT',
           'up': '0.01088000'},
  'initialMargin': None,
  'initialMarginPercentage': None,
  'leverage': None,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'side': 'long',
  'symbol': 'TOKEN/USDT:USDT',
  'timestamp': 1709645827627,
  'unrealizedPnl': 0.01088}]
[{'collateral': None,
  'contractSize': 1.0,
  'contracts': 0.0,
  'datetime': '2024-03-05T13:37:07.627Z',
  'entryPrice': 0.0,
  'hedged': False,
  'id': None,
  'info': {'bep': '0',
           'cr': '0.13100000',
           'ep': '0',
           'iw': '0',
           'ma': 'USDT',
           'mt': 'cross',
           'pa': '0',
           'ps': 'BOTH',
           's': 'TOKENUSDT',
           'up': '0'},
  'initialMargin': None,
  'initialMarginPercentage': None,
  'leverage': None,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'side': 'both',
  'symbol': 'TOKEN/USDT:USDT',
  'timestamp': 1709645827627,
  'unrealizedPnl': 0.0}]

```