### PR TITLE
Remove usage of deprecated python datetime functions

### DIFF
--- a/python/ccxt/async_support/base/ws/functions.py
+++ b/python/ccxt/async_support/base/ws/functions.py
@@ -34,7 +34,7 @@ def iso8601(timestamp=None):
     if int(timestamp) < 0:
         return None
     try:
-        utc = datetime.datetime.utcfromtimestamp(timestamp // 1000)
+        utc = datetime.datetime.fromtimestamp(timestamp // 1000, datetime.timezone.utc)
         return utc.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-6] + "{:03d}".format(int(timestamp) % 1000) + 'Z'
     except (TypeError, OverflowError, OSError):
         return None

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1171,7 +1171,7 @@ class Exchange(object):
             return None
 
         try:
-            utc = datetime.datetime.utcfromtimestamp(timestamp // 1000)
+            utc = datetime.datetime.fromtimestamp(timestamp // 1000, datetime.timezone.utc)
             return utc.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-6] + "{:03d}".format(int(timestamp) % 1000) + 'Z'
         except (TypeError, OverflowError, OSError):
             return None
@@ -1187,13 +1187,13 @@ class Exchange(object):
 
     @staticmethod
     def dmy(timestamp, infix='-'):
-        utc_datetime = datetime.datetime.utcfromtimestamp(int(round(timestamp / 1000)))
+        utc_datetime = datetime.datetime.fromtimestamp(int(round(timestamp / 1000)), datetime.timezone.utc)
         return utc_datetime.strftime('%m' + infix + '%d' + infix + '%Y')
 
     @staticmethod
     def ymd(timestamp, infix='-', fullYear=True):
         year_format = '%Y' if fullYear else '%y'
-        utc_datetime = datetime.datetime.utcfromtimestamp(int(round(timestamp / 1000)))
+        utc_datetime = datetime.datetime.fromtimestamp(int(round(timestamp / 1000)), datetime.timezone.utc)
         return utc_datetime.strftime(year_format + infix + '%m' + infix + '%d')
 
     @staticmethod
@@ -1206,7 +1206,7 @@ class Exchange(object):
 
     @staticmethod
     def ymdhms(timestamp, infix=' '):
-        utc_datetime = datetime.datetime.utcfromtimestamp(int(round(timestamp / 1000)))
+        utc_datetime = datetime.datetime.fromtimestamp(int(round(timestamp / 1000)), datetime.timezone.utc)
         return utc_datetime.strftime('%Y-%m-%d' + infix + '%H:%M:%S')
 
     @staticmethod


### PR DESCRIPTION
python's `datetime.utcfromtimestamp()` (as well as `datetime.utcnow()`) are deprecated since 3.12.

[utcfromtimestamp](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp)
[for utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow)

now the `utcnow()` warning is clearer what the replacement is - but the change proposed in this PR behaves identical to the previous version - though without raising warnings.


Running a python shell with warnings enabled (`python -Walways`) does show warnings like this in the current version:
 
```
/envs/trade_3122/lib/python3.12/site-packages/ccxt/base/exchange.py:1174: DeprecationWarning: datetime.da
tetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).         
    utc = datetime.datetime.utcfromtimestamp(timestamp // 1000) 
```
