### PR TITLE
deribit: new methods, fetchOption and fetchOptionChain

### DIFF
--- a/build/export-exchanges.js
+++ b/build/export-exchanges.js
@@ -526,7 +526,7 @@ async function exportEverything () {
     const flat = flatten (errorHierarchy)
     flat.push ('error_hierarchy')
 
-    const typeExports = ['Market', 'Trade' , 'Fee', 'Ticker', 'OrderBook', 'Order', 'Transaction', 'Tickers', 'Currency', 'Balance', 'DepositAddress', 'WithdrawalResponse', 'DepositAddressResponse', 'OHLCV', 'Balances', 'PartialBalances', 'Dictionary', 'MinMax', 'Position', 'FundingRateHistory', 'Liquidation', 'FundingHistory', 'MarginMode', 'Greeks', 'Leverage', 'Leverages' ]
+    const typeExports = ['Market', 'Trade' , 'Fee', 'Ticker', 'OrderBook', 'Order', 'Transaction', 'Tickers', 'Currency', 'Balance', 'DepositAddress', 'WithdrawalResponse', 'DepositAddressResponse', 'OHLCV', 'Balances', 'PartialBalances', 'Dictionary', 'MinMax', 'Position', 'FundingRateHistory', 'Liquidation', 'FundingHistory', 'MarginMode', 'Greeks', 'Leverage', 'Leverages', 'Option', 'OptionChain' ]
     const errorsExports = ['BaseError', 'ExchangeError', 'PermissionDenied', 'AccountNotEnabled', 'AccountSuspended', 'ArgumentsRequired', 'BadRequest', 'BadSymbol', 'MarginModeAlreadySet', 'BadResponse', 'NullResponse', 'InsufficientFunds', 'InvalidAddress', 'InvalidOrder', 'OrderNotFound', 'OrderNotCached', 'CancelPending', 'OrderImmediatelyFillable', 'OrderNotFillable', 'DuplicateOrderId', 'NotSupported', 'NetworkError', 'DDoSProtection', 'RateLimitExceeded', 'ExchangeNotAvailable', 'OnMaintenance', 'InvalidNonce', 'RequestTimeout', 'AuthenticationError', 'AddressPending', 'NoChange']
     const staticExports = ['version', 'Exchange', 'exchanges', 'pro', 'Precise', 'functions', 'errors'].concat(errorsExports).concat(typeExports)
 

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1002,6 +1002,8 @@ class Transpiler {
             'MarketInterface': /-> MarketInterface:/,
             'MarketType': /: MarketType/,
             'Num': /: Num =/,
+            'Option': /-> Option:/,
+            'OptionChain': /-> OptionChain:/,
             'Order': /-> (?:List\[)?Order\]?:/,
             'OrderBook': /-> OrderBook:/,
             'OrderRequest': /: (?:List\[)?OrderRequest/,

--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -1392,3 +1392,91 @@ public struct Account
         code = Exchange.SafeString(accountStructure, "code");
     }
 }
+
+
+public struct Option
+{
+    public string? currency;
+    public string? symbol;
+    public Int64? timestamp;
+    public string? datetime;
+
+    public double? impliedVolatility;
+
+    public double? openInterest;
+
+    public double? bidPrice;
+    public double? askPrice;
+    public double? midPrice;
+    public double? markPrice;
+    public double? lastPrice;
+    public double? underlyingPrice;
+    public double? change;
+    public double? percentage;
+
+    public double? baseVolume;
+    public double? quoteVolume;
+    public Dictionary<string, object> info;
+
+    public Option(object option2)
+    {
+        var ticker = (Dictionary<string, object>)option2;
+        currency = Exchange.SafeString(option2, "currency");
+        symbol = Exchange.SafeString(option2, "symbol");
+        timestamp = Exchange.SafeInteger(option2, "timestamp");
+        datetime = Exchange.SafeString(option2, "datetime");
+        impliedVolatility = Exchange.SafeFloat(option2, "bidVolume");
+        openInterest = Exchange.SafeFloat(option2, "openInterest");
+        bidPrice = Exchange.SafeFloat(option2, "askVolume");
+        askPrice = Exchange.SafeFloat(option2, "vwap");
+        midPrice = Exchange.SafeFloat(option2, "open");
+        markPrice = Exchange.SafeFloat(option2, "close");
+        lastPrice = Exchange.SafeFloat(option2, "last");
+        underlyingPrice = Exchange.SafeFloat(option2, "previousClose");
+        change = Exchange.SafeFloat(option2, "change");
+        percentage = Exchange.SafeFloat(option2, "percentage");
+        baseVolume = Exchange.SafeFloat(option2, "baseVolume");
+        quoteVolume = Exchange.SafeFloat(option2, "quoteVolume");
+        info = ticker.ContainsKey("info") ? (Dictionary<string, object>)ticker["info"] : null;
+    }
+}
+
+
+public struct OptionChain
+{
+    public Dictionary<string, object> info;
+    public Dictionary<string, Option> chains;
+
+    public OptionChain(object optionchains2)
+    {
+        var marginModes = (Dictionary<string, object>)optionchains2;
+
+        info = marginModes.ContainsKey("info") ? (Dictionary<string, object>)marginModes["info"] : null;
+        this.chains = new Dictionary<string, Option>();
+        foreach (var marginMode in marginModes)
+        {
+            if (marginMode.Key != "info")
+                this.chains.Add(marginMode.Key, new Option(marginMode.Value));
+        }
+    }
+
+    // Indexer
+    public Option this[string key]
+    {
+        get
+        {
+            if (chains.ContainsKey(key))
+            {
+                return chains[key];
+            }
+            else
+            {
+                throw new KeyNotFoundException($"The key '{key}' was not found in the chains.");
+            }
+        }
+        set
+        {
+            chains[key] = value;
+        }
+    }
+}

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -1283,6 +1283,12 @@ class Exchange(BaseExchange):
 
     async def fetch_greeks(self, symbol: str, params={}):
         raise NotSupported(self.id + ' fetchGreeks() is not supported yet')
+    
+    async def fetch_option_chain(self, code: str, params={}):
+        raise NotSupported(self.id + ' fetchOptionChain() is not supported yet')
+
+    async def fetch_option(self, symbol: str, params={}):
+        raise NotSupported(self.id + ' fetchOption() is not supported yet')
 
     async def fetch_deposits_withdrawals(self, code: Str = None, since: Int = None, limit: Int = None, params={}):
         """

--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -302,6 +302,28 @@ class Greeks(TypedDict):
     info: Dict[str, Any]
 
 
+class Option(TypedDict):
+    info: Dict[str, Any]
+    currency: Str
+    symbol: Str
+    timestamp: Int
+    datetime: Str
+    impliedVolatility: Num
+    openInterest: Num
+    bidPrice: Num
+    askPrice: Num
+    midPrice: Num
+    markPrice: Num
+    lastPrice: Num
+    underlyingPrice: Num
+    change: Num
+    percentage: Num
+    baseVolume: Num
+    quoteVolume: Num
+
+
+OptionChain = Dict[str, Option]
+
 class MarketInterface(TypedDict):
     info: Dict[str, Any]
     id: Str

--- a/ts/ccxt.ts
+++ b/ts/ccxt.ts
@@ -33,7 +33,7 @@ import { Exchange }  from './src/base/Exchange.js'
 import { Precise }   from './src/base/Precise.js'
 import * as functions from './src/base/functions.js'
 import * as errors   from './src/base/errors.js'
-import type { Market, Trade , Fee, Ticker, OrderBook, Order, Transaction, Tickers, Currency, Balance, DepositAddress, WithdrawalResponse, DepositAddressResponse, OHLCV, Balances, PartialBalances, Dictionary, MinMax, Position, FundingRateHistory, Liquidation, FundingHistory, MarginMode, Greeks, Leverage, Leverages } from './src/base/types.js'
+import type { Market, Trade , Fee, Ticker, OrderBook, Order, Transaction, Tickers, Currency, Balance, DepositAddress, WithdrawalResponse, DepositAddressResponse, OHLCV, Balances, PartialBalances, Dictionary, MinMax, Position, FundingRateHistory, Liquidation, FundingHistory, MarginMode, Greeks, Leverage, Leverages, Option, OptionChain } from './src/base/types.js'
 import { BaseError, ExchangeError, PermissionDenied, AccountNotEnabled, AccountSuspended, ArgumentsRequired, BadRequest, BadSymbol, MarginModeAlreadySet, BadResponse, NullResponse, InsufficientFunds, InvalidAddress, InvalidOrder, OrderNotFound, OrderNotCached, CancelPending, OrderImmediatelyFillable, OrderNotFillable, DuplicateOrderId, NotSupported, NetworkError, DDoSProtection, RateLimitExceeded, ExchangeNotAvailable, OnMaintenance, InvalidNonce, RequestTimeout, AuthenticationError, AddressPending, NoChange }  from './src/base/errors.js'
 
 
@@ -468,6 +468,8 @@ export {
     Greeks,
     Leverage,
     Leverages,
+    Option,
+    OptionChain,
     ace,
     alpaca,
     ascendex,

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -146,10 +146,10 @@ import { OrderBook as WsOrderBook, IndexedOrderBook, CountedOrderBook } from './
 //
 import { axolotl } from './functions/crypto.js';
 // import types
-import type { Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, DepositAddressResponse, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, FundingRate, DepositWithdrawFeeNetwork, LedgerEntry, BorrowInterest, OpenInterest, LeverageTier, TransferEntry, BorrowRate, FundingRateHistory, Liquidation, FundingHistory, OrderRequest, MarginMode, Tickers, Greeks,  Str, Num, MarketInterface, CurrencyInterface, BalanceAccount, MarginModes, MarketType, Leverage, Leverages, LastPrice, LastPrices, Account, Strings } from './types.js';
+import type { Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, DepositAddressResponse, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, FundingRate, DepositWithdrawFeeNetwork, LedgerEntry, BorrowInterest, OpenInterest, LeverageTier, TransferEntry, BorrowRate, FundingRateHistory, Liquidation, FundingHistory, OrderRequest, MarginMode, Tickers, Greeks, Option, OptionChain, Str, Num, MarketInterface, CurrencyInterface, BalanceAccount, MarginModes, MarketType, Leverage, Leverages, LastPrice, LastPrices, Account, Strings } from './types.js';
 // export {Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, DepositAddressResponse, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, FundingRateHistory, Liquidation, FundingHistory} from './types.js'
 // import { Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, DepositAddressResponse, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, FundingRateHistory, OpenInterest, Liquidation, OrderRequest, FundingHistory, MarginMode, Tickers, Greeks, Str, Num, MarketInterface, CurrencyInterface, Account } from './types.js';
-export type { Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, DepositAddressResponse, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, LedgerEntry, BorrowInterest, OpenInterest, LeverageTier, TransferEntry, BorrowRate, FundingRateHistory, Liquidation, FundingHistory, OrderRequest, MarginMode, Tickers, Greeks,  Str, Num, MarketInterface, CurrencyInterface, BalanceAccount, MarginModes, MarketType, Leverage, Leverages, LastPrice, LastPrices, Account, Strings } from './types.js'
+export type { Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, DepositAddressResponse, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, LedgerEntry, BorrowInterest, OpenInterest, LeverageTier, TransferEntry, BorrowRate, FundingRateHistory, Liquidation, FundingHistory, OrderRequest, MarginMode, Tickers, Greeks, Option, OptionChain, Str, Num, MarketInterface, CurrencyInterface, BalanceAccount, MarginModes, MarketType, Leverage, Leverages, LastPrice, LastPrices, Account, Strings } from './types.js'
 
 // ----------------------------------------------------------------------------
 // move this elsewhere.
@@ -578,6 +578,8 @@ export default class Exchange {
                 'fetchOpenOrder': undefined,
                 'fetchOpenOrders': undefined,
                 'fetchOpenOrdersWs': undefined,
+                'fetchOption': undefined,
+                'fetchOptionChain': undefined,
                 'fetchOrder': undefined,
                 'fetchOrderBook': true,
                 'fetchOrderBooks': undefined,
@@ -4951,6 +4953,14 @@ export default class Exchange {
         throw new NotSupported (this.id + ' fetchGreeks() is not supported yet');
     }
 
+    async fetchOptionChain (code: string, params = {}): Promise<OptionChain> {
+        throw new NotSupported (this.id + ' fetchOptionChain() is not supported yet');
+    }
+
+    async fetchOption (symbol: string, params = {}): Promise<Option> {
+        throw new NotSupported (this.id + ' fetchOption() is not supported yet');
+    }
+
     async fetchDepositsWithdrawals (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         /**
          * @method
@@ -6192,6 +6202,23 @@ export default class Exchange {
 
     parseGreeks (greeks, market: Market = undefined): Greeks {
         throw new NotSupported (this.id + ' parseGreeks () is not supported yet');
+    }
+
+    parseOption (chain, currency: Currency = undefined, market: Market = undefined): Option {
+        throw new NotSupported (this.id + ' parseOption () is not supported yet');
+    }
+
+    parseOptionChain (response: object[], currencyKey: Str = undefined, symbolKey: Str = undefined): OptionChain {
+        const optionStructures = {};
+        for (let i = 0; i < response.length; i++) {
+            const info = response[i];
+            const currencyId = this.safeString (info, currencyKey);
+            const currency = this.safeCurrency (currencyId);
+            const marketId = this.safeString (info, symbolKey);
+            const market = this.safeMarket (marketId, undefined, undefined, 'option');
+            optionStructures[market['symbol']] = this.parseOption (info, currency, market);
+        }
+        return optionStructures;
     }
 
     parseMarginModes (response: object[], symbols: string[] = undefined, symbolKey: Str = undefined, marketType: MarketType = undefined): MarginModes {

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -441,6 +441,27 @@ export interface Greeks {
     info: any;
 }
 
+export interface Option {
+    info: any;
+    currency: string;
+    symbol: string;
+    timestamp?: number
+    datetime?: Str;
+    impliedVolatility: number;
+    openInterest: number;
+    bidPrice: number;
+    askPrice: number;
+    midPrice: number;
+    markPrice: number;
+    lastPrice: number;
+    underlyingPrice: number;
+    change: number;
+    percentage: number;
+    baseVolume: number;
+    quoteVolume: number;
+
+}
+
 export interface LastPrice {
     symbol: string,
     timestamp?: number,
@@ -465,6 +486,9 @@ export interface LastPrices extends Dictionary<LastPrice> {
 }
 
 export interface MarginModes extends Dictionary<MarginMode> {
+}
+
+export interface OptionChain extends Dictionary<Option> {
 }
 
 /** [ timestamp, open, high, low, close, volume ] */

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -459,7 +459,6 @@ export interface Option {
     percentage: number;
     baseVolume: number;
     quoteVolume: number;
-
 }
 
 export interface LastPrice {

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -760,6 +760,26 @@
                     ]
                 ]
             }
+        ],
+        "fetchOption": [
+            {
+                "description": "Fetch an option contract",
+                "method": "fetchOption",
+                "url": "https://www.deribit.com/api/v2/public/get_book_summary_by_instrument?instrument_name=BTC-27DEC24-240000-C",
+                "input": [
+                  "BTC/USD:BTC-241227-240000-C"
+                ]
+            }
+        ],
+        "fetchOptionChain": [
+            {
+                "description": "Fetch an option chain",
+                "method": "fetchOptionChain",
+                "url": "https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=option",
+                "input": [
+                  "BTC"
+                ]
+            }
         ]
     }
 }

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1720,6 +1720,8 @@ The unified ccxt API is a subset of methods common among the exchanges. It curre
 - `fetchCrossBorrowRates (params)`
 - `fetchIsolatedBorrowRate (symbol, params)`
 - `fetchIsolatedBorrowRates (params)`
+- `fetchOption (symbol, params)`
+- `fetchOptionChain (code, params)`
 - ...
 
 ```text
@@ -2091,6 +2093,7 @@ if ($exchange->has['fetchMyTrades']) {
 - [Underlying Assets](#underlying-assets)
 - [Liquidations](#liquidations)
 - [Greeks](#greeks)
+- [OptionChain](#option-chain)
 
 ## Order Book
 
@@ -3313,6 +3316,64 @@ Returns
     'lastPrice': 0.215,                         // the last price of the option
     'underlyingPrice': 39165.86,                // the current market price of the underlying asset
     'info': { ... },                            // the original decoded JSON as is
+}
+```
+
+## Option Chain
+
+*option only*
+
+Use the `fetchOption` method to get the public details of a single option contract from the exchange.
+
+```javascript
+fetchOption (symbol, params = {})
+```
+
+Parameters
+
+- **symbol** (String) Unified CCXT market symbol (e.g. `"BTC/USD:BTC-240927-40000-C"`)
+- **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"category": "options"}`)
+
+Returns
+
+- An [option chain structure](#option-chain-structure)
+
+Use the `fetchOptionChain` method to get the public option chain data of an underlying currency from the exchange.
+
+```javascript
+fetchOptionChain (code, params = {})
+```
+
+Parameters
+
+- **code** (String) Unified CCXT currency code (e.g. `"BTC"`)
+- **params** (Dictionary) Extra parameters specific to the exchange API endpoint (e.g. `{"category": "options"}`)
+
+Returns
+
+- A list of [option chain structures](#option-chain-structure)
+
+### Option Chain Structure
+
+```javascript
+{
+    'info': { ... },                            // the original decoded JSON as is
+    'currency': 'BTC',                          // unified CCXT currency code
+    'symbol': 'BTC/USD:BTC-240927-40000-C',     // unified CCXT market symbol
+    'timestamp': 1699593511632,                 // unix timestamp in milliseconds
+    'datetime': '2023-11-10T05:18:31.632Z',     // ISO8601 datetime with milliseconds
+    'impliedVolatility': 60.06,                 // the expected percentage price change of the underlying asset, over the remaining life of the option
+    'openInterest': 10,                         // the number of open options contracts that have not been settled
+    'bidPrice': 0.214,                          // the bid price of the option
+    'askPrice': 0.2205,                         // the ask price of the option
+    'midPrice': 0.2205,                         // the price in between the bid and the ask
+    'markPrice': 0.2169,                        // the mark price of the option
+    'lastPrice': 0.215,                         // the last price of the option
+    'underlyingPrice': 39165.86,                // the current market price of the underlying asset
+    'change': 15.43,                            // the 24 hour price change in a dollar amount
+    'percentage': 11.86,                        // the 24 hour price change as a percentage
+    'baseVolume': 100.86,                       // the volume in units of the base currency
+    'quoteVolume': 23772.86,                    // the volume in units of the quote currency
 }
 ```
 


### PR DESCRIPTION
Created some new unified methods, `fetchOption` and `fetchOptionChain`, and added support to deribit:
```
deribit.fetchOption (BTC/USD:BTC-241227-240000-C)
2024-03-22T10:07:07.260Z iteration 0 passed in 176 ms

{
  info: {
    mid_price: '0.03975',
    volume_usd: '11045.12',
    quote_currency: 'BTC',
    estimated_delivery_price: '65383.75',
    creation_timestamp: '1711102028463',
    base_currency: 'BTC',
    underlying_index: 'BTC-27DEC24',
    underlying_price: '73663.61',
    volume: '4.0',
    interest_rate: '0.0',
    price_change: '-6.9767',
    open_interest: '274.2',
    ask_price: '0.0415',
    bid_price: '0.038',
    instrument_name: 'BTC-27DEC24-240000-C',
    mark_price: '0.03988742',
    last: '0.04',
    low: '0.04',
    high: '0.043'
  },
  symbol: 'BTC/USD:BTC-241227-240000-C',
  openInterest: 274.2,
  bidPrice: 0.038,
  askPrice: 0.0415,
  midPrice: 0.03975,
  markPrice: 0.03988742,
  lastPrice: 0.04,
  underlyingPrice: 73663.61,
  percentage: -6.9767,
  baseVolume: 4,
  quoteVolume: 11045.12
}
```