### PR TITLE
Fix BingX apiKey query endpoint

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -291,7 +291,6 @@ export default class bingx extends Exchange {
                             'get': {
                                 'list': 3,
                                 'assets': 3,
-                                'apiKey/query': 1,
                             },
                             'post': {
                                 'create': 3,
@@ -308,6 +307,7 @@ export default class bingx extends Exchange {
                         'private': {
                             'get': {
                                 'uid': 1,
+                                'apiKey/query': 1,
                             },
                             'post': {
                                 'innerTransfer/authorizeSubAccount': 3,


### PR DESCRIPTION
Fixed incorrect URL for BingX API information query.

API key information query path is `/openApi/account/v1/apiKey/query` as stated in the [documentation](https://bingx-api.github.io/docs/#/en-us/common/sub-account#Create%20sub%20account%20apikey).
