### PR TITLE
coinex: fetchIsolatedBorrowRate v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -78,7 +78,7 @@ export default class coinex extends Exchange {
                 'fetchFundingRates': true,
                 'fetchIndexOHLCV': false,
                 'fetchIsolatedBorrowRate': true,
-                'fetchIsolatedBorrowRates': true,
+                'fetchIsolatedBorrowRates': false,
                 'fetchLeverage': 'emulated',
                 'fetchLeverages': true,
                 'fetchLeverageTiers': true,
@@ -5206,43 +5206,6 @@ export default class coinex extends Exchange {
         //
         const data = this.safeDict (response, 'data', {});
         return this.parseIsolatedBorrowRate (data, market);
-    }
-
-    async fetchIsolatedBorrowRates (params = {}): Promise<IsolatedBorrowRates> {
-        /**
-         * @method
-         * @name coinex#fetchIsolatedBorrowRates
-         * @description fetch the borrow interest rates of all currencies
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot002_account007_margin_account_settings
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object} a list of [isolated borrow rate structures]{@link https://github.com/ccxt/ccxt/wiki/Manual#isolated-borrow-rate-structure}
-         */
-        await this.loadMarkets ();
-        const response = await this.v1PrivateGetMarginConfig (params);
-        //
-        //     {
-        //         "code": 0,
-        //         "data": [
-        //             {
-        //                 "market": "BTCUSDT",
-        //                 "leverage": 10,
-        //                 "BTC": {
-        //                     "min_amount": "0.002",
-        //                     "max_amount": "200",
-        //                     "day_rate": "0.001"
-        //                 },
-        //                 "USDT": {
-        //                     "min_amount": "60",
-        //                     "max_amount": "5000000",
-        //                     "day_rate": "0.001"
-        //                 }
-        //             },
-        //         ],
-        //         "message": "Success"
-        //     }
-        //
-        const data = this.safeValue (response, 'data', []);
-        return this.parseIsolatedBorrowRates (data);
     }
 
     async fetchBorrowInterest (code: Str = undefined, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -7,7 +7,7 @@ import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { md5 } from './static_dependencies/noble-hashes/md5.js';
-import type { Balances, Currency, FundingHistory, FundingRateHistory, Int, Market, OHLCV, Order, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, OrderRequest, TransferEntry, Leverage, Leverages, Num, MarginModification, TradingFeeInterface, Currencies, TradingFees, Position, IsolatedBorrowRates, IsolatedBorrowRate, Dict, TransferEntries } from './base/types.js';
+import type { Balances, Currency, FundingHistory, FundingRateHistory, Int, Market, OHLCV, Order, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, OrderRequest, TransferEntry, Leverage, Leverages, Num, MarginModification, TradingFeeInterface, Currencies, TradingFees, Position, IsolatedBorrowRate, Dict, TransferEntries } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -715,11 +715,14 @@
         ],
         "fetchIsolatedBorrowRate": [
             {
-                "description": "Fetch isolated borrow rate",
+                "description": "Fetch the isolated borrow rate",
                 "method": "fetchIsolatedBorrowRate",
-                "url": "https://api.coinex.com/v1/margin/config?access_id=86AC33D5904F432C9C9DDD4708233F38&market=BTCUSDT&tonce=1700201048704",
+                "url": "https://api.coinex.com/v2/assets/margin/interest-limit?ccy=USDT&market=BTCUSDT",
                 "input": [
-                    "BTC/USDT"
+                  "BTC/USDT",
+                  {
+                    "code": "USDT"
+                  }
                 ]
             }
         ],

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -726,14 +726,6 @@
                 ]
             }
         ],
-        "fetchIsolatedBorrowRates": [
-            {
-                "description": "Fetch isolated borrow rates",
-                "method": "fetchIsolatedBorrowRates",
-                "url": "https://api.coinex.com/v1/margin/config?access_id=86AC33D5904F432C9C9DDD4708233F38&tonce=1700202207814",
-                "input": []
-            }
-        ],
         "cancelOrders": [
             {
                 "description": "Cancel multiple spot orders at once",


### PR DESCRIPTION
Updated fetchIsolatedBorrowRate to v2 and removed fetchIsolatedBorrowRates because there is no v2 endpoint for it.
```
node examples/js/cli coinex fetchIsolatedBorrowRate BTC/USDT '{"code":"USDT"}'

coinex.fetchIsolatedBorrowRate (BTC/USDT, [object Object])
2024-05-22T22:36:29.604Z iteration 0 passed in 224 ms

{
  symbol: 'BTC/USDT',
  base: 'BTC',
  quote: 'USDT',
  quoteRate: 0.001,
  period: 86400000,
  info: {
    market: 'BTCUSDT',
    ccy: 'USDT',
    leverage: 10,
    min_amount: '60',
    max_amount: '500000',
    daily_interest_rate: '0.001'
  }
}
```