### PR TITLE
binance: add POST /api/v3/orderList/oco

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -971,6 +971,7 @@ export default class binance extends Exchange {
                     },
                     'post': {
                         'order/oco': 0.2,
+                        'orderList/oco': 0.2,
                         'sor/order': 0.2,
                         'sor/order/test': 0.2,
                         'order': 0.2,


### PR DESCRIPTION
I try to add this api: https://binance-docs.github.io/apidocs/spot/en/#new-order-list-oco-trade, but it seems not existed in server......

```
$ n binance privatePostOrderListOco --verbose 
Node.js: v21.6.2
CCXT v4.2.88
binance.privatePostOrderListOco ()
fetch Request:
 binance POST https://api.binance.com/api/v3/orderList/oco 
RequestHeaders:
RequestBody:

handleRestResponse:
 binance POST https://api.binance.com/api/v3/orderList/oco 404 Not Found 
ResponseHeaders:
ResponseBody:
  

ExchangeNotAvailable binance POST https://api.binance.com/api/v3/orderList/oco 404 Not Found 
---------------------------------------------------
[ExchangeNotAvailable] binance POST https://api.binance.com/api/v3/orderList/oco 404 Not Found

    at handleHttpStatusCode       …sktop/projects/opensource/ccxt/js/src/base/Exchange.js:1071  
    at                            …esktop/projects/opensource/ccxt/js/src/base/Exchange.js:973  
    at processTicksAndRejections  node:internal/process/task_queues:95                          
    at fetch2                     …sktop/projects/opensource/ccxt/js/src/base/Exchange.js:3617  
    at request                    …ng/Desktop/projects/opensource/ccxt/js/src/binance.js:11169  
    at async run                  …eng/Desktop/projects/opensource/ccxt/examples/js/cli.js:343  

binance POST https://api.binance.com/api/v3/orderList/oco 404 Not Found
```

TODO:
- [ ] check other updates