### PR TITLE
refactor(exchange): parseLeverageTiers accepts either a dictionary or an array

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -4103,37 +4103,6 @@ export default class coinex extends Exchange {
         return this.parseLeverageTiers (data, symbols, undefined);
     }
 
-    parseLeverageTiers (response, symbols: Strings = undefined, marketIdKey = undefined) {
-        //
-        //     {
-        //         "BTCUSD": [
-        //             ["500001", "100", "0.005"],
-        //             ["1000001", "50", "0.01"],
-        //             ["2000001", "30", "0.015"],
-        //             ["5000001", "20", "0.02"],
-        //             ["10000001", "15", "0.025"],
-        //             ["20000001", "10", "0.03"]
-        //         ],
-        //         ...
-        //     }
-        //
-        const tiers = {};
-        const marketIds = Object.keys (response);
-        for (let i = 0; i < marketIds.length; i++) {
-            const marketId = marketIds[i];
-            const market = this.safeMarket (marketId, undefined, undefined, 'spot');
-            const symbol = this.safeString (market, 'symbol');
-            let symbolsLength = 0;
-            if (symbols !== undefined) {
-                symbolsLength = symbols.length;
-            }
-            if (symbol !== undefined && (symbolsLength === 0 || this.inArray (symbols, symbol))) {
-                tiers[symbol] = this.parseMarketLeverageTiers (response[marketId], market);
-            }
-        }
-        return tiers;
-    }
-
     parseMarketLeverageTiers (item, market: Market = undefined) {
         const tiers = [];
         let minNotional = 0;

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -3783,56 +3783,7 @@ export default class digifinex extends Exchange {
         //
         const data = this.safeValue (response, 'data', []);
         symbols = this.marketSymbols (symbols);
-        return this.parseLeverageTiers (data, symbols, 'symbol');
-    }
-
-    parseLeverageTiers (response, symbols: Strings = undefined, marketIdKey = undefined) {
-        //
-        //     [
-        //         {
-        //             "instrument_id": "BTCUSDTPERP",
-        //             "type": "REAL",
-        //             "contract_type": "PERPETUAL",
-        //             "base_currency": "BTC",
-        //             "quote_currency": "USDT",
-        //             "clear_currency": "USDT",
-        //             "contract_value": "0.001",
-        //             "contract_value_currency": "BTC",
-        //             "is_inverse": false,
-        //             "is_trading": true,
-        //             "status": "ONLINE",
-        //             "price_precision": 1,
-        //             "tick_size": "0.1",
-        //             "min_order_amount": 1,
-        //             "open_max_limits": [
-        //                 {
-        //                     "leverage": "50",
-        //                     "max_limit": "1000000"
-        //                 }
-        //             ]
-        //         },
-        //     ]
-        //
-        const tiers = {};
-        const result = {};
-        for (let i = 0; i < response.length; i++) {
-            const entry = response[i];
-            const marketId = this.safeString (entry, 'instrument_id');
-            const market = this.safeMarket (marketId);
-            const symbol = this.safeSymbol (marketId, market);
-            let symbolsLength = 0;
-            tiers[symbol] = this.parseMarketLeverageTiers (response[i], market);
-            if (symbols !== undefined) {
-                symbolsLength = symbols.length;
-                if (this.inArray (symbol, symbols)) {
-                    result[symbol] = this.parseMarketLeverageTiers (response[i], market);
-                }
-            }
-            if (symbol !== undefined && (symbolsLength === 0 || this.inArray (symbols, symbol))) {
-                result[symbol] = this.parseMarketLeverageTiers (response[i], market);
-            }
-        }
-        return result;
+        return this.parseLeverageTiers (data, symbols, 'instrument_id');
     }
 
     async fetchMarketLeverageTiers (symbol: string, params = {}) {


### PR DESCRIPTION
- parseLeverageTiers can parse a response that is a dictionary
- fixes coinex `fetchLeverageTiers`

```
Python v3.9.6
CCXT v4.2.90
binance.fetchLeverageTiers()
{'1000BONK/USDT:USDT': [{'currency': 'USDT',
                         'info': {'bracket': '1',
                                  'cum': '0.0',
                                  'initialLeverage': '50',
                                  'maintMarginRatio': '0.015',
                                  'notionalCap': '5000',
                                  'notionalFloor': '0'},
                         'maintenanceMarginRate': 0.015,
                         'maxLeverage': 50.0,
                         'maxNotional': 5000.0,
                         'minNotional': 0.0,
                         'tier': 1.0},
                        {'currency': 'USDT',
                         'info': {'bracket': '2',
                                  'cum': '50.0',
                                  'initialLeverage': '20',
                                  'maintMarginRatio': '0.025',
                                  'notionalCap': '25000',
                                  'notionalFloor': '5000'},
                         'maintenanceMarginRate': 0.025,
                         'maxLeverage': 20.0,
                         'maxNotional': 25000.0,
                         'minNotional': 5000.0,
                         'tier': 2.0},
                        {'currency': 'USDT',
                         'info': {'bracket': '3',
                                  'cum': '675.0',
                                  'initialLeverage': '10',
                                  'maintMarginRatio': '0.05',
                                  'notionalCap': '100000',
                                  'notionalFloor': '25000'},
                         'maintenanceMarginRate': 0.05,
                         'maxLeverage': 10.0,
                         'maxNotional': 100000.0,
                         'minNotional': 25000.0,
                         'tier': 3.0},
                        {'currency': 'USDT',
                         'info': {'bracket': '4',
                                  'cum': '5675.0',
                                  'initialLeverage': '5',
                                  'maintMarginRatio': '0.1',
                                  'notionalCap': '200000',
                                  'notionalFloor': '100000'},
                         'maintenanceMarginRate': 0.1,
                         'maxLeverage': 5.0,
                         'maxNotional': 200000.0,
                         'minNotional': 100000.0,
                         'tier': 4.0},
                        {'currency': 'USDT',
                         'info': {'bracket': '5',
                                  'cum': '10675.0',
                                  'initialLeverage': '4',
                                  'maintMarginRatio': '0.125',
                                  'notionalCap': '500000',
                                  'notionalFloor': '200000'},
                         'maintenanceMarginRate': 0.125,
                         'maxLeverage': 4.0,
                         'maxNotional': 500000.0,
                         'minNotional': 200000.0,
                         'tier': 5.0},
                        {'currency': 'USDT',
                         'info': {'bracket': '6',
                                  'cum': '73175.0',
                                  'initialLeverage': '2',
                                  'maintMarginRatio': '0.25',
                                  'notionalCap': '1000000',
                                  'notionalFloor': '500000'},
                         'maintenanceMarginRate': 0.25,
                         'maxLeverage': 2.0,
                         'maxNotional': 1000000.0,
                         'minNotional': 500000.0,
                         'tier': 6.0},
                        {'currency': 'USDT',
                         'info': {'bracket': '7',
                                  'cum': '323175.0',
                                  'initialLeverage': '1',
                                  'maintMarginRatio': '0.5',
                                  'notionalCap': '2000000',
                                  'notionalFloor': '1000000'},
                         'maintenanceMarginRate': 0.5,
                         'maxLeverage': 1.0,
                         'maxNotional': 2000000.0,
                         'minNotional': 1000000.0,
                         'tier': 7.0}],
 ...
 ```

```
Python v3.9.6
CCXT v4.2.90
coinex.fetchLeverageTiers()
{'1INCH/USDT:USDT': [{'currency': '1INCH',
                      'info': ['50001', '20', '0.02'],
                      'maintenanceMarginRate': 0.02,
                      'maxLeverage': 20,
                      'maxNotional': 50001.0,
                      'minNotional': 0,
                      'tier': 1},
                     {'currency': '1INCH',
                      'info': ['100001', '10', '0.04'],
                      'maintenanceMarginRate': 0.04,
                      'maxLeverage': 10,
                      'maxNotional': 100001.0,
                      'minNotional': 50001.0,
                      'tier': 2},
                     {'currency': '1INCH',
                      'info': ['200001', '8', '0.06'],
                      'maintenanceMarginRate': 0.06,
                      'maxLeverage': 8,
                      'maxNotional': 200001.0,
                      'minNotional': 100001.0,
                      'tier': 3},
                     {'currency': '1INCH',
                      'info': ['500001', '5', '0.08'],
                      'maintenanceMarginRate': 0.08,
                      'maxLeverage': 5,
                      'maxNotional': 500001.0,
                      'minNotional': 200001.0,
                      'tier': 4},
                     {'currency': '1INCH',
                      'info': ['1000001', '3', '0.1'],
                      'maintenanceMarginRate': 0.1,
                      'maxLeverage': 3,
                      'maxNotional': 1000001.0,
                      'minNotional': 500001.0,
                      'tier': 5}],
 ```

```
 Python v3.9.6
CCXT v4.2.90
digifinex.fetchLeverageTiers()
{'AAVE/USDT:USDT': [{'currency': 'USDT',
                     'info': {'leverage': '5', 'max_limit': '200000'},
                     'maintenanceMarginRate': None,
                     'maxLeverage': 5.0,
                     'maxNotional': 200000.0,
                     'minNotional': None,
                     'tier': 1},
                    {'currency': 'USDT',
                     'info': {'leverage': '20', 'max_limit': '100000'},
                     'maintenanceMarginRate': None,
                     'maxLeverage': 20.0,
                     'maxNotional': 100000.0,
                     'minNotional': None,
                     'tier': 2},
                    {'currency': 'USDT',
                     'info': {'leverage': '50', 'max_limit': '50000'},
                     'maintenanceMarginRate': None,
                     'maxLeverage': 50.0,
                     'maxNotional': 50000.0,
                     'minNotional': None,
                     'tier': 3}],
....
```