### PR TITLE
ascendex: edit fetchPositions

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2744,7 +2744,8 @@ export default class ascendex extends Exchange {
         if (Precise.stringEq (notional, '0')) {
             notional = this.safeString (position, 'sellOpenOrderNotional');
         }
-        const marginMode = this.safeString (position, 'marginType');
+        const marginType = this.safeString (position, 'marginType');
+        const marginMode = (marginType === 'crossed') ? 'cross' : 'isolated';
         let collateral = undefined;
         if (marginMode === 'isolated') {
             collateral = this.safeString (position, 'isolatedMargin');


### PR DESCRIPTION
Edited fetchPositions so that it shows `cross` instead of `crossed` for the marginMode:

```
ascendex.fetchPositions (LTC/USDT:USDT)
2024-03-16T02:38:24.378Z iteration 0 passed in 1248 ms

       symbol | notional | marginMode | entryPrice | unrealizedPnl | contracts | contractSize |  markPrice | side | leverage | stopLossPrice | takeProfitPrice
--------------------------------------------------------------------------------------------------------------------------------------------------------------
LTC/USDT:USDT |        0 |      cross |          0 |             0 |         0 |            1 | 89.7616235 | long |       50 |             0 |               0
1 objects
```