### PR TITLE
Remove omit_zero check for string id in whitebit.py

### DIFF
--- a/python/ccxt/pro/whitebit.py
+++ b/python/ccxt/pro/whitebit.py
@@ -535,7 +535,7 @@ class whitebit(ccxt.async_support.whitebit):
         marketId = self.safe_string(order, 'market')
         market = self.safe_market(marketId, market)
         id = self.safe_string(order, 'id')
-        clientOrderId = self.omit_zero(self.safe_string(order, 'client_order_id'))
+        clientOrderId = self.safe_string(order, 'client_order_id')
         price = self.safe_string(order, 'price')
         filled = self.safe_string(order, 'deal_stock')
         cost = self.safe_string(order, 'deal_money')

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -578,7 +578,7 @@ export default class whitebit extends whitebitRest {
         const marketId = this.safeString (order, 'market');
         market = this.safeMarket (marketId, market);
         const id = this.safeString (order, 'id');
-        const clientOrderId = this.omitZero (this.safeString (order, 'client_order_id'));
+        const clientOrderId = this.safeString (order, 'client_order_id');
         const price = this.safeString (order, 'price');
         const filled = this.safeString (order, 'deal_stock');
         const cost = this.safeString (order, 'deal_money');


### PR DESCRIPTION
As client_order_id is supposed to be string, self.omit_zero check is not necessary and what is worse it causes an error, because this check fails for string values. Removing self.omit_zero solves the issue