### PR TITLE
fix(coinex)

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -297,7 +297,7 @@ export default class coinex extends Exchange {
                 'v2': {
                     'public': {
                         'get': {
-                            'maintain-info': 1,
+                            'maintain/info': 1,
                             'ping': 1,
                             'time': 1,
                             'spot/market': 1,


### PR DESCRIPTION
Coinex V2 maintain endpoint URL is https://api.coinex.com/v2/maintain/info instead of https://api.coinex.com/v2/maintain-info

See:
https://docs.coinex.com/api/v2/common/http/maintain