### PR TITLE
fix(coinbase) - WS fixes

### DIFF
--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -249,6 +249,34 @@ export default class coinbase extends coinbaseRest {
         //        ]
         //    }
         //
+        // note! seems coinbase might also send empty data like:
+        //
+        //    {
+        //        "channel": "ticker_batch",
+        //        "client_id": "",
+        //        "timestamp": "2024-05-24T18:22:24.546809523Z",
+        //        "sequence_num": 1,
+        //        "events": [
+        //            {
+        //                "type": "snapshot",
+        //                "tickers": [
+        //                    {
+        //                        "type": "ticker",
+        //                        "product_id": "",
+        //                        "price": "",
+        //                        "volume_24_h": "",
+        //                        "low_24_h": "",
+        //                        "high_24_h": "",
+        //                        "low_52_w": "",
+        //                        "high_52_w": "",
+        //                        "price_percent_chg_24_h": ""
+        //                    }
+        //                ]
+        //            }
+        //        ]
+        //    }
+        //
+        //
         const channel = this.safeString (message, 'channel');
         const events = this.safeValue (message, 'events', []);
         const datetime = this.safeString (message, 'timestamp');
@@ -265,6 +293,9 @@ export default class coinbase extends coinbaseRest {
                 const symbol = result['symbol'];
                 this.tickers[symbol] = result;
                 const wsMarketId = this.safeString (ticker, 'product_id');
+                if (wsMarketId === undefined) {
+                    continue;
+                }
                 const messageHash = channel + '::' + wsMarketId;
                 newTickers.push (result);
                 client.resolve (result, messageHash);


### PR DESCRIPTION
I was able to reproduce this only in handleTickers, but not for other methods. maybe for some reason, other subscriptions also cause for api to send that empty data, and maybe this fix could fix others. but the problem (which I was unable to reproduce yet) is exactly how travis log shown (inside `subscribe`).

anyway, this PR needs to be merged, and then I'll try to address next issues whatever will be visible then on travis
