### PR TITLE
fix(tests) - types for skippedProps

### DIFF
--- a/ts/src/pro/test/Exchange/test.watchTickers.ts
+++ b/ts/src/pro/test/Exchange/test.watchTickers.ts
@@ -5,13 +5,13 @@ import testSharedMethods from '../../../test/Exchange/base/test.sharedMethods.js
 import { ArgumentsRequired } from '../../../base/errors.js';
 import { Exchange, Tickers } from '../../../../ccxt.js';
 
-async function testWatchTickers (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testWatchTickers (exchange: Exchange, skippedProperties: object, symbol: string) {
     const withoutSymbol = testWatchTickersHelper (exchange, skippedProperties, undefined);
     const withSymbol = testWatchTickersHelper (exchange, skippedProperties, [ symbol ]);
     await Promise.all ([ withSymbol, withoutSymbol ]);
 }
 
-async function testWatchTickersHelper (exchange: Exchange, skippedProperties: string[], argSymbols: string[], argParams = {}) {
+async function testWatchTickersHelper (exchange: Exchange, skippedProperties: object, argSymbols: string[], argParams = {}) {
     const method = 'watchTickers';
     let now = exchange.milliseconds ();
     const ends = now + 15000;

--- a/ts/src/test/Exchange/base/test.account.ts
+++ b/ts/src/test/Exchange/base/test.account.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testAccount (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testAccount (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'info': {},
         'code': 'BTC', // todo

--- a/ts/src/test/Exchange/base/test.balance.ts
+++ b/ts/src/test/Exchange/base/test.balance.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../../ccxt";
 import Precise from '../../../base/Precise.js';
 import testSharedMethods from './test.sharedMethods.js';
 
-function testBalance (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testBalance (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'free': {},
         'used': {},

--- a/ts/src/test/Exchange/base/test.borrowInterest.ts
+++ b/ts/src/test/Exchange/base/test.borrowInterest.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testBorrowInterest (exchange: Exchange, skippedProperties: string[], method: string, entry: object, requestedCode: string, requestedSymbol: string) {
+function testBorrowInterest (exchange: Exchange, skippedProperties: object, method: string, entry: object, requestedCode: string, requestedSymbol: string) {
     const format = {
         'info': {},
         'account': 'BTC/USDT',

--- a/ts/src/test/Exchange/base/test.borrowRate.ts
+++ b/ts/src/test/Exchange/base/test.borrowRate.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testBorrowRate (exchange: Exchange, skippedProperties: string[], method: string, entry: object, requestedCode: string) {
+function testBorrowRate (exchange: Exchange, skippedProperties: object, method: string, entry: object, requestedCode: string) {
     const format = {
         'info': {}, // Or []
         'currency': 'USDT',

--- a/ts/src/test/Exchange/base/test.currency.ts
+++ b/ts/src/test/Exchange/base/test.currency.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testCurrency (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testCurrency (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'id': 'btc', // string literal for referencing within an exchange
         'code': 'BTC', // uppercase string literal of a pair of currencies

--- a/ts/src/test/Exchange/base/test.depositWithdrawal.ts
+++ b/ts/src/test/Exchange/base/test.depositWithdrawal.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testDepositWithdrawal (exchange: Exchange, skippedProperties: string[], method: string, entry: object, requestedCode: string, now: number) {
+function testDepositWithdrawal (exchange: Exchange, skippedProperties: object, method: string, entry: object, requestedCode: string, now: number) {
     const format = {
         'info': {}, // or []
         'id': '1234',

--- a/ts/src/test/Exchange/base/test.fundingRateHistory.ts
+++ b/ts/src/test/Exchange/base/test.fundingRateHistory.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testFundingRateHistory (exchange: Exchange, skippedProperties: string[], method: string, entry: object, symbol: string) {
+function testFundingRateHistory (exchange: Exchange, skippedProperties: object, method: string, entry: object, symbol: string) {
     const format = {
         'info': {}, // Or []
         'symbol': 'BTC/USDT:USDT',

--- a/ts/src/test/Exchange/base/test.lastPrice.ts
+++ b/ts/src/test/Exchange/base/test.lastPrice.ts
@@ -2,7 +2,7 @@ import { Exchange } from "../../../../ccxt";
 import { LastPrice } from "../../../base/types";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testLastPrice (exchange: Exchange, skippedProperties: string[], method: string, entry: LastPrice, symbol: string) {
+function testLastPrice (exchange: Exchange, skippedProperties: object, method: string, entry: LastPrice, symbol: string) {
     const format = {
         'info': {},
         'symbol': 'ETH/BTC',

--- a/ts/src/test/Exchange/base/test.ledgerEntry.ts
+++ b/ts/src/test/Exchange/base/test.ledgerEntry.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testLedgerEntry (exchange: Exchange, skippedProperties: string[], method: string, entry: object, requestedCode: string, now: number) {
+function testLedgerEntry (exchange: Exchange, skippedProperties: object, method: string, entry: object, requestedCode: string, now: number) {
     const format = {
         'info': {},
         'id': 'x1234',

--- a/ts/src/test/Exchange/base/test.leverageTier.ts
+++ b/ts/src/test/Exchange/base/test.leverageTier.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testLeverageTier (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testLeverageTier (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'tier': exchange.parseNumber ('1'),
         'minNotional': exchange.parseNumber ('0'),

--- a/ts/src/test/Exchange/base/test.marginMode.ts
+++ b/ts/src/test/Exchange/base/test.marginMode.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testMarginMode (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testMarginMode (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'info': {},
         'symbol': 'BTC/USDT:USDT',

--- a/ts/src/test/Exchange/base/test.marginModification.ts
+++ b/ts/src/test/Exchange/base/test.marginModification.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testMarginModification (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testMarginModification (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'info': {}, // or []
         'type': 'add',

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -3,7 +3,7 @@ import Precise from '../../../base/Precise.js';
 import { Exchange, Market } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testMarket (exchange: Exchange, skippedProperties: string[], method: string, market: Market) {
+function testMarket (exchange: Exchange, skippedProperties: object, method: string, market: Market) {
     const format = {
         'id': 'btcusd', // string literal for referencing within an exchange
         'symbol': 'BTC/USD', // uppercase string literal of a pair of currencies

--- a/ts/src/test/Exchange/base/test.ohlcv.ts
+++ b/ts/src/test/Exchange/base/test.ohlcv.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testOHLCV (exchange: Exchange, skippedProperties: string[], method: string, entry: number[], symbol: string, now: number) {
+function testOHLCV (exchange: Exchange, skippedProperties: object, method: string, entry: number[], symbol: string, now: number) {
     const format = [
         1638230400000,
         exchange.parseNumber ('0.123'),

--- a/ts/src/test/Exchange/base/test.openInterest.ts
+++ b/ts/src/test/Exchange/base/test.openInterest.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testOpenInterest (exchange: Exchange, skippedProperties: string[], method: string, entry: object) {
+function testOpenInterest (exchange: Exchange, skippedProperties: object, method: string, entry: object) {
     const format = {
         'symbol': 'BTC/USDT',
         // 'baseVolume': exchange.parseNumber ('81094.084'), // deprecated

--- a/ts/src/test/Exchange/base/test.order.ts
+++ b/ts/src/test/Exchange/base/test.order.ts
@@ -2,7 +2,7 @@ import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 import testTrade from './test.trade.js';
 
-function testOrder (exchange: Exchange, skippedProperties: string[], method: string, entry: object, symbol: string, now: number) {
+function testOrder (exchange: Exchange, skippedProperties: object, method: string, entry: object, symbol: string, now: number) {
     const format = {
         'info': {},
         'id': '123',

--- a/ts/src/test/Exchange/base/test.orderBook.ts
+++ b/ts/src/test/Exchange/base/test.orderBook.ts
@@ -3,7 +3,7 @@ import { Exchange, OrderBook } from "../../../../ccxt";
 import Precise from '../../../base/Precise.js';
 import testSharedMethods from './test.sharedMethods.js';
 
-function testOrderBook (exchange: Exchange, skippedProperties: string[], method: string, orderbook: OrderBook, symbol: string) {
+function testOrderBook (exchange: Exchange, skippedProperties: object, method: string, orderbook: OrderBook, symbol: string) {
     const format = {
         'symbol': 'ETH/BTC',
         'asks': [

--- a/ts/src/test/Exchange/base/test.position.ts
+++ b/ts/src/test/Exchange/base/test.position.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testPosition (exchange: Exchange, skippedProperties: string[], method: string, entry: object, symbol: string, now: number) {
+function testPosition (exchange: Exchange, skippedProperties: object, method: string, entry: object, symbol: string, now: number) {
     const format = {
         'info': {}, // or []
         'symbol': 'XYZ/USDT',

--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -23,7 +23,7 @@ function stringValue (value) {
     return stringVal;
 }
 
-function assertType (exchange: Exchange, skippedProperties: string[], entry: object, key, format) {
+function assertType (exchange: Exchange, skippedProperties: object, entry: object, key, format) {
     if (key in skippedProperties) {
         return undefined;
     }
@@ -39,7 +39,7 @@ function assertType (exchange: Exchange, skippedProperties: string[], entry: obj
     return result;
 }
 
-function assertStructure (exchange: Exchange, skippedProperties: string[], method: string, entry: object, format, emptyAllowedFor = []) {
+function assertStructure (exchange: Exchange, skippedProperties: object, method: string, entry: object, format, emptyAllowedFor = []) {
     const logText = logTemplate (exchange, method, entry);
     assert (entry, 'item is null/undefined' + logText);
     // get all expected & predefined keys for this specific item and ensure thos ekeys exist in parsed structure
@@ -96,7 +96,7 @@ function assertStructure (exchange: Exchange, skippedProperties: string[], metho
     }
 }
 
-function assertTimestamp (exchange: Exchange, skippedProperties: string[], method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : any = 'timestamp') {
+function assertTimestamp (exchange: Exchange, skippedProperties: object, method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : any = 'timestamp') {
     const logText = logTemplate (exchange, method, entry);
     const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
     if (skipValue !== undefined) {
@@ -124,7 +124,7 @@ function assertTimestamp (exchange: Exchange, skippedProperties: string[], metho
     }
 }
 
-function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: string[], method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : any = 'timestamp') {
+function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: object, method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : any = 'timestamp') {
     const logText = logTemplate (exchange, method, entry);
     const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
     if (skipValue !== undefined) {
@@ -148,7 +148,7 @@ function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: stri
     }
 }
 
-function assertCurrencyCode (exchange: Exchange, skippedProperties: string[], method: string, entry: object, actualCode, expectedCode = undefined) {
+function assertCurrencyCode (exchange: Exchange, skippedProperties: object, method: string, entry: object, actualCode, expectedCode = undefined) {
     if (('currency' in skippedProperties) || ('currencyIdAndCode' in skippedProperties)) {
         return;
     }
@@ -162,7 +162,7 @@ function assertCurrencyCode (exchange: Exchange, skippedProperties: string[], me
     }
 }
 
-function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: string[], method: string, entry: object, currencyId, currencyCode) {
+function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: object, method: string, entry: object, currencyId, currencyCode) {
     // this is exclusive exceptional key name to be used in `skip-tests.json`, to skip check for currency id and code
     if (('currency' in skippedProperties) || ('currencyIdAndCode' in skippedProperties)) {
         return;
@@ -181,7 +181,7 @@ function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: st
     }
 }
 
-function assertSymbol (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, expectedSymbol = undefined) {
+function assertSymbol (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, expectedSymbol = undefined) {
     if (key in skippedProperties) {
         return;
     }
@@ -197,13 +197,13 @@ function assertSymbol (exchange: Exchange, skippedProperties: string[], method: 
     }
 }
 
-function assertSymbolInMarkets (exchange: Exchange, skippedProperties: string[], method: string, symbol: string) {
+function assertSymbolInMarkets (exchange: Exchange, skippedProperties: object, method: string, symbol: string) {
     const logText = logTemplate (exchange, method, {});
     assert ((symbol in exchange.markets), 'symbol should be present in exchange.symbols' + logText);
 }
 
 
-function assertGreater (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, compareTo) {
+function assertGreater (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, compareTo) {
     if (key in skippedProperties) {
         return;
     }
@@ -214,7 +214,7 @@ function assertGreater (exchange: Exchange, skippedProperties: string[], method:
     }
 }
 
-function assertGreaterOrEqual (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, compareTo) {
+function assertGreaterOrEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, compareTo) {
     if (key in skippedProperties) {
         return;
     }
@@ -225,7 +225,7 @@ function assertGreaterOrEqual (exchange: Exchange, skippedProperties: string[], 
     }
 }
 
-function assertLess (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, compareTo) {
+function assertLess (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, compareTo) {
     if (key in skippedProperties) {
         return;
     }
@@ -236,7 +236,7 @@ function assertLess (exchange: Exchange, skippedProperties: string[], method: st
     }
 }
 
-function assertLessOrEqual (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, compareTo) {
+function assertLessOrEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, compareTo) {
     if (key in skippedProperties) {
         return;
     }
@@ -247,7 +247,7 @@ function assertLessOrEqual (exchange: Exchange, skippedProperties: string[], met
     }
 }
 
-function assertEqual (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, compareTo) {
+function assertEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, compareTo) {
     if (key in skippedProperties) {
         return;
     }
@@ -258,7 +258,7 @@ function assertEqual (exchange: Exchange, skippedProperties: string[], method: s
     }
 }
 
-function assertNonEqual (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, compareTo) {
+function assertNonEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, compareTo) {
     if (key in skippedProperties) {
         return;
     }
@@ -269,7 +269,7 @@ function assertNonEqual (exchange: Exchange, skippedProperties: string[], method
     }
 }
 
-function assertInArray (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key, expectedArray) {
+function assertInArray (exchange: Exchange, skippedProperties: object, method: string, entry: object, key, expectedArray) {
     if (key in skippedProperties) {
         return;
     }
@@ -282,7 +282,7 @@ function assertInArray (exchange: Exchange, skippedProperties: string[], method:
     }
 }
 
-function assertFeeStructure (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key) {
+function assertFeeStructure (exchange: Exchange, skippedProperties: object, method: string, entry: object, key) {
     const logText = logTemplate (exchange, method, entry);
     const keyString = stringValue (key);
     if (Number.isInteger (key)) {
@@ -316,7 +316,7 @@ function assertTimestampOrder (exchange: Exchange, method: string, codeOrSymbol:
     }
 }
 
-function assertInteger (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key) {
+function assertInteger (exchange: Exchange, skippedProperties: object, method: string, entry: object, key) {
     if (key in skippedProperties) {
         return;
     }
@@ -330,7 +330,7 @@ function assertInteger (exchange: Exchange, skippedProperties: string[], method:
     }
 }
 
-function checkPrecisionAccuracy (exchange: Exchange, skippedProperties: string[], method: string, entry: object, key) {
+function checkPrecisionAccuracy (exchange: Exchange, skippedProperties: object, method: string, entry: object, key) {
     if (key in skippedProperties) {
         return;
     }
@@ -351,7 +351,7 @@ function checkPrecisionAccuracy (exchange: Exchange, skippedProperties: string[]
     }
 }
 
-function removeProxyOptions (exchange: Exchange, skippedProperties: string[]) {
+function removeProxyOptions (exchange: Exchange, skippedProperties: object) {
     const proxyUrl = exchange.checkProxyUrlSettings ();
     const [ httpProxy, httpsProxy, socksProxy ] = exchange.checkProxySettings ();
     // because of bug in transpiled, about `.proxyUrl` being transpiled into `.proxy_url`, we have to use this workaround
@@ -366,7 +366,7 @@ function removeProxyOptions (exchange: Exchange, skippedProperties: string[]) {
     return [ proxyUrl, httpProxy, httpsProxy, socksProxy ];
 }
 
-function setProxyOptions (exchange: Exchange, skippedProperties: string[], proxyUrl, httpProxy, httpsProxy, socksProxy) {
+function setProxyOptions (exchange: Exchange, skippedProperties: object, proxyUrl, httpProxy, httpsProxy, socksProxy) {
     exchange.proxyUrl = proxyUrl;
     exchange.httpProxy = httpProxy;
     exchange.httpsProxy = httpsProxy;

--- a/ts/src/test/Exchange/base/test.status.ts
+++ b/ts/src/test/Exchange/base/test.status.ts
@@ -1,6 +1,6 @@
 import { Exchange } from "../../../../ccxt";
 
-function testStatus (exchange: Exchange, skippedProperties: string[], method: string, entry: object, now : number) {
+function testStatus (exchange: Exchange, skippedProperties: object, method: string, entry: object, now : number) {
     const format = {
         'info': { },
         'status': 'ok', // 'ok', 'shutdown', 'error', 'maintenance'

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -3,7 +3,7 @@ import { Exchange, Ticker } from "../../../../ccxt";
 import Precise from '../../../base/Precise.js';
 import testSharedMethods from './test.sharedMethods.js';
 
-function testTicker (exchange: Exchange, skippedProperties: string[], method: string, entry: Ticker, symbol: string) {
+function testTicker (exchange: Exchange, skippedProperties: object, method: string, entry: Ticker, symbol: string) {
     const format = {
         'info': {},
         'symbol': 'ETH/BTC',

--- a/ts/src/test/Exchange/base/test.trade.ts
+++ b/ts/src/test/Exchange/base/test.trade.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testTrade (exchange: Exchange, skippedProperties: string[], method: string, entry: object, symbol: string, now: number) {
+function testTrade (exchange: Exchange, skippedProperties: object, method: string, entry: object, symbol: string, now: number) {
     const format = {
         'info': { },
         'id': '12345-67890:09876/54321', // string trade id

--- a/ts/src/test/Exchange/base/test.tradingFee.ts
+++ b/ts/src/test/Exchange/base/test.tradingFee.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../../ccxt";
 import testSharedMethods from './test.sharedMethods.js';
 
-function testTradingFee (exchange: Exchange, skippedProperties: string[], method: string, symbol: string, entry: object) {
+function testTradingFee (exchange: Exchange, skippedProperties: object, method: string, symbol: string, entry: object) {
     const format = {
         'info': { },
         'symbol': 'ETH/BTC',

--- a/ts/src/test/Exchange/test.fetchAccounts.ts
+++ b/ts/src/test/Exchange/test.fetchAccounts.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testAccount from './base/test.account.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchAccounts (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchAccounts (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchAccounts';
     const accounts = await exchange.fetchAccounts ();
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, accounts);

--- a/ts/src/test/Exchange/test.fetchBalance.ts
+++ b/ts/src/test/Exchange/test.fetchBalance.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../ccxt";
 import testBalance from './base/test.balance.js';
 
-async function testFetchBalance (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchBalance (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchBalance';
     const response = await exchange.fetchBalance ();
     testBalance (exchange, skippedProperties, method, response);

--- a/ts/src/test/Exchange/test.fetchBorrowInterest.ts
+++ b/ts/src/test/Exchange/test.fetchBorrowInterest.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testBorrowInterest from './base/test.borrowInterest.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchBorrowInterest (exchange: Exchange, skippedProperties: string[], code: string, symbol: string) {
+async function testFetchBorrowInterest (exchange: Exchange, skippedProperties: object, code: string, symbol: string) {
     const method = 'fetchBorrowInterest';
     const borrowInterest = await exchange.fetchBorrowInterest (code, symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, borrowInterest, code);

--- a/ts/src/test/Exchange/test.fetchClosedOrders.ts
+++ b/ts/src/test/Exchange/test.fetchClosedOrders.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testOrder from './base/test.order.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchClosedOrders (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchClosedOrders (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchClosedOrders';
     const orders = await exchange.fetchClosedOrders (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, orders, symbol);

--- a/ts/src/test/Exchange/test.fetchCurrencies.ts
+++ b/ts/src/test/Exchange/test.fetchCurrencies.ts
@@ -2,7 +2,7 @@ import { Exchange } from "../../../ccxt";
 import testCurrency from './base/test.currency.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchCurrencies (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchCurrencies (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchCurrencies';
     // const isNative = exchange.has['fetchCurrencies'] && exchange.has['fetchCurrencies'] !== 'emulated';
     const currencies = await exchange.fetchCurrencies ();

--- a/ts/src/test/Exchange/test.fetchDepositWithdrawals.ts
+++ b/ts/src/test/Exchange/test.fetchDepositWithdrawals.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testDepositWithdrawal from './base/test.depositWithdrawal.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchDepositsWithdrawals (exchange: Exchange, skippedProperties: string[], code: string) {
+async function testFetchDepositsWithdrawals (exchange: Exchange, skippedProperties: object, code: string) {
     const method = 'fetchTransactions';
     const transactions = await exchange.fetchTransactions (code);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, transactions, code);

--- a/ts/src/test/Exchange/test.fetchDeposits.ts
+++ b/ts/src/test/Exchange/test.fetchDeposits.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testDepositWithdrawal from './base/test.depositWithdrawal.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchDeposits (exchange: Exchange, skippedProperties: string[], code: string) {
+async function testFetchDeposits (exchange: Exchange, skippedProperties: object, code: string) {
     const method = 'fetchDeposits';
     const transactions = await exchange.fetchDeposits (code);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, transactions, code);

--- a/ts/src/test/Exchange/test.fetchFundingRateHistory.ts
+++ b/ts/src/test/Exchange/test.fetchFundingRateHistory.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testFundingRateHistory from './base/test.fundingRateHistory.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchFundingRateHistory (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchFundingRateHistory (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchFundingRateHistory';
     const fundingRatesHistory = await exchange.fetchFundingRateHistory (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, fundingRatesHistory, symbol);

--- a/ts/src/test/Exchange/test.fetchL2OrderBook.ts
+++ b/ts/src/test/Exchange/test.fetchL2OrderBook.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../ccxt";
 import testOrderBook from './base/test.orderBook.js';
 
-async function testFetchL2OrderBook (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchL2OrderBook (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchL2OrderBook';
     const orderBook = await exchange.fetchL2OrderBook (symbol);
     testOrderBook (exchange, skippedProperties, method, orderBook, symbol);

--- a/ts/src/test/Exchange/test.fetchLastPrices.ts
+++ b/ts/src/test/Exchange/test.fetchLastPrices.ts
@@ -4,7 +4,7 @@ import testLastPrice from './base/test.lastPrice.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 import { LastPrices } from '../../base/types';
 
-async function testFetchLastPrices (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchLastPrices (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchLastprices';
     // log ('fetching all tickers at once...')
     let response: LastPrices = undefined;

--- a/ts/src/test/Exchange/test.fetchLedger.ts
+++ b/ts/src/test/Exchange/test.fetchLedger.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testLedgerEntry from './base/test.ledgerEntry.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchLedger (exchange: Exchange, skippedProperties: string[], code: string) {
+async function testFetchLedger (exchange: Exchange, skippedProperties: object, code: string) {
     const method = 'fetchLedger';
     const items = await exchange.fetchLedger (code);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, items, code);

--- a/ts/src/test/Exchange/test.fetchLedgerEntry.ts
+++ b/ts/src/test/Exchange/test.fetchLedgerEntry.ts
@@ -2,7 +2,7 @@ import { Exchange } from "../../../ccxt";
 import testLedgerEntry from './base/test.ledgerEntry.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchLedgerEntry (exchange: Exchange, skippedProperties: string[], code: string) {
+async function testFetchLedgerEntry (exchange: Exchange, skippedProperties: object, code: string) {
     const method = 'fetchLedgerEntry';
     const items = await exchange.fetchLedger (code);
     const length = items.length;

--- a/ts/src/test/Exchange/test.fetchLeverageTiers.ts
+++ b/ts/src/test/Exchange/test.fetchLeverageTiers.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testLeverageTier from './base/test.leverageTier.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchLeverageTiers (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchLeverageTiers (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchLeverageTiers';
     const tiers = await exchange.fetchLeverageTiers ([ 'symbol' ]);
     // const format = {

--- a/ts/src/test/Exchange/test.fetchMarginMode.ts
+++ b/ts/src/test/Exchange/test.fetchMarginMode.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../ccxt";
 import testMarginMode from './base/test.marginMode.js';
 
-async function testFetchMarginMode (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchMarginMode (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchMarginMode';
     const marginMode = await exchange.fetchMarginMode (symbol);
     testMarginMode (exchange, skippedProperties, method, marginMode);

--- a/ts/src/test/Exchange/test.fetchMarginModes.ts
+++ b/ts/src/test/Exchange/test.fetchMarginModes.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testMarginMode from './base/test.marginMode.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchMarginModes (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchMarginModes (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchMarginModes';
     const marginModes = await exchange.fetchMarginModes ([ 'symbol' ]);
     assert (typeof marginModes === 'object', exchange.id + ' ' + method + ' ' + symbol + ' must return an object. ' + exchange.json (marginModes));

--- a/ts/src/test/Exchange/test.fetchMarketLeverageTiers.ts
+++ b/ts/src/test/Exchange/test.fetchMarketLeverageTiers.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testLeverageTier from './base/test.leverageTier.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchMarketLeverageTiers (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchMarketLeverageTiers (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchMarketLeverageTiers';
     const tiers = await exchange.fetchMarketLeverageTiers (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, tiers, symbol);

--- a/ts/src/test/Exchange/test.fetchMarkets.ts
+++ b/ts/src/test/Exchange/test.fetchMarkets.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testMarket from './base/test.market.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchMarkets (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchMarkets (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchMarkets';
     const markets = await exchange.fetchMarkets ();
     assert (typeof markets === 'object', exchange.id + ' ' + method + ' must return an object. ' + exchange.json (markets));

--- a/ts/src/test/Exchange/test.fetchMyTrades.ts
+++ b/ts/src/test/Exchange/test.fetchMyTrades.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testSharedMethods from './base/test.sharedMethods.js';
 import testTrade from './base/test.trade.js';
 
-async function testFetchMyTrades (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchMyTrades (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchMyTrades';
     const trades = await exchange.fetchMyTrades (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, trades, symbol);

--- a/ts/src/test/Exchange/test.fetchOHLCV.ts
+++ b/ts/src/test/Exchange/test.fetchOHLCV.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testOHLCV from './base/test.ohlcv.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchOHLCV (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchOHLCV (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchOHLCV';
     const timeframeKeys = Object.keys (exchange.timeframes);
     assert (timeframeKeys.length, exchange.id + ' ' + method + ' - no timeframes found');

--- a/ts/src/test/Exchange/test.fetchOpenInterestHistory.ts
+++ b/ts/src/test/Exchange/test.fetchOpenInterestHistory.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testOpenInterest from './base/test.openInterest.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchOpenInterestHistory (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchOpenInterestHistory (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchOpenInterestHistory';
     const openInterestHistory = await exchange.fetchOpenInterestHistory (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, openInterestHistory, symbol);

--- a/ts/src/test/Exchange/test.fetchOpenOrders.ts
+++ b/ts/src/test/Exchange/test.fetchOpenOrders.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testOrder from './base/test.order.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchOpenOrders (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchOpenOrders (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchOpenOrders';
     const orders = await exchange.fetchOpenOrders (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, orders, symbol);

--- a/ts/src/test/Exchange/test.fetchOrderBook.ts
+++ b/ts/src/test/Exchange/test.fetchOrderBook.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../ccxt";
 import testOrderBook from './base/test.orderBook.js';
 
-async function testFetchOrderBook (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchOrderBook (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchOrderBook';
     const orderbook = await exchange.fetchOrderBook (symbol);
     testOrderBook (exchange, skippedProperties, method, orderbook, symbol);

--- a/ts/src/test/Exchange/test.fetchOrderBooks.ts
+++ b/ts/src/test/Exchange/test.fetchOrderBooks.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { Exchange } from "../../../ccxt";
 import testOrderBook from './base/test.orderBook.js';
 
-async function testFetchOrderBooks (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchOrderBooks (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchOrderBooks';
     const symbol = exchange.symbols[0];
     const orderBooks = await exchange.fetchOrderBooks ([ symbol ]);

--- a/ts/src/test/Exchange/test.fetchOrders.ts
+++ b/ts/src/test/Exchange/test.fetchOrders.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testOrder from './base/test.order.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchOrders (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchOrders (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchOrders';
     const orders = await exchange.fetchOrders (symbol);
     assert (Array.isArray (orders), exchange.id + ' ' + method + ' must return an array, returned ' + exchange.json (orders));

--- a/ts/src/test/Exchange/test.fetchPositions.ts
+++ b/ts/src/test/Exchange/test.fetchPositions.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testPosition from './base/test.position.js';
 import testSharedMethods from '../../test/Exchange/base/test.sharedMethods.js';
 
-async function testFetchPositions (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchPositions (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchPositions';
     const now = exchange.milliseconds ();
     // without symbol

--- a/ts/src/test/Exchange/test.fetchStatus.ts
+++ b/ts/src/test/Exchange/test.fetchStatus.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../ccxt";
 import testStatus from './base/test.status.js';
 
-async function testFetchStatus (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchStatus (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchStatus';
     const status = await exchange.fetchStatus ();
     testStatus (exchange, skippedProperties, method, status, exchange.milliseconds ());

--- a/ts/src/test/Exchange/test.fetchTicker.ts
+++ b/ts/src/test/Exchange/test.fetchTicker.ts
@@ -1,7 +1,7 @@
 import { Exchange } from "../../../ccxt";
 import testTicker from './base/test.ticker.js';
 
-async function testFetchTicker (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchTicker (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchTicker';
     const ticker = await exchange.fetchTicker (symbol);
     testTicker (exchange, skippedProperties, method, ticker, symbol);

--- a/ts/src/test/Exchange/test.fetchTickers.ts
+++ b/ts/src/test/Exchange/test.fetchTickers.ts
@@ -3,13 +3,13 @@ import { Exchange } from "../../../ccxt";
 import testTicker from './base/test.ticker.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchTickers (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchTickers (exchange: Exchange, skippedProperties: object, symbol: string) {
     const withoutSymbol = testFetchTickersHelper (exchange, skippedProperties, undefined);
     const withSymbol = testFetchTickersHelper (exchange, skippedProperties, [ symbol ]);
     await Promise.all ([ withSymbol, withoutSymbol ]);
 }
 
-async function testFetchTickersHelper (exchange: Exchange, skippedProperties: string[], argSymbols, argParams = {}) {
+async function testFetchTickersHelper (exchange: Exchange, skippedProperties: object, argSymbols, argParams = {}) {
     const method = 'fetchTickers';
     const response =  await exchange.fetchTickers (argSymbols, argParams);
     assert (typeof response === 'object', exchange.id + ' ' + method + ' ' + exchange.json (argSymbols) + ' must return an object. ' + exchange.json (response));

--- a/ts/src/test/Exchange/test.fetchTrades.ts
+++ b/ts/src/test/Exchange/test.fetchTrades.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testSharedMethods from './base/test.sharedMethods.js';
 import testTrade from './base/test.trade.js';
 
-async function testFetchTrades (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchTrades (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchTrades';
     const trades = await exchange.fetchTrades (symbol);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, trades);

--- a/ts/src/test/Exchange/test.fetchTradingFee.ts
+++ b/ts/src/test/Exchange/test.fetchTradingFee.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { Exchange } from "../../../ccxt";
 import testTradingFee from './base/test.tradingFee.js';
 
-async function testFetchTradingFee (exchange: Exchange, skippedProperties: string[], symbol: string) {
+async function testFetchTradingFee (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchTradingFee';
     const fee = await exchange.fetchTradingFee (symbol);
     assert (typeof fee === 'object', exchange.id + ' ' + method + ' ' + symbol + ' must return an object. ' + exchange.json (fee));

--- a/ts/src/test/Exchange/test.fetchTradingFees.ts
+++ b/ts/src/test/Exchange/test.fetchTradingFees.ts
@@ -2,7 +2,7 @@ import { Exchange } from "../../../ccxt";
 import testTradingFee from './base/test.tradingFee.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchTradingFees (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchTradingFees (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchTradingFees';
     const fees = await exchange.fetchTradingFees ();
     const symbols = Object.keys (fees);

--- a/ts/src/test/Exchange/test.fetchTransactionFees.ts
+++ b/ts/src/test/Exchange/test.fetchTransactionFees.ts
@@ -1,6 +1,6 @@
 import { Exchange } from "../../../ccxt";
 
-async function testFetchTransactionFees (exchange: Exchange, skippedProperties: string[]) {
+async function testFetchTransactionFees (exchange: Exchange, skippedProperties: object) {
     // const method = 'fetchTransactionFees';
     // const fees = await exchange.fetchTransactionFees ();
     // const withdrawKeys = Object.keys (fees['withdraw']);

--- a/ts/src/test/Exchange/test.fetchWithdrawals.ts
+++ b/ts/src/test/Exchange/test.fetchWithdrawals.ts
@@ -3,7 +3,7 @@ import { Exchange } from "../../../ccxt";
 import testDepositWithdrawal from './base/test.depositWithdrawal.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testFetchWithdrawals (exchange: Exchange, skippedProperties: string[], code: string) {
+async function testFetchWithdrawals (exchange: Exchange, skippedProperties: object, code: string) {
     const method = 'fetchWithdrawals';
     const transactions = await exchange.fetchWithdrawals (code);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, transactions, code);

--- a/ts/src/test/Exchange/test.loadMarkets.ts
+++ b/ts/src/test/Exchange/test.loadMarkets.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { Exchange } from "../../../ccxt";
 import testMarket from './base/test.market.js';
 
-async function testLoadMarkets (exchange: Exchange, skippedProperties: string[]) {
+async function testLoadMarkets (exchange: Exchange, skippedProperties: object) {
     const method = 'loadMarkets';
     const markets = await exchange.loadMarkets ();
     assert (typeof exchange.markets === 'object', '.markets is not an object');

--- a/ts/src/test/Exchange/test.proxies.ts
+++ b/ts/src/test/Exchange/test.proxies.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { Exchange } from "../../../ccxt";
 import testSharedMethods from './base/test.sharedMethods.js';
 
-async function testProxies (exchange: Exchange, skippedProperties: string[]) {
+async function testProxies (exchange: Exchange, skippedProperties: object) {
     await testProxyUrl (exchange, skippedProperties);
     await testHttpProxy (exchange, skippedProperties);
     // 'httpsProxy', 'socksProxy'
@@ -10,7 +10,7 @@ async function testProxies (exchange: Exchange, skippedProperties: string[]) {
 }
 
 
-async function testProxyUrl (exchange: Exchange, skippedProperties: string[]) {
+async function testProxyUrl (exchange: Exchange, skippedProperties: object) {
     const method = 'proxyUrl';
     const proxyServerIp = '5.75.153.75';
     const [ proxyUrl, httpProxy, httpsProxy, socksProxy ] = testSharedMethods.removeProxyOptions (exchange, skippedProperties);
@@ -25,7 +25,7 @@ async function testProxyUrl (exchange: Exchange, skippedProperties: string[]) {
 }
 
 
-async function testHttpProxy (exchange: Exchange, skippedProperties: string[]) {
+async function testHttpProxy (exchange: Exchange, skippedProperties: object) {
     const method = 'httpProxy';
     const proxyServerIp = '5.75.153.75';
     const [ proxyUrl, httpProxy, httpsProxy, socksProxy ] = testSharedMethods.removeProxyOptions (exchange, skippedProperties);
@@ -39,7 +39,7 @@ async function testHttpProxy (exchange: Exchange, skippedProperties: string[]) {
 
 
 // with the below method we test out all variations of possible proxy options, so at least 2 of them should be set together, and such cases must throw exception
-async function testProxyForExceptions (exchange: Exchange, skippedProperties: string[]) {
+async function testProxyForExceptions (exchange: Exchange, skippedProperties: object) {
     const method = 'testProxyForExceptions';
     const [ proxyUrl, httpProxy, httpsProxy, socksProxy ] = testSharedMethods.removeProxyOptions (exchange, skippedProperties);
     const possibleOptionsArray = [

--- a/ts/src/test/Exchange/test.signIn.ts
+++ b/ts/src/test/Exchange/test.signIn.ts
@@ -1,6 +1,6 @@
 import { Exchange } from "../../../ccxt";
 
-async function testSignIn (exchange: Exchange, skippedProperties: string[]) {
+async function testSignIn (exchange: Exchange, skippedProperties: object) {
     const method = 'signIn';
     if (exchange.has[method]) {
         await exchange.signIn ();

--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -111,7 +111,7 @@ function ioDirRead (path) {
     return files;
 }
 
-async function callMethod (testFiles, methodName, exchange, skippedProperties: string[], args) {
+async function callMethod (testFiles, methodName, exchange, skippedProperties: object, args) {
     // used for calling methods from test files
     return await testFiles[methodName] (exchange, skippedProperties, ...args);
 }


### PR DESCRIPTION
seems there was a mistake when making these updates. 
(Carlos, if there are too many files for review, you can just directly replace `skippedProperties: string[]` locally across all files and push them, so you can avoid reviewing this PR files manually).