### PR TITLE
coinex: fetchTrades v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1138,14 +1138,13 @@ export default class coinex extends Exchange {
         //
         // Spot and Swap fetchTrades (public)
         //
-        //      {
-        //          "id":  2611511379,
-        //          "type": "buy",
-        //          "price": "192.63",
-        //          "amount": "0.02266931",
-        //          "date":  1638990110,
-        //          "date_ms":  1638990110518
-        //      },
+        //     {
+        //         "amount": "0.00049432",
+        //         "created_at": 1713849825667,
+        //         "deal_id": 4137517302,
+        //         "price": "66251",
+        //         "side": "buy"
+        //     }
         //
         // Spot and Margin fetchMyTrades (private)
         //
@@ -1199,9 +1198,9 @@ export default class coinex extends Exchange {
         //
         let timestamp = this.safeTimestamp2 (trade, 'create_time', 'time');
         if (timestamp === undefined) {
-            timestamp = this.safeInteger (trade, 'date_ms');
+            timestamp = this.safeInteger (trade, 'created_at');
         }
-        const tradeId = this.safeString (trade, 'id');
+        const tradeId = this.safeString2 (trade, 'id', 'deal_id');
         const orderId = this.safeString (trade, 'order_id');
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'amount');
@@ -1262,9 +1261,9 @@ export default class coinex extends Exchange {
         /**
          * @method
          * @name coinex#fetchTrades
-         * @description get the list of most recent trades for a particular symbol
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot001_market005_market_deals
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http011_market_deals
+         * @description get the list of the most recent trades for a particular symbol
+         * @see https://docs.coinex.com/api/v2/spot/market/http/list-market-deals
+         * @see https://docs.coinex.com/api/v2/futures/market/http/list-market-deals
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int} [since] timestamp in ms of the earliest trade to fetch
          * @param {int} [limit] the maximum amount of trades to fetch
@@ -1282,27 +1281,26 @@ export default class coinex extends Exchange {
         }
         let response = undefined;
         if (market['swap']) {
-            response = await this.v1PerpetualPublicGetMarketDeals (this.extend (request, params));
+            response = await this.v2PublicGetFuturesDeals (this.extend (request, params));
         } else {
-            response = await this.v1PublicGetMarketDeals (this.extend (request, params));
+            response = await this.v2PublicGetSpotDeals (this.extend (request, params));
         }
         //
         // Spot and Swap
         //
-        //      {
-        //          "code":    0,
-        //          "data": [
-        //              {
-        //                  "id":  2611511379,
-        //                  "type": "buy",
-        //                  "price": "192.63",
-        //                  "amount": "0.02266931",
-        //                  "date":  1638990110,
-        //                  "date_ms":  1638990110518
-        //                  },
-        //              ],
-        //          "message": "OK"
-        //      }
+        //     {
+        //         "code": 0,
+        //         "data": [
+        //             {
+        //                 "amount": "0.00049432",
+        //                 "created_at": 1713849825667,
+        //                 "deal_id": 4137517302,
+        //                 "price": "66251",
+        //                 "side": "buy"
+        //             },
+        //         ],
+        //         "message": "OK"
+        //     }
         //
         return this.parseTrades (response['data'], market, since, limit);
     }

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1235,10 +1235,10 @@ export default class coinex extends Exchange {
                 side = 'buy';
             }
             if (side === undefined) {
-                side = this.safeString (trade, 'type');
+                side = this.safeString2 (trade, 'type', 'side');
             }
         } else {
-            side = this.safeString (trade, 'type');
+            side = this.safeString2 (trade, 'type', 'side');
         }
         return this.safeTrade ({
             'info': trade,

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -607,33 +607,17 @@
             {
                 "description": "Spot fetch trades",
                 "method": "fetchTrades",
-                "url": "https://api.coinex.com/v1/market/deals?market=BTCUSDT",
+                "url": "https://api.coinex.com/v2/spot/deals?market=BTCUSDT",
                 "input": [
-                    "BTC/USDT"
+                  "BTC/USDT"
                 ]
             },
             {
                 "description": "Swap fetch trades",
                 "method": "fetchTrades",
-                "url": "https://api.coinex.com/perpetual/v1/market/deals?market=BTCUSDT",
+                "url": "https://api.coinex.com/v2/futures/deals?market=BTCUSDT",
                 "input": [
-                    "BTC/USDT:USDT"
-                ]
-            },
-            {
-                "description": "spot fetchTrades",
-                "method": "fetchTrades",
-                "url": "https://api.coinex.com/v1/market/deals?market=BTCUSDT",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
-                "description": "swap fetchTrades",
-                "method": "fetchTrades",
-                "url": "https://api.coinex.com/perpetual/v1/market/deals?market=BTCUSDT",
-                "input": [
-                    "BTC/USDT:USDT"
+                  "BTC/USDT:USDT"
                 ]
             }
         ],

--- a/ts/src/test/static/response/coinex.json
+++ b/ts/src/test/static/response/coinex.json
@@ -440,12 +440,11 @@
                     "code": 0,
                     "data": [
                         {
-                            "id": 4023534184,
-                            "type": "sell",
-                            "price": "73242.73",
-                            "amount": "0.00037339",
-                            "date": 1710327659,
-                            "date_ms": 1710327659543
+                            "amount": "0.00132336",
+                            "created_at": 1713852267517,
+                            "deal_id": 4137594247,
+                            "price": "66567.15",
+                            "side": "sell"
                         }
                     ],
                     "message": "OK"
@@ -453,24 +452,23 @@
                 "parsedResponse": [
                     {
                         "info": {
-                            "id": 4023534184,
-                            "type": "sell",
-                            "price": "73242.73",
-                            "amount": "0.00037339",
-                            "date": 1710327659,
-                            "date_ms": 1710327659543
+                            "amount": "0.00132336",
+                            "created_at": 1713852267517,
+                            "deal_id": 4137594247,
+                            "price": "66567.15",
+                            "side": "sell"
                         },
-                        "timestamp": 1710327659543,
-                        "datetime": "2024-03-13T11:00:59.543Z",
+                        "timestamp": 1713852267517,
+                        "datetime": "2024-04-23T06:04:27.517Z",
                         "symbol": "BTC/USDT",
-                        "id": "4023534184",
+                        "id": "4137594247",
                         "order": null,
                         "type": null,
                         "side": "sell",
                         "takerOrMaker": null,
-                        "price": 73242.73,
-                        "amount": 0.00037339,
-                        "cost": 27.3481029547,
+                        "price": 66567.15,
+                        "amount": 0.00132336,
+                        "cost": 88.092303624,
                         "fee": null,
                         "fees": []
                     }


### PR DESCRIPTION
Updated fetchTrades to v2:
```
coinex.fetchTrades (BTC/USDT, , 3)
2024-04-23T05:32:02.280Z iteration 0 passed in 221 ms

    timestamp |                 datetime |   symbol |         id |    price |     amount |            cost | fees
-----------------------------------------------------------------------------------------------------------------
1713850304365 | 2024-04-23T05:31:44.365Z | BTC/USDT | 4137531500 | 66439.11 | 0.01545274 | 1026.6662926614 |   []
1713850309370 | 2024-04-23T05:31:49.370Z | BTC/USDT | 4137531855 | 66439.04 | 0.00511481 |  339.8230661824 |   []
1713850314364 | 2024-04-23T05:31:54.364Z | BTC/USDT | 4137532241 | 66438.89 | 0.00029213 |   19.4087929357 |   []
3 objects
```
```
coinex.fetchTrades (BTC/USDT:USDT, , 3)
2024-04-23T05:32:19.409Z iteration 0 passed in 216 ms

    timestamp |                 datetime |        symbol |         id |    price | amount |        cost | fees
--------------------------------------------------------------------------------------------------------------
1713850337913 | 2024-04-23T05:32:17.913Z | BTC/USDT:USDT | 1176735726 | 66480.27 |  0.005 |   332.40135 |   []
1713850337914 | 2024-04-23T05:32:17.914Z | BTC/USDT:USDT | 1176735727 | 66480.27 |  0.002 |   132.96054 |   []
1713850337915 | 2024-04-23T05:32:17.915Z | BTC/USDT:USDT | 1176735728 | 66480.27 | 0.0703 | 4673.562981 |   []
3 objects
```