### PR TITLE
alpaca cancelOrder unified response

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -796,7 +796,7 @@ export default class alpaca extends Exchange {
         //       "message": "order is not found."
         //   }
         //
-        return this.safeValue (response, 'message', {});
+        return this.parseOrder (response);
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {


### PR DESCRIPTION
I can't test this out because theres no balance on the exchange and `fetchDepositAddress` doesn't work