### PR TITLE
gate: patch parseOrder

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4467,7 +4467,10 @@ export default class gate extends Exchange {
         if (lastTradeTimestamp === undefined) {
             lastTradeTimestamp = this.safeTimestamp2 (order, 'update_time', 'finish_time');
         }
-        const marketType = ('currency_pair' in order) ? 'spot' : 'contract';
+        let marketType = 'contract';
+        if (('currency_pair' in order) || ('market' in order)) {
+            marketType = 'spot';
+        }
         const exchangeSymbol = this.safeString2 (order, 'currency_pair', 'market', contract);
         const symbol = this.safeSymbol (exchangeSymbol, market, '_', marketType);
         // Everything below this(above return) is related to fees


### PR DESCRIPTION
fix: ccxt/ccxt#21668

```BASH
$ p gate fetchOrder '683761225' ETH/USDT '{"stop":true}'
gate.fetchOrder(683761225,ETH/USDT,{'stop': True})
{'amount': 0.001,
 'average': None,
 'clientOrderId': None,
 'cost': 0.0,
 'datetime': '2024-03-12T07:13:46.000Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '683761225',
 'info': {'ctime': '1710227626',
          'id': '683761225',
          'market': 'ETH_USDT',
          'put': {'account': 'normal',
                  'amount': '0.00100000000000000000',
                  'auto_borrow': False,
                  'auto_repay': False,
                  'price': '1500',
                  'side': 'buy',
                  'time_in_force': 'gtc',
                  'type': 'limit'},
          'status': 'open',
          'trigger': {'expiration': '86400', 'price': '4100', 'rule': '>='},
          'user': '10406147'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': False,
 'price': 1500.0,
 'reduceOnly': None,
 'remaining': 0.001,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': 4100.0,
 'symbol': 'ETH/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1710227626000,
 'trades': [],
 'triggerPrice': 4100.0,
 'type': 'limit'}
```