### PR TITLE
coinex: fetchOrder v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1728,121 +1728,6 @@ export default class coinex extends Exchange {
 
     parseOrder (order, market: Market = undefined): Order {
         //
-        // fetchOrder
-        //
-        //     {
-        //         "amount": "0.1",
-        //         "asset_fee": "0.22736197736197736197",
-        //         "avg_price": "196.85000000000000000000",
-        //         "create_time": 1537270135,
-        //         "deal_amount": "0.1",
-        //         "deal_fee": "0",
-        //         "deal_money": "19.685",
-        //         "fee_asset": "CET",
-        //         "fee_discount": "0.5",
-        //         "id": 1788259447,
-        //         "left": "0",
-        //         "maker_fee_rate": "0",
-        //         "market": "ETHUSDT",
-        //         "order_type": "limit",
-        //         "price": "170.00000000",
-        //         "status": "done",
-        //         "taker_fee_rate": "0.0005",
-        //         "type": "sell",
-        //         "client_id": "",
-        //     }
-        //
-        // Spot and Margin cancelOrder, fetchOrder
-        //
-        //      {
-        //          "amount":"1.5",
-        //          "asset_fee":"0",
-        //          "avg_price":"0.14208538",
-        //          "client_id":"",
-        //          "create_time":1650993819,
-        //          "deal_amount":"10.55703267",
-        //          "deal_fee":"0.0029999999971787292",
-        //          "deal_money":"1.4999999985893646",
-        //          "fee_asset":null,
-        //          "fee_discount":"1",
-        //          "finished_time":null,
-        //          "id":74556296907,
-        //          "left":"0.0000000014106354",
-        //          "maker_fee_rate":"0",
-        //          "market":"DOGEUSDT",
-        //          "money_fee":"0.0029999999971787292",
-        //          "order_type":"market",
-        //          "price":"0",
-        //          "status":"done",
-        //          "stock_fee":"0",
-        //          "taker_fee_rate":"0.002",
-        //          "type":"buy"
-        //          "client_id": "",
-        //      }
-        //
-        // Swap cancelOrder, fetchOrder
-        //
-        //     {
-        //         "amount": "0.0005",
-        //         "client_id": "",
-        //         "create_time": 1651004578.618224,
-        //         "deal_asset_fee": "0.00000000000000000000",
-        //         "deal_fee": "0.00000000000000000000",
-        //         "deal_profit": "0.00000000000000000000",
-        //         "deal_stock": "0.00000000000000000000",
-        //         "effect_type": 1,
-        //         "fee_asset": "",
-        //         "fee_discount": "0.00000000000000000000",
-        //         "last_deal_amount": "0.00000000000000000000",
-        //         "last_deal_id": 0,
-        //         "last_deal_price": "0.00000000000000000000",
-        //         "last_deal_role": 0,
-        //         "last_deal_time": 0,
-        //         "last_deal_type": 0,
-        //         "left": "0.0005",
-        //         "leverage": "3",
-        //         "maker_fee": "0.00030",
-        //         "market": "BTCUSDT",
-        //         "order_id": 18221659097,
-        //         "position_id": 0,
-        //         "position_type": 1,
-        //         "price": "30000.00",
-        //         "side": 2,
-        //         "source": "api.v1",
-        //         "stop_id": 0,
-        //         "taker_fee": "0.00050",
-        //         "target": 0,
-        //         "type": 1,
-        //         "update_time": 1651004578.618224,
-        //         "user_id": 3620173
-        //     }
-        //
-        // Swap Stop cancelOrder, fetchOrder
-        //
-        //     {
-        //         "amount": "0.0005",
-        //         "client_id": "",
-        //         "create_time": 1651034023.008771,
-        //         "effect_type": 1,
-        //         "fee_asset": "",
-        //         "fee_discount": "0.00000000000000000000",
-        //         "maker_fee": "0.00030",
-        //         "market": "BTCUSDT",
-        //         "order_id": 18256915101,
-        //         "price": "31000.00",
-        //         "side": 2,
-        //         "source": "api.v1",
-        //         "state": 1,
-        //         "stop_price": "31500.00",
-        //         "stop_type": 1,
-        //         "taker_fee": "0.00050",
-        //         "target": 0,
-        //         "type": 1,
-        //         "update_time": 1651034397.193624,
-        //         "user_id": 3620173
-        //     }
-        //
-        //
         // Spot and Margin fetchOpenOrders, fetchClosedOrders
         //
         //     {
@@ -2055,6 +1940,59 @@ export default class coinex extends Exchange {
         //         "trigger_price_type": "latest_price",
         //         "type": "limit",
         //         "updated_at": 1714187974363
+        //     }
+        //
+        // Swap fetchOrder v2
+        //
+        //     {
+        //         "amount": "0.0001",
+        //         "client_id": "x-167673045-da5f31dcd478a829",
+        //         "created_at": 1714460987164,
+        //         "fee": "0",
+        //         "fee_ccy": "USDT",
+        //         "filled_amount": "0",
+        //         "filled_value": "0",
+        //         "last_filled_amount": "0",
+        //         "last_filled_price": "0",
+        //         "maker_fee_rate": "0.0003",
+        //         "market": "BTCUSDT",
+        //         "market_type": "FUTURES",
+        //         "order_id": 137319868771,
+        //         "price": "61000",
+        //         "realized_pnl": "0",
+        //         "side": "buy",
+        //         "status": "open",
+        //         "taker_fee_rate": "0.0005",
+        //         "type": "limit",
+        //         "unfilled_amount": "0.0001",
+        //         "updated_at": 1714460987164
+        //     }
+        //
+        // Spot and Margin fetchOrder v2
+        //
+        //     {
+        //         "amount": "0.0001",
+        //         "base_fee": "0",
+        //         "ccy": "BTC",
+        //         "client_id": "x-167673045-da918d6724e3af81",
+        //         "created_at": 1714461638958,
+        //         "discount_fee": "0",
+        //         "filled_amount": "0",
+        //         "filled_value": "0",
+        //         "last_fill_amount": "0",
+        //         "last_fill_price": "0",
+        //         "maker_fee_rate": "0.002",
+        //         "market": "BTCUSDT",
+        //         "market_type": "SPOT",
+        //         "order_id": 117492012985,
+        //         "price": "61000",
+        //         "quote_fee": "0",
+        //         "side": "buy",
+        //         "status": "open",
+        //         "taker_fee_rate": "0.002",
+        //         "type": "limit",
+        //         "unfilled_amount": "0.0001",
+        //         "updated_at": 1714461638958
         //     }
         //
         const rawStatus = this.safeString (order, 'status');
@@ -3384,9 +3322,8 @@ export default class coinex extends Exchange {
          * @method
          * @name coinex#fetchOrder
          * @description fetches information on an order made by the user
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http028_stop_status
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http026_order_status
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot003_trade007_order_status
+         * @see https://docs.coinex.com/api/v2/spot/order/http/get-order-status
+         * @see https://docs.coinex.com/api/v2/futures/order/http/get-order-status
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -3396,125 +3333,76 @@ export default class coinex extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const swap = market['swap'];
-        const stop = this.safeValue (params, 'stop');
-        params = this.omit (params, 'stop');
         const request = {
             'market': market['id'],
-            // 'id': id, // SPOT
-            // 'order_id': id, // SWAP
+            'order_id': this.parseToNumeric (id),
         };
-        const idRequest = swap ? 'order_id' : 'id';
-        request[idRequest] = id;
         let response = undefined;
-        if (swap) {
-            if (stop) {
-                response = await this.v1PerpetualPrivateGetOrderStopStatus (this.extend (request, params));
-            } else {
-                response = await this.v1PerpetualPrivateGetOrderStatus (this.extend (request, params));
-            }
+        if (market['swap']) {
+            response = await this.v2PrivateGetFuturesOrderStatus (this.extend (request, params));
+            //
+            //     {
+            //         "code": 0,
+            //         "data": {
+            //             "amount": "0.0001",
+            //             "client_id": "x-167673045-da5f31dcd478a829",
+            //             "created_at": 1714460987164,
+            //             "fee": "0",
+            //             "fee_ccy": "USDT",
+            //             "filled_amount": "0",
+            //             "filled_value": "0",
+            //             "last_filled_amount": "0",
+            //             "last_filled_price": "0",
+            //             "maker_fee_rate": "0.0003",
+            //             "market": "BTCUSDT",
+            //             "market_type": "FUTURES",
+            //             "order_id": 137319868771,
+            //             "price": "61000",
+            //             "realized_pnl": "0",
+            //             "side": "buy",
+            //             "status": "open",
+            //             "taker_fee_rate": "0.0005",
+            //             "type": "limit",
+            //             "unfilled_amount": "0.0001",
+            //             "updated_at": 1714460987164
+            //         },
+            //         "message": "OK"
+            //     }
+            //
         } else {
-            response = await this.v1PrivateGetOrderStatus (this.extend (request, params));
+            response = await this.v2PrivateGetSpotOrderStatus (this.extend (request, params));
+            //
+            //     {
+            //         "code": 0,
+            //         "data": {
+            //             "amount": "0.0001",
+            //             "base_fee": "0",
+            //             "ccy": "BTC",
+            //             "client_id": "x-167673045-da918d6724e3af81",
+            //             "created_at": 1714461638958,
+            //             "discount_fee": "0",
+            //             "filled_amount": "0",
+            //             "filled_value": "0",
+            //             "last_fill_amount": "0",
+            //             "last_fill_price": "0",
+            //             "maker_fee_rate": "0.002",
+            //             "market": "BTCUSDT",
+            //             "market_type": "SPOT",
+            //             "order_id": 117492012985,
+            //             "price": "61000",
+            //             "quote_fee": "0",
+            //             "side": "buy",
+            //             "status": "open",
+            //             "taker_fee_rate": "0.002",
+            //             "type": "limit",
+            //             "unfilled_amount": "0.0001",
+            //             "updated_at": 1714461638958
+            //         },
+            //         "message": "OK"
+            //     }
+            //
         }
-        //
-        // Spot
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "amount": "0.1",
-        //             "asset_fee": "0.22736197736197736197",
-        //             "avg_price": "196.85000000000000000000",
-        //             "create_time": 1537270135,
-        //             "deal_amount": "0.1",
-        //             "deal_fee": "0",
-        //             "deal_money": "19.685",
-        //             "fee_asset": "CET",
-        //             "fee_discount": "0.5",
-        //             "id": 1788259447,
-        //             "left": "0",
-        //             "maker_fee_rate": "0",
-        //             "market": "ETHUSDT",
-        //             "order_type": "limit",
-        //             "price": "170.00000000",
-        //             "status": "done",
-        //             "taker_fee_rate": "0.0005",
-        //             "type": "sell",
-        //         },
-        //         "message": "Ok"
-        //     }
-        //
-        // Swap
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "amount": "0.0005",
-        //             "client_id": "",
-        //             "create_time": 1651004578.618224,
-        //             "deal_asset_fee": "0.00000000000000000000",
-        //             "deal_fee": "0.00000000000000000000",
-        //             "deal_profit": "0.00000000000000000000",
-        //             "deal_stock": "0.00000000000000000000",
-        //             "effect_type": 1,
-        //             "fee_asset": "",
-        //             "fee_discount": "0.00000000000000000000",
-        //             "last_deal_amount": "0.00000000000000000000",
-        //             "last_deal_id": 0,
-        //             "last_deal_price": "0.00000000000000000000",
-        //             "last_deal_role": 0,
-        //             "last_deal_time": 0,
-        //             "last_deal_type": 0,
-        //             "left": "0.0005",
-        //             "leverage": "3",
-        //             "maker_fee": "0.00030",
-        //             "market": "BTCUSDT",
-        //             "order_id": 18221659097,
-        //             "position_id": 0,
-        //             "position_type": 1,
-        //             "price": "30000.00",
-        //             "side": 2,
-        //             "source": "api.v1",
-        //             "stop_id": 0,
-        //             "taker_fee": "0.00050",
-        //             "target": 0,
-        //             "type": 1,
-        //             "update_time": 1651004578.618224,
-        //             "user_id": 3620173
-        //         },
-        //         "message": "OK"
-        //     }
-        //
-        // Swap Stop
-        //
-        //     {
-        //         "code": 0,
-        //         "data": {
-        //             "amount": "0.0005",
-        //             "client_id": "",
-        //             "create_time": 1651034023.008771,
-        //             "effect_type": 1,
-        //             "fee_asset": "",
-        //             "fee_discount": "0.00000000000000000000",
-        //             "maker_fee": "0.00030",
-        //             "market": "BTCUSDT",
-        //             "order_id": 18256915101,
-        //             "price": "31000.00",
-        //             "side": 2,
-        //             "source": "api.v1",
-        //             "state": 1,
-        //             "stop_price": "31500.00",
-        //             "stop_type": 1,
-        //             "taker_fee": "0.00050",
-        //             "target": 0,
-        //             "type": 1,
-        //             "update_time": 1651034397.193624,
-        //             "user_id": 3620173
-        //         },
-        //         "message":"OK"
-        //     }
-        //
-        const data = this.safeDict (response, 'data');
+        const data = this.safeDict (response, 'data', {});
         return this.parseOrder (data, market);
     }
 

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -868,33 +868,21 @@
         ],
         "fetchOrder": [
             {
-                "description": "Spot fetch order",
+                "description": "Spot fetch order by the id and symbol",
                 "method": "fetchOrder",
-                "url": "https://api.coinex.com/v1/order/status?market=BTCUSDT&id=420291&access_id=key&tonce=1702016708915",
+                "url": "https://api.coinex.com/v2/spot/order-status?market=BTCUSDT&order_id=117492012985",
                 "input": [
-                    "420291",
-                    "BTC/USDT"
+                  117492012985,
+                  "BTC/USDT"
                 ]
             },
             {
-                "description": "Swap fetch order",
+                "description": "Swap fetch order by the id and symbol",
                 "method": "fetchOrder",
-                "url": "https://api.coinex.com/perpetual/v1/order/status?market=BTCUSDT&order_id=420291&access_id=key&tonce=1702016708915",
+                "url": "https://api.coinex.com/v2/futures/order-status?market=BTCUSDT&order_id=137319868771",
                 "input": [
-                    "420291",
-                    "BTC/USDT:USDT"
-                ]
-            },
-            {
-                "description": "Swap fetch stop order",
-                "method": "fetchOrder",
-                "url": "https://api.coinex.com/perpetual/v1/order/stop_status?market=BTCUSDT&order_id=420291&access_id=key&tonce=1702016708915",
-                "input": [
-                    "420291",
-                    "BTC/USDT:USDT",
-                    {
-                        "stop": true
-                    }
+                  137319868771,
+                  "BTC/USDT:USDT"
                 ]
             }
         ],


### PR DESCRIPTION
Updated fetchOrder to v2 and added static request tests:
```
coinex.fetchOrder (117492012985, BTC/USDT)

{
  id: '117492012985',
  clientOrderId: 'x-167673045-da918d6724e3af81',
  datetime: '2024-04-30T07:20:38.958Z',
  timestamp: 1714461638958,
  lastTradeTimestamp: 1714461638958,
  status: 'open',
  symbol: 'BTC/USDT',
  type: 'limit',
  side: 'buy',
  price: 61000,
  cost: 0,
  amount: 0.0001,
  filled: 0,
  remaining: 0.0001,
  trades: [],
  fee: { currency: 'USDT', cost: '0' },
  info: {
    amount: '0.0001',
    base_fee: '0',
    ccy: 'BTC',
    client_id: 'x-167673045-da918d6724e3af81',
    created_at: '1714461638958',
    discount_fee: '0',
    filled_amount: '0',
    filled_value: '0',
    last_fill_amount: '0',
    last_fill_price: '0',
    maker_fee_rate: '0.002',
    market: 'BTCUSDT',
    market_type: 'SPOT',
    order_id: '117492012985',
    price: '61000',
    quote_fee: '0',
    side: 'buy',
    status: 'open',
    taker_fee_rate: '0.002',
    type: 'limit',
    unfilled_amount: '0.0001',
    updated_at: '1714461638958'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```
```
coinex.fetchOrder (137319868771, BTC/USDT:USDT)

{
  id: '137319868771',
  clientOrderId: 'x-167673045-da5f31dcd478a829',
  datetime: '2024-04-30T07:09:47.164Z',
  timestamp: 1714460987164,
  lastTradeTimestamp: 1714460987164,
  status: 'open',
  symbol: 'BTC/USDT',
  type: 'limit',
  side: 'buy',
  price: 61000,
  cost: 0,
  amount: 0.0001,
  filled: 0,
  remaining: 0.0001,
  trades: [],
  fee: { currency: 'USDT', cost: '0' },
  info: {
    amount: '0.0001',
    client_id: 'x-167673045-da5f31dcd478a829',
    created_at: '1714460987164',
    fee: '0',
    fee_ccy: 'USDT',
    filled_amount: '0',
    filled_value: '0',
    last_filled_amount: '0',
    last_filled_price: '0',
    maker_fee_rate: '0.0003',
    market: 'BTCUSDT',
    market_type: 'FUTURES',
    order_id: '137319868771',
    price: '61000',
    realized_pnl: '0',
    side: 'buy',
    status: 'open',
    taker_fee_rate: '0.0005',
    type: 'limit',
    unfilled_amount: '0.0001',
    updated_at: '1714460987164'
  },
  fees: [ { currency: 'USDT', cost: 0 } ]
}
```