### PR TITLE
fix(kucoin): fetchBalance, cross margin

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -3542,9 +3542,9 @@ export default class kucoin extends Exchange {
          * @method
          * @name kucoin#fetchBalance
          * @description query for balance and get the amount of funds available for trading or funds locked in orders
-         * @see https://docs.kucoin.com/#list-accounts
          * @see https://www.kucoin.com/docs/rest/account/basic-info/get-account-list-spot-margin-trade_hf
-         * @see https://docs.kucoin.com/#query-isolated-margin-account-info
+         * @see https://www.kucoin.com/docs/rest/funding/funding-overview/get-account-detail-margin
+         * @see https://www.kucoin.com/docs/rest/funding/funding-overview/get-account-detail-isolated-margin
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {object} [params.marginMode] 'cross' or 'isolated', margin type for fetching margin balance
          * @param {object} [params.type] extra parameters specific to the exchange API endpoint
@@ -3571,7 +3571,7 @@ export default class kucoin extends Exchange {
         let response = undefined;
         const request = {};
         const isolated = (marginMode === 'isolated') || (type === 'isolated');
-        const cross = (marginMode === 'cross') || (type === 'cross');
+        const cross = (marginMode === 'cross') || (type === 'margin');
         if (isolated) {
             if (currency !== undefined) {
                 request['balanceCurrency'] = currency['id'];
@@ -3639,13 +3639,14 @@ export default class kucoin extends Exchange {
         //        }
         //    }
         //
-        const data = this.safeList (response, 'data', []);
+        let data = undefined;
         const result = {
             'info': response,
             'timestamp': undefined,
             'datetime': undefined,
         };
         if (isolated) {
+            data = this.safeDict (response, 'data', {});
             const assets = this.safeValue (data, 'assets', data);
             for (let i = 0; i < assets.length; i++) {
                 const entry = assets[i];
@@ -3661,6 +3662,7 @@ export default class kucoin extends Exchange {
                 result[symbol] = this.safeBalance (subResult);
             }
         } else if (cross) {
+            data = this.safeDict (response, 'data', {});
             const accounts = this.safeList (data, 'accounts', []);
             for (let i = 0; i < accounts.length; i++) {
                 const balance = accounts[i];
@@ -3669,6 +3671,7 @@ export default class kucoin extends Exchange {
                 result[codeInner] = this.parseBalanceHelper (balance);
             }
         } else {
+            data = this.safeList (response, 'data', []);
             for (let i = 0; i < data.length; i++) {
                 const balance = data[i];
                 const balanceType = this.safeString (balance, 'type');

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -814,6 +814,69 @@
                         "TRX": 0
                     }
                 }
+            },
+            {
+                "description": "cross balance",
+                "method": "fetchBalance",
+                "input": [
+                  {
+                    "marginMode": "cross"
+                  }
+                ],
+                "httpResponse": {
+                  "code": "200000",
+                  "data": {
+                    "debtRatio": "0",
+                    "accounts": [
+                      {
+                        "currency": "USDT",
+                        "totalBalance": "5",
+                        "availableBalance": "5",
+                        "holdBalance": "0",
+                        "liability": "0",
+                        "maxBorrowSize": "20"
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": {
+                  "info": {
+                    "code": "200000",
+                    "data": {
+                      "debtRatio": "0",
+                      "accounts": [
+                        {
+                          "currency": "USDT",
+                          "totalBalance": "5",
+                          "availableBalance": "5",
+                          "holdBalance": "0",
+                          "liability": "0",
+                          "maxBorrowSize": "20"
+                        }
+                      ]
+                    }
+                  },
+                  "timestamp": null,
+                  "datetime": null,
+                  "USDT": {
+                    "free": 5,
+                    "used": 0,
+                    "total": 5,
+                    "debt": 0
+                  },
+                  "free": {
+                    "USDT": 5
+                  },
+                  "used": {
+                    "USDT": 0
+                  },
+                  "total": {
+                    "USDT": 5
+                  },
+                  "debt": {
+                    "USDT": 0
+                  }
+                }
             }
         ],
         "fetchOrderBook": [


### PR DESCRIPTION
Fixed some bugs with the fetchBalance cross margin support:
fixes: #21979
```
[PermissionDenied] kucoin Please enable the margin trading.
```

```
kucoin.fetchBalance ()
2024-04-02T05:10:09.264Z iteration 0 passed in 462 ms

{
  info: {
    code: '200000',
    data: [
      {
        id: '64feeeb6b4f1fb0007948e80',
        currency: 'USDT',
        type: 'trade',
        balance: '41.03048584',
        available: '41.03048584',
        holds: '0'
      },
      {
        id: '64feeec4cd03f30007aa5a8f',
        currency: 'LTC',
        type: 'trade',
        balance: '0.151021',
        available: '0.151021',
        holds: '0'
      },
      {
        id: '64ff093e478dba00072d3bc7',
        currency: 'BTC',
        type: 'trade',
        balance: '0.00001336',
        available: '0.00001336',
        holds: '0'
      },
      {
        id: '655e450a1245b90007517903',
        currency: 'TRX',
        type: 'trade',
        balance: '0',
        available: '0',
        holds: '0'
      }
    ]
  },
  USDT: { free: 41.03048584, used: 0, total: 41.03048584 },
  LTC: { free: 0.151021, used: 0, total: 0.151021 },
  BTC: { free: 0.00001336, used: 0, total: 0.00001336 },
  TRX: { free: 0, used: 0, total: 0 },
  free: { USDT: 41.03048584, LTC: 0.151021, BTC: 0.00001336, TRX: 0 },
  used: { USDT: 0, LTC: 0, BTC: 0, TRX: 0 },
  total: { USDT: 41.03048584, LTC: 0.151021, BTC: 0.00001336, TRX: 0 }
}
```