### PR TITLE
client & protect sendAsync

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -244,8 +244,10 @@ public partial class Exchange
                 }
                 catch (Exception ex)
                 {
-                    _connectSemaphore.Release();
                     tcs.SetException(ex); // Set the exception if something goes wrong
+                }
+                finally {
+                    _connectSemaphore.Release();
                 }
             });
 

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -208,6 +208,9 @@ public partial class Exchange
             }
         }
 
+
+        private static readonly SemaphoreSlim _connectSemaphore = new SemaphoreSlim(1, 1);
+
         public void Connect()
         {
             var tcs = this.connected;
@@ -222,6 +225,7 @@ public partial class Exchange
             {
                 try
                 {
+                    await _connectSemaphore.WaitAsync();
                     if (this.webSocket.State == WebSocketState.Open)
                     {
                         return; // already connected, return. Might happen when we call connect multiple times in a row
@@ -240,6 +244,7 @@ public partial class Exchange
                 }
                 catch (Exception ex)
                 {
+                    _connectSemaphore.Release();
                     tcs.SetException(ex); // Set the exception if something goes wrong
                 }
             });

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -239,7 +239,7 @@ export default class Exchange {
     login:string;
     password: string;
     privateKey: string;// a "0x"-prefixed hexstring private key for a wallet
-    walletAddress: string; // a wallet address "0x"-prefixed hexstring.
+    walletAddress: string; // a wallet address "0x"-prefixed hexstring
     token: string; // reserved for HTTP auth in some cases
 
     balance      = {}


### PR DESCRIPTION
_(fix #21920)_

for me, this fixed the issue of sendAsync. as I read, websocket cant have two simultaneous sendAsync operations, so one needs to be finished before another starts.

However, the second issue of websocket state still remains, will push the update for it too.