### PR TITLE
fix(gate) - fetchOHLCV since & limit for contracts

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2913,7 +2913,7 @@ export default class gate extends Exchange {
         let request = {};
         [ request, params ] = this.prepareRequest (market, undefined, params);
         request['interval'] = this.safeString (this.timeframes, timeframe, timeframe);
-        let maxLimit = 1000;
+        let maxLimit = market['contract'] ? 1999 : 1000;
         limit = (limit === undefined) ? maxLimit : Math.min (limit, maxLimit);
         let until = this.safeInteger (params, 'until');
         if (until !== undefined) {

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -706,43 +706,203 @@
         ],
         "fetchOHLCV": [
             {
-                "description": "Fetch OHLCV - spot",
+                "description": "spot +1m",
                 "method": "fetchOHLCV",
                 "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1m&limit=1000",
                 "input": [
-                    "BTC/USDT"
+                  "BTC/USDT",
+                  "1m"
                 ]
             },
             {
-                "description": "Fetch OHLCV - swap",
+                "description": "spot +1d",
                 "method": "fetchOHLCV",
-                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1m&limit=1000",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&limit=1000",
                 "input": [
-                    "BTC/USDT:USDT"
+                  "BTC/USDT",
+                  "1d"
                 ]
             },
             {
-                "description": "Fetch OHLCV - future",
+                "description": "spot +1d +since",
                 "method": "fetchOHLCV",
-                "url": "https://api.gateio.ws/api/v4/delivery/usdt/candlesticks?contract=BTC_USDT_20240329&interval=1m&limit=1000",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&from=1540000000&to=1626313600",
                 "input": [
-                    "BTC/USDT:USDT-240329"
+                  "BTC/USDT",
+                  "1d",
+                  1540000000000
                 ]
             },
             {
-                "description": "spot ohlcv",
+                "description": "spot +1d +since +limit",
                 "method": "fetchOHLCV",
-                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1m&limit=1000",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&from=1540000000&to=1626313600",
                 "input": [
-                    "BTC/USDT"
+                  "BTC/USDT",
+                  "1d",
+                  1540000000000,
+                  2000
                 ]
             },
             {
-                "description": "swap ohlcv",
+                "description": "spot +1d +since +limit +until (until beyond permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1m&limit=1000",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&from=1540000000&to=1626313600",
                 "input": [
-                    "BTC/USDT:USDT"
+                  "BTC/USDT",
+                  "1d",
+                  1540000000000,
+                  2000,
+                  {
+                    "until": 1670000000000
+                  }
+                ]
+            },
+            {
+                "description": "spot +1d +since +limit +until (until under permitted)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&from=1540000000&to=1610000000",
+                "input": [
+                  "BTC/USDT",
+                  "1d",
+                  1540000000000,
+                  2000,
+                  {
+                    "until": 1610000000000
+                  }
+                ]
+            },
+            {
+                "description": "spot +1d +since +limit +until (limit under until)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&from=1540000000&to=1544233600",
+                "input": [
+                  "BTC/USDT",
+                  "1d",
+                  1540000000000,
+                  50,
+                  {
+                    "until": 1610000000000
+                  }
+                ]
+            },
+            {
+                "description": "spot +1d +since -limit +until (until under permitted)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BTC_USDT&interval=1d&from=1540000000&to=1610000000",
+                "input": [
+                  "BTC/USDT",
+                  "1d",
+                  1540000000000,
+                  null,
+                  {
+                    "until": 1610000000000
+                  }
+                ]
+            },
+            {
+                "description": "swap +1m",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1m&limit=1999",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1m"
+                ]
+            },
+            {
+                "description": "swap +1m +since",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1m&from=1660000000&to=1660119880",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1m",
+                  1660000000000
+                ]
+            },
+            {
+                "description": "swap +1d",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&limit=1999",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d"
+                ]
+            },
+            {
+                "description": "swap +1d +since",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1500000000&to=1672627200",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d",
+                  1500000000000
+                ]
+            },
+            {
+                "description": "swap +1d +since +limit",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1500000000&to=1672627200",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d",
+                  1500000000000,
+                  2000
+                ]
+            },
+            {
+                "description": "swap +1d +since +limit +until (until beyond permitted)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1540000000&to=1690000000",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d",
+                  1460000000000,
+                  3000,
+                  {
+                    "until": 1690000000000
+                  }
+                ]
+            },
+            {
+                "description": "swap +1d +since +limit +until (until under permitted)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1540000000&to=1690000000",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d",
+                  1540000000000,
+                  3000,
+                  {
+                    "until": 1690000000000
+                  }
+                ]
+            },
+            {
+                "description": "swap +1d +since +limit +until (limit under until)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1540000000&to=1544233600",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d",
+                  1540000000000,
+                  50,
+                  {
+                    "until": 1690000000000
+                  }
+                ]
+            },
+            {
+                "description": "swap +1d +since -limit +until (until under permitted)",
+                "method": "fetchOHLCV",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1540000000&to=1690000000",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1d",
+                  1540000000000,
+                  null,
+                  {
+                    "until": 1690000000000
+                  }
                 ]
             }
         ],

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -852,7 +852,7 @@
             {
                 "description": "swap +1d +since +limit +until (until beyond permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1540000000&to=1690000000",
+                "url": "https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1460000000&to=1632627200",
                 "input": [
                   "BTC/USDT:USDT",
                   "1d",


### PR DESCRIPTION
with existing master, if you do:
```
npm run cli.js -- gate fetchOHLCV BTC/USDT:USDT 1d 1540000000000 2000 --report
```
it calls `https://api.gateio.ws/api/v4/futures/usdt/candlesticks?contract=BTC_USDT&interval=1d&from=1540000000&to=1626313600` url. notice the automatically generated `to` timestamp, which is `1000` bars distant (it uses spot's [hardlimit of 1000](https://www.gate.io/docs/developers/apiv4/en/#market-candlesticks) bars instead of allowed [2000 for contracts](https://www.gate.io/docs/developers/apiv4/en/#get-futures-candlesticks)).
this PR fixes that.

```
 npm run cli.js -- gate fetchOHLCV BTC/USDT:USDT 1d 1500000000000 2000  --report

> ccxt@4.2.70 cli.js
> node ./examples/js/cli.js gate fetchOHLCV BTC/USDT:USDT 1d 1500000000000 2000 --report

2024-03-13T18:31:03.951Z
Node.js: v20.10.0
CCXT v4.2.70
gate.fetchOHLCV (BTC/USDT:USDT, 1d, 1500000000000, 2000)
2024-03-13T18:31:13.099Z iteration 0 passed in 696 ms

1574035200000 |    8474 |     8495 |    8112 |    8195 |      42064
1574121600000 |    8188 |   8218.5 |    8030 |    8131 |     258407
...
1672531200000 | 16536.6 |  16616.9 |   16500 | 16608.7 |   37200161
1672617600000 | 16608.6 |  16786.3 | 16541.3 | 16669.3 |   82131581
```