### PR TITLE
gate: add fetchLeverage and fetchLeverages

### DIFF
--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -1127,6 +1127,25 @@
                   "BTC/USDT"
                 ]
             }
+        ],
+        "fetchLeverages": [
+            {
+                "description": "Spot margin unified fetch all leverages",
+                "method": "fetchLeverages",
+                "url": "https://api.gateio.ws/api/v4/margin/uni/currency_pairs",
+                "input": [
+                  null,
+                  {
+                    "unified": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin fetch all leverages",
+                "method": "fetchLeverages",
+                "url": "https://api.gateio.ws/api/v4/margin/currency_pairs",
+                "input": []
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -1106,6 +1106,27 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchLeverage": [
+            {
+                "description": "Spot margin unified fetch leverage",
+                "method": "fetchLeverage",
+                "url": "https://api.gateio.ws/api/v4/margin/uni/currency_pairs/BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  {
+                    "unified": true
+                  }
+                ]
+            },
+            {
+                "description": "Spot margin fetch leverage",
+                "method": "fetchLeverage",
+                "url": "https://api.gateio.ws/api/v4/margin/currency_pairs/BTC_USDT",
+                "input": [
+                  "BTC/USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchLeverage and fetchLeverages to gate:

```
gate fetchLeverage BTC/USDT '{"unified":true}'

gate.fetchLeverage (BTC/USDT, [object Object])
2024-03-13T05:33:11.066Z iteration 0 passed in 250 ms

{
  info: {
    currency_pair: 'BTC_USDT',
    base_min_borrow_amount: '0.0001',
    quote_min_borrow_amount: '1',
    leverage: '10'
  },
  symbol: 'BTC/USDT',
  longLeverage: 10,
  shortLeverage: 10
}
```
```
gate fetchLeverage BTC/USDT

gate.fetchLeverage (BTC/USDT)
2024-03-13T05:33:42.867Z iteration 0 passed in 245 ms

{
  info: {
    id: 'BTC_USDT',
    base: 'BTC',
    quote: 'USDT',
    leverage: '10',
    min_base_amount: '0.0001',
    min_quote_amount: '1',
    max_quote_amount: '40000000',
    status: '1'
  },
  symbol: 'BTC/USDT',
  longLeverage: 10,
  shortLeverage: 10
}
```