### PR TITLE
fix(ruff): fix deprecated warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
 preview = true
+[tool.ruff.lint]p
 select = ["W", "F", "E"]
 ignore = ["F722","F841","F821","E402","E501","E902","E713","E741","E714", "E275","E721"]
 

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -24,7 +24,7 @@ commands =
 [testenv:qa]
 allowlist_externals = ruff
 changedir = {toxinidir}
-commands = ruff ./ccxt/
+commands = ruff check ./ccxt/
 deps = .[qa]
 
 [testenv:type]


### PR DESCRIPTION
Fix following warnings:
- warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
- warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `/home/pablo/github/ccxt2/pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'