### PR TITLE
fix(onetrading) - update api

### DIFF
--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -115,8 +115,8 @@ export default class onetrading extends Exchange {
             'urls': {
                 'logo': 'https://github.com/ccxt/ccxt/assets/43336371/bdbc26fd-02f2-4ca7-9f1e-17333690bb1c',
                 'api': {
-                    'public': 'https://api.onetrading.com/public',
-                    'private': 'https://api.onetrading.com/public',
+                    'public': 'https://api.onetrading.com/fast',
+                    'private': 'https://api.onetrading.com/fast',
                 },
                 'www': 'https://onetrading.com/',
                 'doc': [


### PR DESCRIPTION
as docs https://docs.onetrading.com/#get-orders say, the api url is as pushed in this PR.
so, there is no mention of  `https://api.onetrading.com/public/` in api docs, neither:  https://api.onetrading.com/public/v1/instruments returns any data (already for month/s) , and they placed "fast update" in top of docs, probably they have updated recently. the new api endpoint: https://api.onetrading.com/fast/v1/instruments returns data