### PR TITLE
fix(krakenfutures) - watchTrades reverse timestamp 

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -483,14 +483,13 @@ export default class krakenfutures extends krakenfuturesRest {
             const market = this.market (marketId);
             const symbol = market['symbol'];
             const messageHash = 'trade:' + symbol;
-            let tradesArray = this.safeValue (this.trades, symbol);
-            if (tradesArray === undefined) {
+            if (this.safeList (this.trades, symbol) === undefined) {
                 const tradesLimit = this.safeInteger (this.options, 'tradesLimit', 1000);
-                tradesArray = new ArrayCache (tradesLimit);
-                this.trades[symbol] = tradesArray;
+                this.trades[symbol] = new ArrayCache (tradesLimit);
             }
+            const tradesArray = this.trades[symbol];
             if (channel === 'trade_snapshot') {
-                const trades = this.safeValue (message, 'trades', []);
+                const trades = this.safeList (message, 'trades', []);
                 for (let i = 0; i < trades.length; i++) {
                     const item = trades[i];
                     const trade = this.parseWsTrade (item);

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -490,8 +490,10 @@ export default class krakenfutures extends krakenfuturesRest {
             const tradesArray = this.trades[symbol];
             if (channel === 'trade_snapshot') {
                 const trades = this.safeList (message, 'trades', []);
-                for (let i = 0; i < trades.length; i++) {
-                    const item = trades[i];
+                const length = trades.length;
+                for (let i = 0; i < length; i++) {
+                    const index = length - 1 - i; // need reverse to correct chronology
+                    const item = trades[index];
                     const trade = this.parseWsTrade (item);
                     tradesArray.append (trade);
                 }


### PR DESCRIPTION
raw incoming "trades snapshot" data is like:
```
{
    feed: "trade_snapshot",
    product_id: "PF_XBTUSD",
    trades: [{
            feed: "trade",
            product_id: "PF_XBTUSD",
            uid: "7da94cd8-8feb-4cf1-8599-1dcb3d792661",
            side: "buy",
            type: "fill",
            seq: 271830,
            time: 1710519706481,
            qty: 0.0044,
            price: 67955,
        }, {
            feed: "trade",
            product_id: "PF_XBTUSD",
            uid: "5f9e60f5-cbeb-4ea1-ba06-15d1c65fa154",
            side: "sell",
            type: "fill",
            seq: 271829,
            time: 1710519705685,
            qty: 0.0229,
            price: 67948,
        }, {
```

so you can see the timestamps were decreasing.