### PR TITLE
fix(orderbook): add symbol type

### DIFF
--- a/js/src/base/types.d.ts
+++ b/js/src/base/types.d.ts
@@ -129,7 +129,6 @@ export interface OrderBook {
     datetime: Str;
     timestamp: Int;
     nonce: Int;
-    symbol?: Str;
 }
 export interface Ticker {
     symbol: string;

--- a/js/src/base/types.d.ts
+++ b/js/src/base/types.d.ts
@@ -129,6 +129,7 @@ export interface OrderBook {
     datetime: Str;
     timestamp: Int;
     nonce: Int;
+    symbol?: Str;
 }
 export interface Ticker {
     symbol: string;

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -144,6 +144,7 @@ export interface OrderBook {
     datetime: Str;
     timestamp: Int;
     nonce: Int;
+    symbol: Str;
 }
 
 export interface Ticker {

--- a/ts/src/base/ws/OrderBook.ts
+++ b/ts/src/base/ws/OrderBook.ts
@@ -40,6 +40,8 @@ class OrderBook implements CustomOrderBookProp {
 
     nonce: Int;
 
+    symbol: Str;
+
     constructor (snapshot = {}, depth = undefined) {
 
         Object.defineProperty (this, 'cache', {


### PR DESCRIPTION
fix: missing symbol type from Orderbook. This is only necessary when using watchOrderBookForSymbols()