### PR TITLE
fix(bingx): fetchPosition - notional and collateral values

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1694,19 +1694,27 @@ export default class bingx extends Exchange {
 
     parsePosition (position, market: Market = undefined) {
         //
-        //     {
-        //         "symbol": "BTC-USDT",
-        //         "positionId": "12345678",
-        //         "positionSide": "LONG",
-        //         "isolated": true,
-        //         "positionAmt": "123.33",
-        //         "availableAmt": "128.99",
-        //         "unrealizedProfit": "1.22",
-        //         "realisedProfit": "8.1",
-        //         "initialMargin": "123.33",
-        //         "avgPrice": "2.2",
-        //         "leverage": 10,
-        //     }
+        //    {
+        //        "positionId":"1773122376147623936",
+        //        "symbol":"XRP-USDT",
+        //        "currency":"USDT",
+        //        "positionAmt":"3",
+        //        "availableAmt":"3",
+        //        "positionSide":"LONG",
+        //        "isolated":false,
+        //        "avgPrice":"0.6139",
+        //        "initialMargin":"0.0897",
+        //        "leverage":20,
+        //        "unrealizedProfit":"-0.0023",
+        //        "realisedProfit":"-0.0009",
+        //        "liquidationPrice":0,
+        //        "pnlRatio":"-0.0260",
+        //        "maxMarginReduction":"",
+        //        "riskRate":"",
+        //        "markPrice":"",
+        //        "positionValue":"",
+        //        "onlyOnePosition":false
+        //    }
         //
         // standard position
         //
@@ -1733,7 +1741,7 @@ export default class bingx extends Exchange {
             'info': position,
             'id': this.safeString (position, 'positionId'),
             'symbol': this.safeSymbol (marketId, market, '-', 'swap'),
-            'notional': this.safeNumber (position, 'positionAmt'),
+            'notional': this.safeNumber (position, 'positionValue'),
             'marginMode': marginMode,
             'liquidationPrice': undefined,
             'entryPrice': this.safeNumber2 (position, 'avgPrice', 'entryPrice'),
@@ -1751,7 +1759,7 @@ export default class bingx extends Exchange {
             'lastUpdateTimestamp': undefined,
             'maintenanceMargin': undefined,
             'maintenanceMarginPercentage': undefined,
-            'collateral': this.safeNumber (position, 'positionAmt'),
+            'collateral': undefined,
             'initialMargin': this.safeNumber (position, 'initialMargin'),
             'initialMarginPercentage': undefined,
             'leverage': this.safeNumber (position, 'leverage'),

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -1546,6 +1546,96 @@
                   ]
                 }
             }
+        ],
+        "fetchPositions": [
+            {
+                "description": "fetch position",
+                "method": "fetchPositions",
+                "input": [
+                  [
+                    "LTC/USDT:USDT"
+                  ]
+                ],
+                "httpResponse": {
+                  "code": "0",
+                  "msg": "",
+                  "data": [
+                    {
+                      "positionId": "1773289330136281088",
+                      "symbol": "LTC-USDT",
+                      "currency": "USDT",
+                      "positionAmt": "0.1",
+                      "availableAmt": "0.1",
+                      "positionSide": "LONG",
+                      "isolated": false,
+                      "avgPrice": "95.61",
+                      "initialMargin": "1.9128",
+                      "leverage": "5",
+                      "unrealizedProfit": "0.0005",
+                      "realisedProfit": "-0.0048",
+                      "liquidationPrice": "0",
+                      "pnlRatio": "0.0002",
+                      "maxMarginReduction": "0.0000",
+                      "riskRate": "0.0068",
+                      "markPrice": "95.62",
+                      "positionValue": "9.5616",
+                      "onlyOnePosition": false
+                    }
+                  ]
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "positionId": "1773289330136281088",
+                      "symbol": "LTC-USDT",
+                      "currency": "USDT",
+                      "positionAmt": "0.1",
+                      "availableAmt": "0.1",
+                      "positionSide": "LONG",
+                      "isolated": false,
+                      "avgPrice": "95.61",
+                      "initialMargin": "1.9128",
+                      "leverage": "5",
+                      "unrealizedProfit": "0.0005",
+                      "realisedProfit": "-0.0048",
+                      "liquidationPrice": "0",
+                      "pnlRatio": "0.0002",
+                      "maxMarginReduction": "0.0000",
+                      "riskRate": "0.0068",
+                      "markPrice": "95.62",
+                      "positionValue": "9.5616",
+                      "onlyOnePosition": false
+                    },
+                    "id": "1773289330136281088",
+                    "symbol": "LTC/USDT:USDT",
+                    "notional": 9.5616,
+                    "marginMode": "cross",
+                    "liquidationPrice": null,
+                    "entryPrice": 95.61,
+                    "unrealizedPnl": 0.0005,
+                    "realizedPnl": -0.0048,
+                    "percentage": null,
+                    "contracts": 0.1,
+                    "contractSize": 0.1,
+                    "markPrice": null,
+                    "lastPrice": null,
+                    "side": "long",
+                    "hedged": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastUpdateTimestamp": null,
+                    "maintenanceMargin": null,
+                    "maintenanceMarginPercentage": null,
+                    "collateral": null,
+                    "initialMargin": 1.9128,
+                    "initialMarginPercentage": null,
+                    "leverage": 5,
+                    "marginRatio": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
```
Python v3.9.6
CCXT v4.2.85
bingx.fetchPositions()
[{'collateral': None,
  'contractSize': 0.0,
  'contracts': 3.0,
  'datetime': None,
  'entryPrice': 0.6139,
  'hedged': None,
  'id': '1773122376147623936',
  'info': {'availableAmt': '3',
           'avgPrice': '0.6139',
           'currency': 'USDT',
           'initialMargin': '0.0901',
           'isolated': False,
           'leverage': '20',
           'liquidationPrice': '0',
           'markPrice': '',
           'maxMarginReduction': '',
           'onlyOnePosition': False,
           'pnlRatio': '-0.0214',
           'positionAmt': '3',
           'positionId': '1773122376147623936',
           'positionSide': 'LONG',
           'positionValue': '',
           'realisedProfit': '-0.0009',
           'riskRate': '',
           'symbol': 'XRP-USDT',
           'unrealizedProfit': '-0.0019'},
  'initialMargin': 0.0901,
  'initialMarginPercentage': None,
  'lastPrice': None,
  'lastUpdateTimestamp': None,
  'leverage': 20.0,
  'liquidationPrice': None,
  'maintenanceMargin': None,
  'maintenanceMarginPercentage': None,
  'marginMode': 'cross',
  'marginRatio': None,
  'markPrice': None,
  'notional': None,
  'percentage': None,
  'realizedPnl': -0.0009,
  'side': 'long',
  'stopLossPrice': None,
  'symbol': 'XRP/USDT:USDT',
  'takeProfitPrice': None,
  'timestamp': None,
  'unrealizedPnl': -0.0019}]

```