### PR TITLE
coinex: createDepositAddress, fetchDepositAddress v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3677,10 +3677,13 @@ export default class coinex extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         const network = this.safeString2 (params, 'chain', 'network');
+        if (network === undefined) {
+            throw new ArgumentsRequired (this.id + ' createDepositAddress() requires a network parameter');
+        }
         params = this.omit (params, 'network');
         const request = {
             'ccy': currency['id'],
-            'chain': network,
+            'chain': this.networkCodeToId (network, currency['code']),
         };
         const response = await this.v2PrivatePostAssetsRenewalDepositAddress (this.extend (request, params));
         //

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3668,31 +3668,31 @@ export default class coinex extends Exchange {
          * @method
          * @name coinex#createDepositAddress
          * @description create a currency deposit address
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot002_account019_update_deposit_address
+         * @see https://docs.coinex.com/api/v2/assets/deposit-withdrawal/http/update-deposit-address
          * @param {string} code unified currency code of the currency for the deposit address
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.network] the blockchain network to create a deposit address on
          * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
          */
         await this.loadMarkets ();
         const currency = this.currency (code);
+        const network = this.safeString2 (params, 'chain', 'network');
+        params = this.omit (params, 'network');
         const request = {
-            'coin_type': currency['id'],
+            'ccy': currency['id'],
+            'chain': network,
         };
-        if ('network' in params) {
-            const network = this.safeString (params, 'network');
-            params = this.omit (params, 'network');
-            request['smart_contract_name'] = network;
-        }
-        const response = await this.v1PrivatePutBalanceDepositAddressCoinType (this.extend (request, params));
+        const response = await this.v2PrivatePostAssetsRenewalDepositAddress (this.extend (request, params));
         //
         //     {
         //         "code": 0,
         //         "data": {
-        //             "coin_address": "TV639dSpb9iGRtoFYkCp4AoaaDYKrK1pw5",
-        //             "is_bitcoin_cash": false
+        //             "address": "0xc7vebd6479355142334f45653ad5d8b76105e762",
+        //             "memo": ""
         //         },
-        //         "message": "Success"
+        //         "message": "OK"
         //     }
+        //
         const data = this.safeDict (response, 'data', {});
         return this.parseDepositAddress (data, currency);
     }
@@ -3771,11 +3771,11 @@ export default class coinex extends Exchange {
     parseDepositAddress (depositAddress, currency: Currency = undefined) {
         //
         //     {
-        //         "coin_address": "1P1JqozxioQwaqPwgMAQdNDYNyaVSqgARq",
-        //         "is_bitcoin_cash": false
+        //         "address": "1P1JqozxioQwaqPwgMAQdNDYNyaVSqgARq",
+        //         "memo": ""
         //     }
         //
-        const coinAddress = this.safeString (depositAddress, 'coin_address');
+        const coinAddress = this.safeString (depositAddress, 'address');
         const parts = coinAddress.split (':');
         let address = undefined;
         let tag = undefined;

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1113,6 +1113,19 @@
                 ],
                 "output": "{\"ccy\":\"ETH\",\"chain\":\"ERC20\"}"
             }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "Fetch a deposit address",
+                "method": "fetchDepositAddress",
+                "url": "https://api.coinex.com/v2/assets/deposit-address?ccy=ETH&chain=ERC20",
+                "input": [
+                  "ETH",
+                  {
+                    "network": "ERC20"
+                  }
+                ]
+            }
         ]
     },
     "disabledTests": {}

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1099,6 +1099,20 @@
                 ],
                 "output": "{\"amount\":\"0.0001\",\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\",\"price\":\"61000\",\"stop_id\":137091809783,\"trigger_price\":\"61500\"}"
             }
+        ],
+        "createDepositAddress": [
+            {
+                "description": "Create a deposit address",
+                "method": "createDepositAddress",
+                "url": "https://api.coinex.com/v2/assets/renewal-deposit-address",
+                "input": [
+                  "ETH",
+                  {
+                    "network": "ERC20"
+                  }
+                ],
+                "output": "{\"ccy\":\"ETH\",\"chain\":\"ERC20\"}"
+            }
         ]
     },
     "disabledTests": {}


### PR DESCRIPTION
Updated createDepositAddress and fetchDepositAddress to v2:

### createDepositAddress:
```
coinex createDepositAddress ETH '{"network":"ERC20"}'

{
  info: { address: '0xc7eebc6479355161434f45653ad5d7b76105e765', memo: '' },
  currency: 'ETH',
  address: '0xc7vebd6479355142334f45653ad5d8b76105e762'
}
```

### fetchDepositAddress:
```
coinex fetchDepositAddress ETH '{"network":"ERC20"}'

{
  info: { address: '0x321bd6479355142334f45653ad5d8b76105a1234', memo: '' },
  currency: 'ETH',
  address: '0x321bd6479355142334f45653ad5d8b76105a1234',
  network: 'ERC20'
}
```