### PR TITLE
fix(deribit) - fetchTickers all support

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -1218,6 +1218,31 @@ export default class deribit extends Exchange {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
+        let all = undefined;
+        [ all, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'all', false);
+        if (all) {
+            const promises = [];
+            const keys = Object.keys (this.currencies);
+            for (let i = 0; i < keys.length; i++) {
+                const key = keys[i];
+                const currency = this.currencies[key];
+                const request = {
+                    'currency': currency['id'],
+                };
+                promises.push (this.fetchTickersByCode (symbols, this.extend (request, params)));
+            }
+            const responses = await Promise.all (promises);
+            let result = {};
+            for (let i = 0; i < responses.length; i++) {
+                result = this.extend (result, responses[i]);
+            }
+            return result;
+        } else {
+            return await this.fetchTickersByCode (symbols, params);
+        }
+    }
+
+    async fetchTickersByCode (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         const code = this.codeFromOptions ('fetchTickers', params);
         const currency = this.currency (code);
         const request = {

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -403,6 +403,9 @@ export default class deribit extends Exchange {
                 'transfer': {
                     'method': 'privateGetSubmitTransferToSubaccount', // or 'privateGetSubmitTransferToUser'
                 },
+                'fetchTickers': {
+                    'all': true,
+                },
             },
         });
     }

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -1243,7 +1243,7 @@ export default class deribit extends Exchange {
         } else {
             const baseCoin = this.handleParamString (params, 'baseCoin');
             if (baseCoin === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchTickers() requires a params["baseCoin"] to be set, one from ' + this.json (Object.keys (this.currencies)));
+                throw new ArgumentsRequired (this.id + ' fetchTickers() set or params["baseCoin"] to any from: ' + this.json (Object.keys (this.currencies)) + ' or set .options["fetchTickers"]["all"] = true');
             }
             const request = {
                 'currency': baseCoin,

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -1221,9 +1221,9 @@ export default class deribit extends Exchange {
          */
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        let all = undefined;
-        [ all, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'all', false);
-        if (all) {
+        let fetchAll = undefined;
+        [ fetchAll, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'all', false);
+        if (fetchAll) {
             const promises = [];
             const keys = Object.keys (this.currencies);
             for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
after the previous markets fix PR is merged, then should be this PR reviewed.

so, in most cases, it's for sure that when users want to use "fetchTickers" bulk endpoint without passing symbols, they just want to get "all tickers" (not specifically for one group of 'BTC' symbols: https://docs.deribit.com/#public-get_book_summary_by_currency ). 
So, we should support "all" parameter (but defaulted to false), like we support pagination in methods (for user convenience), for such exchanges where direct "fetch tickers all" is not supported.
deribit has just few currencies that are supported as "base" currency for tickers (BTC,USDT,USDC and few ones) so making few parallel calls for such bulk option should not be a problem.