### PR TITLE
coinex: cancelOrder v2

### DIFF
--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -571,98 +571,102 @@
             {
                 "description": "Spot cancel order",
                 "method": "cancelOrder",
-                "url": "https://api.coinex.com/v1/order/pending?access_id=86AC33D5904F432C9C9DDD4708233F38&id=107745260032&market=BTCUSDT&tonce=1701228187975",
+                "url": "https://api.coinex.com/v2/spot/cancel-order",
                 "input": [
-                    "107745260032",
-                    "BTC/USDT"
-                ]
+                  117401168172,
+                  "BTC/USDT"
+                ],
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\",\"order_id\":117401168172}"
             },
             {
                 "description": "Spot cancel trigger order",
                 "method": "cancelOrder",
-                "url": "https://api.coinex.com/v1/order/stop/pending/107744772540?access_id=86AC33D5904F432C9C9DDD4708233F38&id=107744772540&market=BTCUSDT&tonce=1701228118229",
+                "url": "https://api.coinex.com/v2/spot/cancel-stop-order",
                 "input": [
-                    "107744772540",
-                    "BTC/USDT",
-                    {
-                        "stop": true
-                    }
-                ]
+                  117401897954,
+                  "BTC/USDT",
+                  {
+                    "trigger": true
+                  }
+                ],
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\",\"stop_id\":117401897954}"
             },
             {
                 "description": "Swap cancel order",
                 "method": "cancelOrder",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel",
+                "url": "https://api.coinex.com/v2/futures/cancel-order",
                 "input": [
-                    "115939084611",
-                    "BTC/USDT:USDT"
+                  137174472136,
+                  "BTC/USDT:USDT"
                 ],
-                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_id=115939084611&timestamp=1701232671805"
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"order_id\":137174472136}"
             },
             {
                 "description": "Swap cancel trigger order",
                 "method": "cancelOrder",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel_stop",
+                "url": "https://api.coinex.com/v2/futures/cancel-stop-order",
                 "input": [
-                    "115940250059",
-                    "BTC/USDT:USDT",
-                    {
-                        "stop": true
-                    }
+                  137175039001,
+                  "BTC/USDT:USDT",
+                  {
+                    "trigger": true
+                  }
                 ],
-                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&order_id=115940250059&timestamp=1701233531405"
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"stop_id\":137175039001}"
             },
             {
-                "description": "Spot cancel order by clientOid",
+                "description": "Spot cancel order by client order id",
                 "method": "cancelOrder",
-                "url": "https://api.coinex.com/v1/order/pending/by_client_id?access_id=86AC33D5904F432C9C9DDD4708233F38&client_id=client01&market=BTCUSDT&tonce=1701228187975",
+                "url": "https://api.coinex.com/v2/spot/cancel-order-by-client-id",
                 "input": [
-                    "",
-                    "BTC/USDT",
-                    {
-                        "clientOrderId": "client01"
-                    }
-                ]
-            },
-            {
-                "description": "Spot cancel trigger order by clientOid",
-                "method": "cancelOrder",
-                "url": "https://api.coinex.com/v1/order/stop/pending/by_client_id?access_id=86AC33D5904F432C9C9DDD4708233F38&client_id=client01&market=BTCUSDT&tonce=1701228118229",
-                "input": [
-                    "",
-                    "BTC/USDT",
-                    {
-                        "stop": true,
-                        "clientOrderId": "client01"
-                    }
-                ]
-            },
-            {
-                "description": "Swap cancel order by clientOid",
-                "method": "cancelOrder",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel/by_client_id",
-                "input": [
-                    "",
-                    "BTC/USDT:USDT",
-                    {
-                        "clientOrderId": "client01"
-                    }
+                  "",
+                  "BTC/USDT",
+                  {
+                    "clientOrderId": "client01"
+                  }
                 ],
-                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&client_id=client01&timestamp=1701232671805"
+                "output": "{\"client_id\":\"client01\",\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\"}"
             },
             {
-                "description": "Swap cancel trigger order by clientOid",
+                "description": "Spot cancel trigger order by client order id",
                 "method": "cancelOrder",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel_stop/by_client_id",
+                "url": "https://api.coinex.com/v2/spot/cancel-stop-order-by-client-id",
                 "input": [
-                    "",
-                    "BTC/USDT:USDT",
-                    {
-                        "stop": true,
-                        "clientOrderId": "client01"
-                    }
+                  "",
+                  "BTC/USDT",
+                  {
+                    "clientOrderId": "client01",
+                    "trigger": true
+                  }
                 ],
-                "output": "access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&client_id=client01&timestamp=1701233531405"
+                "output": "{\"client_id\":\"client01\",\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\"}"
+            },
+            {
+                "description": "Swap cancel order by client order id",
+                "method": "cancelOrder",
+                "url": "https://api.coinex.com/v2/futures/cancel-order-by-client-id",
+                "input": [
+                  "",
+                  "BTC/USDT:USDT",
+                  {
+                    "clientOrderId": "client01"
+                  }
+                ],
+                "output": "{\"client_id\":\"client01\",\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\"}"
+            },
+            {
+                "description": "Swap cancel trigger order by client order id",
+                "method": "cancelOrder",
+                "url": "https://api.coinex.com/v2/futures/cancel-stop-order-by-client-id",
+                "input": [
+                  "",
+                  "BTC/USDT:USDT",
+                  {
+                    "trigger": true,
+                    "clientOrderId": "client01"
+                  }
+                ],
+                "output": "{\"client_id\":\"client01\",\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\"}"
             }
         ],
         "fetchIsolatedBorrowRate": [


### PR DESCRIPTION
Updated cancelOrder to v2 and added static request tests:
```
coinex.cancelOrder (137178013812, BTC/USDT:USDT)

{
  id: '137178013812',
  clientOrderId: 'x-167673045-09e7ef4d54f9aaa3',
  datetime: '2024-04-29T05:54:00.258Z',
  timestamp: 1714370040258,
  lastTradeTimestamp: 1714370070458,
  symbol: 'BTC/USDT',
  type: 'limit',
  side: 'buy',
  price: 61000,
  cost: 0,
  amount: 0.0001,
  filled: 0,
  remaining: 0.0001,
  trades: [],
  fee: { currency: 'USDT', cost: '0' },
  info: {
    amount: '0.0001',
    client_id: 'x-167673045-09e7ef4d54f9aaa3',
    created_at: '1714370040258',
    fee: '0',
    fee_ccy: 'USDT',
    filled_amount: '0',
    filled_value: '0',
    last_filled_amount: '0',
    last_filled_price: '0',
    maker_fee_rate: '0.0003',
    market: 'BTCUSDT',
    market_type: 'FUTURES',
    order_id: '137178013812',
    price: '61000',
    realized_pnl: '0',
    side: 'buy',
    taker_fee_rate: '0.0005',
    type: 'limit',
    unfilled_amount: '0.0001',
    updated_at: '1714370070458'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```