### PR TITLE
cli: update fetch with --no-send

### DIFF
--- a/examples/js/cli.js
+++ b/examples/js/cli.js
@@ -321,7 +321,6 @@ async function run () {
                     headers,
                     body,
                 })
-                process.exit ()
             }
         }
 

--- a/examples/ts/cli.ts
+++ b/examples/ts/cli.ts
@@ -313,7 +313,6 @@ async function run () {
                     headers,
                     body,
                 })
-                process.exit ()
             }
         }
 


### PR DESCRIPTION
We called multiple functions in cli. Currently, the cli would exit after execute one function. In this PR. I removed `process.exit()`.