### PR TITLE
bingx: patch authenticate

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -789,8 +789,7 @@ export default class bingx extends bingxRest {
         const lastAuthenticatedTime = this.safeInteger (this.options, 'lastAuthenticatedTime', 0);
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 3600000); // 1 hour
         if (time - lastAuthenticatedTime > listenKeyRefreshRate) {
-            const response = await this.userAuthPrivatePutUserDataStream ({ 'listenKey': listenKey }); // extend the expiry
-            this.options['listenKey'] = this.safeString (response, 'listenKey');
+            await this.userAuthPrivatePutUserDataStream ({ 'listenKey': listenKey }); // extend the expiry
             this.options['lastAuthenticatedTime'] = time;
         }
     }


### PR DESCRIPTION
There is no response for put listen key api.

Related issues: ccxt/ccxt#21702

```BASH
fetch Request:
 bingx PUT https://open-api.bingx.com/openApi/user/auth/userDataStream?listenKey=7ec1a3cea14b4afa9aae521dd45961d8784b9ff7db5f3af5fd57819462a239b1&timestamp=1710385666373&signature=d8d140e28626e9c35b13606fd654592e74c208de539cba679c76b29a7165a30c
RequestHeaders:
 {
  'X-BX-APIKEY': 'G1zKn3t0yvPJE3rjQWUTMKZDnn9XveGx8POqPEW0hw6eDkPYavJrDab0pMp4k3NeBVQ8fHFviobGEtEdQ',
  'X-SOURCE-KEY': 'CCXT'
}
RequestBody:
 undefined

handleRestResponse:
 bingx PUT https://open-api.bingx.com/openApi/user/auth/userDataStream?listenKey=7ec1a3cea14b4afa9aae521dd45961d8784b9ff7db5f3af5fd57819462a239b1&timestamp=1710385666373&signature=d8d140e28626e9c35b13606fd654592e74c208de539cba679c76b29a7165a30c 200 OK
ResponseHeaders:
 {
}
ResponseBody:


2024-03-14T03:07:48.245Z onMessage Ping
```