### PR TITLE
Poloniex precision

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5605,7 +5605,10 @@ export default class Exchange {
 
     costToPrecision (symbol: string, cost) {
         const market = this.market (symbol);
-        return this.decimalToPrecision (cost, TRUNCATE, market['precision']['price'], this.precisionMode, this.paddingMode);
+        const costPrecision = this.safeNumber (market['precision'], 'cost');
+        const pricePrecision = this.safeNumber (market['precision'], 'price');
+        const precision = (costPrecision !== undefined) ? costPrecision : pricePrecision;
+        return this.decimalToPrecision (cost, TRUNCATE, precision, this.precisionMode, this.paddingMode);
     }
 
     priceToPrecision (symbol: string, price): string {

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -551,6 +551,7 @@ export default class poloniex extends Exchange {
             'precision': {
                 'amount': this.parseNumber (this.parsePrecision (this.safeString (symbolTradeLimit, 'quantityScale'))),
                 'price': this.parseNumber (this.parsePrecision (this.safeString (symbolTradeLimit, 'priceScale'))),
+                'cost': this.parseNumber (this.parsePrecision (this.safeString (symbolTradeLimit, 'amountScale'))),
             },
             'limits': {
                 'amount': {


### PR DESCRIPTION
- was receiving this previously `ccxt.base.errors.ExchangeError: poloniex error: "Amount less than minAmount"`

```
% py poloniex createOrder ADA/USDT market buy 3 0.45351  
Python v3.9.6
CCXT v4.3.14
poloniex.createOrder(ADA/USDT,market,buy,3,0.45351)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '309332062333095936',
 'info': {'clientOrderId': '', 'id': '309332062333095936', 'type': 'buy'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'buy'}
 ```
 
 ```
 % py bingx createOrder SOL/USDT market buy 0.04 138.37
Python v3.9.6
CCXT v4.3.14
bingx.createOrder(SOL/USDT,market,buy,0.04,138.37)
{'amount': 0.0399,
 'average': None,
 'clientOrderId': None,
 'cost': 5.52216,
 'datetime': '2024-05-03T06:40:40.890Z',
 'fee': {'cost': None, 'currency': 'SOL'},
 'fees': [{'cost': None, 'currency': 'SOL'}],
 'filled': 0.0399,
 'id': '1786284725959032832',
 'info': {'clientOrderID': '',
          'cummulativeQuoteQty': '5.52269467931645',
          'executedQty': '0.0399',
          'orderId': '1786284725959032832',
          'origQty': '0',
          'price': '138.4',
          'side': 'BUY',
          'status': 'FILLED',
          'stopPrice': '0',
          'symbol': 'SOL-USDT',
          'transactTime': '1714718440890',
          'type': 'MARKET'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 138.4,
 'reduceOnly': None,
 'remaining': 0.0,
 'side': 'buy',
 'status': 'closed',
 'stopLossPrice': None,
 'stopPrice': 0.0,
 'symbol': 'SOL/USDT',
 'takeProfitPrice': None,
 'timeInForce': 'IOC',
 'timestamp': 1714718440890,
 'trades': [],
 'triggerPrice': 0.0,
 'type': 'market'}
 ```