### PR TITLE
fix(test) - exchange close exc

### DIFF
--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -191,7 +191,11 @@ function isNullValue (value) {
 }
 
 async function close (exchange: Exchange) {
-    await exchange.close ();
+    try {
+        await exchange.close ();
+    } catch (e) {
+        dump ('[TEST_WARNING]', 'Exchange close exception', exceptionMessage (e));
+    }
 }
 
 // *********************************


### PR DESCRIPTION
in JS, we have such errors: https://app.travis-ci.com/github/ccxt/ccxt/builds/269648925#L3539 
probably after this clause (when exchange is not loaded): https://github.com/ccxt/ccxt/blob/6ed3f39902e9aa21c0e502c8b98a4e44a7abfa30/ts/src/test/test.ts#L962-L963