### PR TITLE
fix(proxy) - explanations

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1045,7 +1045,7 @@ export default class Exchange {
         let chosenAgent = undefined;
         // in browser-side, proxy modules are not supported in 'fetch/ws' methods
         if (!isNode && (httpProxy || httpsProxy || socksProxy)) {
-            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You can setup local cors proxy server (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder) and override exchange.fetch method to send request through your cors-server backend, which in turn routes all requests through proxy');
+            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You have several choices: (A) setup cors proxy server (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder) on local/remote server and override `exchange.fetch` method to send request through your cors-server address (B) Use .proxyUrl property to redirect through local/remote cors-proxy snippet');
         }
         if (httpProxy) {
             if (this.httpProxyAgentModule === undefined) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1045,7 +1045,7 @@ export default class Exchange {
         let chosenAgent = undefined;
         // in browser-side, proxy modules are not supported in 'fetch/ws' methods
         if (!isNode && (httpProxy || httpsProxy || socksProxy)) {
-            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You have several choices: (A) setup cors proxy server (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder) on local/remote server and override `exchange.fetch` method to send request through your cors-server address (B) Use .proxyUrl property to redirect through local/remote cors-proxy snippet');
+            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You have several choices: [A] Use `exchange.proxyUrl` property to redirect through local/remote cors-proxy snippet (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder, which includes sample for REST requests) [B] override `exchange.fetch` && `exchange.watch` methods to send request through your custom setup local/remote corst proxy server');
         }
         if (httpProxy) {
             if (this.httpProxyAgentModule === undefined) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1043,6 +1043,10 @@ export default class Exchange {
 
     setProxyAgents (httpProxy, httpsProxy, socksProxy) {
         let chosenAgent = undefined;
+        // in browser-side, proxy modules are not supported in 'fetch/ws' methods
+        if (!isNode && (httpProxy || httpsProxy || socksProxy)) {
+            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You can setup local cors proxy server (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder) and override exchange.fetch method to send request through your cors-server backend, which in turn routes all requests through proxy');
+        }
         if (httpProxy) {
             if (this.httpProxyAgentModule === undefined) {
                 throw new NotSupported (this.id + ' you need to load JS proxy modules with `.loadProxyModules()` method at first to use proxies');

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1045,7 +1045,7 @@ export default class Exchange {
         let chosenAgent = undefined;
         // in browser-side, proxy modules are not supported in 'fetch/ws' methods
         if (!isNode && (httpProxy || httpsProxy || socksProxy)) {
-            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You have several choices: [A] Use `exchange.proxyUrl` property to redirect through local/remote cors-proxy snippet (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder, which includes sample for REST requests) [B] override `exchange.fetch` && `exchange.watch` methods to send request through your custom setup local/remote corst proxy server');
+            throw new NotSupported (this.id + ' - proxies in browser-side projects are not supported. You have several choices: [A] Use `exchange.proxyUrl` property to redirect requests through local/remote cors-proxy server (find sample file named "sample-local-proxy-server-with-cors" in https://github.com/ccxt/ccxt/tree/master/examples/ folder, which can be used for REST requests only) [B] override `exchange.fetch` && `exchange.watch` methods to send requests through your custom proxy');
         }
         if (httpProxy) {
             if (this.httpProxyAgentModule === undefined) {


### PR DESCRIPTION
last comment fix #20686

Users should be aware that from browser-side JS, they can't use proxies (because proxy modules rely on 'net & http' native nodejs modules and there does not exist browser-side support for JS proxy functionality yet).