### PR TITLE
fix(gemini) - fetchmarkets reorg

### DIFF
--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -706,6 +706,7 @@ export default class gemini extends Exchange {
             linear = true; // always linear
             inverse = false;
         }
+        const type = swap ? 'swap' : 'spot';
         return {
             'id': marketId,
             'symbol': symbol,
@@ -715,8 +716,8 @@ export default class gemini extends Exchange {
             'baseId': baseId,
             'quoteId': quoteId,
             'settleId': settleId,
-            'type': 'spot',
-            'spot': true,
+            'type': type,
+            'spot': !swap,
             'margin': false,
             'swap': swap,
             'future': false,

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -257,6 +257,7 @@ export default class gemini extends Exchange {
                 'fetchMarketsMethod': 'fetch_markets_from_web', // fetch_markets_from_api, fetch_markets_from_web
                 'fetchMarketFromWebRetries': 10,
                 'fetchMarketsFromAPI': {
+                    'useTradingPairsData': true,
                     'fetchDetailsForAllSymbols': false,
                     'fetchDetailsForMarketIds': [],
                 },
@@ -317,7 +318,14 @@ export default class gemini extends Exchange {
         //
         //    {
         //        "tradingPairs": [
-        //            [ "BTCAUD", 2, 8, "0.00001", 10, true ],
+        //            [
+        //              'BTCUSD',   // symbol
+        //              2,          // priceTickDecimalPlaces
+        //              8,          // quantityTickDecimalPlaces
+        //              '0.00001',  // quantityMinimum)
+        //              10,         // quantityRoundDecimalPlaces
+        //              true        // minimumsAreInclusive
+        //            ],
         //            ...
         //        ],
         //        "currencies": [
@@ -338,6 +346,7 @@ export default class gemini extends Exchange {
         //    }
         //
         const result = {};
+        this.options['tradingPairs'] = this.safeList (data, 'tradingPairs');
         const currenciesArray = this.safeValue (data, 'currencies', []);
         for (let i = 0; i < currenciesArray.length; i++) {
             const currency = currenciesArray[i];

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -592,7 +592,7 @@ export default class gemini extends Exchange {
                 const indexedTradingPairs = this.indexBy (tradingPairs, 0);
                 for (let i = 0; i < marketIds.length; i++) {
                     const marketId = marketIds[i];
-                    const tradingPair = this.safeDict (indexedTradingPairs, marketId.toUpperCase ());
+                    const tradingPair = this.safeList (indexedTradingPairs, marketId.toUpperCase ());
                     if (tradingPair !== undefined) {
                         result.push (this.parseMarket (tradingPair));
                     }

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -709,7 +709,7 @@ export default class gemini extends Exchange {
             'type': 'spot',
             'spot': true,
             'margin': false,
-            'swap': false,
+            'swap': contract,
             'future': false,
             'option': false,
             'active': status,

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -550,7 +550,7 @@ export default class gemini extends Exchange {
     }
 
     async fetchMarketsFromAPI (params = {}) {
-        const marketIds = await this.publicGetV1Symbols (params);
+        const marketIdsRaw = await this.publicGetV1Symbols (params);
         //
         //     [
         //         "btcusd",
@@ -560,6 +560,13 @@ export default class gemini extends Exchange {
         //
         const result = [];
         const options = this.safeDict (this.options, 'fetchMarketsFromAPI', {});
+        const bugSymbol = 'efilfil'; // we skip this inexistent test symbol, which bugs other functions
+        const marketIds = [];
+        for (let i = 0; i < marketIdsRaw.length; i++) {
+            if (marketIdsRaw[i] !== bugSymbol) {
+                marketIds.push (marketIdsRaw[i]);
+            }
+        }
         if (this.safeBool (options, 'fetchDetailsForAllSymbols', false)) {
             const promises = [];
             for (let i = 0; i < marketIds.length; i++) {

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -647,7 +647,7 @@ export default class gemini extends Exchange {
         let increment = undefined;
         let minSize = undefined;
         let status = undefined;
-        let contract = undefined;
+        let swap = false;
         let contractSize = undefined;
         let linear = undefined;
         let inverse = undefined;
@@ -694,7 +694,7 @@ export default class gemini extends Exchange {
         let symbol = base + '/' + quote;
         if (settleId !== undefined) {
             symbol = symbol + ':' + settle;
-            contract = true;
+            swap = true;
             contractSize = tickSize; // always same
             linear = true; // always linear
             inverse = false;
@@ -711,11 +711,11 @@ export default class gemini extends Exchange {
             'type': 'spot',
             'spot': true,
             'margin': false,
-            'swap': contract,
+            'swap': swap,
             'future': false,
             'option': false,
             'active': status,
-            'contract': contract,
+            'contract': swap,
             'linear': linear,
             'inverse': inverse,
             'contractSize': contractSize,

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -258,7 +258,6 @@ export default class gemini extends Exchange {
                 'fetchMarketFromWebRetries': 10,
                 'fetchMarketsFromAPI': {
                     'fetchDetailsForAllSymbols': false,
-                    'useTradingPairsInfo': true,
                     'quoteCurrencies': [ 'USDT', 'GUSD', 'USD', 'DAI', 'EUR', 'GBP', 'SGD', 'BTC', 'ETH', 'LTC', 'BCH' ],
                 },
                 'fetchMarkets': {
@@ -586,19 +585,22 @@ export default class gemini extends Exchange {
             for (let i = 0; i < responses.length; i++) {
                 result.push (this.parseMarket (responses[i]));
             }
-        } else if (this.safeBool (options, 'useTradingPairsInfo', false)) {
-            const tradingPairs = this.safeList (this.options, 'tradingPairs', []);
-            const indexedTradingPairs = this.indexBy (tradingPairs, 0);
-            for (let i = 0; i < marketIds.length; i++) {
-                const marketId = marketIds[i];
-                const tradingPair = this.safeDict (indexedTradingPairs, marketId.toUpperCase ());
-                if (tradingPair !== undefined) {
-                    result.push (this.parseMarket (tradingPair));
-                }
-            }
         } else {
-            for (let i = 0; i < marketIds.length; i++) {
-                result.push (this.parseMarket (marketIds[i]));
+            // use trading-pairs info, if it was fetched
+            const tradingPairs = this.safeList (this.options, 'tradingPairs');
+            if (tradingPairs !== undefined) {
+                const indexedTradingPairs = this.indexBy (tradingPairs, 0);
+                for (let i = 0; i < marketIds.length; i++) {
+                    const marketId = marketIds[i];
+                    const tradingPair = this.safeDict (indexedTradingPairs, marketId.toUpperCase ());
+                    if (tradingPair !== undefined) {
+                        result.push (this.parseMarket (tradingPair));
+                    }
+                }
+            } else {
+                for (let i = 0; i < marketIds.length; i++) {
+                    result.push (this.parseMarket (marketIds[i]));
+                }
             }
         }
         return result;


### PR DESCRIPTION
the existing gemini was too much broken, it fetched markets from "docs" page, which was fragile, unreliable and etcetera. requests being failed frequently, also it didn't include "perp" market, while the `/symbols` API endpoint provided all perps. The "parseMarket" method was also too much broken - it just splat pairs with 3-4 char or "usd" string, which caused many broken markets... 
so, i've reworked fetchMarkets and made it exact and accurate, there is no broken markets now, all markets loaded and no longer relying on "docs" `<table>` html parsing.

```
Node.js: v20.10.0
CCXT v4.2.67
gemini.fetchMarkets ()
fetch Request:
 gemini GET https://api.gemini.com/v1/symbols
RequestHeaders:
 {}
RequestBody:
 undefined

handleRestResponse:
 gemini GET https://api.gemini.com/v1/symbols 200 OK
ResponseHeaders:
 {
  Connection: 'keep-alive',
  'Content-Length': '1186',
  'Content-Type': 'application/json',
  Date: 'Mon, 11 Mar 2024 15:39:04 GMT',
  Server: 'nginx',
  Vary: 'Origin'
}
ResponseBody:
 ["aaveusd","aliusd","ampusd","ankrusd","apeusd","api3usd","atomusd","avaxgusdperp","avaxusd","axsusd","batbtc","bateth","batusd","bchbtc","bcheth","bchusd","bnbgusdperp","btcdai","btceur","btcgbp","btcgusd","btcgusdperp","btcsgd","btcusd","btcusdt","chzusd","compusd","crvusd","ctxusd","cubeusd","daiusd","dogebtc","dogeeth","dogegusdperp","dogeusd","dotgusdperp","dotusd","efilfil","elonusd","ensusd","ernusd","ethbtc","ethdai","etheur","ethgbp","ethgusd","ethgusdperp","ethsgd","ethusd","ethusdt","fetusd","filusd","ftmusd","galausd","galusd","gmtusd","grtusd","gusdgbp","gusdsgd","gusdusd","hntusd","imxusd","injgusdperp","injusd","iotxusd","jamusd","ldousd","linkbtc","linketh","linkgusdperp","linkusd","lptusd","lrcusd","ltcbch","ltcbtc","ltceth","ltcgusdperp","ltcusd","lunausd","manausd","maskusd","maticgusdperp","maticusd","mkrusd","oxtbtc","oxteth","oxtusd","paxgusd","pepegusdperp","pepeusd","qntusd","qrdousd","rareusd","renusd","rndrusd","samousd","sandusd","shibusd","sklusd","snxusd","solgusdperp","solusd","storjusd","sushiusd","umausd","uniusd","usdcusd","usdtusd","xrpgusdperp","xrpusd","xtzusd","yfiusd","zbcusd","zecbch","zecbtc","zeceth","zecltc","zecusd","zrxusd"]

2024-03-11T15:39:05.365Z iteration 0 passed in 962 ms

           id |              symbol |  base | quote | settle | baseId | quoteId | settleId | type | spot | margin |  swap | future | option | active | contract | linear | inverse | contractSize | expiry | expiryDatetime | strike | optionType |                            precision |                                                           limits | created
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      aaveusd |            AAVE/USD |  AAVE |   USD |        |   AAVE |     USD |          | spot | true |  false | false |  false |  false |        |          |        |         |              |        |                |        |            |   {"price":0.000001,"amount":0.0001} |      {"leverage":{},"amount":{"min":0.001},"price":{},"cost":{}} | 
       aliusd |             ALI/USD |   ALI |   USD |        |    ALI |     USD |          | spot | true |  false | false |  false |  false |        |          |        |         |              |        |                |        |            | {"price":0.000001,"amount":0.000001} |          {"leverage":{},"amount":{"min":2},"price":{},"cost":{}} | 
  ...
```