### PR TITLE
feat(ace): cancelOrder - returns unified response

### DIFF
--- a/ts/src/ace.ts
+++ b/ts/src/ace.ts
@@ -533,6 +533,15 @@ export default class ace extends Exchange {
         //             "type": 1
         //         }
         //
+        // cancelOrder
+        //
+        //     {
+        //         "attachment": 200,
+        //         "message": null,
+        //         "parameters": null,
+        //         "status": 200
+        //     }
+        //
         let id: Str;
         let timestamp: Int = undefined;
         let symbol: Str = undefined;
@@ -666,7 +675,7 @@ export default class ace extends Exchange {
         //         "status": 200
         //     }
         //
-        return response;
+        return this.parseOrder (response);
     }
 
     async fetchOrder (id: string, symbol: Str = undefined, params = {}) {


### PR DESCRIPTION
Getting the error below with any order that I try to create

```
ExchangeNotAvailable ace POST https://ace.io/polarisex/open/v2/order/order 400 Bad Request {"timestamp":"2024-06-19 13:53:03","status":400,"error":"Bad Request","path":"/polarisex/open/v2/order/order"}
---------------------------------------------------
[ExchangeNotAvailable] ace POST https://ace.io/polarisex/open/v2/order/order 400 Bad Request {"timestamp":"2024-06-19 13:53:03","status":400,"error":"Bad Request","path":"/polarisex/open/v2/order/order"}

    at                            …/order/order 400 Bad Request {"timestamp":"2024-06-19 13:53                                                                                  
    at handleHttpStatusCode       ts/src/base/Exchange.ts:1402                                  throw new ErrorClass (this.id + ' ' + method + ' ' + url + ' ' + codeAsString +…
    at <anonymous>                ts/src/base/Exchange.ts:1294                                  this.handleHttpStatusCode (response.status, response.statusText, url, method, r…
    at processTicksAndRejections  node:internal/process/task_queues:95                                                                                                          
    at fetch2                     ts/src/base/Exchange.ts:4217                                  return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    ts/src/base/Exchange.ts:4221                                  return await this.fetch2 (path, api, method, params, headers, body, config);    
    at createOrder                ts/src/ace.ts:641                                             const response = await this.privatePostV2OrderOrder (this.extend (request, para…
    at run                        examples/ts/cli.ts:338                                        const result = await exchange[methodName] (... args)                            

ace POST https://ace.io/polarisex/open/v2/order/order 400 Bad Request {"timestamp":"2024-06-19 13:53:03","status":400,"error":"Bad Request","path":"/polarisex/open/v2/order/order"}
```