### PR TITLE
fix(bybit) - fetchTickers and options fixes

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2086,7 +2086,7 @@ export default class bybit extends Exchange {
             request['category'] = 'option';
             // throw meaningful error here, because exchange returns unreadable error if baseCoin not present
             const baseCoins = this.safeList (this.options, 'baseCoinsForOptions', [ 'BTC', 'ETH', 'SOL' ]);
-            if ('baseCoin' in params) {
+            if (!('baseCoin' in params)) {
                 throw new ArgumentsRequired (this.id + ' fetchTickers() requires a params["baseCoin"]  for options markets, one from ' + this.json (baseCoins));
             }
         }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2087,13 +2087,11 @@ export default class bybit extends Exchange {
             request['category'] = subType;
         } else if (type === 'option') {
             request['category'] = 'option';
+            // throw meaningful error here, because exchange returns unreadable error if baseCoin not present
             const baseCoins = this.safeList (this.options, 'baseCoinsForOptions', [ 'BTC', 'ETH', 'SOL' ]);
-            let baseCoin = undefined;
-            [ baseCoin, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'baseCoinForOptions');
-            if (baseCoin === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchTickers() requires a params["baseCoinForOptions"]  for options markets, one from ' + this.json (baseCoins));
+            if ('baseCoin' in params) {
+                throw new ArgumentsRequired (this.id + ' fetchTickers() requires a params["baseCoin"]  for options markets, one from ' + this.json (baseCoins));
             }
-            request['baseCoin'] = baseCoin;
         }
         const response = await this.publicGetV5MarketTickers (this.extend (request, params));
         //

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1383,7 +1383,7 @@ export default class bybit extends Exchange {
             await this.loadTimeDifference ();
         }
         const promisesUnresolved = [];
-        const fetchMarkets = this.safeList (this.options, 'fetchMarkets', [ 'spot', 'linear', 'inverse', 'option' ]);
+        const fetchMarkets = this.safeValue (this.options, 'fetchMarkets', [ 'spot', 'linear', 'inverse' ]);
         for (let i = 0; i < fetchMarkets.length; i++) {
             const marketType = fetchMarkets[i];
             if (marketType === 'spot') {
@@ -1393,11 +1393,9 @@ export default class bybit extends Exchange {
             } else if (marketType === 'inverse') {
                 promisesUnresolved.push (this.fetchFutureMarkets ({ 'category': 'inverse' }));
             } else if (marketType === 'option') {
-                const baseCoins = this.safeList (this.options, 'baseCoinsForOptions', [ 'BTC', 'ETH', 'SOL' ]);
-                for (let j = 0; j < baseCoins.length; j++) {
-                    const baseCoin = baseCoins[j];
-                    promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': baseCoin }));
-                }
+                promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': 'BTC' }));
+                promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': 'ETH' }));
+                promisesUnresolved.push (this.fetchOptionMarkets ({ 'baseCoin': 'SOL' }));
             } else {
                 throw new ExchangeError (this.id + ' fetchMarkets() this.options fetchMarkets "' + marketType + '" is not a supported market type');
             }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2071,8 +2071,7 @@ export default class bybit extends Exchange {
         };
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
-        // `.fetchTickers (undefined, {subType:'inverse'})` or `.fetchTickers (undefined, {subType:'inverse'})`
-        // should be supported for this exchange, so
+        // .fetchTickers (undefined, `{subType:'inverse'}` or `{type:'option'}` should be supported for this exchange, so
         // as "options.defaultSubType" is also set in exchange options, we should consider `params.subType`
         // with higher priority and only default to spot, if `subType` is not set in params
         const subTypePresent = ('subType' in params);

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2076,7 +2076,7 @@ export default class bybit extends Exchange {
         // with higher priority and only default to spot, if `subType` is not set in params
         const subTypePresent = ('subType' in params);
         let subType = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params, 'linear');
         // only if passedSubType is undefined, then use spot
         if (type === 'spot' && !subTypePresent) {
             request['category'] = 'spot';


### PR DESCRIPTION
this request can not succeed:
https://api.bybit.com/v5/market/tickers?category=option
you have to add `baseCoin` parameter in query. Bybit has only 3 option baseCoins: `BTC, ETH, SOL`.
https://api.bybit.com/v5/market/tickers?category=option&baseCoin=BTC


However, currency in some other exchanges we are doing such defaults:
```
'options' : {
  'fetchTickers': {
    'baseCoin': 'BTC'
  }
}
```

and in `fetchTickers` implementation we are doing smth like:
```
[ baseCoin, params ] = .handelOptionAndParams ( .... 'fetchTickers', 'baseCoin', 'BTC');
```
and have returned some "default baseCoin" data response to user, without their any efforts or even knowing what baseCoins are fetchable at all (unless they themselves have an idea popped up to find out manually through codes and documentations which basecoins are possible to be fetched).
there is no good of hiding out all of these and silently defaulting ( in the name of user-convenience)  to any coin, instead we should let users know what they should do, like proposed in this PR: https://github.com/ccxt/ccxt/pull/22041/files#diff-5b072b659fad4f748d901fd07dade97dc83dc072b2a5d3c9c03c9a3b1200da20R2088-R2092

so, only during the **first time** user calls this method, they will get an exception (one time), but after then and onwards they would know how to call fetchTickers with correct params. 