### PR TITLE
fix(transpiler) - reverse

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -414,7 +414,7 @@ class Transpiler {
             // only cases like `x = x.reverse ()` should be transpiled, which will resul as 
             // `x.reverse()` in python. otherwise, if transpiling `x = y.reverse()`, then the
             // left side `x = `will be removed and only `y.reverse()` will end up in python
-            [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], 
+            [ /\s+(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$2.reverse(' ], 
             [ /Number\.MAX_SAFE_INTEGER/g, 'float(\'inf\')'],
             [ /function\s*(\w+\s*\([^)]+\))\s*{/g, 'def $1:'],
             // [ /\.replaceAll\s*\(([^)]+)\)/g, '.replace($1)' ], // still not a part of the standard

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -410,7 +410,9 @@ class Transpiler {
             [ /\!\=\=?/g, '!=' ],
             [ /this\.stringToBinary\s*\((.*)\)/g, '$1' ],
             [ /\.shift\s*\(\)/g, '.pop(0)' ],
-            [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], // opposed to JS, python's 'reverse()' does in-place
+            // drop support for .reverse() atm, because opposed to JS, python's does in-place,
+            // so we can't correctly transpile `const x = y.reverse()` in py for now
+            // [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], 
             [ /Number\.MAX_SAFE_INTEGER/g, 'float(\'inf\')'],
             [ /function\s*(\w+\s*\([^)]+\))\s*{/g, 'def $1:'],
             // [ /\.replaceAll\s*\(([^)]+)\)/g, '.replace($1)' ], // still not a part of the standard
@@ -645,7 +647,7 @@ class Transpiler {
             // a proper \ccxt\Exchange::deep_extend() base method is implemented instead
             // [ /this\.deepExtend\s/g, 'array_replace_recursive'],
             [ /(\w+)\.shift\s*\(\)/g, 'array_shift($1)' ],
-            [ /(\w+)\.reverse\s*\(\)/g, 'array_reverse($1)' ],
+            // [ /(\w+)\.reverse\s*\(\)/g, 'array_reverse($1)' ], // see comment in python .reverse()
             [ /(\w+)\.pop\s*\(\)/g, 'array_pop($1)' ],
             [ /Number\.MAX_SAFE_INTEGER/g, 'PHP_INT_MAX' ],
             [ /Precise\.stringAdd\s/g, 'Precise::string_add' ],

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -410,7 +410,7 @@ class Transpiler {
             [ /\!\=\=?/g, '!=' ],
             [ /this\.stringToBinary\s*\((.*)\)/g, '$1' ],
             [ /\.shift\s*\(\)/g, '.pop(0)' ],
-            // drop support for .reverse() atm, because opposed to JS, python's does in-place,
+            // drop support for .reverse() atm, because opposed to JS, python does in-place,
             // so we can't correctly transpile `const x = y.reverse()` in py for now
             // [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], 
             [ /Number\.MAX_SAFE_INTEGER/g, 'float(\'inf\')'],

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -410,9 +410,11 @@ class Transpiler {
             [ /\!\=\=?/g, '!=' ],
             [ /this\.stringToBinary\s*\((.*)\)/g, '$1' ],
             [ /\.shift\s*\(\)/g, '.pop(0)' ],
-            // drop support for .reverse() atm, because opposed to JS, python does in-place,
-            // so we can't correctly transpile `const x = y.reverse()` in py for now
-            // [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], 
+            // beware of .reverse() in python, because opposed to JS, python does in-place, so 
+            // only cases like `x = x.reverse ()` should be transpiled, which will resul as 
+            // `x.reverse()` in python. otherwise, if transpiling `x = y.reverse()`, then the
+            // left side `x = `will be removed and only `y.reverse()` will end up in python
+            [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], 
             [ /Number\.MAX_SAFE_INTEGER/g, 'float(\'inf\')'],
             [ /function\s*(\w+\s*\([^)]+\))\s*{/g, 'def $1:'],
             // [ /\.replaceAll\s*\(([^)]+)\)/g, '.replace($1)' ], // still not a part of the standard
@@ -647,7 +649,7 @@ class Transpiler {
             // a proper \ccxt\Exchange::deep_extend() base method is implemented instead
             // [ /this\.deepExtend\s/g, 'array_replace_recursive'],
             [ /(\w+)\.shift\s*\(\)/g, 'array_shift($1)' ],
-            // [ /(\w+)\.reverse\s*\(\)/g, 'array_reverse($1)' ], // see comment in python .reverse()
+            [ /(\w+)\.reverse\s*\(\)/g, 'array_reverse($1)' ], // see comment in python .reverse()
             [ /(\w+)\.pop\s*\(\)/g, 'array_pop($1)' ],
             [ /Number\.MAX_SAFE_INTEGER/g, 'PHP_INT_MAX' ],
             [ /Precise\.stringAdd\s/g, 'Precise::string_add' ],

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -410,6 +410,7 @@ class Transpiler {
             [ /\!\=\=?/g, '!=' ],
             [ /this\.stringToBinary\s*\((.*)\)/g, '$1' ],
             [ /\.shift\s*\(\)/g, '.pop(0)' ],
+            [ /(.*?)\s\=\s(.*?)\.reverse\s\(/g, '.reverse(' ], // opposed to JS, python's 'reverse()' does in-place
             [ /Number\.MAX_SAFE_INTEGER/g, 'float(\'inf\')'],
             [ /function\s*(\w+\s*\([^)]+\))\s*{/g, 'def $1:'],
             // [ /\.replaceAll\s*\(([^)]+)\)/g, '.replace($1)' ], // still not a part of the standard

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -410,7 +410,7 @@ class Transpiler {
             [ /\!\=\=?/g, '!=' ],
             [ /this\.stringToBinary\s*\((.*)\)/g, '$1' ],
             [ /\.shift\s*\(\)/g, '.pop(0)' ],
-            [ /(.*?)\s\=\s(.*?)\.reverse\s\(/g, '.reverse(' ], // opposed to JS, python's 'reverse()' does in-place
+            [ /(\w+)\s\=\s(.*?)\.reverse\s\(/g, '$1.reverse(' ], // opposed to JS, python's 'reverse()' does in-place
             [ /Number\.MAX_SAFE_INTEGER/g, 'float(\'inf\')'],
             [ /function\s*(\w+\s*\([^)]+\))\s*{/g, 'def $1:'],
             // [ /\.replaceAll\s*\(([^)]+)\)/g, '.replace($1)' ], // still not a part of the standard

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -331,11 +331,10 @@ export default class bitfinex2 extends bitfinex2Rest {
         const messageLength = message.length;
         if (messageLength === 2) {
             // initial snapshot
-            const trades = this.safeList (message, 1, []);
+            let trades = this.safeList (message, 1, []);
             // needs to be reversed to make chronological order
-            const tradesLength = trades.length;
-            const maxLength = Math.max (0, tradesLength - 1);
-            for (let i = maxLength; i >= 0; i--) {
+            trades = trades.reverse ();
+            for (let i = 0; i < trades.length; i++) {
                 const parsed = this.parseWsTrade (trades[i], market);
                 stored.append (parsed);
             }

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -331,10 +331,11 @@ export default class bitfinex2 extends bitfinex2Rest {
         const messageLength = message.length;
         if (messageLength === 2) {
             // initial snapshot
-            let trades = this.safeList (message, 1, []);
+            const trades = this.safeList (message, 1, []);
             // needs to be reversed to make chronological order
-            trades = trades.reverse ();
-            for (let i = 0; i < trades.length; i++) {
+            const tradesLength = trades.length;
+            const maxLength = Math.max (0, tradesLength - 1);
+            for (let i = maxLength; i >= 0; i--) {
                 const parsed = this.parseWsTrade (trades[i], market);
                 stored.append (parsed);
             }


### PR DESCRIPTION
drop support for .reverse() for now. bitfinex2 was the only that had `.reverse()` used, and i've changed that.
