### PR TITLE
feat(binance): createOrder spot trailingPercent support

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5698,6 +5698,7 @@ export default class binance extends Exchange {
          * @param {float} [params.stopLossPrice] the price that a stop loss order is triggered at
          * @param {float} [params.takeProfitPrice] the price that a take profit order is triggered at
          * @param {boolean} [params.portfolioMargin] set to true if you would like to create an order in a portfolio margin account
+         * @param {string} [params.stopLossOrTakeProfit] 'stopLoss' or 'takeProfit', required for spot trailing orders
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -5811,8 +5812,8 @@ export default class binance extends Exchange {
         const stopLossPrice = this.safeString (params, 'stopLossPrice', triggerPrice); // fallback to stopLoss
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
         const trailingDelta = this.safeString (params, 'trailingDelta');
-        const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activationPrice', this.numberToString (price));
-        const trailingPercent = this.safeString2 (params, 'trailingPercent', 'callbackRate');
+        const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activationPrice');
+        const trailingPercent = this.safeStringN (params, [ 'trailingPercent', 'callbackRate', 'trailingDelta' ]);
         const priceMatch = this.safeString (params, 'priceMatch');
         const isTrailingPercentOrder = trailingPercent !== undefined;
         const isStopLoss = stopLossPrice !== undefined || trailingDelta !== undefined;
@@ -5824,10 +5825,31 @@ export default class binance extends Exchange {
         let uppercaseType = type.toUpperCase ();
         let stopPrice = undefined;
         if (isTrailingPercentOrder) {
-            uppercaseType = 'TRAILING_STOP_MARKET';
-            request['callbackRate'] = trailingPercent;
-            if (trailingTriggerPrice !== undefined) {
-                request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+            if (market['swap']) {
+                uppercaseType = 'TRAILING_STOP_MARKET';
+                request['callbackRate'] = trailingPercent;
+                if (trailingTriggerPrice !== undefined) {
+                    request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+                }
+            } else {
+                if (isMarketOrder) {
+                    throw new InvalidOrder (this.id + ' trailingPercent orders are not supported for ' + symbol + ' ' + type + ' orders');
+                }
+                const stopLossOrTakeProfit = this.safeString (params, 'stopLossOrTakeProfit');
+                params = this.omit (params, 'stopLossOrTakeProfit');
+                if (stopLossOrTakeProfit !== 'stopLoss' && stopLossOrTakeProfit !== 'takeProfit') {
+                    throw new InvalidOrder (this.id + symbol + ' trailingPercent orders require a stopLossOrTakeProfit parameter of either stopLoss or takeProfit');
+                }
+                if (stopLossOrTakeProfit === 'stopLoss') {
+                    uppercaseType = 'STOP_LOSS_LIMIT';
+                } else if (stopLossOrTakeProfit === 'takeProfit') {
+                    uppercaseType = 'TAKE_PROFIT_LIMIT';
+                }
+                if (trailingTriggerPrice !== undefined) {
+                    stopPrice = this.priceToPrecision (symbol, trailingTriggerPrice);
+                }
+                const trailingPercentConverted = Precise.stringMul (trailingPercent, '100');
+                request['trailingDelta'] = trailingPercentConverted;
             }
         } else if (isStopLoss) {
             stopPrice = stopLossPrice;
@@ -5993,8 +6015,8 @@ export default class binance extends Exchange {
                 }
             } else {
                 // check for delta price as well
-                if (trailingDelta === undefined && stopPrice === undefined) {
-                    throw new InvalidOrder (this.id + ' createOrder() requires a stopPrice or trailingDelta param for a ' + type + ' order');
+                if (trailingDelta === undefined && stopPrice === undefined && trailingPercent === undefined) {
+                    throw new InvalidOrder (this.id + ' createOrder() requires a stopPrice, trailingDelta or trailingPercent param for a ' + type + ' order');
                 }
             }
             if (stopPrice !== undefined) {

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -349,6 +349,40 @@
                     }
                 ],
                 "output": "timestamp=1708360882808&symbol=LTCUSDT&side=BUY&newOrderRespType=RESULT&newClientOrderId=x-xcKtGhcu6f60e2c1e1ed4166838709&type=LIMIT&quantity=0.2&timeInForce=GTC&priceMatch=OPPONENT&recvWindow=10000&signature=b73ae983cc2d4995d48e98841152c802ba0b420ee79fc501bde0b6eeee4817ab"
+            },
+            {
+                "description": "spot create a trailing limit stop loss order",
+                "method": "createOrder",
+                "url": "https://testnet.binance.vision/api/v3/order",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "sell",
+                  0.1,
+                  55000,
+                  {
+                    "trailingPercent": 5,
+                    "stopLossOrTakeProfit": "stopLoss"
+                  }
+                ],
+                "output": "timestamp=1715064034670&symbol=BTCUSDT&side=SELL&trailingDelta=500&newClientOrderId=x-R4BD3S827b685798989f41d5802a06&newOrderRespType=FULL&type=STOP_LOSS_LIMIT&quantity=0.1&price=55000&timeInForce=GTC&recvWindow=10000&signature=57d9051c3a5ef532f6124922f104bfd35e73b553b8e46d54598a3fdbb9463cb5"
+            },
+            {
+                "description": "spot create a trailing limit take profit order",
+                "method": "createOrder",
+                "url": "https://testnet.binance.vision/api/v3/order",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "sell",
+                  0.1,
+                  70000,
+                  {
+                    "trailingPercent": 5,
+                    "stopLossOrTakeProfit": "takeProfit"
+                  }
+                ],
+                "output": "timestamp=1715064136268&symbol=BTCUSDT&side=SELL&trailingDelta=500&newClientOrderId=x-R4BD3S829874c25a35ce4766a6c7bc&newOrderRespType=FULL&type=TAKE_PROFIT_LIMIT&quantity=0.1&price=70000&timeInForce=GTC&recvWindow=10000&signature=221d429c7db5a26495d5c0d9287f6e6a08fb59f45b3f71c3c6bfe8e319e35341"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Added spot trailingPercent support to createOrder, a `stopLossOrTakeProfit` exchange specific param was required for the implementation:
```
binance createOrder BTC/USDT limit sell 0.1 55000 '{"trailingPercent":5,"isStopLossOrTakeProfit":"stopLoss"}'

{
  info: {
    symbol: 'BTCUSDT',
    orderId: '1847062',
    orderListId: '-1',
    clientOrderId: 'x-R4BD3S827b685798989f41d5802a06',
    transactTime: '1715064035453',
    price: '55000.00000000',
    origQty: '0.10000000',
    executedQty: '0.00000000',
    cummulativeQuoteQty: '0.00000000',
    status: 'NEW',
    timeInForce: 'GTC',
    type: 'STOP_LOSS_LIMIT',
    side: 'SELL',
    trailingDelta: '500',
    trailingTime: '1715064035453',
    workingTime: '-1',
    fills: [],
    selfTradePreventionMode: 'EXPIRE_MAKER'
  },
  id: '1847062',
  clientOrderId: 'x-R4BD3S827b685798989f41d5802a06',
  timestamp: -1,
  lastUpdateTimestamp: 1715064035453,
  symbol: 'BTC/USDT',
  type: 'stop_loss_limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  price: 55000,
  amount: 0.1,
  cost: 0,
  filled: 0,
  remaining: 0.1,
  status: 'open',
  trades: [],
  fees: []
}
```
```
binance createOrder BTC/USDT limit sell 0.1 70000 '{"trailingPercent":5,"isStopLossOrTakeProfit":"takeProfit"}'

{
  info: {
    symbol: 'BTCUSDT',
    orderId: '1847452',
    orderListId: '-1',
    clientOrderId: 'x-R4BD3S829874c25a35ce4766a6c7bc',
    transactTime: '1715064137054',
    price: '70000.00000000',
    origQty: '0.10000000',
    executedQty: '0.00000000',
    cummulativeQuoteQty: '0.00000000',
    status: 'NEW',
    timeInForce: 'GTC',
    type: 'TAKE_PROFIT_LIMIT',
    side: 'SELL',
    trailingDelta: '500',
    trailingTime: '1715064137054',
    workingTime: '-1',
    fills: [],
    selfTradePreventionMode: 'EXPIRE_MAKER'
  },
  id: '1847452',
  clientOrderId: 'x-R4BD3S829874c25a35ce4766a6c7bc',
  timestamp: -1,
  lastUpdateTimestamp: 1715064137054,
  symbol: 'BTC/USDT',
  type: 'take_profit_limit',
  timeInForce: 'GTC',
  postOnly: false,
  side: 'sell',
  price: 70000,
  amount: 0.1,
  cost: 0,
  filled: 0,
  remaining: 0.1,
  status: 'open',
  trades: [],
  fees: []
}
```