### PR TITLE
Bingx parse status FAILED as canceled

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2474,7 +2474,7 @@ export default class bingx extends Exchange {
             'FILLED': 'closed',
             'CANCELED': 'canceled',
             'CANCELLED': 'canceled',
-            'FAILED': 'failed',
+            'FAILED': 'canceled',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
I thing than is betetr to parse as canceled, to better unification