### PR TITLE
chore: numbers.ts types

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3409,15 +3409,15 @@ export default class Exchange {
         // timestamp and symbol operations don't belong in safeTicker
         // they should be done in the derived classes
         return this.extend (ticker, {
-            'bid': this.parseNumber (this.omitZero (this.safeNumber (ticker, 'bid'))),
+            'bid': this.parseNumber (this.omitZero (this.safeString (ticker, 'bid'))),
             'bidVolume': this.safeNumber (ticker, 'bidVolume'),
-            'ask': this.parseNumber (this.omitZero (this.safeNumber (ticker, 'ask'))),
+            'ask': this.parseNumber (this.omitZero (this.safeString (ticker, 'ask'))),
             'askVolume': this.safeNumber (ticker, 'askVolume'),
             'high': this.parseNumber (this.omitZero (this.safeString (ticker, 'high'))),
-            'low': this.parseNumber (this.omitZero (this.safeNumber (ticker, 'low'))),
-            'open': this.parseNumber (this.omitZero (this.parseNumber (open))),
-            'close': this.parseNumber (this.omitZero (this.parseNumber (close))),
-            'last': this.parseNumber (this.omitZero (this.parseNumber (last))),
+            'low': this.parseNumber (this.omitZero (this.safeString (ticker, 'low'))),
+            'open': this.parseNumber (this.omitZero (open)),
+            'close': this.parseNumber (this.omitZero (close)),
+            'last': this.parseNumber (this.omitZero (last)),
             'change': this.parseNumber (change),
             'percentage': this.parseNumber (percentage),
             'average': this.parseNumber (average),

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -69,7 +69,7 @@ function numberToString (x: any): string | undefined { // avoids scientific nota
 //-----------------------------------------------------------------------------
 // expects non-scientific notation
 
-const truncate_regExpCache = [];  // TODO: Variable 'truncate_regExpCache' implicitly has type 'any[]' in some locations where its type cannot be determined.ts(7034)
+const truncate_regExpCache: any[] = [];
 const truncate_to_string = (num: number | string, precision = 0) => {
     num = numberToString (num) as string;
     if (precision > 0) {

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -37,7 +37,7 @@ const precisionConstants = {
 
 // See https://stackoverflow.com/questions/1685680/how-to-avoid-scientific-notation-for-large-numbers-in-javascript for discussion
 
-function numberToString (x) { // avoids scientific notation for too large and too small numbers
+function numberToString (x: any): string | undefined { // avoids scientific notation for too large and too small numbers
     if (x === undefined) return undefined;
     if (typeof x !== 'number') return x.toString ();
     const s = x.toString ();
@@ -69,9 +69,9 @@ function numberToString (x) { // avoids scientific notation for too large and to
 //-----------------------------------------------------------------------------
 // expects non-scientific notation
 
-const truncate_regExpCache = [];
-const truncate_to_string = (num, precision = 0) => {
-    num = numberToString (num);
+const truncate_regExpCache = [];  // TODO: Variable 'truncate_regExpCache' implicitly has type 'any[]' in some locations where its type cannot be determined.ts(7034)
+const truncate_to_string = (num: number | string, precision = 0) => {
+    num = numberToString (num) as string;
     if (precision > 0) {
         const re = truncate_regExpCache[precision] || (truncate_regExpCache[precision] = new RegExp ('([-]*\\d+\\.\\d{' + precision + '})(\\d)'));
         const [ , result ] = num.toString ().match (re) || [ null, num ];
@@ -79,9 +79,9 @@ const truncate_to_string = (num, precision = 0) => {
     }
     return parseInt (num).toString ();
 };
-const truncate = (num, precision = 0) => parseFloat (truncate_to_string (num, precision));
+const truncate = (num: number | string, precision = 0): number => parseFloat (truncate_to_string (num, precision));
 
-function precisionFromString (str) {
+function precisionFromString (str: string) {
     // support string formats like '1e-4'
     if (str.indexOf ('e') > -1) {
         const numStr = str.replace (/\de/, '')
@@ -154,7 +154,7 @@ const decimalToPrecision = (
 
     /*  Convert to a string (if needed), skip leading minus sign (if any)   */
 
-    const str = numberToString (x);
+    const str = numberToString (x) as string;
     const isNegative = str[0] === '-';
     const strStart = isNegative ? 1 : 0;
     const strEnd = str.length;
@@ -285,7 +285,7 @@ const decimalToPrecision = (
     return String.fromCharCode (...out);
 };
 
-function omitZero (stringNumber) {
+function omitZero (stringNumber: string) {
     if (stringNumber === undefined || stringNumber === '') {
         return undefined;
     }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -6730,19 +6730,19 @@ export default class bybit extends Exchange {
         const isUsdcSettled = market['settle'] === 'USDC';
         // engage in leverage setting
         // we reuse the code here instead of having two methods
-        leverage = this.numberToString (leverage);
+        const leverageString = this.numberToString (leverage);
         const request = {
             'symbol': market['id'],
-            'buyLeverage': leverage,
-            'sellLeverage': leverage,
+            'buyLeverage': leverageString,
+            'sellLeverage': leverageString,
         };
         let response = undefined;
         if (isUsdcSettled && !isUnifiedAccount) {
-            request['leverage'] = leverage;
+            request['leverage'] = leverageString;
             response = await this.privatePostPerpetualUsdcOpenapiPrivateV1PositionLeverageSave (this.extend (request, params));
         } else {
-            request['buyLeverage'] = leverage;
-            request['sellLeverage'] = leverage;
+            request['buyLeverage'] = leverageString;
+            request['sellLeverage'] = leverageString;
             if (market['linear']) {
                 request['category'] = 'linear';
             } else if (market['inverse']) {

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -498,7 +498,8 @@ export default class cryptocom extends Exchange {
             const strike = this.safeString (market, 'strike');
             const marginBuyEnabled = this.safeValue (market, 'margin_buy_enabled');
             const marginSellEnabled = this.safeValue (market, 'margin_sell_enabled');
-            const expiry = this.omitZero (this.safeInteger (market, 'expiry_timestamp_ms'));
+            const expiryString = this.omitZero (this.safeString (market, 'expiry_timestamp_ms'));
+            const expiry = (expiryString !== undefined) ? parseInt (expiryString) : undefined;
             let symbol = base + '/' + quote;
             let type = undefined;
             let contract = undefined;

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2389,7 +2389,7 @@ export default class phemex extends Exchange {
             lastTradeTimestamp = undefined;
         }
         const timeInForce = this.parseTimeInForce (this.safeString (order, 'timeInForce'));
-        const stopPrice = this.omitZero (this.safeNumber2 (order, 'stopPx', 'stopPxRp'));
+        const stopPrice = this.omitZero (this.safeString2 (order, 'stopPx', 'stopPxRp'));
         const postOnly = (timeInForce === 'PO');
         let reduceOnly = this.safeValue (order, 'reduceOnly');
         const execInst = this.safeString (order, 'execInst');

--- a/ts/src/pro/independentreserve.ts
+++ b/ts/src/pro/independentreserve.ts
@@ -140,9 +140,9 @@ export default class independentreserve extends independentreserveRest {
         if (limit === undefined) {
             limit = 100;
         }
-        limit = this.numberToString (limit);
-        const url = this.urls['api']['ws'] + '/orderbook/' + limit + '?subscribe=' + market['base'] + '-' + market['quote'];
-        const messageHash = 'orderbook:' + symbol + ':' + limit;
+        const limitString = this.numberToString (limit);
+        const url = this.urls['api']['ws'] + '/orderbook/' + limitString + '?subscribe=' + market['base'] + '-' + market['quote'];
+        const messageHash = 'orderbook:' + symbol + ':' + limitString;
         const subscription = {
             'receivedSnapshot': false,
         };

--- a/ts/src/pro/poloniex.ts
+++ b/ts/src/pro/poloniex.ts
@@ -669,8 +669,8 @@ export default class poloniex extends poloniexRest {
             'type': this.safeStringLower (trade, 'type'),
             'side': this.safeStringLower2 (trade, 'takerSide', 'side'),
             'takerOrMaker': takerMaker,
-            'price': this.omitZero (this.safeNumber2 (trade, 'tradePrice', 'price')),
-            'amount': this.omitZero (this.safeNumber2 (trade, 'filledQuantity', 'quantity')),
+            'price': this.omitZero (this.safeString2 (trade, 'tradePrice', 'price')),
+            'amount': this.omitZero (this.safeString2 (trade, 'filledQuantity', 'quantity')),
             'cost': this.safeString2 (trade, 'amount', 'filledAmount'),
             'fee': {
                 'rate': undefined,


### PR DESCRIPTION
```
% py binance fetchTicker BTC/USDT
Python v3.9.6
CCXT v4.3.11
binance.fetchTicker(BTC/USDT)
{'ask': 57812.1,
 'askVolume': 1.12503,
 'average': 57680.05,
 'baseVolume': 61290.24079,
 'bid': 57812.09,
 'bidVolume': 3.66284,
 'change': 264.1,
 'close': 57812.1,
 'datetime': '2024-05-02T10:48:24.168Z',
 'high': 59468.0,
 'info': {'askPrice': '57812.10000000',
          'askQty': '1.12503000',
          'bidPrice': '57812.09000000',
          'bidQty': '3.66284000',
          'closeTime': '1714646904168',
          'count': '1882549',
          'firstId': '3581630881',
          'highPrice': '59468.00000000',
          'lastId': '3583513429',
          'lastPrice': '57812.10000000',
          'lastQty': '0.01352000',
          'lowPrice': '56625.09000000',
          'openPrice': '57548.00000000',
          'openTime': '1714560504168',
          'prevClosePrice': '57547.99000000',
          'priceChange': '264.10000000',
          'priceChangePercent': '0.459',
          'quoteVolume': '3539130376.07977270',
          'symbol': 'BTCUSDT',
          'volume': '61290.24079000',
          'weightedAvgPrice': '57743.78319390'},
 'last': 57812.1,
 'low': 56625.09,
 'open': 57548.0,
 'percentage': 0.459,
 'previousClose': 57547.99,
 'quoteVolume': 3539130376.0797725,
 'symbol': 'BTC/USDT',
 'timestamp': 1714646904168,
 'vwap': 57743.7831939}
```

```
% py bybit setLeverage 10 BTC/USDT:USDT --testnet
Python v3.9.6
CCXT v4.3.11
bybit.setLeverage(10,BTC/USDT:USDT)
{'result': {},
 'retCode': '0',
 'retExtInfo': {},
 'retMsg': 'OK',
 'time': '1714647071633'}
```

```
Python v3.9.6
CCXT v4.3.11
cryptocom.fetchMarkets()
[{'active': True,
  'base': '1INCH',
  'baseId': '1INCH',
  'contract': True,
  'contractSize': 1.0,
  'created': None,
  'expiry': None,
  'expiryDatetime': None,
  'future': False,
  'id': '1INCHUSD-PERP',
  'info': {'base_ccy': '1INCH',
           'beta_product': False,
           'contract_size': '1',
           'display_name': '1INCHUSD Perpetual',
           'expiry_timestamp_ms': '0',
           'inst_type': 'PERPETUAL_SWAP',
           'margin_buy_enabled': False,
           'margin_sell_enabled': False,
           'max_leverage': '50',
           'price_tick_size': '0.00001',
           'qty_tick_size': '1',
           'quantity_decimals': '0',
           'quote_ccy': 'USD',
           'quote_decimals': '5',
           'symbol': '1INCHUSD-PERP',
           'tradable': True,
           'underlying_symbol': '1INCHUSD-INDEX'},
  'inverse': False,
  'limits': {'amount': {'max': None, 'min': None},
             'cost': {'max': None, 'min': None},
             'leverage': {'max': 50.0, 'min': 1.0},
             'price': {'max': None, 'min': None}},
  'linear': True,
  'margin': False,
  'option': False,
  'optionType': None,
  'precision': {'amount': 1.0, 'price': 1e-05},
  'quote': 'USD',
  'quoteId': 'USD',
  'settle': 'USD',
  'settleId': 'USD',
  'spot': False,
  'strike': None,
  'swap': True,
  'symbol': '1INCH/USD:USD',
  'type': 'swap'},
...
```

```
 % py poloniex watchTrades BTC/USDT            
Python v3.9.6
CCXT v4.3.11
poloniex.watchTrades(BTC/USDT)
[{'amount': 0.000511,
  'cost': 29.73921377,
  'datetime': '2024-05-02T11:06:55.047Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'id': '92800157',
  'info': {'amount': '29.73921377',
           'createTime': 1714648015047,
           'id': '92800157',
           'price': '58198.07',
           'quantity': '0.000511',
           'symbol': 'BTC_USDT',
           'takerSide': 'buy',
           'ts': 1714648015056},
  'order': None,
  'price': 58198.07,
  'side': 'buy',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1714648015047,
  'type': None}]
```