### PR TITLE
ascendex: add fetchMarginMode and fetchMarginModes

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -6,7 +6,7 @@ import { ArgumentsRequired, AuthenticationError, ExchangeError, InsufficientFund
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import type { TransferEntry, FundingHistory, Int, OHLCV, Order, OrderSide, OrderType, OrderRequest, Str, Trade, Balances, Transaction, Ticker, OrderBook, Tickers, Strings, Num, Currency, Market } from './base/types.js';
+import type { TransferEntry, FundingHistory, Int, OHLCV, Order, OrderSide, OrderType, OrderRequest, Str, Trade, Balances, Transaction, Ticker, OrderBook, Tickers, Strings, Num, Currency, Market, MarginMode, MarginModes } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -61,7 +61,8 @@ export default class ascendex extends Exchange {
                 'fetchIndexOHLCV': false,
                 'fetchLeverage': false,
                 'fetchLeverageTiers': true,
-                'fetchMarginMode': false,
+                'fetchMarginMode': 'emulated',
+                'fetchMarginModes': true,
                 'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
@@ -3305,6 +3306,79 @@ export default class ascendex extends Exchange {
             'id': undefined,
             'amount': this.safeNumber (income, 'paymentInUSDT'),
         };
+    }
+
+    async fetchMarginModes (symbols: string[] = undefined, params = {}): Promise<MarginModes> {
+        /**
+         * @method
+         * @name ascendex#fetchMarginMode
+         * @description fetches the set margin mode of the user
+         * @see https://ascendex.github.io/ascendex-futures-pro-api-v2/#position
+         * @param {string[]} [symbols] a list of unified market symbols
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a list of [margin mode structures]{@link https://docs.ccxt.com/#/?id=margin-mode-structure}
+         */
+        await this.loadMarkets ();
+        await this.loadAccounts ();
+        const account = this.safeValue (this.accounts, 0, {});
+        const accountGroup = this.safeString (account, 'id');
+        const request = {
+            'account-group': accountGroup,
+        };
+        const response = await this.v2PrivateAccountGroupGetFuturesPosition (this.extend (request, params));
+        //
+        //     {
+        //         "code": 0,
+        //         "data": {
+        //             "accountId": "fut2ODPhGiY71Pl4vtXnOZ00ssgD7QGn",
+        //             "ac": "FUTURES",
+        //             "collaterals": [
+        //                 {
+        //                     "asset": "USDT",
+        //                     "balance": "44.570287262",
+        //                     "referencePrice": "1",
+        //                     "discountFactor": "1"
+        //                 }
+        //             ],
+        //             "contracts": [
+        //                 {
+        //                     "symbol": "BTC-PERP",
+        //                     "side": "LONG",
+        //                     "position": "0.0001",
+        //                     "referenceCost": "-3.12277254",
+        //                     "unrealizedPnl": "-0.001700233",
+        //                     "realizedPnl": "0",
+        //                     "avgOpenPrice": "31209",
+        //                     "marginType": "isolated",
+        //                     "isolatedMargin": "1.654972977",
+        //                     "leverage": "2",
+        //                     "takeProfitPrice": "0",
+        //                     "takeProfitTrigger": "market",
+        //                     "stopLossPrice": "0",
+        //                     "stopLossTrigger": "market",
+        //                     "buyOpenOrderNotional": "0",
+        //                     "sellOpenOrderNotional": "0",
+        //                     "markPrice": "31210.723063672",
+        //                     "indexPrice": "31223.148857925"
+        //                 },
+        //             ]
+        //         }
+        //     }
+        //
+        const data = this.safeDict (response, 'data', {});
+        const marginModes = this.safeList (data, 'contracts', []);
+        return this.parseMarginModes (marginModes, symbols, 'symbol');
+    }
+
+    parseMarginMode (marginMode, market = undefined): MarginMode {
+        const marketId = this.safeString (marginMode, 'symbol');
+        const marginType = this.safeString (marginMode, 'marginType');
+        const margin = (marginType === 'crossed') ? 'cross' : 'isolated';
+        return {
+            'info': marginMode,
+            'symbol': this.safeSymbol (marketId, market),
+            'marginMode': margin,
+        } as MarginMode;
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -455,6 +455,14 @@
                 ]
             }
         ],
+        "fetchMarginModes": [
+            {
+                "description": "Fetch all of the set margin modes",
+                "method": "fetchMarginModes",
+                "url": "https://ascendex.com/myAccount/api/pro/v2/futures/position",
+                "input": []
+            }
+        ],
         "fetchFundingRate": [
             {
                 "description": "fundingRate",

--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -463,6 +463,16 @@
                 "input": []
             }
         ],
+        "fetchMarginMode": [
+            {
+                "description": "Fetch the set margin mode of a specified market",
+                "method": "fetchMarginMode",
+                "url": "https://ascendex.com/myAccount/api/pro/v2/futures/position",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
         "fetchFundingRate": [
             {
                 "description": "fundingRate",


### PR DESCRIPTION
Added `fetchMarginMode` and `fetchMarginModes` to ascendex:

```
ascendex.fetchMarginMode (BTC/USDT:USDT)
2024-03-14T08:12:43.925Z iteration 0 passed in 1290 ms

{
  info: {
    symbol: 'BTC-PERP',
    side: 'LONG',
    position: '0',
    referenceCost: '0',
    unrealizedPnl: '0',
    realizedPnl: '0',
    avgOpenPrice: '0',
    marginType: 'isolated',
    isolatedMargin: '0',
    leverage: '10',
    takeProfitPrice: '0',
    takeProfitTrigger: 'market',
    stopLossPrice: '0',
    stopLossTrigger: 'market',
    posStopMode: 'Full',
    buyOpenOrderNotional: '0',
    sellOpenOrderNotional: '0',
    markPrice: '73398.157537945',
    indexPrice: '73338.07'
  },
  symbol: 'BTC/USDT:USDT',
  marginMode: 'isolated'
}
```