### PR TITLE
kraken.parseOrder uses safeDict

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1570,8 +1570,13 @@ export default class kraken extends Exchange {
         //      }
         //  }
         //
-        const description = this.safeValue (order, 'descr', {});
-        const orderDescription = this.safeString (description, 'order', description);
+        const description = this.safeDict (order, 'descr', {});
+        let orderDescription = undefined;
+        if (description !== undefined) {
+            orderDescription = this.safeString (description, 'order');
+        } else {
+            orderDescription = this.safeString (order, 'descr');
+        }
         let side = undefined;
         let type = undefined;
         let marketId = undefined;


### PR DESCRIPTION

```
Python v3.9.6
CCXT v4.2.60
kraken.fetchClosedOrders()
[{'amount': 0.0001,
  'average': 45354.3,
  'clientOrderId': None,
  'cost': 4.53543,
  'datetime': '2021-09-12T05:38:56.293Z',
  'fee': {'cost': '0.01179', 'currency': 'USDT', 'rate': None},
  'fees': [{'cost': 0.01179, 'currency': 'USDT', 'rate': None}],
  'filled': 0.0001,
  'id': 'O5D3QH-MBOAI-OUHEZC',
  'info': {'closetm': '1631425136.293442',
           'cost': '4.53543',
           'descr': {'close': '',
                     'leverage': 'none',
                     'order': 'buy 0.00010000 XBTUSDT @ market',
                     'ordertype': 'market',
                     'pair': 'XBTUSDT',
                     'price': '0',
                     'price2': '0',
                     'type': 'buy'},
           'expiretm': '0',
           'fee': '0.01179',
           'id': 'O5D3QH-MBOAI-OUHEZC',
           'limitprice': '0.00000',
           'misc': '',
           'oflags': 'fciq',
           'opentm': '1631425136.2932632',
           'price': '45354.3',
           'reason': None,
           'refid': None,
           'starttm': '0',
           'status': 'closed',
           'stopprice': '0.00000',
           'userref': None,
           'vol': '0.00010000',
           'vol_exec': '0.00010000'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 45354.3,
  'reduceOnly': None,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1631425136293,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'},
...
 {'amount': 5.0,
  'average': 0.99931,
  'clientOrderId': '0',
  'cost': 4.99655,
  'datetime': '2023-08-02T23:00:29.835Z',
  'fee': {'cost': '0.00999310', 'currency': 'USD', 'rate': None},
  'fees': [{'cost': 0.0099931, 'currency': 'USD', 'rate': None}],
  'filled': 5.0,
  'id': 'OX4JRD-GQMFC-QUZIFC',
  'info': {'closetm': '1691017229.8358514',
           'cost': '4.99655000',
           'descr': {'close': '',
                     'leverage': 'none',
                     'order': 'buy 5.00000000 USDTUSD @ market',
                     'ordertype': 'market',
                     'pair': 'USDTUSD',
                     'price': '0',
                     'price2': '0',
                     'type': 'buy'},
           'expiretm': '0',
           'fee': '0.00999310',
           'id': 'OX4JRD-GQMFC-QUZIFC',
           'limitprice': '0.00000000',
           'misc': '',
           'oflags': 'fciq',
           'opentm': '1691017229.8357813',
           'price': '0.99931',
           'reason': None,
           'refid': None,
           'starttm': '0',
           'status': 'closed',
           'stopprice': '0.00000000',
           'userref': '0',
           'vol': '5.00000000',
           'vol_exec': '5.00000000'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 0.99931,
  'reduceOnly': None,
  'remaining': 0.0,
  'side': 'buy',
  'status': 'closed',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'USDT/USD',
  'takeProfitPrice': None,
  'timeInForce': 'IOC',
  'timestamp': 1691017229835,
  'trades': [],
  'triggerPrice': None,
  'type': 'market'}]
```
