### PR TITLE
read new ask/bid from ticker

### DIFF
--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -144,6 +144,11 @@ export default class coinbase extends coinbaseRest {
         //                        "low_52_w": "15460",
         //                        "high_52_w": "48240",
         //                        "price_percent_chg_24_h": "-4.15775596190603"
+        // new as of 2024-04-12
+        //                        "best_bid":"21835.29",
+        //                        "best_bid_quantity": "0.02000000",
+        //                        "best_ask":"23011.18",
+        //                        "best_ask_quantity": "0.01500000"
         //                    }
         //                ]
         //            }
@@ -169,6 +174,11 @@ export default class coinbase extends coinbaseRest {
         //                        "low_52_w": "0.04908",
         //                        "high_52_w": "0.1801",
         //                        "price_percent_chg_24_h": "0.50177456859626"
+        // new as of 2024-04-12
+        //                        "best_bid":"0.07989",
+        //                        "best_bid_quantity": "500.0",
+        //                        "best_ask":"0.08308",
+        //                        "best_ask_quantity": "300.0"
         //                    }
         //                ]
         //            }
@@ -224,6 +234,11 @@ export default class coinbase extends coinbaseRest {
         //         "low_52_w": "0.04908",
         //         "high_52_w": "0.1801",
         //         "price_percent_chg_24_h": "0.50177456859626"
+        // new as of 2024-04-12
+        //         "best_bid":"0.07989",
+        //         "best_bid_quantity": "500.0",
+        //         "best_ask":"0.08308",
+        //         "best_ask_quantity": "300.0"
         //     }
         //
         const marketId = this.safeString (ticker, 'product_id');
@@ -236,10 +251,10 @@ export default class coinbase extends coinbaseRest {
             'datetime': this.iso8601 (timestamp),
             'high': this.safeString (ticker, 'high_24_h'),
             'low': this.safeString (ticker, 'low_24_h'),
-            'bid': undefined,
-            'bidVolume': undefined,
-            'ask': undefined,
-            'askVolume': undefined,
+            'bid': this.safeString (ticker, 'best_bid'),
+            'bidVolume': this.safeString (ticker, 'best_bid_quantity'),
+            'ask': this.safeString (ticker, 'best_ask'),
+            'askVolume': this.safeString (ticker, 'best_ask_quantity'),
             'vwap': undefined,
             'open': undefined,
             'close': last,


### PR DESCRIPTION
As of april 12th 2024, Coinbase sends additional information in the tickers channel, that can be used to fill following fields:
- ask (info.best_ask)
- askVolume (info.best_ask_quantity)
- bid (info.best_bid)
- bidVolume (info.best_bid_quantity)
