### PR TITLE
fix(htx): fix #22451

### DIFF
--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -2305,9 +2305,6 @@ export default class htx extends htxRest {
             'url': url,
             'hostname': hostname,
         };
-        if (type === 'spot') {
-            this.options['ws']['gunzip'] = false;
-        }
         await this.authenticate (authParams);
         return await this.watch (url, messageHash, this.extend (request, params), channel, extendedSubsription);
     }


### PR DESCRIPTION
When calling first a private channel and then a public channel it would set gunzip to false and would cause errors
This PR removes setting gunzip false for private spot channels.
I believe this was introduced as the exchange docs do say that on private spot channels gunzip is not used, however in ccxt this is ignored because before applying gunzip we check if the message is a binary or not.

- Tested by calling watchBalance in ts,, py, php 