### PR TITLE
Fix BingX fetch_my_liquidations symbol passing

### DIFF
--- a/python/ccxt/bingx.py
+++ b/python/ccxt/bingx.py
@@ -3717,7 +3717,7 @@ class bingx(Exchange, ImplicitAPI):
         market = None
         if symbol is not None:
             market = self.market(symbol)
-            request['symbol'] = symbol
+            request['symbol'] = market['id']
         if since is not None:
             request['startTime'] = since
         if limit is not None:


### PR DESCRIPTION
This PR fixes the incorrect symbol value sent to bingx API in `fetch_my_liquidations()` method.

Unified CCXT symbol string was sent instead of bingx-specific market symbol which resulted in following error:

`ccxt.base.errors.BadRequest: bingx {"code":80014,"msg":"Invalid parameters, err:symbol: Key: 'GetForceOrdersRequest.Symbol' Error:Field validation for 'Symbol' failed on the 'len=0|endswith=-USDT' tag.","data":{}}`.

I've tested the updated method manually.