### PR TITLE
fix: common_currency_code python tranpilation no longer causes error 'AttributeError: list object has no attribute "values"'

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5050,8 +5050,9 @@ export default class Exchange {
             return code;
         }
         // if the provided code already exists as a value in commonCurrencies dict, then we should not again transform it
-        // (more details at: https://github.com/ccxt/ccxt/issues/21112#issuecomment-2031293691)
-        const exists = this.inArray (code, Object.values (this.commonCurrencies));
+        // more details at: https://github.com/ccxt/ccxt/issues/21112#issuecomment-2031293691
+        const commonCurrencies = Object.values (this.commonCurrencies);
+        const exists = this.inArray (code, commonCurrencies);
         if (exists) {
             return code;
         }


### PR DESCRIPTION
fixes this bug

```
% py coinex fetchPositionHistory XRP/USDT:USDT 1709251200000
Python v3.9.6
CCXT v4.2.88
Traceback (most recent call last):
  File "/ccxt/examples/py/cli.py", line 246, in <module>
    asyncio.run(main())
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/ccxt/examples/py/cli.py", line 206, in main
    await exchange.load_markets()
  File "/ccxt/python/ccxt/async_support/base/exchange.py", line 276, in load_markets
    raise e
  File "/ccxt/python/ccxt/async_support/base/exchange.py", line 272, in load_markets
    result = await self.markets_loading
  File "/ccxt/python/ccxt/async_support/base/exchange.py", line 261, in load_markets_helper
    currencies = await self.fetch_currencies()
  File "/ccxt/python/ccxt/async_support/coinex.py", line 523, in fetch_currencies
    code = self.safe_currency_code(currencyId)
  File "/ccxt/python/ccxt/base/exchange.py", line 4604, in safe_currency_code
    currency = self.safe_currency(currencyId, currency)
  File "/ccxt/python/ccxt/base/exchange.py", line 3734, in safe_currency
    code = self.common_currency_code(currencyId.upper())
  File "/ccxt/python/ccxt/base/exchange.py", line 4398, in common_currency_code
    exists = self.in_array(code, list(self.commonCurrencies).values())
AttributeError: 'list' object has no attribute 'values'
coinex requires to release all resources with an explicit call to the .close() coroutine. If you are using the exchange instance with async coroutines, add `await exchange.close()` to your code into a place when you're done with the exchange and don't need the exchange instance anymore (at the end of your async coroutine).
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x107f07880>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x10a1ddee0>, 2.25219225)]']
connector: <aiohttp.connector.TCPConnector object at 0x107f07d90>
```