### PR TITLE
htx parseTrade fee fix

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -2575,7 +2575,10 @@ export default class htx extends Exchange {
         amountString = this.safeString (trade, 'trade_volume', amountString);
         const costString = this.safeString (trade, 'trade_turnover');
         let fee = undefined;
-        let feeCost = this.safeString2 (trade, 'filled-fees', 'trade_fee');
+        let feeCost = this.safeString (trade, 'filled-fees');
+        if (feeCost === undefined) {
+            feeCost = Precise.stringNeg (this.safeString (trade, 'trade_fee'));
+        }
         const feeCurrencyId = this.safeString2 (trade, 'fee-currency', 'fee_asset');
         let feeCurrency = this.safeCurrencyCode (feeCurrencyId);
         const filledPoints = this.safeString (trade, 'filled-points');


### PR DESCRIPTION
It is different for spot and swap.
For spot positive fee is fee and negative is rebate (works fine now).
For swap negative `trade_fee` in response it is positive fee in real (I don't have rebate for futures):
```
{
...
    trade_fee: '-0.000995760000000000',
    fee_asset: 'USDT',
...
}
```
