### PR TITLE
fix(delta) - skipws [QUICK]

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -804,8 +804,7 @@
         }
     },
     "delta": {
-        "skip": "frequent timeouts https://app.travis-ci.com/github/ccxt/ccxt/builds/269273148#L4301",
-        "until": "2024-03-15",
+        "skipCSharp": true,
         "skipMethods": {
             "loadMarkets": "expiryDatetime must be equal to expiry in iso8601 format",
             "fetchOrderBook": "ask crossing bids test failing",


### PR DESCRIPTION
frequent timeouts in C# ws specifically, might be some headers/etc but for now lets skip