### PR TITLE
coinex: fetchTime v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1073,19 +1073,22 @@ export default class coinex extends Exchange {
          * @method
          * @name coinex#fetchTime
          * @description fetches the current integer timestamp in milliseconds from the exchange server
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http005_system_time
+         * @see https://docs.coinex.com/api/v2/common/http/time
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {int} the current integer timestamp in milliseconds from the exchange server
          */
-        const response = await this.v1PerpetualPublicGetTime (params);
+        const response = await this.v2PublicGetTime (params);
         //
         //     {
-        //         "code": "0",
-        //         "data": "1653261274414",
+        //         "code": 0,
+        //         "data": {
+        //             "timestamp": 1711699867777
+        //         },
         //         "message": "OK"
         //     }
         //
-        return this.safeInteger (response, 'data');
+        const data = this.safeDict (response, 'data', {});
+        return this.safeInteger (data, 'timestamp');
     }
 
     async fetchOrderBook (symbol: string, limit: Int = 20, params = {}) {

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -752,9 +752,9 @@
         ],
         "fetchTime": [
             {
-                "description": "fetchTime",
+                "description": "Fetch the time",
                 "method": "fetchTime",
-                "url": "https://api.coinex.com/perpetual/v1/time",
+                "url": "https://api.coinex.com/v2/time",
                 "input": []
             }
         ],


### PR DESCRIPTION
Refactor fetchTime to use the v2 endpoint:
```
coinex.fetchTime ()
2024-03-29T08:11:07.409Z iteration 0 passed in 214 ms

1711699867777
```