### PR TITLE
fix(kucoin): private headers

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4468,7 +4468,7 @@ export default class kucoin extends Exchange {
         url = url + endpoint;
         const isFuturePrivate = (api === 'futuresPrivate');
         const isPrivate = (api === 'private');
-        const isBroker = (api === 'private');
+        const isBroker = (api === 'broker');
         if (isPrivate || isFuturePrivate || isBroker) {
             this.checkRequiredCredentials ();
             const timestamp = this.nonce ().toString ();
@@ -4499,7 +4499,9 @@ export default class kucoin extends Exchange {
             }
             if (isBroker) {
                 const brokerName = this.safeString (partner, 'name');
-                headers['KC-BROKER-NAME'] = brokerName;
+                if (brokerName !== undefined) {
+                    headers['KC-BROKER-NAME'] = brokerName;
+                }
             }
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/21679


```
p kucoin fetchBalance          
Python v3.11.7
CCXT v4.2.68
kucoin.fetchBalance()
{'BTC': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'LTC': {'free': 0.171021, 'total': 0.171021, 'used': 0.0},
 'TRX': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'USDT': {'free': 40.12618754, 'total': 40.12618754, 'used': 0.0},
 'datetime': None,
 'free': {'BTC': 0.0, 'LTC': 0.171021, 'TRX': 0.0, 'USDT': 40.12618754},
 'info': {'code': '200000',
          'data': [{'available': '40.12618754',
                    'balance': '40.12618754',
                    'currency': 'USDT',
                    'holds': '0',
                    'id': '64feeeb6b4f1fb0007948e80',
                    'type': 'trade'},
                   {'available': '0.171021',
                    'balance': '0.171021',
                    'currency': 'LTC',
                    'holds': '0',
                    'id': '64feeec4cd03f30007aa5a8f',
                    'type': 'trade'},
                   {'available': '0',
                    'balance': '0',
                    'currency': 'BTC',
                    'holds': '0',
                    'id': '64ff093e478dba00072d3bc7',
                    'type': 'trade'},
                   {'available': '0',
                    'balance': '0',
                    'currency': 'TRX',
                    'holds': '0',
                    'id': '655e450a1245b90007517903',
                    'type': 'trade'}]},
 'timestamp': None,
 'total': {'BTC': 0.0, 'LTC': 0.171021, 'TRX': 0.0, 'USDT': 40.12618754},
 'used': {'BTC': 0.0, 'LTC': 0.0, 'TRX': 0.0, 'USDT': 0.0}}
```
