### PR TITLE
fix(types) broken existed code (typescript project) for Order type

### DIFF
--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -134,9 +134,9 @@ export interface Order {
     stopLossPrice?: number;
     cost: number;
     trades: Trade[];
-    fee: Fee;
-    reduceOnly: Bool;
-    postOnly: Bool;
+    fee?: Fee;
+    reduceOnly?: Bool;
+    postOnly?: Bool;
     info: any;
 }
 


### PR DESCRIPTION
new property are nullable by itself, then no need to make those required