### PR TITLE
ascendex: add fetchLeverage and fetchLeverages

### DIFF
--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -472,6 +472,16 @@
                 "url": "https://ascendex.com/6/api/pro/v2/futures/position",
                 "input": []
             }
+        ],
+        "fetchLeverage": [
+            {
+                "description": "Fetch the set leverage of a specified market",
+                "method": "fetchLeverage",
+                "url": "https://ascendex.com/6/api/pro/v2/futures/position",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -469,7 +469,7 @@
             {
                 "description": "Fetch all set leverages",
                 "method": "fetchLeverages",
-                "url": "https://ascendex.com/6/api/pro/v2/futures/position",
+                "url": "https://ascendex.com/myAccount/api/pro/v2/futures/position",
                 "input": []
             }
         ],
@@ -477,7 +477,7 @@
             {
                 "description": "Fetch the set leverage of a specified market",
                 "method": "fetchLeverage",
-                "url": "https://ascendex.com/6/api/pro/v2/futures/position",
+                "url": "https://ascendex.com/myAccount/api/pro/v2/futures/position",
                 "input": [
                   "BTC/USDT:USDT"
                 ]

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -464,6 +464,14 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchLeverages": [
+            {
+                "description": "Fetch all set leverages",
+                "method": "fetchLeverages",
+                "url": "https://ascendex.com/6/api/pro/v2/futures/position",
+                "input": []
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchLeverage` and `fetchLeverages` to ascendex:

```
ascendex.fetchLeverage (BTC/USDT:USDT)
2024-03-14T07:54:22.430Z iteration 0 passed in 1246 ms

{
  info: {
    symbol: 'BTC-PERP',
    side: 'LONG',
    position: '0',
    referenceCost: '0',
    unrealizedPnl: '0',
    realizedPnl: '0',
    avgOpenPrice: '0',
    marginType: 'isolated',
    isolatedMargin: '0',
    leverage: '10',
    takeProfitPrice: '0',
    takeProfitTrigger: 'market',
    stopLossPrice: '0',
    stopLossTrigger: 'market',
    posStopMode: 'Full',
    buyOpenOrderNotional: '0',
    sellOpenOrderNotional: '0',
    markPrice: '73210.5',
    indexPrice: '73151.945'
  },
  symbol: 'BTC/USDT:USDT',
  marginMode: 'isolated',
  longLeverage: 10,
  shortLeverage: 10
}
```