### PR TITLE
feat(kraken): add createMarketBuyOrderWithCost

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -47,9 +47,9 @@ export default class kraken extends Exchange {
                 'createStopMarketOrder': true,
                 'createStopOrder': true,
                 'createTrailingAmountOrder': true,
-                'createMarketOrderWithCost': true,
+                'createMarketOrderWithCost': false,
                 'createMarketBuyOrderWithCost': true,
-                'createMarketSellOrderWithCost': true,
+                'createMarketSellOrderWithCost': false,
                 'editOrder': true,
                 'fetchBalance': true,
                 'fetchBorrowInterest': false,
@@ -1387,6 +1387,7 @@ export default class kraken extends Exchange {
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        // only buy orders are supported by the endpoint
         params['cost'] = cost;
         return await this.createOrder (symbol, 'market', side, cost, undefined, params);
     }
@@ -1404,21 +1405,6 @@ export default class kraken extends Exchange {
          */
         await this.loadMarkets ();
         return await this.createMarketOrderWithCost (symbol, 'buy', cost, params);
-    }
-
-    async createMarketSellOrderWithCost (symbol: string, cost: number, params = {}) {
-        /**
-         * @method
-         * @name kraken#createMarketSellOrderWithCost
-         * @description create a market buy order by providing the symbol, side and cost
-         * @see https://docs.kraken.com/rest/#tag/Trading/operation/addOrder
-         * @param {string} symbol unified symbol of the market to create an order in
-         * @param {float} cost how much you want to trade in units of the quote currency
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
-         */
-        await this.loadMarkets ();
-        return await this.createMarketOrderWithCost (symbol, 'sell', cost, params);
     }
 
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -47,6 +47,9 @@ export default class kraken extends Exchange {
                 'createStopMarketOrder': true,
                 'createStopOrder': true,
                 'createTrailingAmountOrder': true,
+                'createMarketOrderWithCost': true,
+                'createMarketBuyOrderWithCost': true,
+                'createMarketSellOrderWithCost': true,
                 'editOrder': true,
                 'fetchBalance': true,
                 'fetchBorrowInterest': false,
@@ -1371,6 +1374,53 @@ export default class kraken extends Exchange {
         return this.parseBalance (response);
     }
 
+    async createMarketOrderWithCost (symbol: string, side: OrderSide, cost: number, params = {}) {
+        /**
+         * @method
+         * @name kraken#createMarketOrderWithCost
+         * @description create a market order by providing the symbol, side and cost
+         * @see https://docs.kraken.com/rest/#tag/Trading/operation/addOrder
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        params['cost'] = cost;
+        return await this.createOrder (symbol, 'market', side, cost, undefined, params);
+    }
+
+    async createMarkeBuyOrderWithCost (symbol: string, cost: number, params = {}) {
+        /**
+         * @method
+         * @name kraken#createMarketBuyOrderWithCost
+         * @description create a market buy order by providing the symbol, side and cost
+         * @see https://docs.kraken.com/rest/#tag/Trading/operation/addOrder
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        return await this.createMarketOrderWithCost (symbol, 'buy', cost, params);
+    }
+
+    async createMarketSellOrderWithCost (symbol: string, cost: number, params = {}) {
+        /**
+         * @method
+         * @name kraken#createMarketSellOrderWithCost
+         * @description create a market buy order by providing the symbol, side and cost
+         * @see https://docs.kraken.com/rest/#tag/Trading/operation/addOrder
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        return await this.createMarketOrderWithCost (symbol, 'sell', cost, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         /**
          * @method
@@ -1401,7 +1451,7 @@ export default class kraken extends Exchange {
             'ordertype': type,
             'volume': this.amountToPrecision (symbol, amount),
         };
-        const orderRequest = this.orderRequest ('createOrder', symbol, type, request, price, params);
+        const orderRequest = this.orderRequest ('createOrder', symbol, type, request, amount, price, params);
         const response = await this.privatePostAddOrder (this.extend (orderRequest[0], orderRequest[1]));
         //
         //     {
@@ -1705,7 +1755,7 @@ export default class kraken extends Exchange {
         }, market);
     }
 
-    orderRequest (method, symbol, type, request, price = undefined, params = {}) {
+    orderRequest (method: string, symbol: string, type: string, request: Dict, amount: Num, price: Num = undefined, params = {}) {
         const clientOrderId = this.safeString2 (params, 'userref', 'clientOrderId');
         params = this.omit (params, [ 'userref', 'clientOrderId' ]);
         if (clientOrderId !== undefined) {
@@ -1720,7 +1770,18 @@ export default class kraken extends Exchange {
         const trailingLimitAmount = this.safeString (params, 'trailingLimitAmount');
         const isTrailingAmountOrder = trailingAmount !== undefined;
         const isLimitOrder = type.endsWith ('limit'); // supporting limit, stop-loss-limit, take-profit-limit, etc
-        if (isLimitOrder && !isTrailingAmountOrder) {
+        const isMarketOrder = type === 'market';
+        const cost = this.safeString (params, 'cost');
+        const flags = this.safeString (params, 'oflags');
+        const isViqcOrder = (flags !== undefined) && (flags.indexOf ('viqc') > -1); // volume in quote currency
+        if (isMarketOrder && (cost !== undefined || isViqcOrder)) {
+            if (cost === undefined && (amount !== undefined)) {
+                request['volume'] = this.costToPrecision (symbol, this.numberToString (amount));
+            } else {
+                request['volume'] = this.costToPrecision (symbol, cost);
+            }
+            request['oflags'] = 'viqc';
+        } else if (isLimitOrder && !isTrailingAmountOrder) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
         const reduceOnly = this.safeValue2 (params, 'reduceOnly', 'reduce_only');
@@ -1825,7 +1886,7 @@ export default class kraken extends Exchange {
         if (amount !== undefined) {
             request['volume'] = this.amountToPrecision (symbol, amount);
         }
-        const orderRequest = this.orderRequest ('editOrder', symbol, type, request, price, params);
+        const orderRequest = this.orderRequest ('editOrder', symbol, type, request, amount, price, params);
         const response = await this.privatePostEditOrder (this.extend (orderRequest[0], orderRequest[1]));
         //
         //     {

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1772,6 +1772,7 @@ export default class kraken extends Exchange {
         const isLimitOrder = type.endsWith ('limit'); // supporting limit, stop-loss-limit, take-profit-limit, etc
         const isMarketOrder = type === 'market';
         const cost = this.safeString (params, 'cost');
+        params = this.omit (params, [ 'cost' ]);
         const flags = this.safeString (params, 'oflags');
         const isViqcOrder = (flags !== undefined) && (flags.indexOf ('viqc') > -1); // volume in quote currency
         if (isMarketOrder && (cost !== undefined || isViqcOrder)) {

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1392,7 +1392,7 @@ export default class kraken extends Exchange {
         return await this.createOrder (symbol, 'market', side, cost, undefined, params);
     }
 
-    async createMarkeBuyOrderWithCost (symbol: string, cost: number, params = {}) {
+    async createMarketBuyOrderWithCost (symbol: string, cost: number, params = {}) {
         /**
          * @method
          * @name kraken#createMarketBuyOrderWithCost

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1380,7 +1380,7 @@ export default class kraken extends Exchange {
          * @name kraken#createMarketOrderWithCost
          * @description create a market order by providing the symbol, side and cost
          * @see https://docs.kraken.com/rest/#tag/Trading/operation/addOrder
-         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} symbol unified symbol of the market to create an order in (only USD markets are supported)
          * @param {string} side 'buy' or 'sell'
          * @param {float} cost how much you want to trade in units of the quote currency
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1388,6 +1388,10 @@ export default class kraken extends Exchange {
          */
         await this.loadMarkets ();
         // only buy orders are supported by the endpoint
+        const market = this.market (symbol);
+        if (market['quote'] !== 'USD') {
+            throw new NotSupported (this.id + ' createMarketOrderWithCost() supports symbols with quote currency USD only');
+        }
         params['cost'] = cost;
         return await this.createOrder (symbol, 'market', side, cost, undefined, params);
     }

--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -5,7 +5,7 @@ import krakenRest from '../kraken.js';
 import { ExchangeError, BadSymbol, PermissionDenied, AccountSuspended, BadRequest, InsufficientFunds, InvalidOrder, OrderNotFound, NotSupported, RateLimitExceeded, ExchangeNotAvailable, InvalidNonce, AuthenticationError } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import { Precise } from '../base/Precise.js';
-import type { Int, Strings, OrderSide, OrderType, Str, OrderBook, Order, Trade, Ticker, Tickers, OHLCV, Num } from '../base/types.js';
+import type { Int, Strings, OrderSide, OrderType, Str, OrderBook, Order, Trade, Ticker, Tickers, OHLCV, Num, Dict } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
@@ -128,7 +128,7 @@ export default class kraken extends krakenRest {
         const url = this.urls['api']['ws']['private'];
         const requestId = this.requestId ();
         const messageHash = requestId;
-        let request = {
+        let request: Dict = {
             'event': 'addOrder',
             'token': token,
             'reqid': requestId,
@@ -137,7 +137,7 @@ export default class kraken extends krakenRest {
             'pair': market['wsId'],
             'volume': this.amountToPrecision (symbol, amount),
         };
-        [ request, params ] = this.orderRequest ('createOrderWs', symbol, type, request, price, params);
+        [ request, params ] = this.orderRequest ('createOrderWs', symbol, type, request, amount, price, params);
         return await this.watch (url, messageHash, this.extend (request, params), messageHash);
     }
 
@@ -187,7 +187,7 @@ export default class kraken extends krakenRest {
         const url = this.urls['api']['ws']['private'];
         const requestId = this.requestId ();
         const messageHash = requestId;
-        let request = {
+        let request: Dict = {
             'event': 'editOrder',
             'token': token,
             'reqid': requestId,
@@ -195,7 +195,7 @@ export default class kraken extends krakenRest {
             'pair': market['wsId'],
             'volume': this.amountToPrecision (symbol, amount),
         };
-        [ request, params ] = this.orderRequest ('editOrderWs', symbol, type, request, price, params);
+        [ request, params ] = this.orderRequest ('editOrderWs', symbol, type, request, amount, price, params);
         return await this.watch (url, messageHash, this.extend (request, params), messageHash);
     }
 

--- a/ts/src/test/static/markets/kraken.json
+++ b/ts/src/test/static/markets/kraken.json
@@ -1798,5 +1798,239 @@
         "wsId": "XRP/USD",
         "darkpool": false,
         "altname": "XRPUSD"
+    },
+    "LTC/USD": {
+        "id": "XLTCZUSD",
+        "symbol": "LTC/USD",
+        "base": "LTC",
+        "quote": "USD",
+        "baseId": "XLTC",
+        "quoteId": "ZUSD",
+        "type": "spot",
+        "spot": true,
+        "margin": true,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.004,
+        "maker": 0.0025,
+        "precision": {
+            "amount": 1e-8,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {
+                "min": 1,
+                "max": 3
+            },
+            "amount": {
+                "min": 0.05
+            },
+            "price": {
+                "min": 0.01
+            },
+            "cost": {
+                "min": 0.5
+            }
+        },
+        "info": {
+            "altname": "LTCUSD",
+            "wsname": "LTC/USD",
+            "aclass_base": "currency",
+            "base": "XLTC",
+            "aclass_quote": "currency",
+            "quote": "ZUSD",
+            "lot": "unit",
+            "cost_decimals": "5",
+            "pair_decimals": "2",
+            "lot_decimals": "8",
+            "lot_multiplier": "1",
+            "leverage_buy": [
+                2,
+                3
+            ],
+            "leverage_sell": [
+                2,
+                3
+            ],
+            "fees": [
+                [
+                    0,
+                    0.4
+                ],
+                [
+                    10000,
+                    0.35
+                ],
+                [
+                    50000,
+                    0.24
+                ],
+                [
+                    100000,
+                    0.22
+                ],
+                [
+                    250000,
+                    0.2
+                ],
+                [
+                    500000,
+                    0.18
+                ],
+                [
+                    1000000,
+                    0.16
+                ],
+                [
+                    2500000,
+                    0.14
+                ],
+                [
+                    5000000,
+                    0.12
+                ],
+                [
+                    10000000,
+                    0.1
+                ]
+            ],
+            "fees_maker": [
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    10000,
+                    0.2
+                ],
+                [
+                    50000,
+                    0.14
+                ],
+                [
+                    100000,
+                    0.12
+                ],
+                [
+                    250000,
+                    0.1
+                ],
+                [
+                    500000,
+                    0.08
+                ],
+                [
+                    1000000,
+                    0.06
+                ],
+                [
+                    2500000,
+                    0.04
+                ],
+                [
+                    5000000,
+                    0.02
+                ],
+                [
+                    10000000,
+                    0
+                ]
+            ],
+            "fee_volume_currency": "ZUSD",
+            "margin_call": "80",
+            "margin_stop": "40",
+            "ordermin": "0.05",
+            "costmin": "0.5",
+            "tick_size": "0.01",
+            "status": "online",
+            "long_position_limit": "5300",
+            "short_position_limit": "3600"
+        },
+        "tierBased": true,
+        "percentage": true,
+        "tiers": {
+            "taker": [
+                [
+                    0,
+                    0.0026
+                ],
+                [
+                    50000,
+                    0.0024
+                ],
+                [
+                    100000,
+                    0.0022
+                ],
+                [
+                    250000,
+                    0.002
+                ],
+                [
+                    500000,
+                    0.0018
+                ],
+                [
+                    1000000,
+                    0.0016
+                ],
+                [
+                    2500000,
+                    0.0014
+                ],
+                [
+                    5000000,
+                    0.0012
+                ],
+                [
+                    10000000,
+                    0.0001
+                ]
+            ],
+            "maker": [
+                [
+                    0,
+                    0.0016
+                ],
+                [
+                    50000,
+                    0.0014
+                ],
+                [
+                    100000,
+                    0.0012
+                ],
+                [
+                    250000,
+                    0.001
+                ],
+                [
+                    500000,
+                    0.0008
+                ],
+                [
+                    1000000,
+                    0.0006
+                ],
+                [
+                    2500000,
+                    0.0004
+                ],
+                [
+                    5000000,
+                    0.0002
+                ],
+                [
+                    10000000,
+                    0
+                ]
+            ]
+        },
+        "wsId": "LTC/USD",
+        "darkpool": false,
+        "altname": "LTCUSD"
     }
 }

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -168,6 +168,18 @@
                 "output": "nonce=1705242796801&pair=LTCUSDT&type=sell&ordertype=take-profit&volume=0.1&price=120"
             }
         ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "market buy order",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.kraken.com/0/private/AddOrder",
+                "input": [
+                  "LTC/USD",
+                  5
+                ],
+                "output": "nonce=1715881618883&pair=XLTCZUSD&type=buy&ordertype=market&volume=5&oflags=viqc"
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Spot private trades",


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/22521


For some reason, the API is throwing 
```
ResponseBody:
 {"error":["EGeneral:Invalid arguments:volume"]} 
```
 when the funds are more than enough