### PR TITLE
test: brokerIdTests - more verbose error messages

### DIFF
--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -1447,7 +1447,8 @@ export default class testMainClass extends baseMainTestClass {
             spotOrderRequest = this.urlencodedToDict (exchange.last_request_body);
         }
         const clientOrderId = spotOrderRequest['newClientOrderId'];
-        assert (clientOrderId.startsWith (spotId.toString ()), 'spot clientOrderId does not start with spotId');
+        const spotIdString = spotId.toString ();
+        assert (clientOrderId.startsWith (spotIdString), 'binance - spot clientOrderId: ' + clientOrderId + ' does not start with spotId' + spotIdString);
         const swapId = 'x-xcKtGhcu';
         let swapOrderRequest = undefined;
         try {
@@ -1461,10 +1462,11 @@ export default class testMainClass extends baseMainTestClass {
         } catch (e) {
             swapInverseOrderRequest = this.urlencodedToDict (exchange.last_request_body);
         }
-        const clientOrderIdSpot = swapOrderRequest['newClientOrderId'];
-        assert (clientOrderIdSpot.startsWith (swapId.toString ()), 'swap clientOrderId does not start with swapId');
+        const clientOrderIdSwap = swapOrderRequest['newClientOrderId'];
+        const swapIdString = swapId.toString ();
+        assert (clientOrderIdSwap.startsWith (swapIdString), 'binance - swap clientOrderId: ' + clientOrderIdSwap + ' does not start with swapId' + swapIdString);
         const clientOrderIdInverse = swapInverseOrderRequest['newClientOrderId'];
-        assert (clientOrderIdInverse.startsWith (swapId.toString ()), 'swap clientOrderIdInverse does not start with swapId');
+        assert (clientOrderIdInverse.startsWith (swapIdString), 'binance - swap clientOrderIdInverse: ' + clientOrderIdInverse + ' does not start with swapId' + swapIdString);
         await close (exchange);
         return true;
     }
@@ -1479,17 +1481,20 @@ export default class testMainClass extends baseMainTestClass {
             spotOrderRequest = jsonParse (exchange.last_request_body);
         }
         const clientOrderId = spotOrderRequest[0]['clOrdId']; // returns order inside array
-        assert (clientOrderId.startsWith (id.toString ()), 'spot clientOrderId does not start with id');
-        assert (spotOrderRequest[0]['tag'] === id, 'id different from spot tag');
+        const idString = id.toString ();
+        assert (clientOrderId.startsWith (idString), 'okx - spot clientOrderId: ' + clientOrderId + ' does not start with id: ' + idString);
+        const spotTag = spotOrderRequest[0]['tag'];
+        assert (spotTag === id, 'okx - id: ' + id + ' different from spot tag: ' + spotTag);
         let swapOrderRequest = undefined;
         try {
             await exchange.createOrder ('BTC/USDT:USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
             swapOrderRequest = jsonParse (exchange.last_request_body);
         }
-        const clientOrderIdSpot = swapOrderRequest[0]['clOrdId'];
-        assert (clientOrderIdSpot.startsWith (id.toString ()), 'swap clientOrderId does not start with id');
-        assert (swapOrderRequest[0]['tag'] === id, 'id different from swap tag');
+        const clientOrderIdSwap = swapOrderRequest[0]['clOrdId'];
+        assert (clientOrderIdSwap.startsWith (idString), 'okx - swap clientOrderId: ' + clientOrderIdSwap + ' does not start with id: ' + idString);
+        const swapTag = swapOrderRequest[0]['tag'];
+        assert (swapTag === id, 'okx - id: ' + id + ' different from swap tag: ' + swapTag);
         await close (exchange);
         return true;
     }
@@ -1504,7 +1509,8 @@ export default class testMainClass extends baseMainTestClass {
         } catch (e) {
             request = jsonParse (exchange.last_request_body);
         }
-        assert (request['params']['broker_id'] === id, 'id different from  broker_id');
+        const brokerId = request['params']['broker_id'];
+        assert (brokerId === id, 'cryptocom - id: ' + id + ' different from  broker_id: ' + brokerId);
         await close (exchange);
         return true;
     }
