### PR TITLE
binance: simplify spot portfolio margin usage

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5858,7 +5858,7 @@ export default class binance extends Exchange {
         }
         let postOnly = undefined;
         if (!isPortfolioMargin) {
-            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'RESULT'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
+            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'FULL'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
             postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
             if (market['spot'] || marketType === 'margin') {
                 // only supported for spot/margin api (all margin markets are spot markets)

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5858,7 +5858,6 @@ export default class binance extends Exchange {
         }
         let postOnly = undefined;
         if (!isPortfolioMargin) {
-            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'FULL'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
             postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
             if (market['spot'] || marketType === 'margin') {
                 // only supported for spot/margin api (all margin markets are spot markets)
@@ -5869,6 +5868,13 @@ export default class binance extends Exchange {
                     request['isIsolated'] = true;
                 }
             }
+        }
+        // handle newOrderRespType response type
+        if (((marketType === 'spot') || (marketType === 'margin')) && !isPortfolioMargin) {
+            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'FULL'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
+        } else {
+            // swap, futures and options
+            request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
         }
         const typeRequest = isPortfolioMarginConditional ? 'strategyType' : 'type';
         request[typeRequest] = uppercaseType;

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5738,7 +5738,7 @@ export default class binance extends Exchange {
             } else {
                 response = await this.dapiPrivatePostOrder (request);
             }
-        } else if (marketType === 'margin' || marginMode !== undefined) {
+        } else if (marketType === 'margin' || marginMode !== undefined || isPortfolioMargin) {
             if (isPortfolioMargin) {
                 response = await this.papiPostMarginOrder (request);
             } else {
@@ -5833,14 +5833,6 @@ export default class binance extends Exchange {
                 uppercaseType = market['contract'] ? 'TAKE_PROFIT' : 'TAKE_PROFIT_LIMIT';
             }
         }
-        if ((marketType === 'spot') || (marketType === 'margin')) {
-            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'RESULT'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
-        } else {
-            // swap, futures and options
-            if (!isPortfolioMargin) {
-                request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
-            }
-        }
         if (market['option']) {
             if (type === 'market') {
                 throw new InvalidOrder (this.id + ' ' + type + ' is not a valid order type for the ' + symbol + ' market');
@@ -5866,6 +5858,7 @@ export default class binance extends Exchange {
         }
         let postOnly = undefined;
         if (!isPortfolioMargin) {
+            request['newOrderRespType'] = this.safeString (this.options['newOrderRespType'], type, 'RESULT'); // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills
             postOnly = this.isPostOnly (isMarketOrder, initialUppercaseType === 'LIMIT_MAKER', params);
             if (market['spot'] || marketType === 'margin') {
                 // only supported for spot/margin api (all margin markets are spot markets)
@@ -6496,7 +6489,7 @@ export default class binance extends Exchange {
             } else {
                 response = await this.dapiPrivateGetOpenOrders (this.extend (request, params));
             }
-        } else if (type === 'margin' || marginMode !== undefined) {
+        } else if (type === 'margin' || marginMode !== undefined || isPortfolioMargin) {
             if (isPortfolioMargin) {
                 response = await this.papiGetMarginOpenOrders (this.extend (request, params));
             } else {
@@ -6974,7 +6967,7 @@ export default class binance extends Exchange {
             } else {
                 response = await this.dapiPrivateDeleteAllOpenOrders (this.extend (request, params));
             }
-        } else if ((type === 'margin') || (marginMode !== undefined)) {
+        } else if ((type === 'margin') || (marginMode !== undefined) || isPortfolioMargin) {
             if (isPortfolioMargin) {
                 response = await this.papiDeleteMarginAllOpenOrders (this.extend (request, params));
             } else {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -319,6 +319,22 @@
                 "output": "timestamp=1707113537828&symbol=BTCUSDT&side=BUY&newOrderRespType=FULL&newClientOrderId=x-R4BD3S82e9ef29d8346440f0b28b86&type=LIMIT&quantity=0.001&price=35000&timeInForce=GTC&recvWindow=10000&signature=08d71bf9a60d5184cc256964f1175179c813d11e038718c0d64d5cc5b982f2f5"
             },
             {
+                "description": "Spot margin portfolio margin limit buy order with only portfolioMargin set to true",
+                "method": "createOrder",
+                "url": "https://papi.binance.com/papi/v1/margin/order",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  50000,
+                  {
+                    "portfolioMargin": true
+                  }
+                ],
+                "output": "timestamp=1712974976336&symbol=BTCUSDT&side=BUY&newClientOrderId=x-R4BD3S828b7395b12d0846afa4643c&type=LIMIT&quantity=0.0001&price=50000&timeInForce=GTC&recvWindow=10000&signature=bf3748a7adae072d411444d031d45b17ba8c8febf47bb0b5f4236e33b963b49f"
+            },
+            {
                 "description": "swap order with priceMatch",
                 "method": "createOrder",
                 "url": "https://testnet.binancefuture.com/fapi/v1/order",
@@ -488,6 +504,18 @@
                         "portfolioMargin": true,
                         "marginMode": "cross"
                     }
+                ]
+            },
+            {
+                "description": "Spot margin portfolio margin cancel order with only portfolioMargin set to true",
+                "method": "cancelOrder",
+                "url": "https://papi.binance.com/papi/v1/margin/order?timestamp=1712975069995&symbol=BTCUSDT&orderId=26447758109&recvWindow=10000&signature=5dc7c88abd58e4adbdc8153a19e33dc189e402184f42694de7a5ce3febfac2e8",
+                "input": [
+                  "26447758109",
+                  "BTC/USDT",
+                  {
+                    "portfolioMargin": true
+                  }
                 ]
             },
             {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -249,7 +249,7 @@
                         "portfolioMargin": true
                     }
                 ],
-                "output": "timestamp=1707112464420&symbol=BTCUSDT&side=BUY&newClientOrderId=x-xcKtGhcu0b020e257d4943d49c0ffe&type=LIMIT&quantity=0.01&price=35000&timeInForce=GTC&recvWindow=10000&signature=6d8b1ae407634704c7d7d26cbb62f0f438a09e9863b81a8a89a24461c4997808"
+                "output": "timestamp=1707112464420&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&newClientOrderId=x-xcKtGhcu0b020e257d4943d49c0ffe&type=LIMIT&quantity=0.01&price=35000&timeInForce=GTC&recvWindow=10000&signature=6d8b1ae407634704c7d7d26cbb62f0f438a09e9863b81a8a89a24461c4997808"
             },
             {
                 "description": "Inverse swap portfolio margin limit buy order",
@@ -265,7 +265,7 @@
                         "portfolioMargin": true
                     }
                 ],
-                "output": "timestamp=1707112388003&symbol=ETHUSD_PERP&side=BUY&newClientOrderId=x-xcKtGhcu69273341d6114bd8b800aa&type=LIMIT&quantity=1&price=2000&timeInForce=GTC&recvWindow=10000&signature=4e4f549a6358aa1731060e825069022389780706305a60eaa58fbbf0c4a7d03f"
+                "output": "timestamp=1707112388003&symbol=ETHUSD_PERP&newOrderRespType=RESULT&side=BUY&newClientOrderId=x-xcKtGhcu69273341d6114bd8b800aa&type=LIMIT&quantity=1&price=2000&timeInForce=GTC&recvWindow=10000&signature=4e4f549a6358aa1731060e825069022389780706305a60eaa58fbbf0c4a7d03f"
             },
             {
                 "description": "Linear swap portfolio margin conditional limit buy order",
@@ -282,7 +282,7 @@
                         "triggerPrice": 45000
                     }
                 ],
