### PR TITLE
binance: add fetchOption

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2897,6 +2897,16 @@
                     "BTC/USDT"
                 ]
             }
+        ],
+        "fetchOption": [
+            {
+                "description": "Fetch an option contract",
+                "method": "fetchOption",
+                "url": "https://eapi.binance.com/eapi/v1/ticker?symbol=BTC-241227-80000-C",
+                "input": [
+                  "BTC/USDT:USDT-241227-80000-C"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchOption` support to binance and set `fetchOptionChain` to false:
```
binance.fetchOption (BTC/USDT:USDT-241227-80000-C)
2024-03-23T02:27:16.807Z iteration 0 passed in 395 ms

{
  info: {
    symbol: 'BTC-241227-80000-C',
    priceChange: '0',
    priceChangePercent: '0',
    lastPrice: '2750',
    lastQty: '0',
    open: '2750',
    high: '2750',
    low: '2750',
    volume: '0',
    amount: '0',
    bidPrice: '4880',
    askPrice: '0',
    openTime: '0',
    closeTime: '0',
    firstTradeId: '0',
    tradeCount: '0',
    strikePrice: '80000',
    exercisePrice: '63940.91568182'
  },
  symbol: 'BTC/USDT:USDT-241227-80000-C',
  bidPrice: 4880,
  askPrice: 0,
  lastPrice: 2750,
  underlyingPrice: 63940.91568182,
  change: 0,
  percentage: 0,
  baseVolume: 0
}
```