### PR TITLE
fix(coinbase): allow params in fetchAccountId

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -2263,9 +2263,9 @@ export default class coinbase extends Exchange {
         };
     }
 
-    async findAccountId (code) {
-        await this.loadMarkets ();
-        await this.loadAccounts ();
+    async findAccountId (code, params = {}) {
+        await this.loadMarkets (false, params);
+        await this.loadAccounts (false, params);
         for (let i = 0; i < this.accounts.length; i++) {
             const account = this.accounts[i];
             if (account['code'] === code) {
@@ -2296,7 +2296,7 @@ export default class coinbase extends Exchange {
             if (code === undefined) {
                 throw new ArgumentsRequired (this.id + ' prepareAccountRequestWithCurrencyCode() method requires an account_id (or accountId) parameter OR a currency code argument');
             }
-            accountId = await this.findAccountId (code);
+            accountId = await this.findAccountId (code, params);
             if (accountId === undefined) {
                 throw new ExchangeError (this.id + ' prepareAccountRequestWithCurrencyCode() could not find account id for ' + code);
             }
@@ -3443,7 +3443,7 @@ export default class coinbase extends Exchange {
             if (code === undefined) {
                 throw new ArgumentsRequired (this.id + ' withdraw() requires an account_id (or accountId) parameter OR a currency code argument');
             }
-            accountId = await this.findAccountId (code);
+            accountId = await this.findAccountId (code, params);
             if (accountId === undefined) {
                 throw new ExchangeError (this.id + ' withdraw() could not find account id for ' + code);
             }
@@ -3671,7 +3671,7 @@ export default class coinbase extends Exchange {
             if (code === undefined) {
                 throw new ArgumentsRequired (this.id + ' deposit() requires an account_id (or accountId) parameter OR a currency code argument');
             }
-            accountId = await this.findAccountId (code);
+            accountId = await this.findAccountId (code, params);
             if (accountId === undefined) {
                 throw new ExchangeError (this.id + ' deposit() could not find account id for ' + code);
             }
@@ -3742,7 +3742,7 @@ export default class coinbase extends Exchange {
             if (code === undefined) {
                 throw new ArgumentsRequired (this.id + ' fetchDeposit() requires an account_id (or accountId) parameter OR a currency code argument');
             }
-            accountId = await this.findAccountId (code);
+            accountId = await this.findAccountId (code, params);
             if (accountId === undefined) {
                 throw new ExchangeError (this.id + ' fetchDeposit() could not find account id for ' + code);
             }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1166,7 +1166,8 @@ export default class coinbase extends Exchange {
             this.v3PrivateGetBrokerageTransactionSummary (params),
         ];
         // const response = await this.v3PrivateGetBrokerageProducts (params);
-        const response = this.safeDict (promisesUnresolved, 0, {});
+        const promises = await Promise.all (promisesUnresolved);
+        const response = this.safeDict (promises, 0, {});
         //
         //     [
         //         {
@@ -1202,7 +1203,7 @@ export default class coinbase extends Exchange {
         //     ]
         //
         // const fees = await this.v3PrivateGetBrokerageTransactionSummary (params);
-        const fees = this.safeDict (promisesUnresolved, 1, {});
+        const fees = this.safeDict (promises, 1, {});
         //
         //     {
         //         "total_volume": 0,


### PR DESCRIPTION
fix ccxt/ccxt#21820

```BASH
$ python3 examples/py/cli.py coinbase findAccountId USDT '{"limit":1,"paginate":true}'
Python v3.8.10
CCXT v4.2.77
coinbase.findAccountId(USDT,{'limit': 1, 'paginate': True})
'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'

$ python3 examples/py/cli.py coinbase findAccountId USDT '{"limit":1}'
Python v3.8.10
CCXT v4.2.77
coinbase.findAccountId(USDT,{'limit': 1})
None
```