### PR TITLE
fix(coinbaseinternational): api docs link

### DIFF
--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -119,7 +119,7 @@ export default class coinbaseinternational extends Exchange {
                 },
                 'www': 'https://international.coinbase.com',
                 'doc': [
-                    'https://docs.cloud.coinbaseinternational.com/intx/docs',
+                    'https://docs.cloud.coinbase.com/intx/docs',
                 ],
                 'fees': [
                     'https://help.coinbaseinternational.com/en/international-exchange/trading-deposits-withdrawals/international-exchange-fees',

--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -122,7 +122,7 @@ export default class coinbaseinternational extends Exchange {
                     'https://docs.cloud.coinbase.com/intx/docs',
                 ],
                 'fees': [
-                    'https://help.coinbaseinternational.com/en/international-exchange/trading-deposits-withdrawals/international-exchange-fees',
+                    'https://help.coinbase.com/en/international-exchange/trading-deposits-withdrawals/international-exchange-fees',
                 ],
                 'referral': '',
             },


### PR DESCRIPTION
I'm getting this with the current docs link, I think that might be really bad for SEO. The new link is for coinbaseinternational anyway

![](https://i.imgur.com/s30V1F7.png)