### PR TITLE
coinex: editOrder v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1947,7 +1947,7 @@ export default class coinex extends Exchange {
         //         "user_id": 3620173
         //     }
         //
-        // Spot and Margin createOrder, createOrders, cancelOrders v2
+        // Spot and Margin createOrder, createOrders, cancelOrders, editOrder v2
         //
         //     {
         //         "amount": "0.0001",
@@ -1973,13 +1973,13 @@ export default class coinex extends Exchange {
         //         "updated_at": 1714114386250
         //     }
         //
-        // Spot, Margin and Swap trigger createOrder, createOrders v2
+        // Spot, Margin and Swap trigger createOrder, createOrders, editOrder v2
         //
         //     {
         //         "stop_id": 117180138153
         //     }
         //
-        // Swap createOrder, createOrders, cancelOrders v2
+        // Swap createOrder, createOrders, cancelOrders, editOrder v2
         //
         //     {
         //         "amount": "0.0001",
@@ -2717,7 +2717,7 @@ export default class coinex extends Exchange {
          * @param {string[]} ids order ids
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @param {boolean} [params.stop] set to true for canceling stop orders
+         * @param {boolean} [params.trigger] set to true for canceling stop orders
          * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
@@ -2885,12 +2885,15 @@ export default class coinex extends Exchange {
         return results;
     }
 
-    async editOrder (id: string, symbol: string, type:OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
+    async editOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
         /**
          * @method
-         * @name okx#editOrder
+         * @name coinex#editOrder
          * @description edit a trade order
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot003_trade022_modify_order
+         * @see https://docs.coinex.com/api/v2/spot/order/http/edit-order
+         * @see https://docs.coinex.com/api/v2/spot/order/http/edit-stop-order
+         * @see https://docs.coinex.com/api/v2/futures/order/http/edit-order
+         * @see https://docs.coinex.com/api/v2/futures/order/http/edit-stop-order
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
@@ -2898,6 +2901,7 @@ export default class coinex extends Exchange {
          * @param {float} amount how much of the currency you want to trade in units of the base currency
          * @param {float} [price] the price at which the order is to be fullfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {float} [params.triggerPrice] the price to trigger stop orders
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
@@ -2905,12 +2909,8 @@ export default class coinex extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (!market['spot']) {
-            throw new NotSupported (this.id + ' editOrder() does not support ' + market['type'] + ' orders, only spot orders are accepted');
-        }
         const request = {
             'market': market['id'],
-            'id': parseInt (id),
         };
         if (amount !== undefined) {
             request['amount'] = this.amountToPrecision (symbol, amount);
@@ -2918,38 +2918,113 @@ export default class coinex extends Exchange {
         if (price !== undefined) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
-        const response = await this.v1PrivatePostOrderModify (this.extend (request, params));
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "id": 35436205,
-        //             "create_time": 1636080705,
-        //             "finished_time": null,
-        //             "amount": "0.30000000",
-        //             "price": " 56000",
-        //             "deal_amount": "0.24721428",
-        //             "deal_money": "13843.9996800000000000",
-        //             "deal_fee": "0",
-        //             "stock_fee": "0",
-        //             "money_fee": "0",
-        //             " asset_fee": "8.721719798400000000000000",
-        //             "fee_asset": "CET",
-        //             "fee_discount": "0.70",
-        //             "avg_price": "56000",
-        //             "market": "BTCUSDT",
-        //             "left": "0.05278572 ",
-        //             "maker_fee_rate": "0.0018",
-        //             "taker_fee_rate": "0.0018",
-        //             "order_type": "limit",
-        //             "type": "buy",
-        //             "status": "cancel",
-        //             "client_id ": "abcd222",
-        //             "source_id": "1234"
-        //     },
-        //         "message": "Success"
-        //     }
-        //
+        let response = undefined;
+        const triggerPrice = this.safeStringN (params, [ 'stopPrice', 'triggerPrice', 'trigger_price' ]);
+        params = this.omit (params, [ 'stopPrice', 'triggerPrice' ]);
+        const isTriggerOrder = triggerPrice !== undefined;
+        if (isTriggerOrder) {
+            request['trigger_price'] = this.priceToPrecision (symbol, triggerPrice);
+            request['stop_id'] = this.parseToNumeric (id);
+        } else {
+            request['order_id'] = this.parseToNumeric (id);
+        }
+        let marginMode = undefined;
+        [ marginMode, params ] = this.handleMarginModeAndParams ('editOrder', params);
+        if (market['spot']) {
+            if (marginMode !== undefined) {
+                request['market_type'] = 'MARGIN';
+            } else {
+                request['market_type'] = 'SPOT';
+            }
+            if (isTriggerOrder) {
+                response = await this.v2PrivatePostSpotModifyStopOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": {
+                //             "stop_id": 117337235167
+                //         },
+                //         "message": "OK"
+                //     }
+                //
+            } else {
+                response = await this.v2PrivatePostSpotModifyOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": {
+                //             "amount": "0.0001",
+                //             "base_fee": "0",
+                //             "ccy": "BTC",
+                //             "client_id": "x-167673045-87eb2bebf42882d8",
+                //             "created_at": 1714290302047,
+                //             "discount_fee": "0",
+                //             "filled_amount": "0",
+                //             "filled_value": "0",
+                //             "last_fill_amount": "0",
+                //             "last_fill_price": "0",
+                //             "maker_fee_rate": "0.002",
+                //             "market": "BTCUSDT",
+                //             "market_type": "SPOT",
+                //             "order_id": 117336922195,
+                //             "price": "61000",
+                //             "quote_fee": "0",
+                //             "side": "buy",
+                //             "status": "open",
+                //             "taker_fee_rate": "0.002",
+                //             "type": "limit",
+                //             "unfilled_amount": "0.0001",
+                //             "updated_at": 1714290191141
+                //         },
+                //         "message": "OK"
+                //     }
+                //
+            }
+        } else {
+            request['market_type'] = 'FUTURES';
+            if (isTriggerOrder) {
+                response = await this.v2PrivatePostFuturesModifyStopOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": {
+                //             "stop_id": 137091875605
+                //         },
+                //         "message": "OK"
+                //     }
+                //
+            } else {
+                response = await this.v2PrivatePostFuturesModifyOrder (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "data": {
+                //             "amount": "0.0001",
+                //             "client_id": "x-167673045-3f2d09191462b207",
+                //             "created_at": 1714290927630,
+                //             "fee": "0",
+                //             "fee_ccy": "USDT",
+                //             "filled_amount": "0",
+                //             "filled_value": "0",
+                //             "last_filled_amount": "0",
+                //             "last_filled_price": "0",
+                //             "maker_fee_rate": "0.0003",
+                //             "market": "BTCUSDT",
+                //             "market_type": "FUTURES",
+                //             "order_id": 137091566717,
+                //             "price": "61000",
+                //             "realized_pnl": "0",
+                //             "side": "buy",
+                //             "taker_fee_rate": "0.0005",
+                //             "type": "limit",
+                //             "unfilled_amount": "0.0001",
+                //             "updated_at": 1714290927630
+                //         },
+                //         "message": "OK"
+                //     }
+                //
+            }
+        }
         const data = this.safeDict (response, 'data', {});
         return this.parseOrder (data, market);
     }

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1030,6 +1030,70 @@
                   }
                 ]
             }
+        ],
+        "editOrder": [
+            {
+                "description": "Spot edit an order",
+                "method": "editOrder",
+                "url": "https://api.coinex.com/v2/spot/modify-order",
+                "input": [
+                  117336840432,
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  61000
+                ],
+                "output": "{\"amount\":\"0.0001\",\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\",\"order_id\":117336840432,\"price\":\"61000\"}"
+            },
+            {
+                "description": "Spot edit a trigger order",
+                "method": "editOrder",
+                "url": "https://api.coinex.com/v2/spot/modify-stop-order",
+                "input": [
+                  117337149743,
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  61000,
+                  {
+                    "triggerPrice": 61500
+                  }
+                ],
+                "output": "{\"amount\":\"0.0001\",\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\",\"price\":\"61000\",\"stop_id\":117337149743,\"trigger_price\":\"61500\"}"
+            },
+            {
+                "description": "Swap edit an order",
+                "method": "editOrder",
+                "url": "https://api.coinex.com/v2/futures/modify-order",
+                "input": [
+                  137091531608,
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  61000
+                ],
+                "output": "{\"amount\":\"0.0001\",\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"order_id\":137091531608,\"price\":\"61000\"}"
+            },
+            {
+                "description": "Swap edit a trigger order",
+                "method": "editOrder",
+                "url": "https://api.coinex.com/v2/futures/modify-stop-order",
+                "input": [
+                  137091809783,
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  61000,
+                  {
+                    "triggerPrice": 61500
+                  }
+                ],
+                "output": "{\"amount\":\"0.0001\",\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"price\":\"61000\",\"stop_id\":137091809783,\"trigger_price\":\"61500\"}"
+            }
         ]
     },
     "disabledTests": {}


### PR DESCRIPTION
Update editOrder to v2 and add swap and trigger order support:
```
coinex editOrder 117336840432 BTC/USDT limit buy 0.0001 61000

{
  id: '117336922195',
  clientOrderId: 'x-167673045-87eb2bebf42882d8',
  datetime: '2024-04-28T07:45:02.047Z',
  timestamp: 1714290302047,
  lastTradeTimestamp: 1714290191141,
  status: 'open',
  symbol: 'BTC/USDT',
  type: 'limit',
  side: 'buy',
  price: 61000,
  cost: 0,
  amount: 0.0001,
  filled: 0,
  remaining: 0.0001,
  trades: [],
  fee: { currency: 'USDT', cost: '0' },
  info: {
    amount: '0.0001',
    base_fee: '0',
    ccy: 'BTC',
    client_id: 'x-167673045-87eb2bebf42882d8',
    created_at: '1714290302047',
    discount_fee: '0',
    filled_amount: '0',
    filled_value: '0',
    last_fill_amount: '0',
    last_fill_price: '0',
    maker_fee_rate: '0.002',
    market: 'BTCUSDT',
    market_type: 'SPOT',
    order_id: '117336922195',
    price: '61000',
    quote_fee: '0',
    side: 'buy',
    status: 'open',
    taker_fee_rate: '0.002',
    type: 'limit',
    unfilled_amount: '0.0001',
    updated_at: '1714290191141'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```
```
coinex editOrder 117337149743 BTC/USDT limit buy 0.0001 61000 '{"triggerPrice":61500}'

{
  id: '117337235167',
  symbol: 'BTC/USDT',
  trades: [],
  fee: { currency: 'USDT' },
  info: { stop_id: '117337235167' },
  fees: [ { currency: 'USDT' } ]
}
```
```
coinex editOrder 137091531608 BTC/USDT:USDT limit buy 0.0001 61000

{
  id: '137091566717',
  clientOrderId: 'x-167673045-3f2d09191462b207',
  datetime: '2024-04-28T07:55:27.630Z',
  timestamp: 1714290927630,
  lastTradeTimestamp: 1714290927630,
  symbol: 'BTC/USDT',
  type: 'limit',
  side: 'buy',
  price: 61000,
  cost: 0,
  amount: 0.0001,
  filled: 0,
  remaining: 0.0001,
  trades: [],
  fee: { currency: 'USDT', cost: '0' },
  info: {
    amount: '0.0001',
    client_id: 'x-167673045-3f2d09191462b207',
    created_at: '1714290927630',
    fee: '0',
    fee_ccy: 'USDT',
    filled_amount: '0',
    filled_value: '0',
    last_filled_amount: '0',
    last_filled_price: '0',
    maker_fee_rate: '0.0003',
    market: 'BTCUSDT',
    market_type: 'FUTURES',
    order_id: '137091566717',
    price: '61000',
    realized_pnl: '0',
    side: 'buy',
    taker_fee_rate: '0.0005',
    type: 'limit',
    unfilled_amount: '0.0001',
    updated_at: '1714290927630'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```
```
coinex editOrder 137091809783 BTC/USDT:USDT limit buy 0.0001 61000 '{"triggerPrice":61500}'

{
  id: '137091875605',
  symbol: 'BTC/USDT:USDT',
  trades: [],
  fee: { currency: 'USDT' },
  info: { stop_id: '137091875605' },
  fees: [ { currency: 'USDT' } ]
}
```