### PR TITLE
blofin: add fetchMarginMode

### DIFF
--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -339,6 +339,16 @@
             "url": "https://openapi.blofin.com/api/v1/account/balance",
             "input": []
           }
+        ],
+        "fetchMarginMode": [
+          {
+            "description": "Fetch the accounts set margin mode",
+            "method": "fetchMarginMode",
+            "url": "https://openapi.blofin.com/api/v1/account/margin-mode",
+            "input": [
+              "BTC/USDT:USDT"
+            ]
+          }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchMarginMode` to blofin:

```
blofin.fetchMarginMode (BTC/USDT:USDT)
2024-03-08T06:34:15.539Z iteration 0 passed in 446 ms

{
  info: { marginMode: 'cross' },
  symbol: 'BTC/USDT:USDT',
  marginMode: 'cross'
}
```