### PR TITLE
wazirx.handleMessage - replace.inArray with string.includes

### DIFF
--- a/ts/src/pro/wazirx.ts
+++ b/ts/src/pro/wazirx.ts
@@ -774,7 +774,8 @@ export default class wazirx extends wazirxRest {
         };
         const streams = Object.keys (streamHandlers);
         for (let i = 0; i < streams.length; i++) {
-            if (this.inArray (streams[i], stream)) {
+            const streamContains = stream.indexOf (streams[i]) > -1;
+            if (streamContains) {
                 const handler = streamHandlers[streams[i]];
                 handler.call (this, client, message);
                 return;


### PR DESCRIPTION
```
% py wazirx watchTicker BTC/USDT 
Python v3.9.6
CCXT v4.2.98
wazirx.watchTicker(BTC/USDT)
{'ask': 63998.0,
 'askVolume': None,
 'average': 62392.5,
 'baseVolume': None,
 'bid': 63680.0,
 'bidVolume': None,
 'change': -825.0,
 'close': 61980.0,
 'datetime': '2024-04-17T04:09:00.000Z',
 'high': 64199.0,
 'info': {'E': 1713326940000,
          'T': 'SPOT',
          'U': 'usdt',
          'a': '63998.0',
          'b': '63680.0',
          'c': '64073.0',
          'h': '64199.0',
          'l': '61980.0',
          'o': '62805',
          'q': '0.53733',
          's': 'btcusdt',
          'u': 'btc'},
 'last': 61980.0,
 'low': 61980.0,
 'open': 62805.0,
 'percentage': -1.3135896823501314,
 'previousClose': None,
 'quoteVolume': 0.53733,
 'symbol': 'BTC/USDT',
 'timestamp': 1713326940000,
 'vwap': None}
 ```

 ```
 % py wazirx watchMyTrades          
Python v3.9.6
CCXT v4.2.98
wazirx.watchMyTrades()
[{'amount': 5.0,
  'cost': 2.5488499999999994,
  'datetime': '2024-04-17T04:14:37.000Z',
  'fee': {'cost': 0.0050977, 'currency': 'USDT', 'rate': None},
  'fees': [{'cost': 0.0050977, 'currency': 'USDT', 'rate': None}],
  'id': '416277681',
  'info': {'E': 1713327277000,
           'S': 'bid',
           'U': 'usdt',
           'a': 12454281,
           'b': 13546454,
           'c': '8da31a59-c4e4-440d-9bad-5d2dfbecc2a6',
           'f': '0.0050977',
           'ga': '0.0',
           'gc': 'usdt',
           'm': True,
           'o': 4359536415,
           'p': '0.5097699999999999',
           'q': '5.0',
           's': 'xrpusdt',
           't': 416277681,
           'w': '2.54885'},
  'order': '4359536415',
  'price': 0.50977,
  'side': 'bid',
  'symbol': 'XRP/USDT',
  'takerOrMaker': 'maker',
  'timestamp': 1713327277000,
  'type': None}]
 ```