### PR TITLE
fix(cli): add needed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,6 @@
     "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
-    "ansicolor": "1.1.81",
-    "as-table": "1.0.37",
     "asciichart": "^1.5.25",
     "assert": "^2.0.0",
     "ast-transpiler": "^0.0.44",
@@ -159,7 +157,6 @@
     "esmify": "^2.1.1",
     "https-proxy-agent": "^5.0.1",
     "jsdoc-to-markdown": "^8.0.0",
-    "ololog": "1.1.155",
     "piscina": "^3.2.0",
     "replace-in-file": "^6.3.5",
     "rollup": "^2.70.1",
@@ -267,6 +264,9 @@
   },
   "ethereum": "0x26a3CB49578F07000575405a57888681249c35Fd",
   "dependencies": {
-    "ws": "^8.8.1"
+    "ws": "^8.8.1",
+    "ansicolor": "1.1.81",
+    "as-table": "1.0.37",
+    "ololog": "1.1.155"
   }
 }


### PR DESCRIPTION
###
Currently global ccxt cli is missing dependencies

### Alternative solution
it was discussed if these should be included as static_dependencies instead of using npm dependencies.

In my opinion this is easier to maintain but if you prefer to use static_dependencies let me know as I started the PR locally and could also upload.
These would the static_dependencies to add:
- [ansicolor](https://www.npmjs.com/package/ansicolor)
- [pipez](https://www.npmjs.com/package/pipez)[printable-characters](https://www.npmjs.com/package/printable-characters)
- [stacktracey](https://www.npmjs.com/package/stacktracey)
- [string.bullet](https://www.npmjs.com/package/string.bullet)
- [string.ify](https://www.npmjs.com/package/string.ify)
- [data-uri-to-buffer](https://www.npmjs.com/package/data-uri-to-buffer)
- [source-map](https://www.npmjs.com/package/source-map)
- [as-table](https://www.npmjs.com/package/as-table)