### PR TITLE
fix(binance): fetchMarkets - correctly loops through options["fetchMarkets"]

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2784,14 +2784,12 @@ export default class binance extends Exchange {
             }
         }
         const promises = await Promise.all (promisesRaw);
-        const spotMarkets = this.safeValue (this.safeValue (promises, 0), 'symbols', []);
-        const futureMarkets = this.safeValue (this.safeValue (promises, 1), 'symbols', []);
-        const deliveryMarkets = this.safeValue (this.safeValue (promises, 2), 'symbols', []);
-        const optionMarkets = this.safeValue (this.safeValue (promises, 3), 'optionSymbols', []);
-        let markets = spotMarkets;
-        markets = this.arrayConcat (markets, futureMarkets);
-        markets = this.arrayConcat (markets, deliveryMarkets);
-        markets = this.arrayConcat (markets, optionMarkets);
+        let markets = [];
+        for (let i = 0; i < fetchMarkets.length; i++) {
+            const promise = this.safeDict (promises, i);
+            const promiseMarkets = this.safeList2 (promise, 'symbols', 'optionSymbols', []);
+            markets = this.arrayConcat (markets, promiseMarkets);
+        }
         //
         // spot / margin
         //


### PR DESCRIPTION
This wasn't working correctly before, if you set `"fetchMarkets": ["option"]` in options it didn't fetch those markets

With `"fetchMarkets": ["option"]` in options

```
Python v3.9.6
CCXT v4.2.62
binance.fetchMarkets()
[{'active': None,
  'base': 'ETH',
  'baseId': 'ETH',
  'contract': True,
  'contractSize': 1.0,
  'created': None,
  'expiry': 1711699200000,
  'expiryDatetime': '2024-03-29T08:00:00.000Z',
  'future': False,
  'id': 'ETH-240329-600-C',
  'info': {'contractId': '3',
           'expiryDate': '1711699200000',
           'filters': [{'filterType': 'PRICE_FILTER',
                        'maxPrice': '3438.4',
                        'minPrice': '2875',
                        'tickSize': '0.1'},
                       {'filterType': 'LOT_SIZE',
                        'maxQty': '1000',
                        'minQty': '0.01',
                        'stepSize': '0.01'}],
           'id': '6152',
           'initialMargin': '0.15000000',
           'maintenanceMargin': '0.07500000',
           'makerFeeRate': '0.00030000',
           'maxQty': '1000',
           'minInitialMargin': '0.10000000',
           'minMaintenanceMargin': '0.05000000',
           'minQty': '0.01',
           'priceScale': '1',
           'quantityScale': '2',
           'quoteAsset': 'USDT',
           'side': 'CALL',
           'strikePrice': '600.00000000',
           'symbol': 'ETH-240329-600-C',
           'takerFeeRate': '0.00030000',
           'underlying': 'ETHUSDT',
           'unit': '1'},
  'inverse': False,
  'limits': {'amount': {'max': 1000.0, 'min': 0.01},
             'cost': {'max': None, 'min': None},
             'leverage': {'max': None, 'min': None},
             'price': {'max': 3438.4, 'min': 2875.0}},
  'linear': True,
  'lowercaseId': 'eth-240329-600-c',
  'maker': 0.0002,
  'margin': False,
  'option': True,
  'optionType': 'call',
  'precision': {'amount': 2, 'base': None, 'price': 1, 'quote': None},
  'quote': 'USDT',
  'quoteId': 'USDT',
  'settle': 'USDT',
  'settleId': 'USDT',
  'spot': False,
  'strike': 600,
  'swap': False,
  'symbol': 'ETH/USDT:USDT-240329-600.00000000-C',
  'taker': 0.0004,
  'type': 'option'},
...
 {'active': None,
  'base': 'ETH',
  'baseId': 'ETH',
  'contract': True,
  'contractSize': 1.0,
  'created': None,
  'expiry': 1711699200000,
  'expiryDatetime': '2024-03-29T08:00:00.000Z',
  'future': False,
  'id': 'ETH-240329-3700-P',
  'info': {'contractId': '3',
           'expiryDate': '1711699200000',
           'filters': [{'filterType': 'PRICE_FILTER',
                        'maxPrice': '789.5',
                        'minPrice': '0.1',
                        'tickSize': '0.1'},
                       {'filterType': 'LOT_SIZE',
                        'maxQty': '2500',
                        'minQty': '0.01',
                        'stepSize': '0.01'}],
           'id': '34065',
           'initialMargin': '0.15000000',
           'maintenanceMargin': '0.07500000',
           'makerFeeRate': '0.00030000',
           'maxQty': '2500',
           'minInitialMargin': '0.10000000',
           'minMaintenanceMargin': '0.05000000',
           'minQty': '0.01',
           'priceScale': '1',
           'quantityScale': '2',
           'quoteAsset': 'USDT',
           'side': 'PUT',
           'strikePrice': '3700.00000000',
           'symbol': 'ETH-240329-3700-P',
           'takerFeeRate': '0.00030000',
           'underlying': 'ETHUSDT',
           'unit': '1'},
  'inverse': False,
  'limits': {'amount': {'max': 2500.0, 'min': 0.01},
             'cost': {'max': None, 'min': None},
             'leverage': {'max': None, 'min': None},
             'price': {'max': 789.5, 'min': 0.1}},
  'linear': True,
  'lowercaseId': 'eth-240329-3700-p',
  'maker': 0.0002,
  'margin': False,
  'option': True,
  'optionType': 'put',
  'precision': {'amount': 2, 'base': None, 'price': 1, 'quote': None},
  'quote': 'USDT',
  'quoteId': 'USDT',
  'settle': 'USDT',
  'settleId': 'USDT',
  'spot': False,
  'strike': 3700,
  'swap': False,
  'symbol': 'ETH/USDT:USDT-240329-3700.00000000-P',
  'taker': 0.0004,
  'type': 'option'}]
```

