### PR TITLE
fix(bitget): remove filled calculation from parseWsOrder

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1323,10 +1323,10 @@ export default class bitget extends bitgetRest {
         if (side === 'buy' && market['spot'] && (type === 'market')) {
             cost = this.safeString (order, 'newSize', cost);
         }
-        let filled = this.safeString2 (order, 'accBaseVolume', 'baseVolume');
-        if (market['spot'] && (rawStatus !== 'live')) {
-            filled = Precise.stringDiv (cost, avgPrice);
-        }
+        const filled = this.safeString2 (order, 'accBaseVolume', 'baseVolume');
+        // if (market['spot'] && (rawStatus !== 'live')) {
+        //     filled = Precise.stringDiv (cost, avgPrice);
+        // }
         let amount = this.safeString (order, 'baseVolume');
         if (!market['spot'] || !(side === 'buy' && type === 'market')) {
             amount = this.safeString (order, 'newSize', amount);


### PR DESCRIPTION





```
n bitget watchOrders DOGE/USDT
Debugger attached.
2024-03-06T16:51:07.705Z
Node.js: v20.7.0
CCXT v4.2.61
bitget.watchOrders (DOGE/USDT)
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side |  price | amount | cost | filled | remaining | status | trades | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1149314598139801609 | fd256a6a-602e-4317-9dfb-5293c58d7ef4 | 1709743874106 | 2024-03-06T16:51:14.106Z |      1709743874106 | limit |         GTC |    false |  buy | 0.1598 |     50 | 7.99 |      0 |        50 |   open |     [] |   []
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side |  price | amount | cost |  average | filled | remaining | status |                               fee | trades |                              fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1149314598139801609 | fd256a6a-602e-4317-9dfb-5293c58d7ef4 | 1709743874106 | 2024-03-06T16:51:14.106Z |      1709743874283 | limit |         GTC |    false |  buy | 0.1598 |     50 | 7.99 | 0.159693 |     50 |         0 |   open | {"cost":"0.05","currency":"DOGE"} |     [] | [{"cost":0.05,"currency":"DOGE"}]
1 objects
   symbol |                  id |                        clientOrderId |     timestamp |                 datetime | lastTradeTimestamp |  type | timeInForce | postOnly | side |  price | amount | cost |  average | filled | remaining | status |                               fee | trades |                              fees
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DOGE/USDT | 1149314598139801609 | fd256a6a-602e-4317-9dfb-5293c58d7ef4 | 1709743874106 | 2024-03-06T16:51:14.106Z |      1709743874283 | limit |         GTC |    false |  buy | 0.1598 |     50 | 7.99 | 0.159693 |     50 |         0 | closed | {"cost":"0.05","currency":"DOGE"} |     [] | [{"cost":0.05,"currency":"DOGE"}]
```
