### PR TITLE
fix(indodax): patch fetchTickers

### DIFF
--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -521,7 +521,7 @@ export default class indodax extends Exchange {
         // }
         //
         const response = await this.publicGetApiTickerAll (params);
-        const tickers = this.safeList (response, 'tickers');
+        const tickers = this.safeDict (response, 'tickers', {});
         return this.parseTickers (tickers, symbols);
     }
 


### PR DESCRIPTION
fix ccxt/ccxt#22427

The response of fetchTickers would be dict instead of list.