### PR TITLE
feat(coinbase): add pagination in fetchLedger

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1339,7 +1339,7 @@ export default class coinbase extends Exchange {
          * @returns {object} an associative dictionary of currencies
          */
         const response = await this.fetchCurrenciesFromCache (params);
-        const currencies = this.safeDict (response, 'currencies', {});
+        const currencies = this.safeList (response, 'currencies', []);
         //
         // fiat
         //

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1904,7 +1904,7 @@ export default class coinbase extends Exchange {
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchLedger', 'paginate');
         if (paginate) {
-            return await this.fetchPaginatedCallCursor ('fetchLedger', undefined, undefined, undefined, params, 'next_starting_after', 'starting_after', undefined, 100);
+            return await this.fetchPaginatedCallCursor ('fetchLedger', code, since, limit, params, 'next_starting_after', 'starting_after', undefined, 100);
         }
         let currency = undefined;
         if (code !== undefined) {


### PR DESCRIPTION
fix: ccxt/ccxt#21756

Test:
```BASH
# should fetch all history
$  n coinbase fetchLedger USDT 1673986028000 100 '{"paginate": true,"account_id":"0e2b7cd9-ce67-53f3-92f2-d61c9410a9f6"}'
$  n coinbase fetchLedger USDT 1673986028000 1 '{"paginate": true,"account_id":"0e2b7cd9-ce67-53f3-92f2-d61c9410a9f6"}'

# should fetch single history
$  n coinbase fetchLedger USDT 1673986028000 1 '{"account_id":"0e2b7cd9-ce67-53f3-92f2-d61c9410a9f6"}'
```