### PR TITLE
feat(coinbase): createOrder - "FOK" option for params["timeInForce"]

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -2617,7 +2617,7 @@ export default class coinbase extends Exchange {
          * @param {float} [params.stopLossPrice] price to trigger stop-loss orders
          * @param {float} [params.takeProfitPrice] price to trigger take-profit orders
          * @param {bool} [params.postOnly] true or false
-         * @param {string} [params.timeInForce] 'GTC', 'IOC', 'GTD' or 'PO'
+         * @param {string} [params.timeInForce] 'GTC', 'IOC', 'GTD' or 'PO', 'FOK'
          * @param {string} [params.stop_direction] 'UNKNOWN_STOP_DIRECTION', 'STOP_DIRECTION_STOP_UP', 'STOP_DIRECTION_STOP_DOWN' the direction the stopPrice is triggered from
          * @param {string} [params.end_time] '2023-05-25T17:01:05.092Z' for 'GTD' orders
          * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
@@ -2712,6 +2712,13 @@ export default class coinbase extends Exchange {
                 } else if (timeInForce === 'IOC') {
                     request['order_configuration'] = {
                         'sor_limit_ioc': {
+                            'base_size': this.amountToPrecision (symbol, amount),
+                            'limit_price': this.priceToPrecision (symbol, price),
+                        },
+                    };
+                } else if (timeInForce === 'FOK') {
+                    request['order_configuration'] = {
+                        'limit_limit_fok': {
                             'base_size': this.amountToPrecision (symbol, amount),
                             'limit_price': this.priceToPrecision (symbol, price),
                         },

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -218,7 +218,23 @@
                   }
                 ],
                 "output": "{\"product_id\":\"ADA-PERP-INTX\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"base_size\":\"20\"}}}"
-              }
+            },
+            {
+                "description": "timeInForce='FOK'",
+                "method": "createOrder",
+                "url": "https://api.coinbase.com/api/v3/brokerage/orders",
+                "input": [
+                  "XRP/USDC",
+                  "limit",
+                  "buy",
+                  10,
+                  0.5,
+                  {
+                    "timeInForce": "FOK"
+                  }
+                ],
+                "output": "{\"client_order_id\":\"ccxt-4018cbc8-f42a-4c79-b078-b16d838e95d6\",\"product_id\":\"XRP-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_fok\":{\"base_size\":\"10\",\"limit_price\":\"0.5\"}}}"
+            }
         ],
         "createMarketBuyOrderWithCost": [
             {


### PR DESCRIPTION
```
% py coinbase createOrder XRP/USDC limit buy 10 0.5 '{"timeInForce": "FOK"}'         
Python v3.9.6
CCXT v4.3.2
coinbase.createOrder(XRP/USDC,limit,buy,10,0.5,{'timeInForce': 'FOK'})
{'amount': None,
 'average': None,
 'clientOrderId': 'ccxt-0c729c84-45e6-4cee-8c14-a577b24551d9',
 'cost': None,
 'datetime': None,
 'fee': {'cost': None, 'currency': None},
 'fees': [{'cost': None, 'currency': None}],
 'filled': None,
 'id': '630d0ed6-1d24-4efe-b5be-82dd2273f907',
 'info': {'client_order_id': 'ccxt-0c729c84-45e6-4cee-8c14-a577b24551d9',
          'order_id': '630d0ed6-1d24-4efe-b5be-82dd2273f907',
          'product_id': 'XRP-USDC',
          'side': 'BUY'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'XRP/USDC',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
 ```