### PR TITLE
fix(gemini) - nonce

### DIFF
--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -109,6 +109,7 @@ export default class gemini extends Exchange {
                     // https://github.com/ccxt/ccxt/issues/7874
                     // https://github.com/ccxt/ccxt/issues/7894
                     'web': 'https://docs.gemini.com',
+                    'webExchange': 'https://exchange.gemini.com',
                 },
                 'fees': [
                     'https://gemini.com/api-fee-schedule',

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -651,7 +651,7 @@ export default class gemini extends Exchange {
         let quoteId = undefined;
         let settleId = undefined;
         let tickSize = undefined;
-        let increment = undefined;
+        let amountPrecision = undefined;
         let minSize = undefined;
         let status = undefined;
         let swap = false;
@@ -662,9 +662,9 @@ export default class gemini extends Exchange {
         const isArray = (Array.isArray (response));
         if (!isString && !isArray) {
             marketId = this.safeStringLower (response, 'symbol');
+            amountPrecision = this.safeNumber (response, 'tick_size'); // right, exchange has an imperfect naming and this turns out to be an amount-precision
+            tickSize = this.safeNumber (response, 'quote_increment'); // this is tick-size actually
             minSize = this.safeNumber (response, 'min_order_size');
-            tickSize = this.safeNumber (response, 'tick_size');
-            increment = this.safeNumber (response, 'quote_increment');
             status = this.parseMarketActive (this.safeString (response, 'status'));
             baseId = this.safeString (response, 'base_currency');
             quoteId = this.safeString (response, 'quote_currency');
@@ -675,9 +675,9 @@ export default class gemini extends Exchange {
                 marketId = response;
             } else {
                 marketId = this.safeStringLower (response, 0);
-                minSize = this.safeNumber (response, 3);
-                tickSize = this.parseNumber (this.parsePrecision (this.safeString (response, 1)));
-                increment = this.parseNumber (this.parsePrecision (this.safeString (response, 2)));
+                tickSize = this.parseNumber (this.parsePrecision (this.safeString (response, 1))); // priceTickDecimalPlaces
+                amountPrecision = this.parseNumber (this.parsePrecision (this.safeString (response, 2))); // quantityTickDecimalPlaces
+                minSize = this.safeNumber (response, 3); // quantityMinimum
             }
             const marketIdUpper = marketId.toUpperCase ();
             const isPerp = (marketIdUpper.indexOf ('PERP') >= 0);
@@ -732,8 +732,8 @@ export default class gemini extends Exchange {
             'strike': undefined,
             'optionType': undefined,
             'precision': {
-                'price': increment,
-                'amount': tickSize,
+                'price': tickSize,
+                'amount': amountPrecision,
             },
             'limits': {
                 'leverage': {

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -286,7 +286,6 @@ export default class gemini extends Exchange {
                     'ATOM': 'cosmos',
                     'DOT': 'polkadot',
                 },
-                'nonce': 'milliseconds', // if getting a Network 400 error change to seconds
             },
         });
     }
@@ -1655,10 +1654,7 @@ export default class gemini extends Exchange {
     }
 
     nonce () {
-        const nonceMethod = this.safeString (this.options, 'nonce', 'milliseconds');
-        if (nonceMethod === 'milliseconds') {
-            return this.milliseconds ();
-        }
+        // previously here was option to choose between milliseconds vs seconds, however, api server proves that it accepts only seconds
         return this.seconds ();
     }
 

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -286,6 +286,7 @@ export default class gemini extends Exchange {
                     'ATOM': 'cosmos',
                     'DOT': 'polkadot',
                 },
+                'nonce': 'milliseconds', // if getting a Network 400 error change to seconds
             },
         });
     }
@@ -1654,8 +1655,11 @@ export default class gemini extends Exchange {
     }
 
     nonce () {
-        // previously here was option to choose between milliseconds vs seconds, however, api server proves that it accepts only seconds
-        return (this.milliseconds () / 1000);
+        const nonceMethod = this.safeString (this.options, 'nonce', 'milliseconds');
+        if (nonceMethod === 'milliseconds') {
+            return this.milliseconds ();
+        }
+        return this.seconds ();
     }
 
     async fetchDepositsWithdrawals (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -1655,7 +1655,7 @@ export default class gemini extends Exchange {
 
     nonce () {
         // previously here was option to choose between milliseconds vs seconds, however, api server proves that it accepts only seconds
-        return this.seconds ();
+        return (this.milliseconds () / 1000);
     }
 
     async fetchDepositsWithdrawals (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
@@ -1823,7 +1823,7 @@ export default class gemini extends Exchange {
             if (apiKey.indexOf ('account') < 0) {
                 throw new AuthenticationError (this.id + ' sign() requires an account-key, master-keys are not-supported');
             }
-            const nonce = this.nonce ();
+            const nonce = this.nonce ().toString ();
             const request = this.extend ({
                 'request': url,
                 'nonce': nonce,


### PR DESCRIPTION
related #22025

1) removed milliseconds option, because when i run `--privateOnly` tests,  API's raw response clearly shows that it works with seconds, not with milliseconds

2) fixed market-parsing, precisions were incorrect