### PR TITLE
feat(zaif): cancelOrder - unification

### DIFF
--- a/ts/src/zaif.ts
+++ b/ts/src/zaif.ts
@@ -491,7 +491,23 @@ export default class zaif extends Exchange {
         const request: Dict = {
             'order_id': id,
         };
-        return await this.privatePostCancelOrder (this.extend (request, params));
+        const response = await this.privatePostCancelOrder (this.extend (request, params));
+        //
+        //    {
+        //        "success": 1,
+        //        "return": {
+        //            "order_id": 184,
+        //            "funds": {
+        //                "jpy": 15320,
+        //                "btc": 1.392,
+        //                "mona": 2600,
+        //                "kaori": 0.1
+        //            }
+        //        }
+        //    }
+        //
+        const data = this.safeDict (response, 'return');
+        return this.parseOrder (data);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -505,6 +521,18 @@ export default class zaif extends Exchange {
         //         "comment" : "demo"
         //     }
         //
+        // cancelOrder
+        //
+        //    {
+        //        "order_id": 184,
+        //        "funds": {
+        //            "jpy": 15320,
+        //            "btc": 1.392,
+        //            "mona": 2600,
+        //            "kaori": 0.1
+        //        }
+        //    }
+        //
         let side = this.safeString (order, 'action');
         side = (side === 'bid') ? 'buy' : 'sell';
         const timestamp = this.safeTimestamp (order, 'timestamp');
@@ -512,7 +540,7 @@ export default class zaif extends Exchange {
         const symbol = this.safeSymbol (marketId, market, '_');
         const price = this.safeString (order, 'price');
         const amount = this.safeString (order, 'amount');
-        const id = this.safeString (order, 'id');
+        const id = this.safeString2 (order, 'id', 'order_id');
         return this.safeOrder ({
             'id': id,
             'clientOrderId': undefined,


### PR DESCRIPTION
none of us are able to get apiKeys for Zaif, but we'll need to unify the response. According to the [api docs](https://zaif-api-document.readthedocs.io/ja/latest/TradingAPI.html#id37), that's the correct response in the response comments