### PR TITLE
bitget parseTrade fee fix

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2926,8 +2926,14 @@ export default class bitget extends Exchange {
             const currencyCode = this.safeCurrencyCode (this.safeString (feeStructure, 'feeCoin'));
             fee = {
                 'currency': currencyCode,
-                'cost': Precise.stringAbs (this.safeString (feeStructure, 'totalFee')),
             };
+            const feeCostString = this.safeString (feeStructure, 'totalFee');
+            const deduction = this.safeString (feeStructure, 'deduction') === 'yes' ? true : false;
+            if (deduction) {
+                fee['cost'] = feeCostString;
+            } else {
+                fee['cost'] = Precise.stringNeg (feeCostString);
+            }
         }
         return this.safeTrade ({
             'info': trade,


### PR DESCRIPTION
So there is 3 cases:
1) We **pay fee in BGB** - `totalFee` positive, `deduction` `yes`
```
feeDetail: {
      deduction: 'yes',
      feeCoin: 'BGB',
      totalDeductionFee: '0',
      totalFee: '0.0015552795869069'
    },
```
2) We **pay fee in base/quote** - `totalFee` negative, `deduction` `no`
```
feeDetail: {
      deduction: 'no',
      feeCoin: 'USDT',
      totalDeductionFee: '',
      totalFee: '-0.0074984155298663'
    },
```
3) We get **rebate** - `totalFee` positive, `deduction` `no`
```
feeDetail: {
      deduction: 'no',
      feeCoin: 'USDT',
      totalDeductionFee: '',
      totalFee: '0.01187046009'
    },
```