### PR TITLE
fix(php): remove define_rest_api

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1699,9 +1699,6 @@ class Exchange {
 
     public function __wakeup() {
         $this->curl = curl_init();
-        if ($this->api) {
-            $this->define_rest_api($this->api, 'request');
-        }
     }
 
     public function __destruct() {


### PR DESCRIPTION
fix: ccxt/ccxt#22076, ccxt/ccxt#18698
Removed the usage of non existed function. Test by adding this line in cli.php: `unserialize(serialize($exchange));`