### PR TITLE
fix(bitfinex2) handleOrderBook

### DIFF
--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -591,8 +591,7 @@ export default class bitfinex2 extends bitfinex2Rest {
         const prec = this.safeString (subscription, 'prec', 'P0');
         const isRaw = (prec === 'R0');
         // if it is an initial snapshot
-        let orderbook = this.safeValue (this.orderbooks, symbol);
-        if (orderbook === undefined) {
+        if (!(symbol in this.orderbooks)) {
             const limit = this.safeInteger (subscription, 'len');
             if (isRaw) {
                 // raw order books
@@ -601,7 +600,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                 // P0, P1, P2, P3, P4
                 this.orderbooks[symbol] = this.countedOrderBook ({}, limit);
             }
-            orderbook = this.orderbooks[symbol];
+            const orderbook = this.orderbooks[symbol];
             if (isRaw) {
                 const deltas = message[1];
                 for (let i = 0; i < deltas.length; i++) {

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -629,6 +629,7 @@ export default class bitfinex2 extends bitfinex2Rest {
             orderbook['symbol'] = symbol;
             client.resolve (orderbook, messageHash);
         } else {
+            const orderbook = this.orderbooks[symbol];
             const deltas = message[1];
             const orderbookItem = this.orderbooks[symbol];
             if (isRaw) {

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -612,7 +612,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                     const bookside = orderbook[side];
                     const idString = this.safeString (delta, 0);
                     const price = this.safeFloat (delta, 1);
-                    bookside.store (price, size, idString);
+                    bookside.storeArray ([price, size, idString]);
                 }
             } else {
                 const deltas = message[1];
@@ -624,7 +624,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                     const size = (amount < 0) ? -amount : amount;
                     const side = (amount < 0) ? 'asks' : 'bids';
                     const bookside = orderbook[side];
-                    bookside.store (price, size, counter);
+                    bookside.storeArray ([price, size, counter]);
                 }
             }
             orderbook['symbol'] = symbol;

--- a/ts/src/pro/bitfinex2.ts
+++ b/ts/src/pro/bitfinex2.ts
@@ -612,7 +612,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                     const bookside = orderbook[side];
                     const idString = this.safeString (delta, 0);
                     const price = this.safeFloat (delta, 1);
-                    bookside.storeArray ([price, size, idString]);
+                    bookside.storeArray ([ price, size, idString ]);
                 }
             } else {
                 const deltas = message[1];
@@ -624,7 +624,7 @@ export default class bitfinex2 extends bitfinex2Rest {
                     const size = (amount < 0) ? -amount : amount;
                     const side = (amount < 0) ? 'asks' : 'bids';
                     const bookside = orderbook[side];
-                    bookside.storeArray ([price, size, counter]);
+                    bookside.storeArray ([ price, size, counter ]);
                 }
             }
             orderbook['symbol'] = symbol;


### PR DESCRIPTION
For a new orderbook, the entry was still added through (CounterOrderBookSide.)store.

This resulted in an error:
`CountedOrderBookSide.store() is not supported, use storeArray([price, size, count]) instead`

In bitfinex.ts, this was already fixed. Applied the same fix in bitfinex2.ts.
