### PR TITLE
fix(Types.cs): order id typo

### DIFF
--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -178,7 +178,7 @@ public struct Trade
     public double? price;
     public double? cost;
     public string? id;
-    public string? orderId;
+    public string? order;
     public Dictionary<string, object>? info;
     public Int64? timestamp;
     public string? datetime;
@@ -194,7 +194,7 @@ public struct Trade
         price = Exchange.SafeFloat(trade, "price");
         cost = Exchange.SafeFloat(trade, "cost");
         id = Exchange.SafeString(trade, "id");
-        orderId = Exchange.SafeString(trade, "orderId");
+        order = Exchange.SafeString(trade, "orderId");
         // info = trade.ContainsKey("info") ? (Dictionary<string, object>)trade["info"] : null;
         timestamp = Exchange.SafeInteger(trade, "timestamp");
         datetime = Exchange.SafeString(trade, "datetime");


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/22295


DEMO

```
npm run cli.cs -- bitget WatchMyTrades "LTC/USDT:USDT"            

> ccxt@4.3.13 cli.cs
> dotnet run --project "./cs/cli/cli.csproj" bitget WatchMyTrades LTC/USDT:USDT

[
  "LTC/USDT:USDT"
]
[
  {
    "amount": 0.1,
    "price": 79.04,
    "cost": 7.904,
    "id": "1169866327549169664",
    "order": "1169866327276036097",
    "info": {
      "orderId": "1169866327276036097",
      "tradeId": "1169866327549169664",
      "symbol": "LTCUSDT",
      "orderType": "market",
      "side": "sell",
      "price": "79.04",
      "baseVolume": "0.1",
      "quoteVolume": "7.904",
      "profit": "0",
      "tradeSide": "open",
      "posMode": "hedge_mode",
      "tradeScope": "taker",
      "feeDetail": [
        {
          "feeCoin": "USDT",
          "deduction": "no",
          "totalDeductionFee": "0",
          "totalFee": "-0.0047424"
        }
      ],
      "cTime": "1714643788230",
      "uTime": "1714643788230"
    },
    "timestamp": 1714643788230,
    "datetime": "2024-05-02T09:56:28.230Z",
    "symbol": "LTC/USDT:USDT",
    "type": "market",
    "side": "sell",
    "takerOrMaker": "taker",
    "fee": {
      "rate": null,
      "cost": 0.0047424
    }
  }
]

```
