### PR TITLE
The ProBit exchange implementation has incorrectly set the 'fetchDepositsWithdrawals' to true.

### DIFF
--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -49,7 +49,7 @@ export default class probit extends Exchange {
                 'fetchDepositAddress': true,
                 'fetchDepositAddresses': true,
                 'fetchDeposits': true,
-                'fetchDepositsWithdrawals': true,
+                'fetchDepositsWithdrawals': false,
                 'fetchFundingHistory': false,
                 'fetchFundingRate': false,
                 'fetchFundingRateHistory': false,


### PR DESCRIPTION
Since the method is not implemented, a call to the method will throw an exception.

Note that the 'fetchDeposits' and 'fetchWithdrawals' are implemented, and can be used normally.