### PR TITLE
fix(binance): return empty object in fetchCurrencies

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2611,19 +2611,19 @@ export default class binance extends Exchange {
          */
         const fetchCurrenciesEnabled = this.safeValue (this.options, 'fetchCurrencies');
         if (!fetchCurrenciesEnabled) {
-            return undefined;
+            return {};
         }
         // this endpoint requires authentication
         // while fetchCurrencies is a public API method by design
         // therefore we check the keys here
         // and fallback to generating the currencies from the markets
         if (!this.checkRequiredCredentials (false)) {
-            return undefined;
+            return {};
         }
         // sandbox/testnet does not support sapi endpoints
         const apiBackup = this.safeValue (this.urls, 'apiBackup');
         if (apiBackup !== undefined) {
-            return undefined;
+            return {};
         }
         const response = await this.sapiGetCapitalConfigGetall (params);
         const result = {};


### PR DESCRIPTION
fix: ccxt/ccxt#22057

Should we return empty object in those cases?