### PR TITLE
coinex: cancelAllOrders v2

### DIFF
--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -138,21 +138,22 @@
         ],
         "cancelAllOrders": [
             {
-                "description": "Cancel swap orders",
+                "description": "Swap cancel all orders",
                 "method": "cancelAllOrders",
-                "url": "https://api.coinex.com/perpetual/v1/order/cancel_all",
+                "url": "https://api.coinex.com/v2/futures/cancel-all-order",
                 "input": [
-                    "LTC/USDT:USDT"
+                  "BTC/USDT:USDT"
                 ],
-                "output": "access_id=53DD577FFFD741D4B53A5424ECD33196&market=LTCUSDT&timestamp=1699458296144"
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\"}"
             },
             {
-                "description": "Cancel spot orders",
+                "description": "Spot cancel all orders",
                 "method": "cancelAllOrders",
-                "url": "https://api.coinex.com/v1/order/pending?access_id=53DD577FFFD741D4B53A5424ECD33196&account_id=0&market=LTCUSDT&tonce=1699458296556",
+                "url": "https://api.coinex.com/v2/spot/cancel-all-order",
                 "input": [
-                    "LTC/USDT"
-                ]
+                  "BTC/USDT"
+                ],
+                "output": "{\"market\":\"BTCUSDT\",\"market_type\":\"SPOT\"}"
             }
         ],
         "fetchBalance": [


### PR DESCRIPTION
Updated cancelAllOrders to v2 and added some static request tests:
```
coinex.cancelAllOrders (BTC/USDT)

{ code: '0', data: {}, message: 'OK' }
```
```
coinex.cancelAllOrders (BTC/USDT:USDT)

{ code: '0', data: {}, message: 'OK' }
```