### PR TITLE
fix(Kucoin): watchTickers topic should not be all if symbols passed

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -193,7 +193,7 @@ export default class kucoin extends kucoinRest {
             messageHash = 'tickers::' + symbols.join (',');
         }
         const url = await this.negotiate (false);
-        const topic = `/market/ticker:${symbols !== undefined ? symbols.join (',') : "all"}`;
+        const topic = '/market/ticker:all';
         const tickers = await this.subscribe (url, messageHash, topic, params);
         if (this.newUpdates) {
             return tickers;

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -193,7 +193,7 @@ export default class kucoin extends kucoinRest {
             messageHash = 'tickers::' + symbols.join (',');
         }
         const url = await this.negotiate (false);
-        const topic = '/market/ticker:all';
+        const topic = `/market/ticker:${symbols !== undefined ? symbols.join (',') : "all"}`;
         const tickers = await this.subscribe (url, messageHash, topic, params);
         if (this.newUpdates) {
             return tickers;


### PR DESCRIPTION
If Symbols are passed to the function, then the `topic` should not be `all` because if topic was `all` then all the markets changes would be received.