### PR TITLE
fix(bingx): symbol inference on trades

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1045,7 +1045,7 @@ export default class bingx extends Exchange {
             time = undefined;
         }
         const cost = this.safeString (trade, 'quoteQty');
-        const type = (cost === undefined) ? 'spot' : 'swap';
+        // const type = (cost === undefined) ? 'spot' : 'swap'; this is not reliable
         const currencyId = this.safeStringN (trade, [ 'currency', 'N', 'commissionAsset' ]);
         const currencyCode = this.safeCurrencyCode (currencyId);
         const m = this.safeBool (trade, 'm');
@@ -1082,7 +1082,7 @@ export default class bingx extends Exchange {
             'info': trade,
             'timestamp': time,
             'datetime': this.iso8601 (time),
-            'symbol': this.safeSymbol (marketId, market, '-', type),
+            'symbol': this.safeSymbol (marketId, market, '-'),
             'order': this.safeString2 (trade, 'orderId', 'i'),
             'type': this.safeStringLower (trade, 'o'),
             'side': this.parseOrderSide (side),

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1061,10 +1061,13 @@ export default class bingx extends bingxRest {
         //         }
         //     }
         //
-        const a = this.safeValue (message, 'a', {});
-        const data = this.safeValue (a, 'B', []);
+        const a = this.safeDict (message, 'a', {});
+        const data = this.safeList (a, 'B', []);
         const timestamp = this.safeInteger2 (message, 'T', 'E');
         const type = ('P' in a) ? 'swap' : 'spot';
+        if (!(type in this.balance)) {
+            this.balance[type] = {};
+        }
         this.balance[type]['info'] = data;
         this.balance[type]['timestamp'] = timestamp;
         this.balance[type]['datetime'] = this.iso8601 (timestamp);

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1004,7 +1004,7 @@ export default class bingx extends bingxRest {
         //    }
         //
         const isSpot = ('dataType' in message);
-        const result = this.safeValue2 (message, 'data', 'o', {});
+        const result = this.safeDict2 (message, 'data', 'o', {});
         let cachedTrades = this.myTrades;
         if (cachedTrades === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1011,7 +1011,10 @@ export default class bingx extends bingxRest {
             cachedTrades = new ArrayCacheBySymbolById (limit);
             this.myTrades = cachedTrades;
         }
-        const parsed = this.parseTrade (result);
+        const type = isSpot ? 'spot' : 'swap';
+        const marketId = this.safeString (result, 's');
+        const market = this.safeMarket (marketId, undefined, '-', type);
+        const parsed = this.parseTrade (result, market);
         const symbol = parsed['symbol'];
         const spotHash = 'spot:mytrades';
         const swapHash = 'swap:mytrades';


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/22657

```
 p bingx fetchTrades "PYTH/USDT" None 1
/Users/cjg/Git/ccxt9/ccxt/examples/py/cli.py:124: SyntaxWarning: invalid escape sequence '\s'
  call_reg = "\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)"
Python v3.12.3
CCXT v4.3.35
bingx.fetchTrades(PYTH/USDT,None,1)
[{'amount': 18.0,
  'cost': 7.7814,
  'datetime': '2024-05-29T09:42:54.056Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'id': '12635364',
  'info': {'buyerMaker': True,
           'id': '12635364',
           'price': '0.4323',
           'qty': '18',
           'time': '1716975774056'},
  'order': None,
  'price': 0.4323,
  'side': 'sell',
  'symbol': 'PYTH/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1716975774056,
```
```
 p bingx fetchTrades "PYTH/USDT:USDT" None 1
/Users/cjg/Git/ccxt9/ccxt/examples/py/cli.py:124: SyntaxWarning: invalid escape sequence '\s'
  call_reg = "\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)"
Python v3.12.3
CCXT v4.3.35
bingx.fetchTrades(PYTH/USDT:USDT,None,1)
[{'amount': 10.0,
  'cost': 4.32,
  'datetime': '2024-05-29T09:43:21.393Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'id': None,
  'info': {'fillId': '41892579',
           'isBuyerMaker': True,
           'price': '0.4318',
           'qty': '10',
           'quoteQty': '4.32',
           'time': '1716975801393',
           'ts': '1716975801393'},
  'order': None,
  'price': 0.4318,
  'side': 'sell',
  'symbol': 'PYTH/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1716975801393,
  'type': None}]
```
```
p bingx watchTrades "PYTH/USDT:USDT" None 1
/Users/cjg/Git/ccxt9/ccxt/examples/py/cli.py:124: SyntaxWarning: invalid escape sequence '\s'
  call_reg = "\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)"
Python v3.12.3
CCXT v4.3.35
bingx.watchTrades(PYTH/USDT:USDT,None,1)
[{'amount': 37.0,
  'cost': 15.9655,
  'datetime': '2024-05-29T09:43:39.396Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'id': None,
  'info': {'T': 1716975819396,
           'm': True,
           'p': '0.4315',
           'q': '37',
           's': 'PYTH-USDT'},
  'order': None,
  'price': 0.4315,
  'side': 'sell',
  'symbol': 'PYTH/USDT:USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1716975819396,
  'type': None}]
```
```
p bingx watchTrades "PYTH/USDT" None 1     
/Users/cjg/Git/ccxt9/ccxt/examples/py/cli.py:124: SyntaxWarning: invalid escape sequence '\s'
  call_reg = "\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)"
Python v3.12.3
CCXT v4.3.35
bingx.watchTrades(PYTH/USDT,None,1)
[{'amount': 11.819102033263167,
  'cost': 5.109397808979667,
  'datetime': '2024-05-29T09:44:08.083Z',
  'fee': {'cost': None, 'currency': None, 'rate': None},
  'fees': [{'cost': None, 'currency': None, 'rate': None}],
  'id': '12635389',
  'info': {'E': 1716975848122,
           'T': 1716975848083,
           'e': 'trade',
           'm': False,
           'p': '0.4323',
           'q': '11.819102033263167',
           's': 'PYTH-USDT',
           't': '12635389'},
  'order': None,
  'price': 0.4323,
  'side': 'buy',
  'symbol': 'PYTH/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1716975848083,
  'type': None}]
```
```
p bingx watchMyTrades
/Users/cjg/Git/ccxt9/ccxt/examples/py/cli.py:124: SyntaxWarning: invalid escape sequence '\s'
  call_reg = "\s*(\w+)\s*\.\s*(\w+)\s*\(([^()]*)\)"
Python v3.12.3
CCXT v4.3.35
bingx.watchMyTrades()
[{'amount': 0.1,
  'cost': 8.342,
  'datetime': '2024-05-29T09:49:25.688Z',
  'fee': {'cost': 0.008341770081260863, 'currency': 'USDT', 'rate': None},
  'fees': [{'cost': 0.008341770081260863, 'currency': 'USDT', 'rate': None}],
  'id': '68096525',
  'info': {'E': 1716976165771,
           'L': 83.41770081260862,
           'N': 'USDT',
           'O': 1716976165681,
           'Q': 8.342,
           'S': 'SELL',
           'T': 1716976165688,
           'X': 'FILLED',
           'Y': 8.341770081260862,
           'Z': 8.341770081260862,
           'e': 'executionReport',
           'i': 1795754310076727296,
           'l': 0.1,
           'm': False,
           'n': -0.008341770081260863,
           'o': 'MARKET',
           'p': 83.42,
           'q': 0.1,
           's': 'LTC-USDT',
           't': 68096525,
           'x': 'TRADE',
           'z': 0.1},
  'order': '1795754310076727296',
  'price': 83.42,
  'side': 'sell',
  'symbol': 'LTC/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1716976165688,
  'type': 'market'}]
```