@@ -1520,7 +1526,8 @@ export default class testMainClass extends baseMainTestClass {
             // we expect an error here, we're only interested in the headers
             reqHeaders = exchange.last_request_headers;
         }
-        assert (reqHeaders['Referer'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['Referer'] === id, 'bybit - id: ' + id + ' not in headers: ' + reqHeadersString);
         await close (exchange);
         return true;
     }
@@ -1528,8 +1535,11 @@ export default class testMainClass extends baseMainTestClass {
     async testKucoin () {
         const exchange = this.initOfflineExchange ('kucoin');
         let reqHeaders = undefined;
-        assert (exchange.options['partner']['spot']['id'] === 'ccxt', 'id not in options');
-        assert (exchange.options['partner']['spot']['key'] === '9e58cc35-5b5e-4133-92ec-166e3f077cb8', 'key not in options');
+        const optionsString = exchange.options.toString ();
+        const spotId =  exchange.options['partner']['spot']['id'];
+        const spotKey =  exchange.options['partner']['spot']['key'];
+        assert (spotId === 'ccxt', 'kucoin - id: ' + spotId + ' not in options: ' + optionsString);
+        assert (spotKey === '9e58cc35-5b5e-4133-92ec-166e3f077cb8', 'kucoin - key: ' + spotKey + ' not in options: ' + optionsString);
         try {
             await exchange.createOrder ('BTC/USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
@@ -1537,7 +1547,8 @@ export default class testMainClass extends baseMainTestClass {
             reqHeaders = exchange.last_request_headers;
         }
         const id = 'ccxt';
-        assert (reqHeaders['KC-API-PARTNER'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['KC-API-PARTNER'] === id, 'kucoin - id: ' + id + ' not in headers: ' + reqHeadersString);
         await close (exchange);
         return true;
     }
@@ -1546,14 +1557,18 @@ export default class testMainClass extends baseMainTestClass {
         const exchange = this.initOfflineExchange ('kucoinfutures');
         let reqHeaders = undefined;
         const id = 'ccxtfutures';
-        assert (exchange.options['partner']['future']['id'] === id, 'id not in options');
-        assert (exchange.options['partner']['future']['key'] === '1b327198-f30c-4f14-a0ac-918871282f15', 'key not in options');
+        const optionsString = exchange.options['partner']['future'].toString ();
+        const futureId = exchange.options['partner']['future']['id'];
+        const futureKey = exchange.options['partner']['future']['key'];
+        assert (futureId === id, 'kucoinfutures - id: ' + futureId + ' not in options: ' + optionsString);
+        assert (futureKey === '1b327198-f30c-4f14-a0ac-918871282f15', 'kucoinfutures - key: ' + futureKey + ' not in options: ' + optionsString);
         try {
             await exchange.createOrder ('BTC/USDT:USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
             reqHeaders = exchange.last_request_headers;
         }
-        assert (reqHeaders['KC-API-PARTNER'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['KC-API-PARTNER'] === id, 'kucoinfutures - id: ' + id + ' not in headers: ' + reqHeadersString);
         await close (exchange);
         return true;
     }
@@ -1562,13 +1577,15 @@ export default class testMainClass extends baseMainTestClass {
         const exchange = this.initOfflineExchange ('bitget');
         let reqHeaders = undefined;
         const id = 'p4sve';
-        assert (exchange.options['broker'] === id, 'id not in options');
+        const optionsString = exchange.options.toString ();
+        assert (exchange.options['broker'] === id, 'bitget - id: ' + id + ' not in options: ' + optionsString);
         try {
             await exchange.createOrder ('BTC/USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
             reqHeaders = exchange.last_request_headers;
         }
-        assert (reqHeaders['X-CHANNEL-API-CODE'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['X-CHANNEL-API-CODE'] === id, 'bitget - id: ' + id + ' not in headers: ' + reqHeadersString);
         await close (exchange);
         return true;
     }
@@ -1577,14 +1594,16 @@ export default class testMainClass extends baseMainTestClass {
         const exchange = this.initOfflineExchange ('mexc');
         let reqHeaders = undefined;
         const id = 'CCXT';
-        assert (exchange.options['broker'] === id, 'id not in options');
+        const optionsString = exchange.options.toString ();
+        assert (exchange.options['broker'] === id, 'mexc - id: ' + id + ' not in options: ' + optionsString);
         await exchange.loadMarkets ();
         try {
             await exchange.createOrder ('BTC/USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
             reqHeaders = exchange.last_request_headers;
         }
-        assert (reqHeaders['source'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['source'] === id, 'mexc - id: ' + id + ' not in headers: ' + reqHeadersString);
         await close (exchange);
         return true;
     }
@@ -1600,7 +1619,8 @@ export default class testMainClass extends baseMainTestClass {
             spotOrderRequest = jsonParse (exchange.last_request_body);
         }
         const clientOrderId = spotOrderRequest['client-order-id'];
-        assert (clientOrderId.startsWith (id.toString ()), 'spot clientOrderId does not start with id');
+        const idString = id.toString ();
+        assert (clientOrderId.startsWith (idString), 'htx - spot clientOrderId ' + clientOrderId + ' does not start with id: ' + idString);
         // swap test
         let swapOrderRequest = undefined;
         try {
@@ -1614,10 +1634,10 @@ export default class testMainClass extends baseMainTestClass {
         } catch (e) {
             swapInverseOrderRequest = jsonParse (exchange.last_request_body);
         }
-        const clientOrderIdSpot = swapOrderRequest['channel_code'];
-        assert (clientOrderIdSpot.startsWith (id.toString ()), 'swap channel_code does not start with id');
+        const clientOrderIdSwap = swapOrderRequest['channel_code'];
+        assert (clientOrderIdSwap.startsWith (idString), 'htx - swap channel_code ' + clientOrderIdSwap + ' does not start with id: ' + idString);
         const clientOrderIdInverse = swapInverseOrderRequest['channel_code'];
-        assert (clientOrderIdInverse.startsWith (id.toString ()), 'swap inverse channel_code does not start with id');
+        assert (clientOrderIdInverse.startsWith (idString), 'htx - swap inverse channel_code ' + clientOrderIdInverse + ' does not start with id: ' + idString);
         await close (exchange);
         return true;
     }
@@ -1633,7 +1653,8 @@ export default class testMainClass extends baseMainTestClass {
             spotOrderRequest = this.urlencodedToDict (exchange.last_request_body);
         }
         const brokerId = spotOrderRequest['broker_id'];
-        assert (brokerId.startsWith (id.toString ()), 'broker_id does not start with id');
+        const idString = id.toString ();
+        assert (brokerId.startsWith (idString), 'woo - broker_id: ' + brokerId + ' does not start with id: ' + idString);
         // swap test
         let stopOrderRequest = undefined;
         try {
@@ -1641,8 +1662,8 @@ export default class testMainClass extends baseMainTestClass {
         } catch (e) {
             stopOrderRequest = jsonParse (exchange.last_request_body);
         }
-        const clientOrderIdSpot = stopOrderRequest['brokerId'];
-        assert (clientOrderIdSpot.startsWith (id.toString ()), 'brokerId does not start with id');
+        const clientOrderIdStop = stopOrderRequest['brokerId'];
+        assert (clientOrderIdStop.startsWith (idString), 'woo - brokerId: ' + clientOrderIdStop + ' does not start with id: ' + idString);
         await close (exchange);
         return true;
     }
@@ -1651,14 +1672,16 @@ export default class testMainClass extends baseMainTestClass {
         const exchange = this.initOfflineExchange ('bitmart');
         let reqHeaders = undefined;
         const id = 'CCXTxBitmart000';
-        assert (exchange.options['brokerId'] === id, 'id not in options');
+        const optionsString = exchange.options.toString ();
+        assert (exchange.options['brokerId'] === id, 'bitmart - id: ' + id + ' not in options' + optionsString);
         await exchange.loadMarkets ();
         try {
             await exchange.createOrder ('BTC/USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
             reqHeaders = exchange.last_request_headers;
         }
-        assert (reqHeaders['X-BM-BROKER-ID'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['X-BM-BROKER-ID'] === id, 'bitmart - id: ' + id + ' not in headers' + reqHeadersString);
         await close (exchange);
         return true;
     }
@@ -1666,7 +1689,8 @@ export default class testMainClass extends baseMainTestClass {
     async testCoinex () {
         const exchange = this.initOfflineExchange ('coinex');
         const id = 'x-167673045';
-        assert (exchange.options['brokerId'] === id, 'id not in options');
+        const optionsString = exchange.options.toString ();
+        assert (exchange.options['brokerId'] === id, 'coinex - id: ' + id + ' not in options: ' + optionsString);
         let spotOrderRequest = undefined;
         try {
             await exchange.createOrder ('BTC/USDT', 'limit', 'buy', 1, 20000);
@@ -1674,7 +1698,8 @@ export default class testMainClass extends baseMainTestClass {
             spotOrderRequest = jsonParse (exchange.last_request_body);
         }
         const clientOrderId = spotOrderRequest['client_id'];
-        assert (clientOrderId.startsWith (id.toString ()), 'clientOrderId does not start with id');
+        const idString = id.toString ();
+        assert (clientOrderId.startsWith (idString), 'coinex - clientOrderId: ' + clientOrderId + ' does not start with id: ' + idString);
         await close (exchange);
         return true;
     }
@@ -1683,14 +1708,16 @@ export default class testMainClass extends baseMainTestClass {
         const exchange = this.initOfflineExchange ('bingx');
         let reqHeaders = undefined;
         const id = 'CCXT';
-        assert (exchange.options['broker'] === id, 'id not in options');
+        const optionsString = exchange.options.toString ();
+        assert (exchange.options['broker'] === id, 'bingx - id: ' + id + ' not in options: ' + optionsString);
         try {
             await exchange.createOrder ('BTC/USDT', 'limit', 'buy', 1, 20000);
         } catch (e) {
             // we expect an error here, we're only interested in the headers
             reqHeaders = exchange.last_request_headers;
         }
-        assert (reqHeaders['X-SOURCE-KEY'] === id, 'id not in headers');
+        const reqHeadersString = reqHeaders !== undefined ? reqHeaders.toString () : 'undefined';
+        assert (reqHeaders['X-SOURCE-KEY'] === id, 'bingx - id: ' + id + ' not in headers: ' + reqHeadersString);
         await close (exchange);
     }
 
@@ -1704,7 +1731,8 @@ export default class testMainClass extends baseMainTestClass {
             request = jsonParse (exchange.last_request_body);
         }
         const clientOrderId = request['clOrdID'];
-        assert (clientOrderId.startsWith (id.toString ()), 'clOrdID does not start with id');
+        const idString = id.toString ();
+        assert (clientOrderId.startsWith (idString), 'phemex - clOrdID: ' + clientOrderId + ' does not start with id: ' + idString);
         await close (exchange);
     }
 
@@ -1718,7 +1746,8 @@ export default class testMainClass extends baseMainTestClass {
             request = jsonParse (exchange.last_request_body);
         }
         const brokerId = request['brokerId'];
-        assert (brokerId.startsWith (id.toString ()), 'brokerId does not start with id');
+        const idString = id.toString ();
+        assert (brokerId.startsWith (idString), 'blofin - brokerId: ' + brokerId + ' does not start with id: ' + idString);
         await close (exchange);
     }
 
@@ -1732,7 +1761,7 @@ export default class testMainClass extends baseMainTestClass {
             request = jsonParse (exchange.last_request_body);
         }
         const brokerId = (request['action']['brokerCode']).toString ();
-        assert (brokerId === id, 'brokerId does not start with id');
+        assert (brokerId === id, 'hyperliquid - brokerId: ' + brokerId + ' does not start with id: ' + id);
         await close (exchange);
     }
 }


### PR DESCRIPTION
I'm not really sure how to test this out

I added these changes because the current Travis error message doesn't really give any hint as to what the problem is

```
Fatal error: Uncaught AssertionError: spot clientOrderId does not start with spotId in /home/travis/build/ccxt/ccxt/php/test/test_async.php on line 1508

AssertionError: spot clientOrderId does not start with spotId in /home/travis/build/ccxt/ccxt/php/test/test_async.php on line 1508
```