### PR TITLE
bybit: update parsePosition

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -6315,6 +6315,12 @@ export default class bybit extends Exchange {
         if (timestamp === undefined) {
             timestamp = this.safeIntegerN (position, [ 'updatedTime', 'updatedAt' ]);
         }
+        const tradeMode = this.safeInteger (position, 'tradeMode', 0);
+        let marginMode = undefined;
+        if ((!this.options['enableUnifiedAccount']) || (this.options['enableUnifiedAccount'] && market['inverse'])) {
+            // tradeMode would work for classic and UTA(inverse)
+            marginMode = tradeMode ? 'isolated' : 'cross';
+        }
         let collateralString = this.safeString (position, 'positionBalance');
         const entryPrice = this.omitZero (this.safeString2 (position, 'entryPrice', 'avgPrice'));
         const liquidationPrice = this.omitZero (this.safeString (position, 'liqPrice'));
@@ -6376,7 +6382,7 @@ export default class bybit extends Exchange {
             'markPrice': this.safeNumber (position, 'markPrice'),
             'lastPrice': undefined,
             'collateral': this.parseNumber (collateralString),
-            'marginMode': undefined,
+            'marginMode': marginMode,
             'side': side,
             'percentage': undefined,
             'stopLossPrice': this.safeNumber2 (position, 'stop_loss', 'stopLoss'),


### PR DESCRIPTION
fix: ccxt/ccxt#21941

```BASH
$ n bybit fetchPositions '["BTC/USD:BTC"]' --test

     symbol |     timestamp |                 datetime | initialMargin | maintenanceMargin | notional | leverage | contracts | contractSize | markPrice | collateral | marginMode | stopLossPrice | takeProfitPrice
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BTC/USD:BTC | 1711524714893 | 2024-03-27T07:31:54.893Z |             0 |                 0 |        0 |       10 |         0 |            1 |  69918.69 |          0 |   isolated |             0 |               0

$ n bybit fetchPositions '["ETH/USD:ETH"]' --test

     symbol |     timestamp |                 datetime | initialMargin | initialMarginPercentage | maintenanceMargin | maintenanceMarginPercentage |    entryPrice |   notional | leverage | unrealizedPnl | contracts | contractSize | marginRatio | markPrice | collateral | marginMode |  side | stopLossPrice | takeProfitPrice
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USD:ETH | 1711524987468 | 2024-03-27T07:36:27.468Z |     0.0000028 |    0.010006432706740048 |              5e-8 |        0.000178686298334643 | 3573.72596669 | 0.00027982 |       10 |        2.3e-7 |         1 |            1 |      0.0017 |   3570.69 | 0.00002813 |      cross | short |             0 |               0
```

> Need to test classic account in bybit.