### PR TITLE
feat(bingx): add TRAILING_TP_SL and test order

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1878,6 +1878,7 @@ export default class bingx extends Exchange {
             const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
             const trailingAmount = this.safeString (params, 'trailingAmount');
             const trailingPercent = this.safeString2 (params, 'trailingPercent', 'priceRate');
+            const trailingType = this.safeString (params, 'trailingType', 'TRAILING_STOP_MARKET');
             const isTriggerOrder = triggerPrice !== undefined;
             const isStopLossPriceOrder = stopLossPrice !== undefined;
             const isTakeProfitPriceOrder = takeProfitPrice !== undefined;
@@ -1918,7 +1919,7 @@ export default class bingx extends Exchange {
                     }
                 }
             } else if (isTrailing) {
-                request['type'] = 'TRAILING_STOP_MARKET';
+                request['type'] = trailingType;
                 if (isTrailingAmountOrder) {
                     request['price'] = this.parseToNumeric (trailingAmount);
                 } else if (isTrailingPercentOrder) {
@@ -1971,7 +1972,7 @@ export default class bingx extends Exchange {
             }
             request['positionSide'] = positionSide;
             request['quantity'] = this.parseToNumeric (this.amountToPrecision (symbol, amount));
-            params = this.omit (params, [ 'reduceOnly', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingPercent', 'takeProfit', 'stopLoss', 'clientOrderId' ]);
+            params = this.omit (params, [ 'reduceOnly', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingPercent', 'trailingType', 'takeProfit', 'stopLoss', 'clientOrderId' ]);
         }
         return this.extend (request, params);
     }
@@ -2003,14 +2004,21 @@ export default class bingx extends Exchange {
          * @param {float} [params.takeProfit.triggerPrice] take profit trigger price
          * @param {object} [params.stopLoss] *stopLoss object in params* containing the triggerPrice at which the attached stop loss order will be triggered
          * @param {float} [params.stopLoss.triggerPrice] stop loss trigger price
+         * @param {boolean} [params.test] *swap only* whether to use the test endpoint or not, default is false
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const test = this.safeBool (params, 'test', false);
+        params = this.omit (params, 'test');
         const request = this.createOrderRequest (symbol, type, side, amount, price, params);
         let response = undefined;
         if (market['swap']) {
-            response = await this.swapV2PrivatePostTradeOrder (request);
+            if (test) {
+                response = await this.swapV2PrivatePostTradeOrderTest (request);
+            } else {
+                response = await this.swapV2PrivatePostTradeOrder (request);
+            }
         } else {
             response = await this.spotV1PrivatePostTradeOrder (request);
         }
@@ -4083,7 +4091,7 @@ export default class bingx extends Exchange {
          * @param {string} [params.newClientOrderId] custom order id consisting of letters, numbers, and _, 1-40 characters, different orders cannot use the same newClientOrderId.
          * @param {string} [params.positionSide] *contract only* position direction, required for single position as BOTH, for both long and short positions only LONG or SHORT can be chosen, defaults to LONG if empty
          * @param {string} [params.reduceOnly] *contract only* true or false, default=false for single position mode. this parameter is not accepted for both long and short positions mode
-         * @param {float} [params.priceRate] *contract only* for type TRAILING_STOP_Market, Max = 1
+         * @param {float} [params.priceRate] *contract only* for type TRAILING_STOP_Market or TRAILING_TP_SL, Max = 1
          * @param {string} [params.workingType] *contract only* StopPrice trigger price types, MARK_PRICE (default), CONTRACT_PRICE, or INDEX_PRICE
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -331,6 +331,22 @@
                     "clientOrderId": "myorder1"
                   }
                 ]
+            },
+            {
+                "description": "Swap send test order",
+                "method": "createOrder",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order/test?positionSide=LONG&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343342279&type=TAKE_PROFIT_MARKET&signature=26051175a041231ba47518249dd2e70c7ccc45185f32bb5551b4cccf49e9cb9d",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
+                    null,
+                    {
+                        "takeProfitPrice": "40000",
+                        "test": true
+                    }
+                ]
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Changes for swap market in bingx:
* add TRAILING_TP_SL: It is a dynamic stop-profit and stop-loss based on open positions.
* support test in param

```BASH
$ python3 examples/py/cli.py bingx createOrder ADA/USDT:USDT limit buy 5 0.5 '{"trailingType":"TRAILING_TP_SL","trailingP
ercent":"90","test":true}'

Python v3.8.10
CCXT v4.2.64
bingx.createOrder(ADA/USDT:USDT,limit,buy,5,0.5,{'trailingType': 'TRAILING_TP_SL', 'trailingPercent': '90', 'test': True})
{'amount': 5.0,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': {'cost': None, 'currency': 'USDT'},
 'fees': [{'cost': None, 'currency': 'USDT'}],
 'filled': None,
 'id': '3437831667989459873',
 'info': {'activationPrice': '0',
          'clientOrderID': '',
          'closePosition': '',
          'orderId': '3437831667989459873',
          'positionSide': 'LONG',
          'price': '0',
          'priceRate': '0.9',
          'quantity': '5',
          'reduceOnly': False,
          'side': 'BUY',
          'stopGuaranteed': '',
          'stopLoss': '',
          'stopPrice': '0',
          'symbol': 'ADA-USDT',
          'takeProfit': '',
          'timeInForce': '',
          'type': 'TRAILING_TP_SL',
          'workingType': ''},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': False,
 'remaining': None,
 'side': 'buy',
 'status': None,
 'stopLossPrice': None,
 'stopPrice': 0.0,
 'symbol': 'ADA/USDT:USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': 0.0,
 'type': 'trailing_tp_sl'}
```