### PR TITLE
fix(bitget): watchBalance spot margin

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1748,6 +1748,8 @@ export default class bitget extends bitgetRest {
             'ordersAlgo': this.handleOrder,
             'account': this.handleBalance,
             'positions': this.handlePositions,
+            'account-isolated': this.handleBalance,
+            'account-crossed': this.handleBalance,
         };
         const arg = this.safeValue (message, 'arg', {});
         const topic = this.safeValue (arg, 'channel', '');


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/22014


DEMO

```
p bitget watchBalance '{"marginMode":"isolated"}'          
Python v3.11.7
CCXT v4.2.88
bitget.watchBalance({'marginMode': 'isolated'})
{'LTC': {'debt': 0.0, 'free': 0.0, 'total': 0.0, 'used': 0.0},
 'USDT': {'debt': 0.0, 'free': 6.0, 'total': 6.0, 'used': 0.0},
 'debt': {'LTC': 0.0, 'USDT': 0.0},
 'free': {'LTC': 0.0, 'USDT': 6.0},
 'total': {'LTC': 0.0, 'USDT': 6.0},
 'used': {'LTC': 0.0, 'USDT': 0.0}}
```

```
 p bitget watchBalance '{"marginMode":"cross"}'    
Python v3.11.7
CCXT v4.2.88
bitget.watchBalance({'marginMode': 'cross'})
{'USDT': {'debt': 0.0, 'free': 5.0, 'total': 5.0, 'used': 0.0},
 'debt': {'USDT': 0.0},
 'free': {'USDT': 5.0},
 'total': {'USDT': 5.0},
 'used': {'USDT': 0.0}}
```