### PR TITLE
fix(coinbase): fetchOHLCV - until timestamp converted to seconds

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3450,12 +3450,12 @@ export default class coinbase extends Exchange {
             sinceString = Precise.stringSub (now, requestedDuration.toString ());
         }
         request['start'] = sinceString;
-        let endString = this.numberToString (until);
-        if (until === undefined) {
+        if (until !== undefined) {
+            request['end'] = this.numberToString (this.parseToInt (until / 1000));
+        } else {
             // 300 candles max
-            endString = Precise.stringAdd (sinceString, requestedDuration.toString ());
+            request['end'] = Precise.stringAdd (sinceString, requestedDuration.toString ());
         }
-        request['end'] = endString;
         const response = await this.v3PrivateGetBrokerageProductsProductIdCandles (this.extend (request, params));
         //
         //     {

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -366,6 +366,20 @@
                 "input": [
                     "BTC/USDT"
                 ]
+            },
+            {
+                "description": "with since and until",
+                "method": "fetchOHLCV",
+                "url": "https://api.coinbase.com/api/v3/brokerage/products/BTC-USDT/candles?granularity=ONE_HOUR&start=1711929600&end=1712016000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1711929600000,
+                  null,
+                  {
+                    "until": 1712016000000
+                  }
+                ]
             }
         ],
         "editOrder": [


### PR DESCRIPTION
fixes: #22191

#Testing

```
% py coinbase fetchOHLCV BTC/USDT 1h 1711929600000 None '{"until": 1712016000000}'         
Python v3.9.6
CCXT v4.3.5
coinbase.fetchOHLCV(BTC/USDT,1h,1711929600000,None,{'until': 1712016000000})
[[1711929600000, 71223.41, 71268.59, 70869.14, 71171.99, 19.79096947],
...
 [1712016000000, 69656.06, 69677.15, 69036.4, 69291.29, 10.53880109]]
```