### PR TITLE
coinex: cancelOrders v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -2728,8 +2728,8 @@ export default class coinex extends Exchange {
         const request = {
             'market': market['id'],
         };
-        const stop = this.safeBool (params, 'stop');
-        params = this.omit (params, 'stop');
+        const stop = this.safeBool2 (params, 'stop', 'trigger');
+        params = this.omit (params, [ 'stop', 'trigger' ]);
         let response = undefined;
         if (stop) {
             request['stop_ids'] = ids;

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1752,7 +1752,7 @@ export default class coinex extends Exchange {
         //         "client_id": "",
         //     }
         //
-        // Spot and Margin cancelOrder, cancelOrders, fetchOrder
+        // Spot and Margin cancelOrder, fetchOrder
         //
         //      {
         //          "amount":"1.5",
@@ -1947,49 +1947,7 @@ export default class coinex extends Exchange {
         //         "user_id": 3620173
         //     }
         //
-        // swap: cancelOrders
-        //
-        //     {
-        //         "amount": "0.0005",
-        //         "client_id": "x-167673045-b0cee0c584718b65",
-        //         "create_time": 1701233683.294231,
-        //         "deal_asset_fee": "0.00000000000000000000",
-        //         "deal_fee": "0.00000000000000000000",
-        //         "deal_profit": "0.00000000000000000000",
-        //         "deal_stock": "0.00000000000000000000",
-        //         "effect_type": 1,
-        //         "fee_asset": "",
-        //         "fee_discount": "0.00000000000000000000",
-        //         "last_deal_amount": "0.00000000000000000000",
-        //         "last_deal_id": 0,
-        //         "last_deal_price": "0.00000000000000000000",
-        //         "last_deal_role": 0,
-        //         "last_deal_time": 0,
-        //         "last_deal_type": 0,
-        //         "left": "0.0005",
-        //         "leverage": "3",
-        //         "maker_fee": "0.00030",
-        //         "market": "BTCUSDT",
-        //         "option": 0,
-        //         "order_id": 115940476323,
-        //         "position_id": 0,
-        //         "position_type": 2,
-        //         "price": "25000.00",
-        //         "side": 2,
-        //         "source": "api.v1",
-        //         "stop_id": 0,
-        //         "stop_loss_price": "0.00000000000000000000",
-        //         "stop_loss_type": 0,
-        //         "take_profit_price": "0.00000000000000000000",
-        //         "take_profit_type": 0,
-        //         "taker_fee": "0.00050",
-        //         "target": 0,
-        //         "type": 1,
-        //         "update_time": 1701233721.718884,
-        //         "user_id": 3620173
-        //     }
-        //
-        // Spot and Margin createOrder, createOrders v2
+        // Spot and Margin createOrder, createOrders, cancelOrders v2
         //
         //     {
         //         "amount": "0.0001",
@@ -2021,7 +1979,7 @@ export default class coinex extends Exchange {
         //         "stop_id": 117180138153
         //     }
         //
-        // Swap createOrder, createOrders v2
+        // Swap createOrder, createOrders, cancelOrders v2
         //
         //     {
         //         "amount": "0.0001",
@@ -2079,6 +2037,24 @@ export default class coinex extends Exchange {
         //         "take_profit_type": "",
         //         "unrealized_pnl": "0",
         //         "updated_at": 1714119054559
+        //     }
+        //
+        // Swap and Spot stop cancelOrders v2
+        //
+        //     {
+        //         "amount": "0.0001",
+        //         "client_id": "x-167673045-a7d7714c6478acf6",
+        //         "created_at": 1714187923820,
+        //         "market": "BTCUSDT",
+        //         "market_type": "FUTURES",
+        //         "price": "61000",
+        //         "side": "buy",
+        //         "stop_id": 136984426097,
+        //         "trigger_direction": "higher",
+        //         "trigger_price": "62000",
+        //         "trigger_price_type": "latest_price",
+        //         "type": "limit",
+        //         "updated_at": 1714187974363
         //     }
         //
         const rawStatus = this.safeString (order, 'status');
@@ -2146,8 +2122,8 @@ export default class coinex extends Exchange {
             'reduceOnly': undefined,
             'side': side,
             'price': this.safeString (order, 'price'),
-            'stopPrice': this.safeString (order, 'stop_price'),
-            'triggerPrice': this.safeString (order, 'stop_price'),
+            'stopPrice': this.safeString2 (order, 'stop_price', 'trigger_price'),
+            'triggerPrice': this.safeString2 (order, 'stop_price', 'trigger_price'),
             'takeProfitPrice': this.safeNumber (order, 'take_profit_price'),
             'stopLossPrice': this.safeNumber (order, 'stop_loss_price'),
             'cost': this.safeString2 (order, 'deal_money', 'filled_value'),
@@ -2734,11 +2710,14 @@ export default class coinex extends Exchange {
          * @method
          * @name coinex#cancelOrders
          * @description cancel multiple orders
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot003_trade016_batch_cancel_order
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http021-0_cancel_order_batch
+         * @see https://docs.coinex.com/api/v2/spot/order/http/cancel-batch-order
+         * @see https://docs.coinex.com/api/v2/spot/order/http/cancel-batch-stop-order
+         * @see https://docs.coinex.com/api/v2/futures/order/http/cancel-batch-order
+         * @see https://docs.coinex.com/api/v2/futures/order/http/cancel-batch-stop-order
          * @param {string[]} ids order ids
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {boolean} [params.stop] set to true for canceling stop orders
          * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
@@ -2749,112 +2728,157 @@ export default class coinex extends Exchange {
         const request = {
             'market': market['id'],
         };
-        const idsString = ids.join (',');
+        const stop = this.safeBool (params, 'stop');
+        params = this.omit (params, 'stop');
         let response = undefined;
-        if (market['spot']) {
-            request['batch_ids'] = idsString;
-            response = await this.v1PrivateDeleteOrderPendingBatch (this.extend (request, params));
+        if (stop) {
+            request['stop_ids'] = ids;
         } else {
-            request['order_ids'] = idsString;
-            response = await this.v1PerpetualPrivatePostOrderCancelBatch (this.extend (request, params));
+            request['order_ids'] = ids;
         }
-        //
-        // spot
-        //
-        //     {
-        //         "code": 0,
-        //         "data": [
-        //             {
-        //                 "code": 0,
-        //                 "data": {
-        //                     "account_id": 0,
-        //                     "amount": "0.0005",
-        //                     "asset_fee": "0",
-        //                     "avg_price": "0.00",
-        //                     "client_id": "x-167673045-d4e03c38f4d19b4e",
-        //                     "create_time": 1701229157,
-        //                     "deal_amount": "0",
-        //                     "deal_fee": "0",
-        //                     "deal_money": "0",
-        //                     "fee_asset": null,
-        //                     "fee_discount": "1",
-        //                     "finished_time": 0,
-        //                     "id": 107745856682,
-        //                     "left": "0",
-        //                     "maker_fee_rate": "0.002",
-        //                     "market": "BTCUSDT",
-        //                     "money_fee": "0",
-        //                     "order_type": "limit",
-        //                     "price": "22000",
-        //                     "status": "not_deal",
-        //                     "stock_fee": "0",
-        //                     "taker_fee_rate": "0.002",
-        //                     "type": "buy"
-        //                 },
-        //                 "message": ""
-        //             },
-        //         ],
-        //         "message": "Success"
-        //     }
-        //
-        // swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": [
-        //             {
-        //                 "code": 0,
-        //                 "message": "",
-        //                 "order": {
-        //                     "amount": "0.0005",
-        //                     "client_id": "x-167673045-b0cee0c584718b65",
-        //                     "create_time": 1701233683.294231,
-        //                     "deal_asset_fee": "0.00000000000000000000",
-        //                     "deal_fee": "0.00000000000000000000",
-        //                     "deal_profit": "0.00000000000000000000",
-        //                     "deal_stock": "0.00000000000000000000",
-        //                     "effect_type": 1,
-        //                     "fee_asset": "",
-        //                     "fee_discount": "0.00000000000000000000",
-        //                     "last_deal_amount": "0.00000000000000000000",
-        //                     "last_deal_id": 0,
-        //                     "last_deal_price": "0.00000000000000000000",
-        //                     "last_deal_role": 0,
-        //                     "last_deal_time": 0,
-        //                     "last_deal_type": 0,
-        //                     "left": "0.0005",
-        //                     "leverage": "3",
-        //                     "maker_fee": "0.00030",
-        //                     "market": "BTCUSDT",
-        //                     "option": 0,
-        //                     "order_id": 115940476323,
-        //                     "position_id": 0,
-        //                     "position_type": 2,
-        //                     "price": "25000.00",
-        //                     "side": 2,
-        //                     "source": "api.v1",
-        //                     "stop_id": 0,
-        //                     "stop_loss_price": "0.00000000000000000000",
-        //                     "stop_loss_type": 0,
-        //                     "take_profit_price": "0.00000000000000000000",
-        //                     "take_profit_type": 0,
-        //                     "taker_fee": "0.00050",
-        //                     "target": 0,
-        //                     "type": 1,
-        //                     "update_time": 1701233721.718884,
-        //                     "user_id": 3620173
-        //                 }
-        //             },
-        //         ],
-        //         "message": "OK"
-        //     }
-        //
-        const data = this.safeValue (response, 'data', []);
+        if (market['spot']) {
+            if (stop) {
+                response = await this.v2PrivatePostSpotCancelBatchStopOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": [
+                //             {
+                //                 "code": 0,
+                //                 "data": {
+                //                     "amount": "0.0001",
+                //                     "ccy": "BTC",
+                //                     "client_id": "x-167673045-8e33d6f4a4bcb022",
+                //                     "created_at": 1714188827291,
+                //                     "market": "BTCUSDT",
+                //                     "market_type": "SPOT",
+                //                     "price": "61000",
+                //                     "side": "buy",
+                //                     "stop_id": 117248845854,
+                //                     "trigger_direction": "higher",
+                //                     "trigger_price": "62000",
+                //                     "trigger_price_type": "mark_price",
+                //                     "type": "limit",
+                //                     "updated_at": 1714188827291
+                //                 },
+                //                 "message": "OK"
+                //             },
+                //         ],
+                //         "message": "OK"
+                //     }
+                //
+            } else {
+                response = await this.v2PrivatePostSpotCancelBatchOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": [
+                //             {
+                //                 "code": 0,
+                //                 "data": {
+                //                     "amount": "0.0001",
+                //                     "base_fee": "0",
+                //                     "ccy": "BTC",
+                //                     "client_id": "x-167673045-c1cc78e5b42d8c4e",
+                //                     "created_at": 1714188449497,
+                //                     "discount_fee": "0",
+                //                     "filled_amount": "0",
+                //                     "filled_value": "0",
+                //                     "last_fill_amount": "0",
+                //                     "last_fill_price": "0",
+                //                     "maker_fee_rate": "0.002",
+                //                     "market": "BTCUSDT",
+                //                     "market_type": "SPOT",
+                //                     "order_id": 117248494358,
+                //                     "price": "60000",
+                //                     "quote_fee": "0",
+                //                     "side": "buy",
+                //                     "taker_fee_rate": "0.002",
+                //                     "type": "limit",
+                //                     "unfilled_amount": "0.0001",
+                //                     "updated_at": 1714188449497
+                //                 },
+                //                 "message": ""
+                //             },
+                //         ],
+                //         "message": "OK"
+                //     }
+                //
+            }
+        } else {
+            request['market_type'] = 'FUTURES';
+            if (stop) {
+                response = await this.v2PrivatePostFuturesCancelBatchStopOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": [
+                //             {
+                //                 "code": 0,
+                //                 "data": {
+                //                     "amount": "0.0001",
+                //                     "client_id": "x-167673045-a7d7714c6478acf6",
+                //                     "created_at": 1714187923820,
+                //                     "market": "BTCUSDT",
+                //                     "market_type": "FUTURES",
+                //                     "price": "61000",
+                //                     "side": "buy",
+                //                     "stop_id": 136984426097,
+                //                     "trigger_direction": "higher",
+                //                     "trigger_price": "62000",
+                //                     "trigger_price_type": "latest_price",
+                //                     "type": "limit",
+                //                     "updated_at": 1714187974363
+                //                 },
+                //                 "message": ""
+                //             },
+                //         ],
+                //         "message": "OK"
+                //     }
+                //
+            } else {
+                response = await this.v2PrivatePostFuturesCancelBatchOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": [
+                //             {
+                //                 "code": 0,
+                //                 "data": {
+                //                     "amount": "0.0001",
+                //                     "client_id": "x-167673045-9f80fde284339a72",
+                //                     "created_at": 1714187491784,
+                //                     "fee": "0",
+                //                     "fee_ccy": "USDT",
+                //                     "filled_amount": "0",
+                //                     "filled_value": "0",
+                //                     "last_filled_amount": "0",
+                //                     "last_filled_price": "0",
+                //                     "maker_fee_rate": "0.0003",
+                //                     "market": "BTCUSDT",
+                //                     "market_type": "FUTURES",
+                //                     "order_id": 136983851788,
+                //                     "price": "61000",
+                //                     "realized_pnl": "0",
+                //                     "side": "buy",
+                //                     "taker_fee_rate": "0.0005",
+                //                     "type": "limit",
+                //                     "unfilled_amount": "0.0001",
+                //                     "updated_at": 1714187567079
+                //                 },
+                //                 "message": ""
+                //             },
+                //         ],
+                //         "message": "OK"
+                //     }
+                //
+            }
+        }
+        const data = this.safeList (response, 'data', []);
         const results = [];
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
-            const dataRequest = market['spot'] ? 'data' : 'order';
-            const item = this.safeValue (entry, dataRequest, {});
+            const item = this.safeDict (entry, 'data', {});
             const order = this.parseOrder (item, market);
             results.push (order);
         }

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -687,27 +687,60 @@
             {
                 "description": "Cancel multiple spot orders at once",
                 "method": "cancelOrders",
-                "url": "https://api.coinex.com/v1/order/pending/batch?access_id=86AC33D5904F432C9C9DDD4708233F38&batch_ids=107745856682,107745856676&market=BTCUSDT&tonce=1701230333560",
+                "url": "https://api.coinex.com/v2/spot/cancel-batch-order",
                 "input": [
-                    [
-                        "107745856682",
-                        "107745856676"
-                    ],
-                    "BTC/USDT"
-                ]
+                  [
+                    117248494358,
+                    117248494357
+                  ],
+                  "BTC/USDT"
+                ],
+                "output": "{\"market\":\"BTCUSDT\",\"order_ids\":[117248494358,117248494357]}"
+            },
+            {
+                "description": "Cancel multiple spot stop orders at once",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/v2/spot/cancel-batch-stop-order",
+                "input": [
+                  [
+                    117248845854,
+                    117248845855
+                  ],
+                  "BTC/USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "{\"market\":\"BTCUSDT\",\"stop_ids\":[117248845854,117248845855]}"
             },
             {
                 "description": "Cancel multiple swap orders at once",
                 "method": "cancelOrders",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel_batch",
+                "url": "https://api.coinex.com/v2/futures/cancel-batch-order",
                 "input": [
-                    [
-                        "115938781741",
-                        "115938847458"
-                    ],
-                    "BTC/USDT:USDT"
+                  [
+                    136983851788,
+                    136983851789
+                  ],
+                  "BTC/USDT:USDT"
                 ],
-                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_ids=115938781741,115938847458&timestamp=1701232526724"
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"order_ids\":[136983851788,136983851789]}"
+            },
+            {
+                "description": "Cancel multiple swap stop orders at once",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/v2/futures/cancel-batch-stop-order",
+                "input": [
+                  [
+                    136984426097,
+                    136984426099
+                  ],
+                  "BTC/USDT:USDT",
+                  {
+                    "stop": true
+                  }
+                ],
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"stop_ids\":[136984426097,136984426099]}"
             }
         ],
         "fetchTicker": [


### PR DESCRIPTION
Updated cancelOrders to v2 and added static request tests:
```
coinex cancelOrders '[136983851788,136983851789]' BTC/USDT:USDT

coinex.cancelOrders (136983851788,136983851789, BTC/USDT:USDT)

          id |                clientOrderId |                 datetime |     timestamp | lastTradeTimestamp |   symbol |  type | side | price | cost | amount | filled | remaining | trades |                            fee |                           fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
136983851788 | x-167673045-9f80fde284339a72 | 2024-04-27T03:11:31.784Z | 1714187491784 |      1714187567079 | BTC/USDT | limit |  buy | 61000 |    0 | 0.0001 |      0 |    0.0001 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
136983851789 | x-167673045-f88feefe94ef92e7 | 2024-04-27T03:11:31.784Z | 1714187491784 |      1714187567079 | BTC/USDT | limit |  buy | 60000 |    0 | 0.0001 |      0 |    0.0001 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
2 objects
```
```
coinex cancelOrders '[117248494358,117248494357]' BTC/USDT

coinex.cancelOrders (117248494358,117248494357, BTC/USDT)

          id |                clientOrderId |                 datetime |     timestamp | lastTradeTimestamp |   symbol |  type | side | price | cost | amount | filled | remaining | trades |                            fee |                           fees
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
117248494358 | x-167673045-c1cc78e5b42d8c4e | 2024-04-27T03:27:29.497Z | 1714188449497 |      1714188449497 | BTC/USDT | limit |  buy | 60000 |    0 | 0.0001 |      0 |    0.0001 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
117248494357 | x-167673045-65ca92ee040a9351 | 2024-04-27T03:27:29.495Z | 1714188449495 |      1714188449495 | BTC/USDT | limit |  buy | 61000 |    0 | 0.0001 |      0 |    0.0001 |     [] | {"currency":"USDT","cost":"0"} | [{"currency":"USDT","cost":0}]
2 objects
```