### PR TITLE
sleep push

### DIFF
--- a/build/push.sh
+++ b/build/push.sh
@@ -17,6 +17,7 @@ echo ""
 if [ "$HEAD_LOCAL" != "$HEAD_REMOTE" ]; then
     echo "HEAD CHANGED, ABORTING BUILD!"
     echo ""
+    sleep 0.1
     exit 1
 fi
 


### PR DESCRIPTION
almost in all cases, the last few printed words are trimmed from travis logs:
https://app.travis-ci.com/github/ccxt/ccxt/builds/270609286#L4444
https://app.travis-ci.com/github/ccxt/ccxt/builds/270586485#L4441
https://app.travis-ci.com/github/ccxt/ccxt/builds/270572490#L4443

so, the message is not clear in many cases (leaving in doubts why build failed).