### PR TITLE
bybit: add fetchOption, fetchOptionChain

### DIFF
--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -939,6 +939,26 @@
                   "LTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchOptionChain": [
+            {
+                "description": "Fetch an entire option chain for an underlying asset",
+                "method": "fetchOptionChain",
+                "url": "https://api-testnet.bybit.com/v5/market/tickers?category=option&baseCoin=BTC",
+                "input": [
+                  "BTC"
+                ]
+            }
+        ],
+        "fetchOption": [
+            {
+                "description": "Fetch an option contract",
+                "method": "fetchOption",
+                "url": "https://api-testnet.bybit.com/v5/market/tickers?category=option&symbol=BTC-27DEC24-55000-P",
+                "input": [
+                  "BTC/USDC:USDC-241227-55000-P"
+                ]
+            }
         ]
     },
     "disabled": []


### PR DESCRIPTION
Added `fetchOption` and `fetchOptionChain` to bybit:
```
bybit.fetchOption (BTC/USDC:USDC-241227-55000-P)
2024-03-23T02:53:53.203Z iteration 0 passed in 952 ms

{
  info: {
    symbol: 'BTC-27DEC24-55000-P',
    bid1Price: '0',
    bid1Size: '0',
    bid1Iv: '0',
    ask1Price: '0',
    ask1Size: '0',
    ask1Iv: '0',
    lastPrice: '10980',
    highPrice24h: '0',
    lowPrice24h: '0',
    markPrice: '11823.35972129',
    indexPrice: '63783.9',
    markIv: '0.8866',
    underlyingPrice: '71652.59003661',
    openInterest: '0.01',
    turnover24h: '0',
    volume24h: '0',
    totalVolume: '2',
    totalTurnover: '78719',
    delta: '-0.23305856',
    gamma: '0.00000551',
    vega: '191.69986811',
    theta: '-30.43549743',
    predictedDeliveryPrice: '0',
    change24h: '0'
  },
  symbol: 'BTC/USDC:USDC-241227-55000-P',
  impliedVolatility: 0.8866,
  openInterest: 0.01,
  bidPrice: 0,
  askPrice: 0,
  markPrice: 11823.35972129,
  lastPrice: 10980,
  underlyingPrice: 71652.59003661,
  change: 0,
  baseVolume: 2
}
```