### PR TITLE
krakenfutures: add fetchLeverages

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -6,7 +6,7 @@ import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable
 import { Precise } from './base/Precise.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
-import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Trade, FundingRateHistory, OrderRequest, Order, Balances, Str, Ticker, OrderBook, Tickers, Strings, Market, Currency, Leverage } from './base/types.js';
+import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Trade, FundingRateHistory, OrderRequest, Order, Balances, Str, Ticker, OrderBook, Tickers, Strings, Market, Currency, Leverage, Leverages } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -56,6 +56,7 @@ export default class krakenfutures extends Exchange {
                 'fetchIsolatedBorrowRates': false,
                 'fetchIsolatedPositions': false,
                 'fetchLeverage': true,
+                'fetchLeverages': true,
                 'fetchLeverageTiers': true,
                 'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
@@ -2470,6 +2471,34 @@ export default class krakenfutures extends Exchange {
         // { result: "success", serverTime: "2023-08-01T09:40:32.345Z" }
         //
         return await this.privatePutLeveragepreferences (this.extend (request, params));
+    }
+
+    async fetchLeverages (symbols: string[] = undefined, params = {}): Promise<Leverages> {
+        /**
+         * @method
+         * @name krakenfutures#fetchLeverages
+         * @description fetch the set leverage for all contract markets
+         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-get-the-leverage-setting-for-a-market
+         * @param {string[]} symbols a list of unified market symbols
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a list of [leverage structures]{@link https://docs.ccxt.com/#/?id=leverage-structure}
+         */
+        await this.loadMarkets ();
+        const response = await this.privateGetLeveragepreferences (params);
+        //
+        //     {
+        //         "result": "success",
+        //         "serverTime": "2024-03-06T02:35:46.336Z",
+        //         "leveragePreferences": [
+        //             {
+        //                 "symbol": "PF_ETHUSD",
+        //                 "maxLeverage": 30.00
+        //             },
+        //         ]
+        //     }
+        //
+        const leveragePreferences = this.safeList (response, 'leveragePreferences', []);
+        return this.parseLeverages (leveragePreferences, symbols, 'symbol');
     }
 
     async fetchLeverage (symbol: string, params = {}): Promise<Leverage> {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2477,9 +2477,9 @@ export default class krakenfutures extends Exchange {
         /**
          * @method
          * @name krakenfutures#fetchLeverages
-         * @description fetch the set leverage for all contract markets
+         * @description fetch the set leverage for all contract and margin markets
          * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-get-the-leverage-setting-for-a-market
-         * @param {string[]} symbols a list of unified market symbols
+         * @param {string[]} [symbols] a list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a list of [leverage structures]{@link https://docs.ccxt.com/#/?id=leverage-structure}
          */

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -187,6 +187,16 @@
                 ],
                 "output": "json={\"batchOrder\":[{\"order\":\"cancel\",\"order_id\":\"3d080c9b-6a50-45c1-8365-11c00295f011\"}]}"
             }
+        ],
+        "fetchLeverage": [
+            {
+                "description": "Swap fetch leverage",
+                "method": "fetchLeverage",
+                "url": "https://demo-futures.kraken.com/derivatives/api/v3/leveragepreferences?symbol=PF_XBTUSD",
+                "input": [
+                  "BTC/USD:USD"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -197,6 +197,14 @@
                   "BTC/USD:USD"
                 ]
             }
+        ],
+        "fetchLeverages": [
+            {
+                "description": "Fetch leverages of all markets with a set leverage value",
+                "method": "fetchLeverages",
+                "url": "https://demo-futures.kraken.com/derivatives/api/v3/leveragepreferences",
+                "input": []
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchLeverages` to krakenfutures:

 ```
krakenfutures.fetchLeverages ()
2024-03-06T04:12:51.702Z iteration 0 passed in 776 ms

{
  'ETH/USD:USD': {
    info: { symbol: 'PF_ETHUSD', maxLeverage: '30.00' },
    symbol: 'ETH/USD:USD',
    longLeverage: 30,
    shortLeverage: 30
  },
  'BTC/USD:USD': {
    info: { symbol: 'PF_XBTUSD', maxLeverage: '25.00' },
    symbol: 'BTC/USD:USD',
    longLeverage: 25,
    shortLeverage: 25
  }
}
```