### PR TITLE
fix(binance) - reduceOnly handling

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5722,11 +5722,11 @@ export default class binance extends Exchange {
         let isPortfolioMargin = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'createOrder', 'papi', 'portfolioMargin', false);
         let marginMode = undefined;
+        const reduceOnly = this.safeBool (params, 'reduceOnly', false);
+        params = this.omit (params, 'reduceOnly');
         [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
         if ((marketType === 'margin') || (marginMode !== undefined) || market['option']) {
             // for swap and future reduceOnly is a string that cant be sent with close position set to true or in hedge mode
-            const reduceOnly = this.safeBool (params, 'reduceOnly', false);
-            params = this.omit (params, 'reduceOnly');
             if (market['option']) {
                 request['reduceOnly'] = reduceOnly;
             } else {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5722,11 +5722,11 @@ export default class binance extends Exchange {
         let isPortfolioMargin = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'createOrder', 'papi', 'portfolioMargin', false);
         let marginMode = undefined;
-        const reduceOnly = this.safeBool (params, 'reduceOnly', false);
-        params = this.omit (params, 'reduceOnly');
         [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
         if ((marketType === 'margin') || (marginMode !== undefined) || market['option']) {
             // for swap and future reduceOnly is a string that cant be sent with close position set to true or in hedge mode
+            const reduceOnly = this.safeBool (params, 'reduceOnly', false);
+            params = this.omit (params, 'reduceOnly');
             if (market['option']) {
                 request['reduceOnly'] = reduceOnly;
             } else {
@@ -5734,6 +5734,9 @@ export default class binance extends Exchange {
                     request['sideEffectType'] = 'AUTO_REPAY';
                 }
             }
+        } else if (market['spot']) {
+            // see: https://github.com/ccxt/ccxt/pull/21608
+            params = this.omit (params, 'reduceOnly');
         }
         const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const stopLossPrice = this.safeString (params, 'stopLossPrice', triggerPrice); // fallback to stopLoss

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -358,14 +358,14 @@
                   "BTC/USDT:USDT",
                   "limit",
                   "buy",
-                  0.01,
-                  10000,
+                  0.002,
+                  70000,
                   {
                     "reduceOnly": true
                   }
                 ],
-                "output": "timestamp=1709895616844&symbol=BTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-xcKtGhcu2aaaefebcaf6437e8084bb&type=LIMIT&quantity=0.01&price=10000&timeInForce=GTC&recvWindow=10000&signature=49c86041752655f5f60308396297ad9b62db1d6480f8c28a74d45f3811071744"
-            }
+                "output": "timestamp=1709910852474&symbol=BTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-xcKtGhcu7a25743993824949b7875d&type=LIMIT&quantity=0.002&price=70000&timeInForce=GTC&reduceOnly=true&recvWindow=10000&signature=5f7dc14eeadbf0064c12426335ba5296a35baa65a8e80a60d46d96c3a82559d7"
+              }
         ],
         "createOrders": [
             {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -333,6 +333,38 @@
                   }
                 ],
                 "output": "timestamp=1708360882808&symbol=LTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-xcKtGhcu6f60e2c1e1ed4166838709&type=LIMIT&quantity=0.2&timeInForce=GTC&priceMatch=OPPONENT&recvWindow=10000&signature=b73ae983cc2d4995d48e98841152c802ba0b420ee79fc501bde0b6eeee4817ab"
+            },
+            {
+                "description": "spot buy limit with reduceOnly",
+                "method": "createOrder",
+                "url": "https://api.binance.com/api/v3/order",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.00008,
+                  65000,
+                  {
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "timestamp=1709895235709&symbol=BTCUSDT&side=BUY&newOrderRespType=FULL&newClientOrderId=x-R4BD3S82c2f30989c60a4e5f8ba05a&type=LIMIT&quantity=0.00008&price=65000&timeInForce=GTC&recvWindow=10000&signature=374010e60a1c9caa093b7b201bec8fef399b5c41e1f932ed11cb97f22a35b6f0"
+            },
+            {
+                "description": "swap buy limit with reduceOnly",
+                "method": "createOrder",
+                "url": "https://fapi.binance.com/fapi/v1/order",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.01,
+                  10000,
+                  {
+                    "reduceOnly": true
+                  }
+                ],
+                "output": "timestamp=1709895616844&symbol=BTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-xcKtGhcu2aaaefebcaf6437e8084bb&type=LIMIT&quantity=0.01&price=10000&timeInForce=GTC&recvWindow=10000&signature=49c86041752655f5f60308396297ad9b62db1d6480f8c28a74d45f3811071744"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
when running :
```
await e.createOrder ('BTC/USDT', 'limit', 'buy', 0.001, 60000, {reduceOnly: true});
```
for spot markets, API throws an error: 
> {"code":-1104,"msg":"Not all sent parameters were read; read '11' parameter(s) but was sent '12'."}

however, `reduceOnly` is unified parameter, and it **has to be handled** correctly, independently whether it's spot or not. even if it's spot, and user provides that, it shouldn't lead to exception.