### PR TITLE
fix(whitebit) - add market order by cost endpoint

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -113,7 +113,7 @@
                   "BTC/USDT",
                   "market",
                   "buy",
-                  null,
+                  0,
                   null,
                   {
                     "cost": 7.1

--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -104,6 +104,22 @@
                     }
                 ],
                 "output": "{\"request\":\"/api/v4/order/collateral/trigger-market\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"activation_price\":\"0.08\"}"
+            },
+            {
+                "description": "market buy +cost",
+                "method": "createOrder",
+                "url": "https://whitebit.com/api/v4/order/market",
+                "input": [
+                  "BTC/USDT",
+                  "market",
+                  "buy",
+                  null,
+                  null,
+                  {
+                    "cost": 7.1
+                  }
+                ],
+                "output": "{\"request\":\"/api/v4/order/market\",\"nonce\":\"1716315544734\",\"market\":\"BTC_USDT\",\"side\":\"buy\",\"amount\":\"7.1\",\"clientOrderId\":\"ccxt014ab638a4a5883b\"}"
             }
         ],
         "editOrder": [


### PR DESCRIPTION
fix #22570

`whitebit createOrder BTC/USDT market buy undefined undefined {'cost':7.1} --report`
```
{
  info: {
    orderId: '586706928417',
    clientOrderId: 'ccxt014ab638a4a5883b',
    market: 'BTC_USDT',
    side: 'buy',
    type: 'market',
    timestamp: '1716315544.588399',
    dealMoney: '7.03521156',
    dealStock: '0.000101',
    amount: '7.09',
    takerFee: '0.001',
    makerFee: '0',
    left: '0.05478844',
    dealFee: '0.00703521156',
    ioc: false,
    postOnly: false
  },
  id: '586706928417',
  symbol: 'BTC/USDT',
  clientOrderId: 'ccxt014ab638a4a5883b',
  timestamp: 1716315544588,
  datetime: '2024-05-21T18:19:04.588Z',
  lastTradeTimestamp: undefined,
  timeInForce: 'IOC',
  postOnly: undefined,
  status: undefined,
  side: 'buy',
  price: 69655560000,
  type: 'market',
  stopPrice: undefined,
  triggerPrice: undefined,
  amount: 0.000101,
  filled: 0.000101,
  remaining: 0,
  average: 69655560000,
  cost: 7.03521156,
  fee: { cost: 0.00703521156, currency: 'USDT' },
  trades: [],
  fees: [ { cost: 0.00703521156, currency: 'USDT' } ],
  lastUpdateTimestamp: undefined,
  reduceOnly: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```