### PR TITLE
fix(bitget) - watch parse orders

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1142,7 +1142,7 @@ export default class bitget extends bitgetRest {
         //         "executePrice": "35123", // this is limit price
         //         "triggerType": "fill_price",
         //         "planType": "amount",
-        //                   #### in case order had fill: ####
+        //                   #### in case order had a partial fill: ####
         //         fillPrice: '35123',
         //         tradeId: '1171775539946528779',
         //         baseVolume: '7', // field present in market order
@@ -1261,13 +1261,20 @@ export default class bitget extends bitgetRest {
         let totalAmount = undefined;
         let filledAmount = undefined;
         let cost = undefined;
+        let remaining = undefined;
+        const totalFilled = this.safeString (order, 'accBaseVolume');
         if (isSpot) {
             if (isMargin) {
                 filledAmount = this.omitZero (this.safeString (order, 'fillTotalAmount'));
                 totalAmount = this.omitZero (this.safeString (order, 'baseSize')); // for margin trading
                 cost = this.safeString (order, 'quoteSize');
             } else {
-                filledAmount = this.omitZero (this.safeString2 (order, 'accBaseVolume', 'baseVolume'));
+                const partialFillAmount = this.safeString (order, 'baseVolume');
+                if (partialFillAmount !== undefined) {
+                    filledAmount = partialFillAmount;
+                } else {
+                    filledAmount = totalFilled;
+                }
                 if (isMarketOrder) {
                     if (isBuy) {
                         totalAmount = accBaseVolume;
@@ -1287,6 +1294,7 @@ export default class bitget extends bitgetRest {
             totalAmount = this.safeString (order, 'size');
             cost = this.safeString (order, 'fillNotionalUsd');
         }
+        remaining = this.omitZero (Precise.stringSub (totalAmount, totalFilled));
         return this.safeOrder ({
             'info': order,
             'symbol': symbol,
@@ -1305,7 +1313,7 @@ export default class bitget extends bitgetRest {
             'cost': cost,
             'average': avgPrice,
             'filled': filledAmount,
-            'remaining': undefined,
+            'remaining': remaining,
             'status': this.parseWsOrderStatus (rawStatus),
             'fee': feeObject,
             'trades': undefined,


### PR DESCRIPTION
```
async function test (){
    const e: Exchange = new pro.bitget();
    e.setSandboxMode(true);
    await e.loadMarkets();
    var symbol = "SEOS/SUSDT:SUSDT";
    e.setPositionMode(true);
     (async () =>
        {
            try
            {
                var _ordersParams = {};
                 _ordersParams["type"] = "future";
                 _ordersParams["productType"] = "SUSDT-FUTURES";

                while (true)
                {
                    var ordersResponse = await exchange.watchOrders(symbol, undefined, undefined, _ordersParams);
                    for (var order of ordersResponse)
                        c(order);
                }
            }
            catch (ex)  {  c(ex); }
        })(); 
        await e.sleep(2500); 
        var ticker = await e.fetchTicker(symbol);
        const prec = e.markets[symbol].precision.price;
        var resp = await e.createOrder(symbol, "limit", "buy", 100, ticker.ask- prec*2 );
        await e.sleep(50);
        await e.createOrder(symbol, "limit", "sell", 10, ticker.bid + prec*2);
        await e.createOrder(symbol, "market", "sell", 20);
        await e.createOrder(symbol, "market", "sell", 40);
        await e.createOrder(symbol, "market", "sell", 30);
}
```


runs now correctly.
I have also tested against spot partial fills