### PR TITLE
fix(kucoin) - chain id currency, network precisions, etc

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -515,7 +515,7 @@ export default class kucoin extends Exchange {
                     '400006': AuthenticationError,
                     '400007': AuthenticationError,
                     '400008': NotSupported,
-                    '400100': InsufficientFunds, // {"msg":"account.available.amount","code":"400100"}
+                    '400100': InsufficientFunds, // {"msg":"account.available.amount","code":"400100"} or {"msg":"Withdrawal amount is below the minimum requirement.","code":"400100"}
                     '400200': InvalidOrder, // {"code":"400200","msg":"Forbidden to place an order"}
                     '400350': InvalidOrder, // {"code":"400350","msg":"Upper limit for holding: 10,000USDT, you can still buy 10,000USDT worth of coin."}
                     '400370': InvalidOrder, // {"code":"400370","msg":"Max. price: 0.02500000000000000000"}
@@ -3201,7 +3201,6 @@ export default class kucoin extends Exchange {
         const request = {
             'currency': currency['id'],
             'address': address,
-            'amount': amount,
             // 'memo': tag,
             // 'isInner': false, // internal transfer or external withdrawal
             // 'remark': 'optional',
@@ -3215,6 +3214,8 @@ export default class kucoin extends Exchange {
         if (networkCode !== undefined) {
             request['chain'] = this.networkCodeToId (networkCode).toLowerCase ();
         }
+        await this.loadCurrencyPrecision (currency, networkCode);
+        request['amount'] = this.currencyToPrecision (code, amount, networkCode);
         let includeFee = undefined;
         [ includeFee, params ] = this.handleOptionAndParams (params, 'withdraw', 'includeFee', false);
         if (includeFee) {
@@ -3233,6 +3234,54 @@ export default class kucoin extends Exchange {
         //
         const data = this.safeDict (response, 'data', {});
         return this.parseTransaction (data, currency);
+    }
+
+    async loadCurrencyPrecision (currency, networkCode: Str = undefined) {
+        // as kucoin might not have network specific precisions defined in fetchCurrencies (because of webapi failure)
+        // we should check and refetch precision once-per-instance for that specific currency & network
+        // so avoids thorwing exceptions and burden to users
+        // Note: this needs to be executed only if networkCode was provided
+        if (networkCode !== undefined) {
+            const networks = currency['networks'];
+            const network = this.safeDict (networks, networkCode);
+            if (this.safeNumber (network, 'precision') !== undefined) {
+                // if precision exists, no need to refetch
+                return;
+            }
+            // otherwise try to fetch and store in instance
+            const request = {
+                'currency': currency['id'],
+                'chain': this.networkCodeToId (networkCode).toLowerCase (),
+            };
+            const response = await this.privateGetWithdrawalsQuotas (request);
+            //
+            //    {
+            //        "code": "200000",
+            //        "data": {
+            //            "currency": "USDT",
+            //            "limitBTCAmount": "14.24094850",
+            //            "usedBTCAmount": "0.00000000",
+            //            "quotaCurrency": "USDT",
+            //            "limitQuotaCurrencyAmount": "999999.00000000",
+            //            "usedQuotaCurrencyAmount": "0",
+            //            "remainAmount": "999999.0000",
+            //            "availableAmount": "10.77545071",
+            //            "withdrawMinFee": "1",
+            //            "innerWithdrawMinFee": "0",
+            //            "withdrawMinSize": "10",
+            //            "isWithdrawEnabled": true,
+            //            "precision": 4,
+            //            "chain": "EOS",
+            //            "reason": null,
+            //            "lockedAmount": "0"
+            //        }
+            //    }
+            //
+            const data = this.safeDict (response, 'data', {});
+            const precision = this.parseNumber (this.parsePrecision (this.safeString (data, 'precision')));
+            const code = currency['code'];
+            this.currencies[code]['networks'][networkCode]['precision'] = precision;
+        }
     }
 
     parseTransactionStatus (status) {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -1153,8 +1153,10 @@ export default class kucoin extends Exchange {
         //              "chains":[
         //                 {
         //                    "chainName":"ERC20",
-        //                    "chain":"eth",
+        //                    "chainId": "eth"
         //                    "withdrawalMinSize":"2999",
+        //                    "depositMinSize":null,
+        //                    "withdrawFeeRate":"0",
         //                    "withdrawalMinFee":"2999",
         //                    "isWithdrawEnabled":false,
         //                    "isDepositEnabled":false,
@@ -1260,7 +1262,7 @@ export default class kucoin extends Exchange {
                             'max': undefined,
                         },
                         'deposit': {
-                            'min': this.safeNumber (chainExtraData, 'depositMinSize'),
+                            'min': this.safeNumber (chain, 'depositMinSize'),
                             'max': undefined,
                         },
                     },

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -333,6 +333,22 @@
                 "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"from\":\"trade\",\"to\":\"trade_hf\",\"clientOid\":\"d0da1feb-d76c-4562-b727-ddfabec6ca45\"}"
             }
         ],
+        "withdraw": [
+            {
+                "description": "network specific withdraw with precision working",
+                "method": "withdraw",
+                "url": "https://api.kucoin.com/api/v1/withdrawals",
+                "input": [
+                    "USDT",
+                    5.12345678,
+                    "sample12345",
+                    {
+                        "network": "EOS"
+                    }
+                ],
+                "output": "{\"currency\":\"USDT\",\"address\":\"sample12345\",\"chain\":\"eos\",\"amount\":\"5.1235\"}"
+            }
+        ],
         "fetchLedger": [
             {
                 "description": "fetch USDT ledger",


### PR DESCRIPTION
at `fetchCurrencies` web endpoint for kucoin specifically is not reliable for some locations/users, then there is no other way to know precisions for networks and impossible to make correctly make withdrawal, as you cant predetermine the precision and get exceptions from exchange. this would help and automatize the process, so users wont notice the problems.