### PR TITLE
fix(hitbtc) handle new orderbook snapshot correctly

### DIFF
--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -254,7 +254,9 @@ export default class hitbtc extends hitbtcRest {
         //        }
         //    }
         //
-        const data = this.safeValue2 (message, 'snapshot', 'update', {});
+        const snapshot = this.safeValue (message, 'snapshot', null);
+        const update = this.safeValue (message, 'update', null);
+        const data = snapshot ?? update;
         const marketIds = Object.keys (data);
         for (let i = 0; i < marketIds.length; i++) {
             const marketId = marketIds[i];
@@ -262,7 +264,7 @@ export default class hitbtc extends hitbtcRest {
             const symbol = market['symbol'];
             const item = data[marketId];
             const messageHash = 'orderbooks::' + symbol;
-            if (!(symbol in this.orderbooks)) {
+            if (snapshot || !(symbol in this.orderbooks)) {
                 const subscription = this.safeValue (client.subscriptions, messageHash, {});
                 const limit = this.safeInteger (subscription, 'limit');
                 this.orderbooks[symbol] = this.orderBook ({}, limit);

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -265,7 +265,7 @@ export default class hitbtc extends hitbtcRest {
             const symbol = market['symbol'];
             const item = data[marketId];
             const messageHash = 'orderbooks::' + symbol;
-            if (type == 'snapshot' || !(symbol in this.orderbooks)) {
+            if (type === 'snapshot' || !(symbol in this.orderbooks)) {
                 const subscription = this.safeValue (client.subscriptions, messageHash, {});
                 const limit = this.safeInteger (subscription, 'limit');
                 this.orderbooks[symbol] = this.orderBook ({}, limit);

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -254,8 +254,8 @@ export default class hitbtc extends hitbtcRest {
         //        }
         //    }
         //
-        const snapshot = this.safeValue (message, 'snapshot', undefined);
-        const update = this.safeValue (message, 'update', undefined);
+        const snapshot = this.safeValue (message, 'snapshot');
+        const update = this.safeValue (message, 'update');
         const data = snapshot ? snapshot : update;
         const type = snapshot ? 'snapshot' : 'update';
         const marketIds = Object.keys (data);

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -254,8 +254,8 @@ export default class hitbtc extends hitbtcRest {
         //        }
         //    }
         //
-        const snapshot = this.safeValue (message, 'snapshot', null);
-        const update = this.safeValue (message, 'update', null);
+        const snapshot = this.safeValue (message, 'snapshot', undefined);
+        const update = this.safeValue (message, 'update', undefined);
         const data = snapshot ? snapshot : update;
         const type = snapshot ? 'snapshot' : 'update';
         const marketIds = Object.keys (data);

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -256,7 +256,7 @@ export default class hitbtc extends hitbtcRest {
         //
         const snapshot = this.safeValue (message, 'snapshot', null);
         const update = this.safeValue (message, 'update', null);
-        const data = snapshot ?? update;
+        const data = snapshot || update;
         const marketIds = Object.keys (data);
         for (let i = 0; i < marketIds.length; i++) {
             const marketId = marketIds[i];

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -256,7 +256,8 @@ export default class hitbtc extends hitbtcRest {
         //
         const snapshot = this.safeValue (message, 'snapshot', null);
         const update = this.safeValue (message, 'update', null);
-        const data = snapshot || update;
+        const data = snapshot ? snapshot : update;
+        const type = snapshot ? 'snapshot' : 'update';
         const marketIds = Object.keys (data);
         for (let i = 0; i < marketIds.length; i++) {
             const marketId = marketIds[i];
@@ -264,7 +265,7 @@ export default class hitbtc extends hitbtcRest {
             const symbol = market['symbol'];
             const item = data[marketId];
             const messageHash = 'orderbooks::' + symbol;
-            if (snapshot || !(symbol in this.orderbooks)) {
+            if (type == 'snapshot' || !(symbol in this.orderbooks)) {
                 const subscription = this.safeValue (client.subscriptions, messageHash, {});
                 const limit = this.safeInteger (subscription, 'limit');
                 this.orderbooks[symbol] = this.orderBook ({}, limit);


### PR DESCRIPTION
## issue
After a re-connect, watchOrderBook would start returning weird(er) orderbook data

## cause
A new orderbook message was always treated as _update_, even when a new _snapshot_ was received

## fix
Upon receiving a _snapshot_, the cached orderbook should be cleared

## please check
Although it works, I'm not sure if the approach I took is the preferred way to make the distinction between _snapshot_ and _update_