### PR TITLE
fix(test) - exmo qv <> bv check fix

### DIFF
--- a/ts/src/test/test.ts
+++ b/ts/src/test/test.ts
@@ -492,6 +492,9 @@ export default class testMainClass extends baseMainTestClass {
         if (('bid' in finalSkips) && !('ask' in finalSkips)) {
             finalSkips['ask'] = finalSkips['bid'];
         }
+        if (('baseVolume' in finalSkips) && !('quoteVolume' in finalSkips)) {
+            finalSkips['quoteVolume'] = finalSkips['baseVolume'];
+        }
         return finalSkips;
     }
 


### PR DESCRIPTION
strange bug, it was already skipped, retested & debugged it but don't know why it happened, should have happened: https://app.travis-ci.com/github/ccxt/ccxt/builds/269352042#L3689
anyway, i've added another skip which was missing