### PR TITLE
gate: Add order type mapping for finish orders

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4272,6 +4272,7 @@ export default class gate extends Exchange {
             'failed': 'canceled',
             'expired': 'canceled',
             'finished': 'closed',
+            'finish': 'closed',
             'succeeded': 'closed',
         };
         return this.safeString (statuses, status, status);


### PR DESCRIPTION
Add order type mapping for finish orders

Stoploss orders do have an additional status in `finish` - which means that the order triggered. This should be mapped accordingly.

https://www.gate.io/docs/developers/apiv4/#spotpricetriggeredorder