### PR TITLE
chore: currencyToPrecision param/return types

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -3160,6 +3160,7 @@ export default class ascendex extends Exchange {
          * @method
          * @name ascendex#transfer
          * @description transfer currency internally between wallets on the same account
+         * @see https://ascendex.github.io/ascendex-pro-api/#balance-transfer
          * @param {string} code unified currency codeåå
          * @param {float} amount amount to transfer
          * @param {string} fromAccount account to transfer from
@@ -3169,11 +3170,11 @@ export default class ascendex extends Exchange {
          */
         await this.loadMarkets ();
         await this.loadAccounts ();
-        const account = this.safeValue (this.accounts, 0, {});
+        const account = this.safeDict (this.accounts, 0, {});
         const accountGroup = this.safeString (account, 'id');
         const currency = this.currency (code);
-        amount = this.currencyToPrecision (code, amount);
-        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const preciseAmount = this.currencyToPrecision (code, amount);
+        const accountsByType = this.safeDict (this.options, 'accountsByType', {});
         const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
         const toId = this.safeString (accountsByType, toAccount, toAccount);
         if (fromId !== 'cash' && toId !== 'cash') {
@@ -3181,7 +3182,7 @@ export default class ascendex extends Exchange {
         }
         const request = {
             'account-group': accountGroup,
-            'amount': amount,
+            'amount': preciseAmount,
             'asset': currency['id'],
             'fromAccount': fromId,
             'toAccount': toId,
@@ -3190,13 +3191,13 @@ export default class ascendex extends Exchange {
         //
         //    { "code": "0" }
         //
-        const transferOptions = this.safeValue (this.options, 'transfer', {});
+        const transferOptions = this.safeDict (this.options, 'transfer', {});
         const fillResponseFromRequest = this.safeBool (transferOptions, 'fillResponseFromRequest', true);
         const transfer = this.parseTransfer (response, currency);
         if (fillResponseFromRequest) {
             transfer['fromAccount'] = fromAccount;
             transfer['toAccount'] = toAccount;
-            transfer['amount'] = amount;
+            transfer['amount'] = this.number (preciseAmount);
             transfer['currency'] = code;
         }
         return transfer;

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5109,7 +5109,7 @@ export default class Exchange {
         return this.decimalToPrecision (fee, ROUND, market['precision']['price'], this.precisionMode, this.paddingMode);
     }
 
-    currencyToPrecision (code: string, fee, networkCode = undefined) {
+    currencyToPrecision (code: string, fee: number, networkCode: Str = undefined): string {
         const currency = this.currencies[code];
         let precision = this.safeValue (currency, 'precision');
         if (networkCode !== undefined) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2506,7 +2506,7 @@ export default class binance extends Exchange {
         return this.decimalToPrecision (cost, TRUNCATE, this.markets[symbol]['precision']['quote'], this.precisionMode, this.paddingMode);
     }
 
-    currencyToPrecision (code, fee, networkCode = undefined) {
+    currencyToPrecision (code: string, fee: number, networkCode: Str = undefined): string {
         // info is available in currencies only if the user has configured his api keys
         if (this.safeValue (this.currencies[code], 'precision') !== undefined) {
             return this.decimalToPrecision (fee, TRUNCATE, this.currencies[code]['precision'], this.precisionMode, this.paddingMode);

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -455,7 +455,7 @@ export default class bitrue extends Exchange {
         });
     }
 
-    currencyToPrecision (code, fee, networkCode = undefined) {
+    currencyToPrecision (code: string, fee: number, networkCode: Str = undefined): string {
         // info is available in currencies only if the user has configured his api keys
         if (this.safeValue (this.currencies[code], 'precision') !== undefined) {
             return this.decimalToPrecision (fee, TRUNCATE, this.currencies[code]['precision'], this.precisionMode, this.paddingMode);

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -278,7 +278,7 @@ export default class bitvavo extends Exchange {
         });
     }
 
-    currencyToPrecision (code, fee, networkCode = undefined) {
+    currencyToPrecision (code: string, fee: number, networkCode: Str = undefined): string {
         return this.decimalToPrecision (fee, 0, this.currencies[code]['precision'], DECIMAL_PLACES);
     }
 

--- a/ts/src/coinlist.ts
+++ b/ts/src/coinlist.ts
@@ -1752,12 +1752,11 @@ export default class coinlist extends Exchange {
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
-        amount = this.currencyToPrecision (code, amount);
         const request = {
             'asset': currency['id'],
-            'amount': amount,
+            'amount': this.currencyToPrecision (code, amount),
         };
-        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountsByType = this.safeDict (this.options, 'accountsByType', {});
         const fromAcc = this.safeString (accountsByType, fromAccount, fromAccount);
         const toAcc = this.safeString (accountsByType, toAccount, toAccount);
         let response = undefined;

--- a/ts/src/huobijp.ts
+++ b/ts/src/huobijp.ts
@@ -1610,7 +1610,7 @@ export default class huobijp extends Exchange {
         return response;
     }
 
-    currencyToPrecision (code, fee, networkCode = undefined) {
+    currencyToPrecision (code: string, fee: number, networkCode: Str = undefined): string {
         return this.decimalToPrecision (fee, 0, this.currencies[code]['precision'], this.precisionMode);
     }
 

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1866,12 +1866,11 @@ export default class poloniex extends Exchange {
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
-        amount = this.currencyToPrecision (code, amount);
-        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
+        const accountsByType = this.safeDict (this.options, 'accountsByType', {});
         const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
         const toId = this.safeString (accountsByType, toAccount, fromAccount);
         const request = {
-            'amount': amount,
+            'amount': this.currencyToPrecision (code, amount),
             'currency': currency['id'],
             'fromAccount': fromId,
             'toAccount': toId,

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -256,6 +256,7 @@ export default class poloniex extends Exchange {
                 },
                 'accountsByType': {
                     'spot': 'spot',
+                    'swap': 'futures',
                     'future': 'futures',
                 },
                 'accountsById': {
@@ -1868,7 +1869,7 @@ export default class poloniex extends Exchange {
         const currency = this.currency (code);
         const accountsByType = this.safeDict (this.options, 'accountsByType', {});
         const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
-        const toId = this.safeString (accountsByType, toAccount, fromAccount);
+        const toId = this.safeString (accountsByType, toAccount, toAccount);
         const request = {
             'amount': this.currencyToPrecision (code, amount),
             'currency': currency['id'],

--- a/ts/src/test/static/request/coinlist.json
+++ b/ts/src/test/static/request/coinlist.json
@@ -95,6 +95,32 @@
                     }
                 ]
             }
+        ],
+        "transfer": [
+            {
+                "description": "Transfer from trading to funding",
+                "method": "transfer",
+                "url": "https://trade-api.coinlist.co/v1/transfers/to-wallet",
+                "input": [
+                  "USDT",
+                  1,
+                  "trading",
+                  "funding"
+                ],
+                "output": "{\"asset\":\"USDT\",\"amount\":\"1\"}"
+            },
+            {
+                "description": "Transfer from funding to trading",
+                "method": "transfer",
+                "url": "https://trade-api.coinlist.co/v1/transfers/from-wallet",
+                "input": [
+                  "USDT",
+                  1,
+                  "funding",
+                  "trading"
+                ],
+                "output": "{\"asset\":\"USDT\",\"amount\":\"1\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/poloniex.json
+++ b/ts/src/test/static/request/poloniex.json
@@ -155,6 +155,44 @@
                 ],
                 "output": "{\"symbol\":\"LTC_USDT\",\"side\":\"buy\",\"type\":\"MARKET\",\"amount\":\"10\"}"
             }
+        ],
+        "transfer": [
+            {
+                "description": "Transfer from spot to futures",
+                "method": "transfer",
+                "url": "https://api.poloniex.com/accounts/transfer",
+                "input": [
+                    "USDT",
+                    0.00001,
+                    "spot",
+                    "futures"
+                ],
+                "output": "{\"amount\":\"0.00001\",\"currency\":\"USDT\",\"fromAccount\":\"spot\",\"toAccount\":\"futures\"}"
+            },
+            {
+                "description": "Transfer from spot to swap",
+                "method": "transfer",
+                "url": "https://api.poloniex.com/accounts/transfer",
+                "input": [
+                  "USDT",
+                  0.00001,
+                  "spot",
+                  "swap"
+                ],
+                "output": "{\"amount\":\"0.00001\",\"currency\":\"USDT\",\"fromAccount\":\"spot\",\"toAccount\":\"futures\"}"
+            },
+            {
+                "description": "Transfer from spot to future",
+                "method": "transfer",
+                "url": "https://api.poloniex.com/accounts/transfer",
+                "input": [
+                  "USDT",
+                  0.00001,
+                  "spot",
+                  "future"
+                ],
+                "output": "{\"amount\":\"0.00001\",\"currency\":\"USDT\",\"fromAccount\":\"spot\",\"toAccount\":\"futures\"}"
+            }
         ]
     }
 }

--- a/ts/src/wavesexchange.ts
+++ b/ts/src/wavesexchange.ts
@@ -1245,9 +1245,9 @@ export default class wavesexchange extends Exchange {
         return this.parseToInt (parseFloat (amountPrecision));
     }
 
-    currencyToPrecision (code, amount, networkCode = undefined) {
-        const amountPrecision = this.numberToString (this.toPrecision (amount, this.currencies[code]['precision']));
-        return this.parseToInt (parseFloat (amountPrecision));
+    currencyToPrecision (code: string, fee: number, networkCode: Str = undefined): string {
+        const amountPrecision = this.numberToString (this.toPrecision (fee, this.currencies[code]['precision']));
+        return amountPrecision;
     }
 
     fromPrecision (amount, scale) {
@@ -2542,7 +2542,8 @@ export default class wavesexchange extends Exchange {
         const feeAssetId = 'WAVES';
         const type = 4;  // transfer
         const version = 2;
-        const amountInteger = this.currencyToPrecision (code, amount);
+        const preciseAmount = this.currencyToPrecision (code, amount);
+        const amountInteger = this.parseToInt (this.parseNumber (preciseAmount));
         const currency = this.currency (code);
         const timestamp = this.milliseconds ();
         const byteArray = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,7 +99,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-    "strictNullChecks":false
+    "strictNullChecks":false,
   },
   "include": [
     "ts/**/*"
@@ -107,5 +107,5 @@
   "exclude": [
     "node_modules",
     "./ts/src/static_dependencies/**/*.cjs"
-  ]
+  ],
 }


### PR DESCRIPTION
- adds param/return types to currencyToPrecision
- fixes default toAccount bug on poloniex
- adds swap to poloniex accountsByType
- coinlist static tests

# Testing

```
% py ascendex transfer SOL 0.0001 spot swap
Python v3.9.6
CCXT v4.2.64
ascendex.transfer(SOL,0.0001,spot,swap)
{'amount': 0.0001,
 'currency': 'SOL',
 'datetime': None,
 'fromAccount': 'spot',
 'id': None,
 'info': {'code': '0'},
 'status': 'ok',
 'timestamp': None,
 'toAccount': 'swap'}
```


```
% py poloniex transfer USDT 0.00001 spot future 
Python v3.9.6
CCXT v4.2.64
poloniex.transfer(USDT,1e-05,spot,future)
{'amount': None,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': None,
 'id': '300428130',
 'info': {'transferId': '300428130'},
 'status': None,
 'timestamp': None,
 'toAccount': None}
```

```
% py coinlist transfer USDT 1 funding trading         
Python v3.9.6
CCXT v4.2.64
coinlist.transfer(USDT,1,funding,trading)
{'amount': None,
 'currency': 'USDT',
 'datetime': None,
 'fromAccount': None,
 'id': 'c0ca4497-ce2d-461a-a5b0-db3cdc3bd71a',
 'info': {'transfer_id': 'c0ca4497-ce2d-461a-a5b0-db3cdc3bd71a'},
 'status': None,
 'timestamp': None,
 'toAccount': None}
```