### PR TITLE
fix(tests) - watchOrderBookForSymbols - unsorted timestamps !Q

### DIFF
--- a/ts/src/pro/test/Exchange/test.watchTradesForSymbols.ts
+++ b/ts/src/pro/test/Exchange/test.watchTradesForSymbols.ts
@@ -27,7 +27,9 @@ async function testWatchTradesForSymbols (exchange, skippedProperties, symbols) 
             testTrade (exchange, skippedProperties, method, trade, symbol, now);
             testSharedMethods.assertInArray (exchange, skippedProperties, method, trade, 'symbol', symbols);
         }
-        testSharedMethods.assertTimestampOrder (exchange, method, symbol, response);
+        if (!('timestamp' in skippedProperties)) {
+            testSharedMethods.assertTimestampOrder (exchange, method, symbol, response);
+        }
     }
 }
 


### PR DESCRIPTION
in watchOrderBook we have same check, was missing from wOBforSymbols