### PR TITLE
fix(hyperliquid): update fetchOpenOrders with frontendOrders

### DIFF
--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -540,7 +540,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"openOrders\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": "{\"type\":\"frontendOpenOrders\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
             }
         ],
         "fetchOrder": [

--- a/ts/src/test/static/response/hyperliquid.json
+++ b/ts/src/test/static/response/hyperliquid.json
@@ -221,6 +221,81 @@
                         "stopLossPrice": null
                     }
                 ]
+            },
+            {
+              "description": "trigger open order",
+              "method": "fetchOpenOrders",
+              "input": [
+                "ADA/USDC:USDC"
+              ],
+              "httpResponse": [
+                {
+                  "children": [],
+                  "cloid": null,
+                  "coin": "ADA",
+                  "isPositionTpsl": false,
+                  "isTrigger": true,
+                  "limitPx": "0.4",
+                  "oid": "8670685324",
+                  "orderType": "Stop Limit",
+                  "origSz": "40.0",
+                  "reduceOnly": false,
+                  "side": "B",
+                  "sz": "40.0",
+                  "tif": null,
+                  "timestamp": "1715524233290",
+                  "triggerCondition": "Price above 0.6",
+                  "triggerPx": "0.6"
+                }
+              ],
+              "parsedResponse": [
+                {
+                  "info": {
+                    "children": [],
+                    "cloid": null,
+                    "coin": "ADA",
+                    "isPositionTpsl": false,
+                    "isTrigger": true,
+                    "limitPx": "0.4",
+                    "oid": "8670685324",
+                    "orderType": "Stop Limit",
+                    "origSz": "40.0",
+                    "reduceOnly": false,
+                    "side": "B",
+                    "sz": "40.0",
+                    "tif": null,
+                    "timestamp": "1715524233290",
+                    "triggerCondition": "Price above 0.6",
+                    "triggerPx": "0.6"
+                  },
+                  "id": "8670685324",
+                  "clientOrderId": null,
+                  "timestamp": 1715524233290,
+                  "datetime": "2024-05-12T14:30:33.290Z",
+                  "lastTradeTimestamp": null,
+                  "lastUpdateTimestamp": null,
+                  "symbol": "ADA/USDC:USDC",
+                  "type": "limit",
+                  "timeInForce": null,
+                  "postOnly": null,
+                  "reduceOnly": false,
+                  "side": "buy",
+                  "price": 0.4,
+                  "triggerPrice": 0.6,
+                  "amount": 40,
+                  "cost": null,
+                  "average": null,
+                  "filled": null,
+                  "remaining": null,
+                  "status": null,
+                  "fee": null,
+                  "trades": [],
+                  "fees": [],
+                  "stopPrice": 0.6,
+                  "takeProfitPrice": null,
+                  "stopLossPrice": null
+                }
+              ]
             }
         ],
         "fetchOrder": [


### PR DESCRIPTION
- Trigger order
```
p hyperliquid fetchOpenOrders "ADA/USDC:USDC" --sandbox           
Python v3.11.7
CCXT v4.3.20
hyperliquid.fetchOpenOrders(ADA/USDC:USDC)
[{'amount': 40.0,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': '2024-05-12T14:30:33.290Z',
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '8670685324',
  'info': {'children': [],
           'cloid': None,
           'coin': 'ADA',
           'isPositionTpsl': False,
           'isTrigger': True,
           'limitPx': '0.4',
           'oid': '8670685324',
           'orderType': 'Stop Limit',
           'origSz': '40.0',
           'reduceOnly': False,
           'side': 'B',
           'sz': '40.0',
           'tif': None,
           'timestamp': '1715524233290',
           'triggerCondition': 'Price above 0.6',
           'triggerPx': '0.6'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 0.4,
  'reduceOnly': False,
  'remaining': None,
  'side': 'buy',
  'status': None,
  'stopLossPrice': None,
  'stopPrice': 0.6,
  'symbol': 'ADA/USDC:USDC',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1715524233290,
  'trades': [],
  'triggerPrice': 0.6,
  'type': 'limit'}]
```
