### PR TITLE
fix(hyperliquid): omit timeInForce

### DIFF
--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -396,8 +396,8 @@ export interface Liquidation {
 
 export interface OrderRequest {
     symbol: string;
-    type: Str;
-    side: Str;
+    type: OrderType;
+    side: OrderSide;
     amount?: number;
     price?: number | undefined;
     params?: any;

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -787,8 +787,9 @@ export default class hyperliquid extends Exchange {
          * @param {bool} [params.postOnly] true or false whether the order is post-only
          * @param {bool} [params.reduceOnly] true or false whether the order is reduce-only
          * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
-         * @param {string} [params.clientOrderId] client order id, optional 128 bit hex string
+         * @param {string} [params.clientOrderId] client order id, (optional 128 bit hex string e.g. 0x1234567890abcdef1234567890abcdef)
          * @param {string} [params.slippage] the slippage for market order
+         * @param {string} [params.vaultAddress] the vault address for order
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -839,7 +840,7 @@ export default class hyperliquid extends Exchange {
                 }
             }
         }
-        params = this.omit (params, [ 'slippage', 'clientOrderId', 'client_id', 'slippage', 'triggerPrice', 'stopPrice', 'stopLossPrice', 'takeProfitPrice' ]);
+        params = this.omit (params, [ 'slippage', 'clientOrderId', 'client_id', 'slippage', 'triggerPrice', 'stopPrice', 'stopLossPrice', 'takeProfitPrice', 'timeInForce' ]);
         const nonce = this.milliseconds ();
         const orderReq = [];
         for (let i = 0; i < orders.length; i++) {
@@ -964,7 +965,7 @@ export default class hyperliquid extends Exchange {
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {string} [params.clientOrderId] client order id (default undefined)
+         * @param {string} [params.clientOrderId] client order id, (optional 128 bit hex string e.g. 0x1234567890abcdef1234567890abcdef)
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         return await this.cancelOrders ([ id ], symbol, params);
@@ -980,7 +981,7 @@ export default class hyperliquid extends Exchange {
          * @param {string[]} ids order ids
          * @param {string} [symbol] unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {string|string[]} [params.clientOrderId] client order ids (default undefined)
+         * @param {string|string[]} [params.clientOrderId] client order ids, (optional 128 bit hex string e.g. 0x1234567890abcdef1234567890abcdef)
          * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         this.checkRequiredCredentials ();
@@ -1063,6 +1064,7 @@ export default class hyperliquid extends Exchange {
          * @param {bool} [params.reduceOnly] true or false whether the order is reduce-only
          * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
          * @param {string} [params.clientOrderId] client order id, (optional 128 bit hex string e.g. 0x1234567890abcdef1234567890abcdef)
+         * @param {string} [params.vaultAddress] the vault address for order
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         this.checkRequiredCredentials ();

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -149,6 +149,22 @@
                   70000.234234324
                 ],
                 "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"73500\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"brokerCode\":1},\"nonce\":1710527621347,\"signature\":{\"r\":\"0xba8575938a44e3e291085efb8e9682af3e9da54d5fbcbf49316c89b4ae84dba4\",\"s\":\"0x1d20dc5973f66161f4cd856d50611543d11f65f59a1bc53e33b01e1a4874b555\",\"v\":28}}"
+            },
+            {
+                "description": "Order with timeInForce",
+                "method": "createOrder",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                  "BTC/USDC:USDC",
+                  "limit",
+                  "buy",
+                  0.0014646006034154486,
+                  60000.234234324,
+                  {
+                    "timeInForce": "GTC"
+                  }
+                ],
+                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"60000\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"brokerCode\":1},\"nonce\":1710929482709,\"signature\":{\"r\":\"0xdae9324db6a93f1c2062d24107f12e1549ec03f3313a6c4d7547e2f11c72b623\",\"s\":\"0x1e42a0c6edd18fe34c41d5c5e891e163449e66df27f537df0a79e5495cd273b1\",\"v\":28}}"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
fix ccxt/ccxt#21824

Changes:
- doc
- types
- omit timeInForce

Test:
```BASH
$ python3 examples/py/cli.py hyperliquid createOrder ETH/USDC:USDC limit buy 0.01 3000 '{"timeInForce": "Gtc"}' --test
Python v3.8.10
CCXT v4.2.77
hyperliquid.createOrder(ETH/USDC:USDC,limit,buy,0.01,3000,{'timeInForce': 'Gtc'})
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '8312969823',
 'info': {'resting': {'oid': '8312969823'}},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': None,
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```