### PR TITLE
fix(kucoin): invalid order error mapping

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -429,6 +429,7 @@ export default class kucoin extends Exchange {
                     'The withdrawal amount is below the minimum requirement.': ExchangeError, // {"code":"400100","msg":"The withdrawal amount is below the minimum requirement."}
                     'Unsuccessful! Exceeded the max. funds out-transfer limit': InsufficientFunds, // {"code":"200000","msg":"Unsuccessful! Exceeded the max. funds out-transfer limit"}
                     'The amount increment is invalid.': BadRequest,
+                    'The quantity is below the minimum requirement.': InvalidOrder, // {"msg":"The quantity is below the minimum requirement.","code":"400100"}
                     '400': BadRequest,
                     '401': AuthenticationError,
                     '403': NotSupported,


### PR DESCRIPTION
DEMO

```
Node.js: v18.18.0
CCXT v4.3.28
kucoin.createMarketBuyOrder (BONK/USDT, 80000)
InvalidOrder kucoin The quantity is below the minimum requirement.
---------------------------------------------------
[InvalidOrder] kucoin The quantity is below the minimum requirement.

    at throwExactlyMatchedException  Users/cjg/Git/ccxt9/ccxt/js/src/base/Exchange.js:4185  
    at handleErrors                  Users/cjg/Git/ccxt9/ccxt/js/src/kucoin.js:4809         
    at                               Users/cjg/Git/ccxt9/ccxt/js/src/base/Exchange.js:1015  
    at processTicksAndRejections     node:internal/process/task_queues:95                   
    at fetch2                        Users/cjg/Git/ccxt9/ccxt/js/src/base/Exchange.js:3737  
    at request                       Users/cjg/Git/ccxt9/ccxt/js/src/base/Exchange.js:3740  
    at createOrder                   Users/cjg/Git/ccxt9/ccxt/js/src/kucoin.js:2027         
    at createMarketBuyOrder          Users/cjg/Git/ccxt9/ccxt/js/src/base/Exchange.js:4967  
    at async run                     Users/cjg/Git/ccxt9/ccxt/examples/js/cli.js:346        

kucoin The quantity is below the minimum requirement.
```