### PR TITLE
fix(kucoinfutures): fetchMyTrades - correct default type

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -2088,8 +2088,8 @@ export default class kucoinfutures extends kucoin {
         //        }
         //    }
         //
-        const data = this.safeValue (response, 'data', {});
-        const trades = this.safeValue (data, 'items', {});
+        const data = this.safeDict (response, 'data', {});
+        const trades = this.safeList (data, 'items', []);
         return this.parseTrades (trades, market, since, limit);
     }
 


### PR DESCRIPTION
```
% py kucoinfutures fetchMyTrades
Python v3.9.6
CCXT v4.2.60
kucoinfutures.fetchMyTrades()
[{'amount': 5.0,
  'cost': 33.7585,
  'datetime': '2024-03-06T03:29:37.305Z',
  'fee': {'cost': 0.0202551, 'currency': 'USDT', 'rate': 0.0006},
  'fees': [{'cost': 0.0202551, 'currency': 'USDT', 'rate': 0.0006}],
  'id': '1696010399916',
  'info': {'closeFeePay': '0',
           'createdAt': 1709695777305,
           'displayType': 'market',
           'fee': '0.0202551',
           'feeCurrency': 'USDT',
           'feeRate': '0.00060',
           'fixFee': '0',
           'forceTaker': False,
           'liquidity': 'taker',
           'openFeePay': '0.0202551',
           'orderId': '154696732830101504',
           'orderType': 'market',
           'price': '0.67517',
           'settleCurrency': 'USDT',
           'side': 'buy',
           'size': 5,
           'stop': '',
           'subTradeType': None,
           'symbol': 'ADAUSDTM',
           'tradeId': '1696010399916',
           'tradeTime': 1709695777290000000,
           'tradeType': 'trade',
           'value': '33.7585'},
  'order': '154696732830101504',
  'price': 0.67517,
  'side': 'buy',
  'symbol': 'ADA/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1709695777305,
  'type': 'market'}]
  ```