### PR TITLE
handleMarketTypeAndParams - add defaultValue parameter

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4459,11 +4459,26 @@ export default class Exchange {
         return result;
     }
 
-    handleMarketTypeAndParams (methodName: string, market: Market = undefined, params = {}): any {
+    handleMarketTypeAndParams (methodName: string, market: Market = undefined, params = {}, defaultValue = undefined): any {
+        /**
+         * @ignore
+         * @method
+         * @name exchange#handleMarketTypeAndParams
+         * @param methodName the method calling handleMarketTypeAndParams
+         * @param {Market} market
+         * @param {object} params
+         * @param {string} [params.type] type assigned by user
+         * @param {string} [params.defaultType] same as params.type
+         * @param {string} [defaultValue] assigned programatically in the method calling handleMarketTypeAndParams
+         * @returns {[string, object]} the market type and params with type and defaultType omitted
+         */
         const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
+        if (defaultValue === undefined) {  // defaultValue takes precendence over exchange wide defaultType
+            defaultValue = defaultType;
+        }
         const methodOptions = this.safeDict (this.options, methodName);
-        let methodType = defaultType;
-        if (methodOptions !== undefined) {
+        let methodType = defaultValue;
+        if (methodOptions !== undefined) {  // user defined methodType takes precedence over defaultValue
             if (typeof methodOptions === 'string') {
                 methodType = methodOptions;
             } else {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1108,14 +1108,14 @@ export default class okx extends Exchange {
         });
     }
 
-    handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
+    handleMarketTypeAndParams (methodName: string, market: Market = undefined, params = {}, defaultValue = undefined): any {
         const instType = this.safeString (params, 'instType');
         params = this.omit (params, 'instType');
         const type = this.safeString (params, 'type');
         if ((type === undefined) && (instType !== undefined)) {
             params['type'] = instType;
         }
-        return super.handleMarketTypeAndParams (methodName, market, params);
+        return super.handleMarketTypeAndParams (methodName, market, params, defaultValue);
     }
 
     convertToInstrumentType (type) {


### PR DESCRIPTION
```
% gate handleMarketTypeAndParams 'fetchBalance' undefined '{}' 'swap'
2024-04-12T00:42:56.627Z
Node.js: v18.12.0
CCXT v4.2.90
gate.handleMarketTypeAndParams (fetchBalance, , [object Object], swap)
2024-04-12T00:43:03.522Z iteration 0 passed in 0 ms

[ 'swap', {} ]
2 objects
2024-04-12T00:43:03.522Z iteration 1 passed in 0 ms
```
```
% gate handleMarketTypeAndParams 'fetchBalance' undefined '{}'       
2024-04-12T00:43:15.072Z
Node.js: v18.12.0
CCXT v4.2.90
gate.handleMarketTypeAndParams (fetchBalance, , [object Object])
2024-04-12T00:43:22.755Z iteration 0 passed in 1 ms

[ 'spot', {} ]
2 objects
2024-04-12T00:43:22.755Z iteration 1 passed in 1 ms
```

with 

```
"options": {
            "fetchBalance": {
                "defaultType": "margin"
            }
        }
```

set in keys.local.json

```
% gate handleMarketTypeAndParams 'fetchBalance' undefined '{}' 'swap'
2024-04-12T00:41:48.532Z
Node.js: v18.12.0
CCXT v4.2.90
gate.handleMarketTypeAndParams (fetchBalance, , [object Object], swap)
2024-04-12T00:41:55.855Z iteration 0 passed in 0 ms

[ 'margin', {} ]
2 objects
2024-04-12T00:41:55.855Z iteration 1 passed in 0 ms
```