-                "output": "timestamp=1707112624772&symbol=BTCUSDT&side=BUY&newClientStrategyId=x-xcKtGhcu27f109953d6e4dc0974006&strategyType=STOP&quantity=0.01&price=35000&stopPrice=45000&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
+                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&newClientStrategyId=x-xcKtGhcu27f109953d6e4dc0974006&strategyType=STOP&quantity=0.01&price=35000&stopPrice=45000&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
             },
             {
                 "description": "Inverse swap portfolio margin conditional limit buy order",
@@ -299,7 +299,7 @@
                         "triggerPrice": 3000
                     }
                 ],
-                "output": "timestamp=1707113097689&symbol=ETHUSD_PERP&side=BUY&newClientStrategyId=x-xcKtGhcuc6b86f054bb34933850739&strategyType=STOP&quantity=1&price=2000&stopPrice=3000&recvWindow=10000&signature=aa5ec5fa5eb51372fa68597242bc2ddc31a32e9be5c084f00c2f6999b31cad2b"
+                "output": "timestamp=1707113097689&symbol=ETHUSD_PERP&newOrderRespType=RESULT&side=BUY&newClientStrategyId=x-xcKtGhcuc6b86f054bb34933850739&strategyType=STOP&quantity=1&price=2000&stopPrice=3000&recvWindow=10000&signature=aa5ec5fa5eb51372fa68597242bc2ddc31a32e9be5c084f00c2f6999b31cad2b"
             },
             {
                 "description": "Spot margin portfolio margin limit buy order",
@@ -316,7 +316,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "timestamp=1707113537828&symbol=BTCUSDT&side=BUY&newOrderRespType=FULL&newClientOrderId=x-R4BD3S82e9ef29d8346440f0b28b86&type=LIMIT&quantity=0.001&price=35000&timeInForce=GTC&recvWindow=10000&signature=08d71bf9a60d5184cc256964f1175179c813d11e038718c0d64d5cc5b982f2f5"
+                "output": "timestamp=1707113537828&symbol=BTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-R4BD3S82e9ef29d8346440f0b28b86&type=LIMIT&quantity=0.001&price=35000&timeInForce=GTC&recvWindow=10000&signature=08d71bf9a60d5184cc256964f1175179c813d11e038718c0d64d5cc5b982f2f5"
             },
             {
                 "description": "Spot margin portfolio margin limit buy order with only portfolioMargin set to true",
@@ -332,7 +332,7 @@
                     "portfolioMargin": true
                   }
                 ],
