### PR TITLE
extend in php

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -648,7 +648,6 @@ class Transpiler {
 
             [ /undefined/g, 'null' ],
             [ /\} else if/g, '} elseif' ],
-            [ /this\.extend\s/g, 'array_merge' ],
             [ /this\.stringToBinary\s*\((.*)\)/g, '$1' ],
             [ /this\.stringToBase64\s/g, 'base64_encode' ],
             [ /this\.binaryToBase16\s/g, 'bin2hex' ],

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -879,6 +879,10 @@ class Exchange {
         return $string;
     }
 
+    public static function extend(...$args) {
+        return array_merge (...$args);
+    }
+
     public static function deep_extend() {
         //
         //     extend associative dictionaries only, replace everything else


### PR DESCRIPTION
for the sake of completeness (external uses for users to simplify unified use of `extend`) we can have it in php too.
also, in tests/custom snippets we somewhere also need to use `.extend` in unifiish way to avoid custom string replacing in transpiler.