### PR TITLE
fix(bingx) websocket ticker timestamp/datetime

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -196,7 +196,7 @@ export default class bingx extends bingxRest {
         //         "b": "2.5747"
         //     }
         //
-        const timestamp = this.safeInteger (message, 'ts');
+        const timestamp = this.safeInteger (message, 'C');
         const marketId = this.safeString (message, 's');
         market = this.safeMarket (marketId, market);
         const close = this.safeString (message, 'c');


### PR DESCRIPTION
The timestamp was taken from field 'ts', which does not exist (anymore). 
Now takes from 'C' (statistics close time), because fetchTicker uses 'closeTime' field too.