### PR TITLE
bitget - fix currency ID vs CODE

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1871,7 +1871,7 @@ export default class bitget extends Exchange {
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
             const id = this.safeString (entry, 'coin'); // we don't use 'coinId' as it has no use. it is 'coin' field that needs to be used in currency related endpoints (deposit, withdraw, etc..)
-            const code = this.safeCurrencyCode (this.safeString (entry, 'coin'));
+            const code = this.safeCurrencyCode (id);
             const chains = this.safeValue (entry, 'chains', []);
             const networks = {};
             let deposit = false;

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1870,7 +1870,7 @@ export default class bitget extends Exchange {
         const data = this.safeValue (response, 'data', []);
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
-            const id = this.safeString (entry, 'coinId');
+            const id = this.safeString (entry, 'coin'); // we don't use 'coinId' as it has no use. it is 'coin' field that needs to be used in currency related endpoints (deposit, withdraw, etc..)
             const code = this.safeCurrencyCode (this.safeString (entry, 'coin'));
             const chains = this.safeValue (entry, 'chains', []);
             const networks = {};

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1297,6 +1297,7 @@ export default class bitget extends Exchange {
             'commonCurrencies': {
                 'JADE': 'Jade Protocol',
                 'DEGEN': 'DegenReborn',
+                'TONCOIN': 'TON',
             },
             'options': {
                 'timeframes': {
@@ -1997,7 +1998,7 @@ export default class bitget extends Exchange {
             }
             params = this.omit (params, 'code');
             const currency = this.currency (code);
-            request['coin'] = currency['code'];
+            request['coin'] = currency['ie'];
             response = await this.privateMarginGetV2MarginCrossedTierData (this.extend (request, params));
         } else {
             throw new BadRequest (this.id + ' fetchMarketLeverageTiers() symbol does not support market ' + market['symbol']);
@@ -2154,7 +2155,7 @@ export default class bitget extends Exchange {
             since = this.milliseconds () - 7776000000; // 90 days
         }
         let request = {
-            'coin': currency['code'],
+            'coin': currency['ie'],
             'startTime': since,
             'endTime': this.milliseconds (),
         };
@@ -2214,7 +2215,7 @@ export default class bitget extends Exchange {
         const currency = this.currency (code);
         const networkId = this.networkCodeToId (chain);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'address': address,
             'chain': networkId,
             'size': amount,
@@ -2301,7 +2302,7 @@ export default class bitget extends Exchange {
             since = this.milliseconds () - 7776000000; // 90 days
         }
         let request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'startTime': since,
             'endTime': this.milliseconds (),
         };
@@ -2447,7 +2448,7 @@ export default class bitget extends Exchange {
         }
         const currency = this.currency (code);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
         };
         if (networkId !== undefined) {
             request['chain'] = networkId;
@@ -5815,7 +5816,7 @@ export default class bitget extends Exchange {
         let request = {};
         if (code !== undefined) {
             currency = this.currency (code);
-            request['coin'] = currency['code'];
+            request['coin'] = currency['id'];
         }
         [ request, params ] = this.handleUntilOption ('endTime', request, params);
         if (since !== undefined) {
@@ -7249,7 +7250,7 @@ export default class bitget extends Exchange {
         type = this.safeString (accountsByType, fromAccount);
         const currency = this.currency (code);
         let request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'fromType': type,
         };
         if (since !== undefined) {
@@ -7309,7 +7310,7 @@ export default class bitget extends Exchange {
             'fromType': fromType,
             'toType': toType,
             'amount': amount,
-            'coin': currency['code'],
+            'coin': currency['id'],
         };
         const symbol = this.safeString (params, 'symbol');
         params = this.omit (params, 'symbol');
@@ -7501,7 +7502,7 @@ export default class bitget extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'borrowAmount': this.currencyToPrecision (code, amount),
         };
         const response = await this.privateMarginPostV2MarginCrossedAccountBorrow (this.extend (request, params));
@@ -7537,7 +7538,7 @@ export default class bitget extends Exchange {
         const currency = this.currency (code);
         const market = this.market (symbol);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'borrowAmount': this.currencyToPrecision (code, amount),
             'symbol': market['id'],
         };
@@ -7575,7 +7576,7 @@ export default class bitget extends Exchange {
         const currency = this.currency (code);
         const market = this.market (symbol);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'repayAmount': this.currencyToPrecision (code, amount),
             'symbol': market['id'],
         };
@@ -7612,7 +7613,7 @@ export default class bitget extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
             'repayAmount': this.currencyToPrecision (code, amount),
         };
         const response = await this.privateMarginPostV2MarginCrossedAccountRepay (this.extend (request, params));
@@ -7978,7 +7979,7 @@ export default class bitget extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {
-            'coin': currency['code'],
+            'coin': currency['id'],
         };
         const response = await this.privateMarginGetV2MarginCrossedInterestRateAndLimit (this.extend (request, params));
         //
@@ -8075,7 +8076,7 @@ export default class bitget extends Exchange {
         let currency = undefined;
         if (code !== undefined) {
             currency = this.currency (code);
-            request['coin'] = currency['code'];
+            request['coin'] = currency['id'];
         }
         if (since !== undefined) {
             request['startTime'] = since;

--- a/ts/src/test/static/currencies/bitget.json
+++ b/ts/src/test/static/currencies/bitget.json
@@ -33,7 +33,7 @@
             "coinId": "1",
             "transfer": "true"
         },
-        "id": "1",
+        "id": "BTC",
         "code": "BTC",
         "networks": {
             "BTC": {
@@ -273,7 +273,7 @@
             "coinId": "2",
             "transfer": "true"
         },
-        "id": "2",
+        "id": "USDT",
         "code": "USDT",
         "networks": {
             "OMNI": {
@@ -646,7 +646,7 @@
             "coin": "EUR",
             "transfer": "false"
         },
-        "id": "590",
+        "id": "EUR",
         "code": "EUR",
         "networks": {},
         "active": false,
@@ -679,7 +679,7 @@
             "coinId": "5",
             "transfer": "true"
         },
-        "id": "5",
+        "id": "LTC",
         "code": "LTC",
         "networks": {
             "LTC": {
@@ -838,7 +838,7 @@
             "coinId": "3",
             "transfer": "true"
         },
-        "id": "3",
+        "id": "ETH",
         "code": "ETH",
         "networks": {
             "ETH": {
@@ -1109,7 +1109,7 @@
             "coinId": "125",
             "transfer": "true"
         },
-        "id": "125",
+        "id": "ADA",
         "code": "ADA",
         "networks": {
             "CARDANO": {
@@ -1177,7 +1177,7 @@
             "coinId": "56",
             "transfer": "true"
         },
-        "id": "56",
+        "id": "XRP",
         "code": "XRP",
         "networks": {
             "XRP": {
@@ -1336,7 +1336,7 @@
             "coinId": "74",
             "transfer": "true"
         },
-        "id": "74",
+        "id": "USDC",
         "code": "USDC",
         "networks": {
             "ARBITRUMONE": {
@@ -1608,7 +1608,7 @@
             ],
             "areaCoin": "no"
         },
-        "id": "1035",
+        "id": "$AI",
         "code": "$AI",
         "networks": {
             "BEP20": {

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1536,6 +1536,26 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "fetch usdt deposits",
+                "method": "fetchDeposits",
+                "url": "https://api.bitget.com/api/v2/spot/wallet/deposit-records?coin=USDT&endTime=1712048378795&startTime=1704272378795",
+                "input": [
+                  "USDT"
+                ]
+            }
+        ],
+        "fetchWithdrawals": [
+            {
+                "description": "fetch withdrawals",
+                "method": "fetchWithdrawals",
+                "url": "https://api.bitget.com/api/v2/spot/wallet/withdrawal-records?coin=USDT&endTime=1712048411669&startTime=1704272411669",
+                "input": [
+                  "USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
there were incorrect uses of currencies (currency-code) in request methods (instead of currency-id).

fix #21112