### PR TITLE
fix(bybit) - fetchTickers subType

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2101,6 +2101,7 @@ export default class bybit extends Exchange {
          * @see https://bybit-exchange.github.io/docs/v5/market/tickers
          * @param {string[]} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.subType] *contract only* 'linear', 'inverse'
          * @returns {object} an array of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
         await this.loadMarkets ();
@@ -2137,11 +2138,11 @@ export default class bybit extends Exchange {
         };
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
-        if (type === 'spot') {
+        let subType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params, 'linear');
+        if (type === 'spot' && subType === undefined) {
             request['category'] = 'spot';
         } else if (type === 'swap' || type === 'future') {
-            let subType = undefined;
-            [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params, 'linear');
             request['category'] = subType;
         } else if (type === 'option') {
             request['category'] = 'option';

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2138,11 +2138,16 @@ export default class bybit extends Exchange {
         };
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        // Calls like `.fetchTickers (undefined, {subType:'inverse'})` should be supported for this exchange, so
+        // as "options.defaultSubType" is also set in exchange options, we should consider `params.subType`
+        // with higher priority and only default to spot, if `subType` is not set in params
+        const passedSubType = this.safeString (params, 'subType');
         let subType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params, 'linear');
-        if (type === 'spot' && subType === undefined) {
+        // only if passedSubType is undefined, then use spot
+        if (type === 'spot' && passedSubType === undefined) {
             request['category'] = 'spot';
-        } else if (type === 'swap' || type === 'future') {
+        } else if (type === 'swap' || type === 'future' || subType !== undefined) {
             request['category'] = subType;
         } else if (type === 'option') {
             request['category'] = 'option';

--- a/ts/src/test/static/markets/bybit.json
+++ b/ts/src/test/static/markets/bybit.json
@@ -11,6 +11,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {
@@ -68,6 +70,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {
@@ -125,6 +129,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {
@@ -182,6 +188,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {
@@ -239,6 +247,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {
@@ -296,6 +306,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {
@@ -353,6 +365,8 @@
         "spot": true,
         "swap": false,
         "future": false,
+        "linear": false,
+        "inverse": false,
         "option": false,
         "contract": false,
         "precision": {

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -755,7 +755,44 @@
                         "BTCUSDT"
                     ]
                 ]
-            }
+            },
+            {
+                "description": "exchange default",
+                "method": "fetchTickers",
+                "url": "https://api.bybit.com/v5/market/tickers?category=linear",
+                "input": []
+            },
+            {
+                "description": "spot with option.defaultType",
+                "options": {
+                    "defaultType": "spot"
+                },
+                "method": "fetchTickers",
+                "url": "https://api.bybit.com/v5/market/tickers?category=spot",
+                "input": []
+            },
+            {
+                "description": "subtype:linear",
+                "method": "fetchTickers",
+                "url": "https://api.bybit.com/v5/market/tickers?category=linear",
+                "input": [
+                  null,
+                  {
+                    "subType": "linear"
+                  }
+                ]
+            },
+            {
+                "description": "subtype:inverse",
+                "method": "fetchTickers",
+                "url": "https://api.bybit.com/v5/market/tickers?category=inverse",
+                "input": [
+                  null,
+                  {
+                    "subType": "inverse"
+                  }
+                ]
+             }
         ],
         "fetchOHLCV": [
             {


### PR DESCRIPTION
with exchange.options.defaultType='spot', the call `await e.fetchTickers (undefined, {subType:'linear'})` should be possible. atm, it would lead to `spot` request 