### PR TITLE
fix(hyperliquid): market orders price precision after slippage

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -874,6 +874,7 @@ export default class hyperliquid extends Exchange {
                     throw new ArgumentsRequired (this.id + '  market orders require price to calculate the max slippage price. Default slippage can be set in options (default is 5%).');
                 }
                 px = (isBuy) ? Precise.stringMul (price, Precise.stringAdd ('1', slippage)) : Precise.stringMul (price, Precise.stringSub ('1', slippage));
+                px = this.priceToPrecision (symbol, px); // round after adding slippage
             } else {
                 px = this.priceToPrecision (symbol, price);
             }

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -148,7 +148,7 @@
                   0.0014646006034154486,
                   70000.234234324
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":3,\"b\":true,\"p\":\"73500\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"brokerCode\":1},\"nonce\":1710527621347,\"signature\":{\"r\":\"0xba8575938a44e3e291085efb8e9682af3e9da54d5fbcbf49316c89b4ae84dba4\",\"s\":\"0x1d20dc5973f66161f4cd856d50611543d11f65f59a1bc53e33b01e1a4874b555\",\"v\":28}}"
+                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"73500\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"brokerCode\":1},\"nonce\":1710527621347,\"signature\":{\"r\":\"0xba8575938a44e3e291085efb8e9682af3e9da54d5fbcbf49316c89b4ae84dba4\",\"s\":\"0x1d20dc5973f66161f4cd856d50611543d11f65f59a1bc53e33b01e1a4874b555\",\"v\":28}}"
             }
         ],
         "createOrders": [

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -136,6 +136,19 @@
                   70000
                 ],
                 "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"70000\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"brokerCode\":1},\"nonce\":1710520063328,\"signature\":{\"r\":\"0xe2bb3f1a26776cab9c49b7e874e5fc07a4ab2cf80b24beed2958be41c2189e3a\",\"s\":\"0x582b3d4ba87cec02d16aa74c16e7b19b465b7d4e454f7e0b543e19a4e8c87ef7\",\"v\":27}}"
+            },
+            {
+                "description": "market order with unformatted price and amount",
+                "method": "createOrder",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                  "BTC/USDC:USDC",
+                  "market",
+                  "buy",
+                  0.0014646006034154486,
+                  70000.234234324
+                ],
+                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":3,\"b\":true,\"p\":\"73500\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"brokerCode\":1},\"nonce\":1710527621347,\"signature\":{\"r\":\"0xba8575938a44e3e291085efb8e9682af3e9da54d5fbcbf49316c89b4ae84dba4\",\"s\":\"0x1d20dc5973f66161f4cd856d50611543d11f65f59a1bc53e33b01e1a4874b555\",\"v\":28}}"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/pull/21745