### PR TITLE
coinex: fetchMyTrades v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3766,10 +3766,6 @@ export default class coinex extends Exchange {
         let response = undefined;
         if (market['swap']) {
             request['market_type'] = 'FUTURES';
-            const side = this.safeString (params, 'side');
-            if (side === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a side parameter');
-            }
             response = await this.v2PrivateGetFuturesUserDeals (this.extend (request, params));
             //
             //     {

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -10,27 +10,39 @@
     "methods": {
         "fetchMyTrades": [
             {
-                "description": "Spot private trades",
+                "description": "Spot fetch my trades",
                 "method": "fetchMyTrades",
-                "url": "https://api.coinex.com/v1/order/user/deals?access_id=53DD577FFFD741D4B53A5424ECD33196&limit=5&market=LTCUSDT&offset=0&page=1&tonce=1699458294212",
+                "url": "https://api.coinex.com/v2/spot/user-deals?limit=1&market=BTCUSDT&market_type=SPOT",
                 "input": [
-                    "LTC/USDT",
-                    1699457638000,
-                    5
+                  "BTC/USDT",
+                  null,
+                  1
                 ]
             },
             {
-                "description": "spot-margin trades",
+                "description": "Spot margin fetch my trades",
                 "method": "fetchMyTrades",
-                "url": "https://api.coinex.com/v1/order/user/deals?access_id=85D9FDDCA1914FB78E2F2448A0EF812A&account_id=6&limit=100&market=LTCUSDT&offset=0&page=1&tonce=1706032695073",
+                "url": "https://api.coinex.com/v2/spot/user-deals?limit=1&market=BTCUSDT&market_type=MARGIN",
                 "input": [
-                    "LTC/USDT",
-                    null,
-                    null,
-                    {
-                        "marginMode": "isolated",
-                        "account_id": 6
-                    }
+                  "BTC/USDT",
+                  null,
+                  1,
+                  {
+                    "marginMode": "isolated"
+                  }
+                ]
+            },
+            {
+                "description": "Swap fetch my trades",
+                "method": "fetchMyTrades",
+                "url": "https://api.coinex.com/v2/futures/user-deals?limit=1&market=BTCUSDT&market_type=FUTURES&side=buy",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  1,
+                  {
+                    "side": "buy"
+                  }
                 ]
             }
         ],

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -33,6 +33,14 @@
                 ]
             },
             {
+              "description": "swap trades",
+              "method": "fetchMyTrades",
+              "url": "https://api.coinex.com/v2/futures/user-deals?market=LTCUSDT&market_type=FUTURES",
+              "input": [
+                "LTC/USDT:USDT"
+              ]
+            },
+            {
                 "description": "Swap fetch my trades",
                 "method": "fetchMyTrades",
                 "url": "https://api.coinex.com/v2/futures/user-deals?limit=1&market=BTCUSDT&market_type=FUTURES&side=buy",

--- a/ts/src/test/static/response/coinex.json
+++ b/ts/src/test/static/response/coinex.json
@@ -106,7 +106,7 @@
                         "order": "136915589622",
                         "type": null,
                         "side": "buy",
-                        "takerOrMaker": "taker",
+                        "takerOrMaker": null,
                         "price": 64376,
                         "amount": 0.0001,
                         "cost": 6.4376,

--- a/ts/src/test/static/response/coinex.json
+++ b/ts/src/test/static/response/coinex.json
@@ -8,183 +8,110 @@
                 "description": "spot trade",
                 "method": "fetchMyTrades",
                 "input": [
-                    "LTC/USDT",
+                    "BTC/USDT",
                     null,
                     1
                 ],
                 "httpResponse": {
-                    "code": "0",
-                    "data": {
-                        "count": "1",
-                        "curr_page": "1",
-                        "data": [
-                            {
-                                "account_id": "0",
-                                "amount": "0.46923575",
-                                "create_time": "1654589906",
-                                "deal_money": "28.97999992",
-                                "fee": "0.0009384715",
-                                "fee_asset": "LTC",
-                                "id": "2892344085",
-                                "market": "LTCUSDT",
-                                "order_id": "78418175782",
-                                "price": "61.76",
-                                "role": "taker",
-                                "type": "buy"
-                            }
-                        ],
-                        "has_next": true,
-                        "total": "0"
-                    },
-                    "message": "Success"
+                    "code": 0,
+                    "data": [
+                        {
+                            "amount": "0.00010087",
+                            "created_at": 1714618087585,
+                            "deal_id": 4161200602,
+                            "margin_market": "",
+                            "market": "BTCUSDT",
+                            "order_id": 117654919342,
+                            "price": "57464.04",
+                            "side": "sell"
+                        }
+                    ],
+                    "message": "OK",
+                    "pagination": {
+                        "has_next": true
+                    }
                 },
                 "parsedResponse": [
                     {
                         "info": {
-                            "account_id": "0",
-                            "amount": "0.46923575",
-                            "create_time": "1654589906",
-                            "deal_money": "28.97999992",
-                            "fee": "0.0009384715",
-                            "fee_asset": "LTC",
-                            "id": "2892344085",
-                            "market": "LTCUSDT",
-                            "order_id": "78418175782",
-                            "price": "61.76",
-                            "role": "taker",
-                            "type": "buy"
+                            "amount": "0.00010087",
+                            "created_at": 1714618087585,
+                            "deal_id": 4161200602,
+                            "margin_market": "",
+                            "market": "BTCUSDT",
+                            "order_id": 117654919342,
+                            "price": "57464.04",
+                            "side": "sell"
                         },
-                        "timestamp": 1654589906000,
-                        "datetime": "2022-06-07T08:18:26.000Z",
-                        "symbol": "LTC/USDT",
-                        "id": "2892344085",
-                        "order": "78418175782",
+                        "timestamp": 1714618087585,
+                        "datetime": "2024-05-02T02:48:07.585Z",
+                        "symbol": "BTC/USDT",
+                        "id": "4161200602",
+                        "order": "117654919342",
                         "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 61.76,
-                        "amount": 0.46923575,
-                        "cost": 28.97999992,
-                        "fee": {
-                            "cost": 0.0009384715,
-                            "currency": "LTC"
-                        },
-                        "fees": [
-                            {
-                                "cost": 0.0009384715,
-                                "currency": "LTC"
-                            }
-                        ]
+                        "side": "sell",
+                        "takerOrMaker": null,
+                        "price": 57464.04,
+                        "amount": 0.00010087,
+                        "cost": 5.7963977148,
+                        "fee": null,
+                        "fees": []
                     }
                 ]
             },
             {
-                "description": "Swap trade",
+                "description": "swap trade",
                 "method": "fetchMyTrades",
                 "input": [
-                    "LTC/USDT:USDT",
+                    "BTC/USDT:USDT",
                     null,
-                    1
+                    1,
+                    {
+                        "side": "buy"
+                    }
                 ],
                 "httpResponse": {
-                    "code": "0",
-                    "data": {
-                        "limit": "1",
-                        "offset": "0",
-                        "records": [
-                            {
-                                "amount": "0.1",
-                                "deal_fee": "0.003689",
-                                "deal_insurance": "0",
-                                "deal_margin": "1.4756",
-                                "deal_order_id": "120234770773",
-                                "deal_profit": "0",
-                                "deal_stock": "7.378",
-                                "deal_type": "1",
-                                "deal_user_id": "2529144",
-                                "fee_asset": "",
-                                "fee_discount": "0",
-                                "fee_price": "0",
-                                "fee_rate": "0.0005",
-                                "fee_real_rate": "0.0005",
-                                "id": "1050281181",
-                                "leverage": "5",
-                                "liq_price": "5.57682491582491582502",
-                                "margin_amount": "1.4756",
-                                "market": "LTCUSDT",
-                                "market_type": "1",
-                                "open_price": "73.78",
-                                "order_id": "120234770970",
-                                "position_amount": "0.1",
-                                "position_id": "277157309",
-                                "position_type": "2",
-                                "price": "73.78",
-                                "role": "2",
-                                "settle_price": "73.78",
-                                "side": "2",
-                                "time": "1703591279.143",
-                                "user_id": "3707264"
-                            }
-                        ]
-                    },
-                    "message": "OK"
+                    "code": 0,
+                    "data": [
+                        {
+                            "deal_id": 1180222387,
+                            "created_at": 1714119054558,
+                            "market": "BTCUSDT",
+                            "side": "buy",
+                            "order_id": 136915589622,
+                            "price": "64376",
+                            "amount": "0.0001"
+                        }
+                    ],
+                    "message": "OK",
+                    "pagination": {
+                        "has_next": true
+                    }
                 },
                 "parsedResponse": [
                     {
                         "info": {
-                            "amount": "0.1",
-                            "deal_fee": "0.003689",
-                            "deal_insurance": "0",
-                            "deal_margin": "1.4756",
-                            "deal_order_id": "120234770773",
-                            "deal_profit": "0",
-                            "deal_stock": "7.378",
-                            "deal_type": "1",
-                            "deal_user_id": "2529144",
-                            "fee_asset": "",
-                            "fee_discount": "0",
-                            "fee_price": "0",
-                            "fee_rate": "0.0005",
-                            "fee_real_rate": "0.0005",
-                            "id": "1050281181",
-                            "leverage": "5",
-                            "liq_price": "5.57682491582491582502",
-                            "margin_amount": "1.4756",
-                            "market": "LTCUSDT",
-                            "market_type": "1",
-                            "open_price": "73.78",
-                            "order_id": "120234770970",
-                            "position_amount": "0.1",
-                            "position_id": "277157309",
-                            "position_type": "2",
-                            "price": "73.78",
-                            "role": "2",
-                            "settle_price": "73.78",
-                            "side": "2",
-                            "time": "1703591279.143",
-                            "user_id": "3707264"
+                            "deal_id": 1180222387,
+                            "created_at": 1714119054558,
+                            "market": "BTCUSDT",
+                            "side": "buy",
+                            "order_id": 136915589622,
+                            "price": "64376",
+                            "amount": "0.0001"
                         },
-                        "timestamp": 1703591279143,
-                        "datetime": "2023-12-26T11:47:59.143Z",
-                        "symbol": "LTC/USDT:USDT",
-                        "id": "1050281181",
-                        "order": "120234770970",
+                        "timestamp": 1714119054558,
+                        "datetime": "2024-04-26T08:10:54.558Z",
+                        "symbol": "BTC/USDT:USDT",
+                        "id": "1180222387",
+                        "order": "136915589622",
                         "type": null,
                         "side": "buy",
                         "takerOrMaker": "taker",
-                        "price": 73.78,
-                        "amount": 0.1,
-                        "cost": 7.378,
-                        "fee": {
-                            "cost": 0.003689,
-                            "currency": null
-                        },
-                        "fees": [
-                            {
-                                "cost": 0.003689,
-                                "currency": null
-                            }
-                        ]
+                        "price": 64376,
+                        "amount": 0.0001,
+                        "cost": 6.4376,
+                        "fee": null,
+                        "fees": []
                     }
                 ]
             }


### PR DESCRIPTION
Updated fetchMyTrades to v2:
```
coinex.fetchMyTrades (BTC/USDT, , 1)
2024-05-03T01:55:54.150Z iteration 0 passed in 310 ms

    timestamp |                 datetime |   symbol |         id |        order | side |    price |     amount |         cost | fees
------------------------------------------------------------------------------------------------------------------------------------
1714618087585 | 2024-05-02T02:48:07.585Z | BTC/USDT | 4161200602 | 117654919342 | sell | 57464.04 | 0.00010087 | 5.7963977148 |   []
1 objects
```
```
coinex fetchMyTrades BTC/USDT:USDT undefined 1 '{"side":"buy"}'

coinex.fetchMyTrades (BTC/USDT:USDT, , 1, [object Object])
2024-05-03T01:56:46.399Z iteration 0 passed in 550 ms

    timestamp |                 datetime |        symbol |         id |        order | side | price | amount |   cost | fees
----------------------------------------------------------------------------------------------------------------------------
1714119054558 | 2024-04-26T08:10:54.558Z | BTC/USDT:USDT | 1180222387 | 136915589622 |  buy | 64376 | 0.0001 | 6.4376 |   []
1 objects
```