### PR TITLE
fix(kraken): update commonCurrencies

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -220,7 +220,8 @@ export default class kraken extends Exchange {
             'commonCurrencies': {
                 'LUNA': 'LUNC',
                 'LUNA2': 'LUNA',
-                'REP': 'REPV1',
+                'REPV2': 'REP',
+                'XREP': 'REPV1',
                 'UST': 'USTC',
                 'XBT': 'BTC',
                 'XBT.M': 'BTC.M', // https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M-

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -220,7 +220,6 @@ export default class kraken extends Exchange {
             'commonCurrencies': {
                 'LUNA': 'LUNC',
                 'LUNA2': 'LUNA',
-                'REPV2': 'REP',
                 'REP': 'REPV1',
                 'UST': 'USTC',
                 'XBT': 'BTC',


### PR DESCRIPTION
fix: ccxt/ccxt#22056

In this issue (ccxt/ccxt#21112), the behavior of safeCurrencyCode was changed. But it may break other exchanges if the item represents two different currency, eg. REPV2 and REP. In this PR, I changed the commonCurrencies, the pair would be: `REPV2/USD` and `REPV1/USD`.

We may either revert that change or find issues in other exchanges (not sure).