### PR TITLE
bybit: update for spot

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4301,8 +4301,8 @@ export default class bybit extends Exchange {
         //         "time": "1709796158501"
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const row = this.safeValue (result, 'list', []);
+        const result = this.safeDict (response, 'result', {});
+        const row = this.safeList (result, 'list', []);
         return this.parseOrders (row, market);
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4224,6 +4224,88 @@ export default class bybit extends Exchange {
         return this.parseOrder (result, market);
     }
 
+    async cancelOrders (ids, symbol: Str = undefined, params = {}) {
+        /**
+         * @method
+         * @name bybit#cancelOrders
+         * @description cancel multiple orders
+         * @see https://bybit-exchange.github.io/docs/v5/order/batch-cancel
+         * @param {string[]} ids order ids
+         * @param {string} symbol unified symbol of the market the order was made in
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string[]} [params.clientOrderIds] client order ids
+         * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument');
+        }
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        let category = undefined;
+        [ category, params ] = this.getBybitType ('cancelOrders', market, params);
+        if (category === 'inverse') {
+            throw new NotSupported (this.id + ' cancelOrders does not allow inverse orders');
+        }
+        const ordersRequests = [];
+        const clientOrderIds = this.safeList2 (params, 'clientOrderIds', 'clientOids', []);
+        params = this.omit (params, [ 'clientOrderIds', 'clientOids' ]);
+        for (let i = 0; i < clientOrderIds.length; i++) {
+            ordersRequests.push ({
+                'symbol': market['id'],
+                'orderLinkId': this.safeString (clientOrderIds, i),
+            });
+        }
+        for (let i = 0; i < ids.length; i++) {
+            ordersRequests.push ({
+                'symbol': market['id'],
+                'orderId': this.safeString (ids, i),
+            });
+        }
+        const request = {
+            'category': category,
+            'request': ordersRequests,
+        };
+        const response = await this.privatePostV5OrderCancelBatch (this.extend (request, params));
+        //
+        //     {
+        //         "retCode": "0",
+        //         "retMsg": "OK",
+        //         "result": {
+        //             "list": [
+        //                 {
+        //                     "category": "spot",
+        //                     "symbol": "BTCUSDT",
+        //                     "orderId": "1636282505818800896",
+        //                     "orderLinkId": "1636282505818800897"
+        //                 },
+        //                 {
+        //                     "category": "spot",
+        //                     "symbol": "BTCUSDT",
+        //                     "orderId": "1636282505818800898",
+        //                     "orderLinkId": "1636282505818800899"
+        //                 }
+        //             ]
+        //         },
+        //         "retExtInfo": {
+        //             "list": [
+        //                 {
+        //                     "code": "0",
+        //                     "msg": "OK"
+        //                 },
+        //                 {
+        //                     "code": "0",
+        //                     "msg": "OK"
+        //                 }
+        //             ]
+        //         },
+        //         "time": "1709796158501"
+        //     }
+        //
+        const result = this.safeValue (response, 'result', {});
+        const row = this.safeValue (result, 'list', []);
+        return this.parseOrders (row, market);
+    }
+
     async cancelAllUsdcOrders (symbol: Str = undefined, params = {}) {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' cancelAllUsdcOrders() requires a symbol argument');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3752,8 +3752,8 @@ export default class bybit extends Exchange {
         const market = this.market (symbols[0]);
         let category = undefined;
         [ category, params ] = this.getBybitType ('createOrders', market, params);
-        if ((category === 'spot') || (category === 'inverse')) {
-            throw new NotSupported (this.id + ' createOrders does not allow spot or inverse orders');
+        if (category === 'inverse') {
+            throw new NotSupported (this.id + ' createOrders does not allow inverse orders');
         }
         const request = {
             'category': category,

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -369,6 +369,30 @@
         ],
         "createOrders": [
             {
+                "description": "Spot create orders",
+                "method": "createOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/create-batch",
+                "input": [
+                    [
+                        {
+                            "symbol": "LTC/USDT",
+                            "amount": 0.1,
+                            "side": "buy",
+                            "type": "limit",
+                            "price": 50
+                        },
+                        {
+                            "symbol": "LTC/USDT",
+                            "amount": 0.11,
+                            "side": "sell",
+                            "type": "limit",
+                            "price": 70
+                        }
+                    ]
+                ],
+                "output": "{\"category\":\"spot\",\"request\":[{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"spot\",\"qty\":\"0.1\",\"price\":\"50\"},{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"category\":\"spot\",\"qty\":\"0.11\",\"price\":\"70\"}]}"
+            },
+            {
                 "description": "Swap create orders",
                 "method": "createOrders",
                 "url": "https://api-testnet.bybit.com/v5/order/create-batch",

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -452,6 +452,41 @@
                 "output": "{\"symbol\":\"BTCUSDT\",\"orderFilter\":\"StopOrder\",\"orderId\":\"1599966662050972416\",\"category\":\"spot\"}"
             }
         ],
+        "cancelOrders": [
+            {
+                "description": "Swap cancelOrders",
+                "method": "cancelOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel-batch",
+                "input": [
+                    ["8caeea8c-cf80-4b06-83e8-bb7df45fc122"],
+                    "LTC/USDT:USDT"
+                ],
+                "output": "{\"category\":\"linear\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderId\":\"8caeea8c-cf80-4b06-83e8-bb7df45fc122\"}]}"
+            },
+            {
+                "description": "Spot cancelOrders",
+                "method": "cancelOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel-batch",
+                "input": [
+                    ["1513125485218108928"],
+                    "LTC/USDT"
+                ],
+                "output": "{\"category\":\"spot\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderId\":\"1513125485218108928\"}]}"
+            },
+            {
+                "description": "cancelOrders by clientOrderId",
+                "method": "cancelOrders",
+                "url": "https://api-testnet.bybit.com/v5/order/cancel-batch",
+                "input": [
+                    [],
+                    "LTC/USDT:USDT",
+                    {
+                        "clientOrderIds": ["test123"]
+                    }
+                ],
+                "output": "{\"category\":\"linear\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderLinkId\":\"test123\"}]}"
+            }
+        ],
         "cancelAllOrders": [
             {
                 "description": "Swap cancel all open orders",


### PR DESCRIPTION
Updated methods for spot:
* createOrders
* cancelOrders

```BASH
$ p bybit createOrders '[{"symbol":"BTC/USDT","type":"limit","side":"buy","amount":0.01,"price":40000}, {"symbol":"BTC/USDT","type":"limit","side":"sell","amount":0.01,"price":50000}]' --test
Python v3.11.3
CCXT v4.2.63
bybit.createOrders([{'symbol': 'BTC/USDT', 'type': 'limit', 'side': 'buy', 'amount': 0.01, 'price': 40000}, {'symbol': 'BTC/USDT', 'type': 'limit', 'side': 'sell', 'amount': 0.01, 'price': 50000}])
[{'amount': None,
  'average': None,
  'clientOrderId': '1636279811053978369',
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '1636279811053978368',
  'info': {'category': 'spot',
           'createAt': '1709795753782',
           'orderId': '1636279811053978368',
           'orderLinkId': '1636279811053978369',
           'symbol': 'BTCUSDT'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None},
 {'amount': None,
  'average': None,
  'clientOrderId': '1636279811053978371',
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '1636279811053978370',
  'info': {'category': 'spot',
           'createAt': '1709795753782',
           'orderId': '1636279811053978370',
           'orderLinkId': '1636279811053978371',
           'symbol': 'BTCUSDT'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]

$ p bybit cancelOrders '[]' BTC/USDT '{"clientOrderIds": ["test126", "test127"]}' --test
Python v3.11.3
CCXT v4.2.63
bybit.cancelOrders([],BTC/USDT,{'clientOrderIds': ['test126', 'test127']})
[{'amount': None,
  'average': None,
  'clientOrderId': 'test126',
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': None,
  'info': {'category': 'spot',
           'orderId': '',
           'orderLinkId': 'test126',
           'symbol': 'BTCUSDT'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None},
 {'amount': None,
  'average': None,
  'clientOrderId': 'test127',
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': None,
  'info': {'category': 'spot',
           'orderId': '',
           'orderLinkId': 'test127',
           'symbol': 'BTCUSDT'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'BTC/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```