### PR TITLE
feat(base) - safeIntegerOmitZero

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2510,7 +2510,7 @@ export default class Exchange {
         const timestampString = this.omitZero (this.safeString (obj, key));
         let timestamp = undefined;
         if (timestampString !== undefined) {
-            timestamp = this.parseToInt (timestampString);
+            timestamp = parseInt (timestampString);
         } else if (defaultValue !== undefined) {
             timestamp = defaultValue;
         }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2506,6 +2506,17 @@ export default class Exchange {
         return res === 0;
     }
 
+    safeIntegerOmitZero (obj: object, key: IndexType, defaultValue: Int = undefined): Int {
+        const timestampString = this.omitZero (this.safeString (obj, key));
+        let timestamp = undefined;
+        if (timestampString !== undefined) {
+            timestamp = this.parseToInt (timestampString);
+        } else if (defaultValue !== undefined) {
+            timestamp = defaultValue;
+        }
+        return timestamp;
+    }
+
     afterConstruct () {
         this.createNetworksByIdObject ();
     }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2509,7 +2509,7 @@ export default class Exchange {
     safeIntegerOmitZero (obj: object, key: IndexType, defaultValue: Int = undefined): Int {
         const timestamp = this.safeInteger (obj, key, defaultValue);
         if (timestamp === undefined || timestamp === 0) {
-           return undefined;
+            return undefined;
         }
         return timestamp;
     }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2507,12 +2507,9 @@ export default class Exchange {
     }
 
     safeIntegerOmitZero (obj: object, key: IndexType, defaultValue: Int = undefined): Int {
-        const timestampString = this.omitZero (this.safeString (obj, key));
-        let timestamp = undefined;
-        if (timestampString !== undefined) {
-            timestamp = parseInt (timestampString);
-        } else if (defaultValue !== undefined) {
-            timestamp = defaultValue;
+        const timestamp = this.safeInteger (obj, key, defaultValue);
+        if (timestamp === undefined || timestamp === 0) {
+           return undefined;
         }
         return timestamp;
     }

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2630,11 +2630,7 @@ export default class bitget extends Exchange {
         //
         const marketId = this.safeString (ticker, 'symbol');
         const close = this.safeString (ticker, 'lastPr');
-        const timestampString = this.omitZero (this.safeString (ticker, 'ts')); // exchange sometimes provided 0
-        let timestamp = undefined;
-        if (timestampString !== undefined) {
-            timestamp = this.parseToInt (timestampString);
-        }
+        const timestamp = this.safeIntegerOmitZero (ticker, 'ts'); // exchange bitget provided 0
         const change = this.safeString (ticker, 'change24h');
         const open24 = this.safeString (ticker, 'open24');
         const open = this.safeString (ticker, 'open');

--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -618,7 +618,7 @@ export default class latoken extends Exchange {
         //
         const marketId = this.safeString (ticker, 'symbol');
         const last = this.safeString (ticker, 'lastPrice');
-        const timestamp = this.safeInteger (ticker, 'updateTimestamp');
+        const timestamp = this.safeIntegerOmitZero (ticker, 'updateTimestamp'); // sometimes latoken provided '0' ts from /ticker endpoint
         return this.safeTicker ({
             'symbol': this.safeSymbol (marketId, market),
             'timestamp': timestamp,


### PR DESCRIPTION
fix: https://app.travis-ci.com/github/ccxt/ccxt/builds/270079297#L5259

also, for simple purposes we had 5-line hardcoded repeated code to parse zero timestamps, and moved into base to simplify the process, as this method would be need in multiple exchanges too