### PR TITLE
krakenfutures - add historical fetchTrades

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3910,8 +3910,16 @@ export default class Exchange {
         return this.safeString (market, 'symbol', symbol);
     }
 
-    handleParamString (params: object, paramName: string, defaultValue = undefined): [string, object] {
+    handleParamString (params: object, paramName: string, defaultValue: Str = undefined): [string, object] {
         const value = this.safeString (params, paramName, defaultValue);
+        if (value !== undefined) {
+            params = this.omit (params, paramName);
+        }
+        return [ value, params ];
+    }
+
+    handleParamInteger (params: object, paramName: string, defaultValue: Int = undefined): [Int, object] {
+        const value = this.safeInteger (params, paramName, defaultValue);
         if (value !== undefined) {
             params = this.omit (params, paramName);
         }

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -735,7 +735,7 @@ export default class krakenfutures extends Exchange {
                 request['sort'] = 'asc';
             }
             if (until !== undefined) {
-                request['lastTime'] = this.iso8601 (until);
+                request['before'] = until;
             }
             if (limit !== undefined) {
                 request['count'] = limit;

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -732,6 +732,7 @@ export default class krakenfutures extends Exchange {
         if (isFullHistoryEndpoint) {
             if (since !== undefined) {
                 request['since'] = since;
+                request['sort'] = 'asc';
             }
             if (until !== undefined) {
                 request['lastTime'] = this.iso8601 (until);

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -797,8 +797,9 @@ export default class krakenfutures extends Exchange {
                 const index = length - 1 - i;
                 const element = elements[index];
                 const event = this.safeDict (element, 'event', {});
-                const execution = this.safeDict (event, 'Execution', {});
-                rawTrades.push (execution);
+                const executionContainer = this.safeDict (event, 'Execution', {});
+                const rawTrade = this.safeDict (executionContainer, 'execution', {});
+                rawTrades.push (rawTrade);
             }
         } else {
             if (until !== undefined) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -720,22 +720,18 @@ export default class krakenfutures extends Exchange {
             return await this.fetchPaginatedCallDynamic ('fetchTrades', symbol, since, limit, params) as Trade[];
         }
         const market = this.market (symbol);
-        const request = {
+        let request = {
             'symbol': market['id'],
         };
-        let until = undefined;
-        [ until, params ] = this.handleParamInteger (params, 'until');
         let method = undefined;
         [ method, params ] = this.handleOptionAndParams (params, 'fetchTrades', 'method', 'historyGetMarketSymbolExecutions');
         let rawTrades = undefined;
         const isFullHistoryEndpoint = (method === 'historyGetMarketSymbolExecutions');
         if (isFullHistoryEndpoint) {
+            [ request, params ] = this.handleUntilOption ('before', request, params);
             if (since !== undefined) {
                 request['since'] = since;
                 request['sort'] = 'asc';
-            }
-            if (until !== undefined) {
-                request['before'] = until;
             }
             if (limit !== undefined) {
                 request['count'] = limit;
@@ -803,9 +799,7 @@ export default class krakenfutures extends Exchange {
                 rawTrades.push (rawTrade);
             }
         } else {
-            if (until !== undefined) {
-                request['lastTime'] = this.iso8601 (until);
-            }
+            [ request, params ] = this.handleUntilOption ('lastTime', request, params);
             const response = await this.publicGetHistory (this.extend (request, params));
             //
             //    {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -737,6 +737,95 @@ export default class krakenfutures extends Exchange {
                 request['lastTime'] = this.iso8601 (until);
             }
             response = await this.historyGetMarketSymbolExecutions (this.extend (request, params));
+            //
+            //    {
+            //        "elements": [
+            //            {
+            //                "uid": "a5105030-f054-44cc-98ab-30d5cae96bef",
+            //                "timestamp": "1710150778607",
+            //                "event": {
+            //                    "Execution": {
+            //                        "execution": {
+            //                            "uid": "2d485b71-cd28-4a1e-9364-371a127550d2",
+            //                            "makerOrder": {
+            //                                "uid": "0a25f66b-1109-49ec-93a3-d17bf9e9137e",
+            //                                "tradeable": "PF_XBTUSD",
+            //                                "direction": "Buy",
+            //                                "quantity": "0.26500",
+            //                                "timestamp": "1710150778570",
+            //                                "limitPrice": "71907",
+            //                                "orderType": "Post",
+            //                                "reduceOnly": false,
+            //                                "lastUpdateTimestamp": "1710150778570"
+            //                            },
+            //                            "takerOrder": {
+            //                                "uid": "04de3ee0-9125-4960-bf8f-f63b577b6790",
+            //                                "tradeable": "PF_XBTUSD",
+            //                                "direction": "Sell",
+            //                                "quantity": "0.0002",
+            //                                "timestamp": "1710150778607",
+            //                                "limitPrice": "71187.00",
+            //                                "orderType": "Market",
+            //                                "reduceOnly": false,
+            //                                "lastUpdateTimestamp": "1710150778607"
+            //                            },
+            //                            "timestamp": "1710150778607",
+            //                            "quantity": "0.0002",
+            //                            "price": "71907",
+            //                            "markPrice": "71903.32715463147",
+            //                            "limitFilled": false,
+            //                            "usdValue": "14.38"
+            //                        },
+            //                        "takerReducedQuantity": ""
+            //                    }
+            //                }
+            //            },
+            //            {
+            //                "uid": "6ffeb768-20c4-43ee-bf19-b2f5c4ca24b7",
+            //                "timestamp": "1710150776808",
+            //                "event": {
+            //                    "Execution": {
+            //                        "execution": {
+            //                            "uid": "ff1e43bc-20ee-4045-b139-ba56f17f67a6",
+            //                            "makerOrder": {
+            //                                "uid": "b32b8f92-ef49-46ff-884d-ab57843342f7",
+            //                                "tradeable": "PF_XBTUSD",
+            //                                "direction": "Buy",
+            //                                "quantity": "0.26500",
+            //                                "timestamp": "1710150775739",
+            //                                "limitPrice": "71905",
+            //                                "orderType": "Post",
+            //                                "reduceOnly": false,
+            //                                "lastUpdateTimestamp": "1710150775739"
+            //                            },
+            //                            "takerOrder": {
+            //                                "uid": "692915fd-a7a8-46a1-90ce-e004f66ddef4",
+            //                                "tradeable": "PF_XBTUSD",
+            //                                "direction": "Sell",
+            //                                "quantity": "0.0002",
+            //                                "timestamp": "1710150776808",
+            //                                "limitPrice": "69029.0",
+            //                                "orderType": "IoC",
+            //                                "reduceOnly": false,
+            //                                "lastUpdateTimestamp": "1710150776808"
+            //                            },
+            //                            "timestamp": "1710150776808",
+            //                            "quantity": "0.0002",
+            //                            "price": "71905",
+            //                            "markPrice": "71902.36833770950",
+            //                            "limitFilled": false,
+            //                            "usdValue": "14.38"
+            //                        },
+            //                        "takerReducedQuantity": ""
+            //                    }
+            //                }
+            //            },
+            //            ...
+            //        ],
+            //        "len": "1000",
+            //        "continuationToken": "QTexMDE0OTe33NTcyXy8xNDIzAjc1NjY5MwI="
+            //    }
+            //
         } else {
             if (until !== undefined) {
                 request['lastTime'] = this.iso8601 (until);
@@ -760,9 +849,9 @@ export default class krakenfutures extends Exchange {
             //        "serverTime": "2022-03-18T06:39:18.056Z"
             //    }
             //
+            const history = this.safeValue (response, 'history');
+            return this.parseTrades (history, market, since, limit);
         }
-        const history = this.safeValue (response, 'history');
-        return this.parseTrades (history, market, since, limit);
     }
 
     parseTrade (trade, market: Market = undefined): Trade {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -711,6 +711,7 @@ export default class krakenfutures extends Exchange {
          * @param {object} [params] Exchange specific params
          * @param {int} [params.until] Timestamp in ms of latest trade
          * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {string} [params.method] The method to use to fetch trades. Can be 'historyGetMarketSymbolExecutions' or 'publicGetHistory' default is 'historyGetMarketSymbolExecutions'
          * @returns An array of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -205,6 +205,39 @@
                 "url": "https://demo-futures.kraken.com/derivatives/api/v3/leveragepreferences",
                 "input": []
             }
+        ],
+        "fetchTrades": [
+            {
+                "description": "without arguments",
+                "method": "fetchTrades",
+                "url": "https://futures.kraken.com/api/history/v3/market/PF_XBTUSD/executions",
+                "input": [
+                  "BTC/USD:USD"
+                ]
+            },
+            {
+                "description": "with since & limit",
+                "method": "fetchTrades",
+                "url": "https://futures.kraken.com/api/history/v3/market/PF_XBTUSD/executions?since=1650000000000&sort=asc&count=2",
+                "input": [
+                  "BTC/USD:USD",
+                  1650000000000,
+                  2
+                ]
+            },
+            {
+                "description": "with until & limit",
+                "method": "fetchTrades",
+                "url": "https://futures.kraken.com/api/history/v3/market/PF_XBTUSD/executions?before=1650000000000&count=2",
+                "input": [
+                  "BTC/USD:USD",
+                  null,
+                  2,
+                  {
+                    "until": 1650000000000
+                  }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -237,7 +237,20 @@
                     "until": 1650000000000
                   }
                 ]
-            }
+            },
+            {
+                "description": "fetch Trades using publicGetHistory",
+                "method": "fetchTrades",
+                "url": "https://futures.kraken.com/derivatives/api/v3/history?symbol=PF_XBTUSD",
+                "input": [
+                  "BTC/USD:USD",
+                  null,
+                  null,
+                  {
+                    "method": "publicGetHistory"
+                  }
+                ]
+              }
         ]
     }
 }


### PR DESCRIPTION
till date, this used:
https://docs.futures.kraken.com/#http-api-trading-v3-api-instrument-details-get-instrument-status
which only supported last 7 days.

uses endpoint which support historical trades data:
https://docs.futures.kraken.com/#http-api-history-market-history-get-public-execution-events

```
 npm run cli.js krakenfutures fetchTrades BTC/USD:USD 165000000000 2 


> ccxt@4.2.66 cli.js
> node ./examples/js/cli.js krakenfutures fetchTrades BTC/USD:USD 165000000000 2

2024-03-11T11:32:37.258Z
Node.js: v20.10.0                                                           
CCXT v4.2.66
krakenfutures.fetchTrades (BTC/USD:USD, 165000000000, 2)
2024-03-11T11:32:38.425Z iteration 0 passed in 932 ms

                                  id |      symbol |     timestamp |                 datetime | side | takerOrMaker | price | amount |    cost | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------
5c680b49-61d6-49fe-917f-db56509d3053 | BTC/USD:USD | 1648029833450 | 2022-03-23T10:03:53.450Z |  buy |        taker | 42175 |  0.005 | 210.875 |   []
83211033-d6f6-4534-b711-91280c82c8fd | BTC/USD:USD | 1648029833498 | 2022-03-23T10:03:53.498Z |  buy |        taker | 42175 | 0.0015 | 63.2625 |   []
2 objects
2024-03-11T11:32:38.425Z iteration 1 passed in 932 ms
```