### PR TITLE
coinex: fetchOrderBook v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1097,8 +1097,8 @@ export default class coinex extends Exchange {
          * @method
          * @name coinex#fetchOrderBook
          * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot001_market004_market_depth
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http010_market_depth
+         * @see https://docs.coinex.com/api/v2/spot/market/http/list-market-depth
+         * @see https://docs.coinex.com/api/v2/futures/market/http/list-market-depth
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int} [limit] the maximum amount of order book entries to return
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1110,64 +1110,70 @@ export default class coinex extends Exchange {
             limit = 20; // default
         }
         const request = {
-            'market': this.marketId (symbol),
-            'merge': '0',
-            'limit': limit.toString (),
+            'market': market['id'],
+            'limit': limit,
+            'interval': '0',
         };
         let response = undefined;
         if (market['swap']) {
-            response = await this.v1PerpetualPublicGetMarketDepth (this.extend (request, params));
+            response = await this.v2PublicGetFuturesDepth (this.extend (request, params));
+            //
+            //     {
+            //         "code": 0,
+            //         "data": {
+            //             "depth": {
+            //                 "asks": [
+            //                     ["70851.94", "0.2119"],
+            //                     ["70851.95", "0.0004"],
+            //                     ["70851.96", "0.0004"]
+            //                 ],
+            //                 "bids": [
+            //                     ["70851.93", "1.0314"],
+            //                     ["70850.93", "0.0021"],
+            //                     ["70850.42", "0.0306"]
+            //                 ],
+            //                 "checksum": 2956436260,
+            //                 "last": "70851.94",
+            //                 "updated_at": 1712824003252
+            //             },
+            //             "is_full": true,
+            //             "market": "BTCUSDT"
+            //         },
+            //         "message": "OK"
+            //     }
+            //
         } else {
-            response = await this.v1PublicGetMarketDepth (this.extend (request, params));
+            response = await this.v2PublicGetSpotDepth (this.extend (request, params));
+            //
+            //     {
+            //         "code": 0,
+            //         "data": {
+            //             "depth": {
+            //                 "asks": [
+            //                     ["70875.31", "0.28670282"],
+            //                     ["70875.32", "0.31008114"],
+            //                     ["70875.42", "0.05876653"]
+            //                 ],
+            //                 "bids": [
+            //                     ["70855.3", "0.00632222"],
+            //                     ["70855.29", "0.36216834"],
+            //                     ["70855.17", "0.10166802"]
+            //                 ],
+            //                 "checksum": 2313816665,
+            //                 "last": "70857.19",
+            //                 "updated_at": 1712823790987
+            //             },
+            //             "is_full": true,
+            //             "market": "BTCUSDT"
+            //         },
+            //         "message": "OK"
+            //     }
+            //
         }
-        //
-        // Spot
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "asks": [
-        //                 ["41056.33", "0.31727613"],
-        //                 ["41056.34", "1.05657294"],
-        //                 ["41056.35", "0.02346648"]
-        //             ],
-        //             "bids": [
-        //                 ["41050.61", "0.40618608"],
-        //                 ["41046.98", "0.13800000"],
-        //                 ["41046.56", "0.22579234"]
-        //             ],
-        //             "last": "41050.61",
-        //             "time": 1650573220346
-        //         },
-        //         "message": "OK"
-        //     }
-        //
-        // Swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "asks": [
-        //                 ["40620.90", "0.0384"],
-        //                 ["40625.50", "0.0219"],
-        //                 ["40625.90", "0.3506"]
-        //             ],
-        //             "bids": [
-        //                 ["40620.89", "19.6861"],
-        //                 ["40620.80", "0.0012"],
-        //                 ["40619.87", "0.0365"]
-        //             ],
-        //             "last": "40620.89",
-        //             "time": 1650587672406,
-        //             "sign_price": "40619.32",
-        //             "index_price": "40609.93"
-        //         },
-        //         "message": "OK"
-        //     }
-        //
-        const result = this.safeValue (response, 'data', {});
-        const timestamp = this.safeInteger (result, 'time');
-        return this.parseOrderBook (result, symbol, timestamp);
+        const data = this.safeDict (response, 'data', {});
+        const depth = this.safeDict (data, 'depth', {});
+        const timestamp = this.safeInteger (depth, 'updated_at');
+        return this.parseOrderBook (depth, symbol, timestamp);
     }
 
     parseTrade (trade, market: Market = undefined): Trade {

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -577,35 +577,19 @@
         ],
         "fetchOrderBook": [
             {
-                "description": "Spot fetch orderbook",
+                "description": "Spot fetch order book",
                 "method": "fetchOrderBook",
-                "url": "https://api.coinex.com/v1/market/depth?market=BTCUSDT&merge=0&limit=20",
+                "url": "https://api.coinex.com/v2/spot/depth?market=BTCUSDT&limit=20&interval=0",
                 "input": [
-                    "BTC/USDT"
+                  "BTC/USDT"
                 ]
             },
             {
-                "description": "Swap fetch orderbook",
+                "description": "Swap fetch order book",
                 "method": "fetchOrderBook",
-                "url": "https://api.coinex.com/perpetual/v1/market/depth?market=BTCUSDT&merge=0&limit=20",
+                "url": "https://api.coinex.com/v2/futures/depth?market=BTCUSDT&limit=20&interval=0",
                 "input": [
-                    "BTC/USDT:USDT"
-                ]
-            },
-            {
-                "description": "spot orderbook",
-                "method": "fetchOrderBook",
-                "url": "https://api.coinex.com/v1/market/depth?market=BTCUSDT&merge=0&limit=20",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
-                "description": "swap orderbook",
-                "method": "fetchOrderBook",
-                "url": "https://api.coinex.com/perpetual/v1/market/depth?market=BTCUSDT&merge=0&limit=20",
-                "input": [
-                    "BTC/USDT:USDT"
+                  "BTC/USDT:USDT"
                 ]
             }
         ],


### PR DESCRIPTION
Updated `fetchOrderBook` to v2:
```
coinex.fetchOrderBook (BTC/USDT:USDT, 5)
2024-04-11T08:32:15.849Z iteration 0 passed in 740 ms

{
  symbol: 'BTC/USDT:USDT',
  bids: [
    [ 70837.84, 0.8581 ],
    [ 70837.83, 0.0624 ],
    [ 70837.16, 0.0376 ],
    [ 70835.27, 0.0828 ],
    [ 70834.25, 0.0895 ]
  ],
  asks: [
    [ 70837.85, 0.5132 ],
    [ 70837.86, 0.0004 ],
    [ 70837.87, 0.0004 ],
    [ 70837.88, 0.0004 ],
    [ 70837.89, 0.0004 ]
  ],
  timestamp: 1712824337204,
  datetime: '2024-04-11T08:32:17.204Z'
}
```