### PR TITLE
fix(base) - load proxy handling

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -973,22 +973,14 @@ export default class Exchange {
     socksProxyAgentModule:any = undefined;
     socksProxyAgentModuleChecked:boolean = false;
     proxyDictionaries:any = {};
-    proxiesModulesLoading:Promise<boolean> = undefined
+    proxiesModulesLoading:Promise<any> = undefined
 
     async loadProxyModules () {
         // when loading markets, multiple parallel calls are made, so need one promise
         if (this.proxiesModulesLoading === undefined) {
-            this.proxiesModulesLoading = new Promise<boolean> (async (resolve, reject) => {
-                await this.loadProxyModulesHelper ();
-                resolve (true);
-            }).catch ((e) => {
-                this.proxiesModulesLoading = undefined;
-                throw e;
-            });
-        } else {
-            await this.proxiesModulesLoading;
-            return;
+            this.proxiesModulesLoading = this.loadProxyModulesHelper ();
         }
+        return await this.proxiesModulesLoading;
     }
 
     async loadProxyModulesHelper () {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1015,7 +1015,6 @@ export default class Exchange {
             } catch (e) {}
             this.socksProxyAgentModuleChecked = true;
         }
-        this.proxiesModulesLoading.resolve (true);
     }
 
     setProxyAgents (httpProxy, httpsProxy, socksProxy) {


### PR DESCRIPTION
when multiple promises were awaited with `promise.all` in `fetchMarkets`, then multiple fetches are made parallely, so, the first of them starts loading proxies (with `import`) however, the other calls does not yet have loaded proxies and thus the boolean property is not yet `true` , throwing these issues: https://app.travis-ci.com/github/ccxt/ccxt/builds/269392261#L3539

so, this PR fixes the problem. like we have awaited for `loadMarketsHelper` we will do same with proxy-modules.