### PR TITLE
fix(okcoin) - ohlcv limits 

### DIFF
--- a/ts/src/okcoin.ts
+++ b/ts/src/okcoin.ts
@@ -1144,8 +1144,10 @@ export default class okcoin extends Exchange {
         const request = {
             'instId': market['id'],
             'bar': bar,
-            'limit': limit,
         };
+        if (limit !== undefined) {
+            request['limit'] = limit; // default 100, max 100
+        }
         let method = undefined;
         [ method, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'method', 'publicGetMarketCandles');
         let response = undefined;

--- a/ts/src/test/static/request/okcoin.json
+++ b/ts/src/test/static/request/okcoin.json
@@ -147,6 +147,16 @@
                 "url": "https://www.okcoin.com/api/v5/public/time",
                 "input": []
             }
+        ],
+        "fetchOHLCV": [
+            {
+                "description": "without args",
+                "method": "fetchOHLCV",
+                "url": "https://www.okcoin.com/api/v5/market/candles?instId=BTC-USD&bar=1m",
+                "input": [
+                  "BTC/USD"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
```
npm run cli.js okcoin -- fetchOHLCV BTC/USD

> ccxt@4.2.84 cli.js
> node ./examples/js/cli.js okcoin fetchOHLCV BTC/USD

2024-03-27T14:27:59.451Z
Node.js: v20.10.0
CCXT v4.2.84
okcoin.fetchOHLCV (BTC/USD)
2024-03-27T14:27:59.951Z iteration 0 passed in 205 ms

1711543680000 | 70132.46 | 70132.46 | 70132.46 | 70132.46 |      0
1711543740000 | 70132.46 | 70132.46 | 70132.46 | 70132.46 |      0
...
```