### PR TITLE
feat(zonda): new deposit & withdrawal endpoints

### DIFF
--- a/ts/src/zonda.ts
+++ b/ts/src/zonda.ts
@@ -171,6 +171,10 @@ export default class zonda extends Exchange {
                         'balances/BITBAY/balance',
                         'fiat_cantor/rate/{baseId}/{quoteId}',
                         'fiat_cantor/history',
+                        'client_payments/v2/customer/crypto/{currency}/channels/deposit',
+                        'client_payments/v2/customer/crypto/{currency}/channels/withdrawal',
+                        'client_payments/v2/customer/crypto/deposit/fee',
+                        'client_payments/v2/customer/crypto/withdrawal/fee',
                     ],
                     'post': [
                         'trading/offer/{symbol}',
@@ -181,6 +185,8 @@ export default class zonda extends Exchange {
                         'fiat_cantor/exchange',
                         'api_payments/withdrawals/crypto',
                         'api_payments/withdrawals/fiat',
+                        'client_payments/v2/customer/crypto/deposit',
+                        'client_payments/v2/customer/crypto/withdrawal',
                     ],
                     'delete': [
                         'trading/offer/{symbol}/{id}/{side}/{price}',


### PR DESCRIPTION
I was trying to update `fetchDepositsWithdrawals` but I don't have the right permissions with the apiKeys that I have

```
 % zonda v1_01PrivatePostClientPaymentsV2CustomerCryptoDeposit '{"currency": "BTC"}'
2024-05-28T22:53:53.733Z
Node.js: v18.12.0
CCXT v4.3.34
zonda.v1_01PrivatePostClientPaymentsV2CustomerCryptoDeposit ([object Object])
PermissionDenied zonda {"status":"Fail","errors":["PERMISSIONS_NOT_SUFFICIENT","Forbidden access to requested resource."]}
---------------------------------------------------
[PermissionDenied] zonda {"status":"Fail","errors":["PERMISSIONS_NOT_SUFFICIENT","Forbidden access to requested resource."]}

    at throwExactlyMatchedException  ts/src/base/Exchange.ts:4702          throw new exact[string] (message);                                              
    at handleErrors                  ts/src/zonda.ts:1901                  this.throwExactlyMatchedException (this.exceptions, error, feedback);           
    at <anonymous>                   ts/src/base/Exchange.ts:1291          const skipFurtherErrorHandling = this.handleErrors (response.status, response.s…
    at processTicksAndRejections     node:internal/process/task_queues:95                                                                                  
    at fetch2                        ts/src/base/Exchange.ts:4216          return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                       ts/src/base/Exchange.ts:4220          return await this.fetch2 (path, api, method, params, headers, body, config);    
    at run                           examples/ts/cli.ts:338                const result = await exchange[methodName] (... args)                            

zonda {"status":"Fail","errors":["PERMISSIONS_NOT_SUFFICIENT","Forbidden access to requested resource."]}
```

----------------

I was trying to update this method because there is no balance on the exchange, so I can't test other methods