### PR TITLE
coinex: withdraw v2

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -4632,7 +4632,7 @@ export default class coinex extends Exchange {
          * @method
          * @name coinex#withdraw
          * @description make a withdrawal
-         * @see https://viabtc.github.io/coinex_api_en_doc/spot/#docsspot002_account015_submit_withdraw
+         * @see https://docs.coinex.com/api/v2/assets/deposit-withdrawal/http/withdrawal
          * @param {string} code unified currency code
          * @param {float} amount the amount to withdraw
          * @param {string} address the address to withdraw to
@@ -4645,37 +4645,44 @@ export default class coinex extends Exchange {
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);
-        const networkCode = this.safeStringUpper (params, 'network');
+        const networkCode = this.safeStringUpper2 (params, 'network', 'chain');
         params = this.omit (params, 'network');
         if (tag) {
             address = address + ':' + tag;
         }
         const request: Dict = {
-            'coin_type': currency['id'],
-            'coin_address': address, // must be authorized, inter-user transfer by a registered mobile phone number or an email address is supported
-            'actual_amount': parseFloat (this.numberToString (amount)), // the actual amount without fees, https://www.coinex.com/fees
-            'transfer_method': 'onchain', // onchain, local
+            'ccy': currency['id'],
+            'to_address': address, // must be authorized, inter-user transfer by a registered mobile phone number or an email address is supported
+            'amount': this.numberToString (amount), // the actual amount without fees, https://www.coinex.com/fees
         };
         if (networkCode !== undefined) {
-            request['smart_contract_name'] = this.networkCodeToId (networkCode);
+            request['chain'] = this.networkCodeToId (networkCode); // required for on-chain, not required for inter-user transfer
         }
-        const response = await this.v1PrivatePostBalanceCoinWithdraw (this.extend (request, params));
+        const response = await this.v2PrivatePostAssetsWithdraw (this.extend (request, params));
         //
         //     {
         //         "code": 0,
         //         "data": {
-        //             "actual_amount": "1.00000000",
-        //             "amount": "1.00000000",
-        //             "coin_address": "1KAv3pazbTk2JnQ5xTo6fpKK7p1it2RzD4",
-        //             "coin_type": "BCH",
-        //             "coin_withdraw_id": 206,
+        //             "withdraw_id": 31193755,
+        //             "created_at": 1716874165038,
+        //             "withdraw_method": "ON_CHAIN",
+        //             "ccy": "USDT",
+        //             "amount": "17.3",
+        //             "actual_amount": "15",
+        //             "chain": "TRC20",
+        //             "tx_fee": "2.3",
+        //             "fee_asset": "USDT",
+        //             "fee_amount": "2.3",
+        //             "to_address": "TY5vq3MT6b5cQVAHWHtpGyPg1ERcQgi3UN",
+        //             "memo": "",
+        //             "tx_id": "",
         //             "confirmations": 0,
-        //             "create_time": 1524228297,
-        //             "status": "audit",
-        //             "tx_fee": "0",
-        //             "tx_id": ""
+        //             "explorer_address_url": "https://tronscan.org/#/address/TY5vq3MT6b5cQVAHWHtpGyPg1ERcQgi3UN",
+        //             "explorer_tx_url": "https://tronscan.org/#/transaction/",
+        //             "remark": "",
+        //             "status": "audit_required"
         //         },
-        //         "message": "Ok"
+        //         "message": "OK"
         //     }
         //
         const transaction = this.safeDict (response, 'data', {});
@@ -4789,7 +4796,7 @@ export default class coinex extends Exchange {
         //         "remark": ""
         //     }
         //
-        // fetchWithdrawals
+        // fetchWithdrawals and withdraw
         //
         //     {
         //         "withdraw_id": 259364,

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -1287,7 +1287,24 @@
               "USDT"
             ]
         }
-     ]
+     ],
+     "withdraw": [
+        {
+          "description": "Withdraw USDT on the TRC20 chain",
+          "method": "withdraw",
+          "url": "https://api.coinex.com/v2/assets/withdraw",
+          "input": [
+            "USDT",
+            15,
+            "TY5vq3MT6b5cQVAHWHtpGyPg1ERcQgi3UN",
+            null,
+            {
+              "network": "TRX"
+            }
+          ],
+          "output": "{\"amount\":\"15\",\"ccy\":\"USDT\",\"chain\":\"TRC20\",\"to_address\":\"TY5vq3MT6b5cQVAHWHtpGyPg1ERcQgi3UN\"}"
+        }
+      ]
     },
     "disabledTests": {}
 }


### PR DESCRIPTION
Updated withdraw to v2:
```
node examples/js/cli coinex withdraw USDT 15 TY5vq3MT6b5cWHtpGyPg1ERcQgiUN undefined '{"network":"TRX"}'

{
  info: {
    withdraw_id: 31193755,
    created_at: 1716874165038,
    withdraw_method: 'ON_CHAIN',
    ccy: 'USDT',
    amount: '17.3',
    actual_amount: '15',
    chain: 'TRC20',
    tx_fee: '2.3',
    fee_asset: 'USDT',
    fee_amount: '2.3',
    to_address: 'TY5vq3MT6b5cWHtpGyPg1ERQgi3UN',
    memo: '',
    tx_id: '',
    confirmations: 0,
    explorer_address_url: 'https://tronscan.org/#/address,
    explorer_tx_url: 'https://tronscan.org/#/transaction/',
    remark: '',
    status: 'audit_required'
  },
  id: '31193755',
  timestamp: 1716874165038,
  datetime: '2024-05-28T05:29:25.038Z',
  network: 'TRX',
  address: 'TY5vq3MT6b5cHtpGyPg1ERcQgi3UN',
  addressTo: 'TY5vq3MT6b5cWHtpGyPg1ERcQgi3N',
  type: 'withdrawal',
  amount: 15,
  currency: 'USDT',
  status: 'audit_required',
  fee: { cost: 2.3, currency: 'USDT' },
  internal: false
}
```