### PR TITLE
fix(coinex): headers

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -6102,6 +6102,7 @@ export default class coinex extends Exchange {
                 const signature = this.hash (this.encode (preparedString), sha256);
                 headers = {
                     'Content-Type': 'application/json; charset=utf-8',
+                    'Accept': 'application/json',
                     'X-COINEX-KEY': this.apiKey,
                     'X-COINEX-SIGN': signature,
                     'X-COINEX-TIMESTAMP': nonce,

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -6101,6 +6101,7 @@ export default class coinex extends Exchange {
                 preparedString += nonce + this.secret;
                 const signature = this.hash (this.encode (preparedString), sha256);
                 headers = {
+                    'Content-Type': 'application/json; charset=utf-8',
                     'X-COINEX-KEY': this.apiKey,
                     'X-COINEX-SIGN': signature,
                     'X-COINEX-TIMESTAMP': nonce,


### PR DESCRIPTION
- Works now
```
 n coinex v2PrivatePostAccountSubs '{"sub_user_name":"ccxt2"}'  --verbose
2024-05-02T11:23:35.484Z
Node.js: v18.18.0
CCXT v4.3.13
coinex.v2PrivatePostAccountSubs ([object Object])
fetch Request:
 coinex POST https://api.coinex.com/v2/account/subs 
RequestHeaders:
 {
  'Content-Type': 'application/json; charset=utf-8',
  Accept: 'application/json',
  'X-COINEX-KEY': '',
  'X-COINEX-SIGN': 'a2d87dcdec7119b2d2dd2fb0694185729ca78c66d374171e2653723ac0329fd4',
  'X-COINEX-TIMESTAMP': '1714649017152'
} 
RequestBody:
 {"sub_user_name":"ccxt2"} 

handleRestResponse:
 coinex POST https://api.coinex.com/v2/account/subs 200 OK 

ResponseBody:
 {"data": {}, "code": 0, "message": "OK"} 

2024-05-02T11:23:37.655Z iteration 0 passed in 507 ms

{ data: {}, code: 0, message: 'OK' }
2024-05-02T11:23:37.655Z iteration 1 passed in 507 ms
```
- fixes https://github.com/ccxt/ccxt/pull/22275#issuecomment-2085831276
