### PR TITLE
coinex: borrowIsolatedMargin, repayIsolatedMargin v2

### DIFF
--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1248,6 +1248,19 @@
                   5
                 ]
             }
+        ],
+        "borrowIsolatedMargin": [
+            {
+                "description": "Borrow isolated margin",
+                "method": "borrowIsolatedMargin",
+                "url": "https://api.coinex.com/v2/assets/margin/borrow",
+                "input": [
+                  "BTC/USDT",
+                  "USDT",
+                  60
+                ],
+                "output": "{\"borrow_amount\":\"60\",\"ccy\":\"USDT\",\"is_auto_renew\":false,\"market\":\"BTCUSDT\"}"
+            }
         ]
     },
     "disabledTests": {}

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1261,6 +1261,19 @@
                 ],
                 "output": "{\"borrow_amount\":\"60\",\"ccy\":\"USDT\",\"is_auto_renew\":false,\"market\":\"BTCUSDT\"}"
             }
+        ],
+        "repayIsolatedMargin": [
+            {
+                "description": "Repay isolated margin",
+                "method": "repayIsolatedMargin",
+                "url": "https://api.coinex.com/v2/assets/margin/repay",
+                "input": [
+                  "BTC/USDT",
+                  "USDT",
+                  60.0025
+                ],
+                "output": "{\"amount\":\"60.0025\",\"ccy\":\"USDT\",\"market\":\"BTCUSDT\"}"
+            }
         ]
     },
     "disabledTests": {}


### PR DESCRIPTION
Updated borrowIsolatedMargin and repayIsolatedMargin to v2:
```
node examples/js/cli coinex borrowIsolatedMargin BTC/USDT USDT 60

{
  id: 13784021,
  currency: 'USDT',
  amount: 60,
  symbol: 'BTC/USDT',
  timestamp: 1717299948340,
  datetime: '2024-06-02T03:45:48.340Z',
  info: {
    borrow_id: 13784021,
    market: 'BTCUSDT',
    ccy: 'USDT',
    daily_interest_rate: '0.001',
    expired_at: 1717299948340,
    borrow_amount: '60',
    to_repaied_amount: '60.0025',
    status: 'loan'
  }
}
```
```
node examples/js/cli coinex repayIsolatedMargin BTC/USDT USDT 60.0025

{ currency: 'USDT', amount: 60.0025, symbol: 'BTC/USDT', info: {} }
```