### PR TITLE
generic.ts omit function type

### DIFF
--- a/ts/src/base/functions/generic.ts
+++ b/ts/src/base/functions/generic.ts
@@ -129,7 +129,7 @@ const flatten = function flatten (x: any[], out: any[] = []) {
 
 const pluck = (x: Dictionary<any>, k: any) => values (x).filter ((v) => k in v).map ((v) => v[k]);
 
-const omit = (x: Dictionary<any>, ...args) => {
+const omit = (x: Dictionary<any>, ...args: any) => {
 
     if (!Array.isArray (x)) {
 


### PR DESCRIPTION
I tried setting the type to `string | string[]` but received the error `A rest parameter must be of an array type.ts(2370)`