### PR TITLE
fix(coinbase) added datetime/timestamp to ws ticker

### DIFF
--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -251,6 +251,8 @@ export default class coinbase extends coinbaseRest {
         //
         const channel = this.safeString (message, 'channel');
         const events = this.safeValue (message, 'events', []);
+        const datetime = this.safeString (message, 'timestamp');
+        const timestamp = this.parse8601 (datetime);
         const newTickers = [];
         for (let i = 0; i < events.length; i++) {
             const tickersObj = events[i];
@@ -258,6 +260,8 @@ export default class coinbase extends coinbaseRest {
             for (let j = 0; j < tickers.length; j++) {
                 const ticker = tickers[j];
                 const result = this.parseWsTicker (ticker);
+                result['timestamp'] = timestamp;
+                result['datetime'] = datetime;
                 const symbol = result['symbol'];
                 this.tickers[symbol] = result;
                 const wsMarketId = this.safeString (ticker, 'product_id');

--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -256,7 +256,7 @@ export default class coinbase extends coinbaseRest {
         const newTickers = [];
         for (let i = 0; i < events.length; i++) {
             const tickersObj = events[i];
-            const tickers = this.safeValue (tickersObj, 'tickers', []);
+            const tickers = this.safeList (tickersObj, 'tickers', []);
             for (let j = 0; j < tickers.length; j++) {
                 const ticker = tickers[j];
                 const result = this.parseWsTicker (ticker);


### PR DESCRIPTION
use the timestamp field of the message to obtain a datetime,  parse it to a timestamp and propagate both fields to all tickers contained in the message