### PR TITLE
fix(base) - parse leverage market type

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6724,6 +6724,10 @@ export default class Exchange {
         for (let i = 0; i < response.length; i++) {
             const info = response[i];
             const marketId = this.safeString (info, symbolKey);
+            if (marketType === undefined && symbols !== undefined) {
+                const market = this.getMarketFromSymbols (symbols);
+                marketType = market['type'];
+            }
             const market = this.safeMarket (marketId, undefined, undefined, marketType);
             if ((symbols === undefined) || this.inArray (market['symbol'], symbols)) {
                 leverageStructures[market['symbol']] = this.parseLeverage (info, market);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6724,10 +6724,6 @@ export default class Exchange {
         for (let i = 0; i < response.length; i++) {
             const info = response[i];
             const marketId = this.safeString (info, symbolKey);
-            if (marketType === undefined && symbols !== undefined) {
-                const market = this.getMarketFromSymbols (symbols);
-                marketType = market['type'];
-            }
             const market = this.safeMarket (marketId, undefined, undefined, marketType);
             if ((symbols === undefined) || this.inArray (market['symbol'], symbols)) {
                 leverageStructures[market['symbol']] = this.parseLeverage (info, market);

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -10385,8 +10385,14 @@ export default class binance extends Exchange {
         } else {
             throw new NotSupported (this.id + ' fetchLeverages() supports linear and inverse contracts only');
         }
+        let marketType = undefined;
+        if (symbols !== undefined) {
+            symbols = this.marketSymbols (symbols, undefined, false, true, true);
+            const market = this.getMarketFromSymbols (symbols);
+            marketType = market['type'];
+        }
         const leverages = this.safeList (response, 'positions', []);
-        return this.parseLeverages (leverages, symbols, 'symbol');
+        return this.parseLeverages (leverages, symbols, 'symbol', marketType);
     }
 
     parseLeverage (leverage: Dict, market: Market = undefined): Leverage {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -10390,6 +10390,8 @@ export default class binance extends Exchange {
             symbols = this.marketSymbols (symbols, undefined, false, true, true);
             const market = this.getMarketFromSymbols (symbols);
             marketType = market['type'];
+        } else {
+            marketType = (type === 'future') ? 'future' : 'swap';
         }
         const leverages = this.safeList (response, 'positions', []);
         return this.parseLeverages (leverages, symbols, 'symbol', marketType);


### PR DESCRIPTION
might be fix #22578
I think this might be better than defaulting https://github.com/ccxt/ccxt/pull/22586/files 
so, there are two scenarios:
A) if exchange has all-in-one endpoint (swap & future ..) then the `parseLeverage` would not have market-ids conflict, so `marketType` wont be needed. 
B) if exchange needs to make a call to market-specific endpoint (swap/spot/etc), then that market-type string should be passed to the `parseLeverage`

if `symbols` are not passed by user, then implementation will go trough either A or B scenario, but if `symbols` are set, and `B` scenario happens, then we will need to derive market type from symbols