### PR TITLE
fix(coinex): handleErrors should also check for "OK"

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -5944,7 +5944,7 @@ export default class coinex extends Exchange {
         const code = this.safeString (response, 'code');
         const data = this.safeValue (response, 'data');
         const message = this.safeString (response, 'message');
-        if ((code !== '0') || ((message !== 'Success') && (message !== 'Succeeded') && (message !== 'Ok') && !data)) {
+        if ((code !== '0') || ((message !== 'Success') && (message !== 'Succeeded') && (message.toLowerCase() !== 'ok') && !data)) {
             const feedback = this.id + ' ' + message;
             this.throwBroadlyMatchedException (this.exceptions['broad'], message, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -5944,7 +5944,7 @@ export default class coinex extends Exchange {
         const code = this.safeString (response, 'code');
         const data = this.safeValue (response, 'data');
         const message = this.safeString (response, 'message');
-        if ((code !== '0') || ((message !== 'Success') && (message !== 'Succeeded') && (message.toLowerCase() !== 'ok') && !data)) {
+        if ((code !== '0') || ((message !== 'Success') && (message !== 'Succeeded') && (message.toLowerCase () !== 'ok') && !data)) {
             const feedback = this.id + ' ' + message;
             this.throwBroadlyMatchedException (this.exceptions['broad'], message, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);


### PR DESCRIPTION
The `handleErrors` method checks for "Ok", but some endpoints return "OK" instead. This causes an `ExchangeError` to be thrown for API responses that use "OK" but simply have no data. 

An example is the pending positions endpoint (https://api.coinex.com/perpetual/v1/position/pending) while there are no open pending positions. 
Also in their docs it isn't consistent if you look at the examples:
- "Ok" according to the docs: https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http043_cancel_stop_order_by_client_id
- "OK" according to the docs: https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http044_get_market_preference

And here is a live example for the V2 of it returning "OK": https://api.coinex.com/v2/maintain/info