-                "output": "timestamp=1712974976336&symbol=BTCUSDT&side=BUY&newClientOrderId=x-R4BD3S828b7395b12d0846afa4643c&type=LIMIT&quantity=0.0001&price=50000&timeInForce=GTC&recvWindow=10000&signature=bf3748a7adae072d411444d031d45b17ba8c8febf47bb0b5f4236e33b963b49f"
+                "output": "timestamp=1712974976336&symbol=BTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-R4BD3S828b7395b12d0846afa4643c&type=LIMIT&quantity=0.0001&price=50000&timeInForce=GTC&recvWindow=10000&signature=bf3748a7adae072d411444d031d45b17ba8c8febf47bb0b5f4236e33b963b49f"
             },
             {
                 "description": "swap order with priceMatch",


### PR DESCRIPTION
Made the spot portfolio margin implementations more user friendly so that the user can just set the `portfolioMargin` param with a `spot symbol` instead of having to also set the `marginMode`:
closes: #22123

```
binance createOrder BTC/USDT limit buy 0.0001 50000 '{"portfolioMargin":true}'

binance.createOrder (BTC/USDT, limit, buy, 0.0001, 50000, [object Object])
2024-04-13T02:22:57.154Z iteration 0 passed in 870 ms

{
  info: {
    clientOrderId: 'x-R4BD3S828b7395b12d0846afa4643c',
    cummulativeQuoteQty: '0.00000000',
    executedQty: '0.00000000',
    fills: [],
    orderId: '26447758109',
    origQty: '0.00010000',
    price: '50000.00000000',
    selfTradePreventionMode: 'EXPIRE_MAKER',
    side: 'BUY',
    status: 'NEW',
    symbol: 'BTCUSDT',
    timeInForce: 'GTC',
    transactTime: '1712974978103',
    type: 'LIMIT'
  },
  id: '26447758109',
  clientOrderId: 'x-R4BD3S828b7395b12d0846afa4643c',
  timestamp: 1712974978103,
  datetime: '2024-04-13T02:22:58.103Z',
  lastUpdateTimestamp: 1712974978103,
  symbol: 'BTC/USDT',
  type: 'limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'buy',
  price: 50000,
  amount: 0.0001,
  cost: 0,
  filled: 0,
  remaining: 0.0001,
  status: 'open',
  trades: [],
  fees: []
}
```