### PR TITLE
fix(kraken): active inside market

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -538,6 +538,8 @@ export default class kraken extends Exchange {
             const leverageBuy = this.safeValue (market, 'leverage_buy', []);
             const leverageBuyLength = leverageBuy.length;
             const precisionPrice = this.parseNumber (this.parsePrecision (this.safeString (market, 'pair_decimals')));
+            const status = this.safeString (market, 'status');
+            const isActive = status === 'online';
             result.push ({
                 'id': id,
                 'wsId': this.safeString (market, 'wsname'),
@@ -556,7 +558,7 @@ export default class kraken extends Exchange {
                 'swap': false,
                 'future': false,
                 'option': false,
-                'active': true,
+                'active': isActive,
                 'contract': false,
                 'linear': undefined,
                 'inverse': undefined,


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/22341

```
n kraken market ZEC/BTC                                                
2024-04-30T16:13:00.967Z
Node.js: v18.18.0
CCXT v4.3.11
kraken.market (ZEC/BTC)
2024-04-30T16:13:02.362Z iteration 0 passed in 0 ms

{
  id: 'XZECXXBT',
  symbol: 'ZEC/BTC',
  base: 'ZEC',
  quote: 'BTC',
  baseId: 'XZEC',
  quoteId: 'XXBT',
  type: 'spot',
  spot: true,
  margin: true,
  swap: false,
  future: false,
  option: false,
  active: false,
  contract: false,
  taker: 0.004,
  maker: 0.0025,
  precision: { amount: 1e-8, price: 0.00001 },
  limits: {
    leverage: { min: 1, max: 2 },
    amount: { min: 0.2 },
    price: { min: 0.00001 },
    cost: { min: 0.00002 }
  },
  info: {
    altname: 'ZECXBT',
    wsname: 'ZEC/XBT',
    aclass_base: 'currency',
    base: 'XZEC',
    aclass_quote: 'currency',
    quote: 'XXBT',
    lot: 'unit',
    cost_decimals: '6',
    pair_decimals: '5',
    lot_decimals: '8',
    lot_multiplier: '1',
    leverage_buy: [ 2 ],
    leverage_sell: [ 2 ],
    fees: [
      [ 0, 0.4 ],
      [ 10000, 0.35 ],
      [ 50000, 0.24 ],
      [ 100000, 0.22 ],
      [ 250000, 0.2 ],
      [ 500000, 0.18 ],
      [ 1000000, 0.16 ],
      [ 2500000, 0.14 ],
      [ 5000000, 0.12 ],
      [ 10000000, 0.1 ]
    ],
    fees_maker: [
      [ 0, 0.25 ],
      [ 10000, 0.2 ],
      [ 50000, 0.14 ],
      [ 100000, 0.12 ],
      [ 250000, 0.1 ],
      [ 500000, 0.08 ],
      [ 1000000, 0.06 ],
      [ 2500000, 0.04 ],
      [ 5000000, 0.02 ],
      [ 10000000, 0 ]
    ],
    fee_volume_currency: 'ZUSD',
    margin_call: '80',
    margin_stop: '40',
    ordermin: '0.2',
    costmin: '0.00002',
    tick_size: '0.00001',
    status: 'cancel_only',
    long_position_limit: '270',
    short_position_limit: '240'
  },
  tierBased: true,
  percentage: true,
  tiers: {
    taker: [
      [ 0, 0.0026 ],
      [ 50000, 0.0024 ],
      [ 100000, 0.0022 ],
      [ 250000, 0.002 ],
      [ 500000, 0.0018 ],
      [ 1000000, 0.0016 ],
      [ 2500000, 0.0014 ],
      [ 5000000, 0.0012 ],
      [ 10000000, 0.0001 ]
    ],
    maker: [
      [ 0, 0.0016 ],
      [ 50000, 0.0014 ],
      [ 100000, 0.0012 ],
      [ 250000, 0.001 ],
      [ 500000, 0.0008 ],
      [ 1000000, 0.0006 ],
      [ 2500000, 0.0004 ],
      [ 5000000, 0.0002 ],
      [ 10000000, 0 ]
    ]
  },
  wsId: 'ZEC/XBT',
  darkpool: false,
  altname: 'ZECXBT'
}
2024-04-30T16:13:02.362Z iteration 1 passed in 0 ms
```
