### PR TITLE
new method: createConvertTrade

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -12494,8 +12494,8 @@ export default class binance extends Exchange {
         await this.loadMarkets ();
         const request = {
             'clientTranId': id,
-            'asset': fromCode.toUpperCase (),
-            'targetAsset': toCode.toUpperCase (),
+            'asset': fromCode,
+            'targetAsset': toCode,
             'amount': amount,
         };
         const response = await this.sapiPostAssetConvertTransfer (this.extend (request, params));

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -39,6 +39,7 @@ export default class bitget extends Exchange {
                 'cancelOrders': true,
                 'closeAllPositions': true,
                 'closePosition': true,
+                'createConvertTrade': true,
                 'createDepositAddress': false,
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrderWithCost': false,
@@ -8384,8 +8385,8 @@ export default class bitget extends Exchange {
          */
         await this.loadMarkets ();
         const request = {
-            'fromCoin': fromCode.toUpperCase (),
-            'toCoin': toCode.toUpperCase (),
+            'fromCoin': fromCode,
+            'toCoin': toCode,
             'fromCoinSize': this.numberToString (amount),
         };
         const response = await this.privateConvertGetV2ConvertQuotedPrice (this.extend (request, params));
@@ -8413,6 +8414,59 @@ export default class bitget extends Exchange {
         return this.parseConversion (data, fromCurrency, toCurrency);
     }
 
+    async createConvertTrade (id: string, fromCode: string, toCode: string, amount: Num = undefined, params = {}): Promise<Conversion> {
+        /**
+         * @method
+         * @name bitget#createConvertTrade
+         * @description convert from one currency to another
+         * @see https://www.bitget.com/api-doc/common/convert/Trade
+         * @param {string} id the id of the trade that you want to make
+         * @param {string} fromCode the currency that you want to sell and convert from
+         * @param {string} toCode the currency that you want to buy and convert into
+         * @param {float} amount how much you want to trade in units of the from currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} params.price the price of the conversion, obtained from fetchConvertQuote()
+         * @param {string} params.toAmount the amount you want to trade in units of the toCurrency, obtained from fetchConvertQuote()
+         * @returns {object} a [conversion structure]{@link https://docs.ccxt.com/#/?id=conversion-structure}
+         */
+        await this.loadMarkets ();
+        const price = this.safeString2 (params, 'price', 'cnvtPrice');
+        if (price === undefined) {
+            throw new ArgumentsRequired (this.id + ' createConvertTrade() requires a price parameter');
+        }
+        const toAmount = this.safeString2 (params, 'toAmount', 'toCoinSize');
+        if (toAmount === undefined) {
+            throw new ArgumentsRequired (this.id + ' createConvertTrade() requires a toAmount parameter');
+        }
+        params = this.omit (params, [ 'price', 'toAmount' ]);
+        const request = {
+            'traceId': id,
+            'fromCoin': fromCode,
+            'toCoin': toCode,
+            'fromCoinSize': this.numberToString (amount),
+            'toCoinSize': toAmount,
+            'cnvtPrice': price,
+        };
+        const response = await this.privateConvertPostV2ConvertTrade (this.extend (request, params));
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1712123746203,
+        //         "data": {
+        //             "cnvtPrice": "0.99940076",
+        //             "toCoin": "USDC",
+        //             "toCoinSize": "4.99700379",
+        //             "ts": "1712123746217"
+        //         }
+        //     }
+        //
+        const data = this.safeDict (response, 'data', {});
+        const toCurrencyId = this.safeString (data, 'toCoin', toCode);
+        const toCurrency = this.currency (toCurrencyId);
+        return this.parseConversion (data, undefined, toCurrency);
+    }
+
     parseConversion (conversion, fromCurrency: Currency = undefined, toCurrency: Currency = undefined): Conversion {
         //
         // fetchConvertQuote
@@ -8425,6 +8479,15 @@ export default class bitget extends Exchange {
         //         "toCoinSize": "4.99650394",
         //         "traceId": "1159288930228187140",
         //         "fee": "0"
+        //     }
+        //
+        // createConvertTrade
+        //
+        //     {
+        //         "cnvtPrice": "0.99940076",
+        //         "toCoin": "USDC",
+        //         "toCoinSize": "4.99700379",
+        //         "ts": "1712123746217"
         //     }
         //
         const timestamp = this.safeInteger (conversion, 'ts');

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -7777,7 +7777,7 @@ export default class okx extends Exchange {
             'info': conversion,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'id': this.safeString2 (conversion, 'clQReqId', 'tradeId'),
+            'id': this.safeStringN (conversion, [ 'clQReqId', 'tradeId', 'quoteId' ]),
             'fromCurrency': fromCode,
             'fromAmount': this.safeNumber2 (conversion, 'baseSz', 'fillBaseSz'),
             'toCurrency': toCode,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -37,6 +37,7 @@ export default class okx extends Exchange {
                 'cancelOrders': true,
                 'closeAllPositions': false,
                 'closePosition': true,
+                'createConvertTrade': true,
                 'createDepositAddress': false,
                 'createMarketBuyOrderWithCost': true,
                 'createMarketSellOrderWithCost': true,
@@ -7676,6 +7677,60 @@ export default class okx extends Exchange {
         return this.parseConversion (result, fromCurrency, toCurrency);
     }
 
+    async createConvertTrade (id: string, fromCode: string, toCode: string, amount: Num = undefined, params = {}): Promise<Conversion> {
+        /**
+         * @method
+         * @name okx#createConvertTrade
+         * @description convert from one currency to another
+         * @see https://www.okx.com/docs-v5/en/#funding-account-rest-api-convert-trade
+         * @param {string} id the id of the trade that you want to make
+         * @param {string} fromCode the currency that you want to sell and convert from
+         * @param {string} toCode the currency that you want to buy and convert into
+         * @param {float} [amount] how much you want to trade in units of the from currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [conversion structure]{@link https://docs.ccxt.com/#/?id=conversion-structure}
+         */
+        await this.loadMarkets ();
+        const request = {
+            'quoteId': id,
+            'baseCcy': fromCode,
+            'quoteCcy': toCode,
+            'szCcy': fromCode,
+            'sz': this.numberToString (amount),
+            'side': 'sell',
+        };
+        const response = await this.privatePostAssetConvertTrade (this.extend (request, params));
+        //
+        //     {
+        //         "code": "0",
+        //         "data": [
+        //             {
+        //                 "baseCcy": "ETH",
+        //                 "clTReqId": "",
+        //                 "fillBaseSz": "0.01023052",
+        //                 "fillPx": "2932.40104429",
+        //                 "fillQuoteSz": "30",
+        //                 "instId": "ETH-USDT",
+        //                 "quoteCcy": "USDT",
+        //                 "quoteId": "quoterETH-USDT16461885104612381",
+        //                 "side": "buy",
+        //                 "state": "fullyFilled",
+        //                 "tradeId": "trader16461885203381437",
+        //                 "ts": "1646188520338"
+        //             }
+        //         ],
+        //         "msg": ""
+        //     }
+        //
+        const data = this.safeList (response, 'data', []);
+        const result = this.safeDict (data, 0, {});
+        const fromCurrencyId = this.safeString (result, 'baseCcy', fromCode);
+        const fromCurrency = this.currency (fromCurrencyId);
+        const toCurrencyId = this.safeString (result, 'quoteCcy', toCode);
+        const toCurrency = this.currency (toCurrencyId);
+        return this.parseConversion (result, fromCurrency, toCurrency);
+    }
+
     parseConversion (conversion, fromCurrency: Currency = undefined, toCurrency: Currency = undefined): Conversion {
         //
         // fetchConvertQuote
@@ -7696,7 +7751,24 @@ export default class okx extends Exchange {
         //         "ttlMs": "10000"
         //     }
         //
-        const timestamp = this.safeInteger (conversion, 'quoteTime');
+        // createConvertTrade
+        //
+        //     {
+        //         "baseCcy": "ETH",
+        //         "clTReqId": "",
+        //         "fillBaseSz": "0.01023052",
+        //         "fillPx": "2932.40104429",
+        //         "fillQuoteSz": "30",
+        //         "instId": "ETH-USDT",
+        //         "quoteCcy": "USDT",
+        //         "quoteId": "quoterETH-USDT16461885104612381",
+        //         "side": "buy",
+        //         "state": "fullyFilled",
+        //         "tradeId": "trader16461885203381437",
+        //         "ts": "1646188520338"
+        //     }
+        //
+        const timestamp = this.safeInteger2 (conversion, 'quoteTime', 'ts');
         const fromCoin = this.safeString (conversion, 'baseCcy');
         const fromCode = this.safeCurrencyCode (fromCoin, fromCurrency);
         const to = this.safeString (conversion, 'quoteCcy');
@@ -7705,12 +7777,12 @@ export default class okx extends Exchange {
             'info': conversion,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'id': this.safeString (conversion, 'clQReqId'),
+            'id': this.safeString2 (conversion, 'clQReqId', 'tradeId'),
             'fromCurrency': fromCode,
-            'fromAmount': this.safeNumber (conversion, 'baseSz'),
+            'fromAmount': this.safeNumber2 (conversion, 'baseSz', 'fillBaseSz'),
             'toCurrency': toCode,
-            'toAmount': this.safeNumber (conversion, 'quoteSz'),
-            'price': this.safeNumber (conversion, 'cnvtPx'),
+            'toAmount': this.safeNumber2 (conversion, 'quoteSz', 'fillQuoteSz'),
+            'price': this.safeNumber2 (conversion, 'cnvtPx', 'fillPx'),
             'fee': undefined,
         } as Conversion;
     }

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1583,7 +1583,7 @@
                 "method": "createConvertTrade",
                 "url": "https://api.bitget.com/api/v2/convert/trade",
                 "input": [
-                  1164014202462613512,
+                  "1164014202462613512",
                   "USDC",
                   "USDT",
                   5,

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1576,6 +1576,24 @@
                 "url": "https://api.bitget.com/api/v2/convert/currencies",
                 "input": []
             }
+        ],
+        "createConvertTrade": [
+            {
+                "description": "Convert from one currency to another",
+                "method": "createConvertTrade",
+                "url": "https://api.bitget.com/api/v2/convert/trade",
+                "input": [
+                  1164014202462613512,
+                  "USDC",
+                  "USDT",
+                  5,
+                  {
+                    "toAmount": "4.9915035",
+                    "price": "0.9983007"
+                  }
+                ],
+                "output": "{\"traceId\":\"1164014202462613512\",\"fromCoin\":\"USDC\",\"toCoin\":\"USDT\",\"fromCoinSize\":\"5\",\"toCoinSize\":\"4.9915035\",\"cnvtPrice\":\"0.9983007\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -1411,6 +1411,20 @@
                 "url": "https://www.okx.com/api/v5/asset/convert/currencies",
                 "input": []
             }
+        ],
+        "createConvertTrade": [
+            {
+                "description": "from usdc to usdt",
+                "method": "createConvertTrade",
+                "url": "https://www.okx.com/api/v5/asset/convert/trade",
+                "input": [
+                  "quoternextUSDC-USDT17133439642216046",
+                  "USDC",
+                  "USDT",
+                  3
+                ],
+                "output": "{\"quoteId\":\"quoternextUSDC-USDT17133439642216046\",\"baseCcy\":\"USDC\",\"quoteCcy\":\"USDT\",\"szCcy\":\"USDC\",\"sz\":\"3\",\"side\":\"sell\"}"
+            }
         ]
     }
 }

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -38,6 +38,7 @@ export default class woo extends Exchange {
                 'cancelWithdraw': false, // exchange have that endpoint disabled atm, but was once implemented in ccxt per old docs: https://kronosresearch.github.io/wootrade-documents/#cancel-withdraw-request
                 'closeAllPositions': false,
                 'closePosition': false,
+                'createConvertTrade': true,
                 'createDepositAddress': false,
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrder': false,
@@ -3061,6 +3062,38 @@ export default class woo extends Exchange {
         return this.parseConversion (data, fromCurrency, toCurrency);
     }
 
+    async createConvertTrade (id: string, fromCode: string, toCode: string, amount: Num = undefined, params = {}): Promise<Conversion> {
+        /**
+         * @method
+         * @name woo#createConvertTrade
+         * @description convert from one currency to another
+         * @see https://docs.woo.org/#send-quote-rft
+         * @param {string} id the id of the trade that you want to make
+         * @param {string} fromCode the currency that you want to sell and convert from
+         * @param {string} toCode the currency that you want to buy and convert into
+         * @param {float} [amount] how much you want to trade in units of the from currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [conversion structure]{@link https://docs.ccxt.com/#/?id=conversion-structure}
+         */
+        await this.loadMarkets ();
+        const request = {
+            'quoteId': id,
+        };
+        const response = await this.v3PrivatePostConvertRft (this.extend (request, params));
+        //
+        //     {
+        //         "success": true,
+        //         "data": {
+        //             "quoteId": 123123123,
+        //             "counterPartyId": "",
+        //             "rftAccepted": 1 // 1 -> success; 2 -> processing; 3 -> fail
+        //         }
+        //     }
+        //
+        const data = this.safeDict (response, 'data', {});
+        return this.parseConversion (data);
+    }
+
     parseConversion (conversion, fromCurrency: Currency = undefined, toCurrency: Currency = undefined): Conversion {
         //
         // fetchConvertQuote
@@ -3075,6 +3108,14 @@ export default class woo extends Exchange {
         //         "buyPrice": "6.77",
         //         "expireTimestamp": 1659084466000,
         //         "message": 1659084466000
+        //     }
+        //
+        // createConvertTrade
+        //
+        //     {
+        //         "quoteId": 123123123,
+        //         "counterPartyId": "",
+        //         "rftAccepted": 1 // 1 -> success; 2 -> processing; 3 -> fail
         //     }
         //
         const timestamp = this.safeInteger (conversion, 'expireTimestamp');

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1723,6 +1723,7 @@ The unified ccxt API is a subset of methods common among the exchanges. It curre
 - `fetchOption (symbol, params)`
 - `fetchOptionChain (code, params)`
 - `fetchConvertQuote (fromCode, toCode, amount, params)`
+- `createConvertTrade (id, fromCode, toCode, amount, params)`
 - ...
 
 ```text
@@ -6298,6 +6299,25 @@ fetchConvertQuote (fromCode, toCode, amount = undefined, params = {})
 
 Parameters
 
+- **fromCode** (String) *required* The unified currency code for the currency to convert from (e.g. `"USDT"`)
+- **toCode** (String) *required* The unified currency code for the currency to be converted into (e.g. `"USDC"`)
+- **amount** (Float) Amount to convert in units of the from currency (e.g. `20.0`)
+- **params** (Dictionary) Parameters specific to the exchange API endpoint (e.g. `{"toAmount": 2.9722}`)
+
+Returns
+
+- A [conversion structure](#conversion-structure)
+
+The `createConvertTrade` method can be used to create a conversion trade order using the id retrieved from fetchConvertQuote.
+The quote usually needs to be used within a certain timeframe specified by the exchange for the convert trade to execute successfully.
+
+```javascript
+createConvertTrade (id, fromCode, toCode, amount = undefined, params = {})
+```
+
+Parameters
+
+- **id** (String) *required* Conversion quote id (e.g. `1645807945000`)
 - **fromCode** (String) *required* The unified currency code for the currency to convert from (e.g. `"USDT"`)
 - **toCode** (String) *required* The unified currency code for the currency to be converted into (e.g. `"USDC"`)
 - **amount** (Float) Amount to convert in units of the from currency (e.g. `20.0`)


### PR DESCRIPTION
Added createConvertTrade to bitget, okx, binance and woo:

On Bitget:
- There's a `"Flash quote expired"` error if the fetched quote isn't used soon enough
- You need to fetch the `id`, `toCoinSize` and `cnvtPrice` from `fetchConvertQuote`

```
bitget.createConvertTrade (1164006087231717393, USDC, USDT, 5)
2024-04-16T05:49:58.474Z iteration 0 passed in 656 ms

{
  info: {
    cnvtPrice: '0.9984006',
    toCoin: 'USDT',
    toCoinSize: '4.992003',
    ts: '1713246598423'
  },
  timestamp: 1713246598423,
  datetime: '2024-04-16T05:49:58.423Z',
  toCurrency: 'USDT',
  toAmount: 4.992003,
  price: 0.9984006
}
```