### PR TITLE
coinex: add fetchLeverage, fetchLeverages

### DIFF
--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -645,6 +645,16 @@
                   }
                 ]
             }
+        ],
+        "fetchLeverage": [
+            {
+                "description": "Fetch the set leverage of a spot margin market",
+                "method": "fetchLeverage",
+                "url": "https://api.coinex.com/v1/margin/config?access_id=36280D3BC1284980A37DDAE67EBABE74&tonce=1709711145773",
+                "input": [
+                  "BTC/USDT"
+                ]
+            }
         ]
     },
     "disabledTests": {}

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -648,12 +648,20 @@
         ],
         "fetchLeverage": [
             {
-                "description": "Fetch the set leverage of a spot margin market",
+                "description": "Fetch the leverage of a spot margin market",
                 "method": "fetchLeverage",
                 "url": "https://api.coinex.com/v1/margin/config?access_id=36280D3BC1284980A37DDAE67EBABE74&tonce=1709711145773",
                 "input": [
                   "BTC/USDT"
                 ]
+            }
+        ],
+        "fetchLeverages": [
+            {
+                "description": "Fetch the leverage of all spot margin markets",
+                "method": "fetchLeverages",
+                "url": "https://api.coinex.com/v1/margin/config?access_id=36280D3BC1284980A37DDAE67EBABE74&tonce=1709711478774",
+                "input": []
             }
         ]
     },


### PR DESCRIPTION
Added support for `fetchLeverage` and `fetchLeverages` to coinex:

```
coinex.fetchLeverage (BTC/USDT)
2024-03-06T07:45:47.646Z iteration 0 passed in 1876 ms

{
  info: {
    market: 'BTCUSDT',
    leverage: 10,
    BTC: { min_amount: '0.0008', max_amount: '200', day_rate: '0.0015' },
    USDT: { min_amount: '50', max_amount: '500000', day_rate: '0.001' }
  },
  symbol: 'BTC/USDT',
  longLeverage: 10,
  shortLeverage: 10
}
```