### PR TITLE
feat(cli): add ccxt global command and raw, update docs

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 import fs from 'fs'
 import path from 'path'
 import ansi from 'ansicolor'
@@ -38,12 +39,14 @@ let [processPath, , exchangeId, methodName, ... params] = process.argv.filter (x
     , shouldCreateRequestReport = process.argv.includes ('--report')
     , shouldCreateResponseReport = process.argv.includes ('--response')
     , shouldCreateBoth = process.argv.includes ('--static')
+    , raw = process.argv.includes ('--raw')
 
 //-----------------------------------------------------------------------------
-
-log ((new Date ()).toISOString())
-log ('Node.js:', process.version)
-log ('CCXT v' + ccxt.version)
+if (!raw) {
+    log ((new Date ()).toISOString())
+    log ('Node.js:', process.version)
+    log ('CCXT v' + ccxt.version)
+}
 
 //-----------------------------------------------------------------------------
 
@@ -198,6 +201,9 @@ function printUsage () {
 //-----------------------------------------------------------------------------
 
 const printHumanReadable = (exchange, result) => {
+    if (raw) {
+        return log (JSON.stringify(result))
+    }
     if (!no_table && Array.isArray (result) || table) {
         result = Object.values (result)
         let arrayOfObjects = (typeof result[0] === 'object')
@@ -323,7 +329,7 @@ async function run () {
 
             if (typeof exchange[methodName] === 'function') {
 
-                log (exchange.id + '.' + methodName, '(' + args.join (', ') + ')')
+                if (!raw) log (exchange.id + '.' + methodName, '(' + args.join (', ') + ')')
 
                 let start = exchange.milliseconds ()
                 let end = exchange.milliseconds ()
@@ -339,11 +345,11 @@ async function run () {
                     try {
                         const result = await exchange[methodName] (... args)
                         end = exchange.milliseconds ()
-                        if (!isWsMethod) {
+                        if (!isWsMethod && !raw) {
                             log (exchange.iso8601 (end), 'iteration', i++, 'passed in', end - start, 'ms\n')
                         }
                         printHumanReadable (exchange, JSON.parse(JSON.stringify(result)))
-                        if (!isWsMethod) {
+                        if (!isWsMethod && !raw) {
                             log (exchange.iso8601 (end), 'iteration', i, 'passed in', end - start, 'ms\n')
                         }
                         if (shouldCreateRequestReport || shouldCreateBoth) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
       "require": "./dist/ccxt.cjs"
     }
   },
+  "bin": {
+    "ccxt": "examples/js/cli.js"
+  },
   "engines": {
     "node": ">=15.0.0"
   },

--- a/wiki/CLI.md
+++ b/wiki/CLI.md
@@ -32,6 +32,12 @@ The source code of the CLI is available here:
 - https://github.com/ccxt/ccxt/blob/master/examples/py/cli.py
 - https://github.com/ccxt/ccxt/blob/master/examples/php/cli.php
 
+## Install globally
+```js
+npm -g ccxt
+```
+- Update using `npm update ccxt -g`
+
 ## Install
 
 1. Clone the CCXT repository:
@@ -98,3 +104,29 @@ For private API calls, by default the CLI script will look for API keys in the `
 ## Unified API vs Exchange-Specific API
 
 CLI supports all possible methods and properties that exist on the exchange instance.
+
+### Run with jq
+Install jq 
+
+<!-- tabs:start -->
+#### **Ubuntu**
+```bash
+sudo apt-get install jq
+```
+#### **Brew (Mac)**
+```bash
+brew install jq
+```
+#### **Choco (Windows)**
+```bash
+choco install jq -y
+```
+<!-- tabs:end -->
+
+#### Examples
+- Get ticker price of BTC/USDT: `ccxt binance fetchTicker BTC/USDT | jq '.price'
+- watch price and amount of trades:
+`ccxt binance watchTrades BTC/USDT --raw | jq -c '[.[] | {price: .price, amount: .amount}]'`
+
+- fuzzy search between trades (requires fzf):
+`ccxt binance fetchTrades --raw | jq -c '.[]' | fzf`

--- a/wiki/CLI.md
+++ b/wiki/CLI.md
@@ -130,3 +130,5 @@ choco install jq -y
 
 - fuzzy search between trades (requires fzf):
 `ccxt binance fetchTrades --raw | jq -c '.[]' | fzf`
+
+![render1710459605924](https://github.com/ccxt/ccxt/assets/12142844/39b22383-42d5-4ebd-8b09-617008b7e4f0)


### PR DESCRIPTION
- Adds ccxt global command
- Adds `--raw` argument to console to be able to pipe results to tools like jq, grep and fzf
- Update docs

To test locally run: `npx ccxt` or `npm i -g`

![render1710459605924](https://github.com/ccxt/ccxt/assets/12142844/39b22383-42d5-4ebd-8b09-617008b7e4f0)
