### PR TITLE
fix(kraken): fetchOHLCV since handling

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1001,9 +1001,7 @@ export default class kraken extends Exchange {
             request['interval'] = timeframe;
         }
         if (since !== undefined) {
-            // contrary to kraken's api documentation, the since parameter must be passed in nanoseconds
-            // the adding of '000000' is copied from the fetchTrades function
-            request['since'] = this.numberToString (since) + '000000'; // expected to be in nanoseconds
+            request['since'] = this.numberToString (this.parseToInt (since / 1000)); // expected to be in seconds
         }
         const response = await this.publicGetOHLC (this.extend (request, params));
         //

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -362,11 +362,11 @@
             {
                 "description": "spot ohlcv with since",
                 "method": "fetchOHLCV",
-                "url": "https://api.kraken.com/0/public/OHLC?pair=XBTUSDT&interval=60&since=1706628191000000000",
+                "url": "https://api.kraken.com/0/public/OHLC?pair=XBTUSDT&interval=60&since=1716523348",
                 "input": [
-                    "BTC/USDT",
-                    "1h",
-                    1706628191000
+                  "BTC/USDT",
+                  "1h",
+                  1716523348000
                 ]
             },
             {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/22606


```
raken.fetchOHLCV (BTC/USDT, 1h, 1716523348000)
fetch Request:
 kraken GET https://api.kraken.com/0/public/OHLC?pair=XBTUSDT&interval=60&since=1716523348 
RequestHeaders:
 {} 
RequestBody:
 undefined 

handleRestResponse:
 kraken GET https://api.kraken.com/0/public/OHLC?pair=XBTUSDT&interval=60&since=1716523348 200 OK 

ResponseBody:
 {"error":[],"result":{"XBTUSDT":[[1716526800,"67692.8","67692.8","67132.0","67307.3","67330.9","20.92610534",399],[1716530400,"67307.4","67578.4","66885.3","66919.2","67267.3","21.12324464",433],[1716534000,"66885.4","67264.5","66885.3","67146.2","67034.2","9.26828411",338],[1716537600,"67164.0","67185.3","66624.9","67185.3","66965.0","7.58390828",320],[1716541200,"67185.3","67405.3","67045.0","67363.6","67226.7","14.83360952",344],[1716544800,"67363.6","67484.7","67316.4","67341.9","67396.0","10.62040474",304],[1716548400,"67353.6","67472.3","67353.6","67426.5","67416.5","11.38174933",169]],"last":1716544800}} 

2024-05-24T11:33:24.521Z iteration 0 passed in 1085 ms

1716526800000 | 67692.8 | 67692.8 |   67132 | 67307.3 | 20.92610534
1716530400000 | 67307.4 | 67578.4 | 66885.3 | 66919.2 | 21.12324464
1716534000000 | 66885.4 | 67264.5 | 66885.3 | 67146.2 |  9.26828411
1716537600000 |   67164 | 67185.3 | 66624.9 | 67185.3 |  7.58390828
1716541200000 | 67185.3 | 67405.3 |   67045 | 67363.6 | 14.83360952
1716544800000 | 67363.6 | 67484.7 | 67316.4 | 67341.9 | 10.62040474
1716548400000 | 67353.6 | 67472.3 | 67353.6 | 67426.5 | 11.38174933
7 objects
```
