### PR TITLE
hyperliquid: patch fetchSpotMerkets

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -452,6 +452,10 @@ export default class hyperliquid extends Exchange {
         for (let i = 0; i < meta.length; i++) {
             const market = this.safeDict (meta, i, {});
             const marketName = this.safeString (market, 'name');
+            if (marketName.indexOf ('/') < 0) {
+                // there are some weird spot markets in testnet, eg @2
+                continue;
+            }
             const marketParts = marketName.split ('/');
             const baseName = this.safeString (marketParts, 0);
             const quoteId = this.safeString (marketParts, 1);


### PR DESCRIPTION
fix ccxt/ccxt#22390

There are weird spot markets in testnet, like @2. It would break fetchMarkets, can find with this command `curl -X POST -d '{"type":"spotMetaAndAssetCtxs"}' -H 'content-type:application/json' https://api.hyperliquid-testnet.xyz/info`.

In this PR, I fix this.