### PR TITLE
fix(binance): addMargin, reduceMargin amount < 1 fix

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -11009,7 +11009,7 @@ export default class binance extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        amount = this.costToPrecision (symbol, amount);
+        amount = this.amountToPrecision (symbol, amount);
         const request = {
             'type': addOrReduce,
             'symbol': market['id'],

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2918,6 +2918,50 @@
                   "BTC/USDT:USDT-241227-80000-C"
                 ]
             }
+        ],
+        "addMargin": [
+            {
+                "description": "add margin",
+                "method": "addMargin",
+                "url": "https://testnet.binancefuture.com/fapi/v1/positionMargin",
+                "input": [
+                  "XRP/USDT:USDT",
+                  5.243432
+                ],
+                "output": "timestamp=1712047896974&type=1&symbol=XRPUSDT&amount=5.2&recvWindow=10000&signature=ab7e4525180db9134418a3b410029cc1a055a4542cb4ebe1d60cc6f0134a2fce"
+            },
+            {
+                "description": "add small amount of margin",
+                "method": "addMargin",
+                "url": "https://testnet.binancefuture.com/fapi/v1/positionMargin",
+                "input": [
+                  "XRP/USDT:USDT",
+                  0.2
+                ],
+                "output": "timestamp=1712047853481&type=1&symbol=XRPUSDT&amount=0.2&recvWindow=10000&signature=09954975fbbf5de734a82d26144d77d6929802345e183c212e6fc49722e34696"
+            }
+        ],
+        "reduceMargin": [
+            {
+                "description": "reduce margin",
+                "method": "reduceMargin",
+                "url": "https://testnet.binancefuture.com/fapi/v1/positionMargin",
+                "input": [
+                  "XRP/USDT:USDT",
+                  5.243432
+                ],
+                "output": "timestamp=1712047923923&type=2&symbol=XRPUSDT&amount=5.2&recvWindow=10000&signature=db336b746bf1266fbe2f3d8887e105ce714f1a8ebbab733610722ee22b9a6fe7"
+            },
+            {
+                "description": "reduce small amount of margin",
+                "method": "reduceMargin",
+                "url": "https://testnet.binancefuture.com/fapi/v1/positionMargin",
+                "input": [
+                  "XRP/USDT:USDT",
+                  0.2
+                ],
+                "output": "timestamp=1712047946547&type=2&symbol=XRPUSDT&amount=0.2&recvWindow=10000&signature=e8c53af6d974c388ca6ff5ec820a4c2ac813fcbaec55b1a50c60779da56be00b"
+            }
         ]
     }
 }


### PR DESCRIPTION
```
% py binance addMargin XRP/USDT:USDT 0.2 --testnet         
Python v3.9.6
CCXT v4.2.87
binance.addMargin(XRP/USDT:USDT,0.2)
{'amount': 0.2,
 'code': 'USDT',
 'datetime': None,
 'info': {'amount': '0.2',
          'code': '200',
          'msg': 'Successfully modify position margin.',
          'type': '1'},
 'status': 'ok',
 'symbol': 'XRP/USDT:USDT',
 'timestamp': None,
 'total': None,
 'type': 'add'}
```