### PR TITLE
fix(gemini): parseMarket was parsing 'USDCUSD' as CUSD/USD.

### DIFF
--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -689,7 +689,7 @@ export default class gemini extends Exchange {
             for (let i = 0; i < quoteQurrencies.length; i++) {
                 const quoteCurrency = quoteQurrencies[i];
                 if (marketIdWithoutPerp.endsWith (quoteCurrency)) {
-                    baseId = marketIdWithoutPerp.replace (quoteCurrency, '');
+                    baseId = marketIdWithoutPerp.slice (0, -quoteCurrency.length);
                     quoteId = quoteCurrency;
                     if (isPerp) {
                         settleId = quoteCurrency; // always same


### PR DESCRIPTION

The market parsing code takes a symbol ID of the form `usdcusd` and attempts to split it into a base and quote using a list of quote currencies.

```
                if (marketIdWithoutPerp.endsWith (quoteCurrency)) {
                    baseId = marketIdWithoutPerp.replace (quoteCurrency, '');
```

However, if the `marketIdWithoutPerp` begins with a quote currency like `USD` then the replace will remove that and leave the baseId as `CUSD`.

Switch the code to use `splice()` on the end of the string rather than `replace()`.

                    baseId = marketIdWithoutPerp.slice (0, -quoteCurrency.length);

cc @ttodua 