### PR TITLE
fix(whitebit): handleMessage uses safeString for result instead of safeMessage

### DIFF
--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -1020,8 +1020,28 @@ export default class tokocrypto extends Exchange {
                 request['limit'] = limit;
             }
             const responseInner = this.publicGetOpenV1MarketTrades (this.extend (request, params));
-            const data = this.safeValue (responseInner, 'data', {});
-            return this.parseTrades (data, market, since, limit);
+            //
+            //    {
+            //       "code": 0,
+            //       "msg": "success",
+            //       "data": {
+            //           "list": [
+            //                {
+            //                    "id": 28457,
+            //                    "price": "4.00000100",
+            //                    "qty": "12.00000000",
+            //                    "time": 1499865549590,
+            //                    "isBuyerMaker": true,
+            //                    "isBestMatch": true
+            //                }
+            //            ]
+            //        },
+            //        "timestamp": 1571921637091
+            //    }
+            //
+            const data = this.safeDict (responseInner, 'data', {});
+            const list = this.safeList (data, 'list', []);
+            return this.parseTrades (list, market, since, limit);
         }
         if (limit !== undefined) {
             request['limit'] = limit; // default = 500, maximum = 1000


### PR DESCRIPTION
```
% tokocrypto fetchTrades BTC/USDT | condense
2024-03-06T01:08:51.706Z
Node.js: v18.12.0
CCXT v4.2.60
tokocrypto.fetchTrades (BTC/USDT)
2024-03-06T01:08:55.569Z iteration 0 passed in 2469 ms
    timestamp |                 datetime |   symbol |         id | order | type | side | takerOrMaker |    price |  amount |          cost | fee | fees
-------------------------------------------------------------------------------------------------------------------------------------------------------
1709687312989 | 2024-03-06T01:08:32.989Z | BTC/USDT | 3460269510 |       |      | sell |        taker | 63717.99 |  0.0007 |     44.602593 |     |   []
...
1709687335596 | 2024-03-06T01:08:55.596Z | BTC/USDT | 3460270009 |       |      | sell |        taker | 63690.61 |   0.002 |     127.38122 |     |   []
500 objects
2024-03-06T01:08:55.569Z iteration 1 passed in 2469 ms
```

```
Python v3.9.6
CCXT v4.2.60
tokocrypto.fetchTrades(BTC/USDT)
[{'amount': 0.00042,
  'cost': 26.674431,
  'datetime': '2024-03-06T01:11:59.983Z',
  'fee': None,
  'fees': [],
  'id': '3460275447',
  'info': {'id': '3460275447',
           'isBestMatch': True,
           'isBuyerMaker': False,
           'price': '63510.55000000',
           'qty': '0.00042000',
           'quoteQty': '26.67443100',
           'time': '1709687519983'},
  'order': None,
  'price': 63510.55,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1709687519983,
  'type': None},
...
 {'amount': 0.00398,
  'cost': 252.654579,
  'datetime': '2024-03-06T01:12:11.117Z',
  'fee': None,
  'fees': [],
  'id': '3460275946',
  'info': {'id': '3460275946',
           'isBestMatch': True,
           'isBuyerMaker': True,
           'price': '63481.05000000',
           'qty': '0.00398000',
           'quoteQty': '252.65457900',
           'time': '1709687531117'},
  'order': None,
  'price': 63481.05,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1709687531117,
  'type': None}]
```