### PR TITLE
feat(bitget): fetches real amount limits based on trade type

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1580,7 +1580,7 @@ export default class bitget extends Exchange {
                 //       }
                 //   }
                 //
-                const accountData = this.safeDict (accountInfo, 'data');
+                const accountData = this.safeDict (accountInfo, 'data', {});
                 const traderType = this.safeString (accountData, 'traderType');
                 if (traderType === 'trader') {
                     const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
@@ -1637,9 +1637,9 @@ export default class bitget extends Exchange {
                     //       }
                     //   }
                     //
-                    const querySettingsData = this.safeDict (querySettings, 'data');
-                    const spotInfoList = this.safeList (querySettingsData, 'spotInfoList');
-                    const traceSymbolList = this.safeList (querySettingsData, 'traceSymbolList');
+                    const querySettingsData = this.safeDict (querySettings, 'data', {});
+                    const spotInfoList = this.safeList (querySettingsData, 'spotInfoList', []);
+                    const traceSymbolList = this.safeList (querySettingsData, 'traceSymbolList', []);
                     spotInfoDict = this.indexBy (spotInfoList, 'symbol');
                     traceSymbolDict = this.indexBy (traceSymbolList, 'symbol');
                 }
@@ -1789,8 +1789,8 @@ export default class bitget extends Exchange {
             }
             const amountMinDefault = this.safeNumber2 (market, 'minTradeNum', 'minTradeAmount');
             const amountMaxDefault = this.safeNumber (market, 'maxTradeAmount');
-            const spotInfo = this.safeDict (spotInfoDict, marketId);
-            const traceSymbol = this.safeDict (traceSymbolDict, marketId);
+            const spotInfo = this.safeDict (spotInfoDict, marketId, {});
+            const traceSymbol = this.safeDict (traceSymbolDict, marketId, {});
             result.push ({
                 'id': marketId,
                 'symbol': symbol,

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1554,7 +1554,7 @@ export default class bitget extends Exchange {
         let spotInfoDict = {};
         let traceSymbolDict = {};
         if (type === 'spot') {
-            if (this.checkRequiredCredentials ()) {
+            if (this.checkRequiredCredentials (false)) {
                 const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
                 //
                 //   {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1554,93 +1554,95 @@ export default class bitget extends Exchange {
         let spotInfoDict = {};
         let traceSymbolDict = {};
         if (type === 'spot') {
-            const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
-            //
-            //   {
-            //       code: '00000',
-            //       msg: 'success',
-            //       requestTime: '1710452758237',
-            //       data: {
-            //           userId: '3182153878',
-            //           inviterId: null,
-            //           channelCode: 'rr7o',
-            //           channel: 'mzk2',
-            //           ips: '',
-            //           authorities: [
-            //               'wtow', 'chow',
-            //               'smow', 'coow',
-            //               'taxw', 'p2pw',
-            //               'cpow', 'ttow',
-            //               'stow'
-            //           ],
-            //           parentId: '3182153878',
-            //           traderType: 'not_trader',
-            //           regisTime: '1706140810000'
-            //       }
-            //   }
-            //
-            const accountData = this.safeDict (accountInfo, 'data');
-            const traderType = this.safeString (accountData, 'traderType');
-            if (traderType === 'trader') {
-                const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
+            if (this.checkRequiredCredentials ()) {
+                const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
                 //
                 //   {
-                //       "code": "00000",
-                //       "msg": "success",
-                //       "requestTime": 1695807020372,
-                //       "data": {
-                //           "removeLimitUsdt": "100",
-                //           "spotInfoList": [
-                //               {
-                //                   "maxQuoteSize": "5000000",
-                //                   "surplusQuoteSize": "4998894.59",
-                //                   "symbol": "BTCUSDT"
-                //               },
-                //               {
-                //                   "maxQuoteSize": "300000",
-                //                   "surplusQuoteSize": "300000",
-                //                   "symbol": "ETHBTC"
-                //               },
-                //               {
-                //                   "maxQuoteSize": "50000",
-                //                   "surplusQuoteSize": "50000",
-                //                   "symbol": "ETHUSDT"
-                //               }
+                //       code: '00000',
+                //       msg: 'success',
+                //       requestTime: '1710452758237',
+                //       data: {
+                //           userId: '3182153878',
+                //           inviterId: null,
+                //           channelCode: 'rr7o',
+                //           channel: 'mzk2',
+                //           ips: '',
+                //           authorities: [
+                //               'wtow', 'chow',
+                //               'smow', 'coow',
+                //               'taxw', 'p2pw',
+                //               'cpow', 'ttow',
+                //               'stow'
                 //           ],
-                //           "labelList": [],
-                //           "enable": "YES",
-                //           "showAssetsMap": "NO",
-                //           "showEquity": "NO",
-                //           "traceSymbolList": [
-                //               {
-                //                   "enable": "NO",
-                //                   "symbol": "BGBUSDT",
-                //                   "minOpenCount": "0.0001"
-                //               },
-                //               {
-                //                   "enable": "YES",
-                //                   "symbol": "BTCUSDT",
-                //                   "minOpenCount": "0.0005"
-                //               },
-                //               {
-                //                   "enable": "YES",
-                //                   "symbol": "ETHBTC",
-                //                   "minOpenCount": "0.0001"
-                //               },
-                //               {
-                //                   "enable": "YES",
-                //                   "symbol": "ETHUSDT",
-                //                   "minOpenCount": "0.0001"
-                //               }
-                //           ]
+                //           parentId: '3182153878',
+                //           traderType: 'not_trader',
+                //           regisTime: '1706140810000'
                 //       }
                 //   }
                 //
-                const querySettingsData = this.safeDict (querySettings, 'data');
-                const spotInfoList = this.safeList (querySettingsData, 'spotInfoList');
-                const traceSymbolList = this.safeList (querySettingsData, 'traceSymbolList');
-                spotInfoDict = this.indexBy (spotInfoList, 'symbol');
-                traceSymbolDict = this.indexBy (traceSymbolList, 'symbol');
+                const accountData = this.safeDict (accountInfo, 'data');
+                const traderType = this.safeString (accountData, 'traderType');
+                if (traderType === 'trader') {
+                    const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
+                    //
+                    //   {
+                    //       "code": "00000",
+                    //       "msg": "success",
+                    //       "requestTime": 1695807020372,
+                    //       "data": {
+                    //           "removeLimitUsdt": "100",
+                    //           "spotInfoList": [
+                    //               {
+                    //                   "maxQuoteSize": "5000000",
+                    //                   "surplusQuoteSize": "4998894.59",
+                    //                   "symbol": "BTCUSDT"
+                    //               },
+                    //               {
+                    //                   "maxQuoteSize": "300000",
+                    //                   "surplusQuoteSize": "300000",
+                    //                   "symbol": "ETHBTC"
+                    //               },
+                    //               {
+                    //                   "maxQuoteSize": "50000",
+                    //                   "surplusQuoteSize": "50000",
+                    //                   "symbol": "ETHUSDT"
+                    //               }
+                    //           ],
+                    //           "labelList": [],
+                    //           "enable": "YES",
+                    //           "showAssetsMap": "NO",
+                    //           "showEquity": "NO",
+                    //           "traceSymbolList": [
+                    //               {
+                    //                   "enable": "NO",
+                    //                   "symbol": "BGBUSDT",
+                    //                   "minOpenCount": "0.0001"
+                    //               },
+                    //               {
+                    //                   "enable": "YES",
+                    //                   "symbol": "BTCUSDT",
+                    //                   "minOpenCount": "0.0005"
+                    //               },
+                    //               {
+                    //                   "enable": "YES",
+                    //                   "symbol": "ETHBTC",
+                    //                   "minOpenCount": "0.0001"
+                    //               },
+                    //               {
+                    //                   "enable": "YES",
+                    //                   "symbol": "ETHUSDT",
+                    //                   "minOpenCount": "0.0001"
+                    //               }
+                    //           ]
+                    //       }
+                    //   }
+                    //
+                    const querySettingsData = this.safeDict (querySettings, 'data');
+                    const spotInfoList = this.safeList (querySettingsData, 'spotInfoList');
+                    const traceSymbolList = this.safeList (querySettingsData, 'traceSymbolList');
+                    spotInfoDict = this.indexBy (spotInfoList, 'symbol');
+                    traceSymbolDict = this.indexBy (traceSymbolList, 'symbol');
+                }
             }
             response = await this.publicSpotGetV2SpotPublicSymbols (params);
             //

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1554,33 +1554,7 @@ export default class bitget extends Exchange {
         let spotInfoDict = {};
         let traceSymbolDict = {};
         if (type === 'spot') {
-            // const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
-            const accountInfo = {
-                'code': '00000',
-                'msg': 'success',
-                'requestTime': '1710452758237',
-                'data': {
-                    'userId': '3182153878',
-                    'inviterId': null,
-                    'channelCode': 'rr7o',
-                    'channel': 'mzk2',
-                    'ips': '',
-                    'authorities': [
-                        'wtow',
-                        'chow',
-                        'smow',
-                        'coow',
-                        'taxw',
-                        'p2pw',
-                        'cpow',
-                        'ttow',
-                        'stow',
-                    ],
-                    'parentId': '3182153878',
-                    'traderType': 'trader',
-                    'regisTime': '1706140810000',
-                },
-            };
+            const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
             //
             //   {
             //       code: '00000',
@@ -1608,58 +1582,7 @@ export default class bitget extends Exchange {
             const accountData = this.safeDict (accountInfo, 'data');
             const traderType = this.safeString (accountData, 'traderType');
             if (traderType === 'trader') {
-                // const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
-                const querySettings = {
-                    'code': '00000',
-                    'msg': 'success',
-                    'requestTime': 1695807020372,
-                    'data': {
-                        'removeLimitUsdt': '100',
-                        'spotInfoList': [
-                            {
-                                'maxQuoteSize': '5000000',
-                                'surplusQuoteSize': '4998894.59',
-                                'symbol': 'BTCUSDT',
-                            },
-                            {
-                                'maxQuoteSize': '300000',
-                                'surplusQuoteSize': '300000',
-                                'symbol': 'ETHBTC',
-                            },
-                            {
-                                'maxQuoteSize': '50000',
-                                'surplusQuoteSize': '50000',
-                                'symbol': 'ETHUSDT',
-                            },
-                        ],
-                        'labelList': [],
-                        'enable': 'YES',
-                        'showAssetsMap': 'NO',
-                        'showEquity': 'NO',
-                        'traceSymbolList': [
-                            {
-                                'enable': 'NO',
-                                'symbol': 'BGBUSDT',
-                                'minOpenCount': '0.0001',
-                            },
-                            {
-                                'enable': 'YES',
-                                'symbol': 'BTCUSDT',
-                                'minOpenCount': '0.0005',
-                            },
-                            {
-                                'enable': 'YES',
-                                'symbol': 'ETHBTC',
-                                'minOpenCount': '0.0001',
-                            },
-                            {
-                                'enable': 'YES',
-                                'symbol': 'ETHUSDT',
-                                'minOpenCount': '0.0001',
-                            },
-                        ],
-                    },
-                };
+                const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
                 //
                 //   {
                 //       "code": "00000",

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1554,89 +1554,168 @@ export default class bitget extends Exchange {
         let spotInfoDict = {};
         let traceSymbolDict = {};
         if (type === 'spot') {
-            const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
+            // const accountInfo = await this.privateSpotGetV2SpotAccountInfo (params);
+            const accountInfo = {
+                'code': '00000',
+                'msg': 'success',
+                'requestTime': '1710452758237',
+                'data': {
+                    'userId': '3182153878',
+                    'inviterId': null,
+                    'channelCode': 'rr7o',
+                    'channel': 'mzk2',
+                    'ips': '',
+                    'authorities': [
+                        'wtow',
+                        'chow',
+                        'smow',
+                        'coow',
+                        'taxw',
+                        'p2pw',
+                        'cpow',
+                        'ttow',
+                        'stow',
+                    ],
+                    'parentId': '3182153878',
+                    'traderType': 'trader',
+                    'regisTime': '1706140810000',
+                },
+            };
             //
-            //    {
-            //        code: '00000',
-            //        msg: 'success',
-            //        requestTime: '1710452758237',
-            //        data: {
-            //            userId: '3182153878',
-            //            inviterId: null,
-            //            channelCode: 'rr7o',
-            //            channel: 'mzk2',
-            //            ips: '',
-            //            authorities: [
-            //                'wtow', 'chow',
-            //                'smow', 'coow',
-            //                'taxw', 'p2pw',
-            //                'cpow', 'ttow',
-            //                'stow'
-            //            ],
-            //            parentId: '3182153878',
-            //            traderType: 'not_trader',
-            //            regisTime: '1706140810000'
-            //        }
-            //    }
+            //   {
+            //       code: '00000',
+            //       msg: 'success',
+            //       requestTime: '1710452758237',
+            //       data: {
+            //           userId: '3182153878',
+            //           inviterId: null,
+            //           channelCode: 'rr7o',
+            //           channel: 'mzk2',
+            //           ips: '',
+            //           authorities: [
+            //               'wtow', 'chow',
+            //               'smow', 'coow',
+            //               'taxw', 'p2pw',
+            //               'cpow', 'ttow',
+            //               'stow'
+            //           ],
+            //           parentId: '3182153878',
+            //           traderType: 'not_trader',
+            //           regisTime: '1706140810000'
+            //       }
+            //   }
             //
-            const traderType = this.safeString (accountInfo, 'traderType');
+            const accountData = this.safeDict (accountInfo, 'data');
+            const traderType = this.safeString (accountData, 'traderType');
             if (traderType === 'trader') {
-                const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
+                // const querySettings = await this.privateCopyGetV2CopySpotTraderConfigQuerySettings (params);
+                const querySettings = {
+                    'code': '00000',
+                    'msg': 'success',
+                    'requestTime': 1695807020372,
+                    'data': {
+                        'removeLimitUsdt': '100',
+                        'spotInfoList': [
+                            {
+                                'maxQuoteSize': '5000000',
+                                'surplusQuoteSize': '4998894.59',
+                                'symbol': 'BTCUSDT',
+                            },
+                            {
+                                'maxQuoteSize': '300000',
+                                'surplusQuoteSize': '300000',
+                                'symbol': 'ETHBTC',
+                            },
+                            {
+                                'maxQuoteSize': '50000',
+                                'surplusQuoteSize': '50000',
+                                'symbol': 'ETHUSDT',
+                            },
+                        ],
+                        'labelList': [],
+                        'enable': 'YES',
+                        'showAssetsMap': 'NO',
+                        'showEquity': 'NO',
+                        'traceSymbolList': [
+                            {
+                                'enable': 'NO',
+                                'symbol': 'BGBUSDT',
+                                'minOpenCount': '0.0001',
+                            },
+                            {
+                                'enable': 'YES',
+                                'symbol': 'BTCUSDT',
+                                'minOpenCount': '0.0005',
+                            },
+                            {
+                                'enable': 'YES',
+                                'symbol': 'ETHBTC',
+                                'minOpenCount': '0.0001',
+                            },
+                            {
+                                'enable': 'YES',
+                                'symbol': 'ETHUSDT',
+                                'minOpenCount': '0.0001',
+                            },
+                        ],
+                    },
+                };
                 //
-                //    {
-                //        "code": "00000",
-                //        "msg": "success",
-                //        "requestTime": 1695807020372,
-                //        "data": {
-                //            "removeLimitUsdt": "100",
-                //            "spotInfoList": [
-                //                {
-                //                    "maxQuoteSize": "5000000",
-                //                    "surplusQuoteSize": "4998894.59",
-                //                    "symbol": "BTCUSDT"
-                //                },
-                //                {
-                //                    "maxQuoteSize": "300000",
-                //                    "surplusQuoteSize": "300000",
-                //                    "symbol": "ETHBTC"
-                //                },
-                //                {
-                //                    "maxQuoteSize": "50000",
-                //                    "surplusQuoteSize": "50000",
-                //                    "symbol": "ETHUSDT"
-                //                }
-                //            ],
-                //            "labelList": [],
-                //            "enable": "YES",
-                //            "showAssetsMap": "NO",
-                //            "showEquity": "NO",
-                //            "traceSymbolList": [
-                //                {
-                //                    "enable": "NO",
-                //                    "symbol": "BGBUSDT",
-                //                    "minOpenCount": "0.0001"
-                //                },
-                //                {
-                //                    "enable": "YES",
-                //                    "symbol": "BTCUSDT",
-                //                    "minOpenCount": "0.0005"
-                //                },
-                //                {
-                //                    "enable": "YES",
-                //                    "symbol": "ETHBTC",
-                //                    "minOpenCount": "0.0001"
-                //                },
-                //                {
-                //                    "enable": "YES",
-                //                    "symbol": "ETHUSDT",
-                //                    "minOpenCount": "0.0001"
-                //                }
-                //            ]
-                //        }
-                //    }
+                //   {
+                //       "code": "00000",
+                //       "msg": "success",
+                //       "requestTime": 1695807020372,
+                //       "data": {
+                //           "removeLimitUsdt": "100",
+                //           "spotInfoList": [
+                //               {
+                //                   "maxQuoteSize": "5000000",
+                //                   "surplusQuoteSize": "4998894.59",
+                //                   "symbol": "BTCUSDT"
+                //               },
+                //               {
+                //                   "maxQuoteSize": "300000",
+                //                   "surplusQuoteSize": "300000",
+                //                   "symbol": "ETHBTC"
+                //               },
+                //               {
+                //                   "maxQuoteSize": "50000",
+                //                   "surplusQuoteSize": "50000",
+                //                   "symbol": "ETHUSDT"
+                //               }
+                //           ],
+                //           "labelList": [],
+                //           "enable": "YES",
+                //           "showAssetsMap": "NO",
+                //           "showEquity": "NO",
+                //           "traceSymbolList": [
+                //               {
+                //                   "enable": "NO",
+                //                   "symbol": "BGBUSDT",
+                //                   "minOpenCount": "0.0001"
+                //               },
+                //               {
+                //                   "enable": "YES",
+                //                   "symbol": "BTCUSDT",
+                //                   "minOpenCount": "0.0005"
+                //               },
+                //               {
+                //                   "enable": "YES",
+                //                   "symbol": "ETHBTC",
+                //                   "minOpenCount": "0.0001"
+                //               },
+                //               {
+                //                   "enable": "YES",
+                //                   "symbol": "ETHUSDT",
+                //                   "minOpenCount": "0.0001"
+                //               }
+                //           ]
+                //       }
+                //   }
                 //
-                const spotInfoList = this.safeList (querySettings, 'spotInfoList');
-                const traceSymbolList = this.safeList (querySettings, 'traceSymbolList');
+                const querySettingsData = this.safeDict (querySettings, 'data');
+                const spotInfoList = this.safeList (querySettingsData, 'spotInfoList');
+                const traceSymbolList = this.safeList (querySettingsData, 'traceSymbolList');
                 spotInfoDict = this.indexBy (spotInfoList, 'symbol');
                 traceSymbolDict = this.indexBy (traceSymbolList, 'symbol');
             }


### PR DESCRIPTION
fixes: #21700

On the second last commit, I replace the api calls with test data. This is the best testing I can do seeing as the account returns `not_trader`. I then remove the test data and uncomment the api calls on the last commit

```
% py bitget market BTC/USDT  
Python v3.9.6
CCXT v4.2.72
bitget.market(BTC/USDT)
{'active': True,
 'base': 'BTC',
 'baseId': 'BTC',
 'contract': False,
 'contractSize': None,
 'created': None,
 'expiry': None,
 'expiryDatetime': None,
 'future': False,
 'id': 'BTCUSDT',
 'index': None,
 'info': {'areaSymbol': 'no',
          'baseCoin': 'BTC',
          'buyLimitPriceRatio': '0.05',
          'makerFeeRate': '0.002',
          'maxTradeAmount': '10000000000',
          'minTradeAmount': '0',
          'minTradeUSDT': '5',
          'pricePrecision': '2',
          'quantityPrecision': '6',
          'quoteCoin': 'USDT',
          'quotePrecision': '6',
          'sellLimitPriceRatio': '0.05',
          'status': 'online',
          'symbol': 'BTCUSDT',
          'takerFeeRate': '0.002'},
 'inverse': None,
 'limits': {'amount': {'max': 5000000.0, 'min': 0.0005},
            'cost': {'max': None, 'min': 5.0},
            'leverage': {'max': None, 'min': None},
            'price': {'max': None, 'min': None}},
 'linear': None,
 'lowercaseId': None,
 'maker': 0.002,
 'margin': None,
 'option': False,
 'optionType': None,
 'percentage': True,
 'precision': {'amount': 1e-06,
               'base': None,
               'cost': None,
               'price': 0.01,
               'quote': None},
 'quote': 'USDT',
 'quoteId': 'USDT',
 'settle': None,
 'settleId': None,
 'spot': True,
 'strike': None,
 'subType': None,
 'swap': False,
 'symbol': 'BTC/USDT',
 'taker': 0.002,
 'type': 'spot'}
 ```