### PR TITLE
fix(binance): update default value of options.leverageBrackets

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -9548,7 +9548,7 @@ export default class binance extends Exchange {
         await this.loadMarkets ();
         // by default cache the leverage bracket
         // it contains useful stuff like the maintenance margin and initial margin for positions
-        const leverageBrackets = this.safeDict (this.options, 'leverageBrackets', {});
+        const leverageBrackets = this.safeDict (this.options, 'leverageBrackets');
         if ((leverageBrackets === undefined) || (reload)) {
             const defaultType = this.safeString (this.options, 'defaultType', 'future');
             const type = this.safeString (params, 'type', defaultType);


### PR DESCRIPTION
fix ccxt/ccxt#22495

Because the default value is not null, the function would always return at the last line.