### PR TITLE
fix(ecdsa): unify the ecdsa signing

### DIFF
--- a/cs/cli/Program.cs
+++ b/cs/cli/Program.cs
@@ -78,6 +78,11 @@ public static class Program
                 {
                     var parsedKey = instance.id.ToUpper() + "_" + key.ToUpper();
                     credentialValue = Environment.GetEnvironmentVariable(parsedKey);
+                    if (credentialValue.StartsWith("-----BEGIN"))
+                    {
+                        credentialValue = credentialValue.Replace("\\n", "\n");
+
+                    }
                 }
 
                 // If a value was found, set the property on the instance

--- a/examples/py/cli.py
+++ b/examples/py/cli.py
@@ -160,6 +160,9 @@ async def main():
             credentialEnvName = (argv.exchange_id + '_' + credential).upper()  # example: KRAKEN_APIKEY
             if credentialEnvName in os.environ:
                 credentialValue = os.environ[credentialEnvName]
+                if credentialValue.startswith('-----BEGIN'):
+                    credentialValue = credentialValue.replace('\\n', '\n')
+
                 setattr(exchange, credential, credentialValue)
 
     if argv.cors:

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1265,7 +1265,7 @@ class Exchange {
             $signature = \base64_decode(static::rsa($token, $secret, $algorithm));
         } else if ($algoType === 'ES') {
             $signed = static::ecdsa($token, $secret, 'p256', $algorithm);
-            $signature = hex2bin($signed['r'] . $signed['s']);
+            $signature = hex2bin(str_pad($signed['r'], 64, '0', STR_PAD_LEFT) . str_pad($signed['s'], 64, '0', STR_PAD_LEFT));
         } else {
             $signature = static::hmac($token, $secret, $algorithm, 'binary');
         }

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1341,7 +1341,7 @@ class Exchange(object):
             signature = Exchange.base64_to_binary(Exchange.rsa(token, Exchange.decode(secret), algorithm))
         elif algoType == 'ES':
             rawSignature = Exchange.ecdsa(token, secret, 'p256', algorithm)
-            signature = Exchange.base16_to_binary(rawSignature['r'] + rawSignature['s'])
+            signature = Exchange.base16_to_binary(rawSignature['r'].rjust(64, "0") + rawSignature['s'].rjust(64, "0"))
         else:
             signature = Exchange.hmac(Exchange.encode(token), secret, algos[algorithm], 'binary')
         return token + '.' + Exchange.base64urlencode(signature)

--- a/ts/src/base/functions/rsa.ts
+++ b/ts/src/base/functions/rsa.ts
@@ -35,8 +35,8 @@ function jwt (request: {}, secret: Uint8Array, hash: CHash, isRSA = false, opts 
         signature = urlencodeBase64 (rsa (token, utf8.encode (secret), hash));
     } else if (algoType === 'ES') {
         const signedHash = ecdsa (token, utf8.encode (secret), P256, hash);
-        const r = (signedHash.r.length === 64) ? signedHash.r : '0' + signedHash.r;
-        const s = (signedHash.s.length === 64) ? signedHash.s : '0' + signedHash.s;
+        const r = signedHash.r.padStart (64, '0');
+        const s = signedHash.s.padStart (64, '0');
         signature = urlencodeBase64 (binaryToBase64 (base16ToBinary (r + s)));
     }
     return [ token, signature ].join ('.');

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3854,7 +3854,9 @@ export default class coinbase extends Exchange {
                     // it may not work for v2
                     let uri = method + ' ' + url.replace ('https://', '');
                     const quesPos = uri.indexOf ('?');
-                    if (quesPos >= 0) {
+                    // Due to we use mb_strpos, quesPos could be false in php. In that case, the quesPos >= 0 is true
+                    // Also it's not possible that the question mark is first character, only check > 0 here.
+                    if (quesPos > 0) {
                         uri = uri.slice (0, quesPos);
                     }
                     const nonce = this.randomBytes (16);


### PR DESCRIPTION
The current signing logic are not the same across languages. In python / php, it's signed with lower s and has while-loop function. Also the length of the signature wasn't fixed in jwt.
 In this PR, I updated ecdsa in ts and fixed the signature.

Test:
```BASH
$ n coinbase fetchBalance --poll
$ p coinbase fetchBalance
$ ph coinbase fetchBalance
$ cs coinbase fetchBalance
```