### PR TITLE
whitebit parseBalance fix

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -1479,7 +1479,7 @@ export default class whitebit extends Exchange {
             const balance = response[id];
             if (typeof balance === 'object' && balance !== undefined) {
                 const account = this.account ();
-                account['free'] = this.safeString (balance, 'available');
+                account['free'] = this.safeString2 (balance, 'available', 'main_balance');
                 account['used'] = this.safeString (balance, 'freeze');
                 account['total'] = this.safeString (balance, 'main_balance');
                 result[code] = account;


### PR DESCRIPTION
in case of main account balance (`funding` account) de facto all balance is always `free`
```
{
     "BTC":{"main_balance":"0.0013929494020316"},
     "ETH":{"main_balance":"0.001398289308"},
}
```