### PR TITLE
fix(OrderBookSide): @typescript-eslint/parser 7.6.0 errors on wrong order

### DIFF
--- a/ts/src/base/ws/OrderBookSide.ts
+++ b/ts/src/base/ws/OrderBookSide.ts
@@ -34,7 +34,7 @@ interface IOrderBookSide<T> extends Array<T> {
     limit();
 }
 
-class OrderBookSide implements IOrderBookSide extends Array {
+class OrderBookSide extends Array implements IOrderBookSide {
     constructor (deltas = [], depth = undefined) {
         super ()
         // a string-keyed dictionary of price levels / ids / indices
@@ -148,7 +148,7 @@ class CountedOrderBookSide extends OrderBookSide {
 // ----------------------------------------------------------------------------
 // stores vector arrays indexed by id (3rd value in a bidask delta array)
 
-class IndexedOrderBookSide implements IOrderBookSide extends Array  {
+class IndexedOrderBookSide extends Array implements IOrderBookSide {
     constructor (deltas = [], depth = Number.MAX_SAFE_INTEGER) {
         super (deltas.length)
         // a string-keyed dictionary of price levels / ids / indices


### PR DESCRIPTION
I have a project that imports ccxt.
```
    Error while parsing .../node_modules/ccxt/js/src/base/ws/OrderBookSide.d.ts
    Line 7, column 54: 'extends' clause must precede 'implements' clause.
    `parseForESLint` from parser `@typescript-eslint/parser` is invalid and will just be ignored
    Line 17, column 61: 'extends' clause must precede 'implements' clause.
    `parseForESLint` from parser `@typescript-eslint/parser` is invalid and will just be ignored
```

From my `package.json`:

```
  "devDependencies": {
    "@typescript-eslint/eslint-plugin": "^7.6.0",
    "@typescript-eslint/parser": "^7.6.0",
    "eslint": "^8.57.0",
    "eslint-import-resolver-typescript": "^3.6.1",
    "eslint-plugin-import": "^2.29.1",
    "source-map-support": "^0.5.21",
    "ts-node": "^10.9.2",
    "typescript": "^5.4.4"
  }
```
