### PR TITLE
fix(base-cs) - fetchStatus from emulated to null [QUICK]

### DIFF
--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -281,7 +281,7 @@ public partial class Exchange
                 { "fetchPositions", null },
                 { "fetchPositionsRisk", null },
                 { "fetchPremiumIndexOHLCV", null },
-                { "fetchStatus", "emulated" },
+                { "fetchStatus", null },
                 { "fetchTicker", true },
                 { "fetchTickers", null },
                 { "fetchTime", null },


### PR DESCRIPTION
in all other langs, we have undefined for `fetchStatus`