### PR TITLE
fix(tokocrypto): fetchTrades - correct default type for response

### DIFF
--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -1020,8 +1020,28 @@ export default class tokocrypto extends Exchange {
                 request['limit'] = limit;
             }
             const responseInner = this.publicGetOpenV1MarketTrades (this.extend (request, params));
-            const data = this.safeValue (responseInner, 'data', {});
-            return this.parseTrades (data, market, since, limit);
+            //
+            //    {
+            //       "code": 0,
+            //       "msg": "success",
+            //       "data": {
+            //           "list": [
+            //                {
+            //                    "id": 28457,
+            //                    "price": "4.00000100",
+            //                    "qty": "12.00000000",
+            //                    "time": 1499865549590,
+            //                    "isBuyerMaker": true,
+            //                    "isBestMatch": true
+            //                }
+            //            ]
+            //        },
+            //        "timestamp": 1571921637091
+            //    }
+            //
+            const data = this.safeDict (responseInner, 'data', {});
+            const list = this.safeList (data, 'list', []);
+            return this.parseTrades (list, market, since, limit);
         }
         if (limit !== undefined) {
             request['limit'] = limit; // default = 500, maximum = 1000


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.60
tokocrypto.fetchTrades(BTC/USDT)
[{'amount': 0.03358,
  'cost': 2112.6914086,
  'datetime': '2024-03-06T03:01:12.055Z',
  'fee': None,
  'fees': [],
  'id': '3460438545',
  'info': {'id': '3460438545',
           'isBestMatch': True,
           'isBuyerMaker': True,
           'price': '62915.17000000',
           'qty': '0.03358000',
           'quoteQty': '2112.69140860',
           'time': '1709694072055'},
  'order': None,
  'price': 62915.17,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1709694072055,
  'type': None},
...
 {'amount': 0.00245,
  'cost': 154.1338855,
  'datetime': '2024-03-06T03:01:36.834Z',
  'fee': None,
  'fees': [],
  'id': '3460439044',
  'info': {'id': '3460439044',
           'isBestMatch': True,
           'isBuyerMaker': True,
           'price': '62911.79000000',
           'qty': '0.00245000',
           'quoteQty': '154.13388550',
           'time': '1709694096834'},
  'order': None,
  'price': 62911.79,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1709694096834,
  'type': None}]

```