### PR TITLE
feat(Exchange.cs): implement Close()

### DIFF
--- a/cs/ccxt/base/Exchange.cs
+++ b/cs/ccxt/base/Exchange.cs
@@ -556,7 +556,15 @@ public partial class Exchange
 
     public async Task Close()
     {
-        // stub
+        if (this.clients.Keys.Count > 0)
+        {
+            foreach (var key in this.clients.Keys)
+            {
+                var client = this.clients[key];
+                await client.Close();
+                this.clients.TryRemove(key, out _);
+            }
+        }
     }
 
     public async Task close()

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -354,6 +354,22 @@ public partial class Exchange
                 this.onError(this, ex);
             }
         }
+
+        public async Task Close()
+        {
+            if (this.webSocket.State == WebSocketState.Open)
+            {
+                await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Close", CancellationToken.None);
+            }
+            foreach (var future in this.futures.Values)
+            {
+                if (!future.task.IsCompleted)
+                {
+                    future.reject(new ExchangeClosedByUser("Connection closed by the user"));
+
+                }
+            }
+        }
     }
 
 }

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -359,7 +359,15 @@ public partial class Exchange
         {
             if (this.webSocket.State == WebSocketState.Open)
             {
-                await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Close", CancellationToken.None);
+                try
+                {
+                    await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Close", CancellationToken.None);
+                }
+                catch (Exception e)
+                {
+                    // Console.WriteLine(e);
+                }
+
             }
             foreach (var future in this.futures.Values)
             {


### PR DESCRIPTION

- relates to https://github.com/ccxt/ccxt/issues/21924
How to test this feature:
```C#

    public static async Task runBackground(ccxt.Exchange exchange)
    {

        while (true)
        {
            try
            {
                var trades = await exchange.WatchTrades("DIAC/USDT");
                Console.WriteLine("Got trade");
            }
            catch (Exception e)
            {
                Console.WriteLine(e);
                break;
            }
        }
    }

```

```C#
        var exchange = new ccxt.pro.coinex();
        exchange.LoadMarkets().Wait();
        Task.Run(async () =>
            {
                await runBackground(exchange);
            });
        Task.Run(async () =>
        {
            await Task.Delay(5000);
            Console.WriteLine("Closing");
            try
            {
                await exchange.Close();
            }
            catch (Exception e)
            {
                Console.WriteLine(e);
            }
            Console.WriteLine("Closed");

        }).Wait();
```
