### PR TITLE
fix(invalidNonce): handleInvalid nonce to reset subscription, fix #21997

### DIFF
--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -693,6 +693,8 @@ export default class bitfinex2 extends bitfinex2Rest {
         const responseChecksum = this.safeInteger (message, 2);
         if (responseChecksum !== localChecksum) {
             const error = new InvalidNonce (this.id + ' invalid checksum');
+            delete client.subscriptions[messageHash];
+            delete this.orderbooks[symbol];
             client.reject (error, messageHash);
         }
     }

--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -571,7 +571,10 @@ export default class bitget extends bitgetRest {
                 const responseChecksum = this.safeInteger (rawOrderBook, 'checksum');
                 if (calculatedChecksum !== responseChecksum) {
                     const error = new InvalidNonce (this.id + ' invalid checksum');
+                    delete client.subscriptions[messageHash];
+                    delete this.orderbooks[symbol];
                     client.reject (error, messageHash);
+                    return;
                 }
             }
         } else {

--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -440,6 +440,8 @@ export default class htx extends htxRest {
                 client.resolve (orderbook, messageHash);
             }
         } catch (e) {
+            delete client.subscriptions[messageHash];
+            delete this.orderbooks[symbol];
             client.reject (e, messageHash);
         }
     }

--- a/ts/src/pro/independentreserve.ts
+++ b/ts/src/pro/independentreserve.ts
@@ -225,6 +225,8 @@ export default class independentreserve extends independentreserveRest {
             const responseChecksum = this.safeInteger (orderBook, 'Crc32');
             if (calculatedChecksum !== responseChecksum) {
                 const error = new InvalidNonce (this.id + ' invalid checksum');
+                delete client.subscriptions[messageHash];
+                delete this.orderbooks[symbol];
                 client.reject (error, messageHash);
             }
         }

--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -788,6 +788,8 @@ export default class kraken extends krakenRest {
                 const localChecksum = this.crc32 (payload, false);
                 if (localChecksum !== c) {
                     const error = new InvalidNonce (this.id + ' invalid checksum');
+                    delete client.subscriptions[messageHash];
+                    delete this.orderbooks[symbol];
                     client.reject (error, messageHash);
                     return;
                 }

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -591,6 +591,8 @@ export default class okx extends okxRest {
         const storedBids = orderbook['bids'];
         this.handleDeltas (storedAsks, asks);
         this.handleDeltas (storedBids, bids);
+        const marketId = this.safeString (message, 'instId');
+        const symbol = this.safeSymbol (marketId);
         const checksum = this.safeBool (this.options, 'checksum', true);
         if (checksum) {
             const asksLength = storedAsks.length;
@@ -611,6 +613,8 @@ export default class okx extends okxRest {
             const localChecksum = this.crc32 (payload, true);
             if (responseChecksum !== localChecksum) {
                 const error = new InvalidNonce (this.id + ' invalid checksum');
+                delete client.subscriptions[messageHash];
+                delete this.orderbooks[symbol];
                 client.reject (error, messageHash);
             }
         }
@@ -706,6 +710,8 @@ export default class okx extends okxRest {
         //         ]
         //     }
         //
+        const random = Math.random()
+        if(random > 0.8) return;
         const arg = this.safeValue (message, 'arg', {});
         const channel = this.safeString (arg, 'channel');
         const action = this.safeString (message, 'action');

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -710,12 +710,10 @@ export default class okx extends okxRest {
         //         ]
         //     }
         //
-        const random = Math.random()
-        if(random > 0.8) return;
-        const arg = this.safeValue (message, 'arg', {});
+        const arg = this.safeDict (message, 'arg', {});
         const channel = this.safeString (arg, 'channel');
         const action = this.safeString (message, 'action');
-        const data = this.safeValue (message, 'data', []);
+        const data = this.safeList (message, 'data', []);
         const marketId = this.safeString (arg, 'instId');
         const market = this.safeMarket (marketId);
         const symbol = market['symbol'];


### PR DESCRIPTION
When throwing an invalid nonce, the subscription was not being reset, and therefore the user would receive continuosly an invalidNonce error after the first time it appeared.

Tested by skipping messages randomly inside the handleOrderBook to cause an invalidNonce