### PR TITLE
coinex fetchFundingHistory v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -4379,8 +4379,8 @@ export default class coinex extends Exchange {
         /**
          * @method
          * @name coinex#fetchFundingHistory
-         * @description fetch the history of funding payments paid and received on this account
-         * @see https://viabtc.github.io/coinex_api_en_doc/futures/#docsfutures001_http034_funding_position
+         * @description fetch the history of funding fee payments paid and received on this account
+         * @see https://docs.coinex.com/api/v2/futures/position/http/list-position-funding-history
          * @param {string} symbol unified market symbol
          * @param {int} [since] the earliest time in ms to fetch funding history for
          * @param {int} [limit] the maximum number of funding history structures to retrieve
@@ -4390,54 +4390,47 @@ export default class coinex extends Exchange {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchFundingHistory() requires a symbol argument');
         }
-        limit = (limit === undefined) ? 100 : limit;
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const request = {
+        let request = {
             'market': market['id'],
-            'limit': limit,
-            // 'offset': 0,
-            // 'end_time': 1638990636000,
-            // 'windowtime': 1638990636000,
+            'market_type': 'FUTURES',
         };
+        [ request, params ] = this.handleUntilOption ('end_time', request, params);
         if (since !== undefined) {
             request['start_time'] = since;
         }
-        const response = await this.v1PerpetualPrivateGetPositionFunding (this.extend (request, params));
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const response = await this.v2PrivateGetFuturesPositionFundingHistory (this.extend (request, params));
         //
         //     {
         //         "code": 0,
-        //         "data": {
-        //             "limit": 100,
-        //             "offset": 0,
-        //             "records": [
-        //                 {
-        //                     "amount": "0.0012",
-        //                     "asset": "USDT",
-        //                     "funding": "-0.0095688273996",
-        //                     "funding_rate": "0.00020034",
-        //                     "market": "BTCUSDT",
-        //                     "position_id": 62052321,
-        //                     "price": "39802.45",
-        //                     "real_funding_rate": "0.00020034",
-        //                     "side": 2,
-        //                     "time": 1650729623.933885,
-        //                     "type": 1,
-        //                     "user_id": 3620173,
-        //                     "value": "47.76294"
-        //                 },
-        //             ]
-        //         },
-        //         "message": "OK"
+        //         "data": [
+        //             {
+        //                 "ccy": "USDT",
+        //                 "created_at": 1715673620183,
+        //                 "funding_rate": "0",
+        //                 "funding_value": "0",
+        //                 "market": "BTCUSDT",
+        //                 "market_type": "FUTURES",
+        //                 "position_id": 306458800,
+        //                 "side": "long"
+        //             },
+        //         ],
+        //         "message": "OK",
+        //         "pagination": {
+        //             "has_next": true
+        //         }
         //     }
         //
-        const data = this.safeValue (response, 'data', {});
-        const resultList = this.safeValue (data, 'records', []);
+        const data = this.safeList (response, 'data', []);
         const result = [];
-        for (let i = 0; i < resultList.length; i++) {
-            const entry = resultList[i];
-            const timestamp = this.safeTimestamp (entry, 'time');
-            const currencyId = this.safeString (entry, 'asset');
+        for (let i = 0; i < data.length; i++) {
+            const entry = data[i];
+            const timestamp = this.safeInteger (entry, 'created_at');
+            const currencyId = this.safeString (entry, 'ccy');
             const code = this.safeCurrencyCode (currencyId);
             result.push ({
                 'info': entry,
@@ -4446,7 +4439,7 @@ export default class coinex extends Exchange {
                 'timestamp': timestamp,
                 'datetime': this.iso8601 (timestamp),
                 'id': this.safeNumber (entry, 'position_id'),
-                'amount': this.safeNumber (entry, 'funding'),
+                'amount': this.safeNumber (entry, 'funding_value'),
             });
         }
         return result as FundingHistory[];

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1215,6 +1215,18 @@
                 ],
                 "output": "{\"amount\":\"-7.4\",\"market\":\"BTCUSDT\",\"market_type\":\"FUTURES\"}"
             }
+        ],
+        "fetchFundingHistory": [
+            {
+                "description": "Swap fetch the private funding fee history",
+                "method": "fetchFundingHistory",
+                "url": "https://api.coinex.com/v2/futures/position-funding-history?limit=5&market=BTCUSDT&market_type=FUTURES",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  5
+                ]
+            }
         ]
     },
     "disabledTests": {}


### PR DESCRIPTION
Updated fetchFundingHistory to v2 and added a static request test:
```
coinex.fetchFundingHistory (BTC/USDT:USDT, , 5)
2024-05-14T09:08:05.223Z iteration 0 passed in 229 ms

       symbol | code |     timestamp |                 datetime |        id |           amount
----------------------------------------------------------------------------------------------
BTC/USDT:USDT | USDT | 1715673620183 | 2024-05-14T08:00:20.183Z | 306458800 |                0
BTC/USDT:USDT | USDT | 1715644821153 | 2024-05-14T00:00:21.153Z | 306458800 |                0
BTC/USDT:USDT | USDT | 1715616021765 | 2024-05-13T16:00:21.765Z | 306458800 |                0
BTC/USDT:USDT | USDT | 1715593934703 | 2024-05-13T09:52:14.703Z | 306458800 |                0
BTC/USDT:USDT | USDT | 1715587219749 | 2024-05-13T08:00:19.749Z | 306458800 | 0.00057428263652
5 objects
```