### PR TITLE
coinex: fetchTradingFee, fetchTradingFees v2

### DIFF
--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -777,6 +777,42 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchTradingFee": [
+            {
+                "description": "Spot fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://api.coinex.com/v2/spot/market?market=BTCUSDT",
+                "input": [
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Swap fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://api.coinex.com/v2/futures/market?market=BTCUSDT",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchTradingFees": [
+            {
+                "description": "Spot fetch trading fees",
+                "method": "fetchTradingFees",
+                "url": "https://api.coinex.com/v2/spot/market",
+                "input": []
+            },
+            {
+                "description": "Swap fetch trading fees",
+                "method": "fetchTradingFees",
+                "url": "https://api.coinex.com/v2/futures/market",
+                "input": [
+                  {
+                    "type": "swap"
+                  }
+                ]
+            }
         ]
     },
     "disabledTests": {}

--- a/ts/src/test/static/response/coinex.json
+++ b/ts/src/test/static/response/coinex.json
@@ -729,6 +729,52 @@
                   }
                 ]
             }
+        ],
+        "fetchTradingFees": [
+            {
+                "description": "trading fee",
+                "method": "fetchTradingFee",
+                "input": [
+                  "BTC/USDT"
+                ],
+                "httpResponse": {
+                  "code": "0",
+                  "data": [
+                    {
+                      "base_ccy": "BTC",
+                      "base_ccy_precision": "8",
+                      "is_amm_available": false,
+                      "is_margin_available": true,
+                      "maker_fee_rate": "0.002",
+                      "market": "BTCUSDT",
+                      "min_amount": "0.0001",
+                      "quote_ccy": "USDT",
+                      "quote_ccy_precision": "2",
+                      "taker_fee_rate": "0.002"
+                    }
+                  ],
+                  "message": "OK"
+                },
+                "parsedResponse": {
+                  "info": {
+                    "base_ccy": "BTC",
+                    "base_ccy_precision": "8",
+                    "is_amm_available": false,
+                    "is_margin_available": true,
+                    "maker_fee_rate": "0.002",
+                    "market": "BTCUSDT",
+                    "min_amount": "0.0001",
+                    "quote_ccy": "USDT",
+                    "quote_ccy_precision": "2",
+                    "taker_fee_rate": "0.002"
+                  },
+                  "symbol": "BTC/USDT",
+                  "maker": 0.002,
+                  "taker": 0.002,
+                  "percentage": true,
+                  "tierBased": true
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Refactored fetchTradingFee and fetchTradingFees to use v2 endpoints:
```
coinex.fetchTradingFee (BTC/USDT)
2024-03-29T09:34:02.395Z iteration 0 passed in 228 ms

{
  info: {
    base_ccy: 'BTC',
    base_ccy_precision: '8',
    is_amm_available: false,
    is_margin_available: true,
    maker_fee_rate: '0.002',
    market: 'BTCUSDT',
    min_amount: '0.0001',
    quote_ccy: 'USDT',
    quote_ccy_precision: '2',
    taker_fee_rate: '0.002'
  },
  symbol: 'BTC/USDT',
  maker: 0.002,
  taker: 0.002,
  percentage: true,
  tierBased: true
}
```
```
coinex.fetchTradingFee (BTC/USDT:USDT)
2024-03-29T09:34:18.340Z iteration 0 passed in 276 ms

{
  info: {
    base_ccy: 'BTC',
    base_ccy_precision: '8',
    contract_type: 'linear',
    leverage: [
      '1',  '2',   '3',
      '5',  '8',   '10',
      '15', '20',  '30',
      '50', '100'
    ],
    maker_fee_rate: '0',
    market: 'BTCUSDT',
    min_amount: '0.0001',
    open_interest_volume: '203.8499',
    quote_ccy: 'USDT',
    quote_ccy_precision: '2',
    taker_fee_rate: '0'
  },
  symbol: 'BTC/USDT:USDT',
  maker: 0,
  taker: 0,
  percentage: true,
  tierBased: true
}
```