### PR TITLE
feat(bingx): cancelOrders, cancelAllOrders - response unification

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2735,7 +2735,9 @@ export default class bingx extends Exchange {
         } else {
             throw new BadRequest (this.id + ' cancelAllOrders is only supported for spot and swap markets.');
         }
-        return response;
+        const data = this.safeDict (response, 'data', {});
+        const orders = this.safeList2 (data, 'success', 'orders', []);
+        return this.parseOrders (orders);
     }
 
     async cancelOrders (ids: string[], symbol: Str = undefined, params = {}) {
@@ -2777,6 +2779,32 @@ export default class bingx extends Exchange {
             const spotReqKey = areClientOrderIds ? 'clientOrderIDs' : 'orderIds';
             request[spotReqKey] = parsedIds.join (',');
             response = await this.spotV1PrivatePostTradeCancelOrders (this.extend (request, params));
+            //
+            //    {
+            //       "code": 0,
+            //       "msg": "",
+            //       "debugMsg": "",
+            //       "data": {
+            //           "orders": [
+            //                {
+            //                    "symbol": "SOL-USDT",
+            //                    "orderId": 1795970045910614016,
+            //                    "transactTime": 1717027601111,
+            //                    "price": "180.25",
+            //                    "stopPrice": "0",
+            //                    "origQty": "0.03",
+            //                    "executedQty": "0",
+            //                    "cummulativeQuoteQty": "0",
+            //                    "status": "CANCELED",
+            //                    "type": "LIMIT",
+            //                    "side": "SELL",
+            //                    "clientOrderID": ""
+            //                },
+            //                ...
+            //            ]
+            //        }
+            //    }
+            //
         } else {
             if (areClientOrderIds) {
                 request['clientOrderIDList'] = this.json (parsedIds);
@@ -2784,37 +2812,39 @@ export default class bingx extends Exchange {
                 request['orderIdList'] = parsedIds;
             }
             response = await this.swapV2PrivateDeleteTradeBatchOrders (this.extend (request, params));
+            //
+            //    {
+            //        "code": 0,
+            //        "msg": "",
+            //        "data": {
+            //          "success": [
+            //            {
+            //              "symbol": "LINK-USDT",
+            //              "orderId": 1597783850786750464,
+            //              "side": "BUY",
+            //              "positionSide": "LONG",
+            //              "type": "TRIGGER_MARKET",
+            //              "origQty": "5.0",
+            //              "price": "5.5710",
+            //              "executedQty": "0.0",
+            //              "avgPrice": "0.0000",
+            //              "cumQuote": "0",
+            //              "stopPrice": "5.0000",
+            //              "profit": "0.0000",
+            //              "commission": "0.000000",
+            //              "status": "CANCELLED",
+            //              "time": 1669776330000,
+            //              "updateTime": 1672370837000
+            //            }
+            //          ],
+            //          "failed": null
+            //        }
+            //    }
+            //
         }
-        //
-        //    {
-        //        "code": 0,
-        //        "msg": "",
-        //        "data": {
-        //          "success": [
-        //            {
-        //              "symbol": "LINK-USDT",
-        //              "orderId": 1597783850786750464,
-        //              "side": "BUY",
-        //              "positionSide": "LONG",
-        //              "type": "TRIGGER_MARKET",
-        //              "origQty": "5.0",
-        //              "price": "5.5710",
-        //              "executedQty": "0.0",
-        //              "avgPrice": "0.0000",
-        //              "cumQuote": "0",
-        //              "stopPrice": "5.0000",
-        //              "profit": "0.0000",
-        //              "commission": "0.000000",
-        //              "status": "CANCELLED",
-        //              "time": 1669776330000,
-        //              "updateTime": 1672370837000
-        //            }
-        //          ],
-        //          "failed": null
-        //        }
-        //    }
-        //
-        return response;
+        const data = this.safeDict (response, 'data', {});
+        const success = this.safeList2 (data, 'success', 'orders', []);
+        return this.parseOrders (success);
     }
 
     async cancelAllOrdersAfter (timeout: Int, params = {}) {


### PR DESCRIPTION
```
% py bingx cancelAllOrders SOL/USDT                   
Python v3.9.6
CCXT v4.3.36
bingx.cancelAllOrders(SOL/USDT)
[{'amount': 0.03,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2024-05-30T00:03:14.315Z',
  'fee': {'cost': None, 'currency': 'USDT'},
  'fees': [{'cost': None, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '1795969178545324032',
  'info': {'clientOrderID': '',
           'cummulativeQuoteQty': '0',
           'executedQty': '0',
           'orderId': '1795969178545324032',
           'origQty': '0.03',
           'price': '185.25',
           'side': 'SELL',
           'status': 'CANCELED',
           'stopPrice': '0',
           'symbol': 'SOL-USDT',
           'transactTime': '1717027394315',
           'type': 'LIMIT'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 185.25,
  'reduceOnly': None,
  'remaining': 0.03,
  'side': 'sell',
  'status': 'canceled',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'SOL/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1717027394315,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'},
 ...
 ]
```

```
% py bingx cancelOrders '["1795970045910614016", "1795970005636907008"]' SOL/USDT
Python v3.9.6
CCXT v4.3.36
bingx.cancelOrders(['1795970045910614016', '1795970005636907008'],SOL/USDT)

[{'amount': 0.03,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2024-05-30T00:06:31.509Z',
  'fee': {'cost': None, 'currency': 'USDT'},
  'fees': [{'cost': None, 'currency': 'USDT'}],
  'filled': 0.0,
  'id': '1795970005636907008',
  'info': {'clientOrderID': '',
           'cummulativeQuoteQty': '0',
           'executedQty': '0',
           'orderId': '1795970005636907008',
           'origQty': '0.03',
           'price': '180.25',
           'side': 'SELL',
           'status': 'CANCELED',
           'stopPrice': '0',
           'symbol': 'SOL-USDT',
           'transactTime': '1717027591509',
           'type': 'LIMIT'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 180.25,
  'reduceOnly': None,
  'remaining': 0.03,
  'side': 'sell',
  'status': 'canceled',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'SOL/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1717027591509,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'},
  ...
 ]
```