### PR TITLE
fix(currencycom) - handle trades [QUICK]

### DIFF
--- a/ts/src/pro/currencycom.ts
+++ b/ts/src/pro/currencycom.ts
@@ -200,7 +200,7 @@ export default class currencycom extends currencycomRest {
         };
     }
 
-    handleTrades (client: Client, message, subscription) {
+    handleTrades (client: Client, message) {
         //
         //     {
         //         "status": "OK",


### PR DESCRIPTION
some strange error surfaced here: https://app.travis-ci.com/github/ccxt/ccxt/builds/269349696#L3734

the third argument, was neither used in that `handleTrades` method body, and it was neither ever passed to that function, because all handler functions are only provided with 2 arguments :  `https://github.com/ccxt/ccxt/blob/master/ts/src/pro/currencycom.ts#L577`