### PR TITLE
btcturk: update timeframes

### DIFF
--- a/ts/src/btcturk.ts
+++ b/ts/src/btcturk.ts
@@ -81,9 +81,9 @@ export default class btcturk extends Exchange {
                 '30m': 30,
                 '1h': 60,
                 '4h': 240,
-                '1d': '1 day',
-                '1w': '1 week',
-                '1y': '1 year',
+                '1d': '1 d',
+                '1w': '1 w',
+                '1y': '1 y',
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/51840849/87153926-efbef500-c2c0-11ea-9842-05b63612c4b9.jpg',


### PR DESCRIPTION
fix: ccxt/ccxt#21732

btcturk seems change the timeframes (although I didn't see on their doc, but api works...). In this PR, I made relevant changes.

```BASH
$ p btcturk fetchOHLCV BTC/USDT 1d
[[1710201600000, 72166.0, 72937.0, 69000.0, 71488.0, 170.19277584],
 [1710288000000, 71449.0, 73638.0, 70852.0, 73093.0, 93.7505499],
 [1710374400000, 73050.0, 73773.0, 68730.0, 71409.0, 168.20126583],
 [1710460800000, 71415.0, 72378.0, 65500.0, 67497.0, 166.59935185]]

$ p btcturk fetchOHLCV BTC/USDT 1w
 [[1709164800000, 62414.0, 68979.0, 58850.0, 66085.0, 1114.46775957],
 [1709769600000, 66043.0, 73638.0, 65500.0, 73093.0, 795.69777691],
 [1710374400000, 73050.0, 73773.0, 65500.0, 67503.0, 334.81539945]]
```