### PR TITLE
fix(coinbase): require payload for GET v2 private endpoint

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3759,7 +3759,8 @@ export default class coinbase extends Exchange {
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {
         const version = api[0];
         const signed = api[1] === 'private';
-        const pathPart = (version === 'v3') ? 'api/v3' : 'v2';
+        const isV3 = version === 'v3';
+        const pathPart = (isV3) ? 'api/v3' : 'v2';
         let fullPath = '/' + pathPart + '/' + this.implodeParams (path, params);
         const query = this.omit (params, this.extractParams (path));
         const savedPath = fullPath;
@@ -3800,9 +3801,17 @@ export default class coinbase extends Exchange {
                         body = this.json (query);
                         payload = body;
                     }
+                } else {
+                    if (!isV3) {
+                        if (Object.keys (query).length) {
+                            payload += '?' + this.urlencode (query);
+                        }
+                    }
                 }
-                // 'GET' doesn't need payload in the signature. inside url is enough
+                // v3: 'GET' doesn't need payload in the signature. inside url is enough
                 // https://docs.cloud.coinbase.com/advanced-trade-api/docs/auth#example-request
+                // v2: 'GET' require payload in the signature
+                // https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/api-key-authentication
                 const auth = timestampString + method + savedPath + payload;
                 const signature = this.hmac (this.encode (auth), this.encode (this.secret), sha256);
                 headers = {


### PR DESCRIPTION
fix: ccxt/ccxt#21596

Coinbase require query payload for v2 private get request.

Test:
```BASH
$ p coinbase v3PrivateGetBrokerageAccounts '{"limit":100}' --verbose
$ p coinbase v2PrivateGetAccounts '{"limit":100}' --verbose
```

How do you think add signature test in static-tests?

Steps to test signature:
1. random key
2. create signature with payload for GET /POST/ PUT / DELETE
3. assert the result with sign function