Without fetchMarkets in options

```
Python v3.9.6
CCXT v4.2.62
binance.fetchMarkets()
[{'active': True,
  'base': 'ETH',
  'baseId': 'ETH',
  'contract': False,
  'contractSize': None,
  'created': None,
  'expiry': None,
  'expiryDatetime': None,
  'future': False,
  'id': 'ETHBTC',
  'info': {'allowTrailingStop': True,
           'allowedSelfTradePreventionModes': ['EXPIRE_TAKER',
                                               'EXPIRE_MAKER',
                                               'EXPIRE_BOTH'],
           'baseAsset': 'ETH',
           'baseAssetPrecision': '8',
           'baseCommissionPrecision': '8',
           'cancelReplaceAllowed': True,
           'defaultSelfTradePreventionMode': 'EXPIRE_MAKER',
           'filters': [{'filterType': 'PRICE_FILTER',
                        'maxPrice': '922327.00000000',
                        'minPrice': '0.00001000',
                        'tickSize': '0.00001000'},
                       {'filterType': 'LOT_SIZE',
                        'maxQty': '100000.00000000',
                        'minQty': '0.00010000',
                        'stepSize': '0.00010000'},
                       {'filterType': 'ICEBERG_PARTS', 'limit': '10'},
                       {'filterType': 'MARKET_LOT_SIZE',
                        'maxQty': '3742.72250083',
                        'minQty': '0.00000000',
                        'stepSize': '0.00000000'},
                       {'filterType': 'TRAILING_DELTA',
                        'maxTrailingAboveDelta': '2000',
                        'maxTrailingBelowDelta': '2000',
                        'minTrailingAboveDelta': '10',
                        'minTrailingBelowDelta': '10'},
                       {'askMultiplierDown': '0.2',
                        'askMultiplierUp': '5',
                        'avgPriceMins': '5',
                        'bidMultiplierDown': '0.2',
                        'bidMultiplierUp': '5',
                        'filterType': 'PERCENT_PRICE_BY_SIDE'},
                       {'applyMaxToMarket': False,
                        'applyMinToMarket': True,
                        'avgPriceMins': '5',
                        'filterType': 'NOTIONAL',
                        'maxNotional': '9000000.00000000',
                        'minNotional': '0.00010000'},
                       {'filterType': 'MAX_NUM_ORDERS', 'maxNumOrders': '200'},
                       {'filterType': 'MAX_NUM_ALGO_ORDERS',
                        'maxNumAlgoOrders': '5'}],
           'icebergAllowed': True,
           'isMarginTradingAllowed': True,
           'isSpotTradingAllowed': True,
           'ocoAllowed': True,
           'orderTypes': ['LIMIT',
                          'LIMIT_MAKER',
                          'MARKET',
                          'STOP_LOSS_LIMIT',
                          'TAKE_PROFIT_LIMIT'],
           'permissions': ['SPOT',
                           'MARGIN',
                           'TRD_GRP_004',
                           'TRD_GRP_005',
                           'TRD_GRP_006',
                           'TRD_GRP_008',
                           'TRD_GRP_009',
                           'TRD_GRP_010',
                           'TRD_GRP_011',
                           'TRD_GRP_012',
                           'TRD_GRP_013',
                           'TRD_GRP_014',
                           'TRD_GRP_015',
                           'TRD_GRP_016',
                           'TRD_GRP_017',
                           'TRD_GRP_018',
                           'TRD_GRP_019',
                           'TRD_GRP_020',
                           'TRD_GRP_021',
                           'TRD_GRP_022',
                           'TRD_GRP_023',
                           'TRD_GRP_024',
                           'TRD_GRP_025'],
           'quoteAsset': 'BTC',
           'quoteAssetPrecision': '8',
           'quoteCommissionPrecision': '8',
           'quoteOrderQtyMarketAllowed': True,
           'quotePrecision': '8',
           'status': 'TRADING',
           'symbol': 'ETHBTC'},
  'inverse': None,
  'limits': {'amount': {'max': 100000.0, 'min': 0.0001},
             'cost': {'max': 9000000.0, 'min': 0.0001},
             'leverage': {'max': None, 'min': None},
             'market': {'max': 3742.72250083, 'min': 0.0},
             'price': {'max': 922327.0, 'min': 1e-05}},
  'linear': None,
  'lowercaseId': 'ethbtc',
  'maker': 0.001,
  'margin': True,
  'option': False,
  'optionType': None,
  'precision': {'amount': 4, 'base': 8, 'price': 5, 'quote': 8},
  'quote': 'BTC',
  'quoteId': 'BTC',
  'settle': None,
  'settleId': None,
  'spot': True,
  'strike': None,
  'swap': False,
  'symbol': 'ETH/BTC',
  'taker': 0.001,
  'type': 'spot'},
 ...
 {'active': True,
  'base': 'BNB',
  'baseId': 'BNB',
  'contract': True,
  'contractSize': 10.0,
  'created': 1703836800000,
  'expiry': 1719561600000,
  'expiryDatetime': '2024-06-28T08:00:00.000Z',
  'future': True,
  'id': 'BNBUSD_240628',
  'info': {'baseAsset': 'BNB',
           'baseAssetPrecision': '8',
           'contractSize': '10',
           'contractStatus': 'TRADING',
           'contractType': 'NEXT_QUARTER',
           'deliveryDate': '1719561600000',
           'equalQtyPrecision': '4',
           'filters': [{'filterType': 'PRICE_FILTER',
                        'maxPrice': '41461',
                        'minPrice': '7',
                        'tickSize': '0.010'},
                       {'filterType': 'LOT_SIZE',
                        'maxQty': '1000000',
                        'minQty': '1',
                        'stepSize': '1'},
                       {'filterType': 'MARKET_LOT_SIZE',
                        'maxQty': '5000',
                        'minQty': '1',
                        'stepSize': '1'},
                       {'filterType': 'MAX_NUM_ORDERS', 'limit': '200'},
                       {'filterType': 'MAX_NUM_ALGO_ORDERS', 'limit': '20'},
                       {'filterType': 'PERCENT_PRICE',
                        'multiplierDecimal': '4',
                        'multiplierDown': '0.9500',
                        'multiplierUp': '1.0500'}],
           'liquidationFee': '0.010000',
           'maintMarginPercent': '2.5000',
           'marginAsset': 'BNB',
           'marketTakeBound': '0.05',
           'maxMoveOrderLimit': '10000',
           'onboardDate': '1703836800000',
           'orderTypes': ['LIMIT',
                          'MARKET',
                          'STOP',
                          'STOP_MARKET',
                          'TAKE_PROFIT',
                          'TAKE_PROFIT_MARKET',
                          'TRAILING_STOP_MARKET'],
           'pair': 'BNBUSD',
           'pricePrecision': '3',
           'quantityPrecision': '0',
           'quoteAsset': 'USD',
           'quotePrecision': '8',
           'requiredMarginPercent': '5.0000',
           'symbol': 'BNBUSD_240628',
           'timeInForce': ['GTC', 'IOC', 'FOK', 'GTX'],
           'triggerProtect': '0.0500',
           'underlyingSubType': [],
           'underlyingType': 'COIN'},
  'inverse': True,
  'limits': {'amount': {'max': 1000000.0, 'min': 1.0},
             'cost': {'max': None, 'min': None},
             'leverage': {'max': None, 'min': None},
             'market': {'max': 5000.0, 'min': 1.0},
             'price': {'max': 41461.0, 'min': 7.0}},
  'linear': False,
  'lowercaseId': 'bnbusd_240628',
  'maker': 0.0001,
  'margin': False,
  'option': False,
  'optionType': None,
  'precision': {'amount': 0, 'base': 8, 'price': 2, 'quote': 8},
  'quote': 'USD',
  'quoteId': 'USD',
  'settle': 'BNB',
  'settleId': 'BNB',
  'spot': False,
  'strike': None,
  'swap': False,
  'symbol': 'BNB/USD:BNB-240628',
  'taker': 0.0005,
  'type': 'future'}]
```