### PR TITLE
bybit.pro streaming["keepAlive"] changed from 20000 to 19000

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -120,7 +120,7 @@ export default class bybit extends bybitRest {
             },
             'streaming': {
                 'ping': this.ping,
-                'keepAlive': 20000,
+                'keepAlive': 19000,
             },
         });
     }


### PR DESCRIPTION
Fixes

```
2024-04-16 23:04:48,888 - ERROR - Exception in callback Future.race.<locals>.callback(<Task finishe...3]]>}, set())>) at /usr/local/lib/python3.10/dist-packages/ccxt/async_support/base/ws/future.py:25
handle: <Handle Future.race.<locals>.callback(<Task finishe...3]]>}, set())>) at /usr/local/lib/python3.10/dist-packages/ccxt/async_support/base/ws/future.py:25>
Traceback (most recent call last):
  File "/usr/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.10/dist-packages/ccxt/async_support/base/ws/future.py", line 56, in callback
    future.set_result(first_result)
asyncio.exceptions.InvalidStateError: invalid state
2024-04-17 00:27:42,081 - INFO - The error is: Connection to wss://stream.bybit.com/v5/public/linear timed out due to a ping-pong keepalive missing on time
```
from https://discord.com/channels/690203284119617602/690203284727660739/1232429510406832180

------------

I've been running watchOHLCV from the cli for about 40 minutes and the error isn't occuring. With keepAlive === 20000, it happens after a few minutes