### PR TITLE
fix(exchange): update safeBoolN

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1770,6 +1770,12 @@ export default class Exchange {
         if (typeof value === 'boolean') {
             return value;
         }
+        if (typeof value === 'string') {
+            return (value === '1') || (value.toLowerCase () === 'true');
+        }
+        if (typeof value === 'number') {
+            return value === 1;
+        }
         return defaultValue;
     }
 


### PR DESCRIPTION
fix: ccxt/ccxt#21531

In yobit, the success value seems to be number / string / bool. I wonder whether we should treat these value to true: `'1' || 'true' || 1`.