### PR TITLE
typo in property name of base class

### DIFF
--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -280,7 +280,7 @@ export interface Position {
     liquidationPrice?: number;
     marginMode?: Str;
     hedged?: boolean;
-    maintenenceMargin?: number;
+    maintenanceMargin?: number;
     maintenanceMarginPercentage?: number;
     initialMargin?: number;
     initialMarginPercentage?: number;


### PR DESCRIPTION
The property ```maintenanceMargin``` is been used in subclasses but wrong defined in the